### PR TITLE
use wcsicmp instead of _stricmp where wchar_t* is provided (on windows)

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -304,7 +304,7 @@ void SurgeStorage::refreshPatchlistAddDir(bool userDir, string subdir)
 
          for (auto& f : fs::directory_iterator(p))
          {
-            if (_stricmp(f.path().extension().c_str(), ".fxp") == 0)
+            if (wcsicmp(f.path().extension().c_str(), L".fxp") == 0)
             {
                patchlist_entry e;
                e.category = category;
@@ -345,7 +345,7 @@ void SurgeStorage::refresh_wtlist()
 
          for (auto& f : fs::directory_iterator(p))
          {
-            if (_stricmp(f.path().extension().c_str(),".wt") == 0)
+            if (wcsicmp(f.path().extension().c_str(), L".wt") == 0)
             {
                patchlist_entry e;
                e.category = category;
@@ -354,7 +354,7 @@ void SurgeStorage::refresh_wtlist()
                e.name = e.name.substr(0, e.name.size() - 3);
                wt_list.push_back(e);
             }
-            else if (_stricmp(f.path().extension().c_str(),".wav") == 0)
+            else if (wcsicmp(f.path().extension().c_str(), L".wav") == 0)
             {
                patchlist_entry e;
                e.category = category;


### PR DESCRIPTION
master currently doesn't build on Windows due to the usage of _stricmp in SurgeStorage.cpp (lines 307, 348, 357)

_stricmp expects const char* but f.path().extension().c_str() is of type const wchar_t*.

The equivalent method to use for wchar_t* is wcsicmp (or _wcsicmp). One issue with a simple redefinition of _stricmp like we've done for mac & linux before is that the second argument is also a wide string, so it needs the L-prefix for string constants. So this needs to be adapted somehow to work on mac/linux as well.