### PR TITLE
.extension() should be a path; then we can use .generic_string() to

### DIFF
--- a/libs/filesystem/filesystem.cpp
+++ b/libs/filesystem/filesystem.cpp
@@ -44,9 +44,10 @@ namespace std::experimental::filesystem {
         return p;
     }
     
-    std::string path::extension() {
+    path path::extension() {
         auto idx = this->p.find_last_of(".");
-        return p.substr(idx);
+        path res(p.substr(idx));
+        return res;
     }
     // emd path class
 

--- a/libs/filesystem/filesystem.h
+++ b/libs/filesystem/filesystem.h
@@ -40,7 +40,7 @@ namespace std::experimental::filesystem {
         
         path filename();
         
-        std::string extension();
+        path extension();
     };
     
     class file {

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -304,7 +304,7 @@ void SurgeStorage::refreshPatchlistAddDir(bool userDir, string subdir)
 
          for (auto& f : fs::directory_iterator(p))
          {
-            if (_stricmp(f.path().extension().c_str(), ".fxp") == 0)
+            if (_stricmp(f.path().extension().generic_string().c_str(), ".fxp") == 0)
             {
                patchlist_entry e;
                e.category = category;
@@ -345,7 +345,7 @@ void SurgeStorage::refresh_wtlist()
 
          for (auto& f : fs::directory_iterator(p))
          {
-            if (_stricmp(f.path().extension().c_str(),".wt") == 0)
+            if (_stricmp(f.path().extension().generic_string().c_str(), ".wt") == 0)
             {
                patchlist_entry e;
                e.category = category;
@@ -354,7 +354,7 @@ void SurgeStorage::refresh_wtlist()
                e.name = e.name.substr(0, e.name.size() - 3);
                wt_list.push_back(e);
             }
-            else if (_stricmp(f.path().extension().c_str(),".wav") == 0)
+            else if (_stricmp(f.path().extension().generic_string().c_str(), ".wav") == 0)
             {
                patchlist_entry e;
                e.category = category;


### PR DESCRIPTION
guarantee a non-wide string and use _stricmp. Absent this change
windows breaks. (Changes from @kurasu and @baconpaul both)