### PR TITLE
Implement a User Reporting class - ready for second review

### DIFF
--- a/src/common/SurgeError.cpp
+++ b/src/common/SurgeError.cpp
@@ -1,12 +1,23 @@
 #include "SurgeError.h"
 
-SurgeError::SurgeError(const std::string &message)
-   : message(message)
-{
-}
 
-
-const std::string &SurgeError::getMessage()
+namespace Surge
 {
-   return message;
-}
+    const std::string Error::DEFAULT_TITLE = "An error has occured";
+
+    Error::Error(const std::string &message, const std::string &title)
+        : message(message), title(title)
+    {
+    }
+    
+    
+    const std::string &Error::getMessage() const
+    {
+        return message;
+    }
+    
+    const std::string &Error::getTitle() const
+    {
+        return title;
+    }
+};

--- a/src/common/SurgeError.h
+++ b/src/common/SurgeError.h
@@ -2,13 +2,21 @@
 
 #include <string>
 
-class SurgeError {
-public:
-   SurgeError(const std::string &message);
-   SurgeError() = delete;
+namespace Surge
+{
 
-   const std::string &getMessage();
+class Error {
+public:
+   static const std::string DEFAULT_TITLE;
+   Error(const std::string &message, const std::string &title = DEFAULT_TITLE );
+   Error() = delete;
+
+   const std::string &getMessage() const;
+   const std::string &getTitle() const;
 
 private:
    std::string message;
+   std::string title;
+};
+
 };

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -4,6 +4,7 @@
 #include "DspUtilities.h"
 #include "SurgeError.h"
 #include "SurgeStorage.h"
+#include "UserInteractions.h"
 #include <set>
 #include <numeric>
 #include <vt_dsp/vt_dsp_endian.h>
@@ -198,27 +199,12 @@ SurgeStorage::SurgeStorage()
 
    if (!snapshotloader.LoadFile(snapshotmenupath.c_str())) // load snapshots (& config-stuff)
    {
-#if MAC
-      SInt32 nRes = 0;
-      CFUserNotificationRef pDlg = NULL;
-      const void* keys[] = {kCFUserNotificationAlertHeaderKey, kCFUserNotificationAlertMessageKey};
-      const void* vals[] = {
-          CFSTR("Surge is not properly installed"),
-          CFSTR("Unable to open configuration.xml from ~/Library/Application Support/Surge")
-
-      };
-
-      CFDictionaryRef dict =
-          CFDictionaryCreate(0, keys, vals, sizeof(keys) / sizeof(*keys),
-                             &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-
-      pDlg = CFUserNotificationCreate(kCFAllocatorDefault, 0, kCFUserNotificationStopAlertLevel,
-                                      &nRes, dict);
-#elif __linux__
-      throw SurgeError("configuration.xml was not found from " + snapshotmenupath);
+      Surge::Error exc("Cannot find 'configuration.xml' in path '" + datapath + "'. Please reinstall surge.",
+                       "Surge is not properly installed.");
+#if __linux__
+      throw exc;
 #else
-      MessageBox(::GetActiveWindow(), "Surge is not properly installed. Please reinstall.",
-                 "Configuration not found", MB_OK | MB_ICONERROR);
+      Surge::UserInteractions::promptError(exc);
 #endif
    }
 

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -14,6 +14,7 @@
 #endif
 #include <fstream>
 #include <iterator>
+#include "UserInteractions.h"
 
 namespace fs = std::experimental::filesystem;
 
@@ -187,26 +188,6 @@ string SurgeSynthesizer::getLegacyUserPatchDirectory()
 #endif
 }
 
-bool askIfShouldOverwrite()
-{
-#if MAC
-   CFOptionFlags responseFlags;
-   CFUserNotificationDisplayAlert(0, kCFUserNotificationPlainAlertLevel, 0, 0, 0,
-                                  CFSTR("Overwrite?"),
-                                  CFSTR("The file already exists, do you wish to overwrite it?"),
-                                  CFSTR("Yes"), CFSTR("No"), 0, &responseFlags);
-   if ((responseFlags & 0x3) != kCFUserNotificationDefaultResponse)
-      return false;
-#elif __linux__
-   printf("Implement me\n");
-#else
-   if (MessageBox(::GetActiveWindow(), "The file already exists, do you wish to overwrite it?",
-                  "Overwrite?", MB_YESNO | MB_ICONQUESTION) != IDYES)
-      return false;
-#endif
-
-   return true;
-}
 
 void SurgeSynthesizer::savePatch()
 {
@@ -246,8 +227,11 @@ void SurgeSynthesizer::savePatch()
 
    if (fs::exists(filename))
    {
-      if (!askIfShouldOverwrite())
-         return;
+       if( Surge::UserInteractions::promptOKCancel(std::string( "The patch '" + storage.getPatch().name + "' already exists in '" + storage.getPatch().category
+                                                                + "'. Are you sure you want to overwrite it?" ),
+                                                   std::string( "Overwrite patch" )) ==
+           Surge::UserInteractions::CANCEL )
+           return;
    }
 
    std::ofstream f(filename, std::ios::out | std::ios::binary);

--- a/src/common/UserInteractions.h
+++ b/src/common/UserInteractions.h
@@ -1,0 +1,42 @@
+/* 
+**  SurgeMessage provides basic functions for the synth to report messages back to the user
+**  with a platform-neutral API. A platform-specific version of each implementation is
+**  registered at startup.
+**
+**  You can call this with
+**
+**    Surge::UserInteractions::reportProblem()
+**
+**  or what not. 
+*/
+
+#pragma once
+
+#include <string>
+#include <atomic>
+#include "SurgeError.h"
+
+namespace Surge
+{
+    namespace UserInteractions
+    {
+        // Show the user an error dialog with an OK button; and wait for them to press it
+        void promptError(const std::string &message, const std::string &title);
+
+        // And a convenience version which does the same from a Surge::Error
+        void promptError(const Surge::Error &e);
+
+        // Prompt the user with an OK/Cance
+        typedef enum MessageResult
+        {
+            OK,
+            CANCEL
+        } MessageResult;
+        MessageResult promptOKCancel(const std::string &message, const std::string &title);
+
+        // Open a URL in a user-appropriate fashion
+        void openURL(const std::string &url);
+    };
+};
+
+

--- a/src/linux/LinuxUserInteractions.cpp
+++ b/src/linux/LinuxUserInteractions.cpp
@@ -1,0 +1,37 @@
+#include "UserInteractions.h"
+#include <iostream>
+#include <iomanip>
+
+namespace Surge
+{
+    namespace UserInteractions
+    {
+        void promptError(const Surge::Error &e)
+        {
+            promptError(e.getMessage(), e.getTitle());
+        }
+
+        void promptError(const std::string &message,
+                         const std::string &title)
+        {
+            std::cerr << "Surge Error\n"
+                      << title << "\n"
+                      << message << "\n" << std::flush;
+        }
+
+        UserInteractions::MessageResult promptOKCancel(const std::string &message,
+                                                       const std::string &title)
+        {
+            std::cerr << "Surge OkCancel\n"
+                      << title << "\n"
+                      << message << "\n" 
+                      << "Returning CANCEL" << std::flush;
+            return UserInteractions::CANCEL;
+        }
+
+        void openURL(const std::string &url)
+        {
+        }
+    };
+};
+

--- a/src/mac/MacUserInteractions.cpp
+++ b/src/mac/MacUserInteractions.cpp
@@ -1,0 +1,61 @@
+#include "UserInteractions.h"
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreServices/CoreServices.h>
+
+namespace Surge
+{
+    namespace UserInteractions
+    {
+        void promptError(const Surge::Error &e)
+        {
+            promptError(e.getMessage(), e.getTitle());
+        }
+
+        void promptError(const std::string &message,
+                         const std::string &title)
+        {
+            CFStringRef cfT = CFStringCreateWithCString(kCFAllocatorDefault, title.c_str(), kCFStringEncodingUTF8);
+            CFStringRef cfM = CFStringCreateWithCString(kCFAllocatorDefault, message.c_str(), kCFStringEncodingUTF8);
+            
+            SInt32 nRes = 0;
+            CFUserNotificationRef pDlg = NULL;
+            const void* keys[] = {kCFUserNotificationAlertHeaderKey, kCFUserNotificationAlertMessageKey};
+            const void* vals[] = {cfT, cfM};
+            
+            CFDictionaryRef dict =
+                CFDictionaryCreate(0, keys, vals, sizeof(keys) / sizeof(*keys),
+                                   &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+            
+            pDlg = CFUserNotificationCreate(kCFAllocatorDefault, 0, kCFUserNotificationStopAlertLevel,
+                                            &nRes, dict);
+            
+            CFRelease(cfT);
+            CFRelease(cfM);
+        }
+
+        UserInteractions::MessageResult promptOKCancel(const std::string &message,
+                                                       const std::string &title)
+        {
+            CFStringRef cfT = CFStringCreateWithCString(kCFAllocatorDefault, title.c_str(), kCFStringEncodingUTF8);
+            CFStringRef cfM = CFStringCreateWithCString(kCFAllocatorDefault, message.c_str(), kCFStringEncodingUTF8);
+            
+            CFOptionFlags responseFlags;
+            CFUserNotificationDisplayAlert(0, kCFUserNotificationPlainAlertLevel, 0, 0, 0,
+                                           cfT,
+                                           cfM,
+                                           CFSTR("OK"), CFSTR("Cancel"), 0, &responseFlags);
+            
+            CFRelease( cfT );
+            CFRelease( cfM );
+            
+            if ((responseFlags & 0x3) != kCFUserNotificationDefaultResponse)
+                return UserInteractions::CANCEL;
+            return UserInteractions::OK;
+        }
+
+        void openURL(const std::string &url)
+        {
+        }
+    };
+};
+

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -26,12 +26,14 @@ namespace VSTGUI { void* soHandle = nullptr; }
 #endif
 
 #include "AbstractSynthesizer.h"
+#include "UserInteractions.h"
 
 //-------------------------------------------------------------------------------------------------------
 
 AudioEffect* createEffectInstance(audioMasterCallback audioMaster)
 {
    initDllGlobals(); // this is a slightly misnamed function since only windows has dlls; it does all setup stuff for globals
+
    return new Vst2PluginInstance(audioMaster);
 }
 
@@ -555,8 +557,8 @@ bool Vst2PluginInstance::tryInit()
 
    try {
       new (synth) SurgeSynthesizer(this);
-   } catch (SurgeError err) {
-      std::cerr << err.getMessage() << std::endl;
+   } catch (Surge::Error err) {
+      Surge::UserInteractions::promptError(err);
       _aligned_free(synth);
       state = DEAD;
       return false;

--- a/src/windows/WinUserInteractions.cpp
+++ b/src/windows/WinUserInteractions.cpp
@@ -1,0 +1,41 @@
+#include <Windows.h>
+#include <string>
+#include "UserInteractions.h"
+
+
+namespace Surge
+{
+    namespace UserInteractions
+    {
+        void promptError(const Surge::Error &e)
+        {
+            promptError(e.getMessage(), e.getTitle());
+        }
+
+        void promptError(const std::string &message,
+                         const std::string &title)
+        {
+            MessageBox(::GetActiveWindow(), 
+                       message.c_str(), 
+                       title.c_str(), 
+                       MB_OK | MB_ICONERROR );
+        }
+
+        UserInteractions::MessageResult promptOKCancel(const std::string &message,
+                                                       const std::string &title)
+        {
+            if (MessageBox(::GetActiveWindow(), 
+                           message.c_str(), 
+                           title.c_str(),
+                           MB_YESNO | MB_ICONQUESTION) != IDYES)
+                return UserInteractions::CANCEL;
+            
+            return UserInteractions::OK;
+        }
+
+        void openURL(const std::string &url)
+        {
+        }
+    };
+};
+


### PR DESCRIPTION
There are lots of times when we want to pop messages to users,
and as we find more cases where we want to tell users things, the
code was going to be littered with #if mac this #else windows that.

So make a class which has some basic functions for reporting an error
and doing an OK cancel; implement it on our platforms under the covers;
and use it in two places (configuration.xml missing and re-save a patch).

Get it working on Mac and Windows, compiles and uses stderr on linux. And voila

@jsakkine I am especially interested in your design review of this (as well as the overall code review). Lets leave aside the throw vs prompt in place in SurgeStorage for a little - that's a separate issue - and let me know if you think this API is the right one for this function and so on.

The issue discussing is #217 
