### PR TITLE
Capitalize global constants

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -387,7 +387,7 @@ ComponentResult aulayer::Render( AudioUnitRenderActionFlags & ioActionFlags, con
 		if(blockpos == 0)
 		{
 			// move clock						
-			plugin_instance->time_data.ppqPos += (double) block_size * plugin_instance->time_data.tempo/(60. * sampleRate);			
+			plugin_instance->time_data.ppqPos += (double) BLOCK_SIZE * plugin_instance->time_data.tempo/(60. * sampleRate);			
 			
 			// process events for the current block
 			while(events_processed < events_this_block)
@@ -422,7 +422,7 @@ ComponentResult aulayer::Render( AudioUnitRenderActionFlags & ioActionFlags, con
 		}
 		
 		blockpos++;
-		if(blockpos>=block_size) blockpos = 0;
+		if(blockpos>=BLOCK_SIZE) blockpos = 0;
     }
 	
 	// process remaining events (there shouldn't be any)

--- a/src/common/AbstractSynthesizer.h
+++ b/src/common/AbstractSynthesizer.h
@@ -59,15 +59,15 @@ public:
    }
    virtual int getBlockSize()
    {
-      return block_size;
+      return BLOCK_SIZE;
    }
    virtual void process() = 0;
    virtual void loadRaw(const void* data, int size, bool preset = false) = 0;
    virtual unsigned int saveRaw(void** data) = 0;
 
 public:
-   float output alignas(16)[n_outputs][block_size];
-   float input alignas(16)[n_inputs][block_size];
+   float output alignas(16)[n_outputs][BLOCK_SIZE];
+   float input alignas(16)[n_inputs][BLOCK_SIZE];
    timedata time_data;
    bool audio_processing_active;
 };

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -89,7 +89,7 @@ void create_fullname(char* dn, char* fn, ControlGroup ctrlgroup, int ctrlgroup_e
 
 void Parameter::set_name(const char* n)
 {
-   strncpy(dispname, n, namechars);
+   strncpy(dispname, n, NAMECHARS);
    create_fullname(dispname, fullname, ctrlgroup, ctrlgroup_entry);
 }
 
@@ -116,7 +116,7 @@ Parameter* Parameter::assign(int id,
    this->scene = scene;
    this->ctrlstyle = ctrlstyle;
 
-   strncpy(this->name, name, namechars);
+   strncpy(this->name, name, NAMECHARS);
    set_name(dispname);
    char prefix[16];
    get_prefix(prefix, ctrlgroup, ctrlgroup_entry, scene);

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -149,7 +149,7 @@ public:
    void bound_value(bool force_integer = false);
    pdata val, val_default, val_min, val_max;
    int id;
-   char name[namechars], dispname[namechars], name_storage[namechars], fullname[namechars];
+   char name[NAMECHARS], dispname[NAMECHARS], name_storage[NAMECHARS], fullname[NAMECHARS];
    bool modulateable;
    int valtype = 0;
    int scene; // 0 = patch, 1 = scene A, 2 = scene B

--- a/src/common/SampleLoadRiffWave.cpp
+++ b/src/common/SampleLoadRiffWave.cpp
@@ -216,7 +216,7 @@ bool Sample::load_riff_wave_mk2(const char* fname)
    //	this->sample_start = 0;
    this->channels = (unsigned char)waveFormat.Format.nChannels;
 
-   unsigned int samplesizewithmargin = WaveDataSamples + 2 * FIRipol_N + block_size + FIRoffset;
+   unsigned int samplesizewithmargin = WaveDataSamples + 2 * FIRipol_N + BLOCK_SIZE + FIRoffset;
    sample_data = new float[samplesizewithmargin];
    unsigned int i;
    for (i = 0; i < samplesizewithmargin; i++)

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -127,7 +127,7 @@ SurgeStorage::SurgeStorage()
       for (int cc = 0; cc < 128; cc++)
          poly_aftertouch[s][cc] = 0.f;
 
-   memset(&audio_in[0][0], 0, 2 * block_size_os * sizeof(float));
+   memset(&audio_in[0][0], 0, 2 * BLOCK_SIZE_OS * sizeof(float));
 
 #if MAC
    char path[1024];
@@ -853,7 +853,7 @@ void SurgeStorage::init_tables()
           (float)sin(2 * M_PI * min(0.5, 440 * table_pitch[i] * dsamplerate_os_inv));
       table_note_omega[1][i] =
           (float)cos(2 * M_PI * min(0.5, 440 * table_pitch[i] * dsamplerate_os_inv));
-      double k = dsamplerate_os * pow(2.0, (((double)i - 256.0) / 16.0)) / (double)block_size_os;
+      double k = dsamplerate_os * pow(2.0, (((double)i - 256.0) / 16.0)) / (double)BLOCK_SIZE_OS;
       table_envrate_lpf[i] = (float)(1.f - exp(log(db60) / k));
       table_envrate_linear[i] = (float)1.f / k;
    }

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -410,7 +410,7 @@ public:
    // data
    SurgeSceneStorage scene[2], morphscene;
    FxStorage fx[8];
-   // char name[namechars];
+   // char name[NAMECHARS];
    int scene_start[2], scene_size;
    Parameter scene_active, scenemode, scenemorph, splitkey;
    Parameter volume;
@@ -465,8 +465,8 @@ enum sub3_copysource
 class SurgeStorage
 {
 public:
-   float audio_in alignas(16)[2][block_size_os];
-   float audio_in_nonOS alignas(16)[2][block_size];
+   float audio_in alignas(16)[2][BLOCK_SIZE_OS];
+   float audio_in_nonOS alignas(16)[2][BLOCK_SIZE];
    //	float sincoffset alignas(16)[(FIRipol_M)*FIRipol_N];	// deprecated
 
    SurgeStorage();

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -98,13 +98,13 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
           storage.getPatch().scene[0].modsources[ms_ctrl1 + i];
    }
 
-   amp.set_blocksize(block_size);
-   FX1.set_blocksize(block_size);
-   FX2.set_blocksize(block_size);
-   send[0][0].set_blocksize(block_size);
-   send[0][1].set_blocksize(block_size);
-   send[1][0].set_blocksize(block_size);
-   send[1][1].set_blocksize(block_size);
+   amp.set_blocksize(BLOCK_SIZE);
+   FX1.set_blocksize(BLOCK_SIZE);
+   FX2.set_blocksize(BLOCK_SIZE);
+   send[0][0].set_blocksize(BLOCK_SIZE);
+   send[0][1].set_blocksize(BLOCK_SIZE);
+   send[1][0].set_blocksize(BLOCK_SIZE);
+   send[1][1].set_blocksize(BLOCK_SIZE);
 
    polydisplay = 0;
    refresh_editor = false;
@@ -115,7 +115,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
    storage.getPatch().author = "";
    midiprogramshavechanged = false;
 
-   for (int i = 0; i < block_size; i++)
+   for (int i = 0; i < BLOCK_SIZE; i++)
    {
       input[0][i] = 0.f;
       input[1][i] = 0.f;
@@ -1023,7 +1023,7 @@ void SurgeSynthesizer::setSamplerate(float sr)
    dsamplerate = sr;
    samplerate_inv = 1.0 / sr;
    dsamplerate_inv = 1.0 / sr;
-   dsamplerate_os = dsamplerate * osc_oversampling;
+   dsamplerate_os = dsamplerate * OSC_OVERSAMPLING;
    dsamplerate_os_inv = 1.0 / dsamplerate_os;
    storage.init_tables();
    sinus.set_rate(1000.0 * dsamplerate_inv);
@@ -2163,13 +2163,13 @@ void SurgeSynthesizer::process()
 
    if (halt_engine)
    {
-      /*for(int k=0; k<block_size; k++)
+      /*for(int k=0; k<BLOCK_SIZE; k++)
       {
               output[0][k] = 0;
               output[1][k] = 0;
       }*/
-      clear_block(output[0], block_size_quad);
-      clear_block(output[1], block_size_quad);
+      clear_block(output[0], BLOCK_SIZE_QUAD);
+      clear_block(output[1], BLOCK_SIZE_QUAD);
       return;
    }
    else if (patchid_queue >= 0)
@@ -2212,8 +2212,8 @@ void SurgeSynthesizer::process()
          SetThreadPriority(hThread, THREAD_PRIORITY_NORMAL);
 #endif
 
-         clear_block(output[0], block_size_quad);
-         clear_block(output[1], block_size_quad);
+         clear_block(output[0], BLOCK_SIZE_QUAD);
+         clear_block(output[1], BLOCK_SIZE_QUAD);
          return;
       }
    }
@@ -2221,34 +2221,34 @@ void SurgeSynthesizer::process()
    // process inputs (upsample & halfrate)
    if (process_input)
    {
-      hardclip_block8(input[0], block_size_quad);
-      hardclip_block8(input[1], block_size_quad);
-      copy_block(input[0], storage.audio_in_nonOS[0], block_size_quad);
-      copy_block(input[1], storage.audio_in_nonOS[1], block_size_quad);
+      hardclip_block8(input[0], BLOCK_SIZE_QUAD);
+      hardclip_block8(input[1], BLOCK_SIZE_QUAD);
+      copy_block(input[0], storage.audio_in_nonOS[0], BLOCK_SIZE_QUAD);
+      copy_block(input[1], storage.audio_in_nonOS[1], BLOCK_SIZE_QUAD);
       halfbandIN->process_block_U2(input[0], input[1], storage.audio_in[0], storage.audio_in[1]);
    }
    else
    {
-      clear_block_antidenormalnoise(storage.audio_in[0], block_size_os_quad);
-      clear_block_antidenormalnoise(storage.audio_in[1], block_size_os_quad);
-      clear_block_antidenormalnoise(storage.audio_in_nonOS[1], block_size_quad);
-      clear_block_antidenormalnoise(storage.audio_in_nonOS[1], block_size_quad);
+      clear_block_antidenormalnoise(storage.audio_in[0], BLOCK_SIZE_OS_QUAD);
+      clear_block_antidenormalnoise(storage.audio_in[1], BLOCK_SIZE_OS_QUAD);
+      clear_block_antidenormalnoise(storage.audio_in_nonOS[1], BLOCK_SIZE_QUAD);
+      clear_block_antidenormalnoise(storage.audio_in_nonOS[1], BLOCK_SIZE_QUAD);
    }
 
-   float sceneout alignas(16)[2][2][block_size_os];
-   float fxsendout alignas(16)[2][2][block_size];
+   float sceneout alignas(16)[2][2][BLOCK_SIZE_OS];
+   float fxsendout alignas(16)[2][2][BLOCK_SIZE];
    bool play_scene[2];
 
    {
-      clear_block_antidenormalnoise(sceneout[0][0], block_size_os_quad);
-      clear_block_antidenormalnoise(sceneout[0][1], block_size_os_quad);
-      clear_block_antidenormalnoise(sceneout[1][0], block_size_os_quad);
-      clear_block_antidenormalnoise(sceneout[1][1], block_size_os_quad);
+      clear_block_antidenormalnoise(sceneout[0][0], BLOCK_SIZE_OS_QUAD);
+      clear_block_antidenormalnoise(sceneout[0][1], BLOCK_SIZE_OS_QUAD);
+      clear_block_antidenormalnoise(sceneout[1][0], BLOCK_SIZE_OS_QUAD);
+      clear_block_antidenormalnoise(sceneout[1][1], BLOCK_SIZE_OS_QUAD);
 
-      clear_block_antidenormalnoise(fxsendout[0][0], block_size_quad);
-      clear_block_antidenormalnoise(fxsendout[0][1], block_size_quad);
-      clear_block_antidenormalnoise(fxsendout[1][0], block_size_quad);
-      clear_block_antidenormalnoise(fxsendout[1][1], block_size_quad);
+      clear_block_antidenormalnoise(fxsendout[0][0], BLOCK_SIZE_QUAD);
+      clear_block_antidenormalnoise(fxsendout[0][1], BLOCK_SIZE_QUAD);
+      clear_block_antidenormalnoise(fxsendout[1][0], BLOCK_SIZE_QUAD);
+      clear_block_antidenormalnoise(fxsendout[1][1], BLOCK_SIZE_QUAD);
    }
 
    // CS ENTER
@@ -2363,15 +2363,15 @@ void SurgeSynthesizer::process()
 
    if (play_scene[0])
    {
-      hardclip_block8(sceneout[0][0], block_size_os_quad);
-      hardclip_block8(sceneout[0][1], block_size_os_quad);
+      hardclip_block8(sceneout[0][0], BLOCK_SIZE_OS_QUAD);
+      hardclip_block8(sceneout[0][1], BLOCK_SIZE_OS_QUAD);
       halfbandA->process_block_D2(sceneout[0][0], sceneout[0][1]);
    }
 
    if (play_scene[1])
    {
-      hardclip_block8(sceneout[1][0], block_size_os_quad);
-      hardclip_block8(sceneout[1][1], block_size_os_quad);
+      hardclip_block8(sceneout[1][0], BLOCK_SIZE_OS_QUAD);
+      hardclip_block8(sceneout[1][1], BLOCK_SIZE_OS_QUAD);
       halfbandB->process_block_D2(sceneout[1][0], sceneout[1][1]);
    }
 
@@ -2405,10 +2405,10 @@ void SurgeSynthesizer::process()
    }
 
    // sum scenes
-   copy_block(sceneout[0][0], output[0], block_size_quad);
-   copy_block(sceneout[0][1], output[1], block_size_quad);
-   accumulate_block(sceneout[1][0], output[0], block_size_quad);
-   accumulate_block(sceneout[1][1], output[1], block_size_quad);
+   copy_block(sceneout[0][0], output[0], BLOCK_SIZE_QUAD);
+   copy_block(sceneout[0][1], output[1], BLOCK_SIZE_QUAD);
+   accumulate_block(sceneout[1][0], output[0], BLOCK_SIZE_QUAD);
+   accumulate_block(sceneout[1][1], output[1], BLOCK_SIZE_QUAD);
 
    bool send1 = false, send2 = false;
    // add send effects
@@ -2417,22 +2417,22 @@ void SurgeSynthesizer::process()
       if (fx[4] && !(storage.getPatch().fx_disable.val.i & (1 << 4)))
       {
          send[0][0].MAC_2_blocks_to(sceneout[0][0], sceneout[0][1], fxsendout[0][0],
-                                    fxsendout[0][1], block_size_quad);
+                                    fxsendout[0][1], BLOCK_SIZE_QUAD);
          send[0][1].MAC_2_blocks_to(sceneout[1][0], sceneout[1][1], fxsendout[0][0],
-                                    fxsendout[0][1], block_size_quad);
+                                    fxsendout[0][1], BLOCK_SIZE_QUAD);
          send1 = fx[4]->process_ringout(fxsendout[0][0], fxsendout[0][1], sc_a || sc_b);
          FX1.MAC_2_blocks_to(fxsendout[0][0], fxsendout[0][1], output[0], output[1],
-                             block_size_quad);
+                             BLOCK_SIZE_QUAD);
       }
       if (fx[5] && !(storage.getPatch().fx_disable.val.i & (1 << 5)))
       {
          send[1][0].MAC_2_blocks_to(sceneout[0][0], sceneout[0][1], fxsendout[1][0],
-                                    fxsendout[1][1], block_size_quad);
+                                    fxsendout[1][1], BLOCK_SIZE_QUAD);
          send[1][1].MAC_2_blocks_to(sceneout[1][0], sceneout[1][1], fxsendout[1][0],
-                                    fxsendout[1][1], block_size_quad);
+                                    fxsendout[1][1], BLOCK_SIZE_QUAD);
          send2 = fx[5]->process_ringout(fxsendout[1][0], fxsendout[1][1], sc_a || sc_b);
          FX2.MAC_2_blocks_to(fxsendout[1][0], fxsendout[1][1], output[0], output[1],
-                             block_size_quad);
+                             BLOCK_SIZE_QUAD);
       }
    }
 
@@ -2446,24 +2446,24 @@ void SurgeSynthesizer::process()
          glob = fx[7]->process_ringout(output[0], output[1], glob);
    }
 
-   amp.multiply_2_blocks(output[0], output[1], block_size_quad);
-   amp_mute.multiply_2_blocks(output[0], output[1], block_size_quad);
+   amp.multiply_2_blocks(output[0], output[1], BLOCK_SIZE_QUAD);
+   amp_mute.multiply_2_blocks(output[0], output[1], BLOCK_SIZE_QUAD);
 
    // VU
    // falloff
    float a = storage.vu_falloff;
    vu_peak[0] = min(2.f, a * vu_peak[0]);
    vu_peak[1] = min(2.f, a * vu_peak[1]);
-   /*for(int i=0; i<block_size; i++)
+   /*for(int i=0; i<BLOCK_SIZE; i++)
    {
            vu_peak[0] = max(vu_peak[0], output[0][i]);
            vu_peak[1] = max(vu_peak[1], output[1][i]);
    }*/
-   vu_peak[0] = max(vu_peak[0], get_absmax(output[0], block_size_quad));
-   vu_peak[1] = max(vu_peak[1], get_absmax(output[1], block_size_quad));
+   vu_peak[0] = max(vu_peak[0], get_absmax(output[0], BLOCK_SIZE_QUAD));
+   vu_peak[1] = max(vu_peak[1], get_absmax(output[1], BLOCK_SIZE_QUAD));
 
-   hardclip_block8(output[0], block_size_quad);
-   hardclip_block8(output[1], block_size_quad);
+   hardclip_block8(output[0], BLOCK_SIZE_QUAD);
+   hardclip_block8(output[1], BLOCK_SIZE_QUAD);
 }
 
 PluginLayer* SurgeSynthesizer::getParent()

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -64,7 +64,7 @@ public:
    }
    int getBlockSize() override
    {
-      return block_size;
+      return BLOCK_SIZE;
    }
    int getMpeMainChannel(int voiceChannel, int key);
    void process() override;

--- a/src/common/dsp/AdsrEnvelope.h
+++ b/src/common/dsp/AdsrEnvelope.h
@@ -162,7 +162,7 @@ public:
          // calculate coefficients for envelope
          const float shortest = 6.f;
          const float longest = -2.f;
-         const float coeff_offset = 2.f - log(samplerate / block_size) / log(2.f);
+         const float coeff_offset = 2.f - log(samplerate / BLOCK_SIZE) / log(2.f);
 
          float coef_A =
              powf(2.f, min(0.f, coeff_offset -

--- a/src/common/dsp/BiquadFilter.cpp
+++ b/src/common/dsp/BiquadFilter.cpp
@@ -285,7 +285,7 @@ void BiquadFilter::process_block(float* data)
    else*/
    {
       int k;
-      for (k = 0; k < block_size; k++)
+      for (k = 0; k < BLOCK_SIZE; k++)
       {
          a1.process();
          a2.process();
@@ -313,7 +313,7 @@ void BiquadFilter::process_block_to(float* __restrict data, float* __restrict da
    else*/
    {
       int k;
-      for (k = 0; k < block_size; k++)
+      for (k = 0; k < BLOCK_SIZE; k++)
       {
          a1.process();
          a2.process();
@@ -347,7 +347,7 @@ void BiquadFilter::process_block_slowlag(float* __restrict dataL, float* __restr
       b2.process();
 
       int k;
-      for (k = 0; k < block_size; k++)
+      for (k = 0; k < BLOCK_SIZE; k++)
       {
          double input = dataL[k];
          double op;
@@ -378,7 +378,7 @@ void BiquadFilter::process_block(float* dataL, float* dataR)
    else*/
    {
       int k;
-      for (k = 0; k < block_size; k++)
+      for (k = 0; k < BLOCK_SIZE; k++)
       {
          a1.process();
          a2.process();
@@ -415,7 +415,7 @@ void BiquadFilter::process_block_to(float* dataL, float* dataR, float* dstL, flo
    else*/
    {
       int k;
-      for (k = 0; k < block_size; k++)
+      for (k = 0; k < BLOCK_SIZE; k++)
       {
          a1.process();
          a2.process();
@@ -452,7 +452,7 @@ void BiquadFilter::process_block(double* data)
    else*/
    {
       int k;
-      for (k = 0; k < block_size; k++)
+      for (k = 0; k < BLOCK_SIZE; k++)
       {
          a1.process();
          a2.process();

--- a/src/common/dsp/BiquadFilterSSE2.cpp
+++ b/src/common/dsp/BiquadFilterSSE2.cpp
@@ -10,7 +10,7 @@
 
 void biquadunit::process_block_SSE2(double *data)
 {	
-	for(int k=0; k<block_size; k+=2)
+	for(int k=0; k<BLOCK_SIZE; k+=2)
 	{		
 		__m128d input = _mm_load_sd(data+k);
 		a1.process_SSE2();	a2.process_SSE2();	b0.process_SSE2();	b1.process_SSE2();	b2.process_SSE2();
@@ -30,7 +30,7 @@ void biquadunit::process_block_SSE2(double *data)
 
 void biquadunit::process_block_SSE2(float *data)
 {	
-	for(int k=0; k<block_size; k+=4)
+	for(int k=0; k<BLOCK_SIZE; k+=4)
 	{
 		// load
 		__m128 vl = _mm_load_ps(data + k);						
@@ -71,7 +71,7 @@ void biquadunit::process_block_SSE2(float *data)
 
 void biquadunit::process_block_SSE2(float *dataL,float *dataR)
 {	
-	for(int k=0; k<block_size; k+=4)
+	for(int k=0; k<BLOCK_SIZE; k+=4)
 	{
 		// load
 		__m128 vl = _mm_load_ps(dataL + k);
@@ -125,7 +125,7 @@ void biquadunit::process_block_slowlag_SSE2(float *dataL,float *dataR)
 {	
 	a1.process_SSE2();	a2.process_SSE2();	b0.process_SSE2();	b1.process_SSE2();	b2.process_SSE2();
 
-	for(int k=0; k<block_size; k+=4)
+	for(int k=0; k<BLOCK_SIZE; k+=4)
 	{
 		// load
 		__m128 vl = _mm_load_ps(dataL + k);
@@ -173,7 +173,7 @@ void biquadunit::process_block_slowlag_SSE2(float *dataL,float *dataR)
 
 void biquadunit::process_block_to_SSE2(float *dataL,float *dataR, float *dstL,float *dstR)
 {	
-	for(int k=0; k<block_size; k+=4)
+	for(int k=0; k<BLOCK_SIZE; k+=4)
 	{
 		// load
 		__m128 vl = _mm_load_ps(dataL + k);

--- a/src/common/dsp/DspUtilities.h
+++ b/src/common/dsp/DspUtilities.h
@@ -61,7 +61,7 @@ public:
       new_v = 0;
       v = 0;
       dv = 0;
-      setBlockSize(block_size);
+      setBlockSize(BLOCK_SIZE);
    }
    inline void newValue(T f)
    {

--- a/src/common/dsp/FMOscillator.cpp
+++ b/src/common/dsp/FMOscillator.cpp
@@ -44,7 +44,7 @@ void FMOscillator::process_block(float pitch, float drift, bool stereo, bool FM,
       FMdepth.newValue(32.0 * M_PI * fmdepth * fmdepth * fmdepth);
    FeedbackDepth.newValue(localcopy[oscdata->p[6].param_id_in_scene].f);
 
-   for (int k = 0; k < block_size_os; k++)
+   for (int k = 0; k < BLOCK_SIZE_OS; k++)
    {
       RM1.process();
       RM2.process();
@@ -65,7 +65,7 @@ void FMOscillator::process_block(float pitch, float drift, bool stereo, bool FM,
    }
    if (stereo)
    {
-      memcpy(outputR, output, sizeof(float) * block_size_os);
+      memcpy(outputR, output, sizeof(float) * BLOCK_SIZE_OS);
    }
 }
 
@@ -149,7 +149,7 @@ void FM2Oscillator::process_block(float pitch, float drift, bool stereo, bool FM
    FeedbackDepth.newValue(localcopy[oscdata->p[6].param_id_in_scene].f);
    PhaseOffset.newValue(2.0 * M_PI * localcopy[oscdata->p[5].param_id_in_scene].f);
 
-   for (int k = 0; k < block_size_os; k++)
+   for (int k = 0; k < BLOCK_SIZE_OS; k++)
    {
       RM1.process();
       RM2.process();
@@ -169,7 +169,7 @@ void FM2Oscillator::process_block(float pitch, float drift, bool stereo, bool FM
    }
    if (stereo)
    {
-      memcpy(outputR, output, sizeof(float) * block_size_os);
+      memcpy(outputR, output, sizeof(float) * BLOCK_SIZE_OS);
    }
 }
 void FM2Oscillator::init_ctrltypes()

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -357,7 +357,7 @@ void FilterCoefficientMaker::Coeff_COMB(float freq, float reso, int subtype)
    float dtime = (1.f / 440.f) * note_to_pitch(-freq);
    dtime = dtime * dsamplerate_os -
            FIRoffset; // 1 sample for feedback, 1 sample for the IIR-filter without resonance
-   dtime = limit_range(dtime, (float)FIRipol_N, (float)max_fb_comb - FIRipol_N);
+   dtime = limit_range(dtime, (float)FIRipol_N, (float)MAX_FB_COMB - FIRipol_N);
    reso = ((subtype & 2) ? -1.0f : 1.0f) * limit_range(reso, 0.f, 1.f);
 
    float c[n_cm_coeffs];
@@ -396,7 +396,7 @@ void FilterCoefficientMaker::FromDirect(float N[n_cm_coeffs])
       for (int i = 0; i < n_cm_coeffs; i++)
       {
          tC[i] = (1.f - smooth) * tC[i] + smooth * N[i];
-         dC[i] = (tC[i] - C[i]) * block_size_os_inv;
+         dC[i] = (tC[i] - C[i]) * BLOCK_SIZE_OS_INV;
       }
    }
 }

--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -73,7 +73,7 @@ void osc_sine::process_block(float pitch, float drift, bool stereo, bool FM, flo
       double omega = min(M_PI, (double)pitch_to_omega(pitch + drift * driftlfo));
       FMdepth.newValue(fmdepth);
 
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          output[k] = sin(phase);
          phase += omega + master_osc[k] * FMdepth.v;
@@ -85,7 +85,7 @@ void osc_sine::process_block(float pitch, float drift, bool stereo, bool FM, flo
       driftlfo = drift_noise(driftlfo2);
       sinus.set_rate(min(M_PI, (double)pitch_to_omega(pitch + drift * driftlfo)));
 
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          sinus.process();
          output[k] = sinus.r;
@@ -110,7 +110,7 @@ void osc_sine::process_block(float pitch, float drift, bool stereo, bool FM, flo
    }
    if (stereo)
    {
-      memcpy(outputR, output, sizeof(float) * block_size_os);
+      memcpy(outputR, output, sizeof(float) * BLOCK_SIZE_OS);
    }
 }
 
@@ -155,7 +155,7 @@ void osc_audioinput::process_block(float pitch, float drift, bool stereo, bool F
       float a = g * (1.f - inp);
       float b = g * (1.f + inp);
 
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          output[k] = a * storage->audio_in[0][k];
          outputR[k] = b * storage->audio_in[1][k];
@@ -169,7 +169,7 @@ void osc_audioinput::process_block(float pitch, float drift, bool stereo, bool F
       float a = g * (1.f - inp);
       float b = g * (1.f + inp);
 
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          output[k] = a * storage->audio_in[0][k] + b * storage->audio_in[1][k];
       }

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -9,8 +9,8 @@ public:
    // The data blocks processed by the SIMD instructions (e.g. SSE2), which must
    // always be before any other variables in the class, in order to be properly
    // aligned to 16 bytes.
-   float output alignas(16)[block_size_os];
-   float outputR alignas(16)[block_size_os];
+   float output alignas(16)[BLOCK_SIZE_OS];
+   float outputR alignas(16)[BLOCK_SIZE_OS];
 
    Oscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
    virtual ~Oscillator();
@@ -110,9 +110,9 @@ public:
    AbstractBlitOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
 
 protected:
-   float oscbuffer alignas(16)[ob_length + FIRipol_N];
-   float oscbufferR alignas(16)[ob_length + FIRipol_N];
-   float dcbuffer alignas(16)[ob_length + FIRipol_N];
+   float oscbuffer alignas(16)[OB_LENGTH + FIRipol_N];
+   float oscbufferR alignas(16)[OB_LENGTH + FIRipol_N];
+   float dcbuffer alignas(16)[OB_LENGTH + FIRipol_N];
    __m128 osc_out, osc_out2, osc_outR, osc_out2R;
    void prepare_unison(int voices);
    float integrator_hpf;
@@ -120,17 +120,17 @@ protected:
    int n_unison;
    int bufpos;
    float out_attenuation, out_attenuation_inv, detune_bias, detune_offset;
-   float oscstate[max_unison], syncstate[max_unison], rate[max_unison];
-   float driftlfo[max_unison], driftlfo2[max_unison];
-   float panL[max_unison], panR[max_unison];
-   int state[max_unison];
+   float oscstate[MAX_UNISON], syncstate[MAX_UNISON], rate[MAX_UNISON];
+   float driftlfo[MAX_UNISON], driftlfo2[MAX_UNISON];
+   float panL[MAX_UNISON], panR[MAX_UNISON];
+   int state[MAX_UNISON];
 };
 
 class SurgeSuperOscillator : public AbstractBlitOscillator
 {
 private:
    lipol_ps li_hpf, li_DC, li_integratormult;
-   float FMphase alignas(16)[block_size_os + 4];
+   float FMphase alignas(16)[BLOCK_SIZE_OS + 4];
 
 public:
    SurgeSuperOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
@@ -144,8 +144,8 @@ public:
 
 private:
    bool first_run;
-   float dc, dc_uni[max_unison], elapsed_time[max_unison], last_level[max_unison],
-       pwidth[max_unison], pwidth2[max_unison];
+   float dc, dc_uni[MAX_UNISON], elapsed_time[MAX_UNISON], last_level[MAX_UNISON],
+       pwidth[MAX_UNISON], pwidth2[MAX_UNISON];
    template <bool is_init> void update_lagvals();
    float pitch;
    lag<float> FMdepth, integrator_mult, l_pw, l_pw2, l_shape, l_sub, l_sync;
@@ -185,8 +185,8 @@ private:
    template <bool FM> void process_blockT(float pitch, float depth, float drift = 0);
    template <bool is_init> void update_lagvals();
    bool first_run;
-   float dc, dc_uni[max_unison], elapsed_time[max_unison], last_level[max_unison],
-       last_level2[max_unison], pwidth[max_unison];
+   float dc, dc_uni[MAX_UNISON], elapsed_time[MAX_UNISON], last_level[MAX_UNISON],
+       last_level2[MAX_UNISON], pwidth[MAX_UNISON];
    float pitch;
    lag<double> FMdepth, hpf_coeff, integrator_mult, l_pw, l_shape, l_smooth, l_sub, l_sync;
    int id_pw, id_shape, id_smooth, id_sub, id_sync, id_detune;
@@ -211,10 +211,10 @@ private:
    template <bool is_init> void update_lagvals();
    inline float distort_level(float);
    bool first_run;
-   float oscpitch[max_unison];
-   float dc, dc_uni[max_unison], last_level[max_unison];
+   float oscpitch[MAX_UNISON];
+   float dc, dc_uni[MAX_UNISON], last_level[MAX_UNISON];
    float pitch;
-   int mipmap[max_unison], mipmap_ofs[max_unison];
+   int mipmap[MAX_UNISON], mipmap_ofs[MAX_UNISON];
    lag<float> FMdepth, hpf_coeff, integrator_mult, l_hskew, l_vskew, l_clip, l_shape;
    float formant_t, formant_last, pitch_last, pitch_t;
    float tableipol, last_tableipol;
@@ -232,8 +232,8 @@ const int wt2_suboscs = 8;
 class WindowOscillator : public Oscillator
 {
 private:
-   int IOutputL alignas(16)[block_size_os];
-   int IOutputR alignas(16)[block_size_os];
+   int IOutputL alignas(16)[BLOCK_SIZE_OS];
+   int IOutputR alignas(16)[BLOCK_SIZE_OS];
    struct
    {
       unsigned int Pos[wt2_suboscs];

--- a/src/common/dsp/QuadFilterChain.cpp
+++ b/src/common/dsp/QuadFilterChain.cpp
@@ -37,7 +37,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
    switch (config)
    {
    case fb_serial: // no feedback at all  (saves CPU)
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          __m128 input = d.DL[k];
          __m128 x = input, y = d.DR[k];
@@ -73,7 +73,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
       }
       break;
    case fb_serial2:
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          d.FB = _mm_add_ps(d.FB, d.dFB);
          __m128 input = vMul(d.FB, d.FBlineL);
@@ -113,7 +113,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
       break;
    case fb_serial3: // filter 2 is only heard in the feedback path, good for physical modelling with
                     // comb as f2
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          d.FB = _mm_add_ps(d.FB, d.dFB);
          __m128 input = vMul(d.FB, d.FBlineL);
@@ -154,7 +154,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
       }
       break;
    case fb_dual:
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          d.FB = _mm_add_ps(d.FB, d.dFB);
          __m128 fb = _mm_mul_ps(d.FB, d.FBlineL);
@@ -187,7 +187,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
       }
       break;
    case fb_dual2:
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          d.FB = _mm_add_ps(d.FB, d.dFB);
          __m128 fb = _mm_mul_ps(d.FB, d.FBlineL);
@@ -220,7 +220,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
       }
       break;
    case fb_ring:
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          d.FB = _mm_add_ps(d.FB, d.dFB);
          __m128 fb = _mm_mul_ps(d.FB, d.FBlineL);
@@ -255,7 +255,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
       }
       break;
    case fb_stereo:
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          d.FB = _mm_add_ps(d.FB, d.dFB);
          __m128 fb = _mm_mul_ps(d.FB, d.FBlineL);
@@ -292,7 +292,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
       }
       break;
    case fb_wide:
-      for (int k = 0; k < block_size_os; k++)
+      for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          d.FB = _mm_add_ps(d.FB, d.dFB);
          __m128 fbL = _mm_mul_ps(d.FB, d.FBlineL);

--- a/src/common/dsp/QuadFilterChain.h
+++ b/src/common/dsp/QuadFilterChain.h
@@ -10,7 +10,7 @@ struct QuadFilterChainState
 
    __m128 wsLPF, FBlineL, FBlineR;
 
-   __m128 DL[block_size_os], DR[block_size_os]; // wavedata
+   __m128 DL[BLOCK_SIZE_OS], DR[BLOCK_SIZE_OS]; // wavedata
 
    __m128 OutL, OutR, dOutL, dOutR;
    __m128 Out2L, Out2R, dOut2L, dOut2R; // fb_stereo only

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -530,7 +530,7 @@ __m128 COMBquad_SSE1(QuadFilterUnitState* __restrict f, __m128 in)
          int DT = e >> 8;
          int SE = (0xff - (e & 0xff)) * (FIRipol_N << 1);
 
-         int RP = (f->WP[i] - DT - FIRoffset) & (max_fb_comb - 1);
+         int RP = (f->WP[i] - DT - FIRoffset) & (MAX_FB_COMB - 1);
 
          // SINC interpolation (12 samples)
          __m128 a = _mm_loadu_ps(&f->DB[i][RP]);
@@ -560,10 +560,10 @@ __m128 COMBquad_SSE1(QuadFilterUnitState* __restrict f, __m128 in)
          __m128 t = _mm_load_ss((float*)&d + i);
          _mm_store_ss(&f->DB[i][f->WP[i]], t);
          if (f->WP[i] < FIRipol_N)
-            _mm_store_ss(&f->DB[i][f->WP[i] + max_fb_comb], t);
+            _mm_store_ss(&f->DB[i][f->WP[i] + MAX_FB_COMB], t);
 
          // Increment write position
-         f->WP[i] = (f->WP[i] + 1) & (max_fb_comb - 1);
+         f->WP[i] = (f->WP[i] + 1) & (MAX_FB_COMB - 1);
       }
    }
    return _mm_add_ps(_mm_mul_ps(f->C[3], DBRead), _mm_mul_ps(f->C[2], in));
@@ -594,7 +594,7 @@ __m128 COMBquad_SSE2(QuadFilterUnitState* __restrict f, __m128 in)
    {
       if (f->active[i])
       {
-         int RP = (f->WP[i] - DTi[i] - FIRoffset) & (max_fb_comb - 1);
+         int RP = (f->WP[i] - DTi[i] - FIRoffset) & (MAX_FB_COMB - 1);
 
          // SINC interpolation (12 samples)
          __m128 a = _mm_loadu_ps(&f->DB[i][RP]);
@@ -625,10 +625,10 @@ __m128 COMBquad_SSE2(QuadFilterUnitState* __restrict f, __m128 in)
          __m128 t = _mm_load_ss((float*)&d + i);
          _mm_store_ss(&f->DB[i][f->WP[i]], t);
          if (f->WP[i] < FIRipol_N)
-            _mm_store_ss(&f->DB[i][f->WP[i] + max_fb_comb], t);
+            _mm_store_ss(&f->DB[i][f->WP[i] + MAX_FB_COMB], t);
 
          // Increment write position
-         f->WP[i] = (f->WP[i] + 1) & (max_fb_comb - 1);
+         f->WP[i] = (f->WP[i] + 1) & (MAX_FB_COMB - 1);
       }
    }
    return _mm_add_ps(_mm_mul_ps(f->C[3], DBRead), _mm_mul_ps(f->C[2], in));

--- a/src/common/dsp/SurgeSuperOscillator.cpp
+++ b/src/common/dsp/SurgeSuperOscillator.cpp
@@ -122,16 +122,16 @@ void SurgeSuperOscillator::init(float pitch, bool is_display)
    l_sub.setRate(rate);
    l_sync.setRate(rate);
 
-   n_unison = limit_range(oscdata->p[6].val.i, 1, max_unison);
+   n_unison = limit_range(oscdata->p[6].val.i, 1, MAX_UNISON);
    if (is_display)
       n_unison = 1;
    prepare_unison(n_unison);
 
-   memset(oscbuffer, 0, sizeof(float) * (ob_length + FIRipol_N));
-   memset(oscbufferR, 0, sizeof(float) * (ob_length + FIRipol_N));
-   memset(dcbuffer, 0, sizeof(float) * (ob_length + FIRipol_N));
-   memset(last_level, 0, max_unison * sizeof(float));
-   memset(elapsed_time, 0, max_unison * sizeof(float));
+   memset(oscbuffer, 0, sizeof(float) * (OB_LENGTH + FIRipol_N));
+   memset(oscbufferR, 0, sizeof(float) * (OB_LENGTH + FIRipol_N));
+   memset(dcbuffer, 0, sizeof(float) * (OB_LENGTH + FIRipol_N));
+   memset(last_level, 0, MAX_UNISON * sizeof(float));
+   memset(elapsed_time, 0, MAX_UNISON * sizeof(float));
 
    this->pitch = pitch;
    update_lagvals<true>();
@@ -418,7 +418,7 @@ void SurgeSuperOscillator::process_block(
    {
       for (l = 0; l < n_unison; l++)
          driftlfo[l] = drift_noise(driftlfo2[l]);
-      for (int s = 0; s < block_size_os; s++)
+      for (int s = 0; s < BLOCK_SIZE_OS; s++)
       {
          float fmmul = limit_range(1.f + depth * master_osc[s], 0.1f, 1.9f);
          float a = pitchmult * fmmul;
@@ -442,7 +442,7 @@ void SurgeSuperOscillator::process_block(
    }
    else
    {
-      float a = (float)block_size_os * pitchmult;
+      float a = (float)BLOCK_SIZE_OS * pitchmult;
       for (l = 0; l < n_unison; l++)
       {
          driftlfo[l] = drift_noise(driftlfo2[l]);
@@ -458,8 +458,8 @@ void SurgeSuperOscillator::process_block(
       }
    }
 
-   float hpfblock alignas(16)[block_size_os];
-   li_hpf.store_block(hpfblock, block_size_os_quad);
+   float hpfblock alignas(16)[BLOCK_SIZE_OS];
+   li_hpf.store_block(hpfblock, BLOCK_SIZE_OS_QUAD);
 
    __m128 mdc = _mm_load_ss(&dc);
    __m128 oa = _mm_load_ss(&out_attenuation);
@@ -470,7 +470,7 @@ void SurgeSuperOscillator::process_block(
    __m128 char_b1 = _mm_load_ss(&CoefB1);
    __m128 char_a1 = _mm_load_ss(&CoefA1);
 
-   for (k = 0; k < block_size_os; k++)
+   for (k = 0; k < BLOCK_SIZE_OS; k++)
    {
       __m128 dcb = _mm_load_ss(&dcbuffer[bufpos + k]);
       __m128 hpf = _mm_load_ss(&hpfblock[k]);
@@ -508,12 +508,12 @@ void SurgeSuperOscillator::process_block(
    }
    _mm_store_ss(&dc, mdc);
 
-   clear_block(&oscbuffer[bufpos], block_size_os_quad);
+   clear_block(&oscbuffer[bufpos], BLOCK_SIZE_OS_QUAD);
    if (stereo)
-      clear_block(&oscbufferR[bufpos], block_size_os_quad);
-   clear_block(&dcbuffer[bufpos], block_size_os_quad);
+      clear_block(&oscbufferR[bufpos], BLOCK_SIZE_OS_QUAD);
+   clear_block(&dcbuffer[bufpos], BLOCK_SIZE_OS_QUAD);
 
-   bufpos = (bufpos + block_size_os) & (ob_length - 1);
+   bufpos = (bufpos + BLOCK_SIZE_OS) & (OB_LENGTH - 1);
 
    // each block overlap FIRipol_N samples into the next (due to impulses not being wrapped around
    // the block edges copy the overlapping samples to the new block position
@@ -524,19 +524,19 @@ void SurgeSuperOscillator::process_block(
       const __m128 zero = _mm_setzero_ps();
       for (k = 0; k < (FIRipol_N); k += 4)
       {
-         overlap[k >> 2] = _mm_load_ps(&oscbuffer[ob_length + k]);
+         overlap[k >> 2] = _mm_load_ps(&oscbuffer[OB_LENGTH + k]);
          _mm_store_ps(&oscbuffer[k], overlap[k >> 2]);
-         _mm_store_ps(&oscbuffer[ob_length + k], zero);
+         _mm_store_ps(&oscbuffer[OB_LENGTH + k], zero);
 
-         dcoverlap[k >> 2] = _mm_load_ps(&dcbuffer[ob_length + k]);
+         dcoverlap[k >> 2] = _mm_load_ps(&dcbuffer[OB_LENGTH + k]);
          _mm_store_ps(&dcbuffer[k], dcoverlap[k >> 2]);
-         _mm_store_ps(&dcbuffer[ob_length + k], zero);
+         _mm_store_ps(&dcbuffer[OB_LENGTH + k], zero);
 
          if (stereo)
          {
-            overlapR[k >> 2] = _mm_load_ps(&oscbufferR[ob_length + k]);
+            overlapR[k >> 2] = _mm_load_ps(&oscbufferR[OB_LENGTH + k]);
             _mm_store_ps(&oscbufferR[k], overlapR[k >> 2]);
-            _mm_store_ps(&oscbufferR[ob_length + k], zero);
+            _mm_store_ps(&oscbufferR[OB_LENGTH + k], zero);
          }
       }
    }

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -453,9 +453,9 @@ template <bool first> void SurgeVoice::calc_ctrldata(QuadFilterChainState* Q, in
       if (Q)
       {
          set1f(Q->Out2L, e, FBP.Out2L);
-         set1f(Q->dOut2L, e, (amp2L - FBP.Out2L) * block_size_os_inv);
+         set1f(Q->dOut2L, e, (amp2L - FBP.Out2L) * BLOCK_SIZE_OS_INV);
          set1f(Q->Out2R, e, FBP.Out2R);
-         set1f(Q->dOut2R, e, (amp2R - FBP.Out2R) * block_size_os_inv);
+         set1f(Q->dOut2R, e, (amp2R - FBP.Out2R) * BLOCK_SIZE_OS_INV);
       }
       FBP.Out2L = amp2L;
       FBP.Out2R = amp2R;
@@ -467,9 +467,9 @@ template <bool first> void SurgeVoice::calc_ctrldata(QuadFilterChainState* Q, in
    if (Q)
    {
       set1f(Q->OutL, e, FBP.OutL);
-      set1f(Q->dOutL, e, (ampL - FBP.OutL) * block_size_os_inv);
+      set1f(Q->dOutL, e, (ampL - FBP.OutL) * BLOCK_SIZE_OS_INV);
       set1f(Q->OutR, e, FBP.OutR);
-      set1f(Q->dOutR, e, (ampR - FBP.OutR) * block_size_os_inv);
+      set1f(Q->dOutR, e, (ampR - FBP.OutR) * BLOCK_SIZE_OS_INV);
    }
 
    FBP.OutL = ampL;
@@ -481,8 +481,8 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
    calc_ctrldata<0>(&Q, Qe);
 
    bool is_wide = scene->filterblock_configuration.val.i == fb_wide;
-   float tblock alignas(16)[block_size_os],
-         tblock2 alignas(16)[block_size_os];
+   float tblock alignas(16)[BLOCK_SIZE_OS],
+         tblock2 alignas(16)[BLOCK_SIZE_OS];
    float* tblockR = is_wide ? tblock2 : tblock;
 
    // float ktrkroot = (float)scene->keytrack_root.val.i;
@@ -490,8 +490,8 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
    float drift = localcopy[scene->drift.param_id_in_scene].f;
 
    // clear output
-   clear_block(output[0], block_size_os_quad);
-   clear_block(output[1], block_size_os_quad);
+   clear_block(output[0], BLOCK_SIZE_OS_QUAD);
+   clear_block(output[1], BLOCK_SIZE_OS_QUAD);
 
    if (osc3 || ring23 || ((osc1 || osc2) && (FMmode == fm_3to2to1)) ||
        (osc1 && (FMmode == fm_2and3to1)))
@@ -507,16 +507,16 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
          if (is_wide)
          {
             osclevels[le_osc3].multiply_2_blocks_to(osc[2]->output, osc[2]->outputR, tblock,
-                                                    tblockR, block_size_os_quad);
+                                                    tblockR, BLOCK_SIZE_OS_QUAD);
          }
          else
          {
-            osclevels[le_osc3].multiply_block_to(osc[2]->output, tblock, block_size_os_quad);
+            osclevels[le_osc3].multiply_block_to(osc[2]->output, tblock, BLOCK_SIZE_OS_QUAD);
          }
          if (route[2] < 2)
-            accumulate_block(tblock, output[0], block_size_os_quad);
+            accumulate_block(tblock, output[0], BLOCK_SIZE_OS_QUAD);
          if (route[2] > 0)
-            accumulate_block(tblockR, output[1], block_size_os_quad);
+            accumulate_block(tblockR, output[1], BLOCK_SIZE_OS_QUAD);
       }
    }
 
@@ -544,17 +544,17 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
          if (is_wide)
          {
             osclevels[le_osc2].multiply_2_blocks_to(osc[1]->output, osc[1]->outputR, tblock,
-                                                    tblockR, block_size_os_quad);
+                                                    tblockR, BLOCK_SIZE_OS_QUAD);
          }
          else
          {
-            osclevels[le_osc2].multiply_block_to(osc[1]->output, tblock, block_size_os_quad);
+            osclevels[le_osc2].multiply_block_to(osc[1]->output, tblock, BLOCK_SIZE_OS_QUAD);
          }
 
          if (route[1] < 2)
-            accumulate_block(tblock, output[0], block_size_os_quad);
+            accumulate_block(tblock, output[0], BLOCK_SIZE_OS_QUAD);
          if (route[1] > 0)
-            accumulate_block(tblockR, output[1], block_size_os_quad);
+            accumulate_block(tblockR, output[1], BLOCK_SIZE_OS_QUAD);
       }
    }
 
@@ -562,7 +562,7 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
    {
       if (FMmode == fm_2and3to1)
       {
-         add_block(osc[1]->output, osc[2]->output, fmbuffer, block_size_os_quad);
+         add_block(osc[1]->output, osc[2]->output, fmbuffer, BLOCK_SIZE_OS_QUAD);
          osc[0]->process_block((scene->osc[0].keytrack.val.b ? state.pitch : ktrkroot) +
                                    localcopy[scene->osc[0].pitch.param_id_in_scene].f *
                                        (scene->osc[0].pitch.extend_range ? 12.f : 1.f) +
@@ -592,16 +592,16 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
          if (is_wide)
          {
             osclevels[le_osc1].multiply_2_blocks_to(osc[0]->output, osc[0]->outputR, tblock,
-                                                    tblockR, block_size_os_quad);
+                                                    tblockR, BLOCK_SIZE_OS_QUAD);
          }
          else
          {
-            osclevels[le_osc1].multiply_block_to(osc[0]->output, tblock, block_size_os_quad);
+            osclevels[le_osc1].multiply_block_to(osc[0]->output, tblock, BLOCK_SIZE_OS_QUAD);
          }
          if (route[0] < 2)
-            accumulate_block(tblock, output[0], block_size_os_quad);
+            accumulate_block(tblock, output[0], BLOCK_SIZE_OS_QUAD);
          if (route[0] > 0)
-            accumulate_block(tblockR, output[1], block_size_os_quad);
+            accumulate_block(tblockR, output[1], BLOCK_SIZE_OS_QUAD);
       }
    }
 
@@ -609,45 +609,45 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
    {
       if (is_wide)
       {
-         mul_block(osc[0]->output, osc[1]->output, tblock, block_size_os_quad);
-         mul_block(osc[0]->outputR, osc[1]->outputR, tblockR, block_size_os_quad);
-         osclevels[le_ring12].multiply_2_blocks(tblock, tblockR, block_size_os_quad);
+         mul_block(osc[0]->output, osc[1]->output, tblock, BLOCK_SIZE_OS_QUAD);
+         mul_block(osc[0]->outputR, osc[1]->outputR, tblockR, BLOCK_SIZE_OS_QUAD);
+         osclevels[le_ring12].multiply_2_blocks(tblock, tblockR, BLOCK_SIZE_OS_QUAD);
       }
       else
       {
-         mul_block(osc[0]->output, osc[1]->output, tblock, block_size_os_quad);
-         osclevels[le_ring12].multiply_block(tblock, block_size_os_quad);
+         mul_block(osc[0]->output, osc[1]->output, tblock, BLOCK_SIZE_OS_QUAD);
+         osclevels[le_ring12].multiply_block(tblock, BLOCK_SIZE_OS_QUAD);
       }
       if (route[3] < 2)
-         accumulate_block(tblock, output[0], block_size_os_quad);
+         accumulate_block(tblock, output[0], BLOCK_SIZE_OS_QUAD);
       if (route[3] > 0)
-         accumulate_block(tblockR, output[1], block_size_os_quad);
+         accumulate_block(tblockR, output[1], BLOCK_SIZE_OS_QUAD);
    }
 
    if (ring23)
    {
       if (is_wide)
       {
-         mul_block(osc[1]->output, osc[2]->output, tblock, block_size_os_quad);
-         mul_block(osc[1]->outputR, osc[2]->outputR, tblockR, block_size_os_quad);
-         osclevels[le_ring23].multiply_2_blocks(tblock, tblockR, block_size_os_quad);
+         mul_block(osc[1]->output, osc[2]->output, tblock, BLOCK_SIZE_OS_QUAD);
+         mul_block(osc[1]->outputR, osc[2]->outputR, tblockR, BLOCK_SIZE_OS_QUAD);
+         osclevels[le_ring23].multiply_2_blocks(tblock, tblockR, BLOCK_SIZE_OS_QUAD);
       }
       else
       {
-         mul_block(osc[1]->output, osc[2]->output, tblock, block_size_os_quad);
-         osclevels[le_ring23].multiply_block(tblock, block_size_os_quad);
+         mul_block(osc[1]->output, osc[2]->output, tblock, BLOCK_SIZE_OS_QUAD);
+         osclevels[le_ring23].multiply_block(tblock, BLOCK_SIZE_OS_QUAD);
       }
 
       if (route[4] < 2)
-         accumulate_block(tblock, output[0], block_size_os_quad);
+         accumulate_block(tblock, output[0], BLOCK_SIZE_OS_QUAD);
       if (route[4] > 0)
-         accumulate_block(tblockR, output[1], block_size_os_quad);
+         accumulate_block(tblockR, output[1], BLOCK_SIZE_OS_QUAD);
    }
 
    if (noise)
    {
       float noisecol = limit_range(localcopy[scene->noise_colour.param_id_in_scene].f, -1.f, 1.f);
-      for (int i = 0; i < block_size_os; i += 2)
+      for (int i = 0; i < BLOCK_SIZE_OS; i += 2)
       {
          ((float*)tblock)[i] = correlated_noise_o2mk2(noisegenL[0], noisegenL[1], noisecol);
          ((float*)tblock)[i + 1] = ((float*)tblock)[i];
@@ -659,22 +659,22 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
       }
       if (is_wide)
       {
-         osclevels[le_noise].multiply_2_blocks(tblock, tblockR, block_size_os_quad);
+         osclevels[le_noise].multiply_2_blocks(tblock, tblockR, BLOCK_SIZE_OS_QUAD);
       }
       else
       {
-         osclevels[le_noise].multiply_block(tblock, block_size_os_quad);
+         osclevels[le_noise].multiply_block(tblock, BLOCK_SIZE_OS_QUAD);
       }
       if (route[5] < 2)
-         accumulate_block(tblock, output[0], block_size_os_quad);
+         accumulate_block(tblock, output[0], BLOCK_SIZE_OS_QUAD);
       if (route[5] > 0)
-         accumulate_block(tblockR, output[1], block_size_os_quad);
+         accumulate_block(tblockR, output[1], BLOCK_SIZE_OS_QUAD);
    }
 
    // PFG
-   osclevels[le_pfg].multiply_2_blocks(output[0], output[1], block_size_os_quad);
+   osclevels[le_pfg].multiply_2_blocks(output[0], output[1], BLOCK_SIZE_OS_QUAD);
 
-   for (int i = 0; i < block_size_os; i++)
+   for (int i = 0; i < BLOCK_SIZE_OS; i++)
    {
       _mm_store_ss(((float*)&Q.DL[i] + Qe), _mm_load_ss(&output[0][i]));
       _mm_store_ss(((float*)&Q.DR[i] + Qe), _mm_load_ss(&output[1][i]));
@@ -730,15 +730,15 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
    if (Q)
    {
       set1f(Q->Gain, e, FBP.Gain);
-      set1f(Q->dGain, e, (Gain - FBP.Gain) * block_size_os_inv);
+      set1f(Q->dGain, e, (Gain - FBP.Gain) * BLOCK_SIZE_OS_INV);
       set1f(Q->Drive, e, FBP.Drive);
-      set1f(Q->dDrive, e, (Drive - FBP.Drive) * block_size_os_inv);
+      set1f(Q->dDrive, e, (Drive - FBP.Drive) * BLOCK_SIZE_OS_INV);
       set1f(Q->FB, e, FBP.FB);
-      set1f(Q->dFB, e, (FB - FBP.FB) * block_size_os_inv);
+      set1f(Q->dFB, e, (FB - FBP.FB) * BLOCK_SIZE_OS_INV);
       set1f(Q->Mix1, e, FBP.Mix1);
-      set1f(Q->dMix1, e, (FMix1 - FBP.Mix1) * block_size_os_inv);
+      set1f(Q->dMix1, e, (FMix1 - FBP.Mix1) * BLOCK_SIZE_OS_INV);
       set1f(Q->Mix2, e, FBP.Mix2);
-      set1f(Q->dMix2, e, (FMix2 - FBP.Mix2) * block_size_os_inv);
+      set1f(Q->dMix2, e, (FMix2 - FBP.Mix2) * BLOCK_SIZE_OS_INV);
    }
 
    FBP.Gain = Gain;

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -16,10 +16,10 @@ struct QuadFilterChainState;
 class SurgeVoice
 {
 public:
-   float output alignas(16)[2][block_size_os];
+   float output alignas(16)[2][BLOCK_SIZE_OS];
    lipol_ps osclevels alignas(16)[7];
    pdata localcopy alignas(16)[n_scene_params];
-   float fmbuffer alignas(16)[block_size_os];
+   float fmbuffer alignas(16)[BLOCK_SIZE_OS];
    // used for the 2>1<3 FM-mode (Needs the pointer earlier)
 
    SurgeVoice(SurgeStorage* storage,
@@ -62,7 +62,7 @@ private:
    struct
    {
       float Gain, FB, Mix1, Mix2, OutL, OutR, Out2L, Out2R, Drive, wsLPF, FBlineL, FBlineR;
-      float Delay[4][max_fb_comb + FIRipol_N];
+      float Delay[4][MAX_FB_COMB + FIRipol_N];
       struct
       {
          float C[n_cm_coeffs], R[n_filter_registers];

--- a/src/common/dsp/WavetableOscillator.cpp
+++ b/src/common/dsp/WavetableOscillator.cpp
@@ -38,7 +38,7 @@ void WavetableOscillator::init(float pitch, bool is_display)
    l_vskew.setRate(rate);
    l_hskew.setRate(rate);
 
-   n_unison = limit_range(oscdata->p[6].val.i, 1, max_unison);
+   n_unison = limit_range(oscdata->p[6].val.i, 1, MAX_UNISON);
    if (oscdata->wt.flags & wtf_is_sample)
    {
       sampleloop = n_unison;
@@ -49,9 +49,9 @@ void WavetableOscillator::init(float pitch, bool is_display)
 
    prepare_unison(n_unison);
 
-   memset(oscbuffer, 0, sizeof(float) * (ob_length + FIRipol_N));
-   memset(oscbufferR, 0, sizeof(float) * (ob_length + FIRipol_N));
-   memset(last_level, 0, max_unison * sizeof(float));
+   memset(oscbuffer, 0, sizeof(float) * (OB_LENGTH + FIRipol_N));
+   memset(oscbufferR, 0, sizeof(float) * (OB_LENGTH + FIRipol_N));
+   memset(last_level, 0, MAX_UNISON * sizeof(float));
 
    pitch_last = pitch;
    pitch_t = pitch;
@@ -139,7 +139,7 @@ float WavetableOscillator::distort_level(float x)
 
 void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
 {
-   float block_pos = oscstate[voice] * block_size_os_inv * pitchmult_inv;
+   float block_pos = oscstate[voice] * BLOCK_SIZE_OS_INV * pitchmult_inv;
 
    double detune = drift * driftlfo[voice];
    if (n_unison > 1)
@@ -425,11 +425,11 @@ void WavetableOscillator::process_block(
    {
       /*FMfilter.coeff_HP(FMfilter.calc_omega(pitch_t - 24.f - 48.f *
       oscdata->p[id_detune].val.f),0.707); FMfilter.process_block(&master_osc[0]);
-      FMfilter.process_block(&master_osc[block_size]);*/
+      FMfilter.process_block(&master_osc[BLOCK_SIZE]);*/
 
       for (l = 0; l < n_unison; l++)
          driftlfo[l] = drift_noise(driftlfo2[l]);
-      for (int s = 0; s < block_size_os; s++)
+      for (int s = 0; s < BLOCK_SIZE_OS; s++)
       {
          float fmmul = limit_range(1.f + depth * master_osc[s], 0.1f, 1.9f);
          float a = pitchmult * fmmul;
@@ -449,7 +449,7 @@ void WavetableOscillator::process_block(
    }
    else
    {
-      float a = (float)block_size_os * pitchmult;
+      float a = (float)BLOCK_SIZE_OS * pitchmult;
       for (l = 0; l < n_unison; l++)
       {
          driftlfo[l] = drift_noise(driftlfo2[l]);
@@ -460,10 +460,10 @@ void WavetableOscillator::process_block(
       // li_DC.set_target(dc);
    }
 
-   float hpfblock alignas(16)[block_size_os];
-   li_hpf.store_block(hpfblock, block_size_os_quad);
+   float hpfblock alignas(16)[BLOCK_SIZE_OS];
+   li_hpf.store_block(hpfblock, BLOCK_SIZE_OS_QUAD);
 
-   for (k = 0; k < block_size_os; k++)
+   for (k = 0; k < BLOCK_SIZE_OS; k++)
    {
       __m128 hpf = _mm_load_ss(&hpfblock[k]);
       __m128 ob = _mm_load_ss(&oscbuffer[bufpos + k]);
@@ -479,11 +479,11 @@ void WavetableOscillator::process_block(
       }
    }
 
-   clear_block(&oscbuffer[bufpos], block_size_os_quad);
+   clear_block(&oscbuffer[bufpos], BLOCK_SIZE_OS_QUAD);
    if (stereo)
-      clear_block(&oscbufferR[bufpos], block_size_os_quad);
+      clear_block(&oscbufferR[bufpos], BLOCK_SIZE_OS_QUAD);
 
-   bufpos = (bufpos + block_size_os) & (ob_length - 1);
+   bufpos = (bufpos + BLOCK_SIZE_OS) & (OB_LENGTH - 1);
 
    // each block overlap FIRipol_N samples into the next (due to impulses not being wrapped around
    // the block edges copy the overlapping samples to the new block position
@@ -494,14 +494,14 @@ void WavetableOscillator::process_block(
       const __m128 zero = _mm_setzero_ps();
       for (k = 0; k < (FIRipol_N); k += 4)
       {
-         overlap[k >> 2] = _mm_load_ps(&oscbuffer[ob_length + k]);
+         overlap[k >> 2] = _mm_load_ps(&oscbuffer[OB_LENGTH + k]);
          _mm_store_ps(&oscbuffer[k], overlap[k >> 2]);
-         _mm_store_ps(&oscbuffer[ob_length + k], zero);
+         _mm_store_ps(&oscbuffer[OB_LENGTH + k], zero);
          if (stereo)
          {
-            overlapR[k >> 2] = _mm_load_ps(&oscbufferR[ob_length + k]);
+            overlapR[k >> 2] = _mm_load_ps(&oscbufferR[OB_LENGTH + k]);
             _mm_store_ps(&oscbufferR[k], overlapR[k >> 2]);
-            _mm_store_ps(&oscbufferR[ob_length + k], zero);
+            _mm_store_ps(&oscbufferR[OB_LENGTH + k], zero);
          }
       }
    }

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -166,7 +166,7 @@ void WindowOscillator::ProcessSubOscs(bool stereo)
          short* WaveAdr = oscdata->wt.TableI16WeakPointers[MipMapB][Sub.Table[so]];
          short* WinAdr = storage->WindowWT.TableI16WeakPointers[MipMapA][Window];
 
-         for (int i = 0; i < block_size_os; i++)
+         for (int i = 0; i < BLOCK_SIZE_OS; i++)
          {
             Pos += RatioA;
             if (Pos & ~SizeMaskWin)
@@ -249,7 +249,7 @@ void WindowOscillator::ProcessSubOscs(bool stereo)
          short* WaveAdr = oscdata->wt.TableI16WeakPointers[MipMapB][Sub.Table[so]];
          short* WinAdr = storage->WindowWT.TableI16WeakPointers[MipMapA][Window];
 
-         for (int i = 0; i < block_size_os; i++)
+         for (int i = 0; i < BLOCK_SIZE_OS; i++)
          {
             Pos += RatioA;
             if (Pos & ~SizeMaskWin)
@@ -302,9 +302,9 @@ void WindowOscillator::ProcessSubOscs(bool stereo)
 
 void WindowOscillator::process_block(float pitch, float drift, bool stereo, bool FM, float fmdepth)
 {
-   memset(IOutputL, 0, block_size_os * sizeof(int));
+   memset(IOutputL, 0, BLOCK_SIZE_OS * sizeof(int));
    if (stereo)
-      memset(IOutputR, 0, block_size_os * sizeof(int));
+      memset(IOutputR, 0, BLOCK_SIZE_OS * sizeof(int));
 
    float Detune = localcopy[oscdata->p[5].param_id_in_scene].f;
    for (int l = 0; l < ActiveSubOscs; l++)
@@ -328,7 +328,7 @@ void WindowOscillator::process_block(float pitch, float drift, bool stereo, bool
       // SSE2 path
       if (stereo)
       {
-         for (int i = 0; i < block_size_os; i += 4)
+         for (int i = 0; i < BLOCK_SIZE_OS; i += 4)
          {
             _mm_store_ps(&output[i], _mm_mul_ps(_mm_cvtepi32_ps(*(__m128i*)&IOutputL[i]), scale));
             _mm_store_ps(&outputR[i], _mm_mul_ps(_mm_cvtepi32_ps(*(__m128i*)&IOutputR[i]), scale));
@@ -336,7 +336,7 @@ void WindowOscillator::process_block(float pitch, float drift, bool stereo, bool
       }
       else
       {
-         for (int i = 0; i < block_size_os; i += 4)
+         for (int i = 0; i < BLOCK_SIZE_OS; i += 4)
          {
             _mm_store_ps(&output[i], _mm_mul_ps(_mm_cvtepi32_ps(*(__m128i*)&IOutputL[i]), scale));
          }
@@ -348,7 +348,7 @@ void WindowOscillator::process_block(float pitch, float drift, bool stereo, bool
       // MMX/SSE1 path
       if (stereo)
       {
-         for (int i = 0; i < block_size_os; i += 4)
+         for (int i = 0; i < BLOCK_SIZE_OS; i += 4)
          {
             _mm_store_ps(&output[i], _mm_mul_ps(_mm_cvtpi32x2_ps(*(__m64*)&IOutputL[i],
                                                                  *(__m64*)&IOutputL[i + 2]),
@@ -360,7 +360,7 @@ void WindowOscillator::process_block(float pitch, float drift, bool stereo, bool
       }
       else
       {
-         for (int i = 0; i < block_size_os; i += 4)
+         for (int i = 0; i < BLOCK_SIZE_OS; i += 4)
          {
             _mm_store_ps(&output[i], _mm_mul_ps(_mm_cvtpi32x2_ps(*(__m64*)&IOutputL[i],
                                                                  *(__m64*)&IOutputL[i + 2]),

--- a/src/common/dsp/effect/ConditionerEffect.cpp
+++ b/src/common/dsp/effect/ConditionerEffect.cpp
@@ -10,10 +10,10 @@ ConditionerEffect::ConditionerEffect(SurgeStorage* storage, FxStorage* fxdata, p
 {
    bufpos = 0;
 
-   ampL.set_blocksize(block_size);
-   ampR.set_blocksize(block_size);
-   width.set_blocksize(block_size);
-   postamp.set_blocksize(block_size);
+   ampL.set_blocksize(BLOCK_SIZE);
+   ampR.set_blocksize(BLOCK_SIZE);
+   width.set_blocksize(BLOCK_SIZE);
+   postamp.set_blocksize(BLOCK_SIZE);
 }
 
 ConditionerEffect::~ConditionerEffect()
@@ -61,7 +61,7 @@ void ConditionerEffect::process_only_control()
    vu[4] = min(8.f, a * vu[4]);
    vu[5] = min(8.f, a * vu[5]);
 
-   for (int k = 0; k < block_size; k++)
+   for (int k = 0; k < BLOCK_SIZE; k++)
    {
       filtered_lamax = (1 - attack) * filtered_lamax + attack;
       filtered_lamax2 = (1 - release) * filtered_lamax2 + (release)*filtered_lamax;
@@ -96,18 +96,18 @@ void ConditionerEffect::process(float* dataL, float* dataR)
    width.set_target_smoothed(clamp1bp(*f[2]));
    postamp.set_target_smoothed(db_to_linear(*f[7]));
 
-   float M alignas(16)[block_size],
-         S alignas(16)[block_size]; // wb = write-buffer
-   encodeMS(dataL, dataR, M, S, block_size_quad);
-   width.multiply_block(S, block_size_quad);
-   decodeMS(M, S, dataL, dataR, block_size_quad);
-   ampL.multiply_block(dataL, block_size_quad);
-   ampR.multiply_block(dataR, block_size_quad);
+   float M alignas(16)[BLOCK_SIZE],
+         S alignas(16)[BLOCK_SIZE]; // wb = write-buffer
+   encodeMS(dataL, dataR, M, S, BLOCK_SIZE_QUAD);
+   width.multiply_block(S, BLOCK_SIZE_QUAD);
+   decodeMS(M, S, dataL, dataR, BLOCK_SIZE_QUAD);
+   ampL.multiply_block(dataL, BLOCK_SIZE_QUAD);
+   ampR.multiply_block(dataR, BLOCK_SIZE_QUAD);
 
-   vu[0] = max(vu[0], get_absmax(dataL, block_size_quad));
-   vu[1] = max(vu[1], get_absmax(dataR, block_size_quad));
+   vu[0] = max(vu[0], get_absmax(dataL, BLOCK_SIZE_QUAD));
+   vu[1] = max(vu[1], get_absmax(dataR, BLOCK_SIZE_QUAD));
 
-   for (int k = 0; k < block_size; k++)
+   for (int k = 0; k < BLOCK_SIZE; k++)
    {
       float dL = delayed[0][bufpos];
       float dR = delayed[1][bufpos];
@@ -144,12 +144,12 @@ void ConditionerEffect::process(float* dataL, float* dataR)
       bufpos = (bufpos + 1) & (lookahead - 1);
    }
 
-   postamp.multiply_2_blocks(dataL, dataR, block_size_quad);
+   postamp.multiply_2_blocks(dataL, dataR, BLOCK_SIZE_QUAD);
 
    vu[2] = gain;
 
-   vu[4] = max(vu[4], get_absmax(dataL, block_size_quad));
-   vu[5] = max(vu[5], get_absmax(dataR, block_size_quad));
+   vu[4] = max(vu[4], get_absmax(dataL, BLOCK_SIZE_QUAD));
+   vu[5] = max(vu[5], get_absmax(dataR, BLOCK_SIZE_QUAD));
 }
 
 int ConditionerEffect::vu_type(int id)

--- a/src/common/dsp/effect/DistortionEffect.cpp
+++ b/src/common/dsp/effect/DistortionEffect.cpp
@@ -12,10 +12,10 @@ DistortionEffect::DistortionEffect(SurgeStorage* storage, FxStorage* fxdata, pda
     : Effect(storage, fxdata, pd), band1(storage), band2(storage), lp1(storage), lp2(storage),
       hr_a(3, false), hr_b(3, true)
 {
-   lp1.setBlockSize(block_size * distortion_OS);
-   lp2.setBlockSize(block_size * distortion_OS);
-   drive.set_blocksize(block_size);
-   outgain.set_blocksize(block_size);
+   lp1.setBlockSize(BLOCK_SIZE * distortion_OS);
+   lp2.setBlockSize(BLOCK_SIZE * distortion_OS);
+   drive.set_blocksize(BLOCK_SIZE);
+   outgain.set_blocksize(BLOCK_SIZE);
 }
 
 DistortionEffect::~DistortionEffect()
@@ -67,13 +67,13 @@ void DistortionEffect::process(float* dataL, float* dataR)
    outgain.set_target_smoothed(db_to_linear(*f[10]));
    float fb = *f[5];
 
-   float bL alignas(16)[block_size << dist_OS_bits];
-   float bR alignas(16)[block_size << dist_OS_bits];
+   float bL alignas(16)[BLOCK_SIZE << dist_OS_bits];
+   float bR alignas(16)[BLOCK_SIZE << dist_OS_bits];
    assert(dist_OS_bits == 2);
 
-   drive.multiply_2_blocks(dataL, dataR, block_size_quad);
+   drive.multiply_2_blocks(dataL, dataR, BLOCK_SIZE_QUAD);
 
-   for (int k = 0; k < block_size; k++)
+   for (int k = 0; k < BLOCK_SIZE; k++)
    {
       float a = (k & 16) ? 0.00000001 : -0.00000001; // denormal thingy
       float Lin = dataL[k];
@@ -95,7 +95,7 @@ void DistortionEffect::process(float* dataL, float* dataR)
       // dataR[k] = R*outgain;
    }
 
-   /*for(int k=0; k<block_size; k++)
+   /*for(int k=0; k<BLOCK_SIZE; k++)
    {
            int kOS = k<<dist_OS_bits;
            //dataL[k] *= drive;
@@ -110,13 +110,13 @@ void DistortionEffect::process(float* dataL, float* dataR)
            //lp1.process_sample_nolag_noinput(L[kOS+7],R[kOS+7]);
    }
 
-   tanh7_block(L,block_size_quad << dist_OS_bits);
-   tanh7_block(R,block_size_quad << dist_OS_bits);*/
+   tanh7_block(L,BLOCK_SIZE_QUAD << dist_OS_bits);
+   tanh7_block(R,BLOCK_SIZE_QUAD << dist_OS_bits);*/
 
    hr_a.process_block_D2(bL, bR, 128);
    hr_b.process_block_D2(bL, bR, 64);
 
-   outgain.multiply_2_blocks_to(bL, bR, dataL, dataR, block_size_quad);
+   outgain.multiply_2_blocks_to(bL, bR, dataL, dataR, BLOCK_SIZE_QUAD);
 
    // lp2.process_block(dataL,dataR);
 

--- a/src/common/dsp/effect/FreqshiftEffect.cpp
+++ b/src/common/dsp/effect/FreqshiftEffect.cpp
@@ -73,7 +73,7 @@ void FreqshiftEffect::setvars(bool init)
    float maxfb = max(db96, feedback.v);
    if (maxfb < 1.f)
    {
-      float f = block_size_inv * time.v * (1.f + log(db96) / log(maxfb));
+      float f = BLOCK_SIZE_INV * time.v * (1.f + log(db96) / log(maxfb));
       ringout_time = (int)f;
    }
    else
@@ -88,18 +88,18 @@ void FreqshiftEffect::process(float* dataL, float* dataR)
    setvars(false);
 
    int k;
-   float L alignas(16)[block_size],
-         R alignas(16)[block_size],
-         Li alignas(16)[block_size],
-         Ri alignas(16)[block_size],
-         Lr alignas(16)[block_size],
-         Rr alignas(16)[block_size];
+   float L alignas(16)[BLOCK_SIZE],
+         R alignas(16)[BLOCK_SIZE],
+         Li alignas(16)[BLOCK_SIZE],
+         Ri alignas(16)[BLOCK_SIZE],
+         Lr alignas(16)[BLOCK_SIZE],
+         Rr alignas(16)[BLOCK_SIZE];
 
-   for (k = 0; k < block_size; k++)
+   for (k = 0; k < BLOCK_SIZE; k++)
    {
       time.process();
 
-      int i_dtime = max(FIRipol_N + block_size, min((int)time.v, max_delay_length - FIRipol_N - 1));
+      int i_dtime = max(FIRipol_N + BLOCK_SIZE, min((int)time.v, max_delay_length - FIRipol_N - 1));
 
       int rp = (wpos - i_dtime + k);
 
@@ -123,8 +123,8 @@ void FreqshiftEffect::process(float* dataL, float* dataR)
       Ri[k] = R[k] * o1R.i;
    }
 
-   fr.process_block(Lr, Rr, block_size);
-   fi.process_block(Li, Ri, block_size);
+   fr.process_block(Lr, Rr, BLOCK_SIZE);
+   fi.process_block(Li, Ri, BLOCK_SIZE);
 
    // do freqshift
    /*{
@@ -156,7 +156,7 @@ void FreqshiftEffect::process(float* dataL, float* dataR)
            R = 2*(r+i);
    }*/
 
-   for (k = 0; k < block_size; k++)
+   for (k = 0; k < BLOCK_SIZE; k++)
    {
       o2L.process();
       Lr[k] *= o2L.r;
@@ -176,9 +176,9 @@ void FreqshiftEffect::process(float* dataL, float* dataR)
       buffer[1][wp] = dataR[k] + (float)lookup_waveshape(0, (R[k] * feedback.v));
    }
 
-   mix.fade_2_blocks_to(dataL, L, dataR, R, dataL, dataR, block_size_quad);
+   mix.fade_2_blocks_to(dataL, L, dataR, R, dataL, dataR, BLOCK_SIZE_QUAD);
 
-   wpos += block_size;
+   wpos += BLOCK_SIZE;
    wpos = wpos & (max_delay_length - 1);
 }
 

--- a/src/common/dsp/effect/PhaserEffect.cpp
+++ b/src/common/dsp/effect/PhaserEffect.cpp
@@ -33,8 +33,8 @@ PhaserEffect::PhaserEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd)
       memset(biquad[i], 0, sizeof(BiquadFilter));
       new (biquad[i]) BiquadFilter(storage);
    }
-   mix.set_blocksize(block_size);
-   feedback.setBlockSize(block_size * slowrate);
+   mix.set_blocksize(BLOCK_SIZE);
+   feedback.setBlockSize(BLOCK_SIZE * slowrate);
    bi = 0;
 }
 
@@ -53,8 +53,8 @@ void PhaserEffect::init()
       // notch[i]->coeff_LP(1.0,1.0);
       biquad[i]->suspend();
    }
-   clear_block(L, block_size_quad);
-   clear_block(R, block_size_quad);
+   clear_block(L, BLOCK_SIZE_QUAD);
+   clear_block(R, BLOCK_SIZE_QUAD);
    mix.set_target(1.f);
    mix.instantize();
    bi = 0;
@@ -109,10 +109,10 @@ void PhaserEffect::process(float* dataL, float* dataR)
    if (bi == 0)
       setvars();
    bi = (bi + 1) & slowrate_m1;
-   // feedback.multiply_2_blocks((__m128*)L,(__m128*)R, block_size_quad);
-   // accumulate_block((__m128*)dataL, (__m128*)L, block_size_quad);
-   // accumulate_block((__m128*)dataR, (__m128*)R, block_size_quad);
-   for (int i = 0; i < block_size; i++)
+   // feedback.multiply_2_blocks((__m128*)L,(__m128*)R, BLOCK_SIZE_QUAD);
+   // accumulate_block((__m128*)dataL, (__m128*)L, BLOCK_SIZE_QUAD);
+   // accumulate_block((__m128*)dataR, (__m128*)R, BLOCK_SIZE_QUAD);
+   for (int i = 0; i < BLOCK_SIZE; i++)
    {
       feedback.process();
       dL = dataL[i] + dL * feedback.v;
@@ -132,7 +132,7 @@ void PhaserEffect::process(float* dataL, float* dataR)
    }
 
    mix.set_target_smoothed(limit_range(*f[pp_mix], 0.f, 1.f));
-   mix.fade_2_blocks_to(dataL, L, dataR, R, dataL, dataR, block_size_quad);
+   mix.fade_2_blocks_to(dataL, L, dataR, R, dataL, dataR, BLOCK_SIZE_QUAD);
 }
 
 void PhaserEffect::suspend()

--- a/src/common/dsp/effect/Reverb1Effect.cpp
+++ b/src/common/dsp/effect/Reverb1Effect.cpp
@@ -184,7 +184,7 @@ void Reverb1Effect::update_rtime()
       max_dt = max(max_dt, delay_time[t]);
    }
    lastf[rp_decaytime] = *f[rp_decaytime];
-   float t = block_size_inv * ((float)(max_dt >> 8) + samplerate * powf(2.f, *f[rp_decaytime]) *
+   float t = BLOCK_SIZE_INV * ((float)(max_dt >> 8) + samplerate * powf(2.f, *f[rp_decaytime]) *
                                                           2.f); // *2 is to get the db120 time
    ringout_time = (int)t;
 }
@@ -200,8 +200,8 @@ void Reverb1Effect::update_rsize()
 
 void Reverb1Effect::process(float* dataL, float* dataR)
 {
-   float wetL alignas(16)[block_size],
-         wetR alignas(16)[block_size];
+   float wetL alignas(16)[BLOCK_SIZE],
+         wetR alignas(16)[BLOCK_SIZE];
 
    if (fxdata->p[rp_shape].val.i != shape)
       loadpreset(fxdata->p[rp_shape].val.i);
@@ -230,7 +230,7 @@ void Reverb1Effect::process(float* dataL, float* dataR)
    __m128 damp4 = _mm_load1_ps(f[rp_damping]);
    __m128 damp4m1 = _mm_sub_ps(one4, damp4);
 
-   for (int k = 0; k < block_size; k++)
+   for (int k = 0; k < BLOCK_SIZE; k++)
    {
       for (int t = 0; t < rev_taps; t += 4)
       {
@@ -292,13 +292,13 @@ void Reverb1Effect::process(float* dataL, float* dataR)
    hicut.process_block_slowlag(wetL, wetR);
 
    // scale width
-   float M alignas(16)[block_size],
-         S alignas(16)[block_size];
-   encodeMS(wetL, wetR, M, S, block_size_quad);
-   width.multiply_block(S, block_size_quad);
-   decodeMS(M, S, wetL, wetR, block_size_quad);
+   float M alignas(16)[BLOCK_SIZE],
+         S alignas(16)[BLOCK_SIZE];
+   encodeMS(wetL, wetR, M, S, BLOCK_SIZE_QUAD);
+   width.multiply_block(S, BLOCK_SIZE_QUAD);
+   decodeMS(M, S, wetL, wetR, BLOCK_SIZE_QUAD);
 
-   mix.fade_2_blocks_to(dataL, wetL, dataR, wetR, dataL, dataR, block_size_quad);
+   mix.fade_2_blocks_to(dataL, wetL, dataR, wetR, dataL, dataR, BLOCK_SIZE_QUAD);
 }
 
 void Reverb1Effect::suspend()

--- a/src/common/dsp/effect/Reverb2Effect.cpp
+++ b/src/common/dsp/effect/Reverb2Effect.cpp
@@ -173,8 +173,8 @@ void Reverb2Effect::process(float* dataL, float* dataR)
    float scale = powf(2.f, 1.f * *f[r2p_room_size]);
    calc_size(scale);
 
-   float wetL alignas(16)[block_size],
-         wetR alignas(16)[block_size];
+   float wetL alignas(16)[BLOCK_SIZE],
+         wetR alignas(16)[BLOCK_SIZE];
 
    float loop_time_s = 0.5508 * scale;
    float decay = powf(db60, loop_time_s / (4.f * (powf(2.f, *f[r2p_decay_time]))));
@@ -191,7 +191,7 @@ void Reverb2Effect::process(float* dataL, float* dataR)
 
    _lfo.set_rate(2.0 * M_PI * powf(2, -2.f) * dsamplerate_inv);
 
-   for (int k = 0; k < block_size; k++)
+   for (int k = 0; k < BLOCK_SIZE; k++)
    {
       float in = (dataL[k] + dataR[k]) * 0.5f;
 
@@ -243,13 +243,13 @@ void Reverb2Effect::process(float* dataL, float* dataR)
    }
 
    // scale width
-   float M alignas(16)[block_size],
-         S alignas(16)[block_size];
-   encodeMS(wetL, wetR, M, S, block_size_quad);
-   width.multiply_block(S, block_size_quad);
-   decodeMS(M, S, wetL, wetR, block_size_quad);
+   float M alignas(16)[BLOCK_SIZE],
+         S alignas(16)[BLOCK_SIZE];
+   encodeMS(wetL, wetR, M, S, BLOCK_SIZE_QUAD);
+   width.multiply_block(S, BLOCK_SIZE_QUAD);
+   decodeMS(M, S, wetL, wetR, BLOCK_SIZE_QUAD);
 
-   mix.fade_2_blocks_to(dataL, wetL, dataR, wetR, dataL, dataR, block_size_quad);
+   mix.fade_2_blocks_to(dataL, wetL, dataR, wetR, dataL, dataR, BLOCK_SIZE_QUAD);
 }
 
 void Reverb2Effect::suspend()

--- a/src/common/dsp/effect/RotarySpeakerEffect.cpp
+++ b/src/common/dsp/effect/RotarySpeakerEffect.cpp
@@ -129,8 +129,8 @@ void RotarySpeakerEffect::init_ctrltypes()
 
 void RotarySpeakerEffect::process_only_control()
 {
-   lfo.set_rate(2 * M_PI * powf(2, *f[rsp_rate]) * dsamplerate_inv * block_size);
-   lf_lfo.set_rate(0.7 * 2 * M_PI * powf(2, *f[rsp_rate]) * dsamplerate_inv * block_size);
+   lfo.set_rate(2 * M_PI * powf(2, *f[rsp_rate]) * dsamplerate_inv * BLOCK_SIZE);
+   lf_lfo.set_rate(0.7 * 2 * M_PI * powf(2, *f[rsp_rate]) * dsamplerate_inv * BLOCK_SIZE);
 
    lfo.process();
    lf_lfo.process();
@@ -138,7 +138,7 @@ void RotarySpeakerEffect::process_only_control()
 
 void RotarySpeakerEffect::process(float* dataL, float* dataR)
 {
-   lfo.set_rate(2 * M_PI * powf(2, *f[rsp_rate]) * dsamplerate_inv * block_size);
+   lfo.set_rate(2 * M_PI * powf(2, *f[rsp_rate]) * dsamplerate_inv * BLOCK_SIZE);
    lf_lfo.set_rate(0.7 * 2 * M_PI * powf(2, *f[rsp_rate]) * dsamplerate_inv);
 
    float precalc0 = (-2 - (float)lfo.i);
@@ -159,15 +159,15 @@ void RotarySpeakerEffect::process(float* dataL, float* dataR)
 
    lfo.process();
 
-   float upper[block_size];
-   float lower[block_size];
-   float lower_sub[block_size];
-   float tbufferL[block_size];
-   float tbufferR[block_size];
+   float upper[BLOCK_SIZE];
+   float lower[BLOCK_SIZE];
+   float lower_sub[BLOCK_SIZE];
+   float tbufferL[BLOCK_SIZE];
+   float tbufferR[BLOCK_SIZE];
 
    int k;
 
-   for (k = 0; k < block_size; k++)
+   for (k = 0; k < BLOCK_SIZE; k++)
    {
       // float input = (float)tanh_fast(0.5f*dataL[k]+dataR[k]*drive.v);
       float input = 0.5f * (dataL[k] + dataR[k]);
@@ -179,7 +179,7 @@ void RotarySpeakerEffect::process(float* dataL, float* dataR)
    xover.process_block(lower);
    // xover->process(lower,0);
 
-   for (k = 0; k < block_size; k++)
+   for (k = 0; k < BLOCK_SIZE; k++)
    {
       // feed delay input
       int wp = (wpos + k) & (max_delay_length - 1);
@@ -187,13 +187,13 @@ void RotarySpeakerEffect::process(float* dataL, float* dataR)
       upper[k] -= lower[k];
       buffer[wp] = upper[k];
 
-      /*int i_dtL = max(block_size,min((int)dL.v,max_delay_length-1)),
-              i_dtR = max(block_size,min((int)dR.v,max_delay_length-1)),
+      /*int i_dtL = max(BLOCK_SIZE,min((int)dL.v,max_delay_length-1)),
+              i_dtR = max(BLOCK_SIZE,min((int)dR.v,max_delay_length-1)),
               sincL = FIRipol_N*(int)(FIRipol_M*(ceil(dL.v)-dL.v)),
               sincR = FIRipol_N*(int)(FIRipol_M*(ceil(dR.v)-dR.v));*/
 
-      int i_dtimeL = max(block_size, min((int)dL.v, max_delay_length - FIRipol_N - 1));
-      int i_dtimeR = max(block_size, min((int)dR.v, max_delay_length - FIRipol_N - 1));
+      int i_dtimeL = max(BLOCK_SIZE, min((int)dL.v, max_delay_length - FIRipol_N - 1));
+      int i_dtimeR = max(BLOCK_SIZE, min((int)dR.v, max_delay_length - FIRipol_N - 1));
 
       int rpL = (wpos - i_dtimeL + k);
       int rpR = (wpos - i_dtimeR + k);
@@ -225,7 +225,7 @@ void RotarySpeakerEffect::process(float* dataL, float* dataR)
    // lowbass->process(lower_sub,0);
    lowbass.process_block(lower_sub);
 
-   for (k = 0; k < block_size; k++)
+   for (k = 0; k < BLOCK_SIZE; k++)
    {
       lower[k] -= lower_sub[k];
 
@@ -238,6 +238,6 @@ void RotarySpeakerEffect::process(float* dataL, float* dataR)
       hornamp[1].process();
    }
 
-   wpos += block_size;
+   wpos += BLOCK_SIZE;
    wpos = wpos & (max_delay_length - 1);
 }

--- a/src/common/dsp/effect/VocoderEffect.cpp
+++ b/src/common/dsp/effect/VocoderEffect.cpp
@@ -32,7 +32,7 @@ VocoderEffect::VocoderEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd
    mVoicedLevel = 0.f;
    mUnvoicedLevel = 0.f;*/
 
-   mGain.set_blocksize(block_size);
+   mGain.set_blocksize(BLOCK_SIZE);
 
    for (int i = 0; i < NVocoderVec; i++)
    {
@@ -95,23 +95,23 @@ void VocoderEffect::process(float* dataL, float* dataR)
       setvars(false);
    }
 
-   float modulator_in alignas(16)[block_size];
+   float modulator_in alignas(16)[BLOCK_SIZE];
 
-   add_block(storage->audio_in_nonOS[0], storage->audio_in_nonOS[1], modulator_in, block_size_quad);
+   add_block(storage->audio_in_nonOS[0], storage->audio_in_nonOS[1], modulator_in, BLOCK_SIZE_QUAD);
 
    float Gain = *f[KGain] + 24.f;
    mGain.set_target_smoothed(db_to_linear(Gain));
-   mGain.multiply_block(modulator_in, block_size_quad);
+   mGain.multiply_block(modulator_in, BLOCK_SIZE_QUAD);
 
    // Voiced / Unvoiced detection
    /*{
 
            mVoicedDetect.process_block_to(modulator_in, modulator_tbuf);
-           float a = min(4.f, get_squaremax(modulator_tbuf,block_size_quad));
+           float a = min(4.f, get_squaremax(modulator_tbuf,BLOCK_SIZE_QUAD));
            mVoicedLevel = mVoicedLevel * (1.f - rate) + a*rate;
 
            mUnvoicedDetect.process_block_to(modulator_in, modulator_tbuf);
-           a = min(4.f, get_squaremax(modulator_tbuf,block_size_quad));
+           a = min(4.f, get_squaremax(modulator_tbuf,BLOCK_SIZE_QUAD));
            mUnvoicedLevel = mUnvoicedLevel * (1.f - rate) + a*rate;
 
            float Ratio = db_to_linear(*f[KUnvoicedThreshold]);
@@ -119,7 +119,7 @@ void VocoderEffect::process(float* dataL, float* dataR)
            if (mUnvoicedLevel > (mVoicedLevel * Ratio))
            {
                    // mix carrier with noise
-                   for(int i=0; i<block_size; i++)
+                   for(int i=0; i<BLOCK_SIZE; i++)
                    {
                            float rand11 = (((float) rand()/RAND_MAX)*2.f - 1.f);
                            dataL[i] = rand11;
@@ -138,7 +138,7 @@ void VocoderEffect::process(float* dataL, float* dataR)
    float Gate = db_to_linear(*f[KGateLevel] + Gain);
    vFloat GateLevel = vLoad1(Gate * Gate);
 
-   for (int k = 0; k < block_size; k++)
+   for (int k = 0; k < BLOCK_SIZE; k++)
    {
       vFloat In = vLoad1(modulator_in[k]);
       vFloat Left = vLoad1(dataL[k]);

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -161,8 +161,8 @@ private:
 class PhaserEffect : public Effect
 {
    lipol_ps mix alignas(16);
-   float L alignas(16)[block_size],
-         R alignas(16)[block_size];
+   float L alignas(16)[BLOCK_SIZE],
+         R alignas(16)[BLOCK_SIZE];
 
 public:
    PhaserEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -32,15 +32,15 @@ static inline int _stricmp(const char *s1, const char *s2)
 #define _SURGE_STR(x) #x
 #define SURGE_STR(x) _SURGE_STR(x)
 
-const int namechars = 64;
-const int block_size = 32;
-const int osc_oversampling = 2;
-const int block_size_os = osc_oversampling * block_size;
-const int block_size_quad = block_size >> 2;
-const int block_size_os_quad = block_size_os >> 2;
-const int max_unison = 16;
-const int ob_length = block_size_os << 1;
-const int ob_length_quad = ob_length >> 2;
-const float block_size_inv = (1.f / block_size);
-const float block_size_os_inv = (1.f / block_size_os);
-const int max_fb_comb = 2048; // must be 2^n
+const int NAMECHARS = 64;
+const int BLOCK_SIZE = 32;
+const int OSC_OVERSAMPLING = 2;
+const int BLOCK_SIZE_OS = OSC_OVERSAMPLING * BLOCK_SIZE;
+const int BLOCK_SIZE_QUAD = BLOCK_SIZE >> 2;
+const int BLOCK_SIZE_OS_QUAD = BLOCK_SIZE_OS >> 2;
+const int MAX_UNISON = 16;
+const int OB_LENGTH = BLOCK_SIZE_OS << 1;
+const int OB_LENGTH_QUAD = OB_LENGTH >> 2;
+const float BLOCK_SIZE_INV = (1.f / BLOCK_SIZE);
+const float BLOCK_SIZE_OS_INV = (1.f / BLOCK_SIZE_OS);
+const int MAX_FB_COMB = 2048; // must be 2^n

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -45,7 +45,7 @@ void COscillatorDisplay::draw(CDrawContext* dc)
       bool use_display = osc->allow_display();
       if (use_display)
          osc->init(disp_pitch_rs, true);
-      int block_pos = block_size_os;
+      int block_pos = BLOCK_SIZE_OS;
       for (int y = 0; y < h2; y++)
          column_d[y] = 0;
 
@@ -55,7 +55,7 @@ void COscillatorDisplay::draw(CDrawContext* dc)
             column[y] = 0;
          for (int s = 0; s < aa_samples; s++)
          {
-            if (use_display && (block_pos >= block_size_os))
+            if (use_display && (block_pos >= BLOCK_SIZE_OS))
             {
                if (uses_wavetabledata(oscdata->type.val.i))
                {
@@ -261,7 +261,7 @@ CMouseEventResult COscillatorDisplay::onMouseDown(CPoint& where, const CButtonSt
 
          for (auto c : storage->wtCategoryOrdering)
          {
-            char name[namechars];
+            char name[NAMECHARS];
             COptionMenu* subMenu = new COptionMenu(getViewSize(), 0, c, 0, 0, kNoDrawStyle);
             subMenu->setNbItemsPerColumn(32);
             int sub = 0;
@@ -280,7 +280,7 @@ CMouseEventResult COscillatorDisplay::onMouseDown(CPoint& where, const CButtonSt
                   sub++;
                }
             }
-            strncpy(name, storage->wt_category[c].name.c_str(), namechars);
+            strncpy(name, storage->wt_category[c].name.c_str(), NAMECHARS);
             contextMenu->addEntry(subMenu, name);
 
             subMenu->forget(); // Important, so that the refcounter gets right

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -117,7 +117,7 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint& where, const CButtonState& 
             if (n_subc > 1)
                sprintf(name, "%s - %i", storage->patch_category[c].name.c_str(), subc + 1);
             else
-               strncpy(name, storage->patch_category[c].name.c_str(), namechars);
+               strncpy(name, storage->patch_category[c].name.c_str(), NAMECHARS);
 
             if (!single_category)
             {

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -109,10 +109,10 @@ void CSnapshotMenu::populate()
          }
          else
          {
-            char name[namechars];
+            char name[NAMECHARS];
             sprintf(name, "default");
 
-            spawn_miniedit_text(name, namechars);
+            spawn_miniedit_text(name, NAMECHARS);
             save_snapshot(sect, name);
             storage->save_snapshots();
             do_nothing = true;
@@ -192,7 +192,7 @@ j;
 
 // CFxMenu
 
-const char fxslot_names[8][namechars] = {"A Insert 1", "A Insert 2", "B Insert 1", "B Insert 2",
+const char fxslot_names[8][NAMECHARS] = {"A Insert 1", "A Insert 2", "B Insert 1", "B Insert 2",
                                          "Send FX 1",  "Send FX 2",  "Master 1",   "Master 2"};
 
 CFxMenu::CFxMenu(const CRect& size,
@@ -233,7 +233,7 @@ void CFxMenu::draw(CDrawContext* dc)
    txtbox.top--;
    txtbox.bottom += 2;
    dc->drawString(fxslot_names[slot], txtbox, kLeftText, true);
-   char fxname[namechars];
+   char fxname[NAMECHARS];
    sprintf(fxname, "%s", fxtype_abberations[fx->type.val.i]);
    dc->drawString(fxname, txtbox, kRightText, true);
 

--- a/src/common/vt_dsp/halfratefilter.cpp
+++ b/src/common/vt_dsp/halfratefilter.cpp
@@ -1,7 +1,7 @@
 #include "halfratefilter.h"
 #include "assert.h"
 
-const unsigned int hr_block_size = 256;
+const unsigned int hr_BLOCK_SIZE = 256;
 const __m128 half = _mm_set_ps1(0.5f);
 
 halfrate_stereo::halfrate_stereo(int M, bool steep)
@@ -17,7 +17,7 @@ void halfrate_stereo::process_block(float* __restrict floatL, float* __restrict 
 {
    __m128* __restrict L = (__m128*)floatL;
    __m128* __restrict R = (__m128*)floatR;
-   __m128 o[hr_block_size];
+   __m128 o[hr_BLOCK_SIZE];
    // fill the buffer with interleaved stereo samples
    for (int k = 0; k < N; k += 4)
    {
@@ -145,7 +145,7 @@ void halfrate_stereo::process_block_D2(
 {
    __m128* L = (__m128*)floatL;
    __m128* R = (__m128*)floatR;
-   __m128 o[hr_block_size];
+   __m128 o[hr_BLOCK_SIZE];
    // fill the buffer with interleaved stereo samples
    for (int k = 0; k < nsamples; k += 4)
    {
@@ -277,7 +277,7 @@ void halfrate_stereo::process_block_U2(
    __m128* L_in = (__m128*)floatL_in;
    __m128* R_in = (__m128*)floatR_in;
 
-   __m128 o[hr_block_size];
+   __m128 o[hr_BLOCK_SIZE];
    // fill the buffer with interleaved stereo samples
    for (int k = 0; k < nsamples; k += 8)
    {

--- a/src/common/vt_dsp/halfratefilter.h
+++ b/src/common/vt_dsp/halfratefilter.h
@@ -33,5 +33,5 @@ private:
    int M;
    bool steep;
    float oldoutL, oldoutR;
-   // unsigned int block_size;
+   // unsigned int BLOCK_SIZE;
 };

--- a/src/common/vt_dsp/lipol.cpp
+++ b/src/common/vt_dsp/lipol.cpp
@@ -15,8 +15,8 @@ lipol_ps::lipol_ps()
 
 void lipol_ps::set_blocksize(int bs)
 {
-   lipol_block_size = _mm_cvt_si2ss(m128_zero, bs);
-   m128_bs4_inv = _mm_div_ss(m128_four, lipol_block_size);
+   lipol_BLOCK_SIZE = _mm_cvt_si2ss(m128_zero, bs);
+   m128_bs4_inv = _mm_div_ss(m128_four, lipol_BLOCK_SIZE);
 }
 
 void lipol_ps::multiply_block(float* src, unsigned int nquads)

--- a/src/common/vt_dsp/lipol.h
+++ b/src/common/vt_dsp/lipol.h
@@ -6,7 +6,7 @@ class lipol_ps
 {
 public:
    __m128 target, currentval, coef, coef_m1;
-   __m128 lipol_block_size;
+   __m128 lipol_BLOCK_SIZE;
    __m128 m128_lipolstarter;
    __m128 m128_bs4_inv;
 

--- a/src/todo/effect_emphasize.cpp
+++ b/src/todo/effect_emphasize.cpp
@@ -42,16 +42,16 @@ void emphasize::process(float *dataL, float *dataR)
 	bi = (bi+1) & slowrate_m1;	
 	outgain.set_target(storage->db_to_linear(*f[0]));
 
-	float bL alignas(16)[block_size << 1];
-	float bR alignas(16)[block_size << 1];
+	float bL alignas(16)[BLOCK_SIZE << 1];
+	float bR alignas(16)[BLOCK_SIZE << 1];
 
 	EQ.process_block_to(dataL,dataR,bL,bR);	
 	
-	pre.process_block_U2((__m128*)bL,(__m128*)bR,(__m128*)bL,(__m128*)bR,block_size_os);	
+	pre.process_block_U2((__m128*)bL,(__m128*)bR,(__m128*)bL,(__m128*)bR,BLOCK_SIZE_OS);	
 
 	__m128 type = _mm_load1_ps(f[3]);
 	__m128 typem1 = _mm_sub_ps(m128_one,type);
-	for(int k=0; k<block_size_os_quad; k++)
+	for(int k=0; k<BLOCK_SIZE_OS_QUAD; k++)
 	{
 		// y = x*x*(t + (1-t)*x)
 		// y = x*x*(t + x - t*x) 
@@ -68,9 +68,9 @@ void emphasize::process(float *dataL, float *dataR)
 		_mm_store_ps(bR + (k<<2), R);
 	}		
 
-	post.process_block_D2((__m128*)bL,(__m128*)bR,block_size_os);		
+	post.process_block_D2((__m128*)bL,(__m128*)bR,BLOCK_SIZE_OS);		
 
-	outgain.MAC_2_blocks_to((__m128*)bL,(__m128*)bR,(__m128*)dataL,(__m128*)dataR,block_size_quad);
+	outgain.MAC_2_blocks_to((__m128*)bL,(__m128*)bR,(__m128*)dataL,(__m128*)dataR,BLOCK_SIZE_QUAD);
 
 }
 

--- a/src/todo/sub3_osc_dot.cpp
+++ b/src/todo/sub3_osc_dot.cpp
@@ -44,7 +44,7 @@ void osc_dotwave::init(float pitch, bool is_display)
 	id_sync = oscdata->p[4].param_id_in_scene;	
 	id_detune = oscdata->p[5].param_id_in_scene;
 
-	n_unison = limit_range(oscdata->p[6].val.i,1,max_unison);	
+	n_unison = limit_range(oscdata->p[6].val.i,1,MAX_UNISON);	
 	if(is_display) n_unison = 1;
 	out_attenuation = 1.0f/sqrt((float)n_unison);
 
@@ -56,9 +56,9 @@ void osc_dotwave::init(float pitch, bool is_display)
 		detune_bias = (float)2/(n_unison);
 		detune_offset = -1;
 	}	
-	memset(oscbuffer,0,sizeof(float)*ob_length);	
-	memset(last_level,0,max_unison*sizeof(float));
-	memset(last_level2,0,max_unison*sizeof(float));
+	memset(oscbuffer,0,sizeof(float)*OB_LENGTH);	
+	memset(last_level,0,MAX_UNISON*sizeof(float));
+	memset(last_level2,0,MAX_UNISON*sizeof(float));
 
 	this->pitch = pitch;
 	update_lagvals<true>();
@@ -195,7 +195,7 @@ void osc_dotwave::convolute(int voice)
 	for(k=0; k<FIRipol_N; k++)
 	{
 		a = storage->sinctable[m+k] + lipol*storage->sincoffset[m+k];		
-		oscbuffer[bufpos+k&(ob_length-1)] += a*g2;
+		oscbuffer[bufpos+k&(OB_LENGTH-1)] += a*g2;
 	//	s += a;	
 	}	
 		
@@ -254,7 +254,7 @@ template<bool FM> void osc_dotwave::process_blockT(float pitch,float depth)
 	__int64 largeFM;
 	double FMmult;	 	
 	
-	for(k=0; k<block_size_os; k++)
+	for(k=0; k<BLOCK_SIZE_OS; k++)
 	{	
 		hpf_coeff.process();
 		integrator_mult.process();
@@ -301,6 +301,6 @@ template<bool FM> void osc_dotwave::process_blockT(float pitch,float depth)
 		oscbuffer[bufpos] = 0.f;
 		
 		bufpos++;
-		bufpos = bufpos&(ob_length-1);			
+		bufpos = bufpos&(OB_LENGTH-1);			
 	}	
 }

--- a/src/todo/sub3_osc_sample.cpp
+++ b/src/todo/sub3_osc_sample.cpp
@@ -55,7 +55,7 @@ template<bool FM> void osc_sample::process_blockT(float pitch,float depth)
 
 	update_lagvals<false>();
 
-	for(int k=0; k<block_size_os; k++)
+	for(int k=0; k<BLOCK_SIZE_OS; k++)
 	{	
 		uint32 m0 =	((sample_subpos>>16)&0xff)*FIRipol_N;
 		float lipol0 = (float)((uint32)(sample_subpos&0xffff));				

--- a/src/todo/sub3_osc_wavetable2.cpp
+++ b/src/todo/sub3_osc_wavetable2.cpp
@@ -36,7 +36,7 @@ void osc_wavetable2::init(float pitch, bool is_display)
 	l_vskew.setRate(rate);	
 	l_hskew.setRate(rate);	
 
-	n_unison = limit_range(oscdata->p[6].val.i,1,max_unison);	
+	n_unison = limit_range(oscdata->p[6].val.i,1,MAX_UNISON);	
 	if(oscdata->wt.flags & wtf_is_sample)
 	{
 		sampleloop = n_unison;
@@ -54,8 +54,8 @@ void osc_wavetable2::init(float pitch, bool is_display)
 		detune_bias = (float)2/(n_unison);
 		detune_offset = -1;
 	}		
-	memset(oscbuffer,0,sizeof(float)*(ob_length+FIRipol_N));
-	memset(last_level,0,max_unison*sizeof(float));	
+	memset(oscbuffer,0,sizeof(float)*(OB_LENGTH+FIRipol_N));
+	memset(last_level,0,MAX_UNISON*sizeof(float));	
 
 	pitch_last = pitch;
 	pitch_t = pitch;	
@@ -135,7 +135,7 @@ float osc_wavetable2::distort_level(float x)
 
 void osc_wavetable2::convolute(int voice, bool FM)
 {
-	float block_pos = oscstate[voice] * block_size_os_inv * pitchmult_inv;
+	float block_pos = oscstate[voice] * BLOCK_SIZE_OS_INV * pitchmult_inv;
 
 	double detune = drift*driftlfo[voice] + localcopy[id_detune].f*(detune_bias*float(voice) + detune_offset);		
 
@@ -156,7 +156,7 @@ void osc_wavetable2::convolute(int voice, bool FM)
 			tableid++;
 			if (tableid > oscdata->wt.n_tables-3) 
 			{				
-				if (sampleloop < max_unison) sampleloop--;
+				if (sampleloop < MAX_UNISON) sampleloop--;
 				
 				if (sampleloop > 0)
 				{					
@@ -365,7 +365,7 @@ template<bool FM> void osc_wavetable2::process_blockT(float pitch0,float depth,f
 	if(FM)
 	{				
 		for(l=0; l<n_unison; l++) driftlfo[l] = drift_noise(driftlfo2[l]);
-		for(int s=0; s<block_size_os; s++)
+		for(int s=0; s<BLOCK_SIZE_OS; s++)
 		{
 			float fmmul = limit_range(1.f + depth*master_osc[s],0.1f,1.9f);			
 			float a = pitchmult * fmmul;		
@@ -385,7 +385,7 @@ template<bool FM> void osc_wavetable2::process_blockT(float pitch0,float depth,f
 	}
 	else
 	{
-		float a = (float)block_size_os*pitchmult;
+		float a = (float)BLOCK_SIZE_OS*pitchmult;
 		for(l=0; l<n_unison; l++)
 		{	
 			driftlfo[l] = drift_noise(driftlfo2[l]);
@@ -395,10 +395,10 @@ template<bool FM> void osc_wavetable2::process_blockT(float pitch0,float depth,f
 		//li_DC.set_target(dc);	
 	}	
 		
-	float hpfblock alignas(16)[block_size_os];
-	li_hpf.store_block(hpfblock,block_size_os_quad);		
+	float hpfblock alignas(16)[BLOCK_SIZE_OS];
+	li_hpf.store_block(hpfblock,BLOCK_SIZE_OS_QUAD);		
 
-	for(k=0; k<block_size_os; k++)
+	for(k=0; k<BLOCK_SIZE_OS; k++)
 	{					
 		__m128 hpf = _mm_load_ss(&hpfblock[k]);
 		__m128 ob = _mm_load_ss(&oscbuffer[bufpos+k]);			
@@ -407,9 +407,9 @@ template<bool FM> void osc_wavetable2::process_blockT(float pitch0,float depth,f
 		_mm_store_ss(&output[k],osc_out);		
 	}	
 
-	vt_dsp::clear_block(&oscbuffer[bufpos],block_size_os_quad);	
+	vt_dsp::clear_block(&oscbuffer[bufpos],BLOCK_SIZE_OS_QUAD);	
 
-	bufpos = (bufpos+block_size_os)&(ob_length-1);		
+	bufpos = (bufpos+BLOCK_SIZE_OS)&(OB_LENGTH-1);		
 	
 	// each block overlap FIRipol_N samples into the next (due to impulses not being wrapped around the block edges
 	// copy the overlapping samples to the new block position
@@ -420,9 +420,9 @@ template<bool FM> void osc_wavetable2::process_blockT(float pitch0,float depth,f
 		const __m128 zero = _mm_setzero_ps();
 		for(k=0; k<(FIRipol_N); k+=4) 
 		{
-			overlap[k>>2] = _mm_load_ps(&oscbuffer[ob_length+k]);	
+			overlap[k>>2] = _mm_load_ps(&oscbuffer[OB_LENGTH+k]);	
 			_mm_store_ps(&oscbuffer[k],overlap[k>>2]);
-			_mm_store_ps(&oscbuffer[ob_length+k],zero);			
+			_mm_store_ps(&oscbuffer[OB_LENGTH+k],zero);			
 		}
 	}
 }

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -403,7 +403,7 @@ void Vst2PluginInstance::processT(float** inputs, float** outputs, VstInt32 samp
          // move clock
          timedata* td = &(_instance->time_data);
          _instance->time_data.ppqPos +=
-             (double)block_size * _instance->time_data.tempo / (60. * sampleRate);
+             (double)BLOCK_SIZE * _instance->time_data.tempo / (60. * sampleRate);
 
          // process events for the current block
          while (events_processed < events_this_block)
@@ -440,7 +440,7 @@ void Vst2PluginInstance::processT(float** inputs, float** outputs, VstInt32 samp
       }
 
       blockpos++;
-      if (blockpos >= block_size)
+      if (blockpos >= BLOCK_SIZE)
          blockpos = 0;
    }
 

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -320,7 +320,7 @@ tresult PLUGIN_API SurgeVst3Processor::process(ProcessData& data)
             timedata* td = &(surgeInstance->time_data);
             surgeInstance->time_data.tempo = tempo;
             surgeInstance->time_data.ppqPos +=
-                (double)block_size * tempo / (60. * data.processContext->sampleRate);
+                (double)BLOCK_SIZE * tempo / (60. * data.processContext->sampleRate);
          }
 
          processEvents(i, data.inputEvents, noteEventIndex);
@@ -345,7 +345,7 @@ tresult PLUGIN_API SurgeVst3Processor::process(ProcessData& data)
       }
 
       blockpos++;
-      if (blockpos >= block_size)
+      if (blockpos >= BLOCK_SIZE)
          blockpos = 0;
    }
 


### PR DESCRIPTION
I might need to add couple of new constants to globals.h as part of my Linux work (namely WINDOW_SIZE_X and WINDOW_SIZE_Y), and I don't want to add anything new with a wrong convention. Generally I think that a good point of time to do coding style fixes is when you need to otherwise change the associated code. I know it is a large diff but the change is fairly mechanical search and replace.

We could later on namespace these (lets say Surge::Globals) but I think that can be later on a separate commit. Right now for me the priority is to be able to add new global constants in capital letters :)

I did test VST2/VST3/AU builds and also tried out VST2 and AU plug-ins in Ableton.