### PR TITLE
Cleanup platform specific user prompts

### DIFF
--- a/src/common/AbstractSynthesizer.cpp
+++ b/src/common/AbstractSynthesizer.cpp
@@ -2,9 +2,7 @@
 //	Copyright 2005 Claes Johanson & vember|audio
 //-------------------------------------------------------------------------------------------------------
 #include "AbstractSynthesizer.h"
-#if WINDOWS
-#include <Windows.h>
-#endif
+#include "UserInteractions.h"
 
 #include <CpuArchitecture.h>
 
@@ -19,20 +17,10 @@ void initDllGlobals()
 
    if (!(CpuArchitecture & CaSSE2))
    {
-#if WINDOWS
-      MessageBox(::GetActiveWindow(), SSE2ErrorText,
-                 "Surge: System requirements not met", MB_OK | MB_ICONERROR);
-#else
-      fprintf(stderr, "%s: %s", __func__, SSE2ErrorText);
-#endif
+       Surge::UserInteractions::promptError( SSE2ErrorText, "Surge System Requirements not met" );
    }
    if (!(CpuArchitecture & CaCMOV))
    {
-#if WINDOWS
-      MessageBox(::GetActiveWindow(), CMOVErrorText,
-                 "Surge: System requirements not met", MB_OK | MB_ICONERROR);
-#else
-      fprintf(stderr, "%s: %s", __func__, CMOVErrorText);
-#endif
+       Surge::UserInteractions::promptError( CMOVErrorText, "Surge System Requirements not met" );
    }
 }

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -376,7 +376,9 @@ void SurgeStorage::refresh_wtlist()
 
    if (wt_category.size() < 1 && wt_list.size() < 1)
    {
-      errorbox("File IO Error: Couldn't locate wavetables on disk!\n\nPlease reinstall..");
+       Surge::UserInteractions::promptError(std::string("Surge was unable to load wavetables from disk. ") +
+                                            "Please reinstall using the surge installer.",
+                                            "Surge Installation Error" );
    }
 
    wtCategoryOrdering = std::vector<int>(wt_category.size());
@@ -508,15 +510,6 @@ void SurgeStorage::load_wt_wt(string filename, Wavetable* wt)
 int SurgeStorage::get_clipboard_type()
 {
    return clipboard_type;
-}
-
-void SurgeStorage::errorbox(string message)
-{
-#if WIN32
-   MessageBox(::GetActiveWindow(), message.c_str(), "ERROR", MB_OK | MB_ICONERROR);
-#elif MAC
-   // TODO add error dialog
-#endif
 }
 
 int SurgeStorage::getAdjacentWaveTable(int id, bool nextPrev)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -504,8 +504,6 @@ public:
    void clipboard_paste(int type, int scene, int entry);
    int get_clipboard_type();
 
-   void errorbox(string message);
-
    int getAdjacentWaveTable(int id, bool nextPrev);
 
    // The in-memory patch database.

--- a/src/common/gui/PopupEditorDialog.cpp
+++ b/src/common/gui/PopupEditorDialog.cpp
@@ -144,12 +144,12 @@ void spawn_miniedit_text(char* c, int maxchars)
 }
 #elif __linux__
 
-#include <stdio.h>
+#include "UserInteractions.h"
 
 void spawn_miniedit_text(char* c, int maxchars)
 {
    // FIXME: Implement text edit popup on Linux.
-   fprintf(stderr, "%s: text edit popup is not implemented.\n", __func__);
+   Surge::UserInteractions::promptError( "miniedit_text is not implemented on linux", "Unimplemented Feature" );
 }
 
 #endif

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -547,10 +547,8 @@ bool Vst2PluginInstance::tryInit()
    SurgeSynthesizer* synth = (SurgeSynthesizer*)_aligned_malloc(sizeof(SurgeSynthesizer), 16);
    if (!synth)
    {
-#if WIN32
-      MessageBox(::GetActiveWindow(), "Could not allocate memory.", "Out of memory",
-                 MB_OK | MB_ICONERROR);
-#endif
+      Surge::UserInteractions::promptError("Unable to allocate SurgeSynthesizer",
+                                           "Out of memory");
       state = DEAD;
       return false;
    }

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -2,6 +2,7 @@
 
 #include "SurgeVst3Processor.h"
 #include "surgecids.h"
+#include "UserInteractions.h"
 
 #include "pluginterfaces/base/ibstream.h"
 #include "pluginterfaces/vst/ivstparameterchanges.h"
@@ -82,11 +83,8 @@ void SurgeVst3Processor::createSurge()
 
    if (!surgeInstance.get())
    {
-      // out of memory
-#if WIN32
-      MessageBoxW(::GetActiveWindow(), L"Could not allocate memory.", L"Out of memory",
-                  MB_OK | MB_ICONERROR);
-#endif
+      Surge::UserInteractions::promptError("Unable to allocate SurgeSynthesizer",
+                                           "Out of memory");
 
       return;
    }


### PR DESCRIPTION
Now we have Surge::UserInteractions, deploy it to a few places
where we can use it to clean up some old pllatform specific
messages.

Pretty innocuous. Would appreciate a quick eyeball if someone wants to.