### PR TITLE
Dont allow blank patch names or categories

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -7,6 +7,7 @@
 #include "UserInteractions.h"
 #include <set>
 #include <numeric>
+#include <cctype>
 #include <vt_dsp/vt_dsp_endian.h>
 #if MAC
 #include <cstdlib>
@@ -998,4 +999,24 @@ float envelope_rate_linear(float x)
    float a = x - (float)e;
 
    return (1 - a) * table_envrate_linear[e & 0x1ff] + a * table_envrate_linear[(e + 1) & 0x1ff];
+}
+
+namespace Surge
+{
+    namespace Storage
+    {
+        bool isValidName(const std::string &patchName)
+        {
+            bool valid = false;
+            
+            // No need to validate size separately as an empty string won't have visible characters.
+            for (const char &c : patchName)
+                if (std::isalnum(c) || std::ispunct(c))
+                    valid = true;
+                else if (c != ' ')
+                    return false;
+
+            return valid;
+        }
+    }
 }

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -547,3 +547,11 @@ float lookup_waveshape(int, float);
 float lookup_waveshape_warp(int, float);
 float envelope_rate_lpf(float);
 float envelope_rate_linear(float);
+
+namespace Surge
+{
+namespace Storage
+{
+    bool isValidName(const std::string &name);
+}
+}

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -19,6 +19,7 @@
 #include "vstcontrols.h"
 #include "SurgeBitmaps.h"
 #include "CNumberField.h"
+#include "UserInteractions.h"
 
 #if TARGET_AUDIOUNIT
 #include "aulayer.h"
@@ -2127,11 +2128,35 @@ void SurgeGUIEditor::valueChanged(CControl* control)
       // frame->setModalView(nullptr);
       frame->setDirty();
 
-      synth->storage.getPatch().name = patchName->getText();
-      synth->storage.getPatch().author = patchCreator->getText();
-      synth->storage.getPatch().category = patchCategory->getText();
-      synth->storage.getPatch().comment = patchComment->getText();
-      synth->savePatch();
+      /*
+      ** Don't allow a blank patch
+      */
+      std::string whatIsBlank = "";
+      bool haveBlanks = false;
+
+      if (! Surge::Storage::isValidName(patchName->getText().getString()))
+      {
+          whatIsBlank = "name"; haveBlanks = true;
+      }
+      if (! Surge::Storage::isValidName(patchCategory->getText().getString()))
+      {
+          whatIsBlank = whatIsBlank + (haveBlanks? " and category" : "category"); haveBlanks = true;
+      }
+      if (haveBlanks)
+      {
+          Surge::UserInteractions::promptError(std::string("Unable to store a patch due to invalid ") +
+                                               whatIsBlank + ". Please save again and provide a complete " +
+                                               whatIsBlank + ".",
+                                               "Error saving patch");
+      }
+      else
+      {
+          synth->storage.getPatch().name = patchName->getText();
+          synth->storage.getPatch().author = patchCreator->getText();
+          synth->storage.getPatch().category = patchCategory->getText();
+          synth->storage.getPatch().comment = patchComment->getText();
+          synth->savePatch();
+      }
    }
    break;
    default:


### PR DESCRIPTION
Prompt a user error in this case rather than making blank named files
Fixes the error reported in #282 by not allowing the user to enter that
code path.

Eyeball or test appreciated. Thanks!