### PR TITLE
VST2: align the plugin class sanitize exception handling

### DIFF
--- a/src/common/AbstractSynthesizer.h
+++ b/src/common/AbstractSynthesizer.h
@@ -21,7 +21,7 @@ const int n_inputs = 2;
 
 void initDllGlobals();
 
-class AbstractSynthesizer
+class alignas(16) AbstractSynthesizer
 {
 public:
    virtual void playNote(char channel, char key, char velocity, char detune) = 0;


### PR DESCRIPTION
Use alignas() to align synthetizers to 16 bytes, and sanitize the exception
handling in Vst2PluginInstance::tryInit(). Synthesizer and GUI editor are
first allocated to temporary variables inside a try-catch-block, and only
if everything goes well, they are assigned to the instance variables.
The instances are freed if something goes wrong.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>