### PR TITLE
Clean up class halfrate_stereo

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -29,12 +29,9 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
     //: halfband_AL(false),halfband_AR(false),halfband_BL(false),halfband_BR(false),
     : hpA(&storage), hpB(&storage), _parent(parent)
 {
-   halfbandA = (halfrate_stereo*)_aligned_malloc(sizeof(halfrate_stereo), 16);
-   halfbandB = (halfrate_stereo*)_aligned_malloc(sizeof(halfrate_stereo), 16);
-   halfbandIN = (halfrate_stereo*)_aligned_malloc(sizeof(halfrate_stereo), 16);
-   new (halfbandA) halfrate_stereo(6, true);
-   new (halfbandB) halfrate_stereo(6, true);
-   new (halfbandIN) halfrate_stereo(6, true);
+   halfbandA = new HalfRateFilter(6, true);
+   halfbandB = new HalfRateFilter(6, true);
+   halfbandIN = new HalfRateFilter(6, true);
 
    switch_toggled_queued = false;
    halt_engine = false;
@@ -154,12 +151,9 @@ SurgeSynthesizer::~SurgeSynthesizer()
 {
    allNotesOff();
 
-   halfbandA->~halfrate_stereo();
-   _aligned_free(halfbandA);
-   halfbandB->~halfrate_stereo();
-   _aligned_free(halfbandB);
-   halfbandIN->~halfrate_stereo();
-   _aligned_free(halfbandIN);
+   delete halfbandA;
+   delete halfbandB;
+   delete halfbandIN;
 
    _aligned_free(FBQ[0]);
    _aligned_free(FBQ[1]);

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -154,7 +154,7 @@ public:
 public:
    int CC0, PCH, patchid;
    float masterfade = 0;
-   halfrate_stereo *halfbandA, *halfbandB, *halfbandIN;
+   HalfRateFilter *halfbandA, *halfbandB, *halfbandIN;
    list<SurgeVoice*> voices[2];
    Effect* fx[8];
    bool halt_engine = false;

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -97,8 +97,8 @@ private:
 class FreqshiftEffect : public Effect
 {
 public:
-   halfrate_stereo fr alignas(16),
-                   fi alignas(16);
+   HalfRateFilter fr alignas(16),
+                  fi alignas(16);
    lipol_ps mix alignas(16);
    FreqshiftEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~FreqshiftEffect();
@@ -234,8 +234,8 @@ protected:
 
 class DistortionEffect : public Effect
 {
-   halfrate_stereo hr_a alignas(16),
-                   hr_b alignas(16);
+   HalfRateFilter hr_a alignas(16),
+                  hr_b alignas(16);
    lipol_ps drive alignas(16),
             outgain alignas(16);
 
@@ -321,8 +321,8 @@ private:
 
 class emphasize : public Effect
 {
-   halfrate_stereo pre alignas(16),
-                   post alignas(16);
+   HalfRateFilter pre alignas(16),
+                  post alignas(16);
    lipol_ps type alignas(16),
             outgain alignas(16);
 

--- a/src/common/vt_dsp/halfratefilter.cpp
+++ b/src/common/vt_dsp/halfratefilter.cpp
@@ -4,7 +4,7 @@
 const unsigned int hr_BLOCK_SIZE = 256;
 const __m128 half = _mm_set_ps1(0.5f);
 
-halfrate_stereo::halfrate_stereo(int M, bool steep)
+HalfRateFilter::HalfRateFilter(int M, bool steep)
 {
    assert(!(M > halfrate_max_M));
    this->M = M;
@@ -13,7 +13,7 @@ halfrate_stereo::halfrate_stereo(int M, bool steep)
    reset();
 }
 
-void halfrate_stereo::process_block(float* __restrict floatL, float* __restrict floatR, int N)
+void HalfRateFilter::process_block(float* __restrict floatL, float* __restrict floatR, int N)
 {
    __m128* __restrict L = (__m128*)floatL;
    __m128* __restrict R = (__m128*)floatR;
@@ -117,7 +117,7 @@ void halfrate_stereo::process_block(float* __restrict floatL, float* __restrict 
 // Software pipelining.. Nice idea, but the compiler does not like it one bit
 // The non-pipelined implementation is quite okay, because ty0 is not used until 2 samples later, therefore the latency dependency
 // is divided by 3
-void halfrate_stereo::process_block(float * __restrict floatL, float * __restrict floatR, int N)
+void HalfRateFilter::process_block(float * __restrict floatL, float * __restrict floatR, int N)
 {		
 	int NM1 = N + M - 1;
 	for(int k = 0; k<NM1; k++)
@@ -140,7 +140,7 @@ void halfrate_stereo::process_block(float * __restrict floatL, float * __restric
 }
 #endif
 
-void halfrate_stereo::process_block_D2(
+void HalfRateFilter::process_block_D2(
     float* floatL, float* floatR, int nsamples, float* outL, float* outR)
 {
    __m128* L = (__m128*)floatL;
@@ -269,7 +269,7 @@ void halfrate_stereo::process_block_D2(
    }
 }
 
-void halfrate_stereo::process_block_U2(
+void HalfRateFilter::process_block_U2(
     float* floatL_in, float* floatR_in, float* floatL, float* floatR, int nsamples)
 {
    __m128* L = (__m128*)floatL;
@@ -380,7 +380,7 @@ void halfrate_stereo::process_block_U2(
    }		*/
 }
 
-void halfrate_stereo::reset()
+void HalfRateFilter::reset()
 {
    for (int i = 0; i < M; i++)
    {
@@ -394,7 +394,7 @@ void halfrate_stereo::reset()
    oldout = _mm_setzero_ps();
 }
 
-void halfrate_stereo::set_coefficients(float* cA, float* cB)
+void HalfRateFilter::set_coefficients(float* cA, float* cB)
 {
    for (int i = 0; i < M; i++)
    {
@@ -403,7 +403,7 @@ void halfrate_stereo::set_coefficients(float* cA, float* cB)
    }
 }
 
-void halfrate_stereo::load_coefficients()
+void HalfRateFilter::load_coefficients()
 {
    int order = M << 1;
    if (steep)

--- a/src/common/vt_dsp/halfratefilter.h
+++ b/src/common/vt_dsp/halfratefilter.h
@@ -3,9 +3,8 @@
 
 const unsigned int halfrate_max_M = 6;
 
-class halfrate_stereo
+class alignas(16) HalfRateFilter
 {
-   // must be aligned
 private:
    __m128 va[halfrate_max_M];
    __m128 vx0[halfrate_max_M];
@@ -17,7 +16,7 @@ private:
    __m128 oldout;
 
 public:
-   halfrate_stereo(int M, bool steep);
+   HalfRateFilter(int M, bool steep);
    void process_block(float* L, float* R, int nsamples = 64);
    void process_block_D2(float* L,
                          float* R,

--- a/src/common/vt_dsp/vt_dsp.h
+++ b/src/common/vt_dsp/vt_dsp.h
@@ -4,5 +4,5 @@
 namespace vt_dsp
 {
 class lipol_ps;
-class halfrate_stereo;
+class HalfRateFilter;
 } // namespace vt_dsp


### PR DESCRIPTION
Move into using alignas() for aligning instances and rename the class to
match the file name by issuing:

git grep -l halfrate_stereo|xargs sed -i -e 's/halfrate_stereo/HalfRateFilter/g

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>