### PR TITLE
Allocate SurgeVoice with the new-operator

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -29,12 +29,13 @@ using namespace std;
 
 SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
     //: halfband_AL(false),halfband_AR(false),halfband_BL(false),halfband_BR(false),
-    : hpA(&storage), hpB(&storage), _parent(parent)
+    : hpA(&storage)
+   , hpB(&storage)
+   , _parent(parent)
+   , halfbandA(6, true)
+   , halfbandB(6, true)
+   , halfbandIN(6, true)
 {
-   halfbandA = new HalfRateFilter(6, true);
-   halfbandB = new HalfRateFilter(6, true);
-   halfbandIN = new HalfRateFilter(6, true);
-
    switch_toggled_queued = false;
    halt_engine = false;
 
@@ -61,8 +62,6 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
    {
       voices_usedby[0][i] = 0;
       voices_usedby[1][i] = 0;
-      voices_array[0][i] = new SurgeVoice();
-      voices_array[1][i] = new SurgeVoice();
    }
 
    FBQ[0] =
@@ -70,31 +69,33 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
    FBQ[1] =
        (QuadFilterChainState*)_aligned_malloc((MAX_VOICES >> 2) * sizeof(QuadFilterChainState), 16);
 
-   storage.getPatch().polylimit.val.i = 8;
+   SurgePatch& patch = storage.getPatch();
+
+   patch.polylimit.val.i = 8;
    for (int sc = 0; sc < 2; sc++)
    {
-
-      storage.getPatch().scene[sc].modsources.resize(n_modsources);
+      SurgeSceneStorage& scene = patch.scene[sc];
+      scene.modsources.resize(n_modsources);
       for (int i = 0; i < n_modsources; i++)
-         storage.getPatch().scene[sc].modsources[i] = 0;
-      storage.getPatch().scene[sc].modsources[ms_modwheel] = new ControllerModulationSource();
-      storage.getPatch().scene[sc].modsources[ms_aftertouch] = new ControllerModulationSource();
-      storage.getPatch().scene[sc].modsources[ms_pitchbend] = new ControllerModulationSource();
+         scene.modsources[i] = 0;
+      scene.modsources[ms_modwheel] = new ControllerModulationSource();
+      scene.modsources[ms_aftertouch] = new ControllerModulationSource();
+      scene.modsources[ms_pitchbend] = new ControllerModulationSource();
 
       for (int l = 0; l < n_lfos_scene; l++)
       {
-         storage.getPatch().scene[sc].modsources[ms_slfo1 + l] = new LfoModulationSource();
-         ((LfoModulationSource*)storage.getPatch().scene[sc].modsources[ms_slfo1 + l])
-             ->assign(&storage, &storage.getPatch().scene[sc].lfo[n_lfos_voice + l],
-                      storage.getPatch().scenedata[sc], 0,
-                      &storage.getPatch().stepsequences[sc][n_lfos_voice + l]);
+         scene.modsources[ms_slfo1 + l] = new LfoModulationSource();
+         ((LfoModulationSource*)scene.modsources[ms_slfo1 + l])
+            ->assign(&storage, &scene.lfo[n_lfos_voice + l],
+            storage.getPatch().scenedata[sc], 0,
+            &patch.stepsequences[sc][n_lfos_voice + l]);
       }
    }
    for (int i = 0; i < n_customcontrollers; i++)
    {
-      storage.getPatch().scene[0].modsources[ms_ctrl1 + i] = new ControllerModulationSource();
-      storage.getPatch().scene[1].modsources[ms_ctrl1 + i] =
-          storage.getPatch().scene[0].modsources[ms_ctrl1 + i];
+      patch.scene[0].modsources[ms_ctrl1 + i] = new ControllerModulationSource();
+      patch.scene[1].modsources[ms_ctrl1 + i] =
+         patch.scene[0].modsources[ms_ctrl1 + i];
    }
 
    amp.set_blocksize(BLOCK_SIZE);
@@ -153,18 +154,8 @@ SurgeSynthesizer::~SurgeSynthesizer()
 {
    allNotesOff();
 
-   delete halfbandA;
-   delete halfbandB;
-   delete halfbandIN;
-
    _aligned_free(FBQ[0]);
    _aligned_free(FBQ[1]);
-
-   for (int i = 0; i < MAX_VOICES; i++)
-   {
-      delete voices_array[0][i];
-      delete voices_array[1][i];
-   }
 
    for (int sc = 0; sc < 2; sc++)
    {
@@ -176,8 +167,6 @@ SurgeSynthesizer::~SurgeSynthesizer()
    }
    for (int i = 0; i < n_customcontrollers; i++)
       delete storage.getPatch().scene[0].modsources[ms_ctrl1 + i];
-   for (int i = 0; i < 8; i++)
-      delete fx[i];
 }
 
 int SurgeSynthesizer::calculateChannelMask(int channel, int key)
@@ -335,7 +324,7 @@ SurgeVoice* SurgeSynthesizer::getUnusedVoice(int scene)
       if (!voices_usedby[scene][i])
       {
          voices_usedby[scene][i] = scene + 1;
-         return voices_array[scene][i];
+         return &voices_array[scene][i];
       }
    }
    return 0;
@@ -345,11 +334,11 @@ void SurgeSynthesizer::freeVoice(SurgeVoice* v)
 {
    for (int i = 0; i < MAX_VOICES; i++)
    {
-      if (voices_usedby[0][i] && (v == voices_array[0][i]))
+      if (voices_usedby[0][i] && (v == &voices_array[0][i]))
       {
          voices_usedby[0][i] = 0;
       }
-      if (voices_usedby[1][i] && (v == voices_array[1][i]))
+      if (voices_usedby[1][i] && (v == &voices_array[1][i]))
       {
          voices_usedby[1][i] = 0;
       }
@@ -481,7 +470,6 @@ void SurgeSynthesizer::releaseScene(int s)
    list<SurgeVoice*>::const_iterator iter;
    for (iter = voices[s].begin(); iter != voices[s].end(); iter++)
    {
-      (*iter)->~SurgeVoice();
       //_aligned_free(*iter);
       freeVoice(*iter);
    }
@@ -987,7 +975,6 @@ void SurgeSynthesizer::allNotesOff()
       list<SurgeVoice*>::const_iterator iter;
       for (iter = voices[s].begin(); iter != voices[s].end(); iter++)
       {
-         (*iter)->~SurgeVoice();
          //_aligned_free(*iter);
          freeVoice(*iter);
       }
@@ -995,9 +982,9 @@ void SurgeSynthesizer::allNotesOff()
    }
    holdbuffer[0].clear();
    holdbuffer[1].clear();
-   halfbandA->reset();
-   halfbandB->reset();
-   halfbandIN->reset();
+   halfbandA.reset();
+   halfbandB.reset();
+   halfbandIN.reset();
 
    hpA.suspend();
    hpB.suspend();
@@ -1308,7 +1295,7 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
       {
          fx_reload[s] = false;
 
-         delete fx[s];
+         fx[s].reset();
          /*if (!force_reload_all)*/ storage.getPatch().fx[s].type.val.i = fxsync[s].type.val.i;
          // else fxsync[s].type.val.i = storage.getPatch().fx[s].type.val.i;
 
@@ -1322,8 +1309,8 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
          if (/*!force_reload_all && */ storage.getPatch().fx[s].type.val.i)
             memcpy(&storage.getPatch().fx[s].p, &fxsync[s].p, sizeof(Parameter) * n_fx_params);
 
-         fx[s] = spawn_effect(storage.getPatch().fx[s].type.val.i, &storage,
-                              &storage.getPatch().fx[s], storage.getPatch().globaldata);
+         fx[s].reset(spawn_effect(storage.getPatch().fx[s].type.val.i, &storage,
+                              &storage.getPatch().fx[s], storage.getPatch().globaldata));
 
          if (fx[s])
          {
@@ -2221,7 +2208,7 @@ void SurgeSynthesizer::process()
       hardclip_block8(input[1], BLOCK_SIZE_QUAD);
       copy_block(input[0], storage.audio_in_nonOS[0], BLOCK_SIZE_QUAD);
       copy_block(input[1], storage.audio_in_nonOS[1], BLOCK_SIZE_QUAD);
-      halfbandIN->process_block_U2(input[0], input[1], storage.audio_in[0], storage.audio_in[1]);
+      halfbandIN.process_block_U2(input[0], input[1], storage.audio_in[0], storage.audio_in[1]);
    }
    else
    {
@@ -2307,7 +2294,6 @@ void SurgeSynthesizer::process()
 
          if (!resume)
          {
-            v->~SurgeVoice();
             //_aligned_free(v);
             freeVoice(v);
             iter = voices[s].erase(iter);
@@ -2361,14 +2347,14 @@ void SurgeSynthesizer::process()
    {
       hardclip_block8(sceneout[0][0], BLOCK_SIZE_OS_QUAD);
       hardclip_block8(sceneout[0][1], BLOCK_SIZE_OS_QUAD);
-      halfbandA->process_block_D2(sceneout[0][0], sceneout[0][1]);
+      halfbandA.process_block_D2(sceneout[0][0], sceneout[0][1]);
    }
 
    if (play_scene[1])
    {
       hardclip_block8(sceneout[1][0], BLOCK_SIZE_OS_QUAD);
       hardclip_block8(sceneout[1][1], BLOCK_SIZE_OS_QUAD);
-      halfbandB->process_block_D2(sceneout[1][0], sceneout[1][1]);
+      halfbandB.process_block_D2(sceneout[1][0], sceneout[1][1]);
    }
 
    hpA.coeff_HP(

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -61,8 +61,8 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
    {
       voices_usedby[0][i] = 0;
       voices_usedby[1][i] = 0;
-      voices_array[0][i] = (SurgeVoice*)_aligned_malloc(sizeof(SurgeVoice), 16);
-      voices_array[1][i] = (SurgeVoice*)_aligned_malloc(sizeof(SurgeVoice), 16);
+      voices_array[0][i] = new SurgeVoice();
+      voices_array[1][i] = new SurgeVoice();
    }
 
    FBQ[0] =
@@ -162,8 +162,8 @@ SurgeSynthesizer::~SurgeSynthesizer()
 
    for (int i = 0; i < MAX_VOICES; i++)
    {
-      _aligned_free(voices_array[0][i]);
-      _aligned_free(voices_array[1][i]);
+      delete voices_array[0][i];
+      delete voices_array[1][i];
    }
 
    for (int sc = 0; sc < 2; sc++)

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -104,7 +104,7 @@ public:
 
    SurgeVoice* getUnusedVoice(int scene);
    void freeVoice(SurgeVoice*);
-   SurgeVoice* voices_array[2][MAX_VOICES];
+   std::array<std::array<SurgeVoice, MAX_VOICES>, 2> voices_array;
    unsigned int voices_usedby[2][MAX_VOICES]; // 0 indicates no user, 1 is scene A & 2 is scene B
 
    bool
@@ -167,9 +167,9 @@ public:
 public:
    int CC0, PCH, patchid;
    float masterfade = 0;
-   HalfRateFilter *halfbandA, *halfbandB, *halfbandIN;
+   HalfRateFilter halfbandA, halfbandB, halfbandIN;
    std::list<SurgeVoice*> voices[2];
-   Effect* fx[8];
+   std::unique_ptr<Effect> fx[8];
    bool halt_engine = false;
    MidiChannelState channelState[16];
    bool mpeEnabled = false;

--- a/src/common/dsp/AdsrEnvelope.h
+++ b/src/common/dsp/AdsrEnvelope.h
@@ -27,7 +27,11 @@ const float db60 = powf(10.f, 0.05f * -60.f);
 class AdsrEnvelope : public ModulationSource
 {
 public:
-   AdsrEnvelope(SurgeStorage* storage, ADSRStorage* adsr, pdata* localcopy, SurgeVoiceState* state)
+   AdsrEnvelope()
+   {
+   }
+
+   void init(SurgeStorage* storage, ADSRStorage* adsr, pdata* localcopy, SurgeVoiceState* state)
    {
       this->storage = storage;
       this->adsr = adsr;
@@ -56,13 +60,13 @@ public:
       _discharge = 0.f;
    }
 
-   virtual void retrigger()
+   void retrigger()
    {
       if (envstate < s_release)
          attack();
    }
 
-   virtual void attack()
+   void attack()
    {
       phase = 0;
       output = 0;
@@ -95,7 +99,7 @@ public:
       return false;
    }
 
-   virtual void release()
+   void release()
    {
       /*if(envstate == s_attack)
       {
@@ -303,18 +307,18 @@ public:
    }
 
 private:
-   ADSRStorage* adsr;
-   SurgeVoiceState* state;
-   SurgeStorage* storage;
-   float phase;
-   float sustain;
-   float scalestage;
-   int idlecount;
-   int envstate;
-   pdata* lc;
-   int a, d, s, r, a_s, d_s, r_s, mode;
+   ADSRStorage* adsr = nullptr;
+   SurgeVoiceState* state = nullptr;
+   SurgeStorage* storage = nullptr;
+   float phase = 0.f;
+   float sustain = 0.f;
+   float scalestage = 0.f;
+   int idlecount = 0;
+   int envstate = 0;
+   pdata* lc = nullptr;
+   int a = 0, d = 0, s = 0, r = 0, a_s = 0, d_s = 0, r_s = 0, mode = 0;
 
-   float _v_c1;
-   float _v_c1_delayed;
-   float _discharge;
+   float _v_c1 = 0.f;
+   float _v_c1_delayed = 0.f;
+   float _discharge = 0.f;
 };

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -39,6 +39,10 @@ float SurgeVoiceState::getPitch()
           detune;
 }
 
+SurgeVoice::SurgeVoice()
+{
+}
+
 SurgeVoice::SurgeVoice(SurgeStorage* storage,
                        SurgeSceneStorage* oscene,
                        pdata* params,

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -98,7 +98,6 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    for (int i = 0; i < n_oscs; i++)
    {
       osctype[i] = -1;
-      osc[i] = 0;
    }
    memset(&FBP, 0, sizeof(FBP));
 
@@ -116,28 +115,28 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    pitch_id = scene->pitch.param_id_in_scene;
    octave_id = scene->octave.param_id_in_scene;
 
-   modsources.resize(n_modsources);
    for (int i = 0; i < 6; i++)
    {
       lfo[i].assign(storage, &scene->lfo[i], localcopy, &state,
                     &storage->getPatch().stepsequences[state.scene_id][i]);
       modsources[ms_lfo1 + i] = &lfo[i];
    }
-   modsources[ms_velocity] = new ModulationSource();
-   modsources[ms_keytrack] = new ModulationSource();
-   modsources[ms_polyaftertouch] = new ControllerModulationSource();
-   ((ControllerModulationSource*)modsources[ms_polyaftertouch])
-       ->init(storage->poly_aftertouch[state.scene_id & 1][state.key & 127]);
-   modsources[ms_velocity]->output = state.fvel;
-   modsources[ms_keytrack]->output = 0;
-   modsources[ms_ampeg] = new AdsrEnvelope(storage, &scene->adsr[0], localcopy, &state);
-   modsources[ms_filtereg] = new AdsrEnvelope(storage, &scene->adsr[1], localcopy, &state);
+   modsources[ms_velocity] = &velocitySource;
+   modsources[ms_keytrack] = &keytrackSource;
+   modsources[ms_polyaftertouch] = &polyAftertouchSource;
+   polyAftertouchSource.init(storage->poly_aftertouch[state.scene_id & 1][state.key & 127]);
+   velocitySource.output = state.fvel;
+   keytrackSource.output = 0;
+   ampEGSource.init(storage, &scene->adsr[0], localcopy, &state);
+   filterEGSource.init(storage, &scene->adsr[1], localcopy, &state);
+   modsources[ms_ampeg] = &ampEGSource;
+   modsources[ms_filtereg] = &filterEGSource;
 
    modsources[ms_modwheel] = oscene->modsources[ms_modwheel];
-   modsources[ms_aftertouch] = new ModulationSource();
-   modsources[ms_aftertouch]->output = state.voiceChannelState->pressure;
-   modsources[ms_timbre] = new ModulationSource();
-   modsources[ms_timbre]->output = state.voiceChannelState->timbre;
+   modsources[ms_aftertouch] = &monoAftertouchSource;
+   monoAftertouchSource.output = state.voiceChannelState->pressure;
+   modsources[ms_timbre] = &timbreSource;
+   timbreSource.output = state.voiceChannelState->timbre;
    modsources[ms_pitchbend] = oscene->modsources[ms_pitchbend];
    for (int i = 0; i < n_customcontrollers; i++)
       modsources[ms_ctrl1 + i] = oscene->modsources[ms_ctrl1 + i];
@@ -163,8 +162,8 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    id_feedback = scene->feedback.param_id_in_scene;
 
    switch_toggled();
-   modsources[ms_ampeg]->attack();
-   modsources[ms_filtereg]->attack();
+   ampEGSource.attack();
+   filterEGSource.attack();
 
    calc_ctrldata<true>(0, 0); // init interpolators
 
@@ -176,16 +175,6 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
 
 SurgeVoice::~SurgeVoice()
 {
-   for (int i = 0; i < n_oscs; i++)
-      delete osc[i];
-   // for(int i=0; i<6; i++) delete lfo[i];
-   delete modsources[ms_velocity];
-   delete modsources[ms_keytrack];
-   delete modsources[ms_polyaftertouch];
-   delete modsources[ms_ampeg];
-   delete modsources[ms_filtereg];
-   delete modsources[ms_aftertouch];
-   delete modsources[ms_timbre];
 }
 
 void SurgeVoice::legato(int key, int velocity, char detune)
@@ -223,8 +212,7 @@ void SurgeVoice::switch_toggled()
    {
       if (osctype[i] != scene->osc[i].type.val.i)
       {
-         delete osc[i];
-         osc[i] = spawn_osc(scene->osc[i].type.val.i, storage, &scene->osc[i], localcopy);
+         osc[i].reset(spawn_osc(scene->osc[i].type.val.i, storage, &scene->osc[i], localcopy));
          if (osc[i])
             osc[i]->init(state.pitch);
          osctype[i] = scene->osc[i].type.val.i;
@@ -304,8 +292,8 @@ void SurgeVoice::switch_toggled()
 
 void SurgeVoice::release()
 {
-   modsources[ms_ampeg]->release();
-   modsources[ms_filtereg]->release();
+   ampEGSource.release();
+   filterEGSource.release();
 
    for (int i = 0; i < 6; i++)
       lfo[i].release();
@@ -315,7 +303,7 @@ void SurgeVoice::release()
 
 void SurgeVoice::uber_release()
 {
-   ((AdsrEnvelope*)modsources[ms_ampeg])->uber_release();
+   ampEGSource.uber_release();
    state.gate = false;
    state.uberrelease = true;
 }

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -13,7 +13,7 @@
 
 struct QuadFilterChainState;
 
-class SurgeVoice
+class alignas(16) SurgeVoice
 {
 public:
    float output alignas(16)[2][BLOCK_SIZE_OS];
@@ -22,6 +22,7 @@ public:
    float fmbuffer alignas(16)[BLOCK_SIZE_OS];
    // used for the 2>1<3 FM-mode (Needs the pointer earlier)
 
+   SurgeVoice();
    SurgeVoice(SurgeStorage* storage,
               SurgeSceneStorage* scene,
               pdata* params,

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -10,6 +10,7 @@
 #include <vt_dsp/lipol.h>
 #include "FilterCoefficientMaker.h"
 #include "QuadFilterChain.h"
+#include <array>
 
 struct QuadFilterChainState;
 
@@ -83,8 +84,19 @@ private:
    bool osc1, osc2, osc3, ring12, ring23, noise;
    int FMmode;
    float noisegenL[2], noisegenR[2];
-   Oscillator* osc[3];
-   std::vector<ModulationSource*> modsources;
+
+   std::unique_ptr<Oscillator> osc[3];
+
+   std::array<ModulationSource*, n_modsources> modsources;
+
+   ModulationSource velocitySource;
+   ModulationSource keytrackSource;
+   ControllerModulationSource polyAftertouchSource;
+   ModulationSource monoAftertouchSource;
+   ModulationSource timbreSource;
+   AdsrEnvelope ampEGSource;
+   AdsrEnvelope filterEGSource;
+
    // filterblock stuff
    int id_cfa, id_cfb, id_kta, id_ktb, id_emoda, id_emodb, id_resoa, id_resob, id_drive, id_vca,
        id_vcavel, id_fbalance, id_feedback;


### PR DESCRIPTION
By using alignas() and adding an empty default constructor, we can
preallocate SurgeVoice instances in the same way we would allocate them
with _aligned_malloc().

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>