### PR TITLE
Implement .wt drag-n-drop

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1206,7 +1206,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
    queue_refresh = false;
    frame->setDirty();
    frame->invalid();
-   // frame->setDropActive(true); // TODO VSTGUI4
 }
 
 void SurgeGUIEditor::close_editor()


### PR DESCRIPTION
Update the drag-n-drop API to be VST4 compatible for a single
file dropped on the Oscillator.

Support drag and drop of .wt files properly

Support error messages for non .wt files and non file drops.