### PR TITLE
Smart bitmap selection on Zoom

### DIFF
--- a/src/common/gui/.#SurgeGUIEditor.cpp
+++ b/src/common/gui/.#SurgeGUIEditor.cpp
@@ -1,1 +1,0 @@
-paul@PWLaptop.local.404

--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -3,6 +3,13 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
+// Remember this is user zoom * display zoom. See comment in CScalableBitmap.h
+int  CScalableBitmap::currentPhysicalZoomFactor = 100;
+void CScalableBitmap::setPhysicalZoomFactor(int zoomFactor)
+{
+    currentPhysicalZoomFactor = zoomFactor;
+}
+
 CScalableBitmap::CScalableBitmap(CResourceDescription desc) : CBitmap(desc)
 {
     int id = 0;
@@ -10,16 +17,17 @@ CScalableBitmap::CScalableBitmap(CResourceDescription desc) : CBitmap(desc)
         id = (int32_t)desc.u.id;
 
     /*
-    ** At this stage this scales array may seem like overkill since it only has two
-    ** values. But to impelemnt scalability we will end up with multiple sizes, including
-    ** 1.5x maybe 1.25x and so on. So build the architecture now to support that even
-    ** though we only populate with two types. And since our sizes will include a 1.25x
-    ** hash on integer percentages (so 100 -> 1x), not on floats.
+    ** Remember, Scales are the percentage scale in units of percents. So 100 is 1x.
+    ** This integerification allows us to hash on the scale values and still support
+    ** things like a 1.25 bitmap set.
     */
-
-    scales = {{ 100, 200 }};
+    
+    scales = {{ 100, 150, 200, 300, 400 }}; // This is the collection of sizes we currently ask skins to export.
     scaleFilePostfixes[ 100 ] = "";
+    scaleFilePostfixes[ 150 ] = "@15x";
     scaleFilePostfixes[ 200 ] = "@2x";
+    scaleFilePostfixes[ 300 ] = "@3x";
+    scaleFilePostfixes[ 400 ] = "@4x";
 
     for(auto sc : scales)
     {
@@ -40,17 +48,35 @@ CScalableBitmap::CScalableBitmap(CResourceDescription desc) : CBitmap(desc)
         }
         
     }
+    lastSeenZoom = currentPhysicalZoomFactor;
 }
+
 
 void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoint& offset, float alpha )
 {
-    /*
-    ** For now this is a fixed 'retina' style draw of using 2x bitmaps at 0.5 scale if they exist
-    */
-    if (scaledBitmaps[ 200 ] != NULL)
+    if (lastSeenZoom != currentPhysicalZoomFactor)
     {
-        CGraphicsTransform tf = CGraphicsTransform().scale( 0.5, 0.5 );
-        CGraphicsTransform invtf = tf.inverse();
+        int ns = -1;
+        for (auto s : scales)
+        {
+            if (s >= currentPhysicalZoomFactor && ns < 0)
+                ns = s;
+        }
+        if (ns<0)
+        {
+            ns = scales.back();
+        }
+        bestFitScaleGroup = ns;
+        lastSeenZoom = currentPhysicalZoomFactor;
+    }
+
+    // Check if my bitmaps are there and if so use them
+    if (scaledBitmaps[ bestFitScaleGroup ] != NULL)
+    {
+        // Seems like you would do this backwards; but the TF shrinks and the invtf regrows for positioning
+        // but it is easier to calculate the grow one since it is at our scale
+        CGraphicsTransform invtf = CGraphicsTransform().scale( bestFitScaleGroup / 100.0, bestFitScaleGroup / 100.0 );
+        CGraphicsTransform tf = invtf.inverse();
         
         CDrawContext::Transform tr(*context, tf);
 
@@ -61,10 +87,12 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
         CPoint ncoff = offset;
         CPoint no = invtf.transform(ncoff);
         
-        scaledBitmaps[ 200 ]->draw(context, nr, no, alpha);
+        scaledBitmaps[ bestFitScaleGroup ]->draw(context, nr, no, alpha);
     }
     else
     {
+        // and if not, fall back to the default bitmap
         CBitmap::draw(context, rect, offset, alpha);
     }
 }
+

--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -13,9 +13,26 @@ class CScalableBitmap : public VSTGUI::CBitmap
 public:
     CScalableBitmap( CResourceDescription d );
 
+    virtual void draw (CDrawContext* context, const CRect& rect, const CPoint& offset, float alpha);
+
+    /*
+    ** The 'zoom factor' is set statically across all bitmaps since it is a
+    ** function of the current editor which contains them.
+    **
+    ** If in the future we have a non 1:1 editor -> instance relationship we
+    ** may need to reconsider the management of this factor.
+    **
+    ** This zoom factor is the product of the logical (user) zoom factor
+    ** and any zoom the display may apply, which is checked in SurgeGUIEditor::getDisplayBackingScale
+    ** and applied *before* this call. See SurgeGUIEditor::setZoomFactor.
+    */
+    static void setPhysicalZoomFactor (int zoomFactor); // See comment on zoom factor units in SurgeGUIEditor.h
+
+private:
     std::vector< int > scales;  // 100, 150, 200, 300 etc... - int percentages
     std::map< int, VSTGUI::CBitmap * > scaledBitmaps;
     std::map< int, std::string > scaleFilePostfixes;
+    int lastSeenZoom, bestFitScaleGroup;
 
-    virtual void draw (CDrawContext* context, const CRect& rect, const CPoint& offset, float alpha);
+    static int currentPhysicalZoomFactor;
 };

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -93,14 +93,35 @@ private:
 
 
    void showSettingsMenu(CRect &menuRect);
+
+   /*
+   ** Zoom Implementation 
+   ** 
+   ** Zoom works by the system maintaining a zoom factor (created by user actions)
+   **
+   ** All zoom factors are set in units of percentages as ints. So no zoom is "100",
+   ** and double size is "200"
+   */
    
-   void zoomInDir( int dir );
    int zoomFactor;
  public:
-   void setZoomCallback( std::function< void(SurgeGUIEditor *) > f ) { zoom_callback = f; }
-   int getZoomFactor() { return zoomFactor; }
-    void setZoomFactor( int zf ) { zoomFactor = zf; zoom_callback( this ); }
- private:
+   void setZoomCallback(std::function< void(SurgeGUIEditor *) > f) {
+       zoom_callback = f;
+       setZoomFactor(getZoomFactor()); // notify the new callback
+   }
+   int  getZoomFactor() { return zoomFactor; }
+   void setZoomFactor(int zf);
+
+   /* 
+   ** Display backing scale is very OS dependent, so is implemented in src/(mac|win|linux)/(Mac|Win|Linux)SurgeGuiEditor.(cpp|mm) and so on
+   ** 'BackignScale' is the term for the difference between a logical and physical pixel. So on a mac retina display it woudl be '2.0'
+   ** then scaled up to an integer to be '200'.
+   ** 
+   ** As of the current state, this is just a function which returns '200' and the above implementation is not yet in place.
+   */
+   int getDisplayBackingScale();
+
+private:
    std::function< void(SurgeGUIEditor *) > zoom_callback;
    
    SurgeBitmaps bitmap_keeper;
@@ -131,3 +152,7 @@ private:
    void* _effect = nullptr;
    CVSTGUITimer* _idleTimer = nullptr;
 };
+
+#if TARGET_AUDIOUNIT && MAC
+#define SUPPORTS_ZOOM 1
+#endif


### PR DESCRIPTION
This change basically redoes zoom in the AU host to be way better in
two key ways

1: Moves it to a menu with more options than a simple +/-
2: Makes CScalableBitmap chose the best size bitmap for our display
setting

This is one diff on the path to zoom. Things like windows, non au hosts,
and detection of actualy screen resolution are still undone here. But
it is one I would like to sweep.

All these features remain off unless you consciously build mac with
vector assets.