### PR TITLE
Use the original-vector assets by default

### DIFF
--- a/scripts/macOS/package-au.sh
+++ b/scripts/macOS/package-au.sh
@@ -1,5 +1,10 @@
 #!/bin/bash          
 
+# If no vectors are specified, use the original-vector by default
+if [[ -z "$SURGE_USE_VECTOR_SKIN" ]]; then
+    SURGE_USE_VECTOR_SKIN=original-vector
+fi
+
 # input config
 RES_SRC_LOCATION="resources"
 PACKAGE_SRC_LOCATION="$RES_SRC_LOCATION/osx-au"

--- a/scripts/macOS/package-vst.sh
+++ b/scripts/macOS/package-vst.sh
@@ -1,5 +1,10 @@
 #!/bin/bash          
 
+# If no vectors are specified, use the original-vector by default
+if [[ -z "$SURGE_USE_VECTOR_SKIN" ]]; then
+    SURGE_USE_VECTOR_SKIN=original-vector
+fi
+
 # input config
 RES_SRC_LOCATION="resources"
 PACKAGE_SRC_LOCATION="$RES_SRC_LOCATION/osx-vst2"

--- a/scripts/macOS/package-vst3.sh
+++ b/scripts/macOS/package-vst3.sh
@@ -1,5 +1,10 @@
 #!/bin/bash          
 
+# If no vectors are specified, use the original-vector by default
+if [[ -z "$SURGE_USE_VECTOR_SKIN" ]]; then
+    SURGE_USE_VECTOR_SKIN=original-vector
+fi
+
 # input config
 RES_SRC_LOCATION="resources"
 PACKAGE_SRC_LOCATION="$RES_SRC_LOCATION/osx-vst3"


### PR DESCRIPTION
@baconpaul explicitly asked @kurasu and he was happy with this
macintosh default switch.