### PR TITLE
Implement zoom for VST2 Mac and Windows

### DIFF
--- a/build-osx.sh
+++ b/build-osx.sh
@@ -36,6 +36,7 @@ Commands are:
         --install-local          Once assets are built, install them locally
         --build-and-install      Build and install the assets
         --build-validate-au      Build and install the audio unit then validate it
+        --build-install-vst2     Build and install only the VST2
 
         --package                Creates a .pkg file from current built state in products
         --clean-and-package      Cleans everything; runs all the builds; makes an installer; drops it in products
@@ -199,6 +200,15 @@ run_build_validate_au()
     auval -vt aumu VmbA
 }
 
+run_build_install_vst2()
+{
+    run_premake_if
+    run_build "vst2"
+
+    rsync -r "resources/data/" "$HOME/Library/Application Support/Surge/"
+    rsync -r --delete "products/Surge.vst/" ~/Library/Audio/Plug-Ins/VST/Surge.vst/
+}
+
 run_clean_builds()
 {
     if [ ! -d "Surge.xcworkspace" ]; then
@@ -288,6 +298,9 @@ case $command in
         ;;
     --build-validate-au)
         run_build_validate_au
+        ;;
+    --build-install-vst2)
+        run_build_install_vst2
         ;;
     --clean)
         run_clean_builds

--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -49,6 +49,7 @@ CScalableBitmap::CScalableBitmap(CResourceDescription desc) : CBitmap(desc)
         
     }
     lastSeenZoom = currentPhysicalZoomFactor;
+    additionalZoom = 100;
 }
 
 
@@ -76,7 +77,7 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
         // Seems like you would do this backwards; but the TF shrinks and the invtf regrows for positioning
         // but it is easier to calculate the grow one since it is at our scale
         CGraphicsTransform invtf = CGraphicsTransform().scale( bestFitScaleGroup / 100.0, bestFitScaleGroup / 100.0 );
-        CGraphicsTransform tf = invtf.inverse();
+        CGraphicsTransform tf = invtf.inverse().scale( additionalZoom / 100.0, additionalZoom / 100.0 );
         
         CDrawContext::Transform tr(*context, tf);
 
@@ -91,7 +92,9 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
     }
     else
     {
-        // and if not, fall back to the default bitmap
+        // and if not, fall back to the default bitmap but still apply the additional zoom
+        CGraphicsTransform tf = CGraphicsTransform().scale( additionalZoom / 100.0, additionalZoom / 100.0 );
+        CDrawContext::Transform tr(*context, tf);
         CBitmap::draw(context, rect, offset, alpha);
     }
 }

--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -28,11 +28,19 @@ public:
     */
     static void setPhysicalZoomFactor (int zoomFactor); // See comment on zoom factor units in SurgeGUIEditor.h
 
+    /*
+    ** VST2 has an error where the background doesn't zoom with the frame. Everything else
+    ** does though. So we need to hand scale the background and only the background image
+    ** when we draw it. We do that, simply, by having this class have an additionalZoom
+    ** which we apply to the BG Bitmap in Vst2PluginInstance::handleZoom.
+    */
+    void setAdditionalZoom (int a) { additionalZoom = a; }
+    
 private:
     std::vector< int > scales;  // 100, 150, 200, 300 etc... - int percentages
     std::map< int, VSTGUI::CBitmap * > scaledBitmaps;
     std::map< int, std::string > scaleFilePostfixes;
-    int lastSeenZoom, bestFitScaleGroup;
+    int lastSeenZoom, bestFitScaleGroup, additionalZoom;
 
     static int currentPhysicalZoomFactor;
 };

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -1,7 +1,8 @@
 #include "SurgeBitmaps.h"
+#include "UserInteractions.h"
 #include <map>
 
-#if MAC  
+#if MAC  || WINDOWS
 #define USE_SCALABLE_BITMAPS 1
 #endif
 
@@ -89,7 +90,34 @@ void SurgeBitmaps::addEntry(int id)
    bitmap_registry[id] = bitmap;
 }
 
-VSTGUI::CBitmap* getSurgeBitmap(int id)
+VSTGUI::CBitmap* getSurgeBitmap(int id, bool newInstance)
 {
-   return bitmap_registry.at(id);
+   if( newInstance )
+   {
+#ifdef USE_SCALABLE_BITMAPS
+      /*
+      ** Background images are specially handled by the frame object with scaling and so each needs
+      ** to maintain an independent 'additional zoom'. For now handle that by allowing the construction of
+      ** a distinct bitmap. 
+      **
+      ** When the arity issues with scalable bitmaps get solved (github issue #356) this code will 
+      ** not be needed any more. Until then it is, but just for the BG image.
+      */
+      if( id != IDB_BG )
+      {
+          // This should never happen.
+          Surge::UserInteractions::promptError(std::string() +
+                                               "You requested a new Instance bitmap with for something other than the BG. Why?",
+                                               "Software Error" );
+      }
+      return new CScalableBitmap(CResourceDescription(id));
+#else
+      return bitmap_registry.at(id);
+#endif
+       
+   }
+   else
+   {
+       return bitmap_registry.at(id);
+   }
 }

--- a/src/common/gui/SurgeBitmaps.h
+++ b/src/common/gui/SurgeBitmaps.h
@@ -13,4 +13,4 @@ protected:
    void addEntry(int id);
 };
 
-VSTGUI::CBitmap* getSurgeBitmap(int id);
+VSTGUI::CBitmap* getSurgeBitmap(int id, bool newInstance = false);

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1220,7 +1220,13 @@ bool PLUGIN_API SurgeGUIEditor::open(void* parent, const PlatformType& platformT
 
    CRect wsize(0, 0, WINDOW_SIZE_X, WINDOW_SIZE_Y);
    frame = new CFrame(wsize, this);
-   frame->setBackground(getSurgeBitmap(IDB_BG));
+
+   bool myOwnBg = false;
+#if TARGET_VST2
+   myOwnBg = true;
+#endif
+   
+   frame->setBackground(getSurgeBitmap(IDB_BG, myOwnBg));
    frame->open(parent, platformType);
    /*#if TARGET_AUDIOUNIT
            synth = (sub3_synth*)_effect;
@@ -1330,10 +1336,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
       {
          CRect r = control->getViewSize();
          CRect menuRect;
-         CPoint where;
-         frame->getCurrentMouseLocation(where);
+
+         CPoint where = getCorrectlyScaledMouseLocation();
          int a = limit_range((int)((3 * (where.x - r.left)) / r.getWidth()), 0, 2);
-         frame->localToFrame(where);
          menuRect.offset(where.x, where.y);
 
          COptionMenu* contextMenu = new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle);
@@ -1384,11 +1389,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
       {
          CRect r = control->getViewSize();
          CRect menuRect;
-         CPoint where;
-         frame->getCurrentMouseLocation(where);
+         CPoint where = getCorrectlyScaledMouseLocation();
+         
          int a = limit_range((int)((2 * (where.x - r.left)) / r.getWidth()), 0, 2);
-         frame->localToFrame(where);
          menuRect.offset(where.x, where.y);
+
          COptionMenu* contextMenu = new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle);
          int eid = 0;
          int id_copy = -1, id_paste = -1;
@@ -1433,9 +1438,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
       if (button & kRButton)
       {
          CRect menuRect;
-         CPoint where;
-         frame->getCurrentMouseLocation(where);
-         frame->localToFrame(where);
+         CPoint where = getCorrectlyScaledMouseLocation();
+         
          menuRect.offset(where.x, where.y);
          COptionMenu* contextMenu =
              new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle | kMultipleCheckStyle);
@@ -1713,10 +1717,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
       if ((button & kRButton) && (p->valtype == vt_float))
       {
          CRect menuRect;
-         CPoint where;
-         frame->getCurrentMouseLocation(where);
+         CPoint where = getCorrectlyScaledMouseLocation();
+
          menuRect.offset(where.x, where.y);
-         frame->localToFrame(where);
+
          COptionMenu* contextMenu =
              new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle | kMultipleCheckStyle);
          int eid = 0;
@@ -2027,9 +2031,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
    {
       CRect r = control->getViewSize();
       CRect menuRect;
-      CPoint where;
-      frame->getCurrentMouseLocation(where);
-      frame->localToFrame(where);
+      CPoint where = getCorrectlyScaledMouseLocation();;
       menuRect.offset(where.x, where.y);
 
       showSettingsMenu(menuRect);
@@ -2407,6 +2409,13 @@ long SurgeGUIEditor::applyParameterOffset(long id)
 void SurgeGUIEditor::setZoomFactor(int zf)
 {
 #if HOST_SUPPORTS_ZOOM    
+
+#if TARGET_VST2 || TARGET_VST3
+   // vstgui zoom is very unreliable shrinking with backgrounds.
+   if( zf < 100 )
+       zf = 100;
+#endif
+
    CRect screenDim = Surge::GUI::getScreenDimensions(getFrame());
    ERect *baseUISize;
    getRect (&baseUISize);
@@ -2414,10 +2423,10 @@ void SurgeGUIEditor::setZoomFactor(int zf)
    float baseW = (baseUISize->right - baseUISize->left);
    float baseH = (baseUISize->top - baseUISize->bottom);
 
-   // Leave enough room for window decoration with that .95
+   // Leave enough room for window decoration with that .9. (You can probably do .95 on mac)
    if (zf != 100.0 && (
-           (baseW * zf / 100.0) > 0.95 * screenDim.getWidth() ||
-           (baseH * zf / 100.0) > 0.95 * screenDim.getHeight()
+           (baseW * zf / 100.0) > 0.9 * screenDim.getWidth() ||
+           (baseH * zf / 100.0) > 0.9 * screenDim.getHeight()
            )
        )
    {
@@ -2440,6 +2449,7 @@ void SurgeGUIEditor::setZoomFactor(int zf)
    float dbs = Surge::GUI::getDisplayBackingScaleFactor(getFrame());
    int fullPhysicalZoomFactor = (int)(zf * dbs);
    CScalableBitmap::setPhysicalZoomFactor(fullPhysicalZoomFactor);
+
 #else
    /*
    ** I don't support zoom, but lets at least keep my internal state consistent in case this gets called
@@ -2522,6 +2532,31 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
         Surge::UserInteractions::openURL("https://surge-synthesizer.github.io/surge-manual/");
     }
 
+}
+
+CPoint SurgeGUIEditor::getCorrectlyScaledMouseLocation()
+{
+    /*
+    ** Please see github issue 356 for discussion on this.
+    **
+    ** vstgui has several bugs around zoom handling. A particular one is the fuction frame->getCurrentMouseLocation() applies the transform incorrectly.
+    ** Rather than applying it forward and backwards, it applies it forward twice. This means using it to pop menus when you are scaled does exactly the wrong thing.
+    ** 
+    ** Our zoom on AU uses a different path, so doesn't need remediating. So we need to conditionally inject code until this bug is fixed and
+    ** make it clear where that is injected. This macro - USE_VST2_MOUSE_LOCATION_FIX(rectname) does that.
+    */
+
+    CPoint where;
+    frame->getCurrentMouseLocation(where);
+    where = frame->localToFrame(where);
+
+#if TARGET_VST2 && HOST_SUPPORTS_ZOOM
+    CGraphicsTransform vstfix = frame->getTransform().inverse();
+    vstfix.transform(where);
+    vstfix.transform(where);
+#endif
+    
+    return where;
 }
 
 //------------------------------------------------------------------------------------------------

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -73,6 +73,8 @@ protected:
 
    void refresh_mod();
 
+   CPoint getCorrectlyScaledMouseLocation();
+
 private:
    void openOrRecreateEditor();
    void close_editor();
@@ -144,6 +146,6 @@ private:
    CVSTGUITimer* _idleTimer = nullptr;
 };
 
-#if TARGET_AUDIOUNIT && MAC
+#if ( MAC && ( TARGET_AUDIOUNIT || TARGET_VST2 )  ) || (WINDOWS && TARGET_VST2 )
 #define HOST_SUPPORTS_ZOOM 1
 #endif

--- a/src/vst2/Vst2PluginInstance.h
+++ b/src/vst2/Vst2PluginInstance.h
@@ -7,6 +7,8 @@
 #include "SurgeSynthesizer.h"
 #include <util/FpuState.h>
 
+class SurgeGUIEditor;
+
 //-------------------------------------------------------------------------------------------------------
 class Vst2PluginInstance : public AudioEffectX
 {
@@ -87,6 +89,8 @@ protected:
    int oldblokkosize;
    int blockpos;
 
+   void handleZoom(SurgeGUIEditor *e);
+   
 public:
    enum State {
       UNINITIALIZED  = 0,

--- a/src/windows/DisplayInfoWin.cpp
+++ b/src/windows/DisplayInfoWin.cpp
@@ -1,24 +1,43 @@
 #include "DisplayInfo.h"
 #include "UserInteractions.h"
 
+#include "wtypes.h"
+#include "vstgui/lib/platform/win32/win32frame.h" // actually 64 bit too!
+
 namespace Surge
 {
 namespace GUI
 {
 
-float getDisplayBackingScaleFactor(CFrame *)
+float getDisplayBackingScaleFactor(CFrame *f)
 {
-    Surge::UserInteractions::promptError("getDisplayBackingScaleFactor not implemented yet on windows.",
-                                         "Software Error");
+    /*
+    ** This API isn't needed until windows supports the scalable bitmaps
+    ** so rough it out but don't include it yet
+    */
+#if 0
+    VSTGUI::Win32Frame *wf = dynamic_cast<VSTGUI::Win32Frame *>(f);
+
+    if (wf && wf->getHWND() )
+    {
+        HMONITOR hMon = MonitorFromWindow(wf->getHWND(), MONITOR_DEFAULTTONEAREST);
+        DEVICE_SCALE_FACTOR pScale; // https://docs.microsoft.com/en-us/windows/desktop/api/shtypes/ne-shtypes-device_scale_factor
+        GetScaleFactorForMonitor(hMon,&pScale);
+        // At this point we would convert this painfully to a float with a big switch. But until
+        // we implement scalable bitmaps it doesn't matter, so:
+        return 1.0;
+    }
+#endif
+
     return 1.0;
 }
     
 CRect getScreenDimensions(CFrame *)
 {
-    Surge::UserInteractions::promptError("getScreenDimensions not implemented yet on windows.",
-                                         "Software Error");
-    
-    return CRect(CPoint(0,0),CPoint(1024,768));;
+    RECT desktop;
+    const HWND hDesktop = GetDesktopWindow();
+    GetWindowRect(hDesktop, &desktop);
+    return CRect(CPoint(0,0), CPoint(desktop.right,desktop.bottom));
 }
 
 }


### PR DESCRIPTION
This diff implements zoom for VST2 Mac and Windows using the
VSTGUI scale APIs in conjunction with the existing ability
of surge to register a zoom callback.

This would have been a relatively prosaic change were it not for
two bugs in VSTGUI

1: When you setzoom on a frame, it does not setzoom on the frame->getBackground
and so we need to explicitly resize the background image in VST2 as we zoom.
See the instance issues and additional scale in CScalableBitmap and SurgeBitmaps

2: the frame->getCurrentMouseLocation method is mistakenly scaled up twice
(as opposed to, one supposes, scaling up and down). So we need to, for vst2,
scale down twice.

This is all discussed in github issue #356.

With these diffs, though, both mac and windows vst2 plugins support
zoom (even though, ad this time, windows is using original not vector
bitmaps).

My testing strategy was

1. Hosting AU and Logic on Mac
2. Bitwig on mac VST2/3
3. Bitwig on windows VST2/3
4. VST3 linux links 

@jsakkine or @kurasu or @kzantow I would love a review if you have time.