### PR TITLE
Pipefail in ./build-unixen

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -107,6 +107,8 @@ run_build()
 
     echo
     echo Building surge-${flavor} with output in build_logs/build_${flavor}.log
+    # Since these are piped we lose status from the tee and get wrong return code so
+    set -o pipefail
     if [[ -z "$OPTION_verbose" ]]; then
         make config=release_x64 2>&1 | tee build_logs/build_${flavor}.log
     else
@@ -114,6 +116,7 @@ run_build()
     fi
 
     build_suc=$?
+    set +o pipefail
     if [[ $build_suc = 0 ]]; then
         echo ${GREEN}Build of surge-${flavor} succeeded${NC}
     else
@@ -121,6 +124,7 @@ run_build()
         echo ${RED}** Build of ${flavor} failed**${NC}
         grep -i error build_logs/build_${flavor}.log
         echo
+        echo ${RED}** Exiting failed ${flavor} build**${NC}
         echo Complete information is in build_logs/build_${flavor}.log
 
         exit 2

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -130,6 +130,9 @@ run_build()
 
     echo
     echo Building surge-${flavor} with output in build_logs/build_${flavor}.log
+
+    # Don't let TEE eat my return status
+    set -o pipefail
     if [[ -z "$OPTION_verbose" ]]; then
     	xcodebuild build -configuration Release -project surge-${flavor}.xcodeproj > build_logs/build_${flavor}.log
     else
@@ -137,6 +140,8 @@ run_build()
     fi
 
     build_suc=$?
+    set +o pipefail
+
     if [[ $build_suc = 0 ]]; then
         echo ${GREEN}Build of surge-${flavor} succeeded${NC}
     else


### PR DESCRIPTION
Both ./build-osx and ./build-linux when teeing output
supressed the return code of build. In osx this was only
in verbose mode; in linux it was in both. This meant a failed
build in these settings returned success

Since these are bash scripts, fix it with set pipefail