### PR TITLE
Documents Patches with SubFolders

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -448,6 +448,8 @@ struct PatchCategory
 {
    string name;
    int order;
+   std::vector<PatchCategory> children;
+   bool isRoot;
 };
 
 enum sub3_copysource

--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -64,5 +64,7 @@ protected:
    int current_category = 0, current_patch = 0;
    SurgeStorage* storage = nullptr;
 
+   void populatePatchMenuForCategory (int index, COptionMenu *contextMenu, bool single_category, int &main_e, bool rootCall);
+   
    CLASS_METHODS(CPatchBrowser, CControl)
 };


### PR DESCRIPTION
If documents have subfolders they show up as submenus.
If you save a patch with category name "foo/bar/thisthat"
then you create directory structure foo/bar/thisthat and
associated nested menus. Addresses the patch part of #288 

This is lower priority to review than my zoom PR.