### PR TITLE
Linux Build for VST24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ build_logs/
 
 # IntelliJ IDEA
 .idea
+
+# linux
+Makefile
+surge-*.make
+premake-stamp

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -186,7 +186,7 @@ run_clean_all()
     run_clean_builds
 
     echo "Cleaning additional assets"
-    rm -rf Makefile surge-vst2.make surge-vst3.make surge-app.make build_logs
+    rm -rf Makefile surge-vst2.make surge-vst3.make surge-app.make build_logs target obj premake-stamp
 }
 
 run_uninstall()

--- a/premake5.lua
+++ b/premake5.lua
@@ -418,6 +418,18 @@ if VST24SDK then
 
 		linkoptions { "/DEF:resources\\windows-vst2\\surge.def" }
 
+	elseif (os.istarget("linux")) then
+	--[[
+		Ideally we wouldn't define __cdecl on linux. It's not needed
+		Alas, the VST2 SDK has in aeffgui a _GNUC define which requires
+		it so without __cdecl blank defined on linux vst2, we don't get
+		reliable builds. We considered defining it just where used but
+		it is used also, indirectly, by the vst3 sdk, so the smallest
+		change is this diff plus this comment.
+	--]]
+		defines {
+			"__cdecl=",
+		}
 	end
 end
 


### PR DESCRIPTION
Alas, the VST24 library requires a definition of __cdecl on linux.
There's a few ways to work around this, including editing the library
or defining it on a where-included basis, but the smallest approach
is to define the symbol __cdecl for vst24 on linux in the build pipeline.

The file which mis-requires it is aeffect.h which defined VSTCALLBACK
as __cdecl. Since VSTCALLBACK mis-definition is used in vst3sdk also
a source-only fix is prohibitve.

While at it, also expand .gitignore and make build-linux clean-all
more completely.

See issue #371 