### PR TITLE
Update to Jan 2019 vst3sdk

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,12 @@ jobs:
       popd
 
       sudo apt-get install -y libgtkmm-3.0-dev
+      sudo apt-get install -y xcb
+      sudo apt-get install -y libxcb-util-dev
+      sudo apt-get install -y libxcb-cursor-dev
+      sudo apt-get install -y libxcb-keysyms1-dev
+      sudo apt-get install -y libxkbcommon-dev
+      sudo apt-get install -y libxkbcommon-x11-dev
 
       ./build-linux.sh --build
 

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -148,7 +148,7 @@ run_build()
     else
         echo
         echo ${RED}** Build of ${flavor} failed**${NC}
-        grep -i error build_logs/build_${flavor}.log
+        grep -i ": error" build_logs/build_${flavor}.log
         echo
         echo Complete information is in build_logs/build_${flavor}.log
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -51,6 +51,7 @@ if (os.istarget("macosx")) then
 	buildoptions 
         { 
             "-std=c++17", "-stdlib=libc++", 
+	    "-ferror-limit=0",
             "-DOBJC_OLD_DISPATCH_PROTOTYPES=1",
             "-Wno-deprecated-declarations",        -- Alas the AU V2 uses a whole bunch of deprecated stuff
 	    "-Wno-inconsistent-missing-override"   -- Surge was written before this was even a keyword! We do need to fix this though
@@ -98,7 +99,8 @@ elseif (os.istarget("windows")) then
 		"VA_SUBTRACTIVE_EXPORTS", 
 		"TIXML_USE_STL", 
 		"USE_LIBPNG", 
-		"_CRT_SECURE_NO_WARNINGS" 
+		"_CRT_SECURE_NO_WARNINGS",
+        "NOMINMAX=1" -- Jan 2019 update to vst3sdk required this to disambiguoaute std::numeric_limits. See #373
 	}
 
 	nuget { "libpng-msvc-x64:1.6.33.8807" }
@@ -274,7 +276,7 @@ function plugincommon()
 			"src/linux/**.cpp",
 			"src/linux/**.h",
 --			"libs/vst/*.mm", --
-			VSTGUI .. "vstgui_linux.cpp",
+--			VSTGUI .. "vstgui_linux.cpp", -- with the Jan 19 pointer upgrade this is no longer needed nor works
 --			VSTGUI .. "vstgui_uidescription_linux.cpp", --
 		}
 	

--- a/src/au/aulayer_cocoaui.mm
+++ b/src/au/aulayer_cocoaui.mm
@@ -35,7 +35,7 @@
 #include "aulayer_cocoaui.h"
 #include <gui/SurgeGUIEditor.h>
 
-
+using namespace VSTGUI;
 
 @interface SurgeNSView : NSView
 {

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -57,39 +57,39 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
 
       param_ptr.push_back(fx[4].return_level.assign(p_id++, 0, "volume_FX1", "FX1 Return",
                                                     ct_amplitude, px, py, 0, cg_GLOBAL, 0, true,
-                                                    kHorizontal));
+                                                    VSTGUI::CSlider::kHorizontal));
       py += gui_hfader_dist;
       param_ptr.push_back(fx[5].return_level.assign(p_id++, 0, "volume_FX2", "FX2 Return",
                                                     ct_amplitude, px, py, 0, cg_GLOBAL, 0, true,
-                                                    kHorizontal));
+                                                    VSTGUI::CSlider::kHorizontal));
       py += gui_hfader_dist;
 
       // TODO don't store in the patch ?
       param_ptr.push_back(volume.assign(
           p_id++, 0, "volume", "Master Volume", ct_decibel_attenuation, hmargin + gui_sec_width * 5,
-          gui_mid_topbar_y + 12, 0, cg_GLOBAL, 0, true, kHorizontal | kEasy));
+          gui_mid_topbar_y + 12, 0, cg_GLOBAL, 0, true, VSTGUI::CSlider::kHorizontal | kEasy));
    }
    param_ptr.push_back(scene_active.assign(p_id++, 0, "scene_active", "Active Scene", ct_scenesel,
                                            7, gui_mid_topbar_y - 2, 0, cg_GLOBAL, 0, false,
-                                           kHorizontal));
+                                           VSTGUI::CSlider::kHorizontal));
    param_ptr.push_back(scenemode.assign(p_id++, 0, "scenemode", "Scene Mode", ct_scenemode,
                                         8 + 51 + 3, gui_mid_topbar_y - 2, 0, cg_GLOBAL, 0, false,
-                                        kHorizontal | kNoPopup));
-   // param_ptr.push_back(scenemorph.assign(p_id++,0,"scenemorph","scenemorph",ct_percent,hmargin+gui_sec_width,gui_mid_topbar_y,0,0,0,false,kHorizontal));
+                                        VSTGUI::CSlider::kHorizontal | kNoPopup));
+   // param_ptr.push_back(scenemorph.assign(p_id++,0,"scenemorph","scenemorph",ct_percent,hmargin+gui_sec_width,gui_mid_topbar_y,0,0,0,false,VSTGUI::CSlider::kHorizontal));
 
    param_ptr.push_back(splitkey.assign(p_id++, 0, "splitkey", "Split Key", ct_midikey, 8 + 91,
                                        gui_mid_topbar_y - 3, 0, cg_GLOBAL, 0, false,
-                                       kHorizontal | kNoPopup));
+                                       VSTGUI::CSlider::kHorizontal | kNoPopup));
    param_ptr.push_back(fx_disable.assign(p_id++, 0, "fx_disable", "FX Disable", ct_none, 0, 0, 0,
                                          cg_GLOBAL, 0, false));
 
    // shouldnt't be stored in the patch
    param_ptr.push_back(polylimit.assign(p_id++, 0, "polylimit", "Poly Limit", ct_polylimit, 8 + 91,
                                         gui_mid_topbar_y + 13, 0, cg_GLOBAL, 0, false,
-                                        kHorizontal | kNoPopup));
+                                        VSTGUI::CSlider::kHorizontal | kNoPopup));
    param_ptr.push_back(fx_bypass.assign(p_id++, 0, "fx_bypass", "FX Bypass", ct_fxbypass, 607,
                                         gui_mid_topbar_y - 6, 0, cg_GLOBAL, 0, false,
-                                        kHorizontal | kNoPopup));
+                                        VSTGUI::CSlider::kHorizontal | kNoPopup));
 
    polylimit.val.i = 8;
    splitkey.val.i = 60;
@@ -100,7 +100,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       int px = gui_col6_x, py = gui_sendfx_y + 20 * 3;
 
       param_ptr.push_back(this->fx[fx].type.assign(p_id++, 0, "type", "FX type", ct_fxtype, px,
-                                                   py - 2, 0, cg_FX, fx, false, kHorizontal));
+                                                   py - 2, 0, cg_FX, fx, false, VSTGUI::CSlider::kHorizontal));
       py += 20;
       for (int p = 0; p < n_fx_params; p++)
       {
@@ -108,7 +108,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          sprintf(label, "p%i", p);
          param_ptr.push_back(
              this->fx[fx].p[p].assign(p_id++, 0, label, "param", ct_none, px, py, 0, cg_FX, fx,
-                                      true, kHorizontal | kHide | ((fx == 0) ? kEasy : 0)));
+                                      true, VSTGUI::CSlider::kHorizontal | kHide | ((fx == 0) ? kEasy : 0)));
          py += 20;
       }
    }
@@ -133,15 +133,15 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       py = gui_mainsec_y;
       a->push_back(scene[sc].octave.assign(p_id++, id_s++, "octave", "Octave", ct_pitch_octave,
                                            px + 46, py + 1, sc_id, cg_GLOBAL, 0, false,
-                                           kHorizontal | kNoPopup));
+                                           VSTGUI::CSlider::kHorizontal | kNoPopup));
       py = gui_mainsec_slider_y;
       a->push_back(scene[sc].pitch.assign(p_id++, id_s++, "pitch", "Pitch", ct_pitch_semi7bp, px,
                                           py, sc_id, cg_GLOBAL, 0, true,
-                                          kHorizontal | kSemitone | sceasy));
+                                          VSTGUI::CSlider::kHorizontal | kSemitone | sceasy));
       py += gui_hfader_dist;
       a->push_back(scene[sc].portamento.assign(p_id++, id_s++, "portamento", "Portamento",
                                                ct_portatime, px, py, sc_id, cg_GLOBAL, 0, true,
-                                               kHorizontal | sceasy));
+                                               VSTGUI::CSlider::kHorizontal | sceasy));
       py += gui_hfader_dist;
       for (int osc = 0; osc < n_oscs; osc++)
       {
@@ -152,11 +152,11 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                                      px + 3, py + 1, sc_id, cg_OSC, osc, false));
          a->push_back(scene[sc].osc[osc].octave.assign(p_id++, id_s++, "octave", "Octave",
                                                        ct_pitch_octave, px - 3, py + 1, sc_id,
-                                                       cg_OSC, osc, false, kHorizontal | kNoPopup));
+                                                       cg_OSC, osc, false, VSTGUI::CSlider::kHorizontal | kNoPopup));
          py = gui_mainsec_slider_y;
          a->push_back(scene[sc].osc[osc].pitch.assign(p_id++, id_s++, "pitch", "Pitch",
                                                       ct_pitch_semi7bp, px, py, sc_id, cg_OSC, osc,
-                                                      true, kHorizontal | kSemitone | sceasy));
+                                                      true, VSTGUI::CSlider::kHorizontal | kSemitone | sceasy));
          py += gui_hfader_dist;
          for (int i = 0; i < n_osc_params; i++)
          {
@@ -164,16 +164,16 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
             sprintf(label, "param%i", i);
             a->push_back(scene[sc].osc[osc].p[i].assign(p_id++, id_s++, label, "-", ct_none, px, py,
                                                         sc_id, cg_OSC, osc, true,
-                                                        kHorizontal | ((i < 6) ? sceasy : 0)));
+                                                        VSTGUI::CSlider::kHorizontal | ((i < 6) ? sceasy : 0)));
             py += gui_hfader_dist;
          }
          py = gui_mainsec_y - 7;
          a->push_back(scene[sc].osc[osc].keytrack.assign(p_id++, id_s++, "keytrack", "Keytrack",
                                                          ct_bool_keytrack, px + 2, py, sc_id,
-                                                         cg_OSC, osc, false, kHorizontal));
+                                                         cg_OSC, osc, false, VSTGUI::CSlider::kHorizontal));
          a->push_back(scene[sc].osc[osc].retrigger.assign(p_id++, id_s++, "retrigger", "Retrigger",
                                                           ct_bool_retrigger, px + 50, py, sc_id,
-                                                          cg_OSC, osc, false, kHorizontal));
+                                                          cg_OSC, osc, false, VSTGUI::CSlider::kHorizontal));
          // a->push_back(scene[sc].osc[osc].startphase.assign(p_id++,id_s++,"startphase","start
          // phase",ct_none,0,0,sc_id,2,osc,false));
 
@@ -188,22 +188,22 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       }
       a->push_back(scene[sc].polymode.assign(p_id++, id_s++, "polymode", "Polymode", ct_polymode,
                                              gui_col2_x + 83, gui_uppersec_y + 9, sc_id, cg_GLOBAL,
-                                             0, false, kVertical | kWhite | kNoPopup));
+                                             0, false, VSTGUI::CSlider::kVertical | kWhite | kNoPopup));
       a->push_back(scene[sc].fm_switch.assign(p_id++, id_s++, "fm_switch", "FM Routing",
                                               ct_fmconfig, gui_col3_x + 3, gui_topbar + 25, sc_id,
                                               cg_GLOBAL, 0, false));
       a->push_back(scene[sc].fm_depth.assign(p_id++, id_s++, "fm_depth", "FM Depth",
                                              ct_decibel_fmdepth, gui_col3_x,
                                              gui_uppersec_y + gui_hfader_dist * 4, sc_id, cg_GLOBAL,
-                                             0, true, kHorizontal | kWhite | sceasy));
+                                             0, true, VSTGUI::CSlider::kHorizontal | kWhite | sceasy));
 
       a->push_back(scene[sc].drift.assign(p_id++, id_s++, "drift", "Osc Drift", ct_percent,
                                           gui_col2_x, gui_uppersec_y + gui_hfader_dist * 3, sc_id,
-                                          cg_GLOBAL, 0, true, kHorizontal | kWhite));
+                                          cg_GLOBAL, 0, true, VSTGUI::CSlider::kHorizontal | kWhite));
       a->push_back(scene[sc].noise_colour.assign(
           p_id++, id_s++, "noisecol", "Noise Color", ct_percent_bidirectional, gui_col2_x,
           gui_uppersec_y + gui_hfader_dist * 4, sc_id, cg_GLOBAL, 0, true,
-          kHorizontal | kWhite | sceasy));
+          VSTGUI::CSlider::kHorizontal | kWhite | sceasy));
       a->push_back(scene[sc].keytrack_root.assign(p_id++, id_s++, "ktrkroot", "Keytrack Root Key",
                                                   ct_midikey, 180 + 127, gui_topbar + 78 + 106 + 24,
                                                   sc_id, cg_GLOBAL, 0, false));
@@ -214,23 +214,23 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       py = gui_uppersec_y;
       a->push_back(scene[sc].volume.assign(p_id++, id_s++, "volume", "Volume", ct_amplitude, px, py,
                                            sc_id, cg_GLOBAL, 0, true,
-                                           kHorizontal | kWhite | sceasy));
+                                           VSTGUI::CSlider::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
       a->push_back(scene[sc].pan.assign(p_id++, id_s++, "pan", "Pan", ct_percent_bidirectional, px,
                                         py, sc_id, cg_GLOBAL, 0, true,
-                                        kHorizontal | kWhite | sceasy));
+                                        VSTGUI::CSlider::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
       a->push_back(scene[sc].width.assign(p_id++, id_s++, "pan2", "Width", ct_percent_bidirectional,
                                           px, py, sc_id, cg_GLOBAL, 0, true,
-                                          kHorizontal | kWhite | sceasy));
+                                          VSTGUI::CSlider::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
       a->push_back(scene[sc].send_level[0].assign(p_id++, id_s++, "send_fx_1", "FX1 Send",
                                                   ct_amplitude, px, py, sc_id, cg_GLOBAL, 0, true,
-                                                  kHorizontal | kWhite | sceasy));
+                                                  VSTGUI::CSlider::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
       a->push_back(scene[sc].send_level[1].assign(p_id++, id_s++, "send_fx_2", "FX2 Send",
                                                   ct_amplitude, px, py, sc_id, cg_GLOBAL, 0, true,
-                                                  kHorizontal | kWhite | sceasy));
+                                                  VSTGUI::CSlider::kHorizontal | kWhite | sceasy));
       scene[sc].send_level[0].val_max.f = 1.5874f;
       scene[sc].send_level[1].val_max.f = 1.5874f;
 
@@ -239,7 +239,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       int mof = -36, sof = mof + 10, rof = mof + 20;
       a->push_back(scene[sc].level_o1.assign(p_id++, id_s++, "level_o1", "Osc1 Level", ct_amplitude,
                                              px, py, sc_id, cg_MIX, 0, true,
-                                             kVertical | kWhite | sceasy));
+                                             VSTGUI::CSlider::kVertical | kWhite | sceasy));
       a->push_back(scene[sc].mute_o1.assign(p_id++, id_s++, "mute_o1", "Osc1 Mute", ct_bool_mute,
                                             px, py + mof, sc_id, cg_MIX, 0, false));
       a->push_back(scene[sc].solo_o1.assign(p_id++, id_s++, "solo_o1", "Osc1 Solo", ct_bool_solo,
@@ -249,7 +249,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       px += gui_vfader_dist;
       a->push_back(scene[sc].level_o2.assign(p_id++, id_s++, "level_o2", "Osc2 Level", ct_amplitude,
                                              px, py, sc_id, cg_MIX, 0, true,
-                                             kVertical | kWhite | sceasy));
+                                             VSTGUI::CSlider::kVertical | kWhite | sceasy));
       a->push_back(scene[sc].mute_o2.assign(p_id++, id_s++, "mute_o2", "Osc2 Mute", ct_bool_mute,
                                             px, py + mof, sc_id, cg_MIX, 0, false));
       a->push_back(scene[sc].solo_o2.assign(p_id++, id_s++, "solo_o2", "Osc2 Solo", ct_bool_solo,
@@ -259,7 +259,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       px += gui_vfader_dist;
       a->push_back(scene[sc].level_o3.assign(p_id++, id_s++, "level_o3", "Osc3 Level", ct_amplitude,
                                              px, py, sc_id, cg_MIX, 0, true,
-                                             kVertical | kWhite | sceasy));
+                                             VSTGUI::CSlider::kVertical | kWhite | sceasy));
       a->push_back(scene[sc].mute_o3.assign(p_id++, id_s++, "mute_o3", "Osc3 Mute", ct_bool_mute,
                                             px, py + mof, sc_id, cg_MIX, 0, false));
       a->push_back(scene[sc].solo_o3.assign(p_id++, id_s++, "solo_o3", "Osc3 Solo", ct_bool_solo,
@@ -269,7 +269,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       px += gui_vfader_dist;
       a->push_back(scene[sc].level_ring_12.assign(p_id++, id_s++, "level_ring12", "Ring Level 1x2",
                                                   ct_amplitude, px, py, sc_id, cg_MIX, 0, true,
-                                                  kVertical | kWhite | sceasy));
+                                                  VSTGUI::CSlider::kVertical | kWhite | sceasy));
       a->push_back(scene[sc].mute_ring_12.assign(p_id++, id_s++, "mute_ring12", "Ring Mute 1x2",
                                                  ct_bool_mute, px, py + mof, sc_id, cg_MIX, 0,
                                                  false));
@@ -282,7 +282,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       px += gui_vfader_dist;
       a->push_back(scene[sc].level_ring_23.assign(p_id++, id_s++, "level_ring23", "Ring Level 2x3",
                                                   ct_amplitude, px, py, sc_id, cg_MIX, 0, true,
-                                                  kVertical | kWhite | sceasy));
+                                                  VSTGUI::CSlider::kVertical | kWhite | sceasy));
       a->push_back(scene[sc].mute_ring_23.assign(p_id++, id_s++, "mute_ring23", "Ring Mute 2x3",
                                                  ct_bool_mute, px, py + mof, sc_id, cg_MIX, 0,
                                                  false));
@@ -295,7 +295,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       px += gui_vfader_dist;
       a->push_back(scene[sc].level_noise.assign(p_id++, id_s++, "level_noise", "Noise Level",
                                                 ct_amplitude, px, py, sc_id, cg_MIX, 0, true,
-                                                kVertical | kWhite | sceasy));
+                                                VSTGUI::CSlider::kVertical | kWhite | sceasy));
       a->push_back(scene[sc].mute_noise.assign(p_id++, id_s++, "mute_noise", "Noise Mute",
                                                ct_bool_mute, px, py + mof, sc_id, cg_MIX, 0,
                                                false));
@@ -308,7 +308,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       px += gui_vfader_dist;
       a->push_back(scene[sc].level_pfg.assign(p_id++, id_s++, "level_pfg", "Pre-Filter Gain",
                                               ct_decibel, px, py, sc_id, cg_MIX, 0, true,
-                                              kVertical | kWhite | sceasy));
+                                              VSTGUI::CSlider::kVertical | kWhite | sceasy));
       px += gui_vfader_dist;
 
       int pbx = 164, pby = 112;
@@ -323,30 +323,30 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       py = gui_envsec_y;
       a->push_back(scene[sc].vca_level.assign(p_id++, id_s++, "vca_level", "Gain", ct_decibel, px,
                                               py, sc_id, cg_GLOBAL, 0, true,
-                                              kVertical | kWhite | sceasy));
+                                              VSTGUI::CSlider::kVertical | kWhite | sceasy));
       px += gui_vfader_dist;
       a->push_back(scene[sc].vca_velsense.assign(p_id++, id_s++, "vca_velsense", "Velocity > Gain",
                                                  ct_decibel_attenuation, px, py, sc_id, cg_GLOBAL,
-                                                 0, false, kVertical | kWhite));
+                                                 0, false, VSTGUI::CSlider::kVertical | kWhite));
       px += gui_vfader_dist;
 
       px = gui_col3_x + gui_sec_width + 1;
       py = gui_uppersec_y + gui_hfader_dist * 4;
       a->push_back(scene[sc].feedback.assign(p_id++, id_s++, "feedback", "Feedback",
                                              ct_percent_bidirectional, px, py, sc_id, cg_GLOBAL, 0,
-                                             true, kHorizontal | kWhite | sceasy));
+                                             true, VSTGUI::CSlider::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
 
       a->push_back(scene[sc].filterblock_configuration.assign(
           p_id++, id_s++, "fb_config", "Filter Configuration", ct_fbconfig, gui_col4_x - 1,
-          gui_topbar + 25, sc_id, cg_GLOBAL, 0, false, kHorizontal));
+          gui_topbar + 25, sc_id, cg_GLOBAL, 0, false, VSTGUI::CSlider::kHorizontal));
       a->push_back(scene[sc].filter_balance.assign(
           p_id++, id_s++, "f_balance", "Filter Balance", ct_percent_bidirectional, gui_col4_x,
-          gui_mainsec_slider_y + 11, sc_id, cg_GLOBAL, 0, true, kHorizontal | sceasy));
+          gui_mainsec_slider_y + 11, sc_id, cg_GLOBAL, 0, true, VSTGUI::CSlider::kHorizontal | sceasy));
 
       a->push_back(scene[sc].lowcut.assign(p_id++, id_s++, "lowcut", "High Pass", ct_freq_hpf,
                                            gui_envsec_x + gui_vfader_dist * 2 + 5, gui_envsec_y,
-                                           sc_id, cg_GLOBAL, 0, true, kVertical | kWhite | sceasy));
+                                           sc_id, cg_GLOBAL, 0, true, VSTGUI::CSlider::kVertical | kWhite | sceasy));
 
       a->push_back(scene[sc].wsunit.type.assign(p_id++, id_s++, "ws_type", "Waveshaper Type",
                                                 ct_wstype, gui_envsec_x + gui_vfader_dist * 4 - 1,
@@ -355,7 +355,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       a->push_back(scene[sc].wsunit.drive.assign(
           p_id++, id_s++, "ws_drive", "Waveshaper Drive", ct_decibel_narrow,
           gui_envsec_x + gui_vfader_dist * 5 + 10, gui_envsec_y, sc_id, cg_GLOBAL, 0, true,
-          kVertical | kWhite | sceasy));
+          VSTGUI::CSlider::kVertical | kWhite | sceasy));
 
       for (int f = 0; f < 2; f++)
       {
@@ -364,14 +364,14 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
 
          a->push_back(scene[sc].filterunit[f].type.assign(p_id++, id_s++, "type", "Filter Type",
                                                           ct_filtertype, px - 2, py + 1, sc_id,
-                                                          cg_FILTER, f, false, kHorizontal));
+                                                          cg_FILTER, f, false, VSTGUI::CSlider::kHorizontal));
          a->push_back(scene[sc].filterunit[f].subtype.assign(
              p_id++, id_s++, "subtype", "Filter Subtype", ct_filtersubtype, px - 3, py + 1, sc_id,
-             cg_FILTER, f, false, kHorizontal));
+             cg_FILTER, f, false, VSTGUI::CSlider::kHorizontal));
          py = gui_mainsec_slider_y;
          a->push_back(scene[sc].filterunit[f].cutoff.assign(
              p_id++, id_s++, "cutoff", "Cutoff", ct_freq_audible, px, py, sc_id, cg_FILTER, f, true,
-             kHorizontal | sceasy));
+             VSTGUI::CSlider::kHorizontal | sceasy));
          if (f == 1)
             a->push_back(scene[sc].f2_cutoff_is_offset.assign(
                 p_id++, id_s++, "f2_cf_is_offset", "Is Offset to F1", ct_bool_relative_switch, px,
@@ -379,7 +379,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          py += gui_hfader_dist;
          a->push_back(scene[sc].filterunit[f].resonance.assign(
              p_id++, id_s++, "resonance", "Resonance", ct_percent, px, py, sc_id, cg_FILTER, f,
-             true, kHorizontal | sceasy));
+             true, VSTGUI::CSlider::kHorizontal | sceasy));
          if (f == 1)
             a->push_back(scene[sc].f2_link_resonance.assign(
                 p_id++, id_s++, "f2_link_resonance", "Link Resonance", ct_bool_link_switch, px, py,
@@ -391,11 +391,11 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          py = gui_envsec_y;
          a->push_back(scene[sc].filterunit[f].envmod.assign(
              p_id++, id_s++, "envmod", "Envmod", ct_freq_mod, px + gui_sec_width, py, sc_id,
-             cg_FILTER, f, true, kVertical | kWhite | sceasy));
+             cg_FILTER, f, true, VSTGUI::CSlider::kVertical | kWhite | sceasy));
          px += 3 * gui_vfader_dist - gui_sec_width;
          a->push_back(scene[sc].filterunit[f].keytrack.assign(
              p_id++, id_s++, "keytrack", "Keytrack", ct_percent_bidirectional, px, py, sc_id,
-             cg_FILTER, f, true, kVertical | kWhite));
+             cg_FILTER, f, true, VSTGUI::CSlider::kVertical | kWhite));
       }
 
       // scene[sc].filterunit[0].type.val.i = 1;
@@ -406,7 +406,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          const int so = -30;
          a->push_back(scene[sc].adsr[e].a.assign(p_id++, id_s++, "attack", "Attack", ct_envtime, px,
                                                  py, sc_id, cg_ENV, e, true,
-                                                 kVertical | kWhite | sceasy));
+                                                 VSTGUI::CSlider::kVertical | kWhite | sceasy));
          a->push_back(scene[sc].adsr[e].a_s.assign(p_id++, id_s++, "attack_shape", "Attack Shape",
                                                    ct_envshape, px, py + so, sc_id, cg_ENV, e,
                                                    false, kNoPopup));
@@ -414,7 +414,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
 
          a->push_back(scene[sc].adsr[e].d.assign(p_id++, id_s++, "decay", "Decay", ct_envtime, px,
                                                  py, sc_id, cg_ENV, e, true,
-                                                 kVertical | kWhite | sceasy));
+                                                 VSTGUI::CSlider::kVertical | kWhite | sceasy));
          a->push_back(scene[sc].adsr[e].d_s.assign(p_id++, id_s++, "decay_shape", "Decay Shape",
                                                    ct_envshape, px, py + so, sc_id, cg_ENV, e,
                                                    false, kNoPopup));
@@ -422,12 +422,12 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
 
          a->push_back(scene[sc].adsr[e].s.assign(p_id++, id_s++, "sustain", "Sustain", ct_percent,
                                                  px, py, sc_id, cg_ENV, e, true,
-                                                 kVertical | kWhite | sceasy));
+                                                 VSTGUI::CSlider::kVertical | kWhite | sceasy));
          px += gui_vfader_dist;
 
          a->push_back(scene[sc].adsr[e].r.assign(p_id++, id_s++, "release", "Release", ct_envtime,
                                                  px, py, sc_id, cg_ENV, e, true,
-                                                 kVertical | kWhite | sceasy));
+                                                 VSTGUI::CSlider::kVertical | kWhite | sceasy));
          a->push_back(scene[sc].adsr[e].r_s.assign(p_id++, id_s++, "release_shape", "Release Shape",
                                                    ct_envshape, px, py + so, sc_id, cg_ENV, e,
                                                    false, kNoPopup));
@@ -447,7 +447,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          sprintf(label, "lfo%i_shape", l);
          a->push_back(scene[sc].lfo[l].shape.assign(p_id++, id_s++, label, "Shape", ct_lfoshape, px,
                                                     py, sc_id, cg_LFO, ms_lfo1 + l, true,
-                                                    kHorizontal));
+                                                    VSTGUI::CSlider::kHorizontal));
 
          px = gui_modsec_x;
          py = gui_modsec_y - 10;
@@ -455,22 +455,22 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          sprintf(label, "lfo%i_rate", l);
          a->push_back(scene[sc].lfo[l].rate.assign(p_id++, id_s++, label, "Rate", ct_lforate, px,
                                                    py, sc_id, cg_LFO, ms_lfo1 + l, true,
-                                                   kHorizontal | sceasy));
+                                                   VSTGUI::CSlider::kHorizontal | sceasy));
          py += gui_hfader_dist;
          sprintf(label, "lfo%i_phase", l);
          a->push_back(scene[sc].lfo[l].start_phase.assign(p_id++, id_s++, label, "Phase / Shuffle",
                                                           ct_percent, px, py, sc_id, cg_LFO,
-                                                          ms_lfo1 + l, true, kHorizontal));
+                                                          ms_lfo1 + l, true, VSTGUI::CSlider::kHorizontal));
          py += gui_hfader_dist;
          sprintf(label, "lfo%i_magnitude", l);
          a->push_back(scene[sc].lfo[l].magnitude.assign(p_id++, id_s++, label, "Magnitude",
                                                         ct_percent, px, py, sc_id, cg_LFO,
-                                                        ms_lfo1 + l, true, kHorizontal | sceasy));
+                                                        ms_lfo1 + l, true, VSTGUI::CSlider::kHorizontal | sceasy));
          py += gui_hfader_dist;
          sprintf(label, "lfo%i_deform", l);
          a->push_back(scene[sc].lfo[l].deform.assign(p_id++, id_s++, label, "Deform",
                                                      ct_percent_bidirectional, px, py, sc_id,
-                                                     cg_LFO, ms_lfo1 + l, true, kHorizontal));
+                                                     cg_LFO, ms_lfo1 + l, true, VSTGUI::CSlider::kHorizontal));
 
          px += gui_sec_width;
          py = gui_modsec_y;
@@ -489,32 +489,32 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          sprintf(label, "lfo%i_delay", l);
          a->push_back(scene[sc].lfo[l].delay.assign(p_id++, id_s++, label, "Delay", ct_envtime, px,
                                                     py, sc_id, cg_LFO, ms_lfo1 + l, true,
-                                                    kVertical | kMini));
+                                                    VSTGUI::CSlider::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_attack", l);
          a->push_back(scene[sc].lfo[l].attack.assign(p_id++, id_s++, label, "Attack", ct_envtime,
                                                      px, py, sc_id, cg_LFO, ms_lfo1 + l, true,
-                                                     kVertical | kMini));
+                                                     VSTGUI::CSlider::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_hold", l);
          a->push_back(scene[sc].lfo[l].hold.assign(p_id++, id_s++, label, "Hold", ct_envtime, px,
                                                    py, sc_id, cg_LFO, ms_lfo1 + l, true,
-                                                   kVertical | kMini));
+                                                   VSTGUI::CSlider::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_decay", l);
          a->push_back(scene[sc].lfo[l].decay.assign(p_id++, id_s++, label, "Decay", ct_envtime, px,
                                                     py, sc_id, cg_LFO, ms_lfo1 + l, true,
-                                                    kVertical | kMini));
+                                                    VSTGUI::CSlider::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_sustain", l);
          a->push_back(scene[sc].lfo[l].sustain.assign(p_id++, id_s++, label, "Sustain", ct_percent,
                                                       px, py, sc_id, cg_LFO, ms_lfo1 + l, true,
-                                                      kVertical | kMini));
+                                                      VSTGUI::CSlider::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_release", l);
          a->push_back(scene[sc].lfo[l].release.assign(p_id++, id_s++, label, "Release",
                                                       ct_envtime_lfodecay, px, py, sc_id, cg_LFO,
-                                                      ms_lfo1 + l, true, kVertical | kMini));
+                                                      ms_lfo1 + l, true, VSTGUI::CSlider::kVertical | kMini));
          px += gui_vfader_dist;
       }
    }

--- a/src/common/gui/CAboutBox.cpp
+++ b/src/common/gui/CAboutBox.cpp
@@ -3,6 +3,8 @@
 #include "resource.h"
 #include <stdio.h>
 
+using namespace VSTGUI;
+
 SharedPointer<CFontDesc> CAboutBox::infoFont;
 
 //------------------------------------------------------------------------
@@ -117,7 +119,9 @@ void CAboutBox::unSplash()
    {
       if (getFrame()->getModalView() == this)
       {
-         getFrame()->setModalView(NULL);
+          // the modal view is never set anywhere. Replace this with the new vstgui
+          // modal view session eventually
+          // getFrame()->setModalView(NULL);
       }
    }
 }

--- a/src/common/gui/CAboutBox.h
+++ b/src/common/gui/CAboutBox.h
@@ -10,37 +10,37 @@
 
 #include "vstcontrols.h"
 
-class CAboutBox : public CControl
+class CAboutBox : public VSTGUI::CControl
 {
 public:
-   CAboutBox(const CRect& size,
-             IControlListener* listener,
+   CAboutBox(const VSTGUI::CRect& size,
+             VSTGUI::IControlListener* listener,
              long tag,
-             CBitmap* background,
-             CRect& toDisplay,
-             CPoint& offset,
-             CBitmap* aboutBitmap);
+             VSTGUI::CBitmap* background,
+             VSTGUI::CRect& toDisplay,
+             VSTGUI::CPoint& offset,
+             VSTGUI::CBitmap* aboutBitmap);
    virtual ~CAboutBox();
 
-   virtual void draw(CDrawContext*);
-   virtual bool hitTest(const CPoint& where, const CButtonState& buttons = -1);
-   // virtual void mouse (CDrawContext *pContext, CPoint &where, long button = -1);
-   virtual CMouseEventResult
-   onMouseDown(CPoint& where,
-               const CButtonState& buttons); ///< called when a mouse down event occurs
+   virtual void draw(VSTGUI::CDrawContext*);
+   virtual bool hitTest(const VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons = -1);
+   // virtual void mouse (VSTGUI::CDrawContext *pContext, VSTGUI::CPoint &where, long button = -1);
+   virtual VSTGUI::CMouseEventResult
+   onMouseDown(VSTGUI::CPoint& where,
+               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
    virtual void unSplash();
 
    void boxShow();
    void boxHide(bool invalidateframe = true);
 
-   CLASS_METHODS(CAboutBox, CControl)
+   CLASS_METHODS(CAboutBox, VSTGUI::CControl)
 
 protected:
-   CRect toDisplay;
-   CRect keepSize;
-   CPoint offset;
-   SharedPointer<CBitmap> _aboutBitmap;
+   VSTGUI::CRect toDisplay;
+   VSTGUI::CRect keepSize;
+   VSTGUI::CPoint offset;
+   VSTGUI::SharedPointer<VSTGUI::CBitmap> _aboutBitmap;
    bool bvalue;
 
-   static SharedPointer<CFontDesc> infoFont;
+   static VSTGUI::SharedPointer<VSTGUI::CFontDesc> infoFont;
 };

--- a/src/common/gui/CCursorHidingControl.cpp
+++ b/src/common/gui/CCursorHidingControl.cpp
@@ -4,6 +4,8 @@
 #include <Windows.h>
 #endif
 
+using namespace VSTGUI;
+
 CCursorHidingControl::CCursorHidingControl(const CRect& size,
                                            IControlListener* listener,
                                            int32_t tag,

--- a/src/common/gui/CCursorHidingControl.h
+++ b/src/common/gui/CCursorHidingControl.h
@@ -4,31 +4,31 @@
 #pragma once
 #include "vstcontrols.h"
 
-class CCursorHidingControl : public CControl
+class CCursorHidingControl : public VSTGUI::CControl
 {
 protected:
-   CCursorHidingControl(const CRect& size,
-                        IControlListener* listener,
+   CCursorHidingControl(const VSTGUI::CRect& size,
+                        VSTGUI::IControlListener* listener,
                         int32_t tag,
-                        CBitmap* pBackground);
+                        VSTGUI::CBitmap* pBackground);
    virtual ~CCursorHidingControl();
 
-   virtual CMouseEventResult onMouseDown(CPoint& where, const CButtonState& buttons);
-   virtual CMouseEventResult onMouseUp(CPoint& where, const CButtonState& buttons);
-   virtual CMouseEventResult onMouseMoved(CPoint& where, const CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
 
    virtual void
-   onMouseMoveDelta(CPoint& where, const CButtonState& buttons, double dx, double dy) = 0;
-   virtual double getMouseDeltaScaling(CPoint& where, const CButtonState& buttons);
+   onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy) = 0;
+   virtual double getMouseDeltaScaling(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
 
-   void detachCursor(CPoint& where);
+   void detachCursor(VSTGUI::CPoint& where);
    void attachCursor();
 
 private:
-   void doDetach(CPoint& where);
+   void doDetach(VSTGUI::CPoint& where);
    void doAttach();
 
-   CPoint _lastPos, _detachPos;
+   VSTGUI::CPoint _lastPos, _detachPos;
    bool _isDetatched = false;
 
    // OS specific (screen-space)

--- a/src/common/gui/CDIBitmap.cpp
+++ b/src/common/gui/CDIBitmap.cpp
@@ -1,6 +1,8 @@
 #include "CDIBitmap.h"
 #include "DspUtilities.h"
 
+using namespace VSTGUI;
+
 /*HBITMAP CreateDIBSection(
   HDC hdc,                 // handle to DC
   CONST BITMAPINFO *pbmi,  // bitmap data

--- a/src/common/gui/CDIBitmap.h
+++ b/src/common/gui/CDIBitmap.h
@@ -24,15 +24,15 @@ public:
    CDIBitmap(long width, long height);
    virtual ~CDIBitmap();
 
-   void draw(CDrawContext* pContext, CRect& rect, const CPoint& offset = CPoint(0, 0));
+   void draw(VSTGUI::CDrawContext* pContext, VSTGUI::CRect& rect, const VSTGUI::CPoint& offset = VSTGUI::CPoint(0, 0));
 
-   void clear(CColor color);
-   unsigned int ccol_to_int(CColor col);
-   CColor int_to_ccol(unsigned int col);
+   void clear(VSTGUI::CColor color);
+   unsigned int ccol_to_int(VSTGUI::CColor col);
+   VSTGUI::CColor int_to_ccol(unsigned int col);
 
    void clear(unsigned int color);
 
-   void fillRect(CRect r, unsigned int color);
+   void fillRect(VSTGUI::CRect r, unsigned int color);
    void setPixel(int x, int y, unsigned int color);
 
    inline int getWidth()
@@ -51,6 +51,6 @@ public:
 
 protected:
 private:
-   SharedPointer<CBitmap> _bitmap;
-   SharedPointer<CBitmapPixelAccess> _bitmapAccess;
+   VSTGUI::SharedPointer<VSTGUI::CBitmap> _bitmap;
+   VSTGUI::SharedPointer<VSTGUI::CBitmapPixelAccess> _bitmapAccess;
 };

--- a/src/common/gui/CEffectLabel.h
+++ b/src/common/gui/CEffectLabel.h
@@ -4,26 +4,26 @@
 #pragma once
 #include "vstcontrols.h"
 
-extern CFontRef surge_minifont;
+extern VSTGUI::CFontRef surge_minifont;
 
-class CEffectLabel : public CControl
+class CEffectLabel : public VSTGUI::CControl
 {
 public:
-   CEffectLabel(const CRect& size) : CControl(size, 0, 0, 0)
+   CEffectLabel(const VSTGUI::CRect& size) : VSTGUI::CControl(size, 0, 0, 0)
    {}
 
-   virtual void draw(CDrawContext* dc)
+    virtual void draw(VSTGUI::CDrawContext* dc)
    {
-      CRect size = getViewSize();
-      CRect bl(size);
+      VSTGUI::CRect size = getViewSize();
+      VSTGUI::CRect bl(size);
       bl.top = bl.bottom - 2;
-      CColor gray = {106, 106, 106, 255};
+      VSTGUI::CColor gray = {106, 106, 106, 255};
       dc->setFillColor(gray);
-      dc->drawRect(bl, kDrawFilled);
+      dc->drawRect(bl, VSTGUI::kDrawFilled);
       dc->setFontColor(gray);
       // dc->setFont(kNormalFontSmaller,8,kBoldFace);
       dc->setFont(surge_minifont);
-      dc->drawString(label.c_str(), size, kLeftText, false);
+      dc->drawString(label.c_str(), size, VSTGUI::kLeftText, false);
       setDirty(false);
    }
    void setLabel(string s)
@@ -34,5 +34,5 @@ public:
 private:
    string label;
 
-   CLASS_METHODS(CEffectLabel, CControl)
+   CLASS_METHODS(CEffectLabel, VSTGUI::CControl)
 };

--- a/src/common/gui/CEffectSettings.cpp
+++ b/src/common/gui/CEffectSettings.cpp
@@ -3,6 +3,8 @@
 #include "CEffectSettings.h"
 #include "SurgeBitmaps.h"
 
+using namespace VSTGUI;
+
 const int blocks[8][2] = {{18, 1},  {44, 1},  {18, 41}, {44, 41},
                           {18, 21}, {44, 21}, {89, 11}, {89, 31}};
 

--- a/src/common/gui/CEffectSettings.h
+++ b/src/common/gui/CEffectSettings.h
@@ -4,19 +4,19 @@
 #pragma once
 #include "vstcontrols.h"
 
-class CEffectSettings : public CControl
+class CEffectSettings : public VSTGUI::CControl
 {
 public:
-   CEffectSettings(const CRect& size, IControlListener* listener, long tag, int current);
-   virtual void draw(CDrawContext* dc);
-   virtual CMouseEventResult
-   onMouseDown(CPoint& where,
-               const CButtonState& buttons); ///< called when a mouse down event occurs
-   virtual CMouseEventResult
-   onMouseUp(CPoint& where, const CButtonState& buttons); ///< called when a mouse up event occurs
+   CEffectSettings(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, int current);
+   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual VSTGUI::CMouseEventResult
+   onMouseDown(VSTGUI::CPoint& where,
+               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
+   virtual VSTGUI::CMouseEventResult
+   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons); ///< called when a mouse up event occurs
 
    int current;
-   CBitmap *bg, *labels;
+   VSTGUI::CBitmap *bg, *labels;
    int type[8], bypass, disabled;
 
    void set_type(int id, int t)
@@ -46,5 +46,5 @@ public:
       return current;
    }
 
-   CLASS_METHODS(CEffectSettings, CControl)
+   CLASS_METHODS(CEffectSettings, VSTGUI::CControl)
 };

--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -4,6 +4,8 @@
 #include "CHSwitch2.h"
 #include <vt_dsp/basic_dsp.h>
 
+using namespace VSTGUI;
+
 void CHSwitch2::draw(CDrawContext* dc)
 {
    if (getBackground())

--- a/src/common/gui/CHSwitch2.h
+++ b/src/common/gui/CHSwitch2.h
@@ -4,18 +4,18 @@
 #pragma once
 #include "vstcontrols.h"
 
-class CHSwitch2 : public CHorizontalSwitch
+class CHSwitch2 : public VSTGUI::CHorizontalSwitch
 {
 public:
-   CHSwitch2(const CRect& size,
-             IControlListener* listener,
+   CHSwitch2(const VSTGUI::CRect& size,
+             VSTGUI::IControlListener* listener,
              long tag,
              long subPixmaps,       // number of subPixmaps
              long heightOfOneImage, // pixel
              long rows,
              long columns,
-             CBitmap* background,
-             CPoint& offset,
+             VSTGUI::CBitmap* background,
+             VSTGUI::CPoint& offset,
              bool dragable = false)
        : CHorizontalSwitch(
              size, listener, tag, subPixmaps, heightOfOneImage, subPixmaps, background, offset)
@@ -30,14 +30,14 @@ public:
    int imgoffset;
    bool dragable;
 
-   virtual void draw(CDrawContext* dc);
-   virtual CMouseEventResult
-   onMouseDown(CPoint& where,
-               const CButtonState& buttons); ///< called when a mouse down event occurs
-   virtual CMouseEventResult
-   onMouseUp(CPoint& where, const CButtonState& buttons); ///< called when a mouse up event occurs
-   virtual CMouseEventResult
-   onMouseMoved(CPoint& where,
-                const CButtonState& buttons); ///< called when a mouse move event occurs
-   CLASS_METHODS(CHSwitch2, CControl)
+   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual VSTGUI::CMouseEventResult
+   onMouseDown(VSTGUI::CPoint& where,
+               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
+   virtual VSTGUI::CMouseEventResult
+   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons); ///< called when a mouse up event occurs
+   virtual VSTGUI::CMouseEventResult
+   onMouseMoved(VSTGUI::CPoint& where,
+                const VSTGUI::CButtonState& buttons); ///< called when a mouse move event occurs
+   CLASS_METHODS(CHSwitch2, VSTGUI::CControl)
 };

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -4,6 +4,8 @@
 #include "CLFOGui.h"
 #include "LfoModulationSource.h"
 
+using namespace VSTGUI;
+
 extern CFontRef surge_minifont;
 extern CFontRef surge_patchfont;
 

--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -7,7 +7,7 @@
 #include "CDIBitmap.h"
 #include "DspUtilities.h"
 
-class CLFOGui : public CControl
+class CLFOGui : public VSTGUI::CControl
 {
 public:
    const static int margin = 2;
@@ -18,14 +18,14 @@ public:
    const static int skugga = 0xff5d5d5d;
    const static int splitpoint = lpsize + 20;
 
-   CLFOGui(const CRect& size,
+   CLFOGui(const VSTGUI::CRect& size,
            bool trigmaskedit,
-           IControlListener* listener = 0,
+           VSTGUI::IControlListener* listener = 0,
            long tag = 0,
            LFOStorage* lfodata = 0,
            SurgeStorage* storage = 0,
            StepSequencerStorage* ss = 0)
-       : CControl(size, listener, tag, 0)
+       : VSTGUI::CControl(size, listener, tag, 0)
    {
       this->lfodata = lfodata;
       this->storage = storage;
@@ -75,16 +75,16 @@ public:
 #endif
        }
    }
-   // virtual void mouse (CDrawContext *pContext, CPoint &where, long buttons = -1);
-   virtual CMouseEventResult onMouseDown(CPoint& where, const CButtonState& buttons);
-   virtual CMouseEventResult onMouseUp(CPoint& where, const CButtonState& buttons);
-   virtual CMouseEventResult onMouseMoved(CPoint& where, const CButtonState& buttons);
+   // virtual void mouse (CDrawContext *pContext, VSTGUI::CPoint &where, long buttons = -1);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
 
    virtual ~CLFOGui()
    {
       delete cdisurf;
    }
-   virtual void draw(CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc);
 
 protected:
    LFOStorage* lfodata;
@@ -92,13 +92,13 @@ protected:
    SurgeStorage* storage;
    unsigned int coltable[256];
    CDIBitmap* cdisurf;
-   CRect shaperect[n_lfoshapes];
-   CRect steprect[n_stepseqsteps];
-   CRect gaterect[n_stepseqsteps];
-   CRect rect_ls, rect_le, rect_shapes, rect_steps, rect_steps_retrig;
-   CRect ss_shift_left, ss_shift_right;
+   VSTGUI::CRect shaperect[n_lfoshapes];
+   VSTGUI::CRect steprect[n_stepseqsteps];
+   VSTGUI::CRect gaterect[n_stepseqsteps];
+   VSTGUI::CRect rect_ls, rect_le, rect_shapes, rect_steps, rect_steps_retrig;
+   VSTGUI::CRect ss_shift_left, ss_shift_right;
    bool edit_trigmask;
    int controlstate;
 
-   CLASS_METHODS(CLFOGui, CControl)
+   CLASS_METHODS(CLFOGui, VSTGUI::CControl)
 };

--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -6,6 +6,8 @@
 #include "SurgeBitmaps.h"
 #include <vt_dsp/basic_dsp.h>
 
+using namespace VSTGUI;
+
 extern CFontRef surge_minifont;
 
 enum

--- a/src/common/gui/CModulationSourceButton.h
+++ b/src/common/gui/CModulationSourceButton.h
@@ -11,7 +11,7 @@ private:
 
 public:
    CModulationSourceButton(
-       const CRect& size, IControlListener* listener, long tag, int state, int msid);
+       const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, int state, int msid);
    ~CModulationSourceButton();
 
    virtual void setValue(float val)
@@ -21,8 +21,8 @@ public:
       value = val;
    }
 
-   virtual void onMouseMoveDelta(CPoint& where, const CButtonState& buttons, double dx, double dy);
-   virtual double getMouseDeltaScaling(CPoint& where, const CButtonState& buttons);
+   virtual void onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy);
+   virtual double getMouseDeltaScaling(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
 
    int state, msid, controlstate;
 
@@ -30,9 +30,9 @@ public:
    int dispval;
    bool click_is_editpart, event_is_drag, is_metacontroller, bipolar;
    char label[16];
-   CRect MCRect;
-   CPoint LastPoint;
-   CPoint SourcePoint;
+   VSTGUI::CRect  MCRect;
+   VSTGUI::CPoint LastPoint;
+   VSTGUI::CPoint SourcePoint;
    float OldValue;
 
    void setblink(bool state);
@@ -44,9 +44,9 @@ public:
    {
       return state;
    }
-   virtual void draw(CDrawContext* dc);
-   // virtual void mouse (CDrawContext *pContext, CPoint &where, long button = -1);
-   virtual CMouseEventResult onMouseDown(CPoint& where, const CButtonState& buttons);
-   virtual CMouseEventResult onMouseUp(CPoint& where, const CButtonState& buttons);
-   CLASS_METHODS(CModulationSourceButton, CControl)
+   virtual void draw(VSTGUI::CDrawContext* dc);
+   // virtual void mouse (VSTGUI::CDrawContext *pContext, VSTGUI::CPoint &where, long button = -1);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   CLASS_METHODS(CModulationSourceButton, VSTGUI::CControl)
 };

--- a/src/common/gui/CNumberField.cpp
+++ b/src/common/gui/CNumberField.cpp
@@ -12,6 +12,8 @@
 #include <math.h>
 #include "unitconversion.h"
 
+using namespace VSTGUI;
+
 const int width = 62, margin = 6, height = 8, vmargin = 1;
 extern CFontRef surge_minifont;
 

--- a/src/common/gui/CNumberField.h
+++ b/src/common/gui/CNumberField.h
@@ -102,35 +102,35 @@ enum label_placement
    lp_above
 };
 
-class CNumberField : public CControl
+class CNumberField : public VSTGUI::CControl
 {
 public:
-   CNumberField(const CRect& size,
-                IControlListener* listener = 0,
+   CNumberField(const VSTGUI::CRect& size,
+                VSTGUI::IControlListener* listener = 0,
                 long tag = 0,
-                CBitmap* pBackground = 0);
+                VSTGUI::CBitmap* pBackground = 0);
    ~CNumberField();
 
-   virtual void setFontColor(CColor color);
-   CColor getFontColor()
+   virtual void setFontColor(VSTGUI::CColor color);
+   VSTGUI::CColor getFontColor()
    {
       return fontColor;
    }
 
-   virtual void setBackColor(CColor color);
-   CColor getBackColor()
+   virtual void setBackColor(VSTGUI::CColor color);
+   VSTGUI::CColor getBackColor()
    {
       return backColor;
    }
 
-   virtual void setLineColor(CColor color);
-   CColor getLineColor()
+   virtual void setLineColor(VSTGUI::CColor color);
+   VSTGUI::CColor getLineColor()
    {
       return lineColor;
    }
 
-   // virtual void setTxtFace (CTxtFace val);
-   CTxtFace getTxtFace()
+   // virtual void setTxtFace (VSTGUI::CTxtFace val);
+   VSTGUI::CTxtFace getTxtFace()
    {
       return txtFace;
    }
@@ -138,7 +138,7 @@ public:
    /*virtual void setFont (CFont fontID);
    CFont getFont () { return fontID; }*/
 
-   void setBgcolor(CColor bgcol)
+   void setBgcolor(VSTGUI::CColor bgcol)
    {
       envColor = bgcol;
    }
@@ -218,21 +218,21 @@ public:
    virtual void setLabel(char* newlabel);
    virtual void setLabelPlacement(int placement);
 
-   virtual void draw(CDrawContext*);
-   // virtual void mouse (CDrawContext *pContext, CPoint &where, long buttons = -1);
-   virtual CMouseEventResult onMouseDown(CPoint& where, const CButtonState& buttons);
-   virtual CMouseEventResult onMouseUp(CPoint& where, const CButtonState& buttons);
-   virtual CMouseEventResult onMouseMoved(CPoint& where, const CButtonState& buttons);
-   // virtual bool onWheel (CDrawContext *pContext, const CPoint &where, float distance);
+   virtual void draw(VSTGUI::CDrawContext*);
+   // virtual void mouse (VSTGUI::CDrawContext *pContext, VSTGUI::CPoint &where, long buttons = -1);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   // virtual bool onWheel (VSTGUI::CDrawContext *pContext, const VSTGUI::CPoint &where, float distance);
    bool altlook;
 
 private:
-   CColor fontColor;
-   CColor backColor;
-   CColor lineColor;
-   CColor envColor;
+   VSTGUI::CColor fontColor;
+   VSTGUI::CColor backColor;
+   VSTGUI::CColor lineColor;
+   VSTGUI::CColor envColor;
    //	CFont   fontID;
-   CTxtFace txtFace;
+   VSTGUI::CTxtFace txtFace;
    int controlmode, controlstate;
    int i_min, i_max, i_stepsize;
    float f_movespeed;
@@ -242,8 +242,8 @@ private:
    int i_poly;
    char label[32];
    int labelplacement;
-   CRect drawsize;
-   CPoint lastmousepos;
+   VSTGUI::CRect drawsize;
+   VSTGUI::CPoint lastmousepos;
 
-   CLASS_METHODS(CNumberField, CControl)
+   CLASS_METHODS(CNumberField, VSTGUI::CControl)
 };

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -14,6 +14,8 @@
 #include "filesystem"
 #endif
 
+using namespace VSTGUI;
+
 namespace fs = std::experimental::filesystem;
 
 const float disp_pitch = 90.15f - 48.f;
@@ -279,12 +281,12 @@ CMouseEventResult COscillatorDisplay::onMouseDown(CPoint& where, const CButtonSt
       {
          CRect menurect(0, 0, 0, 0);
          menurect.offset(where.x, where.y);
-         COptionMenu* contextMenu = new COptionMenu(menurect, 0, 0, 0, 0, kNoDrawStyle);
+         COptionMenu* contextMenu = new COptionMenu(menurect, 0, 0, 0, 0, COptionMenu::kNoDrawStyle);
 
          for (auto c : storage->wtCategoryOrdering)
          {
             char name[NAMECHARS];
-            COptionMenu* subMenu = new COptionMenu(getViewSize(), 0, c, 0, 0, kNoDrawStyle);
+            COptionMenu* subMenu = new COptionMenu(getViewSize(), 0, c, 0, 0, COptionMenu::kNoDrawStyle);
             subMenu->setNbItemsPerColumn(32);
             int sub = 0;
             int p;
@@ -293,7 +295,7 @@ CMouseEventResult COscillatorDisplay::onMouseDown(CPoint& where, const CButtonSt
                if (storage->wt_list[p].category == c)
                {
                   sprintf(name, "%s", storage->wt_list[p].name.c_str());
-                  auto actionItem = new CCommandMenuItem(name);
+                  auto actionItem = new CCommandMenuItem(CCommandMenuItem::Desc(name));
                   auto action = [this, p](CCommandMenuItem* item) { this->loadWavetable(p); };
 
                   actionItem->setActions(action, nullptr);

--- a/src/common/gui/COscillatorDisplay.h
+++ b/src/common/gui/COscillatorDisplay.h
@@ -7,11 +7,11 @@
 #include "CDIBitmap.h"
 #include "DspUtilities.h"
 
-class COscillatorDisplay : public CControl
+class COscillatorDisplay : public VSTGUI::CControl
 {
 public:
-   COscillatorDisplay(const CRect& size, OscillatorStorage* oscdata, SurgeStorage* storage)
-       : CControl(size, 0, 0, 0)
+   COscillatorDisplay(const VSTGUI::CRect& size, OscillatorStorage* oscdata, SurgeStorage* storage)
+       : VSTGUI::CControl(size, 0, 0, 0)
    {
       this->oscdata = oscdata;
       this->storage = storage;
@@ -72,22 +72,22 @@ public:
    {
       delete cdisurf;
    }
-   virtual void draw(CDrawContext* dc);
-   virtual bool onDrop(IDataPackage* drag, const CPoint& where);
+   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual bool onDrop(VSTGUI::IDataPackage* drag, const VSTGUI::CPoint& where);
 
    void loadWavetable(int id);
 
-   // virtual void mouse (CDrawContext *pContext, CPoint &where, long button = -1);
-   virtual CMouseEventResult onMouseDown(CPoint& where, const CButtonState& buttons);
-   virtual CMouseEventResult onMouseUp(CPoint& where, const CButtonState& buttons);
-   virtual CMouseEventResult onMouseMoved(CPoint& where, const CButtonState& buttons);
+   // virtual void mouse (CDrawContext *pContext, VSTGUI::CPoint &where, long button = -1);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
 
 protected:
    OscillatorStorage* oscdata;
    SurgeStorage* storage;
    unsigned int coltable[256], controlstate;
    CDIBitmap* cdisurf;
-   CRect rnext, rprev, rmenu;
-   CPoint lastpos;
-   CLASS_METHODS(COscillatorDisplay, CControl)
+   VSTGUI::CRect rnext, rprev, rmenu;
+   VSTGUI::CPoint lastpos;
+   CLASS_METHODS(COscillatorDisplay, VSTGUI::CControl)
 };

--- a/src/common/gui/CParameterTooltip.h
+++ b/src/common/gui/CParameterTooltip.h
@@ -4,10 +4,10 @@
 #pragma once
 #include "vstcontrols.h"
 
-class CParameterTooltip : public CControl
+class CParameterTooltip : public VSTGUI::CControl
 {
 public:
-   CParameterTooltip(const CRect& size) : CControl(size, 0, 0, 0)
+   CParameterTooltip(const VSTGUI::CRect& size) : VSTGUI::CControl(size, 0, 0, 0)
    {
       label[0][0] = 0;
       label[1][0] = 0;
@@ -51,16 +51,16 @@ public:
       return visible;
    }
 
-   virtual void draw(CDrawContext* dc)
+   virtual void draw(VSTGUI::CDrawContext* dc)
    {
       if (visible)
       {
          // COffscreenContext *dc =
          // COffscreenContext::create(getFrame(),size.width(),size.height());
 
-         dc->setFont(kNormalFontSmall);
+          dc->setFont(VSTGUI::kNormalFontSmall);
 
-         CRect smaller = getViewSize();
+         VSTGUI::CRect smaller = getViewSize();
          int shrink = 0;
          /*if(!label[0][0])
          {
@@ -72,24 +72,24 @@ public:
          smaller.x += shrink;*/
 
          auto size = getViewSize();
-         dc->setFrameColor(kBlackCColor);
+         dc->setFrameColor(VSTGUI::kBlackCColor);
          dc->drawRect(size);
-         CRect sizem1(size);
+         VSTGUI::CRect sizem1(size);
          sizem1.inset(1, 1);
-         dc->setFillColor(kWhiteCColor);
-         dc->drawRect(sizem1, kDrawFilled);
-         dc->setFontColor(kBlackCColor);
-         CRect trect(size);
+         dc->setFillColor(VSTGUI::kWhiteCColor);
+         dc->drawRect(sizem1, VSTGUI::kDrawFilled);
+         dc->setFontColor(VSTGUI::kBlackCColor);
+         VSTGUI::CRect trect(size);
          trect.inset(4, 1);
          trect.right -= shrink;
-         CRect tupper(trect), tlower(trect);
+         VSTGUI::CRect tupper(trect), tlower(trect);
          tupper.bottom = tupper.top + 13;
          tlower.top = tlower.bottom - 15;
 
          if (label[0][0])
-            dc->drawString(label[0], tupper, kLeftText, true);
+             dc->drawString(label[0], tupper, VSTGUI::kLeftText, true);
          // dc->drawString(label[1],tlower,false,label[0][0]?kRightText:kCenterText);
-         dc->drawString(label[1], tlower, kRightText, true);
+         dc->drawString(label[1], tlower, VSTGUI::kRightText, true);
          // dc->copyFrom(dc1,smaller);
          // dc->forget();
       }
@@ -101,5 +101,5 @@ protected:
    bool visible;
    int last_tag;
 
-   CLASS_METHODS(CParameterTooltip, CControl)
+   CLASS_METHODS(CParameterTooltip, VSTGUI::CControl)
 };

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -5,6 +5,8 @@
 
 #include <vector>
 
+using namespace VSTGUI;
+
 extern CFontRef surge_minifont;
 extern CFontRef surge_patchfont;
 
@@ -51,7 +53,7 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint& where, const CButtonState& 
 
    CRect menurect(0, 0, 0, 0);
    menurect.offset(where.x, where.y);
-   COptionMenu* contextMenu = new COptionMenu(menurect, 0, 0, 0, 0, kNoDrawStyle);
+   COptionMenu* contextMenu = new COptionMenu(menurect, 0, 0, 0, 0, COptionMenu::kNoDrawStyle);
 
    int main_e = 0;
    // if RMB is down, only show the current category
@@ -112,7 +114,7 @@ void CPatchBrowser::populatePatchMenuForCategory( int c, COptionMenu *contextMen
             subMenu = contextMenu;
         else
         {
-            subMenu = new COptionMenu(getViewSize(), nullptr, main_e, 0, 0, kNoDrawStyle);
+            subMenu = new COptionMenu(getViewSize(), nullptr, main_e, 0, 0, COptionMenu::kNoDrawStyle);
             subMenu->setNbItemsPerColumn(32);
         }
         
@@ -124,7 +126,7 @@ void CPatchBrowser::populatePatchMenuForCategory( int c, COptionMenu *contextMen
             // sprintf(name,"%i. %s",p,storage->patch_list[p].name.c_str());
             sprintf(name, "%s", storage->patch_list[p].name.c_str());
             
-            auto actionItem = new CCommandMenuItem(name);
+            auto actionItem = new CCommandMenuItem(CCommandMenuItem::Desc(name));
             auto action = [this, p](CCommandMenuItem* item) { this->loadPatch(p); };
             
             actionItem->setActions(action, nullptr);

--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -5,11 +5,11 @@
 #include "vstcontrols.h"
 #include "SurgeStorage.h"
 
-class CPatchBrowser : public CControl
+class CPatchBrowser : public VSTGUI::CControl
 {
 public:
-   CPatchBrowser(const CRect& size, IControlListener* listener, long tag, SurgeStorage* storage)
-       : CControl(size, listener, tag, 0)
+   CPatchBrowser(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, SurgeStorage* storage)
+       : VSTGUI::CControl(size, listener, tag, 0)
    {
       setLabel("Init");
       setCategory("Init");
@@ -52,8 +52,8 @@ public:
          author = "";
       setDirty(true);
    }
-   virtual void draw(CDrawContext* dc);
-   CMouseEventResult onMouseDown(CPoint& where, const CButtonState& button);
+   virtual void draw(VSTGUI::CDrawContext* dc);
+   VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button);
    void loadPatch(int id);
    int sel_id = 0;
 
@@ -64,7 +64,7 @@ protected:
    int current_category = 0, current_patch = 0;
    SurgeStorage* storage = nullptr;
 
-   void populatePatchMenuForCategory (int index, COptionMenu *contextMenu, bool single_category, int &main_e, bool rootCall);
+   void populatePatchMenuForCategory (int index, VSTGUI::COptionMenu *contextMenu, bool single_category, int &main_e, bool rootCall);
    
-   CLASS_METHODS(CPatchBrowser, CControl)
+   CLASS_METHODS(CPatchBrowser, VSTGUI::CControl)
 };

--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -5,6 +5,8 @@
 
 #include "resource.h"
 
+using namespace VSTGUI;
+
 // Remember this is user zoom * display zoom. See comment in CScalableBitmap.h
 int  CScalableBitmap::currentPhysicalZoomFactor = 100;
 void CScalableBitmap::setPhysicalZoomFactor(int zoomFactor)

--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -10,10 +10,11 @@
 
 class CScalableBitmap : public VSTGUI::CBitmap
 {
+    
 public:
-    CScalableBitmap( CResourceDescription d );
+    CScalableBitmap(VSTGUI::CResourceDescription d);
 
-    virtual void draw (CDrawContext* context, const CRect& rect, const CPoint& offset, float alpha);
+    virtual void draw (VSTGUI::CDrawContext* context, const VSTGUI::CRect& rect, const VSTGUI::CPoint& offset, float alpha);
 
     /*
     ** The 'zoom factor' is set statically across all bitmaps since it is a

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -4,6 +4,8 @@
 #include "effect/Effect.h"
 #include "SurgeBitmaps.h"
 
+using namespace VSTGUI;
+
 extern CFontRef surge_minifont;
 
 // CSnapshotMenu
@@ -52,7 +54,7 @@ void CSnapshotMenu::populate()
          {
             strcpy(txt, snapshot->Attribute("name"));
 
-            auto actionItem = new CCommandMenuItem(txt);
+            auto actionItem = new CCommandMenuItem(CCommandMenuItem::Desc(txt));
             auto action = [this, snapshot, type_id](CCommandMenuItem* item) {
                this->loadSnapshot(type_id, snapshot);
             };
@@ -73,7 +75,7 @@ void CSnapshotMenu::populate()
          }
          else
          {
-            auto actionItem = new CCommandMenuItem(txt);
+             auto actionItem = new CCommandMenuItem(CCommandMenuItem::Desc(txt));
             auto action = [this, type_id](CCommandMenuItem* item) {
                this->loadSnapshot(type_id, nullptr);
             };

--- a/src/common/gui/CSnapshotMenu.h
+++ b/src/common/gui/CSnapshotMenu.h
@@ -6,13 +6,13 @@
 #include "SurgeStorage.h"
 #include "PopupEditorSpawner.h"
 
-class CSnapshotMenu : public COptionMenu
+class CSnapshotMenu : public VSTGUI::COptionMenu
 {
 public:
-   CSnapshotMenu(const CRect& size, IControlListener* listener, long tag, SurgeStorage* storage);
+   CSnapshotMenu(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, SurgeStorage* storage);
    virtual ~CSnapshotMenu();
-   virtual void draw(CDrawContext* dc);
-   // virtual CMouseEventResult onMouseDown(CPoint& where, const CButtonState& buttons);
+   virtual void draw(VSTGUI::CDrawContext* dc);
+   // virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
    void populate();
    virtual void loadSnapshot(int type, TiXmlElement* e){};
    virtual void saveSnapshot(TiXmlElement* e, const char* name){};
@@ -26,31 +26,31 @@ protected:
 class COscMenu : public CSnapshotMenu
 {
 public:
-   COscMenu(const CRect& size,
-            IControlListener* listener,
+   COscMenu(const VSTGUI::CRect& size,
+            VSTGUI::IControlListener* listener,
             long tag,
             SurgeStorage* storage,
             OscillatorStorage* osc);
-   virtual void draw(CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc);
    virtual void loadSnapshot(int type, TiXmlElement* e);
 
 protected:
    OscillatorStorage* osc = nullptr;
 
-   CLASS_METHODS(COscMenu, CControl)
+   CLASS_METHODS(COscMenu, VSTGUI::CControl)
 };
 
 class CFxMenu : public CSnapshotMenu
 {
 public:
-   CFxMenu(const CRect& size,
-           IControlListener* listener,
+   CFxMenu(const VSTGUI::CRect& size,
+           VSTGUI::IControlListener* listener,
            long tag,
            SurgeStorage* storage,
            FxStorage* fx,
            FxStorage* fxbuffer,
            int slot);
-   virtual void draw(CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc);
    virtual bool canSave()
    {
       return true;
@@ -62,5 +62,5 @@ protected:
    FxStorage *fx = nullptr, *fxbuffer = nullptr;
    int slot = 0;
 
-   CLASS_METHODS(CFxMenu, CControl)
+   CLASS_METHODS(CFxMenu, VSTGUI::CControl)
 };

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -7,6 +7,8 @@
 #include "MouseCursorControl.h"
 #include "SurgeBitmaps.h"
 
+using namespace VSTGUI;
+
 extern CFontRef surge_minifont;
 
 enum
@@ -45,7 +47,7 @@ CSurgeSlider::CSurgeSlider(
 
    CRect size;
 
-   if (style & kHorizontal)
+   if (style & CSlider::kHorizontal)
    {
       pTray = getSurgeBitmap(IDB_FADERH_BG);
       pHandle = getSurgeBitmap(IDB_FADERH_HANDLE);
@@ -61,8 +63,8 @@ CSurgeSlider::CSurgeSlider(
    }
    else
    {
-      if (!(style & kTop))
-         style |= kBottom; // kBottom by default
+      if (!(style & CSlider::kTop))
+         style |= CSlider::kBottom; // CSlider::kBottom by default
 
       pTray = getSurgeBitmap(IDB_FADERV_BG);
       pHandle = getSurgeBitmap(IDB_FADERV_HANDLE);
@@ -128,7 +130,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
 
    CRect size = getViewSize();
 
-   if (style & kHorizontal)
+   if (style & CSlider::kHorizontal)
    {
       if (style & kSemitone)
          typey = 2;
@@ -157,14 +159,14 @@ void CSurgeSlider::draw(CDrawContext* dc)
    {
       // CRect trect(0,0,pTray->getWidth(),pTray->getHeight());
       CRect trect;
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
          trect = CRect(0, 0, 133, 14);
       else
          trect = CRect(0, 0, 16, 75);
 
       trect.offset(size.left, size.top);
 
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
          trect.offset(2, 5);
       else
          trect.offset(2, 2);
@@ -176,7 +178,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
          alpha = 0x80;
       }
 
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
          pTray->draw(dc, trect, CPoint(133 * typex, 14 * typey), alpha);
       else
          pTray->draw(dc, trect, CPoint(16 * typex, 75 * typey), alpha);
@@ -185,12 +187,12 @@ void CSurgeSlider::draw(CDrawContext* dc)
       return;
 
    CRect headrect;
-   if (style & kHorizontal)
+   if (style & CSlider::kHorizontal)
       headrect = CRect(0, 0, 28, 24);
    else
       headrect = CRect(0, 0, 24, 28);
 
-   if (label[0] && (style & kHorizontal))
+   if (label[0] && (style & CSlider::kHorizontal))
    {
       CRect trect(0, 0, 111, 13);
       trect.offset(size.left, size.top);
@@ -217,15 +219,15 @@ void CSurgeSlider::draw(CDrawContext* dc)
       CRect hrect(headrect);
       handle_rect = handle_rect_orig;
       hrect.offset(size.left, size.top);
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
          hrect.offset(0, 3);
 
       float dispv = limit_range(qdvalue, 0.f, 1.f);
-      if (style & kRight || style & kBottom)
+      if (style & CSlider::kRight || style & CSlider::kBottom)
          dispv = 1 - dispv;
       dispv *= range;
 
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
       {
          hrect.offset(dispv + 1, 0);
          handle_rect.offset(dispv + 1, 0);
@@ -236,7 +238,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
          handle_rect.offset(1, dispv);
       }
 
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
          pHandle->draw(dc, hrect, CPoint(0, 24 * typehy), modmode ? 0x7f : 0xff);
       else
          pHandle->draw(dc, hrect, CPoint(0, 28 * typehy), modmode ? 0x7f : 0xff);
@@ -248,7 +250,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
       CRect hrect(headrect);
       handle_rect = handle_rect_orig;
       hrect.offset(size.left, size.top);
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
          hrect.offset(0, 3);
 
       float dispv;
@@ -257,11 +259,11 @@ void CSurgeSlider::draw(CDrawContext* dc)
       else
          dispv = limit_range(modval + value, 0.f, 1.f);
 
-      if (style & kRight || style & kBottom)
+      if (style & CSlider::kRight || style & CSlider::kBottom)
          dispv = 1 - dispv;
       dispv *= range;
 
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
       {
          hrect.offset(dispv + 1, 0);
          handle_rect.offset(dispv + 1, 0);
@@ -272,7 +274,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
          handle_rect.offset(1, dispv);
       }
 
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
          pHandle->draw(dc, hrect, CPoint(28, 24 * typehy), 0xff);
       else
          pHandle->draw(dc, hrect, CPoint(24, 28 * typehy), 0xff);
@@ -384,12 +386,12 @@ void CSurgeSlider::onMouseMoveDelta(CPoint& where,
       CPoint p;
 
       double diff;
-      if (style & kHorizontal)
+      if (style & CSlider::kHorizontal)
          diff = dx;
       else
          diff = dy;
 
-      if (style & kRight || style & kBottom)
+      if (style & CSlider::kRight || style & CSlider::kBottom)
          diff = -diff;
 
       *edit_value += diff / (float)range;

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -19,24 +19,24 @@ enum CControlEnum_turbodeluxe
 class CSurgeSlider : public CCursorHidingControl
 {
 public:
-   CSurgeSlider(const CPoint& loc,
+   CSurgeSlider(const VSTGUI::CPoint& loc,
                 long style,
-                IControlListener* listener = 0,
+                VSTGUI::IControlListener* listener = 0,
                 long tag = 0,
                 bool is_mod = false);
    ~CSurgeSlider();
-   virtual void draw(CDrawContext*);
-   // virtual void mouse (CDrawContext *pContext, CPoint &where, long buttons = -1);
-   // virtual bool onWheel (CDrawContext *pContext, const CPoint &where, float distance);
+   virtual void draw(VSTGUI::CDrawContext*);
+   // virtual void mouse (VSTGUI::CDrawContext *pContext, VSTGUI::CPoint &where, long buttons = -1);
+   // virtual bool onWheel (VSTGUI::CDrawContext *pContext, const VSTGUI::CPoint &where, float distance);
 
-   virtual CMouseEventResult
-   onMouseDown(CPoint& where,
-               const CButtonState& buttons); ///< called when a mouse down event occurs
-   virtual CMouseEventResult
-   onMouseUp(CPoint& where, const CButtonState& buttons); ///< called when a mouse up event occurs
+   virtual VSTGUI::CMouseEventResult
+   onMouseDown(VSTGUI::CPoint& where,
+               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
+   virtual VSTGUI::CMouseEventResult
+   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons); ///< called when a mouse up event occurs
 
-   virtual double getMouseDeltaScaling(CPoint& where, const CButtonState& buttons);
-   virtual void onMouseMoveDelta(CPoint& where, const CButtonState& buttons, double dx, double dy);
+   virtual double getMouseDeltaScaling(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual void onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy);
 
    virtual void setLabel(const char* txt);
    virtual void setModValue(float val);
@@ -76,9 +76,9 @@ public:
    bool disabled;
 
 private:
-   CBitmap *pHandle, *pTray, *pModHandle;
-   CRect handle_rect, handle_rect_orig;
-   CPoint offsetHandle;
+   VSTGUI::CBitmap *pHandle, *pTray, *pModHandle;
+   VSTGUI::CRect handle_rect, handle_rect_orig;
+   VSTGUI::CPoint offsetHandle;
    int range;
    int controlstate;
    long style;
@@ -89,7 +89,7 @@ private:
    int typex, typey;
    int typehx, typehy;
    bool has_modulation, has_modulation_current;
-   CPoint lastpoint, sourcepoint;
+   VSTGUI::CPoint lastpoint, sourcepoint;
    float oldVal, *edit_value;
    int drawcount_debug;
 };

--- a/src/common/gui/CSurgeVuMeter.cpp
+++ b/src/common/gui/CSurgeVuMeter.cpp
@@ -1,6 +1,8 @@
 #include "CSurgeVuMeter.h"
 #include "DspUtilities.h"
 
+using namespace VSTGUI;
+
 CSurgeVuMeter::CSurgeVuMeter(const CRect& size) : CControl(size, 0, 0, 0)
 {
    stereo = true;

--- a/src/common/gui/CSurgeVuMeter.h
+++ b/src/common/gui/CSurgeVuMeter.h
@@ -13,11 +13,11 @@ enum vutypes
    n_vut,
 };
 
-class CSurgeVuMeter : public CControl
+class CSurgeVuMeter : public VSTGUI::CControl
 {
 public:
-   CSurgeVuMeter(const CRect& size);
-   virtual void draw(CDrawContext* dc);
+   CSurgeVuMeter(const VSTGUI::CRect& size);
+   virtual void draw(VSTGUI::CDrawContext* dc);
    void setType(int vutype);
    // void setSecondaryValue(float v);
    void setValueR(float f);
@@ -26,5 +26,5 @@ public:
 private:
    float valueR;
    int type;
-   CLASS_METHODS(CSurgeVuMeter, CControl)
+   CLASS_METHODS(CSurgeVuMeter, VSTGUI::CControl)
 };

--- a/src/common/gui/CSwitchControl.cpp
+++ b/src/common/gui/CSwitchControl.cpp
@@ -1,5 +1,7 @@
 #include "CSwitchControl.h"
 
+using namespace VSTGUI;
+
 CSwitchControl::CSwitchControl(const CRect& size,
                                IControlListener* listener,
                                long tag,

--- a/src/common/gui/CSwitchControl.h
+++ b/src/common/gui/CSwitchControl.h
@@ -4,25 +4,25 @@
 #pragma once
 #include "vstcontrols.h"
 
-class CSwitchControl : public CControl
+class CSwitchControl : public VSTGUI::CControl
 {
 public:
-   CSwitchControl(const CRect& size, IControlListener* listener, long tag, CBitmap* background);
-   virtual void draw(CDrawContext* dc);
+   CSwitchControl(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, VSTGUI::CBitmap* background);
+   virtual void draw(VSTGUI::CDrawContext* dc);
    virtual void setValue(float f);
-   virtual CMouseEventResult
-   onMouseDown(CPoint& where,
-               const CButtonState& buttons); ///< called when a mouse down event occurs
-   virtual CMouseEventResult
-   onMouseUp(CPoint& where, const CButtonState& buttons); ///< called when a mouse up event occurs
-   virtual CMouseEventResult
-   onMouseMoved(CPoint& where,
-                const CButtonState& buttons); ///< called when a mouse move event occurs
+   virtual VSTGUI::CMouseEventResult
+   onMouseDown(VSTGUI::CPoint& where,
+               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
+   virtual VSTGUI::CMouseEventResult
+   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons); ///< called when a mouse up event occurs
+   virtual VSTGUI::CMouseEventResult
+   onMouseMoved(VSTGUI::CPoint& where,
+                const VSTGUI::CButtonState& buttons); ///< called when a mouse move event occurs
    int ivalue, imax;
    bool is_itype;
 
 private:
    bool down;
 
-   CLASS_METHODS(CSwitchControl, CControl)
+   CLASS_METHODS(CSwitchControl, VSTGUI::CControl)
 };

--- a/src/common/gui/Colors.h
+++ b/src/common/gui/Colors.h
@@ -10,70 +10,70 @@
 
 #include <vstgui/vstgui.h>
 
-const CColor col_plain_std = CColor(214, 209, 198, 255);
-const CColor col_plain_shadow = CColor(192, 188, 175, 255);
-const CColor col_plain_highlight = CColor(236, 234, 230, 255);
-const CColor col_plain_hover = CColor(219, 216, 209, 255);
+const VSTGUI::CColor col_plain_std = VSTGUI::CColor(214, 209, 198, 255);
+const VSTGUI::CColor col_plain_shadow = VSTGUI::CColor(192, 188, 175, 255);
+const VSTGUI::CColor col_plain_highlight = VSTGUI::CColor(236, 234, 230, 255);
+const VSTGUI::CColor col_plain_hover = VSTGUI::CColor(219, 216, 209, 255);
 
-const CColor col_line_weak = CColor(128, 128, 128, 255);
-const CColor col_line_strong = CColor(54, 65, 73, 255);
+const VSTGUI::CColor col_line_weak = VSTGUI::CColor(128, 128, 128, 255);
+const VSTGUI::CColor col_line_strong = VSTGUI::CColor(54, 65, 73, 255);
 
-/*const CColor col_shade1_std = CColor(101,115,126,0);
-const CColor col_shade1_highlight = CColor(121,138,151,0);*/
-const CColor col_shade1_std = CColor(57, 127, 181, 255);
-const CColor col_shade1_highlight = CColor(135, 180, 215, 255);
-const CColor col_shade1_shadow = CColor(78, 89, 97, 255);
+/*const VSTGUI::CColor col_shade1_std = VSTGUI::CColor(101,115,126,0);
+const VSTGUI::CColor col_shade1_highlight = VSTGUI::CColor(121,138,151,0);*/
+const VSTGUI::CColor col_shade1_std = VSTGUI::CColor(57, 127, 181, 255);
+const VSTGUI::CColor col_shade1_highlight = VSTGUI::CColor(135, 180, 215, 255);
+const VSTGUI::CColor col_shade1_shadow = VSTGUI::CColor(78, 89, 97, 255);
 
-/*const CColor col_shade2_std = CColor(101,126,117,0);
-const CColor col_shade2_highlight = CColor(120,150,139,0);*/
-const CColor col_shade2_std = CColor(69, 131, 108, 255);
-const CColor col_shade2_highlight = CColor(126, 184, 163, 255);
-const CColor col_shade2_shadow = CColor(78, 97, 90, 255);
-const CColor col_shade3_std = CColor(181, 57, 57, 255);
-const CColor col_shade3_highlight = CColor(215, 135, 135, 255);
-const CColor col_shade3_shadow = CColor(97, 78, 78, 255);
+/*const VSTGUI::CColor col_shade2_std = VSTGUI::CColor(101,126,117,0);
+const VSTGUI::CColor col_shade2_highlight = VSTGUI::CColor(120,150,139,0);*/
+const VSTGUI::CColor col_shade2_std = VSTGUI::CColor(69, 131, 108, 255);
+const VSTGUI::CColor col_shade2_highlight = VSTGUI::CColor(126, 184, 163, 255);
+const VSTGUI::CColor col_shade2_shadow = VSTGUI::CColor(78, 97, 90, 255);
+const VSTGUI::CColor col_shade3_std = VSTGUI::CColor(181, 57, 57, 255);
+const VSTGUI::CColor col_shade3_highlight = VSTGUI::CColor(215, 135, 135, 255);
+const VSTGUI::CColor col_shade3_shadow = VSTGUI::CColor(97, 78, 78, 255);
 
-const CColor col_shade4_std = CColor(181, 174, 57, 255);
-const CColor col_shade4_highlight = CColor(215, 200, 100, 255);
-const CColor col_shade4_shadow = CColor(97, 78, 57, 255);
+const VSTGUI::CColor col_shade4_std = VSTGUI::CColor(181, 174, 57, 255);
+const VSTGUI::CColor col_shade4_highlight = VSTGUI::CColor(215, 200, 100, 255);
+const VSTGUI::CColor col_shade4_shadow = VSTGUI::CColor(97, 78, 57, 255);
 
 // greyed out
-const CColor col_shade0_std = CColor(76, 76, 76, 255);
-const CColor col_shade0_highlight = CColor(104, 104, 104, 255);
-const CColor col_shade0_shadow = CColor(51, 51, 51, 255);
+const VSTGUI::CColor col_shade0_std = VSTGUI::CColor(76, 76, 76, 255);
+const VSTGUI::CColor col_shade0_highlight = VSTGUI::CColor(104, 104, 104, 255);
+const VSTGUI::CColor col_shade0_shadow = VSTGUI::CColor(51, 51, 51, 255);
 
-const CColor col_white = CColor(255, 255, 255, 255);
-const CColor col_black = CColor(0, 0, 0, 255);
-const CColor col_dark_grey = CColor(42, 42, 42, 255);
-const CColor col_red = CColor(255, 0, 0, 255);
-const CColor col_green = CColor(0, 255, 0, 255);
-const CColor col_blue = CColor(0, 0, 255, 255);
-const CColor col_yellow = CColor(255, 255, 0, 255);
-const CColor col_orange = CColor(255, 144, 0, 255);
+const VSTGUI::CColor col_white = VSTGUI::CColor(255, 255, 255, 255);
+const VSTGUI::CColor col_black = VSTGUI::CColor(0, 0, 0, 255);
+const VSTGUI::CColor col_dark_grey = VSTGUI::CColor(42, 42, 42, 255);
+const VSTGUI::CColor col_red = VSTGUI::CColor(255, 0, 0, 255);
+const VSTGUI::CColor col_green = VSTGUI::CColor(0, 255, 0, 255);
+const VSTGUI::CColor col_blue = VSTGUI::CColor(0, 0, 255, 255);
+const VSTGUI::CColor col_yellow = VSTGUI::CColor(255, 255, 0, 255);
+const VSTGUI::CColor col_orange = VSTGUI::CColor(255, 144, 0, 255);
 
-const CColor col_loopline = CColor(155, 157, 187, 255);
-const CColor col_sampleline = CColor(155, 187, 159, 255);
+const VSTGUI::CColor col_loopline = VSTGUI::CColor(155, 157, 187, 255);
+const VSTGUI::CColor col_sampleline = VSTGUI::CColor(155, 187, 159, 255);
 
-/*const CColor col_disp = CColor(245,173,0);
-const CColor col_disp_dark = CColor(91,57,8,0);
-const CColor col_disp_off = CColor(157,114,9,0);*/
+/*const VSTGUI::CColor col_disp = VSTGUI::CColor(245,173,0);
+const VSTGUI::CColor col_disp_dark = VSTGUI::CColor(91,57,8,0);
+const VSTGUI::CColor col_disp_off = VSTGUI::CColor(157,114,9,0);*/
 
 // yellowish displays
-/*const CColor col_disp = CColor(104,102,91,0);
-const CColor col_disp_dark = CColor(233,230,206,0);
-const CColor col_disp_off = CColor(168,166,151,0);
-const CColor col_disp_faint = CColor(218,215,193,0);
-const CColor col_disp_semifaint = CColor(196,193,174,0);*/
+/*const VSTGUI::CColor col_disp = VSTGUI::CColor(104,102,91,0);
+const VSTGUI::CColor col_disp_dark = VSTGUI::CColor(233,230,206,0);
+const VSTGUI::CColor col_disp_off = VSTGUI::CColor(168,166,151,0);
+const VSTGUI::CColor col_disp_faint = VSTGUI::CColor(218,215,193,0);
+const VSTGUI::CColor col_disp_semifaint = VSTGUI::CColor(196,193,174,0);*/
 
 // blueish displays
-const CColor col_disp = CColor(89, 89, 106, 255);
-const CColor col_disp_dark = CColor(214, 218, 223, 255);
-const CColor col_disp_off = CColor(154, 154, 170, 255);
-const CColor col_disp_faint = CColor(199, 203, 208, 255);
-const CColor col_disp_semifaint = CColor(176, 178, 190, 255);
-const CColor col_hitpoints = CColor(215, 61, 45, 255);
+const VSTGUI::CColor col_disp = VSTGUI::CColor(89, 89, 106, 255);
+const VSTGUI::CColor col_disp_dark = VSTGUI::CColor(214, 218, 223, 255);
+const VSTGUI::CColor col_disp_off = VSTGUI::CColor(154, 154, 170, 255);
+const VSTGUI::CColor col_disp_faint = VSTGUI::CColor(199, 203, 208, 255);
+const VSTGUI::CColor col_disp_semifaint = VSTGUI::CColor(176, 178, 190, 255);
+const VSTGUI::CColor col_hitpoints = VSTGUI::CColor(215, 61, 45, 255);
 
-const CColor col_ctrl_text = col_dark_grey;
-const CColor col_ctrl_frame = col_dark_grey;
-const CColor col_ctrl_fill = col_white; // col_plain_highlight;
-const CColor col_ctrl_selected = col_shade1_std;
+const VSTGUI::CColor col_ctrl_text = col_dark_grey;
+const VSTGUI::CColor col_ctrl_frame = col_dark_grey;
+const VSTGUI::CColor col_ctrl_fill = col_white; // col_plain_highlight;
+const VSTGUI::CColor col_ctrl_selected = col_shade1_std;

--- a/src/common/gui/DisplayInfo.h
+++ b/src/common/gui/DisplayInfo.h
@@ -5,7 +5,7 @@
 ** are in src/(mac|win|linux)/(Mac|Win|Linux)DisplayInformation.cpp
 **
 ** Most of these APIs will require a reference to a UI object of some form
-** so make each of the functions take a CFrame *
+** so make each of the functions take a VSTGUI::CFrame *
 */
 
 #pragma once
@@ -25,11 +25,11 @@ namespace GUI
 ** We retain this value as a float and do not scale it by 100, like we do with
 ** user specified scales, to better match the OS API
 */    
-float  getDisplayBackingScaleFactor(CFrame *); 
+float  getDisplayBackingScaleFactor(VSTGUI::CFrame *); 
 
 /*
 ** Return the screen dimensions of the best screen containing this frame
 */
-CRect  getScreenDimensions(CFrame *);
+VSTGUI::CRect  getScreenDimensions(VSTGUI::CFrame *);
 }
 }

--- a/src/common/gui/MouseCursorControl.h
+++ b/src/common/gui/MouseCursorControl.h
@@ -13,7 +13,7 @@ int x, y;
 
 static void ShowCursor(bool b)
 {}
-static void GetCursorPos(CPoint& p)
+static void GetCursorPos(VSTGUI::CPoint& p)
 {
    /*Point ptMouse;
    GetMouse( &ptMouse );

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -10,6 +10,8 @@
 #include "CScalableBitmap.h"
 #endif
 
+using namespace VSTGUI;
+
 std::map<int, VSTGUI::CBitmap*> bitmap_registry;
 
 static std::atomic_int refCount(0);

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -36,6 +36,8 @@
 //#include <commctrl.h>
 const int yofs = 10;
 
+using namespace VSTGUI;
+
 #if MAC
 SharedPointer<CFontDesc> minifont = new CFontDesc("Lucida Grande", 9);
 SharedPointer<CFontDesc> patchfont = new CFontDesc("Lucida Grande", 14);
@@ -46,6 +48,7 @@ SharedPointer<CFontDesc> patchfont = new CFontDesc("Arial", 14);
 
 CFontRef surge_minifont = minifont;
 CFontRef surge_patchfont = patchfont;
+
 
 enum special_tags
 {
@@ -1350,7 +1353,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          int a = limit_range((int)((3 * (where.x - r.left)) / r.getWidth()), 0, 2);
          menuRect.offset(where.x, where.y);
 
-         COptionMenu* contextMenu = new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle);
+         COptionMenu* contextMenu = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
          int eid = 0;
          int id_copy = -1, id_copymod = -1, id_paste = -1;
          char txt[256];
@@ -1403,7 +1406,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          int a = limit_range((int)((2 * (where.x - r.left)) / r.getWidth()), 0, 2);
          menuRect.offset(where.x, where.y);
 
-         COptionMenu* contextMenu = new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle);
+         COptionMenu* contextMenu = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
          int eid = 0;
          int id_copy = -1, id_paste = -1;
          char txt[256];
@@ -1451,7 +1454,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          
          menuRect.offset(where.x, where.y);
          COptionMenu* contextMenu =
-             new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle | kMultipleCheckStyle);
+             new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle | VSTGUI::COptionMenu::kMultipleCheckStyle);
          int eid = 0;
          int id_clearallmr = -1, id_learnctrl = -1, id_clearctrl = -1, id_bipolar = -1,
              id_copy = -1, id_paste = -1, id_rename = -1;
@@ -1545,13 +1548,13 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
              contextMenu->addEntry("-", eid++);
              
              // Construct submenus for expicit controller mapping
-             COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle);
+             COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
              COptionMenu *currentSub;
              for( int mc = 0; mc < 127; ++mc )
              {
                  if( mc % 10 == 0 )
                  {
-                     currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, kNoDrawStyle );
+                     currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
                      char name[ 256 ];
                      sprintf( name, "CC %d -> %d", mc, min( mc+10, 127 ));
                      midiSub->addEntry( currentSub, name );
@@ -1559,7 +1562,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                  
                  char name[ 256 ];
                  sprintf( name, "CC # %d", mc );
-                 CCommandMenuItem *cmd = new CCommandMenuItem( name );
+                 CCommandMenuItem *cmd = new CCommandMenuItem( CCommandMenuItem::Desc( name ) );
                  cmd->setActions( [this,ccid,mc,&handled](CCommandMenuItem *men) {
                      handled = true;
                      synth->storage.controllers[ccid] = mc;
@@ -1731,7 +1734,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          menuRect.offset(where.x, where.y);
 
          COptionMenu* contextMenu =
-             new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle | kMultipleCheckStyle);
+             new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle | VSTGUI::COptionMenu::kMultipleCheckStyle);
          int eid = 0;
          int id_temposync = -1, id_clearallmr = -1, id_extendrange = -1, id_learnctrl = -1,
              id_clearctrl = -1, id_absolute = -1;
@@ -2474,7 +2477,7 @@ void SurgeGUIEditor::setZoomFactor(int zf)
 void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
 {
     COptionMenu* settingsMenu =
-        new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle | kMultipleCheckStyle);
+        new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle | VSTGUI::COptionMenu::kMultipleCheckStyle);
     int eid = 0;
     bool handled = false;
 
@@ -2486,14 +2489,14 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
 
 #if HOST_SUPPORTS_ZOOM    
     // Zoom submenus
-    COptionMenu *zoomSubMenu = new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle);
+    COptionMenu *zoomSubMenu = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
 
     int zid = 0;
     for(auto s : { 100, 125, 150, 200, 300 }) // These are somewhat arbitrary reasonable defaults
     {
         std::ostringstream lab;
         lab << "Zoom to " << s << "%";
-        CCommandMenuItem *zcmd = new CCommandMenuItem(lab.str());
+        CCommandMenuItem *zcmd = new CCommandMenuItem(CCommandMenuItem::Desc(lab.str()));
         zcmd->setActions([this,s,&handled](CCommandMenuItem *m) {
                 setZoomFactor(s);
                 handled = true;
@@ -2512,7 +2515,7 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
         else
             lab << "Shrink by " << -jog << "%";
         
-        CCommandMenuItem *zcmd = new CCommandMenuItem(lab.str());
+        CCommandMenuItem *zcmd = new CCommandMenuItem(CCommandMenuItem::Desc(lab.str()));
         zcmd->setActions([this,jog,&handled](CCommandMenuItem *m) {
                 setZoomFactor(getZoomFactor() + jog);
                 handled = true;

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -8,16 +8,16 @@
 #if TARGET_AUDIOUNIT
 //#include "vstkeycode.h"
 #include <vstgui/plugin-bindings/plugguieditor.h>
-typedef PluginGUIEditor EditorType;
+typedef VSTGUI::PluginGUIEditor EditorType;
 #elif TARGET_VST3
 #include "public.sdk/source/vst/vstguieditor.h"
 typedef Steinberg::Vst::VSTGUIEditor EditorType;
 #elif TARGET_VST2
 #include <vstgui/plugin-bindings/aeffguieditor.h>
-typedef AEffGUIEditor EditorType;
+typedef VSTGUI::AEffGUIEditor EditorType;
 #else
 #include <vstgui/plugin-bindings/plugguieditor.h>
-typedef PluginGUIEditor EditorType;
+typedef VSTGUI::PluginGUIEditor EditorType;
 #endif
 
 #include "SurgeStorage.h"
@@ -30,7 +30,7 @@ typedef PluginGUIEditor EditorType;
 #include <vector>
 using namespace std;
 
-class SurgeGUIEditor : public EditorType, public IControlListener, public IKeyboardHook
+class SurgeGUIEditor : public EditorType, public VSTGUI::IControlListener, public VSTGUI::IKeyboardHook
 {
 private:
    using super = EditorType;
@@ -50,26 +50,26 @@ public:
 #if !TARGET_VST3
    bool open(void* parent) override;
 #else
-   virtual bool PLUGIN_API open(void* parent, const PlatformType& platformType = kDefaultNative);
+   virtual bool PLUGIN_API open(void* parent, const VSTGUI::PlatformType& platformType = VSTGUI::kDefaultNative);
 #endif
 
    void close() override;
 
 protected:
    int32_t onKeyDown(const VstKeyCode& code,
-                     CFrame* frame) override; ///< should return 1 if no further key down processing
+                     VSTGUI::CFrame* frame) override; ///< should return 1 if no further key down processing
                                               ///< should apply, otherwise -1
    int32_t onKeyUp(const VstKeyCode& code,
-                   CFrame* frame) override; ///< should return 1 if no further key up processing
+                   VSTGUI::CFrame* frame) override; ///< should return 1 if no further key up processing
                                             ///< should apply, otherwise -1
 
    virtual void setParameter(long index, float value);
 
    // listener class
-   void valueChanged(CControl* control) override;
-   int32_t controlModifierClicked(CControl* pControl, CButtonState button) override;
-   void controlBeginEdit(CControl* pControl) override;
-   void controlEndEdit(CControl* pControl) override;
+   void valueChanged(VSTGUI::CControl* control) override;
+   int32_t controlModifierClicked(VSTGUI::CControl* pControl, VSTGUI::CButtonState button) override;
+   void controlBeginEdit(VSTGUI::CControl* pControl) override;
+   void controlEndEdit(VSTGUI::CControl* pControl) override;
 
    void refresh_mod();
 
@@ -80,7 +80,7 @@ protected:
     * but adds, in necessary cases, workarounds for bugs in the
     * vstgui framework. Use it in place of frame->getCurrentMouseLocation
     */
-   CPoint getCurrentMouseLocationCorrectedForVSTGUIBugs();
+   VSTGUI::CPoint getCurrentMouseLocationCorrectedForVSTGUIBugs();
 
 private:
    void openOrRecreateEditor();
@@ -94,14 +94,14 @@ private:
    unsigned int idleinc = 0;
    int fxbypass_tag = 0, resolink_tag = 0, f1resotag = 0, f1subtypetag = 0, f2subtypetag = 0,
        filterblock_tag = 0;
-   void draw_infowindow(int ptag, CControl* control, bool modulate, bool forceMB = false);
+   void draw_infowindow(int ptag, VSTGUI::CControl* control, bool modulate, bool forceMB = false);
 
    bool showPatchStoreDialog(patchdata* p,
                              std::vector<PatchCategory>* patch_category,
                              int startcategory);
 
 
-   void showSettingsMenu(CRect &menuRect);
+   void showSettingsMenu(VSTGUI::CRect &menuRect);
 
    /*
    ** Zoom Implementation 
@@ -126,22 +126,22 @@ private:
    
    SurgeBitmaps bitmap_keeper;
 
-   CControl* vu[16];
-   CControl *infowindow, *patchname, *ccfxconf = nullptr;
-   CControl* aboutbox = nullptr;
-   CViewContainer* saveDialog = nullptr;
-   CTextEdit* patchName = nullptr;
-   CTextEdit* patchCategory = nullptr;
-   CTextEdit* patchCreator = nullptr;
-   CTextEdit* patchComment = nullptr;
-   CControl* polydisp = nullptr;
-   CControl* oscdisplay = nullptr;
-   CControl* param[1024] = {};
-   CControl* nonmod_param[1024] = {}; 
-   CControl* gui_modsrc[n_modsources] = {};
-   CControl* metaparam[n_customcontrollers] = {};
-   CControl* lfodisplay = nullptr;
-   CControl* filtersubtype[2] = {};
+   VSTGUI::CControl* vu[16];
+   VSTGUI::CControl *infowindow, *patchname, *ccfxconf = nullptr;
+   VSTGUI::CControl* aboutbox = nullptr;
+   VSTGUI::CViewContainer* saveDialog = nullptr;
+   VSTGUI::CTextEdit* patchName = nullptr;
+   VSTGUI::CTextEdit* patchCategory = nullptr;
+   VSTGUI::CTextEdit* patchCreator = nullptr;
+   VSTGUI::CTextEdit* patchComment = nullptr;
+   VSTGUI::CControl* polydisp = nullptr;
+   VSTGUI::CControl* oscdisplay = nullptr;
+   VSTGUI::CControl* param[1024] = {};
+   VSTGUI::CControl* nonmod_param[1024] = {}; 
+   VSTGUI::CControl* gui_modsrc[n_modsources] = {};
+   VSTGUI::CControl* metaparam[n_customcontrollers] = {};
+   VSTGUI::CControl* lfodisplay = nullptr;
+   VSTGUI::CControl* filtersubtype[2] = {};
 #if MAC || __linux__
 #else
    HWND ToolTipWnd;
@@ -150,7 +150,7 @@ private:
    float blinktimer = 0;
    bool blinkstate = false;
    void* _effect = nullptr;
-   CVSTGUITimer* _idleTimer = nullptr;
+   VSTGUI::CVSTGUITimer* _idleTimer = nullptr;
 };
 
 #if ( MAC && ( TARGET_AUDIOUNIT || TARGET_VST2 )  ) || (WINDOWS && TARGET_VST2 )

--- a/src/linux/DisplayInfoLinux.cpp
+++ b/src/linux/DisplayInfoLinux.cpp
@@ -6,6 +6,8 @@ namespace Surge
 namespace GUI
 {
 
+using namespace VSTGUI;
+    
 float getDisplayBackingScaleFactor(CFrame *)
 {
     Surge::UserInteractions::promptError("getDisplayBackingScaleFactor not implemented yet on linux.",

--- a/src/mac/DisplayInfoMac.mm
+++ b/src/mac/DisplayInfoMac.mm
@@ -2,6 +2,7 @@
 #include "UserInteractions.h"
 #include <CoreFoundation/CoreFoundation.h>
 #include <Cocoa/Cocoa.h>
+#include <vstgui/vstgui.h>
 #include "vstgui/lib/platform/mac/cocoa/nsviewframe.h"
 
 namespace Surge
@@ -9,10 +10,12 @@ namespace Surge
 namespace GUI
 {
 
+using namespace VSTGUI;
+    
 NSView *getViewFromFrame(CFrame *f)
 {
     IPlatformFrame *pf = f->getPlatformFrame();
-    VSTGUI::NSViewFrame *nf = dynamic_cast<VSTGUI::NSViewFrame*>(pf);
+    NSViewFrame *nf = dynamic_cast<NSViewFrame*>(pf);
     if (!nf)
     {
         Surge::UserInteractions::promptError("Platform frame is not an NSViewFrame. Please report this issue to developers.",

--- a/src/windows/DisplayInfoWin.cpp
+++ b/src/windows/DisplayInfoWin.cpp
@@ -9,6 +9,8 @@ namespace Surge
 namespace GUI
 {
 
+using namespace VSTGUI;
+    
 float getDisplayBackingScaleFactor(CFrame *f)
 {
     /*


### PR DESCRIPTION
This substantial diff undertakes the mechanical changes to update
to the Jan 2019 master version of vst3sdk (hash 82380a8f). This
move consuming nearly 7 months of changes introduced several breaking
changes in our code which required modification, and introduced a couple of
new dependencies and links.

The primary thing breaking the builds was that most classes, including
common ones like CRect and CPoint, are now in the VSTGUI namespace.
This diff follows the convention of never using a namespace in a header
file, and thus has quite a few changes which are namespace additions in
headers and using statements in cpp files. But ironically, since my first
attempt was to just put using in a header and break the rule for once,
if you put using in the header, the code doesn't compile on windows
since VSTGUI::IDropTarget and ::IDropTarget collide. So has to be this way.

On linux several xcb and xkb dependencies emerge with this vst, so they
were added to the azure pipeline. Also the vstgui_linux.cpp is no longer
needed in the way we link, and if linked, doesn't work.

On windows, an ambiguity in std::numeric_limits<T>::max() requires us to
set -DNOMINMAX=1 for, alas.

On mac, we expand the number of errors reported to 'as many as you generate'.

Commands used to update the module were

 git checkout master
 git checkout -b vst3sdk-update-373
 git submodule update --remote --merge --recursive
 git add vst3sdk/
 git commit
 git submodule update --init --recursive

This commit addresses github issue #373.