### PR TITLE
Restore patch checkmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ build_logs/
 Makefile
 surge-*.make
 premake-stamp
+/Debug

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -171,6 +171,10 @@ void SurgeSynthesizer::loadPatch(int id)
       kCFStringEncodingUTF8);
            ((aulayer*)parent)->SetAFactoryPresetAsCurrent(preset);*/
 #endif
+   /*
+   ** Notify the host display that the patch name has changed
+   */
+   updateDisplay();
 }
 
 void SurgeSynthesizer::loadRaw(const void* data, int size, bool preset)
@@ -200,6 +204,28 @@ void SurgeSynthesizer::loadRaw(const void* data, int size, bool preset)
    halt_engine = false;
    patch_loaded = true;
    refresh_editor = true;
+
+   if (patchid < 0)	
+   {
+      /*
+      ** new patch just loaded so I look up and set the current category and patch.
+      ** This is used to draw checkmarks in the menu. If for some reason we don't
+      ** find one, nothing will break
+      */
+      int cnt = storage.patch_list.size();
+      string name = storage.getPatch().name;
+      string cat = storage.getPatch().category;
+      for (int p = 0; p < cnt; ++p)
+      {
+         if (storage.patch_list[p].name == name &&
+            storage.patch_category[storage.patch_list[p].category].name == cat)
+         {
+            current_category_id = storage.patch_list[p].category;
+            patchid = p;
+            break;
+         }
+      }
+   }
 }
 
 #if MAC || __linux__

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -53,7 +53,7 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint& where, const CButtonState& 
 
    CRect menurect(0, 0, 0, 0);
    menurect.offset(where.x, where.y);
-   COptionMenu* contextMenu = new COptionMenu(menurect, 0, 0, 0, 0, COptionMenu::kNoDrawStyle);
+   COptionMenu* contextMenu = new COptionMenu(menurect, 0, 0, 0, 0, COptionMenu::kMultipleCheckStyle);
 
    int main_e = 0;
    // if RMB is down, only show the current category
@@ -114,7 +114,7 @@ void CPatchBrowser::populatePatchMenuForCategory( int c, COptionMenu *contextMen
             subMenu = contextMenu;
         else
         {
-            subMenu = new COptionMenu(getViewSize(), nullptr, main_e, 0, 0, COptionMenu::kNoDrawStyle);
+            subMenu = new COptionMenu(getViewSize(), nullptr, main_e, 0, 0, COptionMenu::kMultipleCheckStyle);
             subMenu->setNbItemsPerColumn(32);
         }
         
@@ -129,6 +129,8 @@ void CPatchBrowser::populatePatchMenuForCategory( int c, COptionMenu *contextMen
             auto actionItem = new CCommandMenuItem(CCommandMenuItem::Desc(name));
             auto action = [this, p](CCommandMenuItem* item) { this->loadPatch(p); };
             
+            if (p == current_patch)
+                actionItem->setChecked(true);
             actionItem->setActions(action, nullptr);
             subMenu->addEntry(actionItem);
             sub++;
@@ -157,7 +159,9 @@ void CPatchBrowser::populatePatchMenuForCategory( int c, COptionMenu *contextMen
         
         if (!single_category)
         {
-            contextMenu->addEntry(subMenu, name);
+            CMenuItem *entry = contextMenu->addEntry(subMenu, name);
+            if (c == current_category)
+                entry->setChecked(true);
             subMenu->forget(); // Important, so that the refcounter gets it right
         }
         main_e++;

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -296,7 +296,19 @@ void Vst2PluginInstance::setProgramName(char* name)
 
 void Vst2PluginInstance::getProgramName(char* name)
 {
-   strcpy(name, programName);
+   getProgramNameIndexed(0, 0, name);
+}
+bool Vst2PluginInstance::getProgramNameIndexed (VstInt32 category, VstInt32 index, char* text)
+{
+   if (tryInit())
+   {
+       SurgeSynthesizer* s = (SurgeSynthesizer*)_instance;
+       /*
+       ** The original surge had this 63. Presume it is documented somewhere in vst land.
+       */
+       strncpy(text, s->storage.getPatch().name.c_str(), 63);
+   }
+   return true;
 }
 
 void Vst2PluginInstance::setParameter(VstInt32 index, float value)

--- a/src/vst2/Vst2PluginInstance.h
+++ b/src/vst2/Vst2PluginInstance.h
@@ -28,6 +28,7 @@ public:
    virtual VstInt32 processEvents(VstEvents* ev);
 
    // Host->Client calls
+   virtual bool getProgramNameIndexed(VstInt32 category, VstInt32 index, char* text);
    virtual void setProgramName(char* name);
    virtual void getProgramName(char* name);
    /*virtual bool getProgramNameIndexed (long category, long index, char *text);


### PR DESCRIPTION
Restore functions from Surge 1.5.2.
- Add patch checkmarks next to category and patch.
- Restore checkmarks again and when patch is reloaded.
- Also expose patchname to host via a single program name.
- Integrate code review comments from @baconpaul and @jsakkine

The commit history here also got conflated with the vst3sdk update
and so is a mix of @sagantech and @baconpaul; but the code author
is @sagantech