### PR TITLE
Implement VST3 zoom

### DIFF
--- a/build-osx.sh
+++ b/build-osx.sh
@@ -37,6 +37,7 @@ Commands are:
         --build-and-install      Build and install the assets
         --build-validate-au      Build and install the audio unit then validate it
         --build-install-vst2     Build and install only the VST2
+        --build-install-vst3     Build and install only the VST3
 
         --package                Creates a .pkg file from current built state in products
         --clean-and-package      Cleans everything; runs all the builds; makes an installer; drops it in products
@@ -214,6 +215,15 @@ run_build_install_vst2()
     rsync -r --delete "products/Surge.vst/" ~/Library/Audio/Plug-Ins/VST/Surge.vst/
 }
 
+run_build_install_vst3()
+{
+    run_premake_if
+    run_build "vst3"
+
+    rsync -r "resources/data/" "$HOME/Library/Application Support/Surge/"
+    rsync -r --delete "products/Surge.vst3/" ~/Library/Audio/Plug-Ins/VST3/Surge.vst3/
+}
+
 run_clean_builds()
 {
     if [ ! -d "Surge.xcworkspace" ]; then
@@ -306,6 +316,9 @@ case $command in
         ;;
     --build-install-vst2)
         run_build_install_vst2
+        ;;
+    --build-install-vst3)
+        run_build_install_vst3
         ;;
     --clean)
         run_clean_builds

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2433,12 +2433,21 @@ void SurgeGUIEditor::setZoomFactor(int zf)
 #endif
 
    CRect screenDim = Surge::GUI::getScreenDimensions(getFrame());
+
+#if TARGET_VST3
+   /*
+   ** VST3 doesn't have this API available to it, so just assume for now
+   */
+   float baseW = WINDOW_SIZE_X;
+   float baseH = WINDOW_SIZE_Y;
+#else
    ERect *baseUISize;
    getRect (&baseUISize);
 
    float baseW = (baseUISize->right - baseUISize->left);
    float baseH = (baseUISize->top - baseUISize->bottom);
-
+#endif
+   
    // Leave enough room for window decoration with that .9. (You can probably do .95 on mac)
    if (zf != 100.0 && (
            (baseW * zf / 100.0) > 0.9 * screenDim.getWidth() ||
@@ -2566,7 +2575,7 @@ CPoint SurgeGUIEditor::getCurrentMouseLocationCorrectedForVSTGUIBugs()
     frame->getCurrentMouseLocation(where);
     where = frame->localToFrame(where);
 
-#if TARGET_VST2 && HOST_SUPPORTS_ZOOM
+#if ( TARGET_VST2 || TARGET_VST3 ) && HOST_SUPPORTS_ZOOM
     CGraphicsTransform vstfix = frame->getTransform().inverse();
     vstfix.transform(where);
     vstfix.transform(where);

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -82,6 +82,19 @@ protected:
     */
    VSTGUI::CPoint getCurrentMouseLocationCorrectedForVSTGUIBugs();
 
+#if TARGET_VST3
+public:
+   /**
+    * getIPlugFrame
+    *
+    * Amazingly, IPlugView has a setFrame( IPlugFrame ) method but
+    * no getter. It does, however, store the value as a protected
+    * variable. To collaborate for zoom, we need this reference
+    * in the VST Processor, so expose this function
+    */
+   Steinberg::IPlugFrame *getIPlugFrame() { return plugFrame; }
+#endif
+   
 private:
    void openOrRecreateEditor();
    void close_editor();
@@ -153,6 +166,6 @@ private:
    VSTGUI::CVSTGUITimer* _idleTimer = nullptr;
 };
 
-#if ( MAC && ( TARGET_AUDIOUNIT || TARGET_VST2 )  ) || (WINDOWS && TARGET_VST2 )
+#if MAC || WINDOWS
 #define HOST_SUPPORTS_ZOOM 1
 #endif

--- a/src/vst3/SurgeVst3Processor.h
+++ b/src/vst3/SurgeVst3Processor.h
@@ -121,5 +121,7 @@ protected:
    std::vector<SurgeGUIEditor*> viewsArray;
    int blockpos;
 
+   void handleZoom(SurgeGUIEditor *e);
+   
    FpuState _fpuState;
 };


### PR DESCRIPTION
VST3 zoom is very similar to VST2 zoom since both rely on
VSTGUI (and the associated bugs therein), but differ on the approach
to notify the host. The primary difference in notifying the host
is requiring a reference to the Steinberg::IPlugFrame frame class,
which has to be publically exposed to allow the processor to see it.
(This may be indicative of issues still with us choosing to not have
a formal processor/editor split, as mentioned in #164). Regardless,
once the IPlugFrame is exposed, we can use the resizeView() API
in vst3 to inform hosts in our zoom callback, as implemented here.

Adresses issue #357