### PR TITLE
Add checks to wavetable popup menu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "vst3sdk"]
 	path = vst3sdk
 	url = https://github.com/steinbergmedia/vst3sdk.git
+   	ignore = dirty

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -491,21 +491,22 @@ void SurgeStorage::refresh_wtlist()
 
 void SurgeStorage::perform_queued_wtloads()
 {
+   SurgePatch& patch = getPatch();  //Change here is for performance and ease of debugging, simply not calling getPatch so many times. Code should behave identically.
    for (int sc = 0; sc < 2; sc++)
    {
       for (int o = 0; o < n_oscs; o++)
       {
-         if (getPatch().scene[sc].osc[o].wt.queue_id != -1)
+         if (patch.scene[sc].osc[o].wt.queue_id != -1)
          {
-            load_wt(getPatch().scene[sc].osc[o].wt.queue_id, &getPatch().scene[sc].osc[o].wt);
-            getPatch().scene[sc].osc[o].wt.refresh_display = true;
+            load_wt(patch.scene[sc].osc[o].wt.queue_id, &patch.scene[sc].osc[o].wt);
+            patch.scene[sc].osc[o].wt.refresh_display = true;
          }
-         else if (getPatch().scene[sc].osc[o].wt.queue_filename[0])
+         else if (patch.scene[sc].osc[o].wt.queue_filename[0])
          {
-            getPatch().scene[sc].osc[o].queue_type = ot_wavetable;
-            getPatch().scene[sc].osc[o].wt.current_id = -1;
-            load_wt(getPatch().scene[sc].osc[o].wt.queue_filename, &getPatch().scene[sc].osc[o].wt);
-            getPatch().scene[sc].osc[o].wt.refresh_display = true;
+            patch.scene[sc].osc[o].queue_type = ot_wavetable;
+            patch.scene[sc].osc[o].wt.current_id = -1;
+            load_wt(patch.scene[sc].osc[o].wt.queue_filename, &patch.scene[sc].osc[o].wt);
+            patch.scene[sc].osc[o].wt.refresh_display = true;
          }
       }
    }


### PR DESCRIPTION
I looked into adding support for adding check marks to the wavetable menu after a preset or a host document is loaded but I don't think it is worth the effort if it is even possible as the data for the wavetable is stored inline in the preset's data and not from an external file.