### PR TITLE
Enable tooltips

### DIFF
--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -52,6 +52,23 @@ public:
          author = "";
       setDirty(true);
    }
+   void setComment(std::string l)
+   {
+       /*
+       ** the patch comment displays as a tooltip if there is one.
+       */
+       if(l.length())
+       {
+           comment = "Comment: " + l;
+           setAttribute(VSTGUI::kCViewTooltipAttribute, comment.length() + 1, comment.c_str());
+       }
+       else
+       {
+           comment = "";
+           setAttribute(VSTGUI::kCViewTooltipAttribute, 0, NULL );
+       }
+       setDirty(true);
+   }
    virtual void draw(VSTGUI::CDrawContext* dc);
    VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button);
    void loadPatch(int id);
@@ -61,6 +78,8 @@ protected:
    std::string pname;
    std::string category;
    std::string author;
+   std::string comment;
+
    int current_category = 0, current_patch = 0;
    SurgeStorage* storage = nullptr;
 


### PR DESCRIPTION
VSTGUI has pretty good tooltip support which is easy enough
to use. As described in issues #384 and #377 we can use these
immediately in two places. (1) when mousing over a slider to
show the current value and (2) when mousing over the patch
browser to display the otherwise unused patch comment.
This diff accomplishes that bu calling the appropriate
setAttribute call at the right times in the value change
and patch set codepaths.

It seems this API is not fully supported on windows right now. I would
like to merge this anyway since I think it is a great idea and immediate improvement
for mac users.

Reviews and comments welcome.