### PR TITLE
Set Init patch HP to lowest frequency (6.875Hz)

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -587,7 +587,7 @@ void SurgePatch::init_default_values()
       scene[sc].route_noise.val.i = 1;
       scene[sc].pbrange_up.val.i = 2.f;
       scene[sc].pbrange_dn.val.i = 2.f;
-      scene[sc].lowcut.val.f = -36; // scene[sc].lowcut.val_min.f;
+      scene[sc].lowcut.val.f = scene[sc].lowcut.val_min.f;
       scene[sc].lowcut.per_voice_processing = false;
 
       scene[sc].adsr[0].a.val.f = scene[sc].adsr[0].a.val_min.f;


### PR DESCRIPTION
Fixes #414 

This changes the Generic HighPass Filter (that is applied whether F1 or F2 are on or off) from 50Hz to minimum, which is 6.875Hz.

Before: HP is at 50Hz
After:
<img width="406" alt="fullscreen_30_01_2019__18_59" src="https://user-images.githubusercontent.com/4966687/51998412-48ca0d00-24c1-11e9-9a65-317240bfeeb9.png">
