### PR TITLE
git remte -> git remote

### DIFF
--- a/doc/git-howto.md
+++ b/doc/git-howto.md
@@ -45,7 +45,7 @@ and `push` which push all the diffs from you to a remote.
 You need to configure these remotes one time per remote. So do this:
 
 ```
-git remte add upstream https://github.com/surge-synthesizer/surge
+git remote add upstream https://github.com/surge-synthesizer/surge
 git remote -v
 ```
 


### PR DESCRIPTION
there's a typo in the git documentation where it reads `git remte` and should read `git remote`.

so just one extra letter added