### PR TITLE
No more using namespace; win -> c++17

### DIFF
--- a/build-osx.sh
+++ b/build-osx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # build-osx.sh is the master script we use to control the multi-step build processes
 #

--- a/libs/wtl/atlapp.h
+++ b/libs/wtl/atlapp.h
@@ -1638,7 +1638,7 @@ public:
 	}
 
 // COM Server methods
-	LONG Unlock()
+	LONG Unlock() noexcept // MODIFICATION added noexcept to compile c++17
 	{
 		LONG lRet = CComModule::Unlock();
 		if(lRet == 0)

--- a/libs/wtl/atlframe.h
+++ b/libs/wtl/atlframe.h
@@ -43,6 +43,8 @@
 //   AtlCreateSimpleToolBar()
 
 
+#include <algorithm>
+
 namespace WTL
 {
 
@@ -537,9 +539,9 @@ public:
 		}
 
 		::SendMessage(hWnd, TB_ADDBUTTONS, nItems, (LPARAM)pTBBtn);
-		::SendMessage(hWnd, TB_SETBITMAPSIZE, 0, MAKELONG(pData->wWidth, max(pData->wHeight, cyFontHeight)));
+		::SendMessage(hWnd, TB_SETBITMAPSIZE, 0, MAKELONG(pData->wWidth, std::max(pData->wHeight, cyFontHeight)));
 		const int cxyButtonMargin = 7;
-		::SendMessage(hWnd, TB_SETBUTTONSIZE, 0, MAKELONG(pData->wWidth + cxyButtonMargin, max(pData->wHeight, cyFontHeight) + cxyButtonMargin));
+		::SendMessage(hWnd, TB_SETBUTTONSIZE, 0, MAKELONG(pData->wWidth + cxyButtonMargin, std::max(pData->wHeight, cyFontHeight) + cxyButtonMargin));
 
 		return hWnd;
 	}
@@ -3418,10 +3420,10 @@ public:
 				int j = 1;
 				for(j = 1; j < nGroupCount; j++)
 				{
-					rectGroup.left = min(rectGroup.left, m_arrData[i + j].m_rect.left);
-					rectGroup.top = min(rectGroup.top, m_arrData[i + j].m_rect.top);
-					rectGroup.right = max(rectGroup.right, m_arrData[i + j].m_rect.right);
-					rectGroup.bottom = max(rectGroup.bottom, m_arrData[i + j].m_rect.bottom);
+					rectGroup.left = std::min(rectGroup.left, m_arrData[i + j].m_rect.left);
+					rectGroup.top = std::min(rectGroup.top, m_arrData[i + j].m_rect.top);
+					rectGroup.right = std::max(rectGroup.right, m_arrData[i + j].m_rect.right);
+					rectGroup.bottom = std::max(rectGroup.bottom, m_arrData[i + j].m_rect.bottom);
 				}
 
 				for(j = 0; j < nGroupCount; j++)

--- a/libs/wtl/atlmisc.h
+++ b/libs/wtl/atlmisc.h
@@ -9,6 +9,19 @@
 // the terms of this license. You must not remove this notice, or
 // any other, from this software.
 
+/*
+** MODIFICATION
+** ALAS this uses a raw 'max' so this is a slightly modified version of
+** this library to not require using namespace std above it and allow
+** us to run with -DNOMINMAX, a combination which is required by 
+** c++-17 and vstgui recent on windows.
+*/
+#include <algorithm>
+/*
+** END MODIFICATION
+*/
+
+
 #ifndef __ATLMISC_H__
 #define __ATLMISC_H__
 
@@ -1783,7 +1796,7 @@ public:
 				else
 				{
 					nItemLen = lstrlen(pstrNextArg);
-					nItemLen = max(1, nItemLen);
+					nItemLen = std::max(1, nItemLen);
 				}
 				break;
 			}
@@ -1799,7 +1812,7 @@ public:
 				else
 				{
 					nItemLen = (int)wcslen(pstrNextArg);
-					nItemLen = max(1, nItemLen);
+					nItemLen = std::max(1, nItemLen);
 				}
 #else // _UNICODE
 				LPCSTR pstrNextArg = va_arg(argList, LPCSTR);
@@ -1814,7 +1827,7 @@ public:
 #else
 					nItemLen = lstrlenA(pstrNextArg);
 #endif
-					nItemLen = max(1, nItemLen);
+					nItemLen = std::max(1, nItemLen);
 				}
 #endif // _UNICODE
 				break;
@@ -1835,7 +1848,7 @@ public:
 #else
 					nItemLen = lstrlenA(pstrNextArg);
 #endif
-					nItemLen = max(1, nItemLen);
+					nItemLen = std::max(1, nItemLen);
 				}
 				break;
 			}
@@ -1851,7 +1864,7 @@ public:
 				else
 				{
 					nItemLen = (int)wcslen(pstrNextArg);
-					nItemLen = max(1, nItemLen);
+					nItemLen = std::max(1, nItemLen);
 				}
 				break;
 			}
@@ -1860,9 +1873,9 @@ public:
 			// adjust nItemLen for strings
 			if (nItemLen != 0)
 			{
-				nItemLen = max(nItemLen, nWidth);
+				nItemLen = std::max(nItemLen, nWidth);
 				if (nPrecision != 0)
-					nItemLen = min(nItemLen, nPrecision);
+					nItemLen = std::min(nItemLen, nPrecision);
 			}
 			else
 			{
@@ -1880,7 +1893,7 @@ public:
 					else
 						va_arg(argList, int);
 					nItemLen = 32;
-					nItemLen = max(nItemLen, nWidth + nPrecision);
+					nItemLen = std::max(nItemLen, nWidth + nPrecision);
 					break;
 
 #ifndef _ATL_USE_CSTRING_FLOAT
@@ -1906,7 +1919,7 @@ public:
 				case _T('G'):
 					va_arg(argList, double);
 					nItemLen = 128;
-					nItemLen = max(nItemLen, nWidth + nPrecision);
+					nItemLen = std::max(nItemLen, nWidth + nPrecision);
 					break;
 				case _T('f'):
 					{
@@ -1915,7 +1928,7 @@ public:
 						// 309 zeroes == max precision of a double
 						// 6 == adjustment in case precision is not specified,
 						//   which means that the precision defaults to 6
-						int cchLen = max(nWidth, 312 + nPrecision + 6);
+						int cchLen = std::max(nWidth, 312 + nPrecision + 6);
 						CTempBuffer<TCHAR, _WTL_STACK_ALLOC_THRESHOLD> buff;
 						LPTSTR pszTemp = buff.Allocate(cchLen);
 						if(pszTemp != NULL)
@@ -1934,7 +1947,7 @@ public:
 				case _T('p'):
 					va_arg(argList, void*);
 					nItemLen = 32;
-					nItemLen = max(nItemLen, nWidth + nPrecision);
+					nItemLen = std::max(nItemLen, nWidth + nPrecision);
 					break;
 
 				// no output

--- a/premake5.lua
+++ b/premake5.lua
@@ -106,7 +106,7 @@ elseif (os.istarget("windows")) then
 	nuget { "libpng-msvc-x64:1.6.33.8807" }
 
 	characterset "MBCS"
-	buildoptions { "/MP /Zc:alignedNew" }
+	buildoptions { "/MP /Zc:alignedNew /std:c++17" }
 
 	includedirs {
 		"libs/wtl"

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -8,6 +8,8 @@
 #include <list>
 #include <vt_dsp/vt_dsp_endian.h>
 
+using namespace std;
+
 const int hmargin = 6;
 // const int gui_topbar = 44;
 const int gui_topbar = 64;

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -40,6 +40,8 @@ float samplerate, samplerate_inv;
 double dsamplerate, dsamplerate_inv;
 double dsamplerate_os, dsamplerate_os_inv;
 
+using namespace std;
+
 #if MAC
 #include <CoreFoundation/CoreFoundation.h>
 string getSelfLocation()

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -10,7 +10,6 @@
 #include <vector>
 #include <thread/CriticalSection.h>
 #include <memory>
-using namespace std;
 
 #ifndef TIXML_USE_STL
 #define TIXML_USE_STL
@@ -369,8 +368,8 @@ struct SurgeSceneStorage
    Parameter feedback, filterblock_configuration, filter_balance;
    Parameter lowcut;
 
-   vector<ModulationRouting> modulation_scene, modulation_voice;
-   vector<ModulationSource*> modsources;
+   std::vector<ModulationRouting> modulation_scene, modulation_voice;
+   std::vector<ModulationSource*> modsources;
 
    bool modsource_doprocess[n_modsources];
 };
@@ -420,24 +419,24 @@ public:
 
    StepSequencerStorage stepsequences[2][n_lfos];
 
-   vector<Parameter*> param_ptr;
-   vector<int> easy_params_id;
+   std::vector<Parameter*> param_ptr;
+   std::vector<int> easy_params_id;
 
-   vector<ModulationRouting> modulation_global;
+   std::vector<ModulationRouting> modulation_global;
    pdata scenedata[2][n_scene_params];
    pdata globaldata[n_global_params];
    void* patchptr;
    SurgeStorage* storage;
 
    // metadata
-   string name, category, author, comment;
+   std::string name, category, author, comment;
    // metaparameters
    char CustomControllerLabel[n_customcontrollers][16];
 };
 
 struct Patch
 {
-   string name;
+   std::string name;
    fs::path path;
    int category;
    int order;
@@ -446,7 +445,7 @@ struct Patch
 
 struct PatchCategory
 {
-   string name;
+   std::string name;
    int order;
    std::vector<PatchCategory> children;
    bool isRoot;
@@ -495,13 +494,13 @@ public:
    float modsource_vu[n_modsources];
    void refresh_wtlist();
    void refresh_patchlist();
-   void refreshPatchlistAddDir(bool userDir, string subdir);
+   void refreshPatchlistAddDir(bool userDir, std::string subdir);
    void perform_queued_wtloads();
 
    void load_wt(int id, Wavetable* wt);
-   void load_wt(string filename, Wavetable* wt);
-   void load_wt_wt(string filename, Wavetable* wt);
-   void load_wt_wav(string filename, Wavetable* wt);
+   void load_wt(std::string filename, Wavetable* wt);
+   void load_wt_wt(std::string filename, Wavetable* wt);
+   void load_wt_wav(std::string filename, Wavetable* wt);
    void clipboard_copy(int type, int scene, int entry);
    void clipboard_paste(int type, int scene, int entry);
    int get_clipboard_type();
@@ -522,20 +521,20 @@ public:
    std::vector<int> wtOrdering;
    std::vector<int> wtCategoryOrdering;
 
-   string wtpath;
-   string datapath;
-   string userDataPath;
-   string defaultsig, defaultname;
+   std::string wtpath;
+   std::string datapath;
+   std::string userDataPath;
+   std::string defaultsig, defaultname;
    // float table_sin[512],table_sin_offset[512];
    CriticalSection CS_WaveTableData, CS_ModRouting;
    Wavetable WindowWT;
 
 private:
    TiXmlDocument snapshotloader;
-   vector<Parameter> clipboard_p;
+   std::vector<Parameter> clipboard_p;
    int clipboard_type;
    StepSequencerStorage clipboard_stepsequences[n_lfos];
-   vector<ModulationRouting> clipboard_modulation_scene, clipboard_modulation_voice;
+   std::vector<ModulationRouting> clipboard_modulation_scene, clipboard_modulation_voice;
    Wavetable clipboard_wt[n_oscs];
 };
 

--- a/src/common/SurgeStorageLoadWavetable.cpp
+++ b/src/common/SurgeStorageLoadWavetable.cpp
@@ -16,6 +16,8 @@ void error_msg(char* c)
 #define uint32 unsigned int
 #define int32 int
 
+using namespace std;
+
 void SurgeStorage::load_wt_wav(string filename, Wavetable* wt)
 {
 #if WINDOWS

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -25,6 +25,8 @@
 #endif
 #include "CSurgeSlider.h"
 
+using namespace std;
+
 SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
     //: halfband_AL(false),halfband_AR(false),halfband_BL(false),halfband_BR(false),
     : hpA(&storage), hpB(&storage), _parent(parent)

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -11,7 +11,6 @@ struct QuadFilterChainState;
 
 #include <list>
 #include <atomic>
-using namespace std;
 
 #if TARGET_AUDIOUNIT
 class aulayer;
@@ -146,8 +145,8 @@ public:
    void incrementPatch(bool nextPrev);
    void incrementCategory(bool nextPrev);
 
-   string getUserPatchDirectory();
-   string getLegacyUserPatchDirectory();
+   std::string getUserPatchDirectory();
+   std::string getLegacyUserPatchDirectory();
 
    void savePatch();
    void updateUsedState();
@@ -169,7 +168,7 @@ public:
    int CC0, PCH, patchid;
    float masterfade = 0;
    HalfRateFilter *halfbandA, *halfbandB, *halfbandIN;
-   list<SurgeVoice*> voices[2];
+   std::list<SurgeVoice*> voices[2];
    Effect* fx[8];
    bool halt_engine = false;
    MidiChannelState channelState[16];
@@ -192,7 +191,7 @@ public:
 
    // hold pedal stuff
 
-   list<int> holdbuffer[2];
+   std::list<int> holdbuffer[2];
    void purgeHoldbuffer(int scene);
    quadr_osc sinus;
    int demo_counter = 0;

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -22,6 +22,8 @@ namespace fs = std::experimental::filesystem;
 #include "aulayer.h"
 #endif
 
+using namespace std;
+
 // seems to be missing from VST2.3, so it's copied from the VST list instead
 //--------------------------------------------------------------------
 // For Preset (Program) (.fxp) with chunk (magic = 'FPCh')

--- a/src/common/dsp/AdsrEnvelope.h
+++ b/src/common/dsp/AdsrEnvelope.h
@@ -165,15 +165,15 @@ public:
          const float coeff_offset = 2.f - log(samplerate / BLOCK_SIZE) / log(2.f);
 
          float coef_A =
-             powf(2.f, min(0.f, coeff_offset -
+             powf(2.f, std::min(0.f, coeff_offset -
                                     lc[a].f * (adsr->a.temposync ? storage->temposyncratio : 1.f)));
          float coef_D =
-             powf(2.f, min(0.f, coeff_offset -
+             powf(2.f, std::min(0.f, coeff_offset -
                                     lc[d].f * (adsr->d.temposync ? storage->temposyncratio : 1.f)));
          float coef_R =
              envstate == s_uberrelease
                  ? 6.f
-                 : powf(2.f, min(0.f, coeff_offset -
+                 : powf(2.f, std::min(0.f, coeff_offset -
                                           lc[r].f *
                                               (adsr->r.temposync ? storage->temposyncratio : 1.f)));
 

--- a/src/common/dsp/BiquadFilter.cpp
+++ b/src/common/dsp/BiquadFilter.cpp
@@ -4,6 +4,8 @@
 #include "globals.h"
 #include <complex>
 
+using namespace std;
+
 inline double square(double x)
 {
    return x * x;

--- a/src/common/dsp/DspUtilities.h
+++ b/src/common/dsp/DspUtilities.h
@@ -257,7 +257,7 @@ inline float clamp1bp(float in)
 
 inline float amp_to_linear(float x)
 {
-   x = max(0.f, x);
+   x = std::max(0.f, x);
    return x * x * x;
 }
 inline float linear_to_amp(float x)

--- a/src/common/dsp/FMOscillator.cpp
+++ b/src/common/dsp/FMOscillator.cpp
@@ -3,6 +3,8 @@
 //-------------------------------------------------------------------------------------------------------
 #include "Oscillator.h"
 
+using namespace std;
+
 /* FM osc */
 
 FMOscillator::FMOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy)

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -2,6 +2,8 @@
 #include "SurgeStorage.h"
 #include <vt_dsp/basic_dsp.h>
 
+using namespace std;
+
 const float smooth = 0.2f;
 
 FilterCoefficientMaker::FilterCoefficientMaker()

--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -1,5 +1,7 @@
 #include "LfoModulationSource.h"
 
+using namespace std;
+
 LfoModulationSource::LfoModulationSource()
 {}
 

--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -4,6 +4,8 @@
 #include "Oscillator.h"
 #include "DspUtilities.h"
 
+using namespace std;
+
 Oscillator*
 spawn_osc(int osctype, SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy)
 {

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -4,6 +4,8 @@
 #include "Oscillator.h"
 #include "DspUtilities.h"
 
+using namespace std;
+
 // const float integrator_hpf = 0.99999999f;
 // const float integrator_hpf = 0.9992144f;		// 44.1 kHz
 // const float integrator_hpf = 0.9964f;		// 44.1 kHz

--- a/src/common/dsp/SurgeSuperOscillator.cpp
+++ b/src/common/dsp/SurgeSuperOscillator.cpp
@@ -4,6 +4,8 @@
 #include "Oscillator.h"
 #include "DspUtilities.h"
 
+using namespace std;
+
 // const float integrator_hpf = 0.99999999f;
 // const float integrator_hpf = 0.9992144f;		// 44.1 kHz
 // const float integrator_hpf = 0.9964f;		// 44.1 kHz

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -5,6 +5,8 @@
 #include "DspUtilities.h"
 #include "QuadFilterChain.h"
 
+using namespace std;
+
 enum lag_entries
 {
    le_osc1,

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -83,7 +83,7 @@ private:
    int FMmode;
    float noisegenL[2], noisegenR[2];
    Oscillator* osc[3];
-   vector<ModulationSource*> modsources;
+   std::vector<ModulationSource*> modsources;
    // filterblock stuff
    int id_cfa, id_cfb, id_kta, id_ktb, id_emoda, id_emodb, id_resoa, id_resob, id_drive, id_vca,
        id_vcavel, id_fbalance, id_feedback;

--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -9,6 +9,8 @@
 #include <intrin.h>
 #endif
 
+using namespace std;
+
 const float hrfilter[63] = {
     -9.637663112e-008f, -2.216513622e-006f, -1.200509132e-006f, 1.79627641e-005f,
     1.773084477e-005f,  -5.898886593e-005f, -8.980041457e-005f, 0.0001233910152f,

--- a/src/common/dsp/WavetableOscillator.cpp
+++ b/src/common/dsp/WavetableOscillator.cpp
@@ -4,6 +4,8 @@
 #include "Oscillator.h"
 #include "DspUtilities.h"
 
+using namespace std;
+
 const float hpf_cycle_loss = 0.99f;
 
 WavetableOscillator::WavetableOscillator(SurgeStorage* storage,

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -138,7 +138,7 @@ void WindowOscillator::ProcessSubOscs(bool stereo)
        (int)oscdata->wt.n_tables - 1);
    int FormantMul =
        (int)(float)(65536.f * note_to_pitch(localcopy[oscdata->p[1].param_id_in_scene].f));
-   FormantMul = max(FormantMul >> WindowVsWavePO2, 1);
+   FormantMul = std::max(FormantMul >> WindowVsWavePO2, 1);
    {
       // SSE2 path
       for (int so = 0; so < ActiveSubOscs; so++)

--- a/src/common/dsp/effect/ConditionerEffect.cpp
+++ b/src/common/dsp/effect/ConditionerEffect.cpp
@@ -1,6 +1,8 @@
 #include "effect_defs.h"
 #include <vt_dsp/basic_dsp.h>
 
+using namespace std;
+
 /* conditioner */
 
 using namespace vt_dsp;

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -1,5 +1,7 @@
 #include "effect_defs.h"
 
+using namespace std;
+
 /* dualdelay			*/
 
 DualDelayEffect::DualDelayEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd)

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -1,5 +1,7 @@
 #include "effect_defs.h"
 
+using namespace std;
+
 Effect* spawn_effect(int id, SurgeStorage* storage, FxStorage* fxdata, pdata* pd)
 {
    switch (id)

--- a/src/common/dsp/effect/FreqshiftEffect.cpp
+++ b/src/common/dsp/effect/FreqshiftEffect.cpp
@@ -1,5 +1,7 @@
 #include "effect_defs.h"
 
+using namespace std;
+
 /* freqshift			*/
 
 enum freqshiftparams

--- a/src/common/dsp/effect/Reverb1Effect.cpp
+++ b/src/common/dsp/effect/Reverb1Effect.cpp
@@ -1,5 +1,7 @@
 #include "effect_defs.h"
 
+using namespace std;
+
 /* reverb			*/
 
 const float db60 = powf(10.f, 0.05f * -60.f);

--- a/src/common/dsp/effect/RotarySpeakerEffect.cpp
+++ b/src/common/dsp/effect/RotarySpeakerEffect.cpp
@@ -2,6 +2,8 @@
 
 /* rotary_speaker	*/
 
+using namespace std;
+
 enum rsparams
 {
    rsp_rate = 0,

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -18,8 +18,6 @@
 #include <immintrin.h>
 #endif
 
-using namespace std;
-
 #if MAC || __linux__
 #include <strings.h>
 

--- a/src/common/gui/CEffectLabel.h
+++ b/src/common/gui/CEffectLabel.h
@@ -26,13 +26,13 @@ public:
       dc->drawString(label.c_str(), size, VSTGUI::kLeftText, false);
       setDirty(false);
    }
-   void setLabel(string s)
+   void setLabel(std::string s)
    {
       label = s;
    }
 
 private:
-   string label;
+   std::string label;
 
    CLASS_METHODS(CEffectLabel, VSTGUI::CControl)
 };

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -5,6 +5,7 @@
 #include "LfoModulationSource.h"
 
 using namespace VSTGUI;
+using namespace std;
 
 extern CFontRef surge_minifont;
 extern CFontRef surge_patchfont;

--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -7,6 +7,7 @@
 #include <vt_dsp/basic_dsp.h>
 
 using namespace VSTGUI;
+using namespace std;
 
 extern CFontRef surge_minifont;
 

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 using namespace VSTGUI;
+using namespace std;
 
 extern CFontRef surge_minifont;
 extern CFontRef surge_patchfont;

--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -23,12 +23,12 @@ public:
       current_category = category;
       current_patch = patch;
    }
-   void setLabel(string l)
+   void setLabel(std::string l)
    {
       pname = l;
       setDirty(true);
    }
-   void setCategory(string l)
+   void setCategory(std::string l)
    {
       if (l.length())
       {
@@ -40,7 +40,7 @@ public:
          category = "";
       setDirty(true);
    }
-   void setAuthor(string l)
+   void setAuthor(std::string l)
    {
       if (l.length())
       {
@@ -58,9 +58,9 @@ public:
    int sel_id = 0;
 
 protected:
-   string pname;
-   string category;
-   string author;
+   std::string pname;
+   std::string category;
+   std::string author;
    int current_category = 0, current_patch = 0;
    SurgeStorage* storage = nullptr;
 

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -8,6 +8,7 @@
 #include "SurgeBitmaps.h"
 
 using namespace VSTGUI;
+using namespace std;
 
 extern CFontRef surge_minifont;
 

--- a/src/common/gui/PopupEditorDialog.cpp
+++ b/src/common/gui/PopupEditorDialog.cpp
@@ -109,6 +109,8 @@ void spawn_miniedit_text(char* c, int maxchars)
 
 #include "PopupEditorDialog.h"
 
+using namespace std;
+
 extern CAppModule _Module;
 
 float spawn_miniedit_float(float f, int ctype)

--- a/src/common/gui/PopupEditorDialog.h
+++ b/src/common/gui/PopupEditorDialog.h
@@ -11,6 +11,7 @@
 
 #include <atlctrls.h>
 #include <atlCRACK.h>
+#include <algorithm>
 
 class PopupEditorDialog : public CDialogImpl<PopupEditorDialog>
 {
@@ -81,7 +82,7 @@ public:
       ce.Detach();
       if (irange > 0) // try to convert string to integer
       {
-         ivalue = min(irange - 1, atoi(textdata));
+         ivalue = std::min(irange - 1, atoi(textdata));
       }
       fvalue = (float)atof(textdata);
 

--- a/src/common/gui/PopupEditorSpawner.h
+++ b/src/common/gui/PopupEditorSpawner.h
@@ -10,7 +10,6 @@
 #include <string>
 #include <vector>
 #include "SurgeSynthesizer.h"
-using namespace std;
 
 float spawn_miniedit_float(float f, int ctype);
 int spawn_miniedit_int(int i, int ctype);
@@ -18,8 +17,8 @@ void spawn_miniedit_text(char* c, int maxchars);
 
 struct patchdata
 {
-   string name;
-   string category;
-   string comments;
-   string author;
+   std::string name;
+   std::string category;
+   std::string comments;
+   std::string author;
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -37,6 +37,7 @@
 const int yofs = 10;
 
 using namespace VSTGUI;
+using namespace std;
 
 #if MAC
 SharedPointer<CFontDesc> minifont = new CFontDesc("Lucida Grande", 9);

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -28,7 +28,6 @@ typedef VSTGUI::PluginGUIEditor EditorType;
 #include "SurgeSynthesizer.h"
 
 #include <vector>
-using namespace std;
 
 class SurgeGUIEditor : public EditorType, public VSTGUI::IControlListener, public VSTGUI::IKeyboardHook
 {

--- a/src/common/vt_dsp/basic_dsp.cpp
+++ b/src/common/vt_dsp/basic_dsp.cpp
@@ -5,9 +5,7 @@
 #include <algorithm>
 #endif
 
-#if __linux__
 using namespace std;
-#endif
 
 int Min(int a, int b)
 {
@@ -82,7 +80,7 @@ unsigned int Max(unsigned int a, unsigned int b)
 int limit_range(int x, int l, int h)
 {
 #if _M_X64 || __linux__ || MAC
-   return max(min(x, h), l);
+   return std::max(std::min(x, h), l);
 #else
    __asm
    {

--- a/src/windows/StdAfx.cpp
+++ b/src/windows/StdAfx.cpp
@@ -2,6 +2,8 @@
 //  MyFirstWTLWindow.pch will be the pre-compiled header
 //  stdafx.obj will contain the pre-compiled type information
 
+
+
 #include "stdafx.h"
 
 // TODO: reference any additional headers you need in STDAFX.H


### PR DESCRIPTION
using namespace in header files is bad for a variety of
well documented reasons. This change removes them in favor
of (1) full scoping in header files and (2) moving the
using namespace std to cpp files after the last include

The reason to do this change is so we can compile windows
with /std:c++17 which this change also does. Without this
change, the using namespace std would conflict between
byte and std::byte in system headers. However, with this
change, combined with the NOMINMAX requires by the vst3sdk
upgrade, min( and max( in our copy of wtl are ambiguous. As
such I took the distasteful route of modifying lib/wtl to
add `#include <algorithm>` and use std::min and std::max.

With this diff, both mac and windows compile and run and
windows compiles with C++ 17

A prior change has resulted in linux linking problems which
I'll resolve separately, but this code all compiles to objects
on linux.