### PR TITLE
Handle VSTGUI upgrade completely

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -81,7 +81,8 @@ elseif (os.istarget("linux")) then
 
 	buildoptions { "-std=c++17" }
 	links { }
-	buildoptions {  }
+
+    buildoptions {  }
 	linkoptions {  }
 
 	platforms { "x64" }
@@ -275,9 +276,12 @@ function plugincommon()
 			"src/linux/*.mm",
 			"src/linux/**.cpp",
 			"src/linux/**.h",
---			"libs/vst/*.mm", --
---			VSTGUI .. "vstgui_linux.cpp", -- with the Jan 19 pointer upgrade this is no longer needed nor works
---			VSTGUI .. "vstgui_uidescription_linux.cpp", --
+            
+            VSTGUI .. "vstgui.cpp",
+            VSTGUI .. "lib/platform/linux/**.cpp",
+            VSTGUI .. "lib/platform/common/genericoptionmenu.cpp",
+            VSTGUI .. "lib/platform/common/generictextedit.cpp",     
+
 		}
 	
 		excludes {
@@ -295,7 +299,19 @@ function plugincommon()
 			"pthread",
 			"stdc++fs",
 			"gcc_s",
-			"gcc"
+			"gcc",
+
+            "xcb",
+            "xcb-xkb",
+            "xcb-cursor", 
+            "X11-xcb", 
+            "xcb-util", 
+            "xcb-keysyms",
+            
+            "xkbcommon",
+            "xkbcommon-x11",
+            
+            "X11",
 		}
 
 		linkoptions {


### PR DESCRIPTION
When I upgraded VSTGUI I had not checked link beyond vst3, and
it turns out links there were suspect event. This diff to
premake (1) includes the neccesary platform files and
(2) links the necessary xcb xkb and x11 libraries.

Closes #422 