### PR TITLE
Make Win32 compile and run

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -107,7 +107,7 @@ elseif (os.istarget("windows")) then
 	nuget { "libpng-msvc-x64:1.6.33.8807" }
 
 	characterset "MBCS"
-	buildoptions { "/MP /Zc:alignedNew /std:c++17" }
+	buildoptions { "/MP /Zc:alignedNew /std:c++17 /bigobj" }
 
 	includedirs {
 		"libs/wtl"
@@ -115,7 +115,7 @@ elseif (os.istarget("windows")) then
 	
 	flags { "StaticRuntime", "NoMinimalRebuild" }
 
-	platforms { "x64" }
+	platforms { "x64", "x86" }
 
 	configuration {}
 end

--- a/scripts/win/build-win.ps1
+++ b/scripts/win/build-win.ps1
@@ -14,7 +14,8 @@ Param(
     [switch]$install,
     [switch]$bi, # build and install
     [switch]$cb, # Clean and Build
-    [switch]$cbi # clean build and install
+    [switch]$cbi, # clean build and install
+    [switch]$w32
 )
 
 function Show-Help
@@ -31,6 +32,8 @@ build-win.ps1 is a powershell script to control builds and do installs. It takes
     -cb         clean + build
     -cbi        clean + build + install
 
+    -w32        Build 32 bit
+
 It does not run premake yet. 
 
 You need to onetime do
@@ -45,6 +48,14 @@ $msBuildExe = "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSB
 $surgeSln = ".\surge.sln"
 $userDir = $($env:HOMEDRIVE) + $($env:HOMEPATH)
 $vst2Dir = "${userDir}\VST2"
+$platform = "/p:Platform=x64"
+
+if( $w32 )
+{
+    Write-Host "Building 32 bit windows"
+    $platform = "/p:Platform=Win32"
+}
+
 
 If( -Not ( Test-Path .\Surge.sln ) )
 {
@@ -55,13 +66,13 @@ If( -Not ( Test-Path .\Surge.sln ) )
 function Build-Surge
 {
     Write-Host "Building"
-    & "$($msBuildExe)" "$($surgeSln)" /t:Build /m /p:Configuration=Release
+    & "$($msBuildExe)" "$($surgeSln)" /t:Build /m /p:Configuration=Release "$($platform)"
 }
 
 function Clean-Surge
 {
     Write-Host "Cleaning"
-    & "$($msBuildExe)" "$($surgeSln)" /t:Clean /m /p:Configuration=Release
+    & "$($msBuildExe)" "$($surgeSln)" /t:Clean /m /p:Configuration=Release "$($platform)"
 }
 
 function Install-Surge

--- a/src/common/gui/CAboutBox.cpp
+++ b/src/common/gui/CAboutBox.cpp
@@ -40,8 +40,18 @@ void CAboutBox::draw(CDrawContext* pContext)
       _aboutBitmap->draw(pContext, getViewSize(), CPoint(0, 0), 0xff);
 
       int strHeight = infoFont->getSize(); // There should really be a better API for this in VSTGUI
+      std::string bittiness = (sizeof(size_t)==4? std::string("32") : std::string("64")) + " bit";
+
+#if TARGET_AUDIOUNIT      
+      std::string flavor = "au";
+#elif TARGET_VST3
+      std::string flavor = "vst3";
+#elif TARGET_VST2
+      std::string flavor = "vst2";
+#endif      
+      
       std::vector< std::string > msgs = { {
-              std::string() + "Version " + SURGE_STR(SURGE_VERSION) + " (build: " +
+              std::string() + "Version " + SURGE_STR(SURGE_VERSION) + " (" + bittiness + " " + flavor + ". Built " +
               __DATE__ + " " + __TIME__ + ")",
               "Released under the GNU General Public License, v3",
               "Copyright 2005-2019 by individual contributors",

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -48,11 +48,12 @@ public:
    
 #if !TARGET_VST3
    bool open(void* parent) override;
+   void close() override;
 #else
    virtual bool PLUGIN_API open(void* parent, const VSTGUI::PlatformType& platformType = VSTGUI::kDefaultNative);
+   virtual void PLUGIN_API close() override;
 #endif
 
-   void close() override;
 
 protected:
    int32_t onKeyDown(const VstKeyCode& code,


### PR DESCRIPTION
Win32 support via (1) premake5.lua adding the architecture;
(2) correct signature on ::close in SurgeGuiEditor;
(3) update to my personal powershell script which I secretly
use to build to support a -w32 flag; and (4) message in the
about box which shows the bits and the plugin flavor.