### PR TITLE
Checkmarks on sub-menus

### DIFF
--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -64,7 +64,13 @@ protected:
    int current_category = 0, current_patch = 0;
    SurgeStorage* storage = nullptr;
 
-   void populatePatchMenuForCategory (int index, VSTGUI::COptionMenu *contextMenu, bool single_category, int &main_e, bool rootCall);
+   /**
+    * populatePatchMenuForCategory
+    *
+    * recursively builds the nexted patch menu. In the event that one of my childrenis checked, return true so I too can be checked.
+    * otherwise, return false.
+    */
+   bool populatePatchMenuForCategory (int index, VSTGUI::COptionMenu *contextMenu, bool single_category, int &main_e, bool rootCall);
    
    CLASS_METHODS(CPatchBrowser, VSTGUI::CControl)
 };


### PR DESCRIPTION
With the introduction of checkmarks on menus, they need to
percolate up to parents so the check marks are on the
parent categories too. This change does that by passing
up the checkedness from the parent up the recursion stack.

Closes #404 