### PR TITLE
Linux linking

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -546,6 +546,12 @@ elseif (os.istarget("linux")) then
 		"vst3sdk/public.sdk/source/main/linuxmain.cpp",
 	}
 
+    excludes {
+        -- This is both deprecated and, on linux, ejects a non-linkable symbol. So exclude it.
+        "vst3sdk/base/source/timer.cpp"
+    }
+
+
 end
 
 -- AUDIO UNIT PLUGIN --

--- a/src/common/gui/CAboutBox.cpp
+++ b/src/common/gui/CAboutBox.cpp
@@ -48,6 +48,8 @@ void CAboutBox::draw(CDrawContext* pContext)
       std::string flavor = "vst3";
 #elif TARGET_VST2
       std::string flavor = "vst2";
+#else
+      std::string flavor = "NON-PLUGIN"; // for linux app
 #endif      
       
       std::vector< std::string > msgs = { {


### PR DESCRIPTION
A few final changes for linux linking and building. (1) CAboutBox
for the app; (2) exclude the deprecated timer.cpp which on linux
only also doesn't link.