### PR TITLE
surge-manual -> manual url

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2555,7 +2555,7 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
     }
     else if(command == id_openmanual)
     {
-        Surge::UserInteractions::openURL("https://surge-synthesizer.github.io/surge-manual/");
+        Surge::UserInteractions::openURL("https://surge-synthesizer.github.io/manual/");
     }
 
 }


### PR DESCRIPTION
this changes the surge manual url from `/surge-manual` to `/manual`.
