### PR TITLE
Restore linux vst3

### DIFF
--- a/src/common/gui/CAboutBox.cpp
+++ b/src/common/gui/CAboutBox.cpp
@@ -51,9 +51,19 @@ void CAboutBox::draw(CDrawContext* pContext)
 #else
       std::string flavor = "NON-PLUGIN"; // for linux app
 #endif      
-      
+
+#if MAC
+      std::string platform = "macOS";
+#elif WINDOWS
+      std::string platform = "windows";
+#elif __linux__
+      std::string platform = "linux";
+#else
+      std::string platform = "orac or skynet or something";
+#endif      
+
       std::vector< std::string > msgs = { {
-              std::string() + "Version " + SURGE_STR(SURGE_VERSION) + " (" + bittiness + " " + flavor + ". Built " +
+              std::string() + "Version " + SURGE_STR(SURGE_VERSION) + " (" + bittiness + " " + platform + " " + flavor + ". Built " +
               __DATE__ + " " + __TIME__ + ")",
               "Released under the GNU General Public License, v3",
               "Copyright 2005-2019 by individual contributors",

--- a/src/linux/linux-aeffguieditor.cpp
+++ b/src/linux/linux-aeffguieditor.cpp
@@ -2,6 +2,8 @@
 // in the LICENSE file found in the top-level directory of this
 // distribution and at http://github.com/steinbergmedia/vstgui/LICENSE
 
+#if TARGET_VST2
+
 #include "linux-aeffguieditor.h"
 #include "public.sdk/source/vst2.x/audioeffectx.h"
 #include "vstgui/lib/platform/platform_x11.h"
@@ -211,3 +213,5 @@ bool LinuxAEffGUIEditor::beforeSizeChange (const CRect& newSize, const CRect& ol
 }
 
 } // VSTGUI
+
+#endif // TARGET_VST guard

--- a/src/linux/linux-aeffguieditor.h
+++ b/src/linux/linux-aeffguieditor.h
@@ -2,6 +2,8 @@
 // in the LICENSE file found in the top-level directory of this
 // distribution and at http://github.com/steinbergmedia/vstgui/LICENSE
 
+#if TARGET_VST2
+
 #ifndef __linux_aeffguieditor__
 #define __linux_aeffguieditor__
 
@@ -66,4 +68,6 @@ private:
 
 } // VSTGUI
 
-#endif
+#endif // include guard
+
+#endif // TARGET VST2


### PR DESCRIPTION
The aeffguieditor changes explicitly reference the VST2 api.
Guard them out for the outer build targets. Also show the platform
in the about box.