### PR TITLE
Load bitmaps on linux from /usr/share

### DIFF
--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -73,6 +73,8 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint& where, const CButtonState& 
       int rightMouseCategory = current_category;
       if (current_category < 0)
       {
+          if (storage->patchCategoryOrdering.size() == 0)
+              return kMouseEventHandled;
           for (auto c : storage->patchCategoryOrdering)
           {
               if (_stricmp(storage->patch_category[c].name.c_str(),"init")==0)

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -87,8 +87,9 @@ void SurgeBitmaps::addEntry(int id)
 #ifdef USE_SCALABLE_BITMAPS
    VSTGUI::CBitmap *bitmap = new CScalableBitmap(CResourceDescription(id));
 #elif __linux__
+   // FIXME use scalable bitmaps, and load stuff from memory
    char filename [1024];
-   snprintf (filename, 1024, "./resources/bitmaps/bmp%05d.png", id);
+   snprintf (filename, 1024, "/usr/share/surge/bitmaps/bmp%05d.png", id);
    filename[1023] = '\0';
    VSTGUI::CBitmap* bitmap = new VSTGUI::CBitmap(IPlatformBitmap::createFromPath( filename ));
 #else

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -86,6 +86,11 @@ void SurgeBitmaps::addEntry(int id)
 
 #ifdef USE_SCALABLE_BITMAPS
    VSTGUI::CBitmap *bitmap = new CScalableBitmap(CResourceDescription(id));
+#elif __linux__
+   char filename [1024];
+   snprintf (filename, 1024, "./resources/bitmaps/bmp%05d.png", id);
+   filename[1023] = '\0';
+   VSTGUI::CBitmap* bitmap = new VSTGUI::CBitmap(IPlatformBitmap::createFromPath( filename ));
 #else
    VSTGUI::CBitmap* bitmap = new VSTGUI::CBitmap(CResourceDescription(id));
 #endif

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -151,7 +151,8 @@ SurgeGUIEditor::~SurgeGUIEditor()
 void SurgeGUIEditor::idle()
 {
 #if TARGET_VST2 && __linux__
-   super::idle();
+   if (!super::idle2())
+       return;
 #endif
    if (!synth)
       return;

--- a/src/linux/linux-aeffguieditor.cpp
+++ b/src/linux/linux-aeffguieditor.cpp
@@ -77,8 +77,15 @@ bool LinuxRunLoop::registerEventHandler (int fd, IEventHandler* handler)
 bool LinuxRunLoop::unregisterEventHandler (IEventHandler* handler)
 {
 	printf("%s %p\n", __func__, handler);
-	// TODO
-	return true;
+	for (auto it = eventHandlers.begin(); it != eventHandlers.end(); it++)
+	{
+		if (it->eventHandler == handler)
+		{
+			eventHandlers.erase(it);
+			return true;
+		}
+	}
+	return false;
 }
 
 //------------------------------------------------------------------------
@@ -95,8 +102,15 @@ bool LinuxRunLoop::registerTimer (uint64_t interval, ITimerHandler* handler)
 bool LinuxRunLoop::unregisterTimer (ITimerHandler* handler)
 {
 	printf("%s %p\n", __func__, handler);
-	// TODO
-	return true;
+	for (auto it = timerHandlers.begin(); it != timerHandlers.end(); it++)
+	{
+		if (it->timerHandler == handler)
+		{
+			timerHandlers.erase(it);
+			return true;
+		}
+	}
+	return false;
 }
 
 //------------------------------------------------------------------------

--- a/src/linux/linux-aeffguieditor.cpp
+++ b/src/linux/linux-aeffguieditor.cpp
@@ -174,12 +174,12 @@ bool LinuxAEffGUIEditor::open (void* ptr)
 }
 
 //-----------------------------------------------------------------------------
-void LinuxAEffGUIEditor::idle ()
+bool LinuxAEffGUIEditor::idle2 ()
 {
 	if (inIdle)
 	{
 		fprintf(stderr, "%s: Caught recursive idle call\n", __func__);
-		return;
+		return false;
 	}
 
 	inIdle = true;
@@ -191,6 +191,7 @@ void LinuxAEffGUIEditor::idle ()
 	LinuxRunLoop::instance().idle();
 
 	inIdle = false;
+	return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/linux/linux-aeffguieditor.h
+++ b/src/linux/linux-aeffguieditor.h
@@ -33,7 +33,7 @@ public :
 	virtual void setParameter (VstInt32 index, float value) {}
 	bool getRect (ERect** ppRect) override;
 	bool open (void* ptr) override;
-	void idle () override;
+	bool idle2 ();
 
 	#if VST_2_1_EXTENSIONS
 	bool onKeyDown (VstKeyCode& keyCode) override;


### PR DESCRIPTION
Experimenting with loading bitmaps on linux.
Obviously only works if "resources" dir is available, but allows Linux to test the full GUI for now.

We need to convert these bitmaps into object code, or embed them in the binary.
I believe premake has built-in utilities for that.
If not, we leverage some tool.
When done, we replace `createFromPath` with `createFromMemory`.

