### PR TITLE
Scalable Bitmaps on Linux

### DIFF
--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -43,5 +43,12 @@ private:
     int lastSeenZoom, bestFitScaleGroup;
     int extraScaleFactor;
 
+    int id;
+
+#if __linux__
+    VSTGUI::SharedPointer<VSTGUI::IPlatformBitmap> originalPlatformBitmapForID(int id);
+    VSTGUI::SharedPointer<VSTGUI::IPlatformBitmap> scalablePlatformBitmapForIDAndScale(int id, std::string scale);
+#endif
+
     static int currentPhysicalZoomFactor;
 };

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -2,13 +2,7 @@
 #include "UserInteractions.h"
 #include <map>
 
-#if MAC  || WINDOWS
-#define USE_SCALABLE_BITMAPS 1
-#endif
-
-#ifdef USE_SCALABLE_BITMAPS
 #include "CScalableBitmap.h"
-#endif
 
 using namespace VSTGUI;
 
@@ -84,11 +78,8 @@ void SurgeBitmaps::addEntry(int id)
 {
    assert(bitmap_registry.find(id) == bitmap_registry.end());
 
-#ifdef USE_SCALABLE_BITMAPS
    VSTGUI::CBitmap *bitmap = new CScalableBitmap(CResourceDescription(id));
-#else
-   VSTGUI::CBitmap* bitmap = new VSTGUI::CBitmap(CResourceDescription(id));
-#endif
+
    bitmap_registry[id] = bitmap;
 }
 
@@ -96,7 +87,6 @@ VSTGUI::CBitmap* getSurgeBitmap(int id, bool newInstance)
 {
    if( newInstance )
    {
-#ifdef USE_SCALABLE_BITMAPS
       /*
       ** Background images are specially handled by the frame object with scaling and so each needs
       ** to maintain an independent 'additional zoom'. For now handle that by allowing the construction of
@@ -113,10 +103,6 @@ VSTGUI::CBitmap* getSurgeBitmap(int id, bool newInstance)
                                                "Software Error" );
       }
       return new CScalableBitmap(CResourceDescription(id));
-#else
-      return bitmap_registry.at(id);
-#endif
-       
    }
    else
    {


### PR DESCRIPTION
Following @falktx using bitmaps from resource files,
factor CScalableBitmap properly so the two functions
we need are clear; and then for now use file loads
from the local file system for them. Condition it
appopriately by OS.