### PR TITLE
Use a different name for 32 bit dll

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -125,7 +125,13 @@ elseif (os.istarget("windows")) then
 
     flags { "StaticRuntime", "NoMinimalRebuild" }
 
-  platforms { "x64", "x86" }
+    platforms { "x64", "x86" }
+
+    filter "platforms:x86"
+        targetsuffix "32"
+    filter "platforms:x64"
+        targetsuffix ""
+    filter {}
 
     configuration { "Debug" }
     links {

--- a/scripts/win/build-win.ps1
+++ b/scripts/win/build-win.ps1
@@ -88,6 +88,7 @@ function Install-Surge
         New-Item -ItemType Directory -Force -Path $vst2Dir
     }
     Copy-Item "target\vst2\Release\Surge.dll" -Destination $vst2Dir -Force 
+    Copy-Item "target\vst2\Release\Surge32.dll" -Destination $vst2Dir -Force 
 
     Write-Host "Start-Process -Verb runAs -WorkingDirectory $PSScriptRoot powershell -argumentlist install-vst3.ps1"
     Start-Process -Verb runAs   "powershell" -argumentlist "$PSScriptRoot\install-vst3.ps1"
@@ -123,6 +124,8 @@ if( $cleanall )
     Write-Host "Delete the visual studio files also"
     Remove-Item -path .\*vcxproj*
     Remove-Item -path .\Surge.sln
+    Remove-Item -path .\target -recurse
+    Remove-Item -path .\obj -recurse  
 }
 if( $build )
 {

--- a/scripts/win/install-vst3.ps1
+++ b/scripts/win/install-vst3.ps1
@@ -6,4 +6,5 @@ If(!(Test-Path $vstDir))
     New-Item -ItemType Directory -Force -Path $vstDir
 }
 
-Copy-Item "$PSScriptRoot\..\..\target\vst3\Release\Surge.vst3" -Destination $vstDir -Force 
+Copy-Item "$PSScriptRoot\..\..\target\vst3\Release\Surge.vst3" -Destination $vstDir -Force
+Copy-Item "$PSScriptRoot\..\..\target\vst3\Release\Surge32.vst3" -Destination $vstDir -Force 


### PR DESCRIPTION
The target name for 64 and 32 was identical so the nightlies
were accidentally distroing the 32 bit plugin. This fixes
that by making the 32 bit dll have the name Surge32.dll.

This means in bitwig I can have all 4 flavors installed and pick
and choose between them!