### PR TITLE
Replace __linux__ with LINUX

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -77,7 +77,10 @@ elseif (os.istarget("linux")) then
     {
     }
 
-    defines { "WINDOWS=0" }
+    defines
+    {
+        "LINUX=1",
+    }
 
     buildoptions { "-std=c++17" }
     links { }

--- a/src/common/Sample.h
+++ b/src/common/Sample.h
@@ -7,7 +7,7 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#if MAC || __linux__
+#if MAC || LINUX
 #else
 #include <windows.h>
 #include <mmreg.h>

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -18,7 +18,7 @@
 //#include <MacErrorHandling.h>
 #include <CoreFoundation/CFBundle.h>
 #include <CoreServices/CoreServices.h>
-#elif __linux__
+#elif LINUX
 #include <stdlib.h>
 #else
 #include <windows.h>
@@ -163,7 +163,7 @@ SurgeStorage::SurgeStorage()
    sprintf( path, "%s/Documents/Surge", getenv( "HOME" ) );
    userDataPath = path;
    
-#elif __linux__
+#elif LINUX
 
    /*
     * Even though Linux distinguishes between configuration and data folders,
@@ -206,7 +206,7 @@ SurgeStorage::SurgeStorage()
    {
       Surge::Error exc("Cannot find 'configuration.xml' in path '" + datapath + "'. Please reinstall surge.",
                        "Surge is not properly installed.");
-#if __linux__
+#if LINUX
       throw exc;
 #else
       Surge::UserInteractions::promptError(exc);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -16,7 +16,7 @@
 #endif
 #include <tinyxml.h>
 
-#if __linux__
+#if LINUX
 #include <experimental/filesystem>
 #elif MAC
 #include <filesystem.h>

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4,7 +4,7 @@
 #include "SurgeSynthesizer.h"
 #include "DspUtilities.h"
 #include <time.h>
-#if MAC || __linux__
+#if MAC || LINUX
 #include <pthread.h>
 #else
 #include <windows.h>
@@ -21,7 +21,7 @@
 #include "vstgui/plugin-bindings/plugguieditor.h"
 #else
 #include "Vst2PluginInstance.h"
-#if __linux__
+#if LINUX
 #include "../linux/linux-aeffguieditor.h"
 #else
 #include "vstgui/plugin-bindings/aeffguieditor.h"
@@ -1977,7 +1977,7 @@ float SurgeSynthesizer::valueToNormalized(long index, float value)
    return 0.f;
 }
 
-#if MAC || __linux__
+#if MAC || LINUX
 void* loadPatchInBackgroundThread(void* sy)
 {
 #else
@@ -2168,7 +2168,7 @@ void SurgeSynthesizer::process()
          // spawn patch-loading thread
          halt_engine = true;
 
-#if MAC || __linux__
+#if MAC || LINUX
          pthread_t thread;
          pthread_attr_t attributes;
          int ret;

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -5,7 +5,7 @@
 #include "DspUtilities.h"
 #include <time.h>
 #include <vt_dsp/vt_dsp_endian.h>
-#if __linux__
+#if LINUX
 #include <experimental/filesystem>
 #elif MAC
 #include <filesystem.h>
@@ -230,7 +230,7 @@ void SurgeSynthesizer::loadRaw(const void* data, int size, bool preset)
    }
 }
 
-#if MAC || __linux__
+#if MAC || LINUX
 #include <sys/types.h>
 #include <sys/stat.h>
 #endif
@@ -241,7 +241,7 @@ string SurgeSynthesizer::getUserPatchDirectory()
 }
 string SurgeSynthesizer::getLegacyUserPatchDirectory()
 {
-#if MAC || __linux__
+#if MAC || LINUX
    return storage.datapath + "patches_user/";
 #else
    return storage.datapath + "patches_user\\";

--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -38,7 +38,7 @@ const int HRFilterI16[64] = {
 
 int min_F32_tables = 3;
 
-#if MAC || __linux__
+#if MAC || LINUX
 bool _BitScanReverse(unsigned int* result, unsigned int bits)
 {
    *result = __builtin_ctz(bits);

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -2,10 +2,10 @@
 //	Copyright 2006 Claes Johanson & Vember Audio
 //-------------------------------------------------------------------------------------------------------
 #include "Oscillator.h"
-#if !MAC && !__linux__
+#if !MAC && !LINUX
 #include <intrin.h>
 #endif
-#if __linux__
+#if LINUX
 #include <stdint.h>
 #endif
 
@@ -97,7 +97,7 @@ inline unsigned int BigMULr16(unsigned int a, unsigned int b)
 #if _M_X64
    unsigned __int64 c = __emulu(a, b);
    return c >> 16;
-#elif __linux__
+#elif LINUX
    uint64_t c = (uint64_t)a * (uint64_t)b;
    return c >> 16;
 #else
@@ -117,7 +117,7 @@ inline unsigned int BigMULr16(unsigned int a, unsigned int b)
 #endif
 }
 
-#if MAC || __linux__
+#if MAC || LINUX
 inline bool _BitScanReverse(unsigned long* result, unsigned long bits)
 {
    *result = __builtin_ctz(bits);

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -14,11 +14,11 @@
 #endif
 #include <xmmintrin.h>
 
-#if __linux__
+#if LINUX
 #include <immintrin.h>
 #endif
 
-#if MAC || __linux__
+#if MAC || LINUX
 #include <strings.h>
 
 static inline int _stricmp(const char *s1, const char *s2)

--- a/src/common/gui/CAboutBox.cpp
+++ b/src/common/gui/CAboutBox.cpp
@@ -56,7 +56,7 @@ void CAboutBox::draw(CDrawContext* pContext)
       std::string platform = "macOS";
 #elif WINDOWS
       std::string platform = "windows";
-#elif __linux__
+#elif LINUX
       std::string platform = "linux";
 #else
       std::string platform = "orac or skynet or something";

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -8,7 +8,7 @@
 #include "UserInteractions.h"
 #if MAC
 #include "filesystem.h"
-#elif __linux__
+#elif LINUX
 #include "experimental/filesystem"
 #else
 #include "filesystem"

--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -7,7 +7,7 @@
 #if MAC
 #include <CoreFoundation/CoreFoundation.h>
 #endif
-#if __linux__
+#if LINUX
 #include "ScalablePiggy.h"
 #endif
 
@@ -15,7 +15,7 @@
 
 using namespace VSTGUI;
 
-#if __linux__
+#if LINUX
 static const struct MemoryBitmap *findMemoryBitmap(const std::string& filename)
 {
     for (const struct MemoryBitmap *bmp = &memoryBitmapList[0];
@@ -67,7 +67,7 @@ CScalableBitmap::CScalableBitmap(CResourceDescription desc)
     {
         CBitmap *scBmp = NULL;
 
-#if MAC || __linux__
+#if MAC || LINUX
         std::stringstream filename;
         auto postfix = scaleFilePostfixes[sc];
         filename << "scalable/bmp" << std::setw(5) << std::setfill('0') << id
@@ -85,7 +85,7 @@ CScalableBitmap::CScalableBitmap(CResourceDescription desc)
 
 #if MAC
         scBmp = new CBitmap(CResourceDescription(filename.str().c_str()));
-#elif __linux__
+#elif LINUX
         try {
             const MemoryBitmap *memBmp = findMemoryBitmap(filename.str());
             auto platBmp = IPlatformBitmap::createFromMemory(

--- a/src/common/gui/PopupEditorDialog.cpp
+++ b/src/common/gui/PopupEditorDialog.cpp
@@ -144,7 +144,7 @@ void spawn_miniedit_text(char* c, int maxchars)
       strncpy(c, me.textdata, maxchars);
    }
 }
-#elif __linux__
+#elif LINUX
 
 #include "UserInteractions.h"
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -150,7 +150,7 @@ SurgeGUIEditor::~SurgeGUIEditor()
 
 void SurgeGUIEditor::idle()
 {
-#if TARGET_VST2 && __linux__
+#if TARGET_VST2 && LINUX
    if (!super::idle2())
        return;
 #endif
@@ -191,7 +191,7 @@ void SurgeGUIEditor::idle()
          }
          synth->storage.CS_ModRouting.leave();
       }
-#if MAC || __linux__
+#if MAC || LINUX
       idleinc++;
       if (idleinc > 15)
       {

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -13,7 +13,7 @@ typedef VSTGUI::PluginGUIEditor EditorType;
 #include "public.sdk/source/vst/vstguieditor.h"
 typedef Steinberg::Vst::VSTGUIEditor EditorType;
 #elif TARGET_VST2
-#if __linux__
+#if LINUX
 #include "../linux/linux-aeffguieditor.h"
 typedef VSTGUI::LinuxAEffGUIEditor EditorType;
 #else
@@ -160,7 +160,7 @@ private:
    VSTGUI::CControl* metaparam[n_customcontrollers] = {};
    VSTGUI::CControl* lfodisplay = nullptr;
    VSTGUI::CControl* filtersubtype[2] = {};
-#if MAC || __linux__
+#if MAC || LINUX
 #else
    HWND ToolTipWnd;
 #endif

--- a/src/common/thread/CriticalSection.cpp
+++ b/src/common/thread/CriticalSection.cpp
@@ -1,6 +1,6 @@
 #include "CriticalSection.h"
 
-#if !__linux__
+#if !LINUX
 
 #include "assert.h"
 

--- a/src/common/thread/CriticalSection.h
+++ b/src/common/thread/CriticalSection.h
@@ -2,12 +2,12 @@
 
 #if MAC
 #include <CoreServices/CoreServices.h>
-#elif __linux__
+#elif LINUX
 #else
 #include "windows.h"
 #endif
 
-#if __linux__
+#if LINUX
 
 #include <stdio.h>
 #include <pthread.h>

--- a/src/common/vt_dsp/basic_dsp.cpp
+++ b/src/common/vt_dsp/basic_dsp.cpp
@@ -1,7 +1,7 @@
 #include "basic_dsp.h"
 #include <assert.h>
 #include <math.h>
-#if MAC || __linux__
+#if MAC || LINUX
 #include <algorithm>
 #endif
 
@@ -9,7 +9,7 @@ using namespace std;
 
 int Min(int a, int b)
 {
-#if _M_X64 || __linux__
+#if _M_X64 || LINUX
    return min(a, b);
 #else
    __asm
@@ -23,7 +23,7 @@ int Min(int a, int b)
 }
 int Max(int a, int b)
 {
-#if _M_X64 || __linux__
+#if _M_X64 || LINUX
    return max(a, b);
 #else
    __asm
@@ -50,7 +50,7 @@ double Max(double a, double b)
 
 unsigned int Min(unsigned int a, unsigned int b)
 {
-#if _M_X64 || __linux__
+#if _M_X64 || LINUX
    return min(a, b);
 #else
    __asm
@@ -64,7 +64,7 @@ unsigned int Min(unsigned int a, unsigned int b)
 }
 unsigned int Max(unsigned int a, unsigned int b)
 {
-#if _M_X64 || __linux__
+#if _M_X64 || LINUX
    return max(a, b);
 #else
    __asm
@@ -79,7 +79,7 @@ unsigned int Max(unsigned int a, unsigned int b)
 
 int limit_range(int x, int l, int h)
 {
-#if _M_X64 || __linux__ || MAC
+#if _M_X64 || LINUX || MAC
    return std::max(std::min(x, h), l);
 #else
    __asm
@@ -97,7 +97,7 @@ int limit_range(int x, int l, int h)
 
 int Wrap(int x, int L, int H)
 {
-#if _M_X64 || __linux__
+#if _M_X64 || LINUX
    // don't remember what this was anymore...
    // int diff = H - L;
    // if(x > H) x = x-H;
@@ -129,7 +129,7 @@ int Wrap(int x, int L, int H)
 
 int Sign(int x)
 {
-#if _M_X64 || __linux__
+#if _M_X64 || LINUX
    return (x < 0) ? -1 : 1;
 #else
    __asm
@@ -145,7 +145,7 @@ int Sign(int x)
 
 unsigned int limit_range(unsigned int x, unsigned int l, unsigned int h)
 {
-#if _M_X64 || __linux__
+#if _M_X64 || LINUX
    return max(min(x, h), l);
 #else
    __asm

--- a/src/common/vt_dsp/portable_intrinsics.h
+++ b/src/common/vt_dsp/portable_intrinsics.h
@@ -1,4 +1,4 @@
-#if __linux__
+#if LINUX
 #include <immintrin.h>
 #endif
 

--- a/src/common/vt_dsp/shared.h
+++ b/src/common/vt_dsp/shared.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if __linux__
+#if LINUX
 #include <immintrin.h>
 #endif
 

--- a/src/common/vt_dsp/vt_dsp_endian.h
+++ b/src/common/vt_dsp/vt_dsp_endian.h
@@ -18,7 +18,7 @@ inline float vt_write_float32LE(float f)
 
 inline int vt_write_int32BE(int t)
 {
-#if (__linux__ || MAC || _M_X64)
+#if (LINUX || MAC || _M_X64)
    // this was `swap_endian`:
    return ((t << 24) & 0xff000000) | ((t << 8) & 0x00ff0000) | ((t >> 8) & 0x0000ff00) |
           ((t >> 24) & 0x000000ff);

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -19,7 +19,7 @@
 
 using namespace std;
 
-#if __linux__
+#if LINUX
 namespace VSTGUI { void* soHandle = nullptr; }
 #endif
 
@@ -40,7 +40,7 @@ Vst2PluginInstance::Vst2PluginInstance(audioMasterCallback audioMaster)
    setNumInputs(2);  // stereo in
    setNumOutputs(2); // stereo out
 
-#if MAC || __linux__
+#if MAC || LINUX
    isSynth();
    plug_is_synth = true;
    setUniqueID('cjs3'); // identify


### PR DESCRIPTION
Make the Linux compilation flag more inline how the flags for macOS and
Windows have been named. Someone might say that, why don't you pick UNIX to
make code more compatible with CMake, which we plan to eventually to
migrate. There is a predefined flag called APPLE on CMake for macOS but
also UNIX is true on macOS compilation.

What people tend to do in their CMakeLists.txt usually is:

if(UNIX AND NOT APPLE)
    set(LINUX TRUE)
endif()

So, in a distant way, this commit makes also the code more ready for the
eventual CMake migration.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>