### PR TITLE
Change #ifndef WINDOWS to #if WINDOWS in unitconversion.h

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -46,7 +46,7 @@ if (os.istarget("macosx")) then
     {
     }
 
-    defines { "MAC=1", "WINDOWS=0",  }
+    defines { "MAC=1" }
 
     buildoptions
         {

--- a/src/common/unitconversion.h
+++ b/src/common/unitconversion.h
@@ -51,13 +51,6 @@ inline float seconds_to_envtime(float in) // ff rev2
    return v;
 }
 
-#ifndef WINDOWS
-inline float log2(float x)
-{
-   return log(x) / log(2.f);
-}
-#endif
-
 inline char* get_notename(char* s, int i_value)
 {
    int octave = (i_value / 12) - 2;


### PR DESCRIPTION
Caused a compilation error when "WINDOWS=0" define was remove from
premake5.lua for Linux. This commit replaces it with a more proper
"#if WINDOWS" as it should be.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>