### PR TITLE
Replace ->ToElement with dynamic cast

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -892,14 +892,14 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
    for (auto& i : fx)
       i.type.val.i = fxt_off;
 
-   TiXmlElement* patch = doc.FirstChild("patch")->ToElement();
+   TiXmlElement* patch = TINYXML_SAFE_TO_ELEMENT(doc.FirstChild("patch"));
    if (!patch)
       return;
 
    int revision = 0;
    patch->QueryIntAttribute("revision", &revision);
 
-   TiXmlElement* meta = patch->FirstChild("meta")->ToElement();
+   TiXmlElement* meta =  TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("meta"));
    if (meta)
    {
       const char* s;
@@ -921,20 +921,20 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
          author = s;
    }
 
-   TiXmlElement* parameters = patch->FirstChild("parameters")->ToElement();
+   TiXmlElement* parameters =  TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("parameters"));
    assert(parameters);
    int n = param_ptr.size();
 
    // delete volume & fx_bypass if it's a preset. Those settings should stick
    if (is_preset)
    {
-      TiXmlElement* tp = parameters->FirstChild("volume")->ToElement();
+      TiXmlElement* tp = TINYXML_SAFE_TO_ELEMENT(parameters->FirstChild("volume"));
       if (tp)
          parameters->RemoveChild(tp);
-      tp = parameters->FirstChild("fx_bypass")->ToElement();
+      tp = TINYXML_SAFE_TO_ELEMENT(parameters->FirstChild("fx_bypass"));
       if (tp)
          parameters->RemoveChild(tp);
-      tp = parameters->FirstChild("polylimit")->ToElement();
+      tp = TINYXML_SAFE_TO_ELEMENT(parameters->FirstChild("polylimit"));
       if (tp)
          parameters->RemoveChild(tp);
    }
@@ -943,13 +943,13 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
    for (int i = 0; i < n; i++)
    {
       if (!i)
-         p = parameters->FirstChild(param_ptr[i]->get_storage_name())->ToElement();
+         p = TINYXML_SAFE_TO_ELEMENT(parameters->FirstChild(param_ptr[i]->get_storage_name()));
       else
       {
          if (p)
-            p = p->NextSibling(param_ptr[i]->get_storage_name())->ToElement();
+            p = TINYXML_SAFE_TO_ELEMENT(p->NextSibling(param_ptr[i]->get_storage_name()));
          if (!p)
-            p = parameters->FirstChild(param_ptr[i]->get_storage_name())->ToElement();
+            p = TINYXML_SAFE_TO_ELEMENT(parameters->FirstChild(param_ptr[i]->get_storage_name()));
       }
       if (p)
       {
@@ -986,7 +986,7 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
 
          int sceneId = param_ptr[i]->scene;
          int paramIdInScene = param_ptr[i]->param_id_in_scene;
-         TiXmlElement* mr = p->FirstChild("modrouting")->ToElement();
+         TiXmlElement* mr = TINYXML_SAFE_TO_ELEMENT(p->FirstChild("modrouting"));
          while (mr)
          {
             int modsource;
@@ -1026,7 +1026,7 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
 
                modlist->push_back(t);
             }
-            mr = mr->NextSibling("modrouting")->ToElement();
+            mr = TINYXML_SAFE_TO_ELEMENT(mr->NextSibling("modrouting"));
          }
       }
    }
@@ -1194,9 +1194,9 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
          l.loop_end = 15;
          l.shuffle = 0.f;
       }
-   TiXmlElement* ss = patch->FirstChild("stepsequences")->ToElement();
+   TiXmlElement* ss = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("stepsequences"));
    if (ss)
-      p = ss->FirstChild("sequence")->ToElement();
+      p = TINYXML_SAFE_TO_ELEMENT(ss->FirstChild("sequence"));
    else
       p = nullptr;
    while (p)
@@ -1225,15 +1225,15 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
                stepsequences[sc][lfo].steps[s] = 0.f;
          }
       }
-      p = p->NextSibling("sequence")->ToElement();
+      p = TINYXML_SAFE_TO_ELEMENT(p->NextSibling("sequence"));
    }
 
    for (int i = 0; i < n_customcontrollers; i++)
       scene[0].modsources[ms_ctrl1 + i]->reset();
 
-   TiXmlElement* cc = patch->FirstChild("customcontroller")->ToElement();
+   TiXmlElement* cc = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("customcontroller"));
    if (cc)
-      p = cc->FirstChild("entry")->ToElement();
+      p = TINYXML_SAFE_TO_ELEMENT(cc->FirstChild("entry"));
    else
       p = nullptr;
    while (p)
@@ -1257,11 +1257,11 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
             CustomControllerLabel[cont][15] = 0;
          }
       }
-      p = p->NextSibling("entry")->ToElement();
+      p = TINYXML_SAFE_TO_ELEMENT(p->NextSibling("entry"));
    }
    if (!is_preset)
    {
-      TiXmlElement* mw = patch->FirstChild("modwheel")->ToElement();
+      TiXmlElement* mw = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("modwheel"));
       if (mw)
       {
          if (mw->QueryDoubleAttribute("s0", &d) == TIXML_SUCCESS)

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -213,7 +213,7 @@ SurgeStorage::SurgeStorage()
 #endif
    }
 
-   TiXmlElement* e = snapshotloader.FirstChild("autometa")->ToElement();
+   TiXmlElement* e = TINYXML_SAFE_TO_ELEMENT(snapshotloader.FirstChild("autometa"));
    if (e)
    {
       defaultname = e->Attribute("name");
@@ -837,14 +837,14 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry)
 
 TiXmlElement* SurgeStorage::getSnapshotSection(const char* name)
 {
-   TiXmlElement* e = snapshotloader.FirstChild(name)->ToElement();
+   TiXmlElement* e = TINYXML_SAFE_TO_ELEMENT(snapshotloader.FirstChild(name));
    if (e)
       return e;
 
    // ok, create a new one then
    TiXmlElement ne(name);
    snapshotloader.InsertEndChild(ne);
-   return snapshotloader.FirstChild(name)->ToElement();
+   return TINYXML_SAFE_TO_ELEMENT(snapshotloader.FirstChild(name));
 }
 
 void SurgeStorage::save_snapshots()
@@ -891,7 +891,7 @@ void SurgeStorage::load_midi_controllers()
    TiXmlElement* mc = getSnapshotSection("midictrl");
    assert(mc);
 
-   TiXmlElement* entry = mc->FirstChild("entry")->ToElement();
+   TiXmlElement* entry = TINYXML_SAFE_TO_ELEMENT(mc->FirstChild("entry"));
    while (entry)
    {
       int id, ctrl;
@@ -902,13 +902,13 @@ void SurgeStorage::load_midi_controllers()
          if (id >= n_global_params)
             getPatch().param_ptr[id + n_scene_params]->midictrl = ctrl;
       }
-      entry = entry->NextSibling("entry")->ToElement();
+      entry = TINYXML_SAFE_TO_ELEMENT(entry->NextSibling("entry"));
    }
 
    TiXmlElement* cc = getSnapshotSection("customctrl");
    assert(cc);
 
-   entry = cc->FirstChild("entry")->ToElement();
+   entry = TINYXML_SAFE_TO_ELEMENT(cc->FirstChild("entry"));
    while (entry)
    {
       int id, ctrl;
@@ -917,7 +917,7 @@ void SurgeStorage::load_midi_controllers()
       {
          controllers[id] = ctrl;
       }
-      entry = entry->NextSibling("entry")->ToElement();
+      entry = TINYXML_SAFE_TO_ELEMENT(entry->NextSibling("entry"));
    }
 }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -554,3 +554,10 @@ namespace Storage
     bool isValidName(const std::string &name);
 }
 }
+
+/*
+** ToElement does a this && check to check nulls. (As does ToDocument and so on).
+** gcc -O3 on linux optimizes that away giving crashes. So do this instead
+** See github issue #469
+*/
+#define TINYXML_SAFE_TO_ELEMENT(expr) ((expr)?(expr)->ToElement():NULL)

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -3,6 +3,7 @@
 #include "CSnapshotMenu.h"
 #include "effect/Effect.h"
 #include "SurgeBitmaps.h"
+#include "SurgeStorage.h" // for TINYXML macro
 
 using namespace VSTGUI;
 
@@ -41,7 +42,7 @@ void CSnapshotMenu::populate()
    TiXmlElement* sect = storage->getSnapshotSection(mtype);
    if (sect)
    {
-      TiXmlElement* type = sect->FirstChild("type")->ToElement();
+      TiXmlElement* type = TINYXML_SAFE_TO_ELEMENT(sect->FirstChild("type"));
 
       while (type)
       {
@@ -49,7 +50,7 @@ void CSnapshotMenu::populate()
          type->Attribute("i", &type_id);
          sub = 0;
          COptionMenu* subMenu = new COptionMenu(getViewSize(), 0, main, 0, 0, kNoDrawStyle);
-         TiXmlElement* snapshot = type->FirstChild("snapshot")->ToElement();
+         TiXmlElement* snapshot = TINYXML_SAFE_TO_ELEMENT(type->FirstChild("snapshot"));
          while (snapshot)
          {
             strcpy(txt, snapshot->Attribute("name"));
@@ -62,7 +63,7 @@ void CSnapshotMenu::populate()
             actionItem->setActions(action, nullptr);
             subMenu->addEntry(actionItem);
 
-            snapshot = snapshot->NextSibling("snapshot")->ToElement();
+            snapshot = TINYXML_SAFE_TO_ELEMENT(snapshot->NextSibling("snapshot"));
             sub++;
             if (sub >= max_sub)
                break;
@@ -85,7 +86,7 @@ void CSnapshotMenu::populate()
          }
          subMenu->forget();
 
-         type = type->NextSibling("type")->ToElement();
+         type = TINYXML_SAFE_TO_ELEMENT(type->NextSibling("type"));
          main++;
          if (main >= max_main)
             break;
@@ -258,7 +259,7 @@ void CFxMenu::loadSnapshot(int type, TiXmlElement* e)
       fxbuffer->type.val.i = type;
    if (e)
    {
-      TiXmlElement* p = e->Parent()->ToElement();
+      TiXmlElement* p = TINYXML_SAFE_TO_ELEMENT(e->Parent());
       p->QueryIntAttribute("i", &type);
       assert(within_range(0, type, num_fxtypes));
       fxbuffer->type.val.i = type;
@@ -302,14 +303,14 @@ void CFxMenu::saveSnapshot(TiXmlElement* e, const char* name)
 {
    if (fx->type.val.i == 0)
       return;
-   TiXmlElement* t = e->FirstChild("type")->ToElement();
+   TiXmlElement* t = TINYXML_SAFE_TO_ELEMENT(e->FirstChild("type"));
    while (t)
    {
       int ii;
       if ((t->QueryIntAttribute("i", &ii) == TIXML_SUCCESS) && (ii == fx->type.val.i))
       {
          // if name already exists, delete old entry
-         TiXmlElement* sn = t->FirstChild("snapshot")->ToElement();
+         TiXmlElement* sn = TINYXML_SAFE_TO_ELEMENT(t->FirstChild("snapshot"));
          while (sn)
          {
             if (sn->Attribute("name") && !strcmp(sn->Attribute("name"), name))
@@ -317,7 +318,7 @@ void CFxMenu::saveSnapshot(TiXmlElement* e, const char* name)
                t->RemoveChild(sn);
                break;
             }
-            sn = sn->NextSibling("snapshot")->ToElement();
+            sn = TINYXML_SAFE_TO_ELEMENT(sn->NextSibling("snapshot"));
          }
 
          TiXmlElement neu("snapshot");
@@ -346,6 +347,6 @@ void CFxMenu::saveSnapshot(TiXmlElement* e, const char* name)
          t->InsertEndChild(neu);
          return;
       }
-      t = t->NextSibling("type")->ToElement();
+      t = TINYXML_SAFE_TO_ELEMENT(t->NextSibling("type"));
    }
 }


### PR DESCRIPTION
The TiXmlDocument thing does a check in a member function of
"if(this &&" which is non standard. Windows is fine, mac warns.
But gcc -O3 correctly optimizes it away. That optimization means
that linux release throws SEGV all over the place. Since the function
is replicating a dynamic_cast, replace it with that. See issue #469
for a more fulsome conversation of this change.

I want to test this a bit more on windows and mac before we sweep it, but am putting it up here so @falkTX and @jsakkine can (1) offer review comments and (2) sweep it into their builds so they can continue progress