### PR TITLE
Shrinks below 100% in VST-en

### DIFF
--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -136,12 +136,25 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
         // but it is easier to calculate the grow one since it is at our scale
         CGraphicsTransform invtf = CGraphicsTransform().scale( bestFitScaleGroup / 100.0, bestFitScaleGroup / 100.0 );
         CGraphicsTransform tf = invtf.inverse().scale(extraScaleFactor / 100.0, extraScaleFactor / 100.0);
+
         
         CDrawContext::Transform tr(*context, tf);
 
         // Have to de-const these to do the transform alas
         CRect ncrect = rect;
         CRect nr = invtf.transform(ncrect);
+        if(extraScaleFactor<100)
+        {
+            /*
+            ** VSTGUI has lots of bugs. One of them is with scaling backgrounds. It never grows a background. 
+            ** and it never shrinks a background. Hence the extraScaleFactor. But it does shrink (and only shrink)
+            ** the draw rectangle for the background. So when we are at scales < 1 we have over-shrunk the 
+            ** extra scale factor. So undo that here. Obviously not great.
+            */
+            CGraphicsTransform upExtra = CGraphicsTransform().scale( 100.0/extraScaleFactor,100.0/extraScaleFactor);
+            nr = upExtra.transform(nr);
+        }
+
 
         CPoint ncoff = offset;
         CPoint no = invtf.transform(ncoff);

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2427,15 +2427,14 @@ void SurgeGUIEditor::setZoomFactor(int zf)
 {
 #if HOST_SUPPORTS_ZOOM    
 
-#if TARGET_VST2 || TARGET_VST3
-   /*
-   ** The current version of the vstgui API scaling code appears to have additional bugs
-   ** with shrinking scales. We need to find and address these bugs but for now, simply
-   ** don't allow users to shrink the UI below 100%
-   */
-   if (zf < 100)
-       zf = 100;
-#endif
+   int minZoom = 50;
+   if (zf < minZoom)
+   {
+       Surge::UserInteractions::promptError("Minimum zoom size is 50%. I'm sorry, you cant make surge any smaller.",
+                                            "No Teensy Surge for You");
+       zf = minZoom;
+   }
+
 
    CRect screenDim = Surge::GUI::getScreenDimensions(getFrame());
 


### PR DESCRIPTION
VSTGUI has all sorts of background image scaling bugs. When you
grow the background doesn't. When you shrink, it also doesn't.
But the bounding box does. So back out the fact that we need
to grow it > 100 by not double shrinking it <100 and add with
another if and another comment.

Closes #458 