### PR TITLE
build-linux.sh: Do not use the option syntax for commands

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -214,22 +214,22 @@ fi
 prerequisite_check
 
 case $command in
-    --premake)
+    premake)
         run_premake
         ;;
-    --build)
+    build)
         run_all_builds
         ;;
-    --install-local)
+    install-local)
         run_install_local
         ;;
-    --clean)
+    clean)
         run_clean_builds
         ;;
-    --clean-all)
+    clean-all)
         run_clean_all
         ;;
-    --uninstall)
+    uninstall)
         run_uninstall
         ;;
     "")


### PR DESCRIPTION
My plan is to parse options with getopt, and differentiate them from
these command, e.g. to select debug/release and the type of plugin.