### PR TITLE
Print help message on -h or --help

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -176,6 +176,11 @@ while true ; do
     esac
 done
 
+if [[ ! -z "$OPTION_verbose" ]]; then
+    help_message
+    exit 0
+fi
+
 case $1 in
     premake)
         run_premake


### PR DESCRIPTION
Forgot to add a branch for printing the help message while updating
build-linux.sh.