### PR TITLE
linux: Read the default configuration from memory

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -80,7 +80,8 @@ elseif (os.istarget("linux")) then
 
     files
     {
-        "src/linux/ScalablePiggy.S"
+        "src/linux/ConfigurationXml.S",
+        "src/linux/ScalablePiggy.S",
     }
 
     includedirs

--- a/src/linux/ConfigurationXml.S
+++ b/src/linux/ConfigurationXml.S
@@ -1,0 +1,5 @@
+    .section ".rodata", "a"
+
+configurationXmlStart:
+    .globl configurationXmlStart
+    .incbin "../../resources/data/configuration.xml"

--- a/src/linux/ConfigurationXml.h
+++ b/src/linux/ConfigurationXml.h
@@ -1,0 +1,1 @@
+extern unsigned char configurationXmlStart[];


### PR DESCRIPTION
Bundle configuration.xml with the DSO binary and parse it directly from the
memory. Saving should be postponed to the stage when we have plugin
settings (e.g. save setting buttons there).

Fixes: 465 ("Have a default configuration.xml bundled for Linux")