### PR TITLE
Sub-folder sorting

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -350,6 +350,7 @@ void SurgeStorage::refreshPatchlistAddDir(bool userDir, string subdir)
    ** scanning for names; setting the 'root' to everything without a slash
    ** and finding the parent in the name map for everything with a slash
    */
+
    std::map<std::string,int> nameToLocalIndex;
    int idx=0;
    for (auto &pc : local_patch_category)
@@ -367,6 +368,23 @@ void SurgeStorage::refreshPatchlistAddDir(bool userDir, string subdir)
            local_patch_category[ nameToLocalIndex[ parent ] ].children.push_back( pc );
        }
    }
+
+   /*
+   ** We need to sort the local patch category child to make sure subfolders remain
+   ** sorted when displayed using the child data structure in the menu view.
+   */
+   
+   auto catCompare =
+       [this](const PatchCategory &c1, const PatchCategory &c2) -> bool
+       {
+           return _stricmp(c1.name.c_str(),c2.name.c_str()) < 0;
+       };
+   for (auto &pc : local_patch_category)
+   {
+       std::sort(pc.children.begin(), pc.children.end(), catCompare);
+   }
+
+
 
    /*
    ** Then copy our local patch category onto the member and be done


### PR DESCRIPTION
Patches were sorted correctly as were categories, but in order to
enable sub-folders I construct an explicit child list in
categories. I do that before the patch sort and traverse it
at menu build time. That category list requires a sort to
display correctly.

Fixes #481 

@jsakkine a review would be lovely. @esaruoho if you want to test with your patches that would be great. I tested with a pretty deep hierarchy.