### PR TITLE
Initalize member variables

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -527,6 +527,8 @@ void Parameter::set_type(int ctrltype)
       sprintf(dispname, "-");
       valtype = vt_int;
 
+      val_min.i = std::numeric_limits<int>::min();
+      val_max.i = std::numeric_limits<int>::max();
       val_default.i = 0;
       break;
    }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -46,6 +46,11 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
 {
    switch_toggled_queued = false;
    halt_engine = false;
+   release_if_latched[0] = true;
+   release_if_latched[1] = true;
+   release_anyway[0] = false;
+   release_anyway[1] = false;
+   load_fx_needed = true;
 
    fx_suspend_bitmask = 0;
 

--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -87,6 +87,7 @@ Wavetable::Wavetable()
    memset(TableI16WeakPointers, 0, sizeof(TableI16WeakPointers));
    current_id = -1;
    queue_id = -1;
+   refresh_display = true; // I have never been drawn so assume I need refresh if asked
 }
 
 void Wavetable::Copy(Wavetable* wt)

--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -33,6 +33,7 @@ CModulationSourceButton::CModulationSourceButton(
    dispval = 0;
    controlstate = cs_none;
    label[0] = 0;
+   blink = 0;
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Valgrnd on the VST2 shows some switch paths without an initialized
switch. This cleans up those warnings by making sure things are
initialized to reasonable values. 