### PR TITLE
Fix Linux Drawing Errors

### DIFF
--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -159,6 +159,19 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
         CPoint ncoff = offset;
         CPoint no = invtf.transform(ncoff);
         
+#if LINUX
+        /*
+        ** For some reason alpha = 255 inbound to this function on linux (and maybe on
+        ** mac and windows) but unlike mac and windows that misscaling actually causes
+        ** draw errors on linux because of the comparison in cairocontext.cpp at line
+        ** 396 (the (if (alpha != 1.f )) so hand-rescale it here for now
+        **
+        ** FIXME: Find out why alpha = 255 inbound here in VSTGUI Linux.
+        */
+        if (alpha==255)
+            alpha = 1.0f;
+#endif
+
         scaledBitmaps[ bestFitScaleGroup ]->draw(context, nr, no, alpha);
     }
     else


### PR DESCRIPTION
Linux drawing was mis-rendering terribly. Turns out this was
because, for some reason, the inbound alpha to bitmap::draw
was 255, not 1.0f, and cairocontext.cpp has a branch decision
based on equality with 1.0f. This indicates there may still be
a problem in vstgui (why was the 255 inbound?) but an interim
fix on linux is to reset alpha=255 to alpha=1.0 which completely
fixes the painting issues reported in #513

Closes #513 - Linux Painting Issues