### PR TITLE
Fix category next with nested folders

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -342,7 +342,7 @@ void SurgeStorage::refreshPatchlistAddDir(bool userDir, string subdir)
    {
       PatchCategory c;
       c.name = p.generic_string().substr(patchpathSubstrLength);
-      local_patch_category.push_back(c);
+      c.numberOfPatchesInCatgory = 0;
       
       for (auto& f : fs::directory_iterator(p))
       {
@@ -354,9 +354,12 @@ void SurgeStorage::refreshPatchlistAddDir(bool userDir, string subdir)
               e.name = f.path().filename().generic_string();
               e.name = e.name.substr(0, e.name.size() - 4);
               patch_list.push_back(e);
+
+              c.numberOfPatchesInCatgory ++;
           }
       }
       
+      local_patch_category.push_back(c);
       category++;
    }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -449,6 +449,8 @@ struct PatchCategory
    int order;
    std::vector<PatchCategory> children;
    bool isRoot;
+
+   int numberOfPatchesInCatgory;
 };
 
 enum sub3_copysource

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -109,12 +109,18 @@ void SurgeSynthesizer::incrementCategory(bool nextPrev)
    else
    {
        int order = storage.patch_category[current_category_id].order;
-       if (nextPrev)
-           order = (order >= (n - 1)) ? 0 : order + 1;
-       else
-           order = (order <= 0) ? n - 1 : order - 1;
-       
-       current_category_id = storage.patchCategoryOrdering[order];
+       int orderOrig = order;
+       do
+       {
+           if (nextPrev)
+               order = (order >= (n - 1)) ? 0 : order + 1;
+           else
+               order = (order <= 0) ? n - 1 : order - 1;
+
+           current_category_id = storage.patchCategoryOrdering[order];
+       }
+       while (storage.patch_category[current_category_id].numberOfPatchesInCatgory == 0 && order != orderOrig);
+       // That order != orderOrig isn't needed unless we have an entire empty category tree, in which case it stops an inf loop
    }
    
    // Find the first patch within the category.


### PR DESCRIPTION
Nested folders meant parents existed which were valid categories
with no patches. Navigating to them with category +/- gave a very
counterintuitive result of not doing anything when you
arrived at them.  Fix that by accumulating the number of patches
in each category and only doing incrementCategory into a category
with patches.

Closes #533