### PR TITLE
WIP: Fix Set Controller To... to be 0-127 (instead of 0-126), make Set Controller To... display in context menu for each slider in Surge (not fully working), code comment typo fixes

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1570,12 +1570,12 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                  {
                      currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
                      char name[256];
-                     sprintf( name, "CC %d -> %d", mc, min( mc+20, 127 ));
+                     sprintf(name, "CC %d -> %d", mc, min( mc+20, 127 ));
                      midiSub->addEntry( currentSub, name );
                  }
                  
                  char name[256];
-                 sprintf( name, "CC # %d", mc );
+                 sprintf(name, "CC # %d", mc );
                  CCommandMenuItem *cmd = new CCommandMenuItem( CCommandMenuItem::Desc( name ) );
                  cmd->setActions( [this,ccid,mc,&handled](CCommandMenuItem *men) {
                      handled = true;
@@ -1772,12 +1772,12 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                  {
                      currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
                      char name[256];
-                     sprintf( name, "CC %d -> %d", mc, min( mc+20, 127 ));
+                     sprintf(name, "CC %d -> %d", mc, min( mc+20, 127 ));
                      midiSub->addEntry( currentSub, name );
                  }
                  
                  char name[256];
-                 sprintf( name, "CC # %d", mc );
+                 sprintf(name, "CC # %d", mc );
                  CCommandMenuItem *cmd = new CCommandMenuItem( CCommandMenuItem::Desc( name ) );
                  cmd->setActions( [this,ccid,mc,&handled](CCommandMenuItem *men) {
                      handled = true;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1571,7 +1571,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                      currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
                      char name[256];
                      sprintf(name, "CC %d -> %d", mc, min( mc+20, 127 ));
-                     midiSub->addEntry( currentSub, name );
+                     midiSub->addEntry(currentSub, name);
                  }
                  
                  char name[256];
@@ -1773,7 +1773,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                      currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
                      char name[256];
                      sprintf(name, "CC %d -> %d", mc, min( mc+20, 127 ));
-                     midiSub->addEntry( currentSub, name );
+                     midiSub->addEntry(currentSub, name);
                  }
                  
                  char name[256];

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1683,7 +1683,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                /* In the case where you have modulations like "Attack", "Pitch" and "Release" the default name
                   of the modulation will be "Attack". So if you clear "Attack" you and you haven't renamed
                   you want to change the name to "Pitch". But you have to do quite a bit of work to recreate what
-                  the next parameter short name is and comapre it in the same way it is done. So that's
+                  the next parameter short name is and compare it in the same way it is done. So that's
                   what this splat of code does.
                */
                if (clear_md[md] == command)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -229,10 +229,10 @@ void SurgeGUIEditor::idle()
 
       if (polydisp)
       {
-         CNumberField *cnpd = static_cast< CNumberField* >( polydisp );
+         CNumberField *cnpd = static_cast< CNumberField* >(polydisp);
          int prior = cnpd->getPoly();
-         cnpd->setPoly( synth->polydisplay );
-         if( prior != synth->polydisplay )
+         cnpd->setPoly(synth->polydisplay);
+         if(prior != synth->polydisplay)
              cnpd->invalid();
       }
 
@@ -353,7 +353,7 @@ void SurgeGUIEditor::idle()
             }
             else
             {
-                // printf( "Bailing out of all possible refreshes on %d\n", j );
+                // printf("Bailing out of all possible refreshes on %d\n", j);
                 // This is not really a problem
             }
          }
@@ -426,7 +426,7 @@ void SurgeGUIEditor::refresh_mod()
 
 int32_t SurgeGUIEditor::onKeyDown(const VstKeyCode& code, CFrame* frame)
 {
-    if(code.virt != 0 )
+    if(code.virt != 0)
     {
         switch (code.virt)
         {
@@ -1127,7 +1127,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
         {
           bool curr = ((CSurgeSlider*)param[i])->disabled;
           ((CSurgeSlider*)param[i])->disabled = true;
-          if( ! curr )
+          if(! curr)
             {
               param[i]->setDirty();
               param[i]->invalid();
@@ -1175,10 +1175,10 @@ void SurgeGUIEditor::openOrRecreateEditor()
     *
     * See GitHub Issue #231 for an explanation of the behaviour without these changes as of Jan 2019.
     */
-   patchName->setImmediateTextChange( true );
-   patchCategory->setImmediateTextChange( true );
-   patchCreator->setImmediateTextChange( true );
-   patchComment->setImmediateTextChange( true );
+   patchName->setImmediateTextChange(true);
+   patchCategory->setImmediateTextChange(true);
+   patchCreator->setImmediateTextChange(true);
+   patchComment->setImmediateTextChange(true);
    
    patchName->setBackColor(kWhiteCColor);
    patchCategory->setBackColor(kWhiteCColor);
@@ -1564,19 +1564,19 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
              // Construct submenus for explicit controller mapping
              COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
              COptionMenu *currentSub;
-             for( int mc = 0; mc < 128; mc++ )
+             for(int mc = 0; mc < 128; mc++)
              {
-                 if( mc % 20 == 0 )
+                 if(mc % 20 == 0)
                  {
-                     currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
+                     currentSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
                      char name[256];
-                     sprintf(name, "CC %d -> %d", mc, min( mc+20, 127 ));
+                     sprintf(name, "CC %d -> %d", mc, min(mc+20, 127));
                      midiSub->addEntry(currentSub, name);
                  }
                  
                  char name[256];
                  sprintf(name, "CC # %d", mc);
-                 CCommandMenuItem *cmd = new CCommandMenuItem( CCommandMenuItem::Desc( name ) );
+                 CCommandMenuItem *cmd = new CCommandMenuItem(CCommandMenuItem::Desc(name));
                  cmd->setActions([this,ccid,mc,&handled](CCommandMenuItem *men) {
                      handled = true;
                      synth->storage.controllers[ccid] = mc;
@@ -1695,7 +1695,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                   {
                       if (strncmp(synth->storage.getPatch().CustomControllerLabel[ccid],
                                   clearControlTargetNames[0].c_str(),
-                                  15) == 0 )
+                                  15) == 0)
                       {
                           // So my modulator is named after my short name. I haven't been renamed. So I want to
                           // reset at least to "-" unless someone is after me
@@ -1766,20 +1766,20 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             // Construct submenus for explicit controller mapping
              COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
              COptionMenu *currentSub;
-             for (int mc = 0; mc < 128; mc++ )
+             for (int mc = 0; mc < 128; mc++)
              {
-                 if(mc % 20 == 0 )
+                 if(mc % 20 == 0)
                  {
-                     currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
+                     currentSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
                      char name[256];
-                     sprintf(name, "CC %d -> %d", mc, min( mc+20, 127 ));
+                     sprintf(name, "CC %d -> %d", mc, min(mc+20, 127));
                      midiSub->addEntry(currentSub, name);
                  }
                  
                  char name[256];
-                 sprintf(name, "CC # %d", mc );
-                 CCommandMenuItem *cmd = new CCommandMenuItem( CCommandMenuItem::Desc( name ) );
-                 cmd->setActions( [this,ccid,mc,&handled](CCommandMenuItem *men) {
+                 sprintf(name, "CC # %d", mc);
+                 CCommandMenuItem *cmd = new CCommandMenuItem(CCommandMenuItem::Desc(name));
+                 cmd->setActions([this,ccid,mc,&handled](CCommandMenuItem *men) {
                      handled = true;
                      synth->storage.controllers[ccid] = mc;
                      synth->storage.save_midi_controllers();
@@ -1787,7 +1787,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                  currentSub->addEntry(cmd);
                  
              }
-             contextMenu->addEntry( midiSub, "Set Controller To..." );
+             contextMenu->addEntry(midiSub, "Set Controller To...");
 
 
 
@@ -2557,12 +2557,12 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
         zoomSubMenu->addEntry(zcmd); zid++;
     }
 
-    zoomSubMenu->addEntry( "-", zid++ );
+    zoomSubMenu->addEntry("-", zid++);
     
-    for(auto jog : { -25, -10, 10, 25 } ) // These are somewhat arbitrary reasonable defaults also
+    for(auto jog : { -25, -10, 10, 25 }) // These are somewhat arbitrary reasonable defaults also
     {
         std::ostringstream lab;
-        if( jog > 0 )
+        if(jog > 0)
             lab << "Grow by " << jog << "%";
         else
             lab << "Shrink by " << -jog << "%";
@@ -2593,7 +2593,7 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
     int command = settingsMenu->getLastResult();
     frame->removeView(settingsMenu, true);
 
-    if( handled )
+    if(handled)
     {
         // Someone else got it
     }
@@ -2625,7 +2625,7 @@ CPoint SurgeGUIEditor::getCurrentMouseLocationCorrectedForVSTGUIBugs()
     frame->getCurrentMouseLocation(where);
     where = frame->localToFrame(where);
 
-#if ( TARGET_VST2 || TARGET_VST3 )
+#if (TARGET_VST2 || TARGET_VST3)
     CGraphicsTransform vstfix = frame->getTransform().inverse();
     vstfix.transform(where);
     vstfix.transform(where);

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1569,12 +1569,12 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                  if( mc % 20 == 0 )
                  {
                      currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
-                     char name[ 256 ];
+                     char name[256];
                      sprintf( name, "CC %d -> %d", mc, min( mc+20, 127 ));
                      midiSub->addEntry( currentSub, name );
                  }
                  
-                 char name[ 256 ];
+                 char name[256];
                  sprintf( name, "CC # %d", mc );
                  CCommandMenuItem *cmd = new CCommandMenuItem( CCommandMenuItem::Desc( name ) );
                  cmd->setActions( [this,ccid,mc,&handled](CCommandMenuItem *men) {
@@ -1760,24 +1760,23 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          contextMenu->addEntry(txt2, eid++);
          bool cancellearn = false;
          int ccid = 0;
-          bool handled = false;
-
-            ccid = modsource - ms_ctrl1;
-            contextMenu->addEntry("-", eid++);
+         bool handled = false;
+         ccid = modsource - ms_ctrl1;
+         contextMenu->addEntry("-", eid++);
             // Construct submenus for explicit controller mapping
              COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
              COptionMenu *currentSub;
-             for( int mc = 0; mc < 128; ++mc )
+             for (int mc = 0; mc < 128; mc++ )
              {
-                 if( mc % 20 == 0 )
+                 if(mc % 20 == 0 )
                  {
                      currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
-                     char name[ 256 ];
+                     char name[256];
                      sprintf( name, "CC %d -> %d", mc, min( mc+20, 127 ));
                      midiSub->addEntry( currentSub, name );
                  }
                  
-                 char name[ 256 ];
+                 char name[256];
                  sprintf( name, "CC # %d", mc );
                  CCommandMenuItem *cmd = new CCommandMenuItem( CCommandMenuItem::Desc( name ) );
                  cmd->setActions( [this,ccid,mc,&handled](CCommandMenuItem *men) {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1564,7 +1564,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
              // Construct submenus for explicit controller mapping
              COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
              COptionMenu *currentSub;
-             for( int mc = 0; mc < 128; ++mc )
+             for( int mc = 0; mc < 128; mc++ )
              {
                  if( mc % 20 == 0 )
                  {
@@ -1575,17 +1575,17 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                  }
                  
                  char name[256];
-                 sprintf(name, "CC # %d", mc );
+                 sprintf(name, "CC # %d", mc);
                  CCommandMenuItem *cmd = new CCommandMenuItem( CCommandMenuItem::Desc( name ) );
-                 cmd->setActions( [this,ccid,mc,&handled](CCommandMenuItem *men) {
+                 cmd->setActions([this,ccid,mc,&handled](CCommandMenuItem *men) {
                      handled = true;
                      synth->storage.controllers[ccid] = mc;
                      synth->storage.save_midi_controllers();
                  });
-                 currentSub->addEntry( cmd );
+                 currentSub->addEntry(cmd);
                  
              }
-             contextMenu->addEntry( midiSub, "Set Controller To..." );
+             contextMenu->addEntry(midiSub, "Set Controller To...");
              
          }
 
@@ -1609,7 +1609,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          int command = contextMenu->getLastResult();
          frame->removeView(contextMenu, true); // remove from frame and forget
 
-         if (command >= 0 && ! handled )
+         if (command >= 0 && ! handled)
          {
             if (command == id_clearallmr)
             {
@@ -1784,7 +1784,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                      synth->storage.controllers[ccid] = mc;
                      synth->storage.save_midi_controllers();
                  });
-                 currentSub->addEntry( cmd );
+                 currentSub->addEntry(cmd);
                  
              }
              contextMenu->addEntry( midiSub, "Set Controller To..." );

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1759,6 +1759,38 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          sprintf(txt2, "Value: %s", txt);
          contextMenu->addEntry(txt2, eid++);
          bool cancellearn = false;
+         int ccid = 0;
+          bool handled = false;
+
+            ccid = modsource - ms_ctrl1;
+            contextMenu->addEntry("-", eid++);
+            // Construct submenus for explicit controller mapping
+             COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
+             COptionMenu *currentSub;
+             for( int mc = 0; mc < 128; ++mc )
+             {
+                 if( mc % 20 == 0 )
+                 {
+                     currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
+                     char name[ 256 ];
+                     sprintf( name, "CC %d -> %d", mc, min( mc+20, 127 ));
+                     midiSub->addEntry( currentSub, name );
+                 }
+                 
+                 char name[ 256 ];
+                 sprintf( name, "CC # %d", mc );
+                 CCommandMenuItem *cmd = new CCommandMenuItem( CCommandMenuItem::Desc( name ) );
+                 cmd->setActions( [this,ccid,mc,&handled](CCommandMenuItem *men) {
+                     handled = true;
+                     synth->storage.controllers[ccid] = mc;
+                     synth->storage.save_midi_controllers();
+                 });
+                 currentSub->addEntry( cmd );
+                 
+             }
+             contextMenu->addEntry( midiSub, "Set Controller To..." );
+
+
 
          // if(p->can_temposync() || p->can_extend_range())	contextMenu->addEntry("-",eid++);
          if (p->can_temposync())

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1564,13 +1564,13 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
              // Construct submenus for explicit controller mapping
              COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
              COptionMenu *currentSub;
-             for( int mc = 0; mc < 127; ++mc )
+             for( int mc = 0; mc < 128; ++mc )
              {
-                 if( mc % 10 == 0 )
+                 if( mc % 20 == 0 )
                  {
                      currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle );
                      char name[ 256 ];
-                     sprintf( name, "CC %d -> %d", mc, min( mc+10, 127 ));
+                     sprintf( name, "CC %d -> %d", mc, min( mc+20, 127 ));
                      midiSub->addEntry( currentSub, name );
                  }
                  

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1561,7 +1561,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
              
              contextMenu->addEntry("-", eid++);
              
-             // Construct submenus for expicit controller mapping
+             // Construct submenus for explicit controller mapping
              COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
              COptionMenu *currentSub;
              for( int mc = 0; mc < 127; ++mc )


### PR DESCRIPTION
- Fixes minor typos in comments in code
- Modifies CC subfolder branching to no longer be 10 per subfolder, now 20 per subfolder
- Surge used to only show CC up until 126 - now shows CC up until 127. ( #558 )
- Maintain subfolder-counting 0-127 (if you switched both `126` numbers to `127`, it would count from 0-128).
- Show `Set Controller To...` context menu in regular Surge sliders (not just Control 1 - Control 8) (IMPORTANT DETAIL: when you set a CC, the context menu does not currently update to display which CC it has been bound to. i don't know how to do that - hence the WIP) (#557)

Screenshots:
![fullscreen_10_02_2019__11_25](https://user-images.githubusercontent.com/4966687/52532025-0d340c00-2d27-11e9-9ffe-861ae345288b.jpg)
Note: This screenshot shows the context menu, but if you bind something, nothing appears to happen. I'll refer to clever-er people on this one, i.e. how to modify the context menu to display which CC has been bound to that parameter, and how to check that the CC has actually been bound!

![fullscreen_10_02_2019__11_29](https://user-images.githubusercontent.com/4966687/52532041-3ce31400-2d27-11e9-8f00-432983d9e12c.jpg)
Grouping `Set Controller To...` by 20 instead of 10. Make `CC # 127` display.


Additional steps that could be added - or done in a separate PR: #559 - show checkmarks in already-assigned-CC.

Fixes #558 
might fix #557 if i got some coding assist :)