### PR TITLE
Include Steinberg PR responses

### DIFF
--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -116,7 +116,7 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint& where, const CButtonState& 
    contextMenu->popup();
    getFrame()->removeView(contextMenu, true); // remove from frame and forget
 
-   return kMouseEventHandled;
+   return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
 }
 
 bool CPatchBrowser::populatePatchMenuForCategory( int c, COptionMenu *contextMenu, bool single_category, int &main_e, bool rootCall )


### PR DESCRIPTION
We sent 3 pull requests to steinberg for vstgui and they correctly
responded that 2/3 were indicative of us not using their API correctly

As such I've removed those commits from vstgui/surge, applied the
changes to our code, and have confirmed that the two issues
(capture on mouse click and diacriticals and emojis in patch
and category names) work with the vstgui without the associated
incorrect patches.

The final patch for checmark submenus is still in vstgui.surge in
this commit