### PR TITLE
DisplayInfoLinux improved

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -296,7 +296,7 @@ function plugincommon()
 
         buildoptions {
             "-Wno-unused-variable",
-            "`pkg-config --cflags cairo fontconfig freetype2 xkbcommon-x11 xcb-cursor xcb-keysyms xcb-xkb xcb-util`",
+            "`pkg-config --cflags cairo fontconfig freetype2 xkbcommon-x11 xcb-cursor xcb-keysyms xcb-xkb xcb-util x11`",
             "-std=c++14"
         }
 
@@ -333,7 +333,7 @@ function plugincommon()
         }
 
         linkoptions {
-            "`pkg-config --libs cairo fontconfig freetype2 xkbcommon-x11 xcb-cursor xcb-keysyms xcb-xkb xcb-util`",
+            "`pkg-config --libs cairo fontconfig freetype2 xkbcommon-x11 xcb-cursor xcb-keysyms xcb-xkb xcb-util x11`",
             "-Wl,--no-undefined",
         }
     elseif (os.istarget("windows")) then


### PR DESCRIPTION
1: getBackingScaleFactor doesn't need to alarmingly report an error
   when it returns 1.0, but rather just spool a log message to stdout

2: getScreenDimensions constrains zoom limits (or fails to) on large
   (or small) screens, so do a simple implementation of returning the
   size of the primary screen

Closes #594: Zoom limit issues linux vs windows

@falkTX or @jsakkine you know these APIs better than I do, but this seems like a positive step forward and at least will help @tank-trax continue to debug problems for us without overblowing his surge. Comments welcome!