### PR TITLE
Only use shift for swipe moves

### DIFF
--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -76,7 +76,7 @@ CMouseEventResult CHSwitch2::onMouseUp(CPoint& where, const CButtonState& button
 }
 CMouseEventResult CHSwitch2::onMouseMoved(CPoint& where, const CButtonState& buttons)
 {
-   if (dragable && buttons != 0)
+   if (dragable && ( buttons.getButtonState() || ( buttons.getModifierState() & kShift ) ) )
    {
       auto mouseableArea = getMouseableArea();
       double coefX, coefY;


### PR DESCRIPTION
Surge had an odd feature that shift, control, alt - really any
modifier - meant that as you swiped over a control it changed.
@sense-amr had the excellent suggestion that we limit this to
shift to avoid accidental changes and this PR does that.

Closes #337 Holding down alt etc quick changes