### PR TITLE
UTF8 for Wavetables; Noisier Mis-installation; Win Categories

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -538,6 +538,7 @@ private:
    StepSequencerStorage clipboard_stepsequences[n_lfos];
    std::vector<ModulationRouting> clipboard_modulation_scene, clipboard_modulation_voice;
    Wavetable clipboard_wt[n_oscs];
+
 };
 
 float note_to_pitch(float);
@@ -553,7 +554,16 @@ namespace Surge
 {
 namespace Storage
 {
-    bool isValidName(const std::string &name);
+bool isValidName(const std::string &name);
+
+#if WINDOWS
+/*
+** Windows filesystem names are properly wstrings which, if we want them to
+** display properly in vstgui, need to be converted to UTF8 using the
+** windows widechar API. Linux and Mac do not require this.
+*/
+std::string wstringToUTF8(const std::wstring &ws);
+#endif
 }
 }
 

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -189,8 +189,12 @@ bool CPatchBrowser::populatePatchMenuForCategory( int c, COptionMenu *contextMen
         }
         
         std::string menuName = storage->patch_category[c].name;
-        if (menuName.find_last_of("/") != string::npos)
-            menuName = menuName.substr(menuName.find_last_of("/") + 1);
+        std::string pathSep = "/";
+#if WINDOWS
+        pathSep = "\\";
+#endif
+        if (menuName.find_last_of(pathSep) != string::npos)
+            menuName = menuName.substr(menuName.find_last_of(pathSep) + 1);
         
         if (n_subc > 1)
             sprintf(name, "%s - %i", menuName.c_str(), subc + 1);


### PR DESCRIPTION
UTF8 filename conversion is required on windows for vstgui so factor
the UTF8 string conversion into a function and adjust the callpoints.

Those callpoints intersect with places where we load patches and
wavetables, so at the same time, make the system report user errors
if wavetables or factory patches are non-loadable

In the course of testing this, I also realized that nested directories
didn't work properly on windows due to path separator being "\" rather
than "/", which this commit also addresses.

Closes #584 UTF8 for wavetables
Closes #543 Alert user to mis-installation
