### PR TITLE
Don't crash when mis-installed

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -54,6 +54,11 @@ void COscillatorDisplay::draw(CDrawContext* dc)
       // srand(2);
       float disp_pitch_rs = disp_pitch + 12.0 * log2(dsamplerate / 44100.0);
       bool use_display = osc->allow_display();
+
+      // Mis-install check #2
+      if (uses_wavetabledata(oscdata->type.val.i) && storage->wt_list.size() == 0)
+          use_display = false;
+
       if (use_display)
          osc->init(disp_pitch_rs, true);
       int block_pos = BLOCK_SIZE_OS;


### PR DESCRIPTION
When wavetables were not properly isntalled, the oscillator
display would crash rather than render blank in situations
where you loaded patches which reference specific wavetables
or try to pick them with a menu. Check for an empty wavetable
list and supress display in that situation

Closes #525 Linux Crash on Wavetable
Closes #521 Linux Patches which Crash