### PR TITLE
Fix VSTGUI Scaling bugs

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -78,15 +78,6 @@ protected:
 
    void refresh_mod();
 
-   /**
-    * getCurrentMouseLocationCorrectedForVSTGUIBugs
-    *
-    * This function gets the current mouse location for the frame
-    * but adds, in necessary cases, workarounds for bugs in the
-    * vstgui framework. Use it in place of frame->getCurrentMouseLocation
-    */
-   VSTGUI::CPoint getCurrentMouseLocationCorrectedForVSTGUIBugs();
-
 #if TARGET_VST3
 public:
    /**


### PR DESCRIPTION
VSTGUI had two scaling bugs which impacted surge. First
frame currentpoint was mis-scaled (and we had previously
worked around this on windows and mac) and second
genericOptionMenu mis-calculated position in screen
vs app space (and this plagued linux). Along with the
changes to vstgui, this surge change backs down our
workaround and uses a correctly patched vstgui to
address both these issues.