### PR TITLE
UserDefaults; Zoom Defaulting

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -227,6 +227,7 @@ function plugincommon()
         "src/common/SurgeStorageLoadWavetable.cpp",
         "src/common/SurgeSynthesizer.cpp",
         "src/common/SurgeSynthesizerIO.cpp",
+        "src/common/UserDefaults.cpp",
         "libs/xml/tinyxml.cpp",
         "libs/xml/tinyxmlerror.cpp",
         "libs/xml/tinyxmlparser.cpp",

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -1,0 +1,190 @@
+#include "UserDefaults.h"
+#include "UserInteractions.h"
+
+
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <fstream>
+
+#if LINUX
+#include <experimental/filesystem>
+#elif MAC
+#include <filesystem.h>
+#else
+#include <filesystem>
+#endif
+
+namespace fs = std::experimental::filesystem;
+
+namespace Surge
+{
+namespace Storage
+{
+
+/*
+** These functions and variables are not exported in the header 
+*/
+struct UserDefaultValue
+{
+    typedef enum ValueType
+    {
+        ud_string = 1,
+        ud_int = 2
+    } ValueType;
+
+    std::string key; 
+    std::string value;
+    ValueType   type;
+};
+
+std::map<std::string, UserDefaultValue> defaultsFileContents;
+bool haveReadDefaultsFile = false;
+
+std::string defaultsFileName(SurgeStorage *storage)
+{
+    std::string fn = storage->userDataPath + "/SurgeUserDefaults.xml";
+    return fn;
+}
+
+void readDefaultsFile(std::string fn, bool forceRead=false)
+{
+    if (!haveReadDefaultsFile || forceRead)
+    {
+        defaultsFileContents.clear();
+
+        TiXmlDocument defaultsLoader;
+        defaultsLoader.LoadFile(fn.c_str());
+        TiXmlElement *e = TINYXML_SAFE_TO_ELEMENT(defaultsLoader.FirstChild("defaults"));
+        if(e)
+        {
+            const char* version = e->Attribute("version");
+            if (strcmp(version, "1") != 0)
+            {
+                std::ostringstream oss;
+                oss << "This version of Surge only reads version 1 defaults. You user defaults version is "
+                    << version << ". Defaults ignored";
+                Surge::UserInteractions::promptError(oss.str(), "Defaults File Version Error");
+                return;
+            }
+
+            TiXmlElement *def = TINYXML_SAFE_TO_ELEMENT(e->FirstChild("default"));
+            while(def)
+            {
+                UserDefaultValue v;
+                v.key = def->Attribute("key");
+                v.value = def->Attribute("value");
+                int vt;
+                def->Attribute("type", &vt);
+                v.type = (UserDefaultValue::ValueType)vt;
+
+                defaultsFileContents[v.key] = v;
+
+                def = TINYXML_SAFE_TO_ELEMENT(def->NextSibling("default"));
+            }
+        }
+        haveReadDefaultsFile = true;
+    }
+}
+
+bool storeUserDefaultValue(SurgeStorage *storage, const std::string &key, const std::string &val, UserDefaultValue::ValueType type)
+{
+    // Re-read the file in case another surge has updated it
+    readDefaultsFile(defaultsFileName(storage), true);
+
+    /*
+    ** Surge has a habit of creating the user directories it needs. 
+    ** See SurgeSytnehsizer::savePatch for instance
+    ** and so we have to do the same here
+    */
+    fs::create_directories(storage->userDataPath);
+
+    
+    UserDefaultValue v;
+    v.key = key;
+    v.value = val;
+    v.type = type;
+
+    defaultsFileContents[v.key] = v;
+
+    /*
+    ** For now, the format of our defaults file is so simple that we don't need to mess
+    ** around with tinyxml to create it, just to parse it
+    */
+    std::ofstream dFile(defaultsFileName(storage));
+    if (!dFile.is_open())
+    {
+        std::ostringstream emsg;
+        emsg << "Unable to open defaults file '" << defaultsFileName(storage) << "' for writing.";
+        Surge::UserInteractions::promptError(emsg.str(), "Defaults Not Saved");
+        return false;
+    }
+        
+    dFile << "<?xml version = \"1.0\" encoding = \"UTF-8\" ?>\n"
+          << "<!-- User Defaults for Surge Synthesizer -->\n"
+          << "<defaults version=\"1\">" << std::endl;
+
+    for (auto &el : defaultsFileContents)
+    {
+        dFile << "  <default key=\"" << el.first << "\" value=\"" << el.second.value << "\" type=\"" << (int)el.second.type << "\">\n";
+    }
+
+    dFile << "</defaults>" << std::endl;
+    dFile.close();
+
+    return true;
+}
+
+/*
+** Functions from the header
+*/    
+
+std::string getUserDefaultValue(SurgeStorage *storage, const std::string &key, const std::string &valueIfMissing)
+{
+    readDefaultsFile(defaultsFileName(storage));
+
+    if (defaultsFileContents.find(key) != defaultsFileContents.end())
+    {
+        auto vStruct = defaultsFileContents[key];
+        if(vStruct.type != UserDefaultValue::ud_string)
+        {
+            return valueIfMissing;
+        }
+        return vStruct.value;
+    }
+   
+    return valueIfMissing;
+}
+
+int getUserDefaultValue(SurgeStorage *storage, const std::string &key, int valueIfMissing)
+{
+    readDefaultsFile(defaultsFileName(storage));
+
+    if (defaultsFileContents.find(key) != defaultsFileContents.end())
+    {
+        auto vStruct = defaultsFileContents[key];
+        if(vStruct.type != UserDefaultValue::ud_int)
+        {
+            return valueIfMissing;
+        }
+        return std::stoi(vStruct.value);
+    }
+    return valueIfMissing;
+}
+
+bool updateUserDefaultValue(SurgeStorage *storage, const std::string &key, const std::string &value)
+{
+    return storeUserDefaultValue(storage, key, value, UserDefaultValue::ud_string);
+}
+
+bool updateUserDefaultValue(SurgeStorage *storage, const std::string &key, const int value)
+{
+    std::ostringstream oss;
+    oss << value;
+    return storeUserDefaultValue(storage, key, oss.str(), UserDefaultValue::ud_int);
+}
+
+}
+}

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "SurgeStorage.h"
+
+/*
+** Surge has a variety of settings which users can update and save across
+** sessions. These two functions give a vector to a persisted key-value
+** pair store which we can use in our application logic. Our reference
+** to SurgeStorage allows us to find paths in which we can load or
+** persist this information.
+*/
+
+namespace Surge
+{
+namespace Storage
+{
+
+/**
+ * getUserDefaultValue
+ *
+ * Given a key, return the std::string which is the persisted user default value.
+ * If no such key is persisted, return the value "valueIfMissing". There is a variation
+ * on this for both std::string and int stored values.
+ */
+std::string getUserDefaultValue(SurgeStorage *storage, const std::string &key, const std::string &valueIfMissing);
+int         getUserDefaultValue(SurgeStorage *storage, const std::string &key, int valueIfMissing);
+
+/**
+ * updateUserDefaultValue
+ *
+ * Given a key and a value, update the user default file
+ */
+bool updateUserDefaultValue(SurgeStorage *storage, const std::string &key, const std::string &value);
+bool updateUserDefaultValue(SurgeStorage *storage, const std::string &key, const int value);
+
+}
+}

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -150,6 +150,7 @@ private:
    
 private:
    std::function< void(SurgeGUIEditor *) > zoom_callback;
+   bool zoomInvalid;
    
    SurgeBitmaps bitmap_keeper;
 


### PR DESCRIPTION
Introduce a UserDefaults mechanism for surge, where users can set
a persistent value for some configuration element of surge and
store it between sessions. This is accomplished using the API in
src/common/UserDefaults.h which is pretty simple key/value store
and retrieve of strings and ints (now).

Use UserDefaults to create a default zoom option. This option
stores the defaultZoom and restores it across host and session
when you restart surge.

Closes #375: Have UserDefaults
Closes #374: Retain Zoom Settings
Closes #456: Allows a default zoom setting not 100%