### PR TITLE
Linux Default Fonts

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -17,6 +17,8 @@ extern CFontRef surge_patchfont;
 // to resolve github issue #214
 #if MAC
 SharedPointer<CFontDesc> lfoLabelFont = new CFontDesc("Lucida Grande", 8); // one smaller than minifont
+#elif LINUX
+SharedPointer<CFontDesc> lfoLabelFont = new CFontDesc("sans-serif", 8);
 #else
 SharedPointer<CFontDesc> lfoLabelFont = new CFontDesc("Microsoft Sans Serif", 8);
 #endif


### PR DESCRIPTION
As reported by @rghvdberg in #614, bad font defaults in vstgui cfont
can cause crashes on some linuxen. Patch our vstgui and move the
surge pointer.

Closes #614 Linux Font Patches