### PR TITLE
Floor linux zoom at 100%

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -151,7 +151,8 @@ private:
 private:
    std::function< void(SurgeGUIEditor *) > zoom_callback;
    bool zoomInvalid;
-   
+   int minimumZoom;
+
    SurgeBitmaps bitmap_keeper;
 
    VSTGUI::CControl* vu[16];


### PR DESCRIPTION
As described in issue #628, Linux zoom < 100% clips menus
and I was unable to debug it. So rather than having a confusing
user experience, floor linux at 100% zoom for now.