### PR TITLE
Refactor Menus

### DIFF
--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -125,11 +125,12 @@ void CSnapshotMenu::populateSubmenuFromTypeElement(TiXmlElement *type, VSTGUI::C
       addEntry("Store Current");
       }*/
     /*
-      int32_t sel_id = contextMenu->getLastResult();
+      int32_t sel_id = contextMenu->get Last Result();
+      this is commented so put in spaces so my grep to kill all these doesn't flag it PW
       int32_t sub_id, main_id;
       COptionMenu *b = contextMenu->getLastItemMenu(sub_id);
       if (b) main_id = b->getTag();
-      
+
       if ((sel_id >= 0) && (sel_id < contextMenu->getNbEntries()))
       {
       if (sel_id < main)
@@ -141,7 +142,7 @@ void CSnapshotMenu::populateSubmenuFromTypeElement(TiXmlElement *type, VSTGUI::C
       {
       char name[NAMECHARS];
       sprintf(name, "default");
-      
+
       spawn_miniedit_text(name, NAMECHARS);
       save_snapshot(sect, name);
       storage->save_snapshots();
@@ -154,12 +155,11 @@ void CSnapshotMenu::populateSubmenuFromTypeElement(TiXmlElement *type, VSTGUI::C
       {
       int type_id = 0; xpp[main_id&(max_main - 1)]->Attribute("i", &type_id);		//
       get "i" value from xmldata
-      
+
       load_snapshot(type_id, xp[main_id][sub_id]);
       }
       }
       else do_nothing = true;*/
-    
 }
 
 // COscMenu

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -180,5 +180,10 @@ private:
    bool blinkstate = false;
    void* _effect = nullptr;
    VSTGUI::CVSTGUITimer* _idleTimer = nullptr;
+
+   /*
+   ** Utility Function
+   */
+   void addCallbackMenu(VSTGUI::COptionMenu* toThis, std::string label, std::function<void()> op);
 };
 


### PR DESCRIPTION
This change is a large code change for zero functionality change,
required because of the semantics of menus and ::popup on Linux.
On Linux, because of various event loop handling, making
menu::popup() block is very difficult. The same idle loop which
pops up the UI also paints the on-screen menus, unlike in mac and
windows where they are separate elements.

So we have to change all of our menus from return-a-value-after-block
to bind-a-lambda-and-call fashion. That is, from

  id = 3;
  menu->add("do this", id );
  menu->popup();
  r = menu->getLastResult();
  if (r == 3)
    doThis()

we have

   menu>-add("do this", []() { doThis(); } )
   menu->popup()

which is cleaner but requires us to bind the correct state into lambdas
and reorder the code. Thus this commit is a massive code shuffle to
do exactly that, along with a helper function which actually adds a
no arg lambda to a menu in SurgeGUIEditor.

All of the menus were accordingly adjusted for copy, paste, rebind,
about, and so on.

Closes #536 popup menus on Linux