### PR TITLE
Defer bounds check on MacOS Default Zoom

### DIFF
--- a/src/common/gui/DisplayInfo.h
+++ b/src/common/gui/DisplayInfo.h
@@ -28,7 +28,9 @@ namespace GUI
 float  getDisplayBackingScaleFactor(VSTGUI::CFrame *); 
 
 /*
-** Return the screen dimensions of the best screen containing this frame
+** Return the screen dimensions of the best screen containing this frame. If the
+** frame is not valid or has not yet been shown or so on, return a screen of
+** size 0x0 at position 0,0.
 */
 VSTGUI::CRect  getScreenDimensions(VSTGUI::CFrame *);
 }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -215,11 +215,6 @@ SurgeGUIEditor::~SurgeGUIEditor()
 
 void SurgeGUIEditor::idle()
 {
-    if(zoomInvalid)
-    {
-        setZoomFactor(getZoomFactor());
-        zoomInvalid = false;
-    }
 #if TARGET_VST2 && LINUX
    if (!super::idle2())
        return;
@@ -228,6 +223,12 @@ void SurgeGUIEditor::idle()
       return;
    if (editor_open && frame && !synth->halt_engine)
    {
+      if(zoomInvalid)
+      {
+         setZoomFactor(getZoomFactor());
+         zoomInvalid = false;
+      }
+      
       if (aboutbox && (aboutbox->getValue() > 0.5f))
          return;
       /*static CDrawContext drawContext
@@ -2535,6 +2536,16 @@ void SurgeGUIEditor::setZoomFactor(int zf)
 
    CRect screenDim = Surge::GUI::getScreenDimensions(getFrame());
 
+   /*
+   ** If getScreenDimensions() can't determine a size on all paltforms it now
+   ** returns a size 0 screen. In that case we will skip the min check but
+   ** need to remember the zoom is invalid
+   */
+   if (screenDim.getWidth() == 0 || screenDim.getHeight() == 0)
+   {
+      zoomInvalid = true;
+   }
+   
 #if TARGET_VST3
    /*
    ** VST3 doesn't have this API available to it, so just assume for now
@@ -2557,7 +2568,13 @@ void SurgeGUIEditor::setZoomFactor(int zf)
    */
    int maxScreenUsage = 90;
 
-   if (zf != 100.0 && zf > 100 && (
+   /*
+   ** In the startup path we may not have a clean window yet to give us a trustworthy
+   ** screen dimension; so allow callers to supress this check with an optional
+   ** variable and set it only in the constructor of SurgeGUIEditor
+   */
+   if (zf != 100.0 && zf > 100 &&
+       screenDim.getHeight() > 0 && screenDim.getWidth() > 0 && (
            (baseW * zf / 100.0) > maxScreenUsage * screenDim.getWidth() / 100.0 ||
            (baseH * zf / 100.0) > maxScreenUsage * screenDim.getHeight() / 100.0
            )

--- a/src/linux/DisplayInfoLinux.cpp
+++ b/src/linux/DisplayInfoLinux.cpp
@@ -46,11 +46,9 @@ CRect getScreenDimensions(CFrame *)
         }
         else
         {
-            std::cerr << "Linux Screen Size: Falling back to defaut mid sized laptop screen since no display available" << std::endl;
-            dispinfoScreenW = 1440;
-            dispinfoScreenH = 1050;
+            dispinfoScreenW = 0;
+            dispinfoScreenH = 0;
         }
-
     }
         
     return CRect(CPoint(0,0), CPoint(dispinfoScreenW, dispinfoScreenH)); 

--- a/src/mac/DisplayInfoMac.mm
+++ b/src/mac/DisplayInfoMac.mm
@@ -49,8 +49,7 @@ float getDisplayBackingScaleFactor(CFrame *f)
 
 CRect getScreenDimensions(CFrame *f)
 {
-    // This default is a 15" macbooc pro with scaling at half size
-    CRect defaultDimension(CPoint(0,0),CPoint(1440,900)); 
+    CRect defaultDimension(CPoint(0,0),CPoint(0,0)); 
     
     if (!f)
     {


### PR DESCRIPTION
On MacOS the bounds check happens before the window opens now
we have implemented default zoom; And the window is used to find
the screen for resolution check, so the resolution check fails on
large screens causing persisted large zooms to nonsensically reset.
Fix that by having the display size in the event of no window be
0,0 on macos (and 0,0 with no display on linux); supress the zoom
check size in that case; and check it again once the window is open
by forcing the idle loop by resetting zoom invalidation.

Closes #635 default zoom on macOS timing