### PR TITLE
Optimize VU Meter Draw

### DIFF
--- a/src/common/gui/CSurgeVuMeter.cpp
+++ b/src/common/gui/CSurgeVuMeter.cpp
@@ -53,15 +53,19 @@ void CSurgeVuMeter::draw(CDrawContext* dc)
    CRect size = getViewSize();
    CRect lbox(size);
 
-   dc->setFrameColor(kBlackCColor);
-   CRect f1(lbox), f2(lbox);
-   f1.inset(1, 1);
-   f2.inset(0, 2);
-   dc->drawRect(f1);
-   dc->drawRect(f2);
+   VSTGUI::CDrawMode origMode = dc->getDrawMode();
+   VSTGUI::CDrawMode newMode(VSTGUI::kAntiAliasing);
+   dc->setDrawMode(newMode);
 
-   lbox.right--;
-   lbox.bottom--;
+   dc->setFillColor(VSTGUI::CColor(0xCD, 0xCE, 0xD4)); // The light gray from origina-vector skin
+   dc->drawRect(size, VSTGUI::kDrawFilled);
+
+   CRect rectBox = lbox;
+   rectBox.inset(1, 1);
+   VSTGUI::CGraphicsPath* path = dc->createRoundRectGraphicsPath(rectBox, 2);
+
+   dc->setFillColor(kBlackCColor);
+   dc->drawGraphicsPath(path, VSTGUI::CDrawContext::kPathFilled);
 
    CRect bar(lbox);
    bar.inset(2, 2);
@@ -104,15 +108,15 @@ void CSurgeVuMeter::draw(CDrawContext* dc)
 
       barblack.left = bar.right - 1;
       barblack.right++;
-      dc->setFillColor(kBlackCColor);
-      dc->drawRect(barblack, kDrawFilled);
 
       if (stereo)
       {
          CRect midline(lbox);
          midline.inset(0, 4);
-         midline.left++;
-         midline.top++;
+         midline.left+=2;
+         midline.right-=2;
+         midline.top+=2;
+         midline.bottom --;
          // midline.bottom = midline.top+2;
          bar.offset(0, 3);
          barblack.offset(0, 3);
@@ -124,9 +128,16 @@ void CSurgeVuMeter::draw(CDrawContext* dc)
 
          barblack.left = bar.right - 1;
          dc->setFillColor(kBlackCColor);
-         dc->drawRect(barblack, kDrawFilled);
          dc->drawRect(midline, kDrawFilled);
       }
    }
+
+   dc->setFrameColor(VSTGUI::CColor(0xA1, 0xA4, 0xB7)); // the dark gray from original vector skin
+   dc->setLineWidth(1);
+   dc->drawGraphicsPath(path, VSTGUI::CDrawContext::kPathStroked);
+
+   path->forget();
+   dc->setDrawMode(origMode);
+
    setDirty(false);
 }

--- a/src/common/gui/CSurgeVuMeter.h
+++ b/src/common/gui/CSurgeVuMeter.h
@@ -21,6 +21,10 @@ public:
    void setType(int vutype);
    // void setSecondaryValue(float v);
    void setValueR(float f);
+   float getValueR()
+   {
+      return valueR;
+   }
    bool stereo;
 
 private:

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -320,9 +320,20 @@ void SurgeGUIEditor::idle()
          }
       }
 
-      vu[0]->setValue(synth->vu_peak[0]);
-      ((CSurgeVuMeter*)vu[0])->setValueR(synth->vu_peak[1]);
-      vu[0]->invalid();
+      bool vuInvalid = false;
+      if (synth->vu_peak[0] != vu[0]->getValue())
+      {
+         vuInvalid = true;
+         vu[0]->setValue(synth->vu_peak[0]);
+      }
+      if (synth->vu_peak[1] != ((CSurgeVuMeter*)vu[0])->getValueR())
+      {
+         ((CSurgeVuMeter*)vu[0])->setValueR(synth->vu_peak[1]);
+         vuInvalid = true;
+      }
+      if (vuInvalid)
+         vu[0]->invalid();
+
       for (int i = 0; i < 8; i++)
       {
          assert(i + 1 < Effect::KNumVuSlots);


### PR DESCRIPTION
The VU Meter was a cause of substantial idle load. In a 30 second
timer sample, a full half second was spent drawing background
images - as much time as was spent filling up the audio buffer
with no sound. There were a couple of key reasons for this:

1. The VU Meter invalidates every idle even if value hasn't changed
2. When the VU meter invalidates even legitimately it forces a
   full repaint of the background image into a clip rect because
   that's what VSTGUI::CViewContainer does

So - somewhat unsatisfactorily in the second case - this diff
fixes those by only invalidating when value changes (which is
great for idle) and supressing the background image repaint
using knowledge of the placement of the VU meter (which is
fragile and unsatisfying but the only option we have given
the protection of VSTGUI::CFrame's final status and so on).

While at it, replace the pixel painted edges so the VU meeter
has a better boundary when zoomed.

Closes #639 - Re-Implement VU Meter
Addresses parts of #446 and #556; performance and pixely bits