### PR TITLE
Tab key corrected in Save dialog

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -495,6 +495,13 @@ int32_t SurgeGUIEditor::onKeyDown(const VstKeyCode& code, CFrame* frame)
         switch (code.virt)
         {
         case VKEY_TAB:
+            if (saveDialog && saveDialog->isVisible())
+            {
+               /* 
+               ** SaveDialog gets access to the tab key to switch between fields if it is open
+               */
+               return -1;
+            }
             toggle_mod_editing();
             return 1;
 #if !LINUX


### PR DESCRIPTION
With the restoration of key bindings, the Tab toggled
modulation. That interfered with the save dialog.
So have the GUI editor not bind and eat the tab key
if the saveDialog is visible.

Closes #633 - tab key interfering with store