### PR TITLE
Implement openURL on Linux

### DIFF
--- a/src/linux/UserInteractionsLinux.cpp
+++ b/src/linux/UserInteractionsLinux.cpp
@@ -1,6 +1,8 @@
 #include "UserInteractions.h"
 #include <iostream>
 #include <iomanip>
+#include <sys/types.h>
+#include <unistd.h>
 
 namespace Surge
 {
@@ -31,6 +33,13 @@ namespace Surge
 
         void openURL(const std::string &url)
         {
+           if (vfork()==0)
+           {
+              if (execlp("xdg-open", "xdg-open", url.c_str(), (char*)nullptr) < 0)
+              {
+                 exit(0);
+              }
+           }
         }
     };
 };


### PR DESCRIPTION
Implement openURL using xdg-open, the freedesktop.org command to
open a resource in the default browser or viewer.

Closes #638 menu manual on linux broken