### PR TITLE
Fix VST2 from clean

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -221,7 +221,7 @@ if [[ ! -z "$OPTION_help" ]]; then
 fi
 
 if [ -z "$OPTION_project" ] || [ "$OPTION_project" == "vst2" ]; then
-    if [ -e "surge-vst2.make" ]; then
+    if [ -e "surge-vst2.make" ] || [ ! -z "$VST2SDK_DIR" ]; then
         OPTION_vst2=1
     fi
 fi


### PR DESCRIPTION
If you did a build-linux clean-all then a build-linux build --project=vst2
the vst2 didn't build since the vst2 triggereing was based on existance
of surge-make.vst. Now it is triggered on either the vst2 makefile
or the VST2SDK_DIR being set (which means the makefile is about to
be created)