### PR TITLE
VST3 on Linux packages and installs

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -141,8 +141,9 @@ run_install()
 
     if [ ! -z "$OPTION_vst3" ]; then
         echo "Installing VST3"
+        # No dest plugin name here since we are a bundle
         rsync -r --delete $OPTION_vst3_src_path \
-                          $OPTION_vst3_dest_path/$OPTION_dest_plugin_name
+                          $OPTION_vst3_dest_path
     fi
 
     if [ ! -z "$OPTION_headless" ]; then
@@ -237,7 +238,7 @@ fi
 if [ -z "$OPTION_debug" ]; then
     OPTION_config="config=release_x64"
     OPTION_vst2_src_path="target/vst2/Release/Surge.so"
-    OPTION_vst3_src_path="target/vst3/Release/Surge.so"
+    OPTION_vst3_src_path="products/Surge.vst3"
     OPTION_headless_src_path="target/headless/Release/Surge"
     OPTION_dest_plugin_name="Surge.so"
     OPTION_dest_headless_name="Surge-Headless"

--- a/premake5.lua
+++ b/premake5.lua
@@ -551,6 +551,7 @@ elseif (os.istarget("windows")) then
     targetextension ".vst3"
 
 elseif (os.istarget("linux")) then
+    postbuildcommands { "./scripts/linux/package-vst3.sh" }
 
     files
     {

--- a/scripts/linux/package-vst3.sh
+++ b/scripts/linux/package-vst3.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+OUTPUT_DIR=products
+BUNDLE_NAME="Surge.vst3"
+BUNDLE_DIR="$OUTPUT_DIR/$BUNDLE_NAME"
+
+echo "Creating Linux VST3 Bundle..."
+
+# create basic bundle structure
+
+if test -d "$BUNDLE_DIR"; then
+	rm -rf "$BUNDLE_DIR"
+fi
+
+VST_SO_DIR="$BUNDLE_DIR/Contents/x86_64-linux"
+mkdir -p "$VST_SO_DIR"
+cp target/vst3/Release/Surge.so "$VST_SO_DIR"


### PR DESCRIPTION
VST3 on Linux requires a mac-like bundle, as described in
the VST3 documentation vst3sdk/doc/vstinterfaces/vst3loc.html.
These changes move VST3 from a raw dll to a bundle using the
same techniques we use on macOS. Since we bake the images
and so on into the bundle, the bundle contains only the DLL.

With this change, bitwig studio will load our VST3, but it
crashes if you open the UI and gives corrupted parameter names.
But we are able to begin to debug.

Addresses part of #514