### PR TITLE
Visibility Flags for Linux

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -302,6 +302,15 @@ function plugincommon()
             "-std=c++14"
         }
 
+        configuration { "Release*" }
+        buildoptions {
+            "-fvisibility=hidden",
+            "-fvisibility-inlines-hidden",
+            "-fdata-sections",
+            "-ffunction-sections",
+        }
+        configuration {}
+
         files
         {
             "src/linux/*.mm",
@@ -338,6 +347,17 @@ function plugincommon()
             "`pkg-config --libs cairo fontconfig freetype2 xkbcommon-x11 xcb-cursor xcb-keysyms xcb-xkb xcb-util x11`",
             "-Wl,--no-undefined",
         }
+
+        configuration ("Release")
+        linkoptions {
+            "-fdata-sections",
+            "-ffunction-sections",
+            "-Wl,-O1",
+            "-Wl,--as-needed",
+            "-Wl,--gc-sections",
+            "-Wl,--strip-all",
+        }
+        configuration()
     elseif (os.istarget("windows")) then
 
         pchheader "precompiled.h"


### PR DESCRIPTION
Bitwig 2 with Surge consistently crashed as described in issue
number #648. After banging at it for a while, I gave up, but
@falkTX found the answer, basically resolving a symbol clash which
corrupted the base class with -fvisilbity flags. This change turns
those on on linux for the releas build only.

Closes #648 Linux

Co-authored-by: Filipe Coelho <falktx@falktx.com>