### PR TITLE
Reformat the AU Layer code

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -9,111 +9,111 @@ typedef SurgeSynthesizer sub3_synth;
 
 //----------------------------------------------------------------------------------------------------
 
-aulayer::aulayer (AudioUnit au) : AUInstrumentBase (au,1,1)
+aulayer::aulayer(AudioUnit au) : AUInstrumentBase(au, 1, 1)
 {
-	plugin_instance = 0;
-    editor_instance = 0;
+   plugin_instance = 0;
+   editor_instance = 0;
 }
 
 //----------------------------------------------------------------------------------------------------
 
 aulayer::~aulayer()
 {
-	if(plugin_instance)
-	{
-		plugin_instance->~plugin();
-		_aligned_free(plugin_instance);
-	}
-    
-    if( editor_instance )
-    {
-        delete editor_instance;
-    }
+   if (plugin_instance)
+   {
+      plugin_instance->~plugin();
+      _aligned_free(plugin_instance);
+   }
+
+   if (editor_instance)
+   {
+      delete editor_instance;
+   }
 }
 
 //----------------------------------------------------------------------------------------------------
 
-int aulayer::GetNumCustomUIComponents ()
+int aulayer::GetNumCustomUIComponents()
 {
-	return 1;
+   return 1;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-UInt32 aulayer::SupportedNumChannels (const AUChannelInfo** outInfo)
+UInt32 aulayer::SupportedNumChannels(const AUChannelInfo** outInfo)
 {
-	if(!outInfo) return 2;
-	cinfo[0].inChannels = 0;
-	cinfo[0].outChannels = 2;
-	cinfo[1].inChannels = 2;
-	cinfo[1].outChannels = 2;
-	*outInfo = cinfo;
-	return 2;
+   if (!outInfo)
+      return 2;
+   cinfo[0].inChannels = 0;
+   cinfo[0].outChannels = 2;
+   cinfo[1].inChannels = 2;
+   cinfo[1].outChannels = 2;
+   *outInfo = cinfo;
+   return 2;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-#define kComponentSubType	'Srge'
+#define kComponentSubType 'Srge'
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult aulayer::Version ()
-{ 
-	return kVersionNumber; 
-}
-
-//----------------------------------------------------------------------------------------------------
-
-void aulayer::GetUIComponentDescs (ComponentDescription* inDescArray)
+ComponentResult aulayer::Version()
 {
-	inDescArray[0].componentType = kAudioUnitCarbonViewComponentType;
-	inDescArray[0].componentSubType = kComponentSubType;
-	inDescArray[0].componentManufacturer = kComponentManuf;
-	inDescArray[0].componentFlags = 0;
-	inDescArray[0].componentFlagsMask = 0;
+   return kVersionNumber;
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void aulayer::GetUIComponentDescs(ComponentDescription* inDescArray)
+{
+   inDescArray[0].componentType = kAudioUnitCarbonViewComponentType;
+   inDescArray[0].componentSubType = kComponentSubType;
+   inDescArray[0].componentManufacturer = kComponentManuf;
+   inDescArray[0].componentFlags = 0;
+   inDescArray[0].componentFlagsMask = 0;
 }
 
 //----------------------------------------------------------------------------------------------------
 
 bool aulayer::HasIcon()
 {
-	return true;
+   return true;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CFURLRef aulayer::GetIconLocation ()
+CFURLRef aulayer::GetIconLocation()
 {
-	CFURLRef icon = 0;
-#ifdef DEMO
-	CFBundleRef bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.vemberaudio.audiounit.surgedemo"));
-#else
-	CFBundleRef bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.vemberaudio.audiounit.surge"));
-#endif
-	
-	if(bundle){
-		CFURLRef resources = CFBundleCopyResourcesDirectoryURL(bundle);
-		if(resources)
-		{
-			icon = CFURLCreateCopyAppendingPathComponent(NULL,resources,CFSTR("surgeicon.icns"),false);
-			CFRelease(resources);
-		}
-	}
-	return icon;
+   CFURLRef icon = 0;
+   CFBundleRef bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.vemberaudio.audiounit.surge"));
+
+   if (bundle)
+   {
+      CFURLRef resources = CFBundleCopyResourcesDirectoryURL(bundle);
+      if (resources)
+      {
+         icon =
+             CFURLCreateCopyAppendingPathComponent(NULL, resources, CFSTR("surgeicon.icns"), false);
+         CFRelease(resources);
+      }
+   }
+   return icon;
 }
 
 //----------------------------------------------------------------------------------------------------
 
 void aulayer::InitializePlugin()
 {
-	if(!plugin_instance)
-	{
-      //sub3_synth* synth = (sub3_synth*)_aligned_malloc(sizeof(sub3_synth),16);
-      //new(synth) sub3_synth(this);
+   if (!plugin_instance)
+   {
+      // sub3_synth* synth = (sub3_synth*)_aligned_malloc(sizeof(sub3_synth),16);
+      // new(synth) sub3_synth(this);
       // FIXME: The VST uses a std::unique_ptr<> and we probably should here also
-      plugin_instance = new SurgeSynthesizer( this );
+      plugin_instance = new SurgeSynthesizer(this);
 
-      // This allows us standalone performance mode. See issue #146 and comment below tagged with issue number
+      // This allows us standalone performance mode. See issue #146 and comment below tagged with
+      // issue number
       plugin_instance->time_data.ppqPos = 0;
    }
    assert(plugin_instance);
@@ -123,550 +123,595 @@ void aulayer::InitializePlugin()
 
 bool aulayer::IsPluginInitialized()
 {
-	return plugin_instance != 0;
+   return plugin_instance != 0;
 }
 
 //----------------------------------------------------------------------------------------------------
 
 ComponentResult aulayer::Initialize()
 {
-	if(!IsPluginInitialized()) 
-	{
-		InitializePlugin();
-	}
-	
-	double samplerate = GetOutput(0)->GetStreamFormat().mSampleRate;
-	plugin_instance->setSamplerate(samplerate);
-	plugin_instance->audio_processing_active = true;
-	plugin_instance->allNotesOff();
+   if (!IsPluginInitialized())
+   {
+      InitializePlugin();
+   }
+
+   double samplerate = GetOutput(0)->GetStreamFormat().mSampleRate;
+   plugin_instance->setSamplerate(samplerate);
+   plugin_instance->audio_processing_active = true;
+   plugin_instance->allNotesOff();
    sampleRateCache = samplerate;
-	
-	blockpos = 0;
-	events_this_block = 0;
-	//init parameters
-	for(UInt32 i=0; i<n_total_params; i++)
-	{
-		parameterIDlist[i] = i;
-		parameterIDlist_CFString[i] = 0;
-	}
-	
-	AUInstrumentBase::Initialize();
-	return noErr;
+
+   blockpos = 0;
+   events_this_block = 0;
+   // init parameters
+   for (UInt32 i = 0; i < n_total_params; i++)
+   {
+      parameterIDlist[i] = i;
+      parameterIDlist_CFString[i] = 0;
+   }
+
+   AUInstrumentBase::Initialize();
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void aulayer::Cleanup()	
-{	
-	AUInstrumentBase::Cleanup();
-}
-
-//----------------------------------------------------------------------------------------------------
-
-bool aulayer::StreamFormatWritable( AudioUnitScope scope, AudioUnitElement element)
+void aulayer::Cleanup()
 {
-	
-	return true; //IsInitialized() ? false : true;
+   AUInstrumentBase::Cleanup();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult		aulayer::ChangeStreamFormat(
-	AudioUnitScope					inScope,
-	AudioUnitElement				inElement,
-	const CAStreamBasicDescription & inPrevFormat,
-	const CAStreamBasicDescription &	inNewFormat)
+bool aulayer::StreamFormatWritable(AudioUnitScope scope, AudioUnitElement element)
 {
-	double samplerate = inNewFormat.mSampleRate;
-	ComponentResult result = AUBase::ChangeStreamFormat(inScope,inElement,inPrevFormat,inNewFormat);
 
-	if(plugin_instance) plugin_instance->setSamplerate(samplerate);
-	sampleRateCache = samplerate;
-   
-	return result;
+   return true; // IsInitialized() ? false : true;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult	aulayer::Reset(AudioUnitScope inScope, AudioUnitElement inElement)
+ComponentResult aulayer::ChangeStreamFormat(AudioUnitScope inScope,
+                                            AudioUnitElement inElement,
+                                            const CAStreamBasicDescription& inPrevFormat,
+                                            const CAStreamBasicDescription& inNewFormat)
 {
-	if((inScope == kAudioUnitScope_Global) && (inElement == 0) && plugin_instance)
-	{
-		double samplerate = GetOutput(0)->GetStreamFormat().mSampleRate;
-		plugin_instance->setSamplerate(samplerate);
-		plugin_instance->allNotesOff();
+   double samplerate = inNewFormat.mSampleRate;
+   ComponentResult result =
+       AUBase::ChangeStreamFormat(inScope, inElement, inPrevFormat, inNewFormat);
+
+   if (plugin_instance)
+      plugin_instance->setSamplerate(samplerate);
+   sampleRateCache = samplerate;
+
+   return result;
+}
+
+//----------------------------------------------------------------------------------------------------
+
+ComponentResult aulayer::Reset(AudioUnitScope inScope, AudioUnitElement inElement)
+{
+   if ((inScope == kAudioUnitScope_Global) && (inElement == 0) && plugin_instance)
+   {
+      double samplerate = GetOutput(0)->GetStreamFormat().mSampleRate;
+      plugin_instance->setSamplerate(samplerate);
+      plugin_instance->allNotesOff();
       sampleRateCache == samplerate;
-	}
-	return noErr;
+   }
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-bool aulayer::ValidFormat( AudioUnitScope inScope, AudioUnitElement	inElement, const CAStreamBasicDescription &inNewFormat)
+bool aulayer::ValidFormat(AudioUnitScope inScope,
+                          AudioUnitElement inElement,
+                          const CAStreamBasicDescription& inNewFormat)
 {
-	
-	if(!FormatIsCanonical(inNewFormat)) return false;
-	if(inElement>0) return false; // only 1 input/output element supported
-	if(inScope == kAudioUnitScope_Input)
-	{
-		if(inNewFormat.NumberChannels() == 0) return true;
-		else if(inNewFormat.NumberChannels() == 2)
-		{
-			return true;
-		}
-	}
-	else if(inScope == kAudioUnitScope_Output)
-	{
-		if(inNewFormat.NumberChannels() == 2) return true;
-	}
-	else if(inScope == kAudioUnitScope_Global)
-	{
-		return true;
-	}
-	return false;
-}
 
-//----------------------------------------------------------------------------------------------------	
-	
-ComponentResult aulayer::StartNote( 
-	MusicDeviceInstrumentID inInstrument,
-	MusicDeviceGroupID inGroupID,
-	NoteInstanceID* outNoteInstanceID,
-	UInt32 inOffsetSampleFrame,
-	const MusicDeviceNoteParams &inParams)
-{
-	return 0;
+   if (!FormatIsCanonical(inNewFormat))
+      return false;
+   if (inElement > 0)
+      return false; // only 1 input/output element supported
+   if (inScope == kAudioUnitScope_Input)
+   {
+      if (inNewFormat.NumberChannels() == 0)
+         return true;
+      else if (inNewFormat.NumberChannels() == 2)
+      {
+         return true;
+      }
+   }
+   else if (inScope == kAudioUnitScope_Output)
+   {
+      if (inNewFormat.NumberChannels() == 2)
+         return true;
+   }
+   else if (inScope == kAudioUnitScope_Global)
+   {
+      return true;
+   }
+   return false;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult aulayer::StopNote(
-	MusicDeviceGroupID inGroupID, NoteInstanceID inNoteInstanceID, UInt32 inOffsetSampleFrame)
+ComponentResult aulayer::StartNote(MusicDeviceInstrumentID inInstrument,
+                                   MusicDeviceGroupID inGroupID,
+                                   NoteInstanceID* outNoteInstanceID,
+                                   UInt32 inOffsetSampleFrame,
+                                   const MusicDeviceNoteParams& inParams)
 {
-	return 0;
+   return 0;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-OSStatus aulayer::HandleNoteOn(UInt8 inChannel, UInt8 inNoteNumber, UInt8 inVelocity, UInt32 inStartFrame)
+ComponentResult aulayer::StopNote(MusicDeviceGroupID inGroupID,
+                                  NoteInstanceID inNoteInstanceID,
+                                  UInt32 inOffsetSampleFrame)
 {
-	plugin_instance->playNote(inChannel,inNoteNumber,inVelocity,0);
-	return noErr;
-}
-
-//----------------------------------------------------------------------------------------------------
-	
-OSStatus aulayer::HandleNoteOff(UInt8 inChannel, UInt8 inNoteNumber, UInt8 inVelocity, UInt32 inStartFrame)
-{
-	plugin_instance->releaseNote(inChannel,inNoteNumber,inVelocity);
-	return noErr;
+   return 0;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-OSStatus aulayer::HandleControlChange(UInt8 inChannel, UInt8 inController,	UInt8 inValue, UInt32 inStartFrame)
+OSStatus
+aulayer::HandleNoteOn(UInt8 inChannel, UInt8 inNoteNumber, UInt8 inVelocity, UInt32 inStartFrame)
 {
-	plugin_instance->channelController(inChannel,inController, inValue);
-	return noErr;
+   plugin_instance->playNote(inChannel, inNoteNumber, inVelocity, 0);
+   return noErr;
+}
+
+//----------------------------------------------------------------------------------------------------
+
+OSStatus
+aulayer::HandleNoteOff(UInt8 inChannel, UInt8 inNoteNumber, UInt8 inVelocity, UInt32 inStartFrame)
+{
+   plugin_instance->releaseNote(inChannel, inNoteNumber, inVelocity);
+   return noErr;
+}
+
+//----------------------------------------------------------------------------------------------------
+
+OSStatus aulayer::HandleControlChange(UInt8 inChannel,
+                                      UInt8 inController,
+                                      UInt8 inValue,
+                                      UInt32 inStartFrame)
+{
+   plugin_instance->channelController(inChannel, inController, inValue);
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
 OSStatus aulayer::HandleChannelPressure(UInt8 inChannel, UInt8 inValue, UInt32 inStartFrame)
 {
-	plugin_instance->channelAftertouch(inChannel,inValue);
-	return noErr;
+   plugin_instance->channelAftertouch(inChannel, inValue);
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-OSStatus aulayer::HandlePitchWheel(UInt8 inChannel, UInt8 inPitch1, UInt8 inPitch2, UInt32 inStartFrame)
+OSStatus
+aulayer::HandlePitchWheel(UInt8 inChannel, UInt8 inPitch1, UInt8 inPitch2, UInt32 inStartFrame)
 {
-	long value = (inPitch1 & 0x7f) + (	(inPitch2 & 0x7f) << 7);
-	plugin_instance->pitchBend(inChannel,value-8192);
-	return noErr;
+   long value = (inPitch1 & 0x7f) + ((inPitch2 & 0x7f) << 7);
+   plugin_instance->pitchBend(inChannel, value - 8192);
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-OSStatus aulayer::HandlePolyPressure(UInt8 inChannel, UInt8 inKey, UInt8 inValue, UInt32 inStartFrame)
+OSStatus
+aulayer::HandlePolyPressure(UInt8 inChannel, UInt8 inKey, UInt8 inValue, UInt32 inStartFrame)
 {
-    plugin_instance->polyAftertouch(inChannel,inKey,inValue);
-	return noErr;
+   plugin_instance->polyAftertouch(inChannel, inKey, inValue);
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
 OSStatus aulayer::HandleProgramChange(UInt8 inChannel, UInt8 inValue)
 {
-    plugin_instance->programChange(inChannel,inValue);
-	return noErr;
+   plugin_instance->programChange(inChannel, inValue);
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult aulayer::Render( AudioUnitRenderActionFlags & ioActionFlags, const AudioTimeStamp & inTimeStamp, UInt32 inNumberFrames)
+ComponentResult aulayer::Render(AudioUnitRenderActionFlags& ioActionFlags,
+                                const AudioTimeStamp& inTimeStamp,
+                                UInt32 inNumberFrames)
 {
-	assert(IsPluginInitialized());
-	assert(IsInitialized());
-	SurgeSynthesizer *s = (SurgeSynthesizer*) plugin_instance;
-	s->process_input = 0;
-	
-	float sampleRate = sampleRateCache;
-	float* outputs[N_OUTPUTS];
-	float* inputs[N_INPUTS];
-	
-	AudioUnitRenderActionFlags xflags = 0;
-	if(HasInput(0))
-	{
-		ComponentResult result = PullInput(0, xflags, inTimeStamp, inNumberFrames);	
-		
-		if(result == noErr)
-		{
-			for (long i=0; i<N_INPUTS; i++){
-				inputs[i]=GetInput(0)->GetChannelData(i);
-			}
-			s->process_input = inputs[0] != 0;
-		}
-	}
-	// Get output buffer list and extract the i/o buffer pointers.
-	//if (N_OUTPUTS>0)
-	{
-		AudioBufferList& asOutBufs=GetOutput(0)->GetBufferList();
-		for (long o=0; o<N_OUTPUTS; ++o){
-			outputs[o]=(float*)(asOutBufs.mBuffers[o].mData);
-			if(asOutBufs.mBuffers[o].mDataByteSize<=0 || o>=asOutBufs.mNumberBuffers)
-				outputs[o]=nil;
-		}
-	}
+   assert(IsPluginInitialized());
+   assert(IsInitialized());
+   SurgeSynthesizer* s = (SurgeSynthesizer*)plugin_instance;
+   s->process_input = 0;
 
-    // Get the transport status
-    Boolean isPlaying;
+   float sampleRate = sampleRateCache;
+   float* outputs[N_OUTPUTS];
+   float* inputs[N_INPUTS];
 
-    if(CallHostTransportState( &isPlaying,
-                               NULL, // &isTransportStateChanged,
-                               NULL, // &currentSampleInTimeline,
-                               NULL, // &isCycling,
-                               NULL, // &cycleStartBeat,
-                               NULL // &cycleEndBeat
-           ) < 0 )
-    {
-        isPlaying = false;
-    }
-        
+   AudioUnitRenderActionFlags xflags = 0;
+   if (HasInput(0))
+   {
+      ComponentResult result = PullInput(0, xflags, inTimeStamp, inNumberFrames);
 
+      if (result == noErr)
+      {
+         for (long i = 0; i < N_INPUTS; i++)
+         {
+            inputs[i] = GetInput(0)->GetChannelData(i);
+         }
+         s->process_input = inputs[0] != 0;
+      }
+   }
+   // Get output buffer list and extract the i/o buffer pointers.
+   // if (N_OUTPUTS>0)
+   {
+      AudioBufferList& asOutBufs = GetOutput(0)->GetBufferList();
+      for (long o = 0; o < N_OUTPUTS; ++o)
+      {
+         outputs[o] = (float*)(asOutBufs.mBuffers[o].mData);
+         if (asOutBufs.mBuffers[o].mDataByteSize <= 0 || o >= asOutBufs.mNumberBuffers)
+            outputs[o] = nil;
+      }
+   }
 
-	// do each buffer
-	Float64 CurrentBeat,CurrentTempo; 
-	if(CallHostBeatAndTempo (&CurrentBeat, &CurrentTempo) >= 0)
-	{
-		plugin_instance->time_data.tempo = CurrentTempo;
+   // Get the transport status
+   Boolean isPlaying;
 
-        // If the engine isn't playing, so CurrentBeat is a constant, then result here is
-        // resetting time_data.ppqPos to the same thing over and over. That means the lfo_freerun
-        // mode basically acts like keypress mode since time_data.ppqPos - which maps to songpos
-        // is always reset to zero or a frame or so beyond. If instead we only reset it when
-        // playing then exactly what we want occurs. In playback mode we get perfectly predictable
-        // oscillator start and stop; but in performance mode we get freerun working off the internal clock
-        // which we synthesize by running the "move clock" block below.
-        // 
-        // See github issue #146
-        if( isPlaying )
-            plugin_instance->time_data.ppqPos = CurrentBeat;
-	}
-	else
-	{
-		plugin_instance->time_data.tempo = 120;
-	}	
-	
-	unsigned int events_processed = 0;
-		
-    unsigned int i;
-	for(i=0; i<inNumberFrames; i++)
-    {
-		if(blockpos == 0)
-		{
-			// move clock						
-			plugin_instance->time_data.ppqPos += (double) BLOCK_SIZE * plugin_instance->time_data.tempo/(60. * sampleRate);			
-			
-			// process events for the current block
-			while(events_processed < events_this_block)
-			{
-				if ((i + blockpos) > eventbuffer[events_processed].inStartFrame)
-				{
-					AuMIDIEvent *e = &eventbuffer[events_processed];
-					AUMIDIBase::HandleMidiEvent(e->status,e->channel,e->data1,e->data2,e->inStartFrame);
-					events_processed++;
-				}
-				else
-					break;
-			}
-			
-			// run synth engine for the current block
-			plugin_instance->process();
-		}
+   if (CallHostTransportState(&isPlaying,
+                              NULL, // &isTransportStateChanged,
+                              NULL, // &currentSampleInTimeline,
+                              NULL, // &isCycling,
+                              NULL, // &cycleStartBeat,
+                              NULL  // &cycleEndBeat
+                              ) < 0)
+   {
+      isPlaying = false;
+   }
 
-		if(s->process_input)
-		{
-			int inp;
-			for(inp=0; inp<N_INPUTS; inp++)
-			{
-				plugin_instance->input[inp][blockpos] = inputs[inp][i]; 
-			}
-		}
+   // do each buffer
+   Float64 CurrentBeat, CurrentTempo;
+   if (CallHostBeatAndTempo(&CurrentBeat, &CurrentTempo) >= 0)
+   {
+      plugin_instance->time_data.tempo = CurrentTempo;
 
-		int outp;
-		for(outp=0; outp<N_OUTPUTS; outp++)
-		{
-			outputs[outp][i] = (float)plugin_instance->output[outp][blockpos];    // replacing
-		}
-		
-		blockpos++;
-		if(blockpos>=BLOCK_SIZE) blockpos = 0;
-    }
-	
-	// process remaining events (there shouldn't be any)
-	while(events_processed < events_this_block)
-	{
-		AuMIDIEvent *e = &eventbuffer[events_processed];
-		AUMIDIBase::HandleMidiEvent(e->status,e->channel,e->data1,e->data2,e->inStartFrame);
-		events_processed++;
-	}
-	events_this_block = 0;	// reset eventbuffer
-	
-	return noErr;
-}
+      // If the engine isn't playing, so CurrentBeat is a constant, then result here is
+      // resetting time_data.ppqPos to the same thing over and over. That means the lfo_freerun
+      // mode basically acts like keypress mode since time_data.ppqPos - which maps to songpos
+      // is always reset to zero or a frame or so beyond. If instead we only reset it when
+      // playing then exactly what we want occurs. In playback mode we get perfectly predictable
+      // oscillator start and stop; but in performance mode we get freerun working off the internal
+      // clock which we synthesize by running the "move clock" block below.
+      //
+      // See github issue #146
+      if (isPlaying)
+         plugin_instance->time_data.ppqPos = CurrentBeat;
+   }
+   else
+   {
+      plugin_instance->time_data.tempo = 120;
+   }
 
+   unsigned int events_processed = 0;
 
-//----------------------------------------------------------------------------------------------------
+   unsigned int i;
+   for (i = 0; i < inNumberFrames; i++)
+   {
+      if (blockpos == 0)
+      {
+         // move clock
+         plugin_instance->time_data.ppqPos +=
+             (double)BLOCK_SIZE * plugin_instance->time_data.tempo / (60. * sampleRate);
 
+         // process events for the current block
+         while (events_processed < events_this_block)
+         {
+            if ((i + blockpos) > eventbuffer[events_processed].inStartFrame)
+            {
+               AuMIDIEvent* e = &eventbuffer[events_processed];
+               AUMIDIBase::HandleMidiEvent(e->status, e->channel, e->data1, e->data2,
+                                           e->inStartFrame);
+               events_processed++;
+            }
+            else
+               break;
+         }
 
+         // run synth engine for the current block
+         plugin_instance->process();
+      }
 
-//----------------------------------------------------------------------------------------------------
+      if (s->process_input)
+      {
+         int inp;
+         for (inp = 0; inp < N_INPUTS; inp++)
+         {
+            plugin_instance->input[inp][blockpos] = inputs[inp][i];
+         }
+      }
 
-ComponentResult aulayer::GetPropertyInfo(AudioUnitPropertyID iID, AudioUnitScope iScope, AudioUnitElement iElem, UInt32& iSize, Boolean& fWritable)
-{
-  // OK so big todo here and in GetProperty
-  // 1: Switch these all to have an inScope--kAudioUnitScope_Global guard
-  // 2: Switch these to be a switch
-  // 3: Make Cocoa UI make the datasize the size of the view info. Take a look in juce_audio_plugin_client/AU/juce_AU_Wrapper.mm
-  // 4: That will probably core out since the calss isn't defined. That's OK! MOve on from there.
-  if( iScope == kAudioUnitScope_Global )
-    {
-      switch( iID )
-        {
-            case kAudioUnitProperty_CocoaUI:
-                iSize = sizeof (AudioUnitCocoaViewInfo);
-                fWritable = true;
-                return noErr;
-                break;
-            case kVmbAAudioUnitProperty_GetEditPointer:
-                iSize = sizeof( SurgeGUIEditor *);
-                fWritable = true;
-                return noErr;
-                break;
-            case kAudioUnitProperty_ParameterValueName:
-                iSize = sizeof( AudioUnitParameterValueName );
-                return noErr;
-                break;
-            case kAudioUnitProperty_ParameterClumpName:
-                iSize = sizeof( AudioUnitParameterNameInfo );
-                return noErr;
-                break;
-            case kVmbAAudioUnitProperty_GetPluginCPPInstance:
-                iSize = sizeof( void* );
-                return noErr;
-                break;
-        }
-    }
-    
-  return AUInstrumentBase::GetPropertyInfo(iID, iScope, iElem, iSize,fWritable);
+      int outp;
+      for (outp = 0; outp < N_OUTPUTS; outp++)
+      {
+         outputs[outp][i] = (float)plugin_instance->output[outp][blockpos]; // replacing
+      }
+
+      blockpos++;
+      if (blockpos >= BLOCK_SIZE)
+         blockpos = 0;
+   }
+
+   // process remaining events (there shouldn't be any)
+   while (events_processed < events_this_block)
+   {
+      AuMIDIEvent* e = &eventbuffer[events_processed];
+      AUMIDIBase::HandleMidiEvent(e->status, e->channel, e->data1, e->data2, e->inStartFrame);
+      events_processed++;
+   }
+   events_this_block = 0; // reset eventbuffer
+
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult aulayer::RestoreState(CFPropertyListRef	plist)
+//----------------------------------------------------------------------------------------------------
+
+ComponentResult aulayer::GetPropertyInfo(AudioUnitPropertyID iID,
+                                         AudioUnitScope iScope,
+                                         AudioUnitElement iElem,
+                                         UInt32& iSize,
+                                         Boolean& fWritable)
 {
-	ComponentResult result = AUBase::RestoreState(plist);
-	if(result != noErr) return result;
+   // OK so big todo here and in GetProperty
+   // 1: Switch these all to have an inScope--kAudioUnitScope_Global guard
+   // 2: Switch these to be a switch
+   // 3: Make Cocoa UI make the datasize the size of the view info. Take a look in
+   // juce_audio_plugin_client/AU/juce_AU_Wrapper.mm 4: That will probably core out since the calss
+   // isn't defined. That's OK! MOve on from there.
+   if (iScope == kAudioUnitScope_Global)
+   {
+      switch (iID)
+      {
+      case kAudioUnitProperty_CocoaUI:
+         iSize = sizeof(AudioUnitCocoaViewInfo);
+         fWritable = true;
+         return noErr;
+         break;
+      case kVmbAAudioUnitProperty_GetEditPointer:
+         iSize = sizeof(SurgeGUIEditor*);
+         fWritable = true;
+         return noErr;
+         break;
+      case kAudioUnitProperty_ParameterValueName:
+         iSize = sizeof(AudioUnitParameterValueName);
+         return noErr;
+         break;
+      case kAudioUnitProperty_ParameterClumpName:
+         iSize = sizeof(AudioUnitParameterNameInfo);
+         return noErr;
+         break;
+      case kVmbAAudioUnitProperty_GetPluginCPPInstance:
+         iSize = sizeof(void*);
+         return noErr;
+         break;
+      }
+   }
 
-	CFDictionaryRef dict = static_cast<CFDictionaryRef>(plist);	
-
-	CFDataRef data = reinterpret_cast<CFDataRef>(CFDictionaryGetValue (dict, rawchunkname));
-	if (data != NULL) 
-	{
-		if(!IsPluginInitialized()) 
-		{
-			InitializePlugin();
-		}
-		const UInt8 *p;		
-		p = CFDataGetBytePtr(data);
-		size_t psize = CFDataGetLength(data);		
-        plugin_instance->loadRaw(p,psize,false);
-	}
-	return noErr;
+   return AUInstrumentBase::GetPropertyInfo(iID, iScope, iElem, iSize, fWritable);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult	aulayer::SaveState(CFPropertyListRef *	plist)
+ComponentResult aulayer::RestoreState(CFPropertyListRef plist)
 {
-	// store AUBase class data
-	ComponentResult result = AUBase::SaveState(plist);
-	if(result != noErr) return result;
-	if(!IsInitialized()) return kAudioUnitErr_Uninitialized;
-		
-	// append raw chunk data
-	// TODO det är här det finns ze memleaks!!!
-	// TODO It is here that we can find memory leaks!!!
-	
-	CFMutableDictionaryRef dict = (CFMutableDictionaryRef)*plist;
-	void* data;
-    CFIndex size = plugin_instance->saveRaw(&data);
-	CFDataRef dataref = CFDataCreateWithBytesNoCopy(NULL, (const UInt8*) data, size, kCFAllocatorNull);
-	CFDictionarySetValue(dict, rawchunkname, dataref);
-	CFRelease (dataref);
-	return noErr;
+   ComponentResult result = AUBase::RestoreState(plist);
+   if (result != noErr)
+      return result;
+
+   CFDictionaryRef dict = static_cast<CFDictionaryRef>(plist);
+
+   CFDataRef data = reinterpret_cast<CFDataRef>(CFDictionaryGetValue(dict, rawchunkname));
+   if (data != NULL)
+   {
+      if (!IsPluginInitialized())
+      {
+         InitializePlugin();
+      }
+      const UInt8* p;
+      p = CFDataGetBytePtr(data);
+      size_t psize = CFDataGetLength(data);
+      plugin_instance->loadRaw(p, psize, false);
+   }
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult	aulayer::GetPresets (CFArrayRef *outData) const
+ComponentResult aulayer::SaveState(CFPropertyListRef* plist)
 {
-  // kAudioUnitProperty_FactoryPresets
-  
-  // Type: CFArrayRef containing AUPreset's
-  // Returns an array of AUPreset that contain a number and name for each of the presets. 
-  //The number of each preset must be greater (or equal to) zero, and the numbers need not be ordered or contiguous. 
-  //The name of each preset can be presented to the user as a means of identifying each preset. 
-  // The CFArrayRef should be released by the caller.
-  
-  if(!IsInitialized()) return kAudioUnitErr_Uninitialized;
-  
-  if (outData == NULL)
-    return noErr;
-  
-  
-  sub3_synth *s = (sub3_synth*)plugin_instance;
-  UInt32 n_presets = s->storage.patch_list.size();
-  
-  CFMutableArrayRef newArray = CFArrayCreateMutable(kCFAllocatorDefault, n_presets, &kCFAUPresetArrayCallBacks);
-  if (newArray == NULL)
-    return coreFoundationUnknownErr;
-  
-  
-  
-  for (long i=0; i < n_presets; i++)
-    {
-      CFAUPresetRef newPreset = CFAUPresetCreate(kCFAllocatorDefault, i, CFStringCreateWithCString(NULL,s->storage.patch_list[i].name.c_str(), kCFStringEncodingUTF8));
+   // store AUBase class data
+   ComponentResult result = AUBase::SaveState(plist);
+   if (result != noErr)
+      return result;
+   if (!IsInitialized())
+      return kAudioUnitErr_Uninitialized;
+
+   // append raw chunk data
+   // TODO It is here that we can find memory leaks!!!
+
+   CFMutableDictionaryRef dict = (CFMutableDictionaryRef)*plist;
+   void* data;
+   CFIndex size = plugin_instance->saveRaw(&data);
+   CFDataRef dataref =
+       CFDataCreateWithBytesNoCopy(NULL, (const UInt8*)data, size, kCFAllocatorNull);
+   CFDictionarySetValue(dict, rawchunkname, dataref);
+   CFRelease(dataref);
+   return noErr;
+}
+
+//----------------------------------------------------------------------------------------------------
+
+ComponentResult aulayer::GetPresets(CFArrayRef* outData) const
+{
+   // kAudioUnitProperty_FactoryPresets
+
+   // Type: CFArrayRef containing AUPreset's
+   // Returns an array of AUPreset that contain a number and name for each of the presets.
+   // The number of each preset must be greater (or equal to) zero, and the numbers need not be
+   // ordered or contiguous. The name of each preset can be presented to the user as a means of
+   // identifying each preset.
+   // The CFArrayRef should be released by the caller.
+
+   if (!IsInitialized())
+      return kAudioUnitErr_Uninitialized;
+
+   if (outData == NULL)
+      return noErr;
+
+   sub3_synth* s = (sub3_synth*)plugin_instance;
+   UInt32 n_presets = s->storage.patch_list.size();
+
+   CFMutableArrayRef newArray =
+       CFArrayCreateMutable(kCFAllocatorDefault, n_presets, &kCFAUPresetArrayCallBacks);
+   if (newArray == NULL)
+      return coreFoundationUnknownErr;
+
+   for (long i = 0; i < n_presets; i++)
+   {
+      CFAUPresetRef newPreset =
+          CFAUPresetCreate(kCFAllocatorDefault, i,
+                           CFStringCreateWithCString(NULL, s->storage.patch_list[i].name.c_str(),
+                                                     kCFStringEncodingUTF8));
       if (newPreset != NULL)
-		{
-                  CFArrayAppendValue(newArray, newPreset);
-                  CFAUPresetRelease(newPreset);
-		}
-    }
-  
-  *outData = (CFArrayRef)newArray;
-  return noErr;
-  // return coreFoundationUnknownErr; // this isn't OK so tell the host that	
+      {
+         CFArrayAppendValue(newArray, newPreset);
+         CFAUPresetRelease(newPreset);
+      }
+   }
+
+   *outData = (CFArrayRef)newArray;
+   return noErr;
+   // return coreFoundationUnknownErr; // this isn't OK so tell the host that
 }
 
 //----------------------------------------------------------------------------------------------------
 
-OSStatus aulayer::NewFactoryPresetSet (const AUPreset & inNewFactoryPreset)
+OSStatus aulayer::NewFactoryPresetSet(const AUPreset& inNewFactoryPreset)
 {
-	if(!IsInitialized()) return false;	
-	if(inNewFactoryPreset.presetNumber<0) return false;
-	sub3_synth *s = (sub3_synth*)plugin_instance;
-	s->patchid_queue = inNewFactoryPreset.presetNumber;
-    s->processThreadunsafeOperations();
-	return true;
+   if (!IsInitialized())
+      return false;
+   if (inNewFactoryPreset.presetNumber < 0)
+      return false;
+   sub3_synth* s = (sub3_synth*)plugin_instance;
+   s->patchid_queue = inNewFactoryPreset.presetNumber;
+   s->processThreadunsafeOperations();
+   return true;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult aulayer::GetParameterList(AudioUnitScope inScope, AudioUnitParameterID *outParameterList, UInt32 &outNumParameters)
+ComponentResult aulayer::GetParameterList(AudioUnitScope inScope,
+                                          AudioUnitParameterID* outParameterList,
+                                          UInt32& outNumParameters)
 {
-	if((inScope != kAudioUnitScope_Global) || !IsInitialized())
-	{
-		outNumParameters = 0;
-		return noErr;
-	}
+   if ((inScope != kAudioUnitScope_Global) || !IsInitialized())
+   {
+      outNumParameters = 0;
+      return noErr;
+   }
 
-	outNumParameters = n_total_params;
-	if(outParameterList) memcpy(outParameterList,parameterIDlist,sizeof(AudioUnitParameterID)*n_total_params);
-	return noErr;
+   outNumParameters = n_total_params;
+   if (outParameterList)
+      memcpy(outParameterList, parameterIDlist, sizeof(AudioUnitParameterID) * n_total_params);
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult aulayer::GetParameterInfo(
-	AudioUnitScope          inScope,
-	AudioUnitParameterID    inParameterID,
-        AudioUnitParameterInfo  &outParameterInfo)
+ComponentResult aulayer::GetParameterInfo(AudioUnitScope inScope,
+                                          AudioUnitParameterID inParameterID,
+                                          AudioUnitParameterInfo& outParameterInfo)
 {
-  //FIXME: I think this code can be a bit tighter and cleaner, but it works OK for now
-	outParameterInfo.unit = kAudioUnitParameterUnit_Generic;
-	outParameterInfo.minValue = 0.f;
-	outParameterInfo.maxValue = 1.f;
-	outParameterInfo.defaultValue = 0.f;
-	
-	outParameterInfo.flags = kAudioUnitParameterFlag_IsWritable | kAudioUnitParameterFlag_IsReadable; 
+   // FIXME: I think this code can be a bit tighter and cleaner, but it works OK for now
+   outParameterInfo.unit = kAudioUnitParameterUnit_Generic;
+   outParameterInfo.minValue = 0.f;
+   outParameterInfo.maxValue = 1.f;
+   outParameterInfo.defaultValue = 0.f;
 
-	//kAudioUnitParameterFlag_IsGlobalMeta
-	
-	sprintf(outParameterInfo.name,"-");			
-	//outParameterInfo.unitName 
+   outParameterInfo.flags = kAudioUnitParameterFlag_IsWritable | kAudioUnitParameterFlag_IsReadable;
 
-	inParameterID = plugin_instance->remapExternalApiToInternalId(inParameterID);
-		
-	if (inScope != kAudioUnitScope_Global) return kAudioUnitErr_InvalidParameter;
-	if(!IsInitialized()) return kAudioUnitErr_Uninitialized;	// return defaults
-	
-	plugin_instance->getParameterName(inParameterID,outParameterInfo.name);
-	outParameterInfo.flags |= kAudioUnitParameterFlag_HasCFNameString | kAudioUnitParameterFlag_CFNameRelease | kAudioUnitParameterFlag_HasClump | kAudioUnitParameterFlag_HasName;
-	outParameterInfo.cfNameString = CFStringCreateWithCString(NULL,outParameterInfo.name,kCFStringEncodingUTF8);
-	
-	parametermeta pm;
-	plugin_instance->getParameterMeta(inParameterID,pm);
-	outParameterInfo.minValue = pm.fmin;
-	outParameterInfo.maxValue = pm.fmax;
-	outParameterInfo.defaultValue = pm.fdefault;	
-	if (pm.expert) outParameterInfo.flags |= kAudioUnitParameterFlag_ExpertMode;
-	if (pm.meta) outParameterInfo.flags |= kAudioUnitParameterFlag_IsGlobalMeta;
-	
-	outParameterInfo.clumpID = pm.clump;
-	
-	return noErr;
+   // kAudioUnitParameterFlag_IsGlobalMeta
+
+   sprintf(outParameterInfo.name, "-");
+   // outParameterInfo.unitName
+
+   inParameterID = plugin_instance->remapExternalApiToInternalId(inParameterID);
+
+   if (inScope != kAudioUnitScope_Global)
+      return kAudioUnitErr_InvalidParameter;
+   if (!IsInitialized())
+      return kAudioUnitErr_Uninitialized; // return defaults
+
+   plugin_instance->getParameterName(inParameterID, outParameterInfo.name);
+   outParameterInfo.flags |= kAudioUnitParameterFlag_HasCFNameString |
+                             kAudioUnitParameterFlag_CFNameRelease |
+                             kAudioUnitParameterFlag_HasClump | kAudioUnitParameterFlag_HasName;
+   outParameterInfo.cfNameString =
+       CFStringCreateWithCString(NULL, outParameterInfo.name, kCFStringEncodingUTF8);
+
+   parametermeta pm;
+   plugin_instance->getParameterMeta(inParameterID, pm);
+   outParameterInfo.minValue = pm.fmin;
+   outParameterInfo.maxValue = pm.fmax;
+   outParameterInfo.defaultValue = pm.fdefault;
+   if (pm.expert)
+      outParameterInfo.flags |= kAudioUnitParameterFlag_ExpertMode;
+   if (pm.meta)
+      outParameterInfo.flags |= kAudioUnitParameterFlag_IsGlobalMeta;
+
+   outParameterInfo.clumpID = pm.clump;
+
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult aulayer::GetParameter(AudioUnitParameterID inID, AudioUnitScope inScope, AudioUnitElement inElement, Float32 &outValue)
+ComponentResult aulayer::GetParameter(AudioUnitParameterID inID,
+                                      AudioUnitScope inScope,
+                                      AudioUnitElement inElement,
+                                      Float32& outValue)
 {
-	if (inScope != kAudioUnitScope_Global) return kAudioUnitErr_InvalidParameter;
-	if(inID >= n_total_params) return kAudioUnitErr_InvalidParameter;
-	if(!IsInitialized()) return kAudioUnitErr_Uninitialized;	
-	outValue = plugin_instance->getParameter01(plugin_instance->remapExternalApiToInternalId(inID));
-	return noErr;
+   if (inScope != kAudioUnitScope_Global)
+      return kAudioUnitErr_InvalidParameter;
+   if (inID >= n_total_params)
+      return kAudioUnitErr_InvalidParameter;
+   if (!IsInitialized())
+      return kAudioUnitErr_Uninitialized;
+   outValue = plugin_instance->getParameter01(plugin_instance->remapExternalApiToInternalId(inID));
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-ComponentResult	aulayer::SetParameter(AudioUnitParameterID inID, AudioUnitScope inScope, AudioUnitElement inElement, Float32 inValue, UInt32 inBufferOffsetInFrames)
+ComponentResult aulayer::SetParameter(AudioUnitParameterID inID,
+                                      AudioUnitScope inScope,
+                                      AudioUnitElement inElement,
+                                      Float32 inValue,
+                                      UInt32 inBufferOffsetInFrames)
 {
-    if (inScope != kAudioUnitScope_Global) return kAudioUnitErr_InvalidParameter;
-	if(inID >= n_total_params) return kAudioUnitErr_InvalidParameter;
-	if(!IsInitialized()) return kAudioUnitErr_Uninitialized;	
-	plugin_instance->setParameter01(plugin_instance->remapExternalApiToInternalId(inID),inValue,true);
-	// TODO lägg till signalering från här -> editor om den är öppen
-	// glöm inte att mappa om parametrarna ifall det är ableton live som är host
-	// EDIT gör det hellre med en threadsafe buffer i sub3_synth
-	// Translated:
-	// TODO: Add signaling from here to the editor, if the editor is open
-	// Do not forget to map the parameters if Ableton Live is the host
-	// EDIT: Do it rather with a threadsafe buffer within sub3_synth
-	return noErr;
+   if (inScope != kAudioUnitScope_Global)
+      return kAudioUnitErr_InvalidParameter;
+   if (inID >= n_total_params)
+      return kAudioUnitErr_InvalidParameter;
+   if (!IsInitialized())
+      return kAudioUnitErr_Uninitialized;
+   plugin_instance->setParameter01(plugin_instance->remapExternalApiToInternalId(inID), inValue,
+                                   true);
+   return noErr;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -680,143 +725,70 @@ bool aulayer::CanScheduleParameters() const
 
 bool aulayer::ParameterBeginEdit(int p)
 {
-	AudioUnitEvent event;
-	event.mEventType = kAudioUnitEvent_BeginParameterChangeGesture;
-	event.mArgument.mParameter.mAudioUnit = GetComponentInstance();
-	event.mArgument.mParameter.mParameterID = p;
-	event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
-	event.mArgument.mParameter.mElement = 0;
-	AUEventListenerNotify(NULL,NULL,&event);
-	return true;
+   AudioUnitEvent event;
+   event.mEventType = kAudioUnitEvent_BeginParameterChangeGesture;
+   event.mArgument.mParameter.mAudioUnit = GetComponentInstance();
+   event.mArgument.mParameter.mParameterID = p;
+   event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
+   event.mArgument.mParameter.mElement = 0;
+   AUEventListenerNotify(NULL, NULL, &event);
+   return true;
 }
 
 //----------------------------------------------------------------------------------------------------
 
 bool aulayer::ParameterEndEdit(int p)
 {
-	AudioUnitEvent event;
-	event.mEventType = kAudioUnitEvent_EndParameterChangeGesture;
-	event.mArgument.mParameter.mAudioUnit = GetComponentInstance();
-	event.mArgument.mParameter.mParameterID = p;
-	event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
-	event.mArgument.mParameter.mElement = 0;
-	AUEventListenerNotify(NULL,NULL,&event);
-	return true;
+   AudioUnitEvent event;
+   event.mEventType = kAudioUnitEvent_EndParameterChangeGesture;
+   event.mArgument.mParameter.mAudioUnit = GetComponentInstance();
+   event.mArgument.mParameter.mParameterID = p;
+   event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
+   event.mArgument.mParameter.mElement = 0;
+   AUEventListenerNotify(NULL, NULL, &event);
+   return true;
 }
 
 //----------------------------------------------------------------------------------------------------
 
 bool aulayer::ParameterUpdate(int p)
 {
-	//AUParameterChange_TellListeners(GetComponentInstance(), p);
-	// set up an AudioUnitParameter structure with all of the necessary values
-	AudioUnitParameter dirtyParam;
-	memset(&dirtyParam, 0, sizeof(dirtyParam));	// zero out the struct
-	dirtyParam.mAudioUnit = GetComponentInstance();
-	dirtyParam.mParameterID = p;
-	dirtyParam.mScope = kAudioUnitScope_Global;
-	dirtyParam.mElement = 0;
+   // AUParameterChange_TellListeners(GetComponentInstance(), p);
+   // set up an AudioUnitParameter structure with all of the necessary values
+   AudioUnitParameter dirtyParam;
+   memset(&dirtyParam, 0, sizeof(dirtyParam)); // zero out the struct
+   dirtyParam.mAudioUnit = GetComponentInstance();
+   dirtyParam.mParameterID = p;
+   dirtyParam.mScope = kAudioUnitScope_Global;
+   dirtyParam.mElement = 0;
 
-	AUParameterListenerNotify(NULL, NULL, &dirtyParam);
-	
-	return true;
+   AUParameterListenerNotify(NULL, NULL, &dirtyParam);
+
+   return true;
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //	AUMIDIBase::HandleMidiEvent
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-OSStatus aulayer::HandleMidiEvent(UInt8 status, UInt8 channel, UInt8 data1, UInt8 data2, UInt32 inStartFrame)
+OSStatus
+aulayer::HandleMidiEvent(UInt8 status, UInt8 channel, UInt8 data1, UInt8 data2, UInt32 inStartFrame)
 {
-	if (!IsInitialized()) return kAudioUnitErr_Uninitialized;
-	
-	if(events_this_block >= 1024) return -1;  // buffer full
-	
-	eventbuffer[events_this_block].status = status;
-	eventbuffer[events_this_block].channel = channel;
-	eventbuffer[events_this_block].data1 = data1;
-	eventbuffer[events_this_block].data2 = data2;
-	eventbuffer[events_this_block].inStartFrame = inStartFrame;
-	
-	events_this_block++;
-	
-	return noErr;
+   if (!IsInitialized())
+      return kAudioUnitErr_Uninitialized;
+
+   if (events_this_block >= 1024)
+      return -1; // buffer full
+
+   eventbuffer[events_this_block].status = status;
+   eventbuffer[events_this_block].channel = channel;
+   eventbuffer[events_this_block].data1 = data1;
+   eventbuffer[events_this_block].data2 = data2;
+   eventbuffer[events_this_block].inStartFrame = inStartFrame;
+
+   events_this_block++;
+
+   return noErr;
 }
-
-#if MAC_CARBON
-
-SHAZBOT
-
-#include "AUCarbonViewBase.h"
-#include "plugguieditor.h"
-
-class VSTGUIAUView : public AUCarbonViewBase 
-{
-public:
-	VSTGUIAUView (AudioUnitCarbonView auv) 
-	: AUCarbonViewBase (auv)
-	, editor (0)
-	, xOffset (0)
-	, yOffset (0)
-	{
-	}
-
-	virtual ~VSTGUIAUView ()
-	{
-		if (editor)
-		{
-			editor->close ();
-			delete editor;
-		}
-	}
-	
-	void RespondToEventTimer (EventLoopTimerRef inTimer) 
-	{
-		if (editor)
-			editor->doIdleStuff ();
-	}
-
-	virtual OSStatus CreateUI(Float32 xoffset, Float32 yoffset)
-	{
-		AudioUnit unit = GetEditAudioUnit ();
-		if (unit)
-		{
-			void* pluginAddr=0;
-			UInt32 dataSize = sizeof(pluginAddr);
-			ComponentResult err = AudioUnitGetProperty(mEditAudioUnit,kVmbAAudioUnitProperty_GetPluginCPPInstance, kAudioUnitScope_Global, 0, &pluginAddr, &dataSize);
-
-			editor = new sub3_editor (pluginAddr);
-			WindowRef window = GetCarbonWindow ();
-			editor->open (window);
-			HIViewRef platformControl = (HIViewRef)editor->getFrame()->getPlatformControl();
-//			HIViewMoveBy ((HIViewRef)editor->getFrame ()->getPlatformControl (), xoffset, yoffset);
-			EmbedControl (platformControl);
-			CRect fsize = editor->getFrame ()->getViewSize (fsize);
-			SizeControl (mCarbonPane, fsize.width (), fsize.height ());
-			// CreateEventLoopTimer verkar sno focus och göra så den tappar mouseup-events
-			// CreateEventLoopTimer Sees no focus OR seems to steal the? focus, and then starts losing mouse-up events
-			CreateEventLoopTimer (kEventDurationSecond, kEventDurationSecond / 30);
-			HIViewSetVisible (platformControl, true);
-			HIViewSetNeedsDisplay (platformControl, true);
-			//SetMouseCoalescingEnabled(false,NULL);
-		}
-		return noErr;
-	}
-
-	Float32 xOffset, yOffset;
-protected:
-	sub3_editor* editor;
-};
-
-COMPONENT_ENTRY(VSTGUIAUView);
-
-#elif MAC_COCOA
-
-// #error Implement the UI here, probably cribbing off of that AudioKit again
-// TODO AU
-
-
-
-#endif
 
 AUDIOCOMPONENT_ENTRY(AUMusicDeviceFactory, aulayer);

--- a/src/au/aulayer.h
+++ b/src/au/aulayer.h
@@ -7,152 +7,170 @@
 #include "surge_auversion.h"
 #include "SurgeStorage.h"
 
-
 class SurgeGUIEditor;
 class SurgeSynthesizer;
 typedef SurgeSynthesizer plugin;
-
 
 //-------------------------------------------------------------------------------------------------------
 const CFStringRef rawchunkname = CFSTR("VmbA_chunk");
 
 enum
 {
-	kVmbAAudioUnitProperty_GetPluginCPPInstance = 70000,
-    kVmbAAudioUnitProperty_GetEditPointer = 70001,
+   kVmbAAudioUnitProperty_GetPluginCPPInstance = 70000,
+   kVmbAAudioUnitProperty_GetEditPointer = 70001,
 };
 
 // event
 struct AuMIDIEvent
 {
-	UInt8 status, channel, data1, data2;
-	long inStartFrame;
+   UInt8 status, channel, data1, data2;
+   long inStartFrame;
 };
 
 class aulayer : public AUInstrumentBase
 {
 public:
-	aulayer (AudioUnit au);
-	virtual ~aulayer();
-	
-	virtual int GetNumCustomUIComponents ();
-	virtual void GetUIComponentDescs (ComponentDescription* inDescArray);
-	
-	virtual ComponentResult Initialize();
-	virtual void Cleanup();
-	virtual ComponentResult Version ();
-	virtual ComponentResult Reset(
-		AudioUnitScope inScope,
-		AudioUnitElement inElement);
+   aulayer(AudioUnit au);
+   virtual ~aulayer();
 
-	virtual	ComponentResult		ChangeStreamFormat(
-		AudioUnitScope					inScope,
-		AudioUnitElement				inElement,
-		const CAStreamBasicDescription & inPrevFormat,
-		const CAStreamBasicDescription & inNewFormat);
+   virtual int GetNumCustomUIComponents();
+   virtual void GetUIComponentDescs(ComponentDescription* inDescArray);
 
-	virtual ComponentResult Render( AudioUnitRenderActionFlags & ioActionFlags,const AudioTimeStamp & inTimeStamp,UInt32 inNumberFrames);
+   virtual ComponentResult Initialize();
+   virtual void Cleanup();
+   virtual ComponentResult Version();
+   virtual ComponentResult Reset(AudioUnitScope inScope, AudioUnitElement inElement);
 
-	virtual UInt32 SupportedNumChannels (const AUChannelInfo** outInfo);
-	virtual bool StreamFormatWritable( AudioUnitScope scope,AudioUnitElement element);
-	virtual bool ValidFormat( AudioUnitScope inScope, AudioUnitElement	inElement, const CAStreamBasicDescription &inNewFormat);
-	
-	virtual ComponentResult StartNote(
-		MusicDeviceInstrumentID inInstrument,
-		MusicDeviceGroupID		inGroupID,
-		NoteInstanceID*			outNoteInstanceID,	
-		UInt32						inOffsetSampleFrame,
-		const MusicDeviceNoteParams &inParams);
-		
-	virtual ComponentResult StopNote(
-		MusicDeviceGroupID inGroupID,
-		NoteInstanceID inNoteInstanceID,
-		UInt32 inOffsetSampleFrame);
+   virtual ComponentResult ChangeStreamFormat(AudioUnitScope inScope,
+                                              AudioUnitElement inElement,
+                                              const CAStreamBasicDescription& inPrevFormat,
+                                              const CAStreamBasicDescription& inNewFormat);
 
-	virtual OSStatus HandleNoteOn(UInt8 inChannel, UInt8 inNoteNumber, UInt8 inVelocity, UInt32 inStartFram);
-	virtual OSStatus HandleNoteOff(UInt8 inChannel, UInt8 inNoteNumber, UInt8 inVelocity, UInt32 inStartFrame);
-	virtual OSStatus HandleControlChange(UInt8 inChannel, UInt8 inController, UInt8 inValue, UInt32 inStartFrame);
-	virtual OSStatus HandleChannelPressure(UInt8 inChannel, UInt8 inValue, UInt32 inStartFrame);
-	virtual OSStatus HandlePitchWheel(UInt8 inChannel,UInt8 inPitch1, UInt8 inPitch2, UInt32 inStartFrame);
-	virtual OSStatus HandlePolyPressure(UInt8 inChannel, UInt8 inKey, UInt8 inValue, UInt32 inStartFrame);
-	virtual OSStatus HandleProgramChange(UInt8 inChannel, UInt8 inValue);
-	
-	virtual ComponentResult GetProperty(AudioUnitPropertyID inID,AudioUnitScope inScope,AudioUnitElement inElement,void* outData);
-	virtual ComponentResult GetPropertyInfo(
-		AudioUnitPropertyID inID,
-		AudioUnitScope inScope, 
-		AudioUnitElement inElement, 
-		UInt32& outDataSize, 
-		Boolean& outWritable);
-			
-	virtual ComponentResult	SaveState(CFPropertyListRef *	outData);
-	virtual ComponentResult	RestoreState(CFPropertyListRef	inData);
-	
-	virtual bool HasIcon ();
-	virtual CFURLRef GetIconLocation ();
-	
-	virtual ComponentResult	GetPresets (CFArrayRef *outData) const;
-	virtual OSStatus NewFactoryPresetSet (const AUPreset & inNewFactoryPreset);
-	
-	virtual OSStatus HandleMidiEvent(UInt8 status, UInt8 channel, UInt8 data1, UInt8 data2, UInt32 inStartFrame);
-	
-	virtual ComponentResult GetParameterList(AudioUnitScope inScope, AudioUnitParameterID *outParameterList, UInt32 &outNumParameters);
-	virtual ComponentResult GetParameterInfo(AudioUnitScope inScope, AudioUnitParameterID inParameterID, AudioUnitParameterInfo  &outParameterInfo);
-	virtual ComponentResult GetParameter(AudioUnitParameterID inID, AudioUnitScope inScope, AudioUnitElement inElement, Float32 &outValue);	
-	virtual ComponentResult	SetParameter(AudioUnitParameterID inID, AudioUnitScope inScope, AudioUnitElement inElement, Float32 inValue, UInt32 inBufferOffsetInFrames);
-   
+   virtual ComponentResult Render(AudioUnitRenderActionFlags& ioActionFlags,
+                                  const AudioTimeStamp& inTimeStamp,
+                                  UInt32 inNumberFrames);
+
+   virtual UInt32 SupportedNumChannels(const AUChannelInfo** outInfo);
+   virtual bool StreamFormatWritable(AudioUnitScope scope, AudioUnitElement element);
+   virtual bool ValidFormat(AudioUnitScope inScope,
+                            AudioUnitElement inElement,
+                            const CAStreamBasicDescription& inNewFormat);
+
+   virtual ComponentResult StartNote(MusicDeviceInstrumentID inInstrument,
+                                     MusicDeviceGroupID inGroupID,
+                                     NoteInstanceID* outNoteInstanceID,
+                                     UInt32 inOffsetSampleFrame,
+                                     const MusicDeviceNoteParams& inParams);
+
+   virtual ComponentResult StopNote(MusicDeviceGroupID inGroupID,
+                                    NoteInstanceID inNoteInstanceID,
+                                    UInt32 inOffsetSampleFrame);
+
+   virtual OSStatus
+   HandleNoteOn(UInt8 inChannel, UInt8 inNoteNumber, UInt8 inVelocity, UInt32 inStartFram);
+   virtual OSStatus
+   HandleNoteOff(UInt8 inChannel, UInt8 inNoteNumber, UInt8 inVelocity, UInt32 inStartFrame);
+   virtual OSStatus
+   HandleControlChange(UInt8 inChannel, UInt8 inController, UInt8 inValue, UInt32 inStartFrame);
+   virtual OSStatus HandleChannelPressure(UInt8 inChannel, UInt8 inValue, UInt32 inStartFrame);
+   virtual OSStatus
+   HandlePitchWheel(UInt8 inChannel, UInt8 inPitch1, UInt8 inPitch2, UInt32 inStartFrame);
+   virtual OSStatus
+   HandlePolyPressure(UInt8 inChannel, UInt8 inKey, UInt8 inValue, UInt32 inStartFrame);
+   virtual OSStatus HandleProgramChange(UInt8 inChannel, UInt8 inValue);
+
+   virtual ComponentResult GetProperty(AudioUnitPropertyID inID,
+                                       AudioUnitScope inScope,
+                                       AudioUnitElement inElement,
+                                       void* outData);
+   virtual ComponentResult GetPropertyInfo(AudioUnitPropertyID inID,
+                                           AudioUnitScope inScope,
+                                           AudioUnitElement inElement,
+                                           UInt32& outDataSize,
+                                           Boolean& outWritable);
+
+   virtual ComponentResult SaveState(CFPropertyListRef* outData);
+   virtual ComponentResult RestoreState(CFPropertyListRef inData);
+
+   virtual bool HasIcon();
+   virtual CFURLRef GetIconLocation();
+
+   virtual ComponentResult GetPresets(CFArrayRef* outData) const;
+   virtual OSStatus NewFactoryPresetSet(const AUPreset& inNewFactoryPreset);
+
+   virtual OSStatus
+   HandleMidiEvent(UInt8 status, UInt8 channel, UInt8 data1, UInt8 data2, UInt32 inStartFrame);
+
+   virtual ComponentResult GetParameterList(AudioUnitScope inScope,
+                                            AudioUnitParameterID* outParameterList,
+                                            UInt32& outNumParameters);
+   virtual ComponentResult GetParameterInfo(AudioUnitScope inScope,
+                                            AudioUnitParameterID inParameterID,
+                                            AudioUnitParameterInfo& outParameterInfo);
+   virtual ComponentResult GetParameter(AudioUnitParameterID inID,
+                                        AudioUnitScope inScope,
+                                        AudioUnitElement inElement,
+                                        Float32& outValue);
+   virtual ComponentResult SetParameter(AudioUnitParameterID inID,
+                                        AudioUnitScope inScope,
+                                        AudioUnitElement inElement,
+                                        Float32 inValue,
+                                        UInt32 inBufferOffsetInFrames);
+
    virtual bool CanScheduleParameters() const;
-   
+
    /*virtual OSStatus 	ScheduleParameter (const AudioUnitParameterEvent 	*inParameterEvent,
-                                        UInt32							inNumEvents);*/
-		
-	bool ParameterUpdate(int p);
-	bool ParameterBeginEdit(int p);
-	bool ParameterEndEdit(int p);
-	
-	// These methods initialize the plugin itself, and is seperate from the AU initialization
-	// THis is needed sometimes, as the AU may ask to store a state before the AU has been initialized 
-	void InitializePlugin();
-	bool IsPluginInitialized();
-	
-    // FIXME: Move to std::unique_ptr<>
-	plugin *plugin_instance;
-    SurgeGUIEditor *editor_instance;
-protected:		
-	//void handleEvent(VstEvent*);
-	AuMIDIEvent eventbuffer[1024];
-	int blockpos,events_this_block;	
-	AUChannelInfo cinfo[2]; // stored output configs
-	AudioUnitParameterID parameterIDlist[n_total_params];
-	CFStringRef parameterIDlist_CFString[n_total_params];
+                                        UInt32
+      inNumEvents);*/
+
+   bool ParameterUpdate(int p);
+   bool ParameterBeginEdit(int p);
+   bool ParameterEndEdit(int p);
+
+   // These methods initialize the plugin itself, and is seperate from the AU initialization
+   // THis is needed sometimes, as the AU may ask to store a state before the AU has been
+   // initialized
+   void InitializePlugin();
+   bool IsPluginInitialized();
+
+   // FIXME: Move to std::unique_ptr<>
+   plugin* plugin_instance;
+   SurgeGUIEditor* editor_instance;
+
+protected:
+   // void handleEvent(VstEvent*);
+   AuMIDIEvent eventbuffer[1024];
+   int blockpos, events_this_block;
+   AUChannelInfo cinfo[2]; // stored output configs
+   AudioUnitParameterID parameterIDlist[n_total_params];
+   CFStringRef parameterIDlist_CFString[n_total_params];
    float sampleRateCache;
 };
 
 struct CFAUPreset
 {
-	AUPreset auPreset;
-	UInt32 version;
-	CFAllocatorRef allocator;
-	CFIndex retainCount;
+   AUPreset auPreset;
+   UInt32 version;
+   CFAllocatorRef allocator;
+   CFIndex retainCount;
 };
-
 
 // from DFX au lib
 // måste lägga in updaten från 2006-08-18, fanns error-lalala innan
 /* these are CFArray callbacks for use when creating an AU's FactoryPresets array */
-extern const void * auPresetCFArrayRetainCallback(CFAllocatorRef inAllocator, const void * inPreset);
-extern void auPresetCFArrayReleaseCallback(CFAllocatorRef inAllocator, const void * inPreset);
-extern Boolean auPresetCFArrayEqualCallback(const void * inPreset1, const void * inPreset2);
-extern CFStringRef auPresetCFArrayCopyDescriptionCallback(const void * inPreset);
+extern const void* auPresetCFArrayRetainCallback(CFAllocatorRef inAllocator, const void* inPreset);
+extern void auPresetCFArrayReleaseCallback(CFAllocatorRef inAllocator, const void* inPreset);
+extern Boolean auPresetCFArrayEqualCallback(const void* inPreset1, const void* inPreset2);
+extern CFStringRef auPresetCFArrayCopyDescriptionCallback(const void* inPreset);
 /* and this will initialize a CFArray callbacks structure to use the above callback functions */
 /*extern void AUPresetCFArrayCallbacks_Init(CFArrayCallBacks * outArrayCallbacks);
 extern const CFArrayCallBacks kAUPresetCFArrayCallbacks;*/
 
 // new DFX lib (2006-08-18)
 /* these handle a CoreFoundation-like container object for AUPreset called CFAUPreset */
-typedef const struct CFAUPreset * CFAUPresetRef;
-extern CFAUPresetRef CFAUPresetCreate(CFAllocatorRef inAllocator, SInt32 inPresetNumber, CFStringRef inPresetName);
+typedef const struct CFAUPreset* CFAUPresetRef;
+extern CFAUPresetRef
+CFAUPresetCreate(CFAllocatorRef inAllocator, SInt32 inPresetNumber, CFStringRef inPresetName);
 extern CFAUPresetRef CFAUPresetRetain(CFAUPresetRef inPreset);
 extern void CFAUPresetRelease(CFAUPresetRef inPreset);
 extern const CFArrayCallBacks kCFAUPresetArrayCallBacks;
-

--- a/src/au/aulayer_presets.cpp
+++ b/src/au/aulayer_presets.cpp
@@ -1,8 +1,7 @@
 #include "aulayer.h"
 
-
 //-----------------------------------------------------------------------------
-// The following defines and implements CoreFoundation-like handling of 
+// The following defines and implements CoreFoundation-like handling of
 // an AUPreset container object:  CFAUPreset
 //-----------------------------------------------------------------------------
 
@@ -10,233 +9,230 @@ const UInt32 kCFAUPreset_CurrentVersion = 0;
 
 //-----------------------------------------------------------------------------
 // create an instance of a CFAUPreset object
-CFAUPresetRef CFAUPresetCreate(CFAllocatorRef inAllocator, SInt32 inPresetNumber, CFStringRef inPresetName)
+CFAUPresetRef
+CFAUPresetCreate(CFAllocatorRef inAllocator, SInt32 inPresetNumber, CFStringRef inPresetName)
 {
-	CFAUPreset * newPreset = (CFAUPreset*) CFAllocatorAllocate(inAllocator, sizeof(CFAUPreset), 0);
-	if (newPreset != NULL)
-	{
-		newPreset->auPreset.presetNumber = inPresetNumber;
-		newPreset->auPreset.presetName = NULL;
-		// create our own a copy rather than retain the string, in case the input string is mutable, 
-		// this will keep it from changing under our feet
-		if (inPresetName != NULL)
-			newPreset->auPreset.presetName = CFStringCreateCopy(inAllocator, inPresetName);
-		newPreset->version = kCFAUPreset_CurrentVersion;
-		newPreset->allocator = inAllocator;
-		newPreset->retainCount = 1;
-	}
-	return (CFAUPresetRef)newPreset;
+   CFAUPreset* newPreset = (CFAUPreset*)CFAllocatorAllocate(inAllocator, sizeof(CFAUPreset), 0);
+   if (newPreset != NULL)
+   {
+      newPreset->auPreset.presetNumber = inPresetNumber;
+      newPreset->auPreset.presetName = NULL;
+      // create our own a copy rather than retain the string, in case the input string is mutable,
+      // this will keep it from changing under our feet
+      if (inPresetName != NULL)
+         newPreset->auPreset.presetName = CFStringCreateCopy(inAllocator, inPresetName);
+      newPreset->version = kCFAUPreset_CurrentVersion;
+      newPreset->allocator = inAllocator;
+      newPreset->retainCount = 1;
+   }
+   return (CFAUPresetRef)newPreset;
 }
 
 //-----------------------------------------------------------------------------
 // retain a reference of a CFAUPreset object
 CFAUPresetRef CFAUPresetRetain(CFAUPresetRef inPreset)
 {
-	if (inPreset != NULL)
-	{
-		CFAUPreset * incomingPreset = (CFAUPreset*) inPreset;
-		// retain the input AUPreset's name string for this reference to the preset
-		if (incomingPreset->auPreset.presetName != NULL)
-			CFRetain(incomingPreset->auPreset.presetName);
-		incomingPreset->retainCount += 1;
-	}
-	return inPreset;
+   if (inPreset != NULL)
+   {
+      CFAUPreset* incomingPreset = (CFAUPreset*)inPreset;
+      // retain the input AUPreset's name string for this reference to the preset
+      if (incomingPreset->auPreset.presetName != NULL)
+         CFRetain(incomingPreset->auPreset.presetName);
+      incomingPreset->retainCount += 1;
+   }
+   return inPreset;
 }
 
 //-----------------------------------------------------------------------------
 // release a reference of a CFAUPreset object
 void CFAUPresetRelease(CFAUPresetRef inPreset)
 {
-	CFAUPreset * incomingPreset = (CFAUPreset*) inPreset;
-	// these situations shouldn't happen
-	if (inPreset == NULL)
-		return;
-	if (incomingPreset->retainCount <= 0)
-		return;
-	
-	// first release the name string, CF-style, since it's a CFString
-	if (incomingPreset->auPreset.presetName != NULL)
-		CFRelease(incomingPreset->auPreset.presetName);
-	incomingPreset->retainCount -= 1;
-	// check if this is the end of this instance's life
-	if (incomingPreset->retainCount == 0)
-	{
-		// wipe out the data so that, if anyone tries to access stale memory later, it will be (semi)invalid
-		incomingPreset->auPreset.presetName = NULL;
-		incomingPreset->auPreset.presetNumber = 0;
-		// and finally, free the memory for the CFAUPreset struct
-		CFAllocatorDeallocate(incomingPreset->allocator, (void*)inPreset);
-	}
+   CFAUPreset* incomingPreset = (CFAUPreset*)inPreset;
+   // these situations shouldn't happen
+   if (inPreset == NULL)
+      return;
+   if (incomingPreset->retainCount <= 0)
+      return;
+
+   // first release the name string, CF-style, since it's a CFString
+   if (incomingPreset->auPreset.presetName != NULL)
+      CFRelease(incomingPreset->auPreset.presetName);
+   incomingPreset->retainCount -= 1;
+   // check if this is the end of this instance's life
+   if (incomingPreset->retainCount == 0)
+   {
+      // wipe out the data so that, if anyone tries to access stale memory later, it will be
+      // (semi)invalid
+      incomingPreset->auPreset.presetName = NULL;
+      incomingPreset->auPreset.presetNumber = 0;
+      // and finally, free the memory for the CFAUPreset struct
+      CFAllocatorDeallocate(incomingPreset->allocator, (void*)inPreset);
+   }
 }
 
 //-----------------------------------------------------------------------------
-// The following 4 functions are CFArray callbacks for use when creating 
+// The following 4 functions are CFArray callbacks for use when creating
 // an AU's factory presets array to support kAudioUnitProperty_FactoryPresets.
 //-----------------------------------------------------------------------------
 
-const void * CFAUPresetArrayRetainCallBack(CFAllocatorRef inAllocator, const void * inPreset);
-void CFAUPresetArrayReleaseCallBack(CFAllocatorRef inAllocator, const void * inPreset);
-Boolean CFAUPresetArrayEqualCallBack(const void * inPreset1, const void * inPreset2);
-CFStringRef CFAUPresetArrayCopyDescriptionCallBack(const void * inPreset);
-void CFAUPresetArrayCallBacks_Init(CFArrayCallBacks * outArrayCallBacks);
+const void* CFAUPresetArrayRetainCallBack(CFAllocatorRef inAllocator, const void* inPreset);
+void CFAUPresetArrayReleaseCallBack(CFAllocatorRef inAllocator, const void* inPreset);
+Boolean CFAUPresetArrayEqualCallBack(const void* inPreset1, const void* inPreset2);
+CFStringRef CFAUPresetArrayCopyDescriptionCallBack(const void* inPreset);
+void CFAUPresetArrayCallBacks_Init(CFArrayCallBacks* outArrayCallBacks);
 
 //-----------------------------------------------------------------------------
-// This function is called when an item (an AUPreset) is added to the CFArray, 
-// or when a CFArray containing an AUPreset is retained.  
-const void * CFAUPresetArrayRetainCallBack(CFAllocatorRef inAllocator, const void * inPreset)
+// This function is called when an item (an AUPreset) is added to the CFArray,
+// or when a CFArray containing an AUPreset is retained.
+const void* CFAUPresetArrayRetainCallBack(CFAllocatorRef inAllocator, const void* inPreset)
 {
-	return CFAUPresetRetain((CFAUPresetRef)inPreset);
+   return CFAUPresetRetain((CFAUPresetRef)inPreset);
 }
 
 //-----------------------------------------------------------------------------
-// This function is called when an item (an AUPreset) is removed from the CFArray 
+// This function is called when an item (an AUPreset) is removed from the CFArray
 // or when the array is released.
 // Since a reference to the data belongs to the array, we need to release that here.
-void CFAUPresetArrayReleaseCallBack(CFAllocatorRef inAllocator, const void * inPreset)
+void CFAUPresetArrayReleaseCallBack(CFAllocatorRef inAllocator, const void* inPreset)
 {
-	CFAUPresetRelease((CFAUPresetRef)inPreset);
+   CFAUPresetRelease((CFAUPresetRef)inPreset);
 }
 
 //-----------------------------------------------------------------------------
-// This function is called when someone wants to compare to items (AUPresets) 
+// This function is called when someone wants to compare to items (AUPresets)
 // in the CFArray to see if they are equal or not.
 // For our AUPresets, we will compare based on the preset number and the name string.
-Boolean CFAUPresetArrayEqualCallBack(const void * inPreset1, const void * inPreset2)
+Boolean CFAUPresetArrayEqualCallBack(const void* inPreset1, const void* inPreset2)
 {
-	AUPreset * preset1 = (AUPreset*) inPreset1;
-	AUPreset * preset2 = (AUPreset*) inPreset2;
-	// the two presets are only equal if they have the same preset number and 
-	// if the two name strings are the same (which we rely on the CF function to compare)
-	return (preset1->presetNumber == preset2->presetNumber) && 
-		(CFStringCompare(preset1->presetName, preset2->presetName, 0) == kCFCompareEqualTo);
+   AUPreset* preset1 = (AUPreset*)inPreset1;
+   AUPreset* preset2 = (AUPreset*)inPreset2;
+   // the two presets are only equal if they have the same preset number and
+   // if the two name strings are the same (which we rely on the CF function to compare)
+   return (preset1->presetNumber == preset2->presetNumber) &&
+          (CFStringCompare(preset1->presetName, preset2->presetName, 0) == kCFCompareEqualTo);
 }
 
 //-----------------------------------------------------------------------------
-// This function is called when someone wants to get a description of 
-// a particular item (an AUPreset) as though it were a CF type.  
-// That happens, for example, when using CFShow().  
-// This will create and return a CFString that indicates that 
+// This function is called when someone wants to get a description of
+// a particular item (an AUPreset) as though it were a CF type.
+// That happens, for example, when using CFShow().
+// This will create and return a CFString that indicates that
 // the object is an AUPreset and tells the preset number and preset name.
-CFStringRef CFAUPresetArrayCopyDescriptionCallBack(const void * inPreset)
+CFStringRef CFAUPresetArrayCopyDescriptionCallBack(const void* inPreset)
 {
-	AUPreset * preset = (AUPreset*) inPreset;
-	return CFStringCreateWithFormat(kCFAllocatorDefault, NULL, 
-									CFSTR("AUPreset:\npreset number = %d\npreset name = %@"), 
-									preset->presetNumber, preset->presetName);
+   AUPreset* preset = (AUPreset*)inPreset;
+   return CFStringCreateWithFormat(kCFAllocatorDefault, NULL,
+                                   CFSTR("AUPreset:\npreset number = %d\npreset name = %@"),
+                                   preset->presetNumber, preset->presetName);
 }
 
 //-----------------------------------------------------------------------------
 // this will initialize a CFArray callbacks structure to use the above callback functions
-void CFAUPresetArrayCallBacks_Init(CFArrayCallBacks * outArrayCallBacks)
+void CFAUPresetArrayCallBacks_Init(CFArrayCallBacks* outArrayCallBacks)
 {
-	if (outArrayCallBacks == NULL)
-		return;
-	// wipe the struct clean
-	memset(outArrayCallBacks, 0, sizeof(*outArrayCallBacks));
-	// set all of the values and function pointers in the callbacks struct
-	outArrayCallBacks->version = 0;	// currently, 0 is the only valid version value for this
-	outArrayCallBacks->retain = CFAUPresetArrayRetainCallBack;
-	outArrayCallBacks->release = CFAUPresetArrayReleaseCallBack;
-	outArrayCallBacks->copyDescription = CFAUPresetArrayCopyDescriptionCallBack;
-	outArrayCallBacks->equal = CFAUPresetArrayEqualCallBack;
+   if (outArrayCallBacks == NULL)
+      return;
+   // wipe the struct clean
+   memset(outArrayCallBacks, 0, sizeof(*outArrayCallBacks));
+   // set all of the values and function pointers in the callbacks struct
+   outArrayCallBacks->version = 0; // currently, 0 is the only valid version value for this
+   outArrayCallBacks->retain = CFAUPresetArrayRetainCallBack;
+   outArrayCallBacks->release = CFAUPresetArrayReleaseCallBack;
+   outArrayCallBacks->copyDescription = CFAUPresetArrayCopyDescriptionCallBack;
+   outArrayCallBacks->equal = CFAUPresetArrayEqualCallBack;
 }
 
 //-----------------------------------------------------------------------------
 
 const CFArrayCallBacks kCFAUPresetArrayCallBacks = {
-	0, 
-	CFAUPresetArrayRetainCallBack, 
-	CFAUPresetArrayReleaseCallBack, 
-	CFAUPresetArrayCopyDescriptionCallBack, 
-	CFAUPresetArrayEqualCallBack
-};
+    0, CFAUPresetArrayRetainCallBack, CFAUPresetArrayReleaseCallBack,
+    CFAUPresetArrayCopyDescriptionCallBack, CFAUPresetArrayEqualCallBack};
 
 /*
 obsolete code below
  //-----------------------------------------------------------------------------
-// The following 4 functions are CFArray callbacks for use when creating 
+// The following 4 functions are CFArray callbacks for use when creating
 // an AU's factory presets array to support kAudioUnitProperty_FactoryPresets.
 //-----------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
-// This function is called when an item (an AUPreset) is added to the CFArray.  
-// At this time, we need to make a fully independent copy of the AUPreset so that 
-// the data will be guaranteed to be valid regardless of what the AU does, and 
+// This function is called when an item (an AUPreset) is added to the CFArray.
+// At this time, we need to make a fully independent copy of the AUPreset so that
+// the data will be guaranteed to be valid regardless of what the AU does, and
 // regardless of whether the AU instance is still open or not.
-// This means that we need to allocate memory for an AUPreset struct just for the 
+// This means that we need to allocate memory for an AUPreset struct just for the
 // array and create a copy of the preset name string.
 const void * auPresetCFArrayRetainCallback(CFAllocatorRef inAllocator, const void * inPreset)
 {
-	AUPreset * preset = (AUPreset*) inPreset;
-	// first allocate new memory for the array's copy of this AUPreset
-	AUPreset * newPreset = (AUPreset*) CFAllocatorAllocate(inAllocator, sizeof(AUPreset), 0);
-	// set the number of the new copy to that of the input AUPreset
-	newPreset->presetNumber = preset->presetNumber;
-	// create a copy of the input AUPreset's name string for this new copy of the preset
-	newPreset->presetName = CFStringCreateCopy(kCFAllocatorDefault, preset->presetName);
-	// return the pointer to the new memory, which belongs to the array, rather than the input pointer
-	return newPreset;
+        AUPreset * preset = (AUPreset*) inPreset;
+        // first allocate new memory for the array's copy of this AUPreset
+        AUPreset * newPreset = (AUPreset*) CFAllocatorAllocate(inAllocator, sizeof(AUPreset), 0);
+        // set the number of the new copy to that of the input AUPreset
+        newPreset->presetNumber = preset->presetNumber;
+        // create a copy of the input AUPreset's name string for this new copy of the preset
+        newPreset->presetName = CFStringCreateCopy(kCFAllocatorDefault, preset->presetName);
+        // return the pointer to the new memory, which belongs to the array, rather than the input
+pointer return newPreset;
 }
 
 //-----------------------------------------------------------------------------
-// This function is called when an item (an AUPreset) is removed from the CFArray 
+// This function is called when an item (an AUPreset) is removed from the CFArray
 // or when the array is released.
 // Since the memory for the data belongs to the array, we need to release it all here.
 void auPresetCFArrayReleaseCallback(CFAllocatorRef inAllocator, const void * inPreset)
 {
-	AUPreset * preset = (AUPreset*) inPreset;
-	// first release the name string, CF-style, since it's a CFString
-	if (preset->presetName != NULL)
-		CFRelease(preset->presetName);
-	// wipe out the data so that, if anyone tries to access stale memory later, it will be invalid
-	preset->presetName = NULL;
-	preset->presetNumber = 0;
-	// and finally, free the memory for the AUPreset struct
-	CFAllocatorDeallocate(inAllocator, (void*)inPreset);
+        AUPreset * preset = (AUPreset*) inPreset;
+        // first release the name string, CF-style, since it's a CFString
+        if (preset->presetName != NULL)
+                CFRelease(preset->presetName);
+        // wipe out the data so that, if anyone tries to access stale memory later, it will be
+invalid preset->presetName = NULL; preset->presetNumber = 0;
+        // and finally, free the memory for the AUPreset struct
+        CFAllocatorDeallocate(inAllocator, (void*)inPreset);
 }
 
 //-----------------------------------------------------------------------------
-// This function is called when someone wants to compare to items (AUPresets) 
+// This function is called when someone wants to compare to items (AUPresets)
 // in the CFArray to see if they are equal or not.
 // For our AUPresets, we will compare based on the preset number and the name string.
 Boolean auPresetCFArrayEqualCallback(const void * inPreset1, const void * inPreset2)
 {
-	AUPreset * preset1 = (AUPreset*) inPreset1;
-	AUPreset * preset2 = (AUPreset*) inPreset2;
-	// the two presets are only equal if they have the same preset number and 
-	// if the two name strings are the same (which we rely on the CF function to compare)
-	return (preset1->presetNumber == preset2->presetNumber) && 
-		(CFStringCompare(preset1->presetName, preset2->presetName, 0) == kCFCompareEqualTo);
+        AUPreset * preset1 = (AUPreset*) inPreset1;
+        AUPreset * preset2 = (AUPreset*) inPreset2;
+        // the two presets are only equal if they have the same preset number and
+        // if the two name strings are the same (which we rely on the CF function to compare)
+        return (preset1->presetNumber == preset2->presetNumber) &&
+                (CFStringCompare(preset1->presetName, preset2->presetName, 0) == kCFCompareEqualTo);
 }
 
 //-----------------------------------------------------------------------------
-// This function is called when someone wants to get a description of 
-// a particular item (an AUPreset) as though it were a CF type.  
-// That happens, for example, when using CFShow().  
-// This will create and return a CFString that indicates that 
+// This function is called when someone wants to get a description of
+// a particular item (an AUPreset) as though it were a CF type.
+// That happens, for example, when using CFShow().
+// This will create and return a CFString that indicates that
 // the object is an AUPreset and tells the preset number and preset name.
 CFStringRef auPresetCFArrayCopyDescriptionCallback(const void * inPreset)
 {
-	AUPreset * preset = (AUPreset*) inPreset;
-	return CFStringCreateWithFormat(kCFAllocatorDefault, NULL, 
-									CFSTR("AUPreset:\npreset number = %d\npreset name = %@"), 
-									preset->presetNumber, preset->presetName);
+        AUPreset * preset = (AUPreset*) inPreset;
+        return CFStringCreateWithFormat(kCFAllocatorDefault, NULL,
+                                                                        CFSTR("AUPreset:\npreset
+number = %d\npreset name = %@"), preset->presetNumber, preset->presetName);
 }
 
 //-----------------------------------------------------------------------------
 // this will initialize a CFArray callbacks structure to use the above callback functions
 void AUPresetCFArrayCallbacks_Init(CFArrayCallBacks * outArrayCallbacks)
 {
-	if (outArrayCallbacks == NULL)
-		return;
-	// wipe the struct clean
-	memset(outArrayCallbacks, 0, sizeof(*outArrayCallbacks));
-	// set all of the values and function pointers in the callbacks struct
-	outArrayCallbacks->version = 0;	// currently, 0 is the only valid version value for this
-	outArrayCallbacks->retain = auPresetCFArrayRetainCallback;
-	outArrayCallbacks->release = auPresetCFArrayReleaseCallback;
-	outArrayCallbacks->copyDescription = auPresetCFArrayCopyDescriptionCallback;
-	outArrayCallbacks->equal = auPresetCFArrayEqualCallback;
+        if (outArrayCallbacks == NULL)
+                return;
+        // wipe the struct clean
+        memset(outArrayCallbacks, 0, sizeof(*outArrayCallbacks));
+        // set all of the values and function pointers in the callbacks struct
+        outArrayCallbacks->version = 0;	// currently, 0 is the only valid version value for this
+        outArrayCallbacks->retain = auPresetCFArrayRetainCallback;
+        outArrayCallbacks->release = auPresetCFArrayReleaseCallback;
+        outArrayCallbacks->copyDescription = auPresetCFArrayCopyDescriptionCallback;
+        outArrayCallbacks->equal = auPresetCFArrayEqualCallback;
 }
 
 //-----------------------------------------------------------------------------
@@ -244,19 +240,19 @@ void AUPresetCFArrayCallbacks_Init(CFArrayCallBacks * outArrayCallbacks)
 // XXX what is the best way to do this?
 #if 1
 const CFArrayCallBacks kAUPresetCFArrayCallbacks = {
-version: 0, 
-retain: auPresetCFArrayRetainCallback, 
-release: auPresetCFArrayReleaseCallback, 
-copyDescription: auPresetCFArrayCopyDescriptionCallback, 
+version: 0,
+retain: auPresetCFArrayRetainCallback,
+release: auPresetCFArrayReleaseCallback,
+copyDescription: auPresetCFArrayCopyDescriptionCallback,
 equal: auPresetCFArrayEqualCallback
 };
 #elif 0
 const CFArrayCallBacks kAUPresetCFArrayCallbacks = {
-	.version = 0, 
-	.retain = auPresetCFArrayRetainCallback, 
-	.release = auPresetCFArrayReleaseCallback, 
-	.copyDescription = auPresetCFArrayCopyDescriptionCallback, 
-	.equal = auPresetCFArrayEqualCallback
+        .version = 0,
+        .retain = auPresetCFArrayRetainCallback,
+        .release = auPresetCFArrayReleaseCallback,
+        .copyDescription = auPresetCFArrayCopyDescriptionCallback,
+        .equal = auPresetCFArrayEqualCallback
 };
 #else
 // this seems to be the only way of the 3 that is fully valid C, but unfortunately only for GCC
@@ -264,23 +260,21 @@ const CFArrayCallBacks kAUPresetCFArrayCallbacks;
 static void kAUPresetCFArrayCallbacks_constructor() __attribute__((constructor));
 static void kAUPresetCFArrayCallbacks_constructor()
 {
-	AUPresetCFArrayCallbacks_Init( (CFArrayCallBacks*) &kAUPresetCFArrayCallbacks );
+        AUPresetCFArrayCallbacks_Init( (CFArrayCallBacks*) &kAUPresetCFArrayCallbacks );
 }
 #endif
 #else
-// XXX I'll use this for other compilers, even though I hate initializing structs with all arguments at once 
+// XXX I'll use this for other compilers, even though I hate initializing structs with all arguments
+at once
 // (cuz what if I ever decided to change the order of the struct members or something like that?)
 const CFArrayCallBacks kAUPresetCFArrayCallbacks = {
-	0, 
-	auPresetCFArrayRetainCallback, 
-	auPresetCFArrayReleaseCallback, 
-	auPresetCFArrayCopyDescriptionCallback, 
-	auPresetCFArrayEqualCallback
+        0,
+        auPresetCFArrayRetainCallback,
+        auPresetCFArrayReleaseCallback,
+        auPresetCFArrayCopyDescriptionCallback,
+        auPresetCFArrayEqualCallback
 };
 #endif
 
 
 */
-
-
-


### PR DESCRIPTION
The AU Layer code was a mis-mash of tabs, spaces, styles, etc...
since it was never really cleaned up after being resurrected.
Since I have to go back in there for a few issues this was painful
so clean it up once.

This is a big textual diff but contains nothing other than formatting
and dead code removal.

Closes #663 Code Reformat AU