### PR TITLE
Plus key for zoom on Linux

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -546,6 +546,18 @@ int32_t SurgeGUIEditor::onKeyDown(const VstKeyCode& code, CFrame* frame)
         case '+':
             setZoomFactor(getZoomFactor()+10);
             return 1;
+        case '=':
+           /*
+           ** This is a bit unsatisfying. The '+' key on linux with a US standard
+           ** keyboard delivers as = with a shift modifier. I dislike hardcoding keyboard
+           ** layouts but I don't see an API and this is a commonly used feature
+           */
+           if (code.modifier == VstModifierKey::MODIFIER_SHIFT)
+           {
+              setZoomFactor(getZoomFactor()+10);
+              return 1;
+           }
+           break;
         case '-':
             setZoomFactor(getZoomFactor()-10);
             return 1;


### PR DESCRIPTION
Unsatisfyingly, the plus key (shift-= on US keyboards) on linux
doesn't report the character '+' to onKeyDown in VSTGUI but rather
reports '=' with shift depressed. Ideally the keyboard layer would
handle keyboard mapping of course (it does on mac) but this is a
useful enough feature and common enough keyboard mapping that I
choose to make the ugly choice to also bind shift-= to zoom increase
which defacto fixes the +/- zoom on linux.

Closes #600: +/- key on linux zoom