### PR TITLE
frame->close in ~SurgeGUIEditor

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -205,8 +205,7 @@ SurgeGUIEditor::~SurgeGUIEditor()
    if (frame)
    {
       getFrame()->unregisterKeyboardHook(this);
-      frame->removeAll(true);
-      frame->forget();
+      frame->close();
    }
 }
 


### PR DESCRIPTION
Call frame->close which does a removeAll and a forget, like we
used to, but also does a bunch of other internal implementations.
Reported by @sagantech. Reading the vstgui code for close this
is obviously correct.

Closes #503 call close