### PR TITLE
disable mousewheel on category and patch buttons

### DIFF
--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -109,24 +109,31 @@ CMouseEventResult CHSwitch2::onMouseMoved(CPoint& where, const CButtonState& but
 }
 bool CHSwitch2::onWheel(const CPoint& where, const float& distance, const CButtonState& buttons)
 {
-   float newVal=value;
-   float rate = 1.0f;
-   float range = getRange();
-   if (columns >1)
+   if (usesMouseWheel)
    {
-      rate = range / (float)columns;
-      newVal += rate * distance;
+      float newVal=value;
+      float rate = 1.0f;
+      float range = getRange();
+      if (columns >1)
+      {
+         rate = range / (float)columns;
+         newVal += rate * distance;
+      }
+      else
+      {
+         rate = range / (float)rows;
+         newVal += rate * -distance; // flip distance (==direction) because it makes more sense when wheeling
+      }
+      beginEdit();
+      value = newVal;
+      bounceValue();
+      if (listener)
+         listener->valueChanged(this);
+      setValue(value);
    }
-   else
-   {
-      rate = range / (float)rows;
-      newVal += rate * -distance; // flip distance (==direction) because it makes more sense when wheeling
-   }
-   beginEdit();
-   value = newVal;
-   bounceValue();
-   if (listener)
-      listener->valueChanged(this);
-   setValue(value);
    return true;
+}
+void CHSwitch2::setUsesMouseWheel(bool wheel)
+{
+   usesMouseWheel = wheel;
 }

--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -130,8 +130,9 @@ bool CHSwitch2::onWheel(const CPoint& where, const float& distance, const CButto
       if (listener)
          listener->valueChanged(this);
       setValue(value);
+      return true;
    }
-   return true;
+   return false;
 }
 void CHSwitch2::setUsesMouseWheel(bool wheel)
 {

--- a/src/common/gui/CHSwitch2.h
+++ b/src/common/gui/CHSwitch2.h
@@ -24,11 +24,13 @@ public:
       this->columns = columns;
       this->dragable = dragable;
       imgoffset = 0;
+      usesMouseWheel = true; // use mousewheel by default
    }
 
    int rows, columns;
    int imgoffset;
    bool dragable;
+   bool usesMouseWheel;
 
    virtual void draw(VSTGUI::CDrawContext* dc);
    virtual VSTGUI::CMouseEventResult
@@ -42,4 +44,5 @@ public:
    virtual bool
    onWheel (const VSTGUI::CPoint& where, const float& distance, const VSTGUI::CButtonState& buttons); ///< called when scrollwheel events occurs    
    CLASS_METHODS(CHSwitch2, VSTGUI::CControl)
+   void setUsesMouseWheel(bool wheel);
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -734,10 +734,12 @@ void SurgeGUIEditor::openOrRecreateEditor()
    CHSwitch2* mp_cat =
        new CHSwitch2(CRect(157, 41, 157 + 37, 41 + 12), this, tag_mp_category, 2, 12, 1, 2,
                      getSurgeBitmap(IDB_BUTTON_MINUSPLUS), nopoint, false);
+   mp_cat->setUsesMouseWheel(false); // mousewheel on category and patch buttons is undesirable     
    frame->addView(mp_cat);
 
    CHSwitch2* mp_patch = new CHSwitch2(CRect(242, 41, 242 + 37, 41 + 12), this, tag_mp_patch, 2, 12,
                                        1, 2, getSurgeBitmap(IDB_BUTTON_MINUSPLUS), nopoint, false);
+   mp_patch->setUsesMouseWheel(false);// mousewheel on category and patch buttons is undesirable                                
    frame->addView(mp_patch);
 
    CHSwitch2* b_store = new CHSwitch2(CRect(591 - 37, 41, 591, 41 + 12), this, tag_store, 1, 12, 1,


### PR DESCRIPTION
added bool and a setter function to enable/disable use of mouse-wheel for editing `CHSwitch2`