### PR TITLE
Check for LATO built in

### DIFF
--- a/installer_win/surge-x86.iss
+++ b/installer_win/surge-x86.iss
@@ -44,6 +44,7 @@ Name: VST3; Description: VST3 Plug-in (32 bit); Types: full compact custom; Flag
 Source: ..\target\vst2\Release\Surge32.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\target\vst3\Release\Surge32.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
 Source: ..\resources\data\*; DestDir: {localappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
+Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/installer_win/surge.iss
+++ b/installer_win/surge.iss
@@ -44,6 +44,7 @@ Name: VST3; Description: VST3 Plug-in (64 bit); Types: full compact custom; Flag
 Source: ..\target\vst2\Release\Surge.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\target\vst3\Release\Surge.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
 Source: ..\resources\data\*; DestDir: {localappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
+Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/premake5.lua
+++ b/premake5.lua
@@ -372,7 +372,6 @@ function plugincommon()
             "src/windows/scalableui.rc",
             "resources/bitmaps/*.png",
             "assets/original-vector/exported/*.png",
-            "resources/fonts/**.ttf",
             VSTGUI .. "vstgui_win32.cpp",
             VSTGUI .. "vstgui_uidescription_win32.cpp",
         }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -185,16 +185,20 @@ SurgeGUIEditor::SurgeGUIEditor(void* effect, SurgeSynthesizer* synth) : super(ef
 #if MAC
        SharedPointer<CFontDesc> minifont = new CFontDesc("Lucida Grande", 9);
        SharedPointer<CFontDesc> patchfont = new CFontDesc("Lucida Grande", 14);
+       SharedPointer<CFontDesc> lfofont = new CFontDesc("Lucida Grande", 8);
 #elif LINUX
        SharedPointer<CFontDesc> minifont = new CFontDesc("sans-serif", 9);
        SharedPointer<CFontDesc> patchfont = new CFontDesc("sans-serif", 14);
+       SharedPointer<CFontDesc> lfofont = new CFontDesc("sans-serif", 8);
 #else
        SharedPointer<CFontDesc> minifont = new CFontDesc("Microsoft Sans Serif", 9);
        SharedPointer<CFontDesc> patchfont = new CFontDesc("Arial", 14);
+       SharedPointer<CFontDesc> lfofont = new CFontDesc("Microsoft Sans Serif", 8 );
 #endif
 
        displayFont = minifont;
        patchNameFont = patchfont;
+       lfoTypeFont = lfofont;
 
    }
 #endif

--- a/src/windows/surge.rc
+++ b/src/windows/surge.rc
@@ -69,8 +69,6 @@ LANGUAGE LANG_NEUTRAL,
 #include "scalableui.rc"
 
 
-     IDR_LATO_FONT BINARY "resources/fonts/Lato-SemiBold.ttf"
-     
     /////////////////////////////////////////////////////////////////////////////
     //
     // Dialog


### PR DESCRIPTION
Rather than try and runtime load the Lato font assume it is installed
and react accordingly if it is not. No longer bundle it with the dll
and instead bundle it with the installer.

Closes #678 : Font causes Hang on some Windows
Closes #673 : De-Bold our Lato