### PR TITLE
Use Lato on Linux

### DIFF
--- a/installer_linux/make_deb.sh
+++ b/installer_linux/make_deb.sh
@@ -42,6 +42,7 @@ rm -rf ${PACKAGE_NAME} product
 mkdir -p ${PACKAGE_NAME}/usr/lib/vst
 mkdir -p ${PACKAGE_NAME}/usr/lib/vst3
 mkdir -p ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc
+mkdir -p ${PACKAGE_NAME}/usr/share/fonts/truetype/lato
 mkdir -p ${PACKAGE_NAME}/DEBIAN
 
 # build control file
@@ -78,6 +79,7 @@ EOT
 cp ../LICENSE ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc
 cp -r ../resources/data/* ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/
 cp ../target/vst2/Release/Surge.so ${PACKAGE_NAME}/usr/lib/vst/${SURGE_NAME}.so
+cp ../resources/fonts/Lato-Regular.ttf ${PACKAGE_NAME}/usr/share/fonts/truetype/lato
 
 # Once VST3 works, this will be ../products/vst3
 # cp ../target/vst3/Release/Surge.so ${PACKAGE_NAME}/usr/lib/vst3/${SURGE_NAME}.so

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -32,15 +32,8 @@
 #include "aulayer.h"
 #endif
 
-#if MAC || WINDOWS
-#define USE_RUNTIME_LOADED_FONTS 1
-#else
-#define USE_RUNTIME_LOADED_FONTS 0
-#endif
 
-#if USE_RUNTIME_LOADED_FONTS
 #include "RuntimeFont.h"
-#endif
 
 const int yofs = 10;
 
@@ -48,22 +41,9 @@ using namespace VSTGUI;
 using namespace std;
 
 
-#if USE_RUNTIME_LOADED_FONTS
 CFontRef displayFont = NULL;
 CFontRef patchNameFont = NULL;
 CFontRef lfoTypeFont = NULL;
-#else
-
-#if LINUX
-SharedPointer<CFontDesc> minifont = new CFontDesc("sans-serif", 9);
-SharedPointer<CFontDesc> patchfont = new CFontDesc("sans-serif", 14);
-SharedPointer<CFontDesc> lfofont = new CFontDesc("sans-serif", 8);
-#endif
-
-CFontRef displayFont = minifont;
-CFontRef patchNameFont = patchfont;
-CFontRef lfoTypeFont = lfofont;
-#endif
 
 
 enum special_tags
@@ -160,7 +140,6 @@ SurgeGUIEditor::SurgeGUIEditor(void* effect, SurgeSynthesizer* synth) : super(ef
    setZoomFactor(userDefaultZoomFactor);
    zoomInvalid = (userDefaultZoomFactor != 100);
 
-#if USE_RUNTIME_LOADED_FONTS
    /*
    ** As documented in RuntimeFonts.h, the contract of this function is to side-effect
    ** onto globals displayFont and patchNameFont with valid fonts from the runtime
@@ -201,7 +180,6 @@ SurgeGUIEditor::SurgeGUIEditor(void* effect, SurgeSynthesizer* synth) : super(ef
        lfoTypeFont = lfofont;
 
    }
-#endif
 }
 
 SurgeGUIEditor::~SurgeGUIEditor()

--- a/src/linux/RuntimeFontLinux.cpp
+++ b/src/linux/RuntimeFontLinux.cpp
@@ -1,0 +1,47 @@
+#include "RuntimeFont.h"
+#include <list>
+#include <iostream>
+
+using namespace VSTGUI;
+
+namespace Surge
+{
+namespace GUI
+{
+
+void initializeRuntimeFont()
+{
+    /*
+    ** Someone may have already initialized the globals. Don't do it twice
+    */
+    if (displayFont != NULL || patchNameFont != NULL)
+        return;
+
+    /*
+    ** If Lato isn't installed, bail and use defaults
+    */
+    std::list<std::string> fontNames;
+    if (IPlatformFont::getAllPlatformFontFamilies (fontNames))
+    {
+        if (std::find(fontNames.begin(), fontNames.end(), "Lato") == fontNames.end())
+        {
+           /*
+           ** Lato is not installed; bail out
+           */
+           return;
+        }
+    }
+    
+    /*
+    ** Set up the global fonts
+    */
+    VSTGUI::SharedPointer<VSTGUI::CFontDesc> minifont = new VSTGUI::CFontDesc("Lato", 9);
+    VSTGUI::SharedPointer<VSTGUI::CFontDesc> patchfont = new VSTGUI::CFontDesc("Lato", 14);
+    VSTGUI::SharedPointer<VSTGUI::CFontDesc> lfofont = new VSTGUI::CFontDesc("Lato", 8);
+    displayFont = minifont;
+    patchNameFont = patchfont;
+    lfoTypeFont = lfofont;
+}
+
+}
+}


### PR DESCRIPTION
If Lato is installed on linux use it; have the .deb file
install the font. Effectively this means lato works on linux.

Closes #615 Lato on Linux