### PR TITLE
A Proposal for organizing Headless

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(surge-headless
 
    src/headless/HeadlessApps.cpp
    src/headless/HeadlessTools.cpp
+   src/headless/HeadlessPlayer.cpp
 )
 
 target_compile_features(surge-headless

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ add_executable(surge-headless
    src/headless/DisplayInfoHeadless.cpp
    src/headless/UserInteractionsHeadless.cpp
    src/headless/LinkFixesHeadless.cpp
+
+   src/headless/HeadlessApps.cpp
+   src/headless/HeadlessTools.cpp
 )
 
 target_compile_features(surge-headless

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -39,6 +39,7 @@ Commands are:
         --build-install-vst2     Build and install only the VST2
         --build-install-vst3     Build and install only the VST3
         --build-headless         Build the headless application
+        --run-headless           Build and run the headless application
 
         --package                Creates a .pkg file from current built state in products
         --clean-and-package      Cleans everything; runs all the builds; makes an installer; drops it in products
@@ -369,8 +370,11 @@ case $command in
         run_build_install_vst3
         ;;
     --build-headless)
-        run_premake_if
         run_build_headless
+        ;;
+    --run-headless)
+        run_build_headless
+        ./build/Release/surge-headless
         ;;
     --clean)
         run_clean_builds

--- a/src/headless/HeadlessApps.cpp
+++ b/src/headless/HeadlessApps.cpp
@@ -1,5 +1,6 @@
 #include "HeadlessApps.h"
 #include "HeadlessTools.h"
+#include "HeadlessPlayer.h"
 #include <iostream>
 #include <iomanip>
 
@@ -77,7 +78,7 @@ void scanAllPresets(SurgeSynthesizer* surge)
    int nPresets = surge->storage.patch_list.size();
    int nCats = surge->storage.patch_category.size();
 
-   for (auto c = 0; c < nCats; ++c)
+   for (auto c : surge->storage.patchCategoryOrdering)
    {
       for (auto i = 0; i < nPresets; ++i)
       {
@@ -87,15 +88,25 @@ void scanAllPresets(SurgeSynthesizer* surge)
          {
             PatchCategory pc = surge->storage.patch_category[p.category];
 
-            std::cout << "idx= " << std::setw(4) << i << "; cat = '" << pc.name << "'; patch = '"
-                      << p.name << "'" << std::endl;
+            std::cout << "idx= " << std::right << std::setw(4) << i << "; cat = " << std::left
+                      << std::setw(30) << pc.name << "; patch = " << std::left << std::setw(30)
+                      << p.name << "";
 
             loadPatchByIndex(surge, i);
 
             /*
             ** So lets play some notes and gather some waveforms
-            ** FIXME
             */
+            std::vector<float> data;
+            Surge::Headless::Player::play120BPMCMajorQuarterNoteScale(surge, data);
+            if (data.size() > 0)
+            {
+               const auto [mind, maxd] = std::minmax_element(begin(data), end(data));
+
+               std::cout << "; data = [" << std::setw(12) << *mind << ", " << std::setw(12) << *maxd
+                         << "] in " << data.size() << " samples";
+            }
+            std::cout << std::endl;
          }
       }
    }

--- a/src/headless/HeadlessApps.cpp
+++ b/src/headless/HeadlessApps.cpp
@@ -1,0 +1,105 @@
+#include "HeadlessApps.h"
+#include "HeadlessTools.h"
+#include <iostream>
+#include <iomanip>
+
+namespace Surge
+{
+namespace Headless
+{
+
+void runSimpleSynthToStdout(SurgeSynthesizer* surge)
+{
+   /*
+   ** Change a parameter in the scene. Do this by traversing the
+   ** graph in the current patch (which is in surge->storage).
+   **
+   ** Clearly a more fulsome headless API would provide wrappers around
+   ** this for common activities. This sets up a pair of detuned saw waves
+   ** both active.
+   */
+   surge->storage.getPatch().scene[0].osc[0].pitch.set_value_f01(4);
+   surge->storage.getPatch().scene[0].mute_o2.set_value_f01(0, true);
+   surge->storage.getPatch().scene[0].osc[1].pitch.set_value_f01(1);
+
+   /*
+   ** Play a note. channel, note, velocity, detune
+   */
+   surge->playNote((char)0, (char)60, (char)100, 0);
+
+   /*
+   ** Strip off some processing first to avoid the attach transient
+   */
+   for (auto i = 0; i < 20; ++i)
+      surge->process();
+
+   /*
+   ** Then run the sampler
+   */
+   int blockCount = 30;
+   int overSample = 8; // we want to include n samples per printed row.
+   float overS = 0;
+   int sampleCount = 0;
+   for (auto i = 0; i < blockCount; ++i)
+   {
+      surge->process();
+
+      for (int sm = 0; sm < BLOCK_SIZE; ++sm)
+      {
+         float avgOut = 0;
+         for (int oi = 0; oi < surge->getNumOutputs(); ++oi)
+         {
+            avgOut += surge->output[oi][sm];
+         }
+
+         overS += avgOut;
+         sampleCount++;
+
+         if (((sampleCount) % overSample) == 0)
+         {
+            overS /= overSample;
+            int gWidth = (int)((overS + 1) * 30);
+            std::cout << "Sample: " << std::setw(15) << overS << std::setw(gWidth) << "X"
+                      << std::endl;
+            ;
+            overS = 0.0; // start accumulating again
+         }
+      }
+   }
+}
+
+void scanAllPresets(SurgeSynthesizer* surge)
+{
+   /*
+   ** The patches are not sorted in category order so traverse an outer loop of categories and
+   ** inner of patches. We should clean up these data structures one day...
+   */
+   int nPresets = surge->storage.patch_list.size();
+   int nCats = surge->storage.patch_category.size();
+
+   for (auto c = 0; c < nCats; ++c)
+   {
+      for (auto i = 0; i < nPresets; ++i)
+      {
+         int idx = surge->storage.patchOrdering[i];
+         Patch p = surge->storage.patch_list[idx];
+         if (p.category == c)
+         {
+            PatchCategory pc = surge->storage.patch_category[p.category];
+
+            std::cout << "idx= " << std::setw(4) << i << "; cat = '" << pc.name << "'; patch = '"
+                      << p.name << "'" << std::endl;
+
+            loadPatchByIndex(surge, i);
+
+            /*
+            ** So lets play some notes and gather some waveforms
+            ** FIXME
+            */
+         }
+      }
+   }
+}
+
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/HeadlessApps.h
+++ b/src/headless/HeadlessApps.h
@@ -1,0 +1,23 @@
+#include "SurgeSynthesizer.h"
+
+namespace Surge
+{
+namespace Headless
+{
+
+/**
+ * runSimpleSynthToStdout
+ *
+ * Shows how to create and run a synth putting output to stdout
+ */
+void runSimpleSynthToStdout(SurgeSynthesizer* surge);
+
+/**
+ * scanAllPresets
+ *
+ * Loads each preset, scans for volume characteristics under a few playing modes
+ */
+void scanAllPresets(SurgeSynthesizer* surge);
+
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/HeadlessPlayer.cpp
+++ b/src/headless/HeadlessPlayer.cpp
@@ -1,0 +1,48 @@
+#include "HeadlessPlayer.h"
+
+namespace Surge
+{
+namespace Headless
+{
+namespace Player
+{
+void grabNBlocks(SurgeSynthesizer* surge, int nBlocks, std::vector<float>& output)
+{
+   int no = surge->getNumOutputs();
+   for (auto i = 0; i < nBlocks; ++i)
+   {
+      surge->process();
+      for (int sm = 0; sm < BLOCK_SIZE; ++sm)
+      {
+         for (int io = 0; io < no; ++io)
+         {
+            output.push_back(surge->output[io][sm]);
+         }
+      }
+   }
+}
+
+void play120BPMCMajorQuarterNoteScale(SurgeSynthesizer* surge, std::vector<float>& output)
+{
+   // int sr = surge->getSampleRate(); // really? That's not there
+   // FIXME
+   int sr = 44100;
+
+   int samplesPerNote = 60.0 / 120.0 * sr;
+   int blocksPerNote = samplesPerNote / BLOCK_SIZE;
+   int currSamp = 0;
+
+   auto notes = {60, 62, 64, 65, 67, 69, 71, 72};
+   for (auto n : notes)
+   {
+      surge->playNote((char)0, (char)n, (char)100, 0);
+      grabNBlocks(surge, blocksPerNote - 1, output);
+      surge->playNote((char)0, (char)n, (char)100, 0);
+      grabNBlocks(surge, 1, output);
+   }
+   return;
+}
+
+} // namespace Player
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/HeadlessPlayer.h
+++ b/src/headless/HeadlessPlayer.h
@@ -1,0 +1,21 @@
+#include "SurgeSynthesizer.h"
+#include <vector>
+
+namespace Surge
+{
+namespace Headless
+{
+namespace Player
+{
+
+/*
+** A variety of player routines all with the same signature of "SurgeSynth *, vector<float>&"
+** plays the type in the name and outputs the data into the float vector as itnerleaved stero
+** (so l1 r1 l2 r3 l2 r3 etc...)
+*/
+
+void play120BPMCMajorQuarterNoteScale(SurgeSynthesizer* synth, std::vector<float>& output);
+
+} // namespace Player
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/HeadlessPluginLayerProxy.h
+++ b/src/headless/HeadlessPluginLayerProxy.h
@@ -8,6 +8,5 @@ class HeadlessPluginLayerProxy
 public:
     void updateDisplay()
     {
-        std::cerr << "HeadlessPluginLayerProxy::updateDisplay" << std::endl;
     }
 };

--- a/src/headless/HeadlessTools.cpp
+++ b/src/headless/HeadlessTools.cpp
@@ -1,0 +1,29 @@
+#include "HeadlessApps.h"
+#include "HeadlessPluginLayerProxy.h"
+
+namespace Surge
+{
+namespace Headless
+{
+
+SurgeSynthesizer* createSurge()
+{
+   HeadlessPluginLayerProxy* parent = new HeadlessPluginLayerProxy();
+   SurgeSynthesizer* surge = new SurgeSynthesizer(parent);
+   surge->setSamplerate(44100);
+   return surge;
+}
+
+bool loadPatchByIndex(SurgeSynthesizer* s, int index)
+{
+   if (index > s->storage.patch_list.size() || index < 0)
+      return false;
+
+   s->patchid_queue = index;
+   s->processThreadunsafeOperations();
+
+   return true;
+}
+
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/HeadlessTools.h
+++ b/src/headless/HeadlessTools.h
@@ -1,0 +1,25 @@
+#include "SurgeSynthesizer.h"
+
+namespace Surge
+{
+namespace Headless
+{
+
+/**
+ * createSurge
+ *
+ * Create an instance of a SurgeSynthesizer object correctly configured
+ * to run in headless mode
+ */
+SurgeSynthesizer* createSurge();
+
+/**
+ * loadPatchByIndex
+ *
+ * Appropriately loads the surge patch at "index", returning false if
+ * no patch is available
+ */
+bool loadPatchByIndex(SurgeSynthesizer* s, int index);
+
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -1,69 +1,13 @@
 #include <iostream>
 #include <iomanip>
 
-#include "SurgeSynthesizer.h"
-
-#include "HeadlessPluginLayerProxy.h"
+#include "HeadlessTools.h"
+#include "HeadlessApps.h"
 
 int main(int argc, char** argv)
 {
     std::cout << "Surge Headless Mode" << std::endl;
+    SurgeSynthesizer* surge = Surge::Headless::createSurge();
 
-    HeadlessPluginLayerProxy *parent = new HeadlessPluginLayerProxy();
-    std::unique_ptr<SurgeSynthesizer> surge(new SurgeSynthesizer(parent));
-    surge->setSamplerate(44100);
-
-    /*
-    ** Change a parameter in the scene. Do this by traversing the 
-    ** graph in the current patch (which is in surge->storage).
-    **
-    ** Clearly a more fulsome headless API would provide wrappers around
-    ** this for common activities. This sets up a pair of detuned saw waves
-    ** both active.
-    */
-    surge->storage.getPatch().scene[0].osc[0].pitch.set_value_f01(4);
-    surge->storage.getPatch().scene[0].mute_o2.set_value_f01(0,true);
-    surge->storage.getPatch().scene[0].osc[1].pitch.set_value_f01(1);
-
-    /*
-    ** Play a note. channel, note, velocity, detune
-    */
-    surge->playNote((char)0, (char)60, (char)100, 0); 
-
-    /*
-    ** Strip off some processing first to avoid the attach transient
-    */
-    for(auto i=0; i<20; ++i) surge->process();
-
-    /*
-    ** Then run the sampler
-    */
-    int blockCount = 30;
-    int overSample = 8; // we want to include n samples per printed row. 
-    float overS = 0;
-    int sampleCount = 0;
-    for (auto i = 0; i < blockCount; ++i )
-    {
-        surge->process();
-
-        for (int sm = 0; sm < BLOCK_SIZE; ++sm)
-        {
-            float avgOut = 0;
-            for (int oi = 0; oi < surge->getNumOutputs(); ++oi)
-            {
-                avgOut += surge->output[oi][sm];
-            }
-
-            overS += avgOut;
-            sampleCount ++;
-
-            if (((sampleCount) % overSample) == 0)
-            {
-                overS /= overSample;
-                int gWidth = (int)((overS + 1)*30);
-                std::cout << "Sample: " << std::setw( 15 ) << overS << std::setw(gWidth) << "X" << std::endl;;
-                overS = 0.0; // start accumulating again
-            }
-        }
-    }
+    Surge::Headless::scanAllPresets(surge);
 }


### PR DESCRIPTION
This PR expands the capability of the headless app to start adding
functions and helpers we can use to debug. Specifically this adds
HeadlessApps.h and HeadlessTools.h which have various top level
activities and tools you can use, and replaces the main (which is
still available as Surge::Headless::runSimpleSynthToStdout) with
a program which loads all the presets into a headless surge.

Soon I'll make it so it can play them too, probably by adding
a "HeadlessPlayer.h/cpp" which plays various note sequences
into various synths.