### PR TITLE
A More Expansive Headless Proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ premake-stamp
 /Debug
 src/linux/ScalablePiggy*
 *.deb
+
+# cmake
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ add_executable(surge-headless
    src/headless/DisplayInfoHeadless.cpp
    src/headless/UserInteractionsHeadless.cpp
    src/headless/LinkFixesHeadless.cpp
+   src/headless/HeadlessUtils.cpp
+   src/headless/Player.cpp
 )
 
 target_compile_features(surge-headless

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -369,8 +369,11 @@ case $command in
         run_build_install_vst3
         ;;
     --build-headless)
-        run_premake_if
         run_build_headless
+        ;;
+    --run-headless)
+        run_build_headless
+        ./build/Release/surge-headless 
         ;;
     --clean)
         run_clean_builds

--- a/premake5.lua
+++ b/premake5.lua
@@ -673,7 +673,10 @@ if (os.istarget("windows")) then
         "src/headless/main.cpp",
         "src/headless/DisplayInfoHeadless.cpp",
         "src/headless/UserInteractionsHeadless.cpp",
-        "src/headless/LinkFixesHeadless.cpp"
+        "src/headless/LinkFixesHeadless.cpp",
+        "src/headless/HeadlessUtils.cpp",
+        "src/headless/Player.cpp"
+        
     }
 
     excludes

--- a/src/headless/HeadlessPluginLayerProxy.h
+++ b/src/headless/HeadlessPluginLayerProxy.h
@@ -8,6 +8,5 @@ class HeadlessPluginLayerProxy
 public:
     void updateDisplay()
     {
-        std::cerr << "HeadlessPluginLayerProxy::updateDisplay" << std::endl;
     }
 };

--- a/src/headless/HeadlessUtils.cpp
+++ b/src/headless/HeadlessUtils.cpp
@@ -1,0 +1,39 @@
+#include "HeadlessUtils.h"
+#include "HeadlessPluginLayerProxy.h"
+
+#include <iostream>
+#include <iomanip>
+
+namespace Surge
+{
+namespace Headless
+{
+SurgeSynthesizer* createSurge(int sr)
+{
+   HeadlessPluginLayerProxy* parent = new HeadlessPluginLayerProxy();
+   SurgeSynthesizer* surge = new SurgeSynthesizer(parent);
+   surge->setSamplerate(sr);
+   return surge;
+}
+
+void writeToStream(const float* data, int nSamples, int nChannels, std::ostream& str)
+{
+   int overSample = 8;
+   float avgOut = 0;
+   for (auto i = 0; i < nSamples; i += nChannels)
+   {
+      for (auto j = 0; j < nChannels; ++j)
+         avgOut += data[i + j] / nChannels;
+      if ((i % overSample) == 0)
+      {
+         avgOut /= overSample;
+         int gWidth = (int)((avgOut + 1) * 40);
+         str << "Sample: " << std::setw(15) << avgOut << std::setw(gWidth) << "X" << std::endl;
+
+         avgOut = 0;
+      }
+   }
+}
+
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/HeadlessUtils.h
+++ b/src/headless/HeadlessUtils.h
@@ -1,0 +1,27 @@
+/*
+** HeadlessUtils provides a collection of utility functions to manage and output
+** data and construct and manipulate surge
+*/
+#pragma once
+
+#include "SurgeSynthesizer.h"
+
+namespace Surge
+{
+namespace Headless
+{
+
+SurgeSynthesizer* createSurge(int sr);
+
+void writeToStream(const float* data, int nSamples, int nChannels, std::ostream& str);
+
+/*
+** One imagines expansions along these lines:
+
+void writeWavFile(const float * data, int nSamples, int nChannels, std::string fname);
+void writeGnuplotFile(const float *data, int nSamples, int nChannels, std::string fname);
+
+*/
+
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/Player.cpp
+++ b/src/headless/Player.cpp
@@ -1,0 +1,153 @@
+#include "Player.h"
+
+namespace Surge
+{
+namespace Headless
+{
+
+playerEvents_t makeHoldMiddleC(int forSamples, int withTail)
+{
+   playerEvents_t result;
+
+   Event on;
+   on.type = Event::NOTE_ON;
+   on.channel = 0;
+   on.data1 = 60;
+   on.data2 = 100;
+   on.atSample = 0;
+
+   result.push_back(on);
+
+   on.atSample = forSamples;
+   on.type = Event::NOTE_OFF;
+   on.data2 = 0;
+   result.push_back(on);
+
+   if (withTail != 0)
+   {
+      on.type = Event::NO_EVENT;
+      on.atSample = forSamples + withTail;
+      result.push_back(on);
+   }
+
+   return result;
+}
+
+playerEvents_t make120BPMCMajorQuarterNoteScale(long s0, int sr)
+{
+   int samplesPerNote = 60.0 / 120.0 * sr;
+   int currSamp = s0;
+   auto notes = {60, 62, 64, 65, 67, 69, 71, 72};
+
+   playerEvents_t result;
+   for (auto n : notes)
+   {
+      Event e;
+      e.type = Event::NOTE_ON;
+      e.channel = 0;
+      e.data1 = n;
+      e.data2 = 100;
+      e.atSample = currSamp;
+
+      result.push_back(e);
+
+      e.type = Event::NOTE_OFF;
+      e.data2 = 0;
+      e.atSample += 0.95 * samplesPerNote;
+      result.push_back(e);
+
+      currSamp += samplesPerNote;
+   }
+   return result;
+}
+
+void playAsConfigured(SurgeSynthesizer* surge,
+                      const playerEvents_t& events,
+                      float** data,
+                      int* nSamples,
+                      int* nChannels)
+{
+   if (events.size() == 0)
+      return;
+
+   int desiredSamples = events.back().atSample;
+   int blockCount = desiredSamples / BLOCK_SIZE;
+   int currEvt = 0;
+
+   *nChannels = 2;
+   *nSamples = desiredSamples;
+   float* ldata = new float[desiredSamples * 2];
+   *data = ldata;
+
+   size_t flidx = 0;
+
+   for (auto i = 0; i < blockCount; ++i)
+   {
+      int cs = i * BLOCK_SIZE;
+      while (events[currEvt].atSample <= cs + BLOCK_SIZE - 1 && currEvt < events.size())
+      {
+         Event e = events[currEvt];
+         if (e.type == Event::NOTE_ON)
+            surge->playNote(e.channel, e.data1, e.data2, 0);
+         if (e.type == Event::NOTE_OFF)
+            surge->releaseNote(e.channel, e.data1, e.data2);
+
+         currEvt++;
+      }
+
+      surge->process();
+      for (int sm = 0; sm < BLOCK_SIZE; ++sm)
+      {
+         for (int oi = 0; oi < surge->getNumOutputs(); ++oi)
+         {
+            ldata[flidx++] = surge->output[oi][sm];
+         }
+      }
+   }
+}
+
+void playOnPatch(SurgeSynthesizer* surge,
+                 int patch,
+                 const playerEvents_t& events,
+                 float** data,
+                 int* nSamples,
+                 int* nChannels)
+{
+   surge->loadPatch(patch);
+   playAsConfigured(surge, events, data, nSamples, nChannels);
+}
+
+void playOnEveryPatch(
+    SurgeSynthesizer* surge,
+    const playerEvents_t& events,
+    std::function<void(
+        const Patch& p, const PatchCategory& c, const float* data, int nSamples, int nChannels)> cb)
+{
+   int nPresets = surge->storage.patch_list.size();
+   int nCats = surge->storage.patch_category.size();
+
+   for (auto c : surge->storage.patchCategoryOrdering)
+   {
+      for (auto i = 0; i < nPresets; ++i)
+      {
+         int idx = surge->storage.patchOrdering[i];
+         Patch p = surge->storage.patch_list[idx];
+         if (p.category == c)
+         {
+            PatchCategory pc = surge->storage.patch_category[p.category];
+
+            float* data = NULL;
+            int nSamples, nChannels;
+
+            playOnPatch(surge, i, events, &data, &nSamples, &nChannels);
+            cb(p, pc, data, nSamples, nChannels);
+
+            if (data)
+               delete[] data;
+         }
+      }
+   }
+}
+
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/Player.h
+++ b/src/headless/Player.h
@@ -1,0 +1,91 @@
+/*
+** The Player.h construct allows us to make things which look like midi streams and play
+** them onto headless surges collecting the data in big accumulated vectors. As a result
+** it has structures which look like midi events, midi sequence generators, and players
+*/
+
+#pragma once
+
+#include "HeadlessUtils.h"
+#include <vector>
+
+namespace Surge
+{
+namespace Headless
+{
+
+/*
+** Event and the std::vector<Event> (typedefed as playerEvents_t in case we need to
+** change that data structure) hold a sequence of midi-like events. Right now we
+** only support note on and note off at a particular sample, or NO_EVENT, which is
+** useful for holding for tails. channel, data1, and data2 follow the MIDI 1.0 naming
+** convention.
+*/
+struct Event
+{
+   typedef enum Type
+   {
+      NOTE_ON,
+      NOTE_OFF,
+
+      NO_EVENT // Useful if you want to keep the player running and have nothing happen
+   } Type;     // FIXME: Controllers etc...
+
+   Type type;
+   char channel;
+   char data1;
+   char data2;
+
+   long atSample;
+};
+
+typedef std::vector<Event> playerEvents_t; // We assume these are monotonic in Event.atSample
+
+/**
+ * makeHoldMiddleC
+ *
+ * Returns an event stream holding middle C
+ */
+playerEvents_t makeHoldMiddleC(int forSamples, int withTail = 0);
+
+playerEvents_t make120BPMCMajorQuarterNoteScale(long sample0 = 0, int sr = 44100);
+
+/**
+ * playAsConfigured
+ *
+ * given a surge, play the events from first to last accumulating the result in the audiodata
+ */
+void playAsConfigured(SurgeSynthesizer* synth,
+                      const playerEvents_t& events,
+                      float** resultData,
+                      int* nSamples,
+                      int* nChannels);
+
+/**
+ * playOnPatch
+ *
+ * given a surge and a patch, play the events accumulating the data. This is a convenience
+ * for loadpatch / playAsConfigured
+ */
+void playOnPatch(SurgeSynthesizer* synth,
+                 int patch,
+                 const playerEvents_t& events,
+                 float** resultData,
+                 int* nSamples,
+                 int* nChannels);
+
+/**
+ * playOnEveryPatch
+ *
+ * Play the events on every patch Surge knows callign the callback for each one with
+ * the result.
+ */
+void playOnEveryPatch(
+    SurgeSynthesizer* synth,
+    const playerEvents_t& events,
+    std::function<void(
+        const Patch& p, const PatchCategory& c, const float* data, int nSamples, int nChannels)>
+        completedCallback);
+
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -1,69 +1,76 @@
 #include <iostream>
 #include <iomanip>
 
-#include "SurgeSynthesizer.h"
+#include "HeadlessUtils.h"
+#include "Player.h"
 
-#include "HeadlessPluginLayerProxy.h"
+void simpleOscillatorToStdOut()
+{
+   SurgeSynthesizer* surge = Surge::Headless::createSurge(44100);
 
+   /*
+   ** Change a parameter in the scene. Do this by traversing the
+   ** graph in the current patch (which is in surge->storage).
+   **
+   ** Clearly a more fulsome headless API would provide wrappers around
+   ** this for common activities. This sets up a pair of detuned saw waves
+   ** both active.
+   */
+   surge->storage.getPatch().scene[0].osc[0].pitch.set_value_f01(4);
+   surge->storage.getPatch().scene[0].mute_o2.set_value_f01(0, true);
+   surge->storage.getPatch().scene[0].osc[1].pitch.set_value_f01(1);
+
+   Surge::Headless::playerEvents_t terryRiley = Surge::Headless::makeHoldMiddleC(4410);
+
+   float* data = NULL;
+   int nSamples, nChannels;
+
+   Surge::Headless::playAsConfigured(surge, terryRiley, &data, &nSamples, &nChannels);
+   Surge::Headless::writeToStream(data, nSamples, nChannels, std::cout);
+
+   if (data)
+      delete[] data;
+   delete surge;
+}
+
+void statsFromPlayingEveryPatch()
+{
+   /*
+   ** This is a very clean use of the built in APIs, just making a surge
+   ** and a scale then asking headless to map it onto every patch
+   ** and call us back with a result
+   */
+   SurgeSynthesizer* surge = Surge::Headless::createSurge(44100);
+
+   Surge::Headless::playerEvents_t scale =
+       Surge::Headless::make120BPMCMajorQuarterNoteScale(0, 44100);
+
+   auto callBack = [](const Patch& p, const PatchCategory& pc, const float* data, int nSamples,
+                      int nChannels) -> void {
+      std::cout << "cat = " << std::left << std::setw(30) << pc.name << "; patch = " << std::left
+                << std::setw(30) << p.name << "";
+
+      if (nSamples * nChannels > 0)
+      {
+         const auto [mind, maxd] = std::minmax_element(data, data + nSamples * nChannels);
+
+         std::cout << "; data = [" << std::setw(10) << std::fixed << *mind << ", " << std::setw(10)
+                   << std::fixed << *maxd << "] in " << nSamples << " samples";
+      }
+      std::cout << std::endl;
+   };
+
+   Surge::Headless::playOnEveryPatch(surge, scale, callBack);
+}
+
+/*
+** This is a simple main that, for now, you make call out to the application
+** stub of your choosing. We have two in Applications and we call them both
+*/
 int main(int argc, char** argv)
 {
-    std::cout << "Surge Headless Mode" << std::endl;
+   simpleOscillatorToStdOut();
+   statsFromPlayingEveryPatch();
 
-    HeadlessPluginLayerProxy *parent = new HeadlessPluginLayerProxy();
-    std::unique_ptr<SurgeSynthesizer> surge(new SurgeSynthesizer(parent));
-    surge->setSamplerate(44100);
-
-    /*
-    ** Change a parameter in the scene. Do this by traversing the 
-    ** graph in the current patch (which is in surge->storage).
-    **
-    ** Clearly a more fulsome headless API would provide wrappers around
-    ** this for common activities. This sets up a pair of detuned saw waves
-    ** both active.
-    */
-    surge->storage.getPatch().scene[0].osc[0].pitch.set_value_f01(4);
-    surge->storage.getPatch().scene[0].mute_o2.set_value_f01(0,true);
-    surge->storage.getPatch().scene[0].osc[1].pitch.set_value_f01(1);
-
-    /*
-    ** Play a note. channel, note, velocity, detune
-    */
-    surge->playNote((char)0, (char)60, (char)100, 0); 
-
-    /*
-    ** Strip off some processing first to avoid the attach transient
-    */
-    for(auto i=0; i<20; ++i) surge->process();
-
-    /*
-    ** Then run the sampler
-    */
-    int blockCount = 30;
-    int overSample = 8; // we want to include n samples per printed row. 
-    float overS = 0;
-    int sampleCount = 0;
-    for (auto i = 0; i < blockCount; ++i )
-    {
-        surge->process();
-
-        for (int sm = 0; sm < BLOCK_SIZE; ++sm)
-        {
-            float avgOut = 0;
-            for (int oi = 0; oi < surge->getNumOutputs(); ++oi)
-            {
-                avgOut += surge->output[oi][sm];
-            }
-
-            overS += avgOut;
-            sampleCount ++;
-
-            if (((sampleCount) % overSample) == 0)
-            {
-                overS /= overSample;
-                int gWidth = (int)((overS + 1)*30);
-                std::cout << "Sample: " << std::setw( 15 ) << overS << std::setw(gWidth) << "X" << std::endl;;
-                overS = 0.0; // start accumulating again
-            }
-        }
-    }
+   return 0;
 }


### PR DESCRIPTION
This commit suggests a way to implement Headless which is as a
player of internal events to buffers. For now the buffers are
vectors as are the events. Right now, this implements the
play and monitor of every patch with a simple C major scale,
as well as a quick test of a direct patch configuration.

APIs for Wav and Gnuplot are declared but not implemented.