### PR TITLE
Move to VST rather than NSView Scaling

### DIFF
--- a/src/au/aulayer_cocoaui.mm
+++ b/src/au/aulayer_cocoaui.mm
@@ -33,7 +33,9 @@
 #import <AudioUnit/AUCocoaUIView.h>
 #include "aulayer.h"
 #include "aulayer_cocoaui.h"
+
 #include <gui/SurgeGUIEditor.h>
+#include <gui/CScalableBitmap.h>
 
 using namespace VSTGUI;
 
@@ -114,10 +116,26 @@ void timerCallback( CFRunLoopTimerRef timer, void *info )
             newSize = NSMakeRect (0, 0,
                                   lastScale * ( vr->right - vr->left ),
                                   lastScale * ( vr->bottom - vr->top ) ) ;
-            [self scaleUnitSquareToSize:NSMakeSize( lastScale, lastScale )];
             setSizeByZoom = true;
             [self setFrame:newSize];
             setSizeByZoom = false;
+
+            VSTGUI::CFrame *frame = cont->getFrame();
+            if(frame)
+            {
+               frame->setZoom( zf );
+               VSTGUI::CBitmap *bg = frame->getBackground();
+               if(bg != NULL)
+               {
+                  CScalableBitmap *sbm = dynamic_cast<CScalableBitmap *>(bg); // dynamic casts are gross but better safe
+                  if (sbm)
+                  {
+                     sbm->setExtraScaleFactor(cont->getZoomFactor());
+                  }
+               }
+               frame->setDirty(true);
+               frame->invalid();
+            }
         }
 
         cont->setZoomCallback( [self]( SurgeGUIEditor *ed ) {
@@ -128,12 +146,29 @@ void timerCallback( CFRunLoopTimerRef timer, void *info )
                 NSRect newSize = NSMakeRect (0, 0,
                                              (int)( (vr->right - vr->left) * zf ),
                                              (int)( (vr->bottom - vr->top) * zf ) );
-                [self scaleUnitSquareToSize:NSMakeSize( zf / lastScale, zf / lastScale )];
                 lastScale = zf;
                 
                 setSizeByZoom = true;
                 [self setFrame:newSize];
                 setSizeByZoom = false;
+
+                VSTGUI::CFrame *frame = ed->getFrame();
+                if(frame)
+                {
+                   frame->setZoom( zf );
+                   VSTGUI::CBitmap *bg = frame->getBackground();
+                   if(bg != NULL)
+                   {
+                      CScalableBitmap *sbm = dynamic_cast<CScalableBitmap *>(bg); // dynamic casts are gross but better safe
+                      if (sbm)
+                      {
+                         sbm->setExtraScaleFactor(ed->getZoomFactor());
+                      }
+                   }
+                   frame->setDirty(true);
+                   frame->invalid();
+                }
+
             }
             
         }


### PR DESCRIPTION
VST2 and 3 plugins use VST scaling whereas AU used NSView scaling.
This was fine for bitmap displays - cocoa does a great job -
but it meant the actual display size of my draw areas were different
VST to AU. This diff adjusts to use the (now finally working)
vst zoom in AU also.

Closes #708 make AU zoom symmetric