### PR TITLE
Set frame size when zooming

### DIFF
--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -580,11 +580,12 @@ bool Vst2PluginInstance::tryInit()
 void Vst2PluginInstance::handleZoom(SurgeGUIEditor *e)
 {
     ERect *vr;
+    int newW, newH;
     if (e->getRect(&vr))
     {
         float fzf = e->getZoomFactor() / 100.0;
-        int newW = (vr->right - vr->left) * fzf;
-        int newH = (vr->bottom - vr->top) * fzf;
+        newW = (vr->right - vr->left) * fzf;
+        newH = (vr->bottom - vr->top) * fzf;
         sizeWindow( newW, newH );
     }
 
@@ -592,6 +593,12 @@ void Vst2PluginInstance::handleZoom(SurgeGUIEditor *e)
     if(frame)
     {
         frame->setZoom( e->getZoomFactor() / 100.0 );
+        /*
+        ** cframe::setZoom uses prior size and integer math which means repeated resets drift
+        ** look at the "oroginWidth" math around in CFrame::setZoom. So rather than let those
+        ** drifts accumulate, just reset the size here since we know it
+        */
+        frame->setSize(newW, newH);
         
         /*
         ** VST2 has an error which is that the background bitmap doesn't get the frame transform

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -617,7 +617,7 @@ void SurgeVst3Processor::handleZoom(SurgeGUIEditor *e)
     if(frame)
     {
         frame->setZoom( e->getZoomFactor() / 100.0 );
-
+        frame->setSize(newW, newH);
         /*
         ** rather than calling setSize on myself as in vst2, I have to
         ** inform the plugin frame that I have resized wiht a reference


### PR DESCRIPTION
CFrame::setZoom sets the size of the frame to the ostensible
size, but if you zoom in and out a lot, it drifts by a pixel
here and a pixel there. One of those "(int)((int)a * 1.5)/1.5)"
over and over type things. Look in cframe ::setZoom and you will see.

But if after zooming you explicitly set the pixel size you want
this rounding leak disappears.

Closes #712 zoom size artifacts