### PR TITLE
VST3 Velocity

### DIFF
--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -12,6 +12,8 @@
 
 #include "CScalableBitmap.h"
 
+#include <algorithm>
+
 using namespace Steinberg::Vst;
 
 #define CHECK_INITIALIZED                                                                          \
@@ -198,7 +200,8 @@ void SurgeVst3Processor::processEvent(const Event& e)
       }
       else
       {
-         getSurge()->playNote(e.noteOn.channel, e.noteOn.pitch, e.noteOn.velocity, e.noteOn.tuning);
+         char cVel = std::min((char)(e.noteOn.velocity * 128.0), (char)127); // Why oh why is this a float in VST3?
+         getSurge()->playNote(e.noteOn.channel, e.noteOn.pitch, cVel, e.noteOn.tuning);
       }
       break;
 


### PR DESCRIPTION
In VST3 NoteOnEvent::velocity is a float between 0 and 1.
Why? Who knows. But in every other midi thing it is a
char between 0 and 127. So when passed to surge directly
in VST3 it doesn't work. This change simply multiplies the velocity
and casts it to a char.

addresses parts of issues #389 and #26 but not all of them