### PR TITLE
Require CMake 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(Surge VERSION 1.0.0 LANGUAGES CXX ASM)
 
 set(SURGE_COMMON_SOURCES


### PR DESCRIPTION
CMake 3.10 is needed to have C++17.

Closes: #720