### PR TITLE
disable cursors in save dialog from changing presets

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -506,15 +506,43 @@ int32_t SurgeGUIEditor::onKeyDown(const VstKeyCode& code, CFrame* frame)
             ** event loop)
             */
         case VKEY_LEFT:
+            if (saveDialog && saveDialog->isVisible())
+            {
+               /* 
+               ** SaveDialog gets access to the cursor keys if it is open
+               */
+               return -1;
+            }
             synth->incrementCategory(false);
             return 1;
         case VKEY_RIGHT:
+            if (saveDialog && saveDialog->isVisible())
+            {
+               /* 
+               ** SaveDialog gets access to the cursor keys if it is open
+               */
+               return -1;
+            }
             synth->incrementCategory(true);
             return 1;
         case VKEY_UP:
+            if (saveDialog && saveDialog->isVisible())
+            {
+               /* 
+               ** SaveDialog gets access to the cursor keys if it is open
+               */
+               return -1;
+            }
             synth->incrementPatch(false);
             return 1;
         case VKEY_DOWN:
+            if (saveDialog && saveDialog->isVisible())
+            {
+               /* 
+               ** SaveDialog gets access to the cursor keys if it is open
+               */
+               return -1;
+            }
             synth->incrementPatch(true);
             return 1;
 #endif


### PR DESCRIPTION
fixes #727 but in a blunt / heavyhanded way. 