### PR TITLE
Remove a C++-17ism

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -51,7 +51,9 @@ void statsFromPlayingEveryPatch()
 
       if (nSamples * nChannels > 0)
       {
-         const auto [mind, maxd] = std::minmax_element(data, data + nSamples * nChannels);
+         const auto minmaxres = std::minmax_element(data, data + nSamples * nChannels);
+         auto mind = minmaxres.first;
+         auto maxd = minmaxres.first;
 
          float rms=0, L1=0;
          for( int i=0; i<nSamples*nChannels; ++i)


### PR DESCRIPTION
the c++-17-ism auto [k,v] = (thing-returning-pair) doesn't work with
gcc6 it seems. So knock it out rather than requiring users to
upgrade their compiler.