### PR TITLE
Remove Arrow Keys altogether from changing category+presets since it was destructive

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -505,46 +505,6 @@ int32_t SurgeGUIEditor::onKeyDown(const VstKeyCode& code, CFrame* frame)
             ** (On Mac and Win menus are separate parent windows so have a different 
             ** event loop)
             */
-        case VKEY_LEFT:
-            if (saveDialog && saveDialog->isVisible())
-            {
-               /* 
-               ** SaveDialog gets access to the cursor keys if it is open
-               */
-               return -1;
-            }
-            synth->incrementCategory(false);
-            return 1;
-        case VKEY_RIGHT:
-            if (saveDialog && saveDialog->isVisible())
-            {
-               /* 
-               ** SaveDialog gets access to the cursor keys if it is open
-               */
-               return -1;
-            }
-            synth->incrementCategory(true);
-            return 1;
-        case VKEY_UP:
-            if (saveDialog && saveDialog->isVisible())
-            {
-               /* 
-               ** SaveDialog gets access to the cursor keys if it is open
-               */
-               return -1;
-            }
-            synth->incrementPatch(false);
-            return 1;
-        case VKEY_DOWN:
-            if (saveDialog && saveDialog->isVisible())
-            {
-               /* 
-               ** SaveDialog gets access to the cursor keys if it is open
-               */
-               return -1;
-            }
-            synth->incrementPatch(true);
-            return 1;
 #endif
         }
     }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -498,14 +498,6 @@ int32_t SurgeGUIEditor::onKeyDown(const VstKeyCode& code, CFrame* frame)
             }
             toggle_mod_editing();
             return 1;
-#if !LINUX
-            /* 
-            ** On linux the arrow keys navigate menus but do it in the same window as the
-            ** UI, so this eating of the key causes core dumps and makes menus non-navigable.
-            ** (On Mac and Win menus are separate parent windows so have a different 
-            ** event loop)
-            */
-#endif
         }
     }
     else


### PR DESCRIPTION
This _should_ remove all cursor up down left right keys from working in Surge (no more category+preset changing). This saves the user from accidentally destroying their preset with an accidental cursor key press.

closes #734 
closes #729 