### PR TITLE
Surge32.dll -> Surge_x86.dll = fixes Windows issues

### DIFF
--- a/installer_win/surge-x86.iss
+++ b/installer_win/surge-x86.iss
@@ -41,8 +41,8 @@ Name: VST2; Description: VST2 Plug-in (32 bit); Types: full custom; Flags: check
 Name: VST3; Description: VST3 Plug-in (32 bit); Types: full compact custom; Flags: checkablealone
 
 [Files]
-Source: ..\target\vst2\Release\Surge_32bit_x86.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
-Source: ..\target\vst3\Release\Surge_32bit_x86.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
+Source: ..\target\vst2\Release\Surge_x86.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
+Source: ..\target\vst3\Release\Surge_x86.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
 Source: ..\resources\data\*; DestDir: {localappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
 Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 

--- a/installer_win/surge-x86.iss
+++ b/installer_win/surge-x86.iss
@@ -41,8 +41,8 @@ Name: VST2; Description: VST2 Plug-in (32 bit); Types: full custom; Flags: check
 Name: VST3; Description: VST3 Plug-in (32 bit); Types: full compact custom; Flags: checkablealone
 
 [Files]
-Source: ..\target\vst2\Release\Surge32.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
-Source: ..\target\vst3\Release\Surge32.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
+Source: ..\target\vst2\Release\Surge_32bit_x86.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
+Source: ..\target\vst3\Release\Surge_32bit_x86.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
 Source: ..\resources\data\*; DestDir: {localappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
 Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -132,7 +132,7 @@ elseif (os.istarget("windows")) then
     platforms { "x64", "x86" }
 
     filter "platforms:x86"
-        targetsuffix "_32bit_x86"
+        targetsuffix "_x86"
     filter "platforms:x64"
         targetsuffix ""
     filter {}

--- a/premake5.lua
+++ b/premake5.lua
@@ -132,7 +132,7 @@ elseif (os.istarget("windows")) then
     platforms { "x64", "x86" }
 
     filter "platforms:x86"
-        targetsuffix "32"
+        targetsuffix "_32bit_x86"
     filter "platforms:x64"
         targetsuffix ""
     filter {}


### PR DESCRIPTION
fixes #610 

where surge32.dll would actually accidentally open some completely different plugin. this way the names are completely separated for .dll and .vst3.
