### PR TITLE
MPE SubMenu; Options to set pitchbend

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -33,6 +33,8 @@
 #endif
 #include "CSurgeSlider.h"
 
+#include "UserDefaults.h"
+
 using namespace std;
 
 SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
@@ -157,7 +159,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
 
    mpeEnabled = false;
    mpeVoices = 0;
-   mpePitchBendRange = 48;
+   mpePitchBendRange = Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
    mpeGlobalPitchBendRange = 2;
 
    //	load_patch(0);
@@ -728,7 +730,7 @@ void SurgeSynthesizer::onRPN(int channel, int lsbRPN, int msbRPN, int lsbValue, 
    {
       mpeEnabled = msbValue > 0;
       mpeVoices = msbValue & 0xF;
-      mpePitchBendRange = 48;
+      mpePitchBendRange = Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
       mpeGlobalPitchBendRange = 2;
       return;
    }
@@ -737,7 +739,7 @@ void SurgeSynthesizer::onRPN(int channel, int lsbRPN, int msbRPN, int lsbValue, 
        // This is the invalid message which the ROLI sends. Rather than have the Roli not work
        mpeEnabled = true;
        mpeVoices = msbValue & 0xF;
-       mpePitchBendRange = 48;
+       mpePitchBendRange = Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
        mpeGlobalPitchBendRange = 2;
        return;
    }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2639,6 +2639,33 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
 
     settingsMenu->addEntry(zoomSubMenu, "Zoom"); eid++;
 
+    COptionMenu* mpeSubMenu =
+        new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
+    std::string endis = "Enable MPE";
+    if (synth->mpeEnabled)
+       endis = "Disable MPE";
+    addCallbackMenu(mpeSubMenu, endis.c_str(),
+                    [this]() { this->synth->mpeEnabled = !this->synth->mpeEnabled; });
+
+    std::ostringstream oss;
+    oss << "Change default pitch bend range (" << synth->mpePitchBendRange << ")";
+    addCallbackMenu(mpeSubMenu, oss.str().c_str(), [this]() {
+       // FIXME! This won't work on linux
+       char c[256];
+       snprintf(c, 256, "%d", synth->mpePitchBendRange);
+       spawn_miniedit_text(c, 16);
+       int newVal = ::atoi(c);
+       Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "mpePitchBendRange", newVal);
+       this->synth->mpePitchBendRange = newVal;
+    });
+
+    std::string mpeMenuName = "MPE (disabled)";
+    if (synth->mpeEnabled)
+       mpeMenuName = "MPE (enabled)";
+    settingsMenu->addEntry(mpeSubMenu, mpeMenuName.c_str());
+    eid++;
+    mpeSubMenu->forget();
+
     settingsMenu->addSeparator(eid++);
 
     addCallbackMenu(settingsMenu, "Open User Data Folder", [this]() {


### PR DESCRIPTION
Add an MPE SubMenu. Add an option to select surge's system
wide default pitchbend range.

Closes #709 - set pitchbend range