### PR TITLE
open WT context menu with RMB too

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -260,6 +260,7 @@ bool COscillatorDisplay::onDrop(IDataPackage* drag, const CPoint& where)
 CMouseEventResult COscillatorDisplay::onMouseDown(CPoint& where, const CButtonState& button)
 {
    if (!((button & kLButton) || (button & kRButton)))
+
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
 
    assert(oscdata);

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -259,7 +259,7 @@ bool COscillatorDisplay::onDrop(IDataPackage* drag, const CPoint& where)
 
 CMouseEventResult COscillatorDisplay::onMouseDown(CPoint& where, const CButtonState& button)
 {
-   if (!(button & kLButton))
+   if (!((button & kLButton) || (button & kRButton)))
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
 
    assert(oscdata);


### PR DESCRIPTION
fixes #724 
objective: make right-mouse-button clicking open WaveTable Context menu too!
