### PR TITLE
RMB control over Wavetable Context.

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -259,7 +259,7 @@ bool COscillatorDisplay::onDrop(IDataPackage* drag, const CPoint& where)
 
 CMouseEventResult COscillatorDisplay::onMouseDown(CPoint& where, const CButtonState& button)
 {
-   if (!(button & kLButton))
+   if (!((button & kLButton) || (button & kRButton)))
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
 
    assert(oscdata);


### PR DESCRIPTION
ok so @baconpaul - does this now break windows? .. i did it all on the commandline.
even used pico.

fixes #724
objective: make right-mouse-button clicking open WaveTable Context menu too!
