### PR TITLE
Fix a tiny headless typo

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -53,7 +53,7 @@ void statsFromPlayingEveryPatch()
       {
          const auto minmaxres = std::minmax_element(data, data + nSamples * nChannels);
          auto mind = minmaxres.first;
-         auto maxd = minmaxres.first;
+         auto maxd = minmaxres.second;
 
          float rms=0, L1=0;
          for( int i=0; i<nSamples*nChannels; ++i)


### PR DESCRIPTION
Headless had a tiny typo when I removed the c++17 pair binding
construct that max and min were the same pair element.

Closes #743