### PR TITLE
Fix locale problems with preset loading and saving

### DIFF
--- a/libs/xml/tinyxml.cpp
+++ b/libs/xml/tinyxml.cpp
@@ -23,11 +23,11 @@ distribution.
 */
 
 #include <ctype.h>
+#include <clocale>
+#include <iomanip>
+#include <sstream>
 #include "tinyxml.h"
 
-#ifdef TIXML_USE_STL
-#include <sstream>
-#endif
 
 
 bool TiXmlBase::condenseWhiteSpace = true;
@@ -722,9 +722,15 @@ void TiXmlElement::SetAttribute( const char * name, int val )
 
 void TiXmlElement::SetDoubleAttribute( const char * name, double val )
 {	
-	char buf[128];
-	sprintf( buf, "%f", val );
-	SetAttribute( name, buf );
+	char buf[64];
+	std::stringstream sst;
+	sst.imbue(std::locale::classic());
+	sst << std::fixed;
+	sst << std::showpoint;
+	sst << std::setprecision(6);
+	sst << val;
+	strncpy( buf, sst.str().c_str(), 63 );
+	SetAttribute( name, buf);
 }
 
 
@@ -1126,7 +1132,10 @@ int TiXmlAttribute::QueryIntValue( int* ival ) const
 
 int TiXmlAttribute::QueryDoubleValue( double* dval ) const
 {
-	if ( sscanf( value.c_str(), "%lf", dval ) == 1 )
+	std::stringstream sst;
+	sst.imbue(std::locale::classic());
+	sst << value.c_str();
+	if ( sst >> *dval )
 		return TIXML_SUCCESS;
 	return TIXML_WRONG_TYPE;
 }
@@ -1141,7 +1150,13 @@ void TiXmlAttribute::SetIntValue( int _value )
 void TiXmlAttribute::SetDoubleValue( double _value )
 {
 	char buf [64];
-	sprintf (buf, "%lf", _value);
+	std::stringstream sst;
+	sst.imbue(std::locale::classic());
+	sst << std::fixed;
+	sst << std::showpoint;
+	sst << std::setprecision(6);
+	sst << _value;
+	strncpy( buf, sst.str().c_str(), 63 );
 	SetValue (buf);
 }
 

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -6,6 +6,8 @@
 #include "DspUtilities.h"
 #include <string.h>
 #include <math.h>
+#include <iomanip>
+#include <sstream>
 
 Parameter::Parameter()
 {
@@ -606,14 +608,20 @@ char* Parameter::get_storage_value(char* str)
 {
    switch (valtype)
    {
-   case vt_float:
-      sprintf(str, "%f", val.f);
-      break;
    case vt_int:
       sprintf(str, "%i", val.i);
       break;
    case vt_bool:
       sprintf(str, "%i", val.b ? 1 : 0);
+      break;
+   case vt_float:
+      std::stringstream sst;
+      sst.imbue(std::locale::classic());
+      sst << std::fixed;
+      sst << std::showpoint;
+      sst << std::setprecision(6);
+      sst << val.f;
+      strncpy(str, sst.str().c_str(),15);
       break;
    };
 


### PR DESCRIPTION
Preset loading and saving used sscanf and sprintf. This will fail
with locales which have some other decimal separator than '.'
Closes surge-synthesizer/surge#710