### PR TITLE
UserInteractions defaults to OK on LInux

### DIFF
--- a/src/linux/UserInteractionsLinux.cpp
+++ b/src/linux/UserInteractionsLinux.cpp
@@ -27,8 +27,8 @@ namespace Surge
             std::cerr << "Surge OkCancel\n"
                       << title << "\n"
                       << message << "\n" 
-                      << "Returning CANCEL" << std::flush;
-            return UserInteractions::CANCEL;
+                      << "Returning OK" << std::flush;
+            return UserInteractions::OK;
         }
 
         void openURL(const std::string &url)


### PR DESCRIPTION
OKCancel is only used to chicken box overwritign a patch.
Neither default is great, but chosing OK means at least
the user action is not silently ignored.

Closes #749
Will be greatly improved by the correct implementation of #562