### PR TITLE
VST3 Fixes for automation and midi

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -133,6 +133,9 @@ elseif (os.istarget("windows")) then
 
     filter "platforms:x86"
         targetsuffix "_x86"
+        defines { 
+           "WIN_X86=1"
+        }
     filter "platforms:x64"
         targetsuffix ""
     filter {}

--- a/scripts/win/build-win.ps1
+++ b/scripts/win/build-win.ps1
@@ -88,7 +88,7 @@ function Install-Surge
         New-Item -ItemType Directory -Force -Path $vst2Dir
     }
     Copy-Item "target\vst2\Release\Surge.dll" -Destination $vst2Dir -Force 
-    Copy-Item "target\vst2\Release\Surge32.dll" -Destination $vst2Dir -Force 
+    Copy-Item "target\vst2\Release\Surge_x86.dll" -Destination $vst2Dir -Force 
 
     Write-Host "Start-Process -Verb runAs -WorkingDirectory $PSScriptRoot powershell -argumentlist install-vst3.ps1"
     Start-Process -Verb runAs   "powershell" -argumentlist "$PSScriptRoot\install-vst3.ps1"

--- a/scripts/win/install-vst3.ps1
+++ b/scripts/win/install-vst3.ps1
@@ -7,4 +7,4 @@ If(!(Test-Path $vstDir))
 }
 
 Copy-Item "$PSScriptRoot\..\..\target\vst3\Release\Surge.vst3" -Destination $vstDir -Force
-Copy-Item "$PSScriptRoot\..\..\target\vst3\Release\Surge32.vst3" -Destination $vstDir -Force 
+Copy-Item "$PSScriptRoot\..\..\target\vst3\Release\Surge_x86.vst3" -Destination $vstDir -Force 

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1913,7 +1913,8 @@ void SurgeSynthesizer::getParameterNameW(long index, wchar_t* ptr)
 {
    if ((index >= 0) && (index < storage.getPatch().param_ptr.size()))
    {
-      swprintf(ptr, 128, L"%S", storage.getPatch().param_ptr[index]->get_full_name());
+      // the input is not wide so don't use %S
+      swprintf(ptr, 128, L"%s", storage.getPatch().param_ptr[index]->get_full_name());
    }
    else if (index >= metaparam_offset)
    {
@@ -1924,7 +1925,7 @@ void SurgeSynthesizer::getParameterNameW(long index, wchar_t* ptr)
       }
       else
       {
-         swprintf(ptr, 128, L"C%i:%S", c + 1, storage.getPatch().CustomControllerLabel[c]);
+         swprintf(ptr, 128, L"C%i:%s", c + 1, storage.getPatch().CustomControllerLabel[c]);
       }
    }
    else
@@ -1937,7 +1938,7 @@ void SurgeSynthesizer::getParameterShortNameW(long index, wchar_t* ptr)
 {
    if ((index >= 0) && (index < storage.getPatch().param_ptr.size()))
    {
-      swprintf(ptr, 128, L"%S", storage.getPatch().param_ptr[index]->get_name());
+      swprintf(ptr, 128, L"%s", storage.getPatch().param_ptr[index]->get_name());
    }
    else if (index >= metaparam_offset)
    {
@@ -1948,7 +1949,7 @@ void SurgeSynthesizer::getParameterShortNameW(long index, wchar_t* ptr)
       }
       else
       {
-         swprintf(ptr, 128, L"C%i:%S", c + 1, storage.getPatch().CustomControllerLabel[c]);
+         swprintf(ptr, 128, L"C%i:%s", c + 1, storage.getPatch().CustomControllerLabel[c]);
       }
    }
    else
@@ -1976,7 +1977,7 @@ void SurgeSynthesizer::getParameterStringW(long index, float value, wchar_t* ptr
       char text[128];
       storage.getPatch().param_ptr[index]->get_display(text);
 
-      swprintf(ptr, 128, L"%S", text);
+      swprintf(ptr, 128, L"%s", text);
    }
    else if (index >= metaparam_offset)
    {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -40,7 +40,6 @@ const int yofs = 10;
 using namespace VSTGUI;
 using namespace std;
 
-
 CFontRef displayFont = NULL;
 CFontRef patchNameFont = NULL;
 CFontRef lfoTypeFont = NULL;
@@ -2448,6 +2447,11 @@ bool SurgeGUIEditor::showPatchStoreDialog(patchdata* p,
 long SurgeGUIEditor::applyParameterOffset(long id)
 {
     return id-start_paramtags;
+}
+
+long SurgeGUIEditor::unapplyParameterOffset(long id)
+{
+   return id + start_paramtags;
 }
 
 void SurgeGUIEditor::setZoomFactor(int zf)

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -49,8 +49,9 @@ public:
    virtual void beginEdit(long index);
    virtual void endEdit(long index);
 
-   virtual long applyParameterOffset(long index);
-   
+   static long applyParameterOffset(long index);
+   static long unapplyParameterOffset(long index);
+
 #if !TARGET_VST3
    bool open(void* parent) override;
    void close() override;

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -530,12 +530,14 @@ VstInt32 Vst2PluginInstance::setChunk(void* data, VstInt32 byteSize, bool isPres
 
 bool Vst2PluginInstance::beginEdit( VstInt32 index )
 {
-    return AudioEffectX::beginEdit( ((SurgeGUIEditor *)editor)->applyParameterOffset( _instance->remapExternalApiToInternalId(index ) ) );
+   return AudioEffectX::beginEdit(
+       SurgeGUIEditor::applyParameterOffset(_instance->remapExternalApiToInternalId(index)));
 }
 
 bool Vst2PluginInstance::endEdit( VstInt32 index )
 {
-    return AudioEffectX::endEdit( ((SurgeGUIEditor *)editor)->applyParameterOffset( _instance->remapExternalApiToInternalId(index)));
+   return AudioEffectX::endEdit(
+       SurgeGUIEditor::applyParameterOffset(_instance->remapExternalApiToInternalId(index)));
 }
 
 bool Vst2PluginInstance::tryInit()


### PR DESCRIPTION
This commit implements the core non-MPE VST3 features which were missing
on mac and windows.

* Parameter names are long names in VST3 and were swprintfed as such
  even though they are non-wchar in surge internals
* Parameter changes in VST3 flow to the UI and adjust widgets
* Bound parameters in the DAW are named correctly
* Midi controllers and pitch bend are captured and sent to surge
* Unicode support is corrected for systems where wchar_t != char16
  (like mac) while still working on Windows, albeit in a somewhat
  clumsy fashion
* Handle oddities around call type allow the plugin to also work
  32 and 64 bit windows (Although demand for 32 bit VST3 seems
  more a formality than practicality, it does work)

Closes #766 VST3 names not correct when learning
Closes #752 VST3 Automation in Bitwig
Closes #26 VST3-Win MIDI Control Issues