### PR TITLE
Supress LFO Reset Gestures

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1914,14 +1914,23 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          }
          else
          {
-            p->set_value_f01(p->get_default_value_f01());
-            control->setValue(p->get_value_f01());
-            if (oscdisplay && (p->ctrlgroup == cg_OSC))
-               oscdisplay->invalid();
-            if (lfodisplay && (p->ctrlgroup == cg_LFO))
-               lfodisplay->invalid();
-            control->invalid();
-            return 0;
+            /*
+            ** This code resets you to default if you double click or ctrl click
+            ** but on the lfoshape UI this is undesirable; it means if you accidentally
+            ** control click on step sequencer, say, you go back to sin and lose your
+            ** edits. So supress
+            */
+            if (p->ctrltype != ct_lfoshape)
+            {
+               p->set_value_f01(p->get_default_value_f01());
+               control->setValue(p->get_value_f01());
+               if (oscdisplay && (p->ctrlgroup == cg_OSC))
+                  oscdisplay->invalid();
+               if (lfodisplay && (p->ctrlgroup == cg_LFO))
+                  lfodisplay->invalid();
+               control->invalid();
+               return 0;
+            }
          }
       }
       else


### PR DESCRIPTION
The LFO display (the wav) handles double click and ctrl click
like any other control - reset to default value. That's really
bad in the LFO display though, since if you ccidentally control
click or double click on your step sequencer you go back to sin.
So supress this gesture for ct_lfoshape.

Closes #376