### PR TITLE
Headless can write wav files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(Surge VERSION 1.0.0 LANGUAGES CXX ASM)
 
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
+
 set(SURGE_COMMON_SOURCES
     src/common/dsp/effect/ConditionerEffect.cpp
     src/common/dsp/effect/DistortionEffect.cpp
@@ -90,6 +92,19 @@ target_include_directories(surge-headless
         ${SURGE_COMMON_INCLUDES}
         src/headless
 )
+
+find_package(LibSndFile ${PACKAGE_OPTION})
+if(NOT LIBSNDFILE_FOUND)
+    message(WARNING "LibSndFile not installed; building without wav support")
+    message(WARNING "You can 'brew install libsndfile' or 'apt-get install libsndfile1-dev'")
+else()
+    target_compile_definitions(surge-headless
+        PRIVATE
+            LIBSNDFILE=1
+    )
+    target_link_libraries(surge-headless ${LIBSNDFILE_LIBRARIES})
+    include_directories(surge-headless ${LIBSNDFILE_INCLUDE_DIRS})
+endif()
 
 # *NIX
 if (UNIX)

--- a/cmake/FindLibSndFile.cmake
+++ b/cmake/FindLibSndFile.cmake
@@ -1,0 +1,40 @@
+# LICENSE TERMS:
+#
+# This file is copied from https://github.com/neXyon/audaspace/blob/master/cmake/FindLibSndFile.cmake
+# which is licensed under the Apache 2.0 license https://github.com/neXyon/audaspace/blob/master/LICENSE
+# and as such this file, unlike the rest of Surge, is a goverend under Apache 2.0.
+# 
+# - Try to find libsndfile
+# Once done, this will define
+#
+#  LIBSNDFILE_FOUND - system has libsndfile
+#  LIBSNDFILE_INCLUDE_DIRS - the libsndfile include directories
+#  LIBSNDFILE_LIBRARIES - link these to use libsndfile
+
+# Use pkg-config to get hints about paths
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+	pkg_check_modules(LIBSNDFILE_PKGCONF sndfile)
+endif(PKG_CONFIG_FOUND)
+
+# Include dir
+find_path(LIBSNDFILE_INCLUDE_DIR
+	NAMES sndfile.h
+	PATHS ${LIBSNDFILE_PKGCONF_INCLUDE_DIRS}
+)
+
+# Library
+find_library(LIBSNDFILE_LIBRARY
+	NAMES sndfile libsndfile-1
+	PATHS ${LIBSNDFILE_PKGCONF_LIBRARY_DIRS}
+)
+
+find_package(PackageHandleStandardArgs)
+find_package_handle_standard_args(LibSndFile  DEFAULT_MSG  LIBSNDFILE_LIBRARY LIBSNDFILE_INCLUDE_DIR)
+
+if(LIBSNDFILE_FOUND)
+  set(LIBSNDFILE_LIBRARIES ${LIBSNDFILE_LIBRARY})
+  set(LIBSNDFILE_INCLUDE_DIRS ${LIBSNDFILE_INCLUDE_DIR})
+endif(LIBSNDFILE_FOUND)
+
+mark_as_advanced(LIBSNDFILE_LIBRARY LIBSNDFILE_LIBRARIES LIBSNDFILE_INCLUDE_DIR LIBSNDFILE_INCLUDE_DIRS)

--- a/src/headless/HeadlessUtils.cpp
+++ b/src/headless/HeadlessUtils.cpp
@@ -4,6 +4,10 @@
 #include <iostream>
 #include <iomanip>
 
+#if LIBSNDFILE
+#include <sndfile.h>
+#endif
+
 namespace Surge
 {
 namespace Headless
@@ -35,5 +39,22 @@ void writeToStream(const float* data, int nSamples, int nChannels, std::ostream&
    }
 }
 
+void writeToWav(const float* data, int nSamples, int nChannels, float sampleRate, std::string wavFileName)
+{
+#if LIBSNDFILE
+   SF_INFO sfinfo;
+   sfinfo.channels = nChannels;
+   sfinfo.samplerate = sampleRate;
+   sfinfo.format = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
+   
+   SNDFILE *of = sf_open(wavFileName.c_str(), SFM_WRITE, &sfinfo);
+   sf_count_t count = sf_write_float(of, &data[0], nSamples * nChannels);
+   sf_write_sync(of);
+   sf_close(of);
+#else
+   std::cout << "writeToWav requires libsndfile which is not available on your platform." << std::endl;
+#endif
+}
+   
 } // namespace Headless
 } // namespace Surge

--- a/src/headless/HeadlessUtils.h
+++ b/src/headless/HeadlessUtils.h
@@ -14,11 +14,11 @@ namespace Headless
 SurgeSynthesizer* createSurge(int sr);
 
 void writeToStream(const float* data, int nSamples, int nChannels, std::ostream& str);
+void writeToWav(const float* data, int nSamples, int nChannels, float sampleRate, std::string wavFileName);
 
 /*
 ** One imagines expansions along these lines:
 
-void writeWavFile(const float * data, int nSamples, int nChannels, std::string fname);
 void writeGnuplotFile(const float *data, int nSamples, int nChannels, std::string fname);
 
 */

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 
 #include "HeadlessUtils.h"
 #include "Player.h"
@@ -47,6 +48,7 @@ void statsFromPlayingEveryPatch()
 
    auto callBack = [](const Patch& p, const PatchCategory& pc, const float* data, int nSamples,
                       int nChannels) -> void {
+      bool writeWav = false; // toggle this to true to write each sample to a wav file
       std::cout << "cat/patch = " <<  pc.name << " / " << std::left << std::setw(30) << p.name;
 
       if (nSamples * nChannels > 0)
@@ -69,6 +71,12 @@ void statsFromPlayingEveryPatch()
                    << " L1=" << L1
                    << " rms=" << rms
                    << " samp=" << nSamples << " chan=" << nChannels;
+         if (writeWav)
+         {
+            std::ostringstream oss;
+            oss << "headless " << pc.name << " " << p.name << ".wav";
+            Surge::Headless::writeToWav(data, nSamples, nChannels, 44100, oss.str());
+         }
       }
       std::cout << std::endl;
    };


### PR DESCRIPTION
To debug click n pop I want headless to be able to make a file
I can hear. This change allows that by (1) making CMakeLists
check for libsndfile and (2) if it is there building a libsndfile
writer