### PR TITLE
Correct defaults XML stream

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -128,7 +128,7 @@ bool storeUserDefaultValue(SurgeStorage *storage, const std::string &key, const 
 
     for (auto &el : defaultsFileContents)
     {
-        dFile << "  <default key=\"" << el.first << "\" value=\"" << el.second.value << "\" type=\"" << (int)el.second.type << "\">\n";
+        dFile << "  <default key=\"" << el.first << "\" value=\"" << el.second.value << "\" type=\"" << (int)el.second.type << "\"/>\n";
     }
 
     dFile << "</defaults>" << std::endl;


### PR DESCRIPTION
Adding and using a second default showed a bug in the XML stream
writer. This fixes it. If you have a corrupt file just save a default
again with this version.

Closes #781