### PR TITLE
Play MidiFiles in Headless mode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = vstgui.surge
 	url = https://github.com/surge-synthesizer/vstgui.git
 	branch = surge
+[submodule "libs/midifile"]
+	path = libs/midifile
+	url = https://github.com/craigsapp/midifile.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 project(Surge VERSION 1.0.0 LANGUAGES CXX ASM)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
+find_package(LibMidiFile ${PACKAGE_OPTIONS})
+
 
 set(SURGE_COMMON_SOURCES
     src/common/dsp/effect/ConditionerEffect.cpp
@@ -69,6 +71,7 @@ set(SURGE_COMMON_INCLUDES
 
 add_executable(surge-headless
     ${SURGE_COMMON_SOURCES}
+    ${LIB_MIDIFILE_SOURCES}
    src/headless/main.cpp
    src/headless/DisplayInfoHeadless.cpp
    src/headless/UserInteractionsHeadless.cpp
@@ -85,11 +88,13 @@ target_compile_features(surge-headless
 target_compile_definitions(surge-headless
     PRIVATE
         TARGET_HEADLESS=1
+        LIBMIDIFILE=1
 )
 
 target_include_directories(surge-headless
     PRIVATE
         ${SURGE_COMMON_INCLUDES}
+        ${LIB_MIDIFILE_INCLUDES}
         src/headless
 )
 

--- a/cmake/FindLibMidiFile.cmake
+++ b/cmake/FindLibMidiFile.cmake
@@ -1,0 +1,17 @@
+# Build and include libs/midifile
+
+set(LIB_MIDIFILE_DIR libs/midifile)
+set(LIB_MIDIFILE_SRC_DIR "${LIB_MIDIFILE_DIR}/src-library/")
+set(LIB_MIDIFILE_INCLUDES "${LIB_MIDIFILE_DIR}/include/")
+
+set(LIB_MIDIFILE_SOURCES
+   ${LIB_MIDIFILE_SRC_DIR}/Binasc.cpp
+   ${LIB_MIDIFILE_SRC_DIR}/MidiEvent.cpp
+   ${LIB_MIDIFILE_SRC_DIR}/MidiEventList.cpp
+   ${LIB_MIDIFILE_SRC_DIR}/MidiFile.cpp
+   ${LIB_MIDIFILE_SRC_DIR}/MidiMessage.cpp
+)
+
+# If we upgrade to cmake 3.12 we could do this instead
+# list(TRANSFORM LIB_MIDIFILE_SOURCES PREPEND ${LIB_MIDIFILE_SRC_DIR})
+

--- a/src/headless/Player.cpp
+++ b/src/headless/Player.cpp
@@ -1,5 +1,12 @@
 #include "Player.h"
 
+#if LIBMIDIFILE
+#include "MidiFile.h"
+#endif
+#if LIBSNDFILE
+#include <sndfile.h>
+#endif
+
 namespace Surge
 {
 namespace Headless
@@ -147,6 +154,102 @@ void playOnEveryPatch(
          }
       }
    }
+}
+
+void playMidiFile(SurgeSynthesizer* synth,
+                  std::string midiFileName,
+                  long callBackEvery,
+                  std::function<void(float* data, int nSamples, int nChannels)> dataCB)
+{
+#if LIBMIDIFILE
+   smf::MidiFile mf;
+   mf.read(midiFileName.c_str());
+   mf.doTimeAnalysis();
+   mf.linkNotePairs();
+   mf.joinTracks();
+
+   // float sampleRate = synth->getSampleRate();
+   float sampleRate = 44100.0;
+
+   int tracks = mf.getTrackCount();
+   if (tracks != 1)
+   {
+      std::cerr << "Track Join failed\n";
+      return;
+   }
+
+   int currentEvent = 0;
+   double currentTime = mf[0][currentEvent].seconds;
+
+   if ((callBackEvery) % (BLOCK_SIZE * 2) != 0)
+   {
+      std::cerr << "Please make callBackEvery a multiple of " << BLOCK_SIZE << "*2" << std::endl;
+      return;
+   }
+
+   float* ldata = new float[callBackEvery * 2];
+   long flidx = 0;
+   double deltaT = BLOCK_SIZE / sampleRate;
+
+   while (currentEvent < mf[0].size() ||
+          (synth->getNonUltrareleaseVoices(0) > 0 || synth->getNonUltrareleaseVoices(1) > 0))
+   {
+      while (currentEvent < mf[0].size() && mf[0][currentEvent].seconds < currentTime + deltaT)
+      {
+         smf::MidiEvent& evt = mf[0][currentEvent];
+         if (evt.isNoteOn())
+            synth->playNote(1, evt.getKeyNumber(), evt.getVelocity(), 0);
+         if (evt.isNoteOff())
+            synth->releaseNote(1, evt.getKeyNumber(), evt.getVelocity());
+
+         currentEvent++;
+      }
+      currentTime += deltaT;
+
+      synth->process();
+      for (int sm = 0; sm < BLOCK_SIZE; ++sm)
+      {
+         for (int oi = 0; oi < synth->getNumOutputs(); ++oi)
+         {
+            ldata[flidx++] = synth->output[oi][sm];
+         }
+      }
+      if (flidx >= callBackEvery * 2)
+      {
+         flidx = 0;
+         dataCB(ldata, callBackEvery, 2);
+      }
+   }
+
+#else
+   std::cout << "LIB_MIDIFILE not included on this platform." << std::endl;
+#endif
+}
+
+void renderMidiFileToWav(SurgeSynthesizer* surge,
+                         std::string midiFileName,
+                         std::string outputWavFile)
+{
+#if LIBSNDFILE
+   SF_INFO sfinfo;
+   sfinfo.channels = 2;
+   sfinfo.samplerate = 44100; // FIX
+   sfinfo.format = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
+
+   SNDFILE* of = sf_open(outputWavFile.c_str(), SFM_WRITE, &sfinfo);
+
+   playMidiFile(surge, midiFileName,
+                1024 * 100, // write every 100k
+                [of](float* data, int nSamples, int nChannels) {
+                   sf_write_float(of, &data[0], nSamples * nChannels);
+                   sf_write_sync(of);
+                });
+   sf_close(of);
+
+#else
+   std::cout << "renderMidiFileToWav requires libsndfile which is not available on your platform."
+             << std::endl;
+#endif
 }
 
 } // namespace Headless

--- a/src/headless/Player.h
+++ b/src/headless/Player.h
@@ -87,5 +87,27 @@ void playOnEveryPatch(
         const Patch& p, const PatchCategory& c, const float* data, int nSamples, int nChannels)>
         completedCallback);
 
+/**
+ * playMidiFile
+ *
+ * Given a SurgeSynthesizer and a MidiFile Name, play the midi file on the current
+ * configuration of the synth. Rather than generate a mass of data, this calls you
+ * back with a pointer to the data every (n) samples
+ */
+void playMidiFile(SurgeSynthesizer* synth,
+                  std::string midiFileName,
+                  long callBackEvery,
+                  std::function<void(float* data, int nSamples, int nChannels)> dataCB);
+
+/**
+ * renderMidiFileToWav
+ *
+ * Given a surge synthesizer and MidiFile name, create a Wav file which results
+ * from playing that midi file.
+ */
+void renderMidiFileToWav(SurgeSynthesizer* synth,
+                         std::string midiFileName,
+                         std::string outputWavFile);
+
 } // namespace Headless
 } // namespace Surge

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -84,14 +84,45 @@ void statsFromPlayingEveryPatch()
    Surge::Headless::playOnEveryPatch(surge, scale, callBack);
 }
 
+void playSomeBach()
+{ 
+   SurgeSynthesizer* surge = Surge::Headless::createSurge(44100);
+
+   std::string tmpdir = "/tmp";
+   std::string fname = tmpdir + "/988-v05.mid";
+
+   FILE* tf = fopen(fname.c_str(), "r");
+   if (!tf)
+   {
+      std::string cmd = "curl -o " + fname + " http://www.jsbach.net/midi/bwv988/988-v05.mid";
+      system(cmd.c_str()); 
+   }
+   else
+      fclose(tf);
+
+   std::string otp = "DX EP 1";
+   for (int i = 0; i < surge->storage.patch_list.size(); ++i)
+   {
+      Patch p = surge->storage.patch_list[i];
+      if (p.name == otp)
+      {
+         std::cout << "Found '" << otp << "' patch @" << i << std::endl;
+         surge->loadPatch(i);
+         break;
+      }
+   }
+   Surge::Headless::renderMidiFileToWav(surge, fname, fname + ".wav");
+}
+
 /*
 ** This is a simple main that, for now, you make call out to the application
 ** stub of your choosing. We have two in Applications and we call them both
 */
 int main(int argc, char** argv)
 {
-   simpleOscillatorToStdOut();
-   statsFromPlayingEveryPatch();
+   // simpleOscillatorToStdOut();
+   // statsFromPlayingEveryPatch();
+   playSomeBach();
 
    return 0;
 }


### PR DESCRIPTION
To better debug click n pop I thought it woudl be useful if the
headless player could play midi files. Here's the first step
on that path to that, handling note on and note off events
and rendering a wav file, and showing a little example which renders
some bach.
