### PR TITLE
Fix click n pop; add headless stress modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(surge-headless
    src/headless/LinkFixesHeadless.cpp
    src/headless/HeadlessUtils.cpp
    src/headless/Player.cpp
+   src/headless/Stress.cpp   
 )
 
 target_compile_features(surge-headless

--- a/premake5.lua
+++ b/premake5.lua
@@ -678,8 +678,8 @@ if (os.istarget("windows")) then
         "src/headless/UserInteractionsHeadless.cpp",
         "src/headless/LinkFixesHeadless.cpp",
         "src/headless/HeadlessUtils.cpp",
-        "src/headless/Player.cpp"
-        
+        "src/headless/Player.cpp",
+        "src/headless/Stress.cpp"
     }
 
     excludes

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -84,6 +84,13 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
    FBQ[1] =
        (QuadFilterChainState*)_aligned_malloc((MAX_VOICES >> 2) * sizeof(QuadFilterChainState), 16);
 
+   for(int i=0; i<(MAX_VOICES >> 2); ++i)
+   {
+       FBQ[0][i].initToZero();
+       FBQ[1][i].initToZero();
+   }
+
+
    SurgePatch& patch = storage.getPatch();
 
    patch.polylimit.val.i = 8;

--- a/src/common/dsp/QuadFilterChain.h
+++ b/src/common/dsp/QuadFilterChain.h
@@ -14,6 +14,39 @@ struct QuadFilterChainState
 
    __m128 OutL, OutR, dOutL, dOutR;
    __m128 Out2L, Out2R, dOut2L, dOut2R; // fb_stereo only
+
+   void initToZero()
+   {
+       Gain = _mm_setzero_ps();
+       FB = _mm_setzero_ps();
+       Mix1 = _mm_setzero_ps();
+       Mix2 = _mm_setzero_ps();
+       Drive = _mm_setzero_ps();
+       dGain = _mm_setzero_ps();
+       dFB = _mm_setzero_ps();
+       dMix1 = _mm_setzero_ps();
+       dMix2 = _mm_setzero_ps();
+       dDrive = _mm_setzero_ps();
+
+       wsLPF = _mm_setzero_ps();
+       FBlineL = _mm_setzero_ps();
+       FBlineR = _mm_setzero_ps();
+
+       for(auto i=0; i<BLOCK_SIZE_OS; ++i)
+       {
+           DL[i] = _mm_setzero_ps();
+           DR[i] = _mm_setzero_ps();
+       }
+
+       OutL = _mm_setzero_ps();
+       OutR = _mm_setzero_ps();
+       dOutL = _mm_setzero_ps();
+       dOutR = _mm_setzero_ps();
+       Out2L = _mm_setzero_ps();
+       Out2R = _mm_setzero_ps();
+       dOut2L = _mm_setzero_ps();
+       dOut2R = _mm_setzero_ps();
+   }
 };
 
 struct fbq_global

--- a/src/common/vt_dsp/halfratefilter.cpp
+++ b/src/common/vt_dsp/halfratefilter.cpp
@@ -405,6 +405,11 @@ void HalfRateFilter::set_coefficients(float* cA, float* cB)
 
 void HalfRateFilter::load_coefficients()
 {
+   for (int i = 0; i < M; i++)
+   {
+     va[i] = _mm_setzero_ps();
+   }
+
    int order = M << 1;
    if (steep)
    {

--- a/src/headless/Stress.cpp
+++ b/src/headless/Stress.cpp
@@ -1,0 +1,57 @@
+#include "Stress.h"
+#include "Player.h"
+#include <random>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+void Surge::Headless::createAndDestroyWithScaleAndRandomPatch(int timesToTry)
+{
+   SurgeSynthesizer* synth = Surge::Headless::createSurge(44100);
+   std::default_random_engine generator;
+   generator.seed(17);
+   std::uniform_int_distribution<int> distribution(0, synth->storage.patch_list.size() - 1);
+   delete synth;
+
+   int faultCount = 0;
+   
+   playerEvents_t scale = make120BPMCMajorQuarterNoteScale();
+   for (int i = 0; i < timesToTry && faultCount < 3; ++i)
+   {
+      SurgeSynthesizer* synth = Surge::Headless::createSurge(44100);
+      int patch = distribution(generator);
+      std::cout << std::setw(5) << i << ": Patch " << std::setw(5) << patch << " = " << std::setw(50)
+                << synth->storage.patch_list[patch].name;
+      synth->loadPatch(patch);
+
+      float* data = nullptr;
+      int nSamples, nChannels;
+      Surge::Headless::playAsConfigured(synth, scale, &data, &nSamples, &nChannels);
+
+      const auto minmaxres = std::minmax_element(data, data + nSamples * nChannels);
+      auto mind = minmaxres.first;
+      auto maxd = minmaxres.second;
+
+      std::cout << "   Range: [" << *mind << ", " << *maxd << "]" << std::endl;
+      if (fabs(*mind) > 5 || fabs(*maxd) > 5)
+      {
+         std::cout << " **** FAULT " << faultCount << " **** " << std::endl;
+         for( int j=0; j<nSamples*nChannels; ++j )
+             if(data[j] == *maxd)
+                 std::cout << "Element " << j << " " << j / nChannels << " " << data[j] << std::endl;
+         
+         std::ostringstream oss;
+         oss << "faultWav" << faultCount << ".csv";
+         std::ofstream of(oss.str().c_str());
+         for( int j=0; j<nSamples; ++j)
+         {
+             of << j << "," << data[j * nChannels ] << ", " << data[ j*nChannels + 1 ] << std::endl;
+         }
+         of.close();
+         faultCount ++;
+      }
+
+      delete[] data;
+      delete synth;
+   }
+}

--- a/src/headless/Stress.h
+++ b/src/headless/Stress.h
@@ -1,0 +1,21 @@
+/*
+** These are routines that stress single surges or buckets of surges. I mostly
+** wrote them while chasing click-n-pop
+*/
+
+#pragma once
+
+#include "HeadlessUtils.h"
+
+namespace Surge
+{
+namespace Headless
+{
+
+/*
+** Create and destroy a lot of surges with a random patch and play a major scale on each
+*/
+void createAndDestroyWithScaleAndRandomPatch(int timesToTry = 5000);
+
+} // namespace Headless
+} // namespace Surge

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -4,6 +4,7 @@
 
 #include "HeadlessUtils.h"
 #include "Player.h"
+#include "Stress.h"
 
 void simpleOscillatorToStdOut()
 {
@@ -123,6 +124,7 @@ int main(int argc, char** argv)
    // simpleOscillatorToStdOut();
    // statsFromPlayingEveryPatch();
    playSomeBach();
+   Surge::Headless::createAndDestroyWithScaleAndRandomPatch(20000);
 
    return 0;
 }


### PR DESCRIPTION
These two commits add headless stress test code (in the first commit) and then using that, let me find the uninitialized filter memory that causes the synth to go unstable occasionally, which is fixed in the second commit.