### PR TITLE
Clean up some valgrnd reported errors

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -53,7 +53,8 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
    release_anyway[0] = false;
    release_anyway[1] = false;
    load_fx_needed = true;
-
+   process_input = false; // hosts set this if there are input busses
+   
    fx_suspend_bitmask = 0;
 
    demo_counter = 10;
@@ -365,6 +366,7 @@ void SurgeSynthesizer::freeVoice(SurgeVoice* v)
          voices_usedby[1][i] = 0;
       }
    }
+   v->freeAllocatedElements();
 }
 
 int SurgeSynthesizer::getMpeMainChannel(int voiceChannel, int key)

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -843,3 +843,12 @@ void SurgeVoice::GetQFB()
    FBP.FBlineR = get1f(fbq->FBlineR, fbqi);
    FBP.wsLPF = get1f(fbq->wsLPF, fbqi);
 }
+
+void SurgeVoice::freeAllocatedElements()
+{
+   for(int i=0;i<3;++i)
+   {
+      osc[i].reset(nullptr);
+      osctype[i] = -1;
+   }
+}

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -44,6 +44,7 @@ public:
    void GetQFB(); // Get the updated registers from the QuadFB
    void legato(int key, int velocity, char detune);
    void switch_toggled();
+   void freeAllocatedElements();
    int osctype[n_oscs];
    SurgeVoiceState state;
    int age, age_release;

--- a/src/headless/HeadlessUtils.cpp
+++ b/src/headless/HeadlessUtils.cpp
@@ -12,10 +12,12 @@ namespace Surge
 {
 namespace Headless
 {
+static std::unique_ptr<HeadlessPluginLayerProxy> parent = nullptr;
 SurgeSynthesizer* createSurge(int sr)
 {
-   HeadlessPluginLayerProxy* parent = new HeadlessPluginLayerProxy();
-   SurgeSynthesizer* surge = new SurgeSynthesizer(parent);
+   if (parent.get()==nullptr)
+      parent.reset(new HeadlessPluginLayerProxy());
+   SurgeSynthesizer* surge = new SurgeSynthesizer(parent.get());
    surge->setSamplerate(sr);
    return surge;
 }


### PR DESCRIPTION
The SurgeVoice allocator leaking a few oscillators. Now it doesn't.
Also we initialize the SurgeSynthesizer properly (but the AU were doing
it so that doesn't matter in normal use) and fix a trivial leak which was particular
to Headless.

Addresses #797 but still a load to do