### PR TITLE
chmod in makedeb

### DIFF
--- a/installer_linux/make_deb.sh
+++ b/installer_linux/make_deb.sh
@@ -43,6 +43,7 @@ mkdir -p ${PACKAGE_NAME}/usr/lib/vst
 mkdir -p ${PACKAGE_NAME}/usr/lib/vst3
 mkdir -p ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc
 mkdir -p ${PACKAGE_NAME}/DEBIAN
+chmod -R 0755 ${PACKAGE_NAME}
 
 # build control file
 


### PR DESCRIPTION
make_deb in the pipelines was throwing a directory permission error. This does an explcit chmod to see if it corrects the problem.