### PR TITLE
Move the QFC Init

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -87,8 +87,8 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
 
    for(int i=0; i<(MAX_VOICES >> 2); ++i)
    {
-       FBQ[0][i].initToZero();
-       FBQ[1][i].initToZero();
+       InitQuadFilterChainStateToZero(&(FBQ[0][i]));
+       InitQuadFilterChainStateToZero(&(FBQ[1][i]));
    }
 
 

--- a/src/common/dsp/QuadFilterChain.cpp
+++ b/src/common/dsp/QuadFilterChain.cpp
@@ -411,3 +411,36 @@ FBQFPtr GetFBQPointer(int config, bool A, bool WS, bool B)
    }
    return 0;
 }
+
+void InitQuadFilterChainStateToZero(QuadFilterChainState *Q)
+{
+    Q->Gain = _mm_setzero_ps();
+    Q->FB = _mm_setzero_ps();
+    Q->Mix1 = _mm_setzero_ps();
+    Q->Mix2 = _mm_setzero_ps();
+    Q->Drive = _mm_setzero_ps();
+    Q->dGain = _mm_setzero_ps();
+    Q->dFB = _mm_setzero_ps();
+    Q->dMix1 = _mm_setzero_ps();
+    Q->dMix2 = _mm_setzero_ps();
+    Q->dDrive = _mm_setzero_ps();
+    
+    Q->wsLPF = _mm_setzero_ps();
+    Q->FBlineL = _mm_setzero_ps();
+    Q->FBlineR = _mm_setzero_ps();
+    
+    for(auto i=0; i<BLOCK_SIZE_OS; ++i)
+    {
+        Q->DL[i] = _mm_setzero_ps();
+        Q->DR[i] = _mm_setzero_ps();
+    }
+    
+    Q->OutL = _mm_setzero_ps();
+    Q->OutR = _mm_setzero_ps();
+    Q->dOutL = _mm_setzero_ps();
+    Q->dOutR = _mm_setzero_ps();
+    Q->Out2L = _mm_setzero_ps();
+    Q->Out2R = _mm_setzero_ps();
+    Q->dOut2L = _mm_setzero_ps();
+    Q->dOut2R = _mm_setzero_ps();
+}

--- a/src/common/dsp/QuadFilterChain.h
+++ b/src/common/dsp/QuadFilterChain.h
@@ -15,39 +15,14 @@ struct QuadFilterChainState
    __m128 OutL, OutR, dOutL, dOutR;
    __m128 Out2L, Out2R, dOut2L, dOut2R; // fb_stereo only
 
-   void initToZero()
-   {
-       Gain = _mm_setzero_ps();
-       FB = _mm_setzero_ps();
-       Mix1 = _mm_setzero_ps();
-       Mix2 = _mm_setzero_ps();
-       Drive = _mm_setzero_ps();
-       dGain = _mm_setzero_ps();
-       dFB = _mm_setzero_ps();
-       dMix1 = _mm_setzero_ps();
-       dMix2 = _mm_setzero_ps();
-       dDrive = _mm_setzero_ps();
-
-       wsLPF = _mm_setzero_ps();
-       FBlineL = _mm_setzero_ps();
-       FBlineR = _mm_setzero_ps();
-
-       for(auto i=0; i<BLOCK_SIZE_OS; ++i)
-       {
-           DL[i] = _mm_setzero_ps();
-           DR[i] = _mm_setzero_ps();
-       }
-
-       OutL = _mm_setzero_ps();
-       OutR = _mm_setzero_ps();
-       dOutL = _mm_setzero_ps();
-       dOutR = _mm_setzero_ps();
-       Out2L = _mm_setzero_ps();
-       Out2R = _mm_setzero_ps();
-       dOut2L = _mm_setzero_ps();
-       dOut2R = _mm_setzero_ps();
-   }
 };
+
+/*
+** I originally had this as a member but since moved it out of line so as to
+** not run any risk of alignment problems in QuadFilterChainState where
+** only the head of the array is __align_malloced
+*/
+void InitQuadFilterChainStateToZero(QuadFilterChainState *Q);
 
 struct fbq_global
 {


### PR DESCRIPTION
I had implmented initToZero as a mebmer of QuadFilterChain but
QuadFilterChain is align malloced in a wierd way. While this
hadn't caused a problem yet, it gave me concern that the additional
vtable element would misalign the FBQ _aligned_malloc array
and so I moved it to a standalone function.