### PR TITLE
Headless clean for VALGRND

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(Surge VERSION 1.0.0 LANGUAGES CXX ASM)
+#set(CMAKE_BUILD_TYPE Debug)
+
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 find_package(LibMidiFile ${PACKAGE_OPTIONS})

--- a/src/headless/Player.cpp
+++ b/src/headless/Player.cpp
@@ -78,12 +78,14 @@ void playAsConfigured(SurgeSynthesizer* surge,
       return;
 
    int desiredSamples = events.back().atSample;
-   int blockCount = desiredSamples / BLOCK_SIZE;
+   int blockCount = desiredSamples / BLOCK_SIZE + 1;
    int currEvt = 0;
 
    *nChannels = 2;
-   *nSamples = desiredSamples;
-   float* ldata = new float[desiredSamples * 2];
+   *nSamples = blockCount * BLOCK_SIZE;
+   size_t dataSize = *nChannels * *nSamples;
+   float* ldata = new float[dataSize];
+   memset(ldata, 0, dataSize);
    *data = ldata;
 
    size_t flidx = 0;
@@ -91,7 +93,7 @@ void playAsConfigured(SurgeSynthesizer* surge,
    for (auto i = 0; i < blockCount; ++i)
    {
       int cs = i * BLOCK_SIZE;
-      while (events[currEvt].atSample <= cs + BLOCK_SIZE - 1 && currEvt < events.size())
+      while (currEvt < events.size() && events[currEvt].atSample <= cs + BLOCK_SIZE - 1)
       {
          Event e = events[currEvt];
          if (e.type == Event::NOTE_ON)

--- a/src/headless/Stress.cpp
+++ b/src/headless/Stress.cpp
@@ -5,6 +5,31 @@
 #include <iomanip>
 #include <sstream>
 
+void Surge::Headless::pullInitSamplesWithNoNotes(int sampleCount)
+{
+   SurgeSynthesizer* synth = Surge::Headless::createSurge(44100);
+   Surge::Headless::playerEvents_t events;
+   Surge::Headless::Event on;
+   on.type = Surge::Headless::Event::NO_EVENT;
+   on.atSample = sampleCount;
+   events.push_back(on);
+
+   float *data;
+   int nSamples, nChannels;
+   Surge::Headless::playAsConfigured(synth, events, &data, &nSamples, &nChannels);
+
+   float sumAbs = 0;
+   for(int i=0;i<nSamples*nChannels; ++i )
+   {
+       sumAbs += fabs(data[i]);
+       std::cout << i << " " << data[i] << std::endl;
+   }
+   std::cout << "Sum of Absolute Value of play is " << sumAbs << std::endl;
+   
+   delete[] data;
+   delete synth;
+}
+
 void Surge::Headless::createAndDestroyWithScaleAndRandomPatch(int timesToTry)
 {
    SurgeSynthesizer* synth = Surge::Headless::createSurge(44100);

--- a/src/headless/Stress.h
+++ b/src/headless/Stress.h
@@ -13,6 +13,11 @@ namespace Headless
 {
 
 /*
+** Run no notes and make sure I get all zeroes
+*/
+void pullInitSamplesWithNoNotes( int sampleCount = 10000 );
+    
+/*
 ** Create and destroy a lot of surges with a random patch and play a major scale on each
 */
 void createAndDestroyWithScaleAndRandomPatch(int timesToTry = 5000);

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -123,8 +123,9 @@ int main(int argc, char** argv)
 {
    // simpleOscillatorToStdOut();
    // statsFromPlayingEveryPatch();
-   playSomeBach();
-   Surge::Headless::createAndDestroyWithScaleAndRandomPatch(20000);
+   //playSomeBach();
+   //Surge::Headless::createAndDestroyWithScaleAndRandomPatch(20000);
+    Surge::Headless::pullInitSamplesWithNoNotes(1000);
 
    return 0;
 }


### PR DESCRIPTION
This change makes Headless run clean for valgrnd. There were a few
stupid errors in memory limits which left uniitialized memory in place
distractingly. This squashes them and pulls 1000 samples from an inited
surge.

A developer only change. No effect on the main synth.