### PR TITLE
fonkle/linux-mousebehavior-793 adds optional settings for 'Mouse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,8 @@ premake-stamp
 src/linux/ScalablePiggy*
 *.deb
 
+# Qt Creator
+*.txt.user
+
 # cmake
 build/

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ David Bata <oddy.o.trax@gmail.com>
 Alexandre Bique <bique.alexandre@gmail.com>
 Filipe Coelho <falktx@falktx.com>
 Rich Elmes <richie@juic3.com>
+Erik-Jan Maalderink <fonkle@gmx.com>
 Kjetil Matheussen <k.s.matheussen@notam02.no>
 Dave Palmer <itsmedavep@gmail.com>
 Adam Raisbeck <sense@i2pi.com>

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -18,7 +18,7 @@ enum
    cs_drag = 1,
 };
 
-MoveRateState CSurgeSlider::sliderMoveRateState = kUnInitialized;
+CSurgeSlider::MoveRateState CSurgeSlider::sliderMoveRateState = kUnInitialized;
 
 CSurgeSlider::CSurgeSlider(
     const CPoint& loc, long stylee, IControlListener* listener, long tag, bool is_mod)

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -18,6 +18,8 @@ enum
    cs_drag = 1,
 };
 
+MoveRateState CSurgeSlider::sliderMoveRateState = kUnInitialized;
+
 CSurgeSlider::CSurgeSlider(
     const CPoint& loc, long stylee, IControlListener* listener, long tag, bool is_mod)
     : CCursorHidingControl(CRect(loc, CPoint(1, 1)), listener, tag, 0)
@@ -363,7 +365,24 @@ CMouseEventResult CSurgeSlider::onMouseUp(CPoint& where, const CButtonState& but
 
 double CSurgeSlider::getMouseDeltaScaling(CPoint& where, const CButtonState& buttons)
 {
-   double rate = 0.3 * moverate;
+   double rate;
+
+   switch (CSurgeSlider::sliderMoveRateState)
+   {
+   case kSlow:
+      rate = 0.3;
+      break;
+   case kMedium:
+      rate = 0.7;
+      break;
+   case kExact:
+      rate = 1.0;
+      break;
+   case kClassic:
+   default:
+      rate = 0.3 * moverate;
+      break;
+   }
 
    if (buttons & kRButton)
       rate *= 0.1;
@@ -466,5 +485,5 @@ bool CSurgeSlider::onWheel(const VSTGUI::CPoint& where, const float &distance, c
    ** doesn't appear twice
    */
    edit_value = nullptr;
-   return true;   
+   return true;
 }

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -16,15 +16,6 @@ enum CControlEnum_turbodeluxe
    kNoPopup = 1 << 22,
 };
 
-typedef enum MoveRateState
-{
-   kUnInitialized = 0,
-   kClassic,
-   kSlow,
-   kMedium,
-   kExact
-} MoveRateState;
-
 class CSurgeSlider : public CCursorHidingControl
 {
 public:
@@ -85,6 +76,15 @@ public:
 
    bool is_mod;
    bool disabled;
+
+   enum MoveRateState
+   {
+      kUnInitialized = 0,
+      kClassic,
+      kSlow,
+      kMedium,
+      kExact
+   };
 
    static MoveRateState sliderMoveRateState;
 

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -16,6 +16,15 @@ enum CControlEnum_turbodeluxe
    kNoPopup = 1 << 22,
 };
 
+typedef enum MoveRateState
+{
+   kUnInitialized = 0,
+   kClassic,
+   kSlow,
+   kMedium,
+   kExact
+} MoveRateState;
+
 class CSurgeSlider : public CCursorHidingControl
 {
 public:
@@ -76,6 +85,8 @@ public:
 
    bool is_mod;
    bool disabled;
+
+   static MoveRateState sliderMoveRateState;
 
 private:
    VSTGUI::CBitmap *pHandle, *pTray, *pModHandle;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1237,6 +1237,11 @@ void SurgeGUIEditor::openOrRecreateEditor()
    patchCreator = new CTextEdit(CRect(CPoint(96, 85), CPoint(340, 21)), this, tag_store_creator);
    patchComment = new CTextEdit(CRect(CPoint(96, 112), CPoint(340, 21)), this, tag_store_comments);
 
+   // Mouse behavior
+   if (CSurgeSlider::sliderMoveRateState == MoveRateState::kUnInitialized)
+      CSurgeSlider::sliderMoveRateState = (MoveRateState)Surge::Storage::getUserDefaultValue(
+          &(synth->storage), "sliderMoveRateState", (int)MoveRateState::kClassic);
+
    /*
     * There is, apparently, a bug in VSTGui that focus events don't fire reliably on some mac hosts.
     * This leads to the odd behaviour when you click out of a box that in some hosts - Logic Pro for 
@@ -2635,6 +2640,72 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
     settingsMenu->addEntry(mpeSubMenu, mpeMenuName.c_str());
     eid++;
     mpeSubMenu->forget();
+
+    // Mouse behavior
+
+    int mid = 0;
+
+    COptionMenu* mouseSubMenu =
+        new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
+
+    std::string mouseClassic = "Classic";
+    std::string mouseSlow = "Slow";
+    std::string mouseMedium = "Medium";
+    std::string mouseExact = "Exact";
+
+    addCallbackMenu(mouseSubMenu, mouseClassic.c_str(), [this]() {
+       CSurgeSlider::sliderMoveRateState = MoveRateState::kClassic;
+       Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
+                                              CSurgeSlider::sliderMoveRateState);
+    });
+    mid++;
+
+    addCallbackMenu(mouseSubMenu, mouseSlow.c_str(), [this]() {
+       CSurgeSlider::sliderMoveRateState = MoveRateState::kSlow;
+       Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
+                                              CSurgeSlider::sliderMoveRateState);
+    });
+    mid++;
+
+    addCallbackMenu(mouseSubMenu, mouseMedium.c_str(), [this]() {
+       CSurgeSlider::sliderMoveRateState = MoveRateState::kMedium;
+       Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
+                                              CSurgeSlider::sliderMoveRateState);
+    });
+    mid++;
+
+    addCallbackMenu(mouseSubMenu, mouseExact.c_str(), [this]() {
+       CSurgeSlider::sliderMoveRateState = MoveRateState::kExact;
+       Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
+                                              CSurgeSlider::sliderMoveRateState);
+    });
+    mid++;
+
+    std::string mouseMenuName = "Mouse Behavior ";
+
+    switch (CSurgeSlider::sliderMoveRateState)
+    {
+    case MoveRateState::kClassic:
+       mouseMenuName.append("(Classic)");
+       break;
+    case MoveRateState::kSlow:
+       mouseMenuName.append("(Slow)");
+       break;
+    case MoveRateState::kMedium:
+       mouseMenuName.append("(Medium)");
+       break;
+    case MoveRateState::kExact:
+       mouseMenuName.append("(Exact)");
+       break;
+    default:
+       break;
+    }
+
+    settingsMenu->addEntry(mouseSubMenu, mouseMenuName.c_str());
+    eid++;
+    mouseSubMenu->forget();
+
+    // End Mouse behavior
 
     settingsMenu->addSeparator(eid++);
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1238,9 +1238,10 @@ void SurgeGUIEditor::openOrRecreateEditor()
    patchComment = new CTextEdit(CRect(CPoint(96, 112), CPoint(340, 21)), this, tag_store_comments);
 
    // Mouse behavior
-   if (CSurgeSlider::sliderMoveRateState == MoveRateState::kUnInitialized)
-      CSurgeSlider::sliderMoveRateState = (MoveRateState)Surge::Storage::getUserDefaultValue(
-          &(synth->storage), "sliderMoveRateState", (int)MoveRateState::kClassic);
+   if (CSurgeSlider::sliderMoveRateState == CSurgeSlider::kUnInitialized)
+      CSurgeSlider::sliderMoveRateState =
+          (CSurgeSlider::MoveRateState)Surge::Storage::getUserDefaultValue(
+              &(synth->storage), "sliderMoveRateState", (int)CSurgeSlider::kClassic);
 
    /*
     * There is, apparently, a bug in VSTGui that focus events don't fire reliably on some mac hosts.
@@ -2645,61 +2646,54 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
 
     int mid = 0;
 
-    COptionMenu* mouseSubMenu =
-        new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
+    COptionMenu* mouseSubMenu = new COptionMenu(menuRect, 0, 0, 0, 0,
+                                                VSTGUI::COptionMenu::kNoDrawStyle |
+                                                    VSTGUI::COptionMenu::kMultipleCheckStyle);
 
     std::string mouseClassic = "Classic";
     std::string mouseSlow = "Slow";
     std::string mouseMedium = "Medium";
     std::string mouseExact = "Exact";
 
-    addCallbackMenu(mouseSubMenu, mouseClassic.c_str(), [this]() {
-       CSurgeSlider::sliderMoveRateState = MoveRateState::kClassic;
+    VSTGUI::CCommandMenuItem* menuItem = nullptr;
+
+    menuItem = addCallbackMenu(mouseSubMenu, mouseClassic.c_str(), [this]() {
+       CSurgeSlider::sliderMoveRateState = CSurgeSlider::kClassic;
        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
                                               CSurgeSlider::sliderMoveRateState);
     });
+    if (menuItem)
+       menuItem->setChecked((CSurgeSlider::sliderMoveRateState == CSurgeSlider::kClassic));
     mid++;
 
-    addCallbackMenu(mouseSubMenu, mouseSlow.c_str(), [this]() {
-       CSurgeSlider::sliderMoveRateState = MoveRateState::kSlow;
+    menuItem = addCallbackMenu(mouseSubMenu, mouseSlow.c_str(), [this]() {
+       CSurgeSlider::sliderMoveRateState = CSurgeSlider::kSlow;
        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
                                               CSurgeSlider::sliderMoveRateState);
     });
+    if (menuItem)
+       menuItem->setChecked((CSurgeSlider::sliderMoveRateState == CSurgeSlider::kSlow));
     mid++;
 
-    addCallbackMenu(mouseSubMenu, mouseMedium.c_str(), [this]() {
-       CSurgeSlider::sliderMoveRateState = MoveRateState::kMedium;
+    menuItem = addCallbackMenu(mouseSubMenu, mouseMedium.c_str(), [this]() {
+       CSurgeSlider::sliderMoveRateState = CSurgeSlider::kMedium;
        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
                                               CSurgeSlider::sliderMoveRateState);
     });
+    if (menuItem)
+       menuItem->setChecked((CSurgeSlider::sliderMoveRateState == CSurgeSlider::kMedium));
     mid++;
 
-    addCallbackMenu(mouseSubMenu, mouseExact.c_str(), [this]() {
-       CSurgeSlider::sliderMoveRateState = MoveRateState::kExact;
+    menuItem = addCallbackMenu(mouseSubMenu, mouseExact.c_str(), [this]() {
+       CSurgeSlider::sliderMoveRateState = CSurgeSlider::kExact;
        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
                                               CSurgeSlider::sliderMoveRateState);
     });
+    if (menuItem)
+       menuItem->setChecked((CSurgeSlider::sliderMoveRateState == CSurgeSlider::kExact));
     mid++;
 
-    std::string mouseMenuName = "Mouse Behavior ";
-
-    switch (CSurgeSlider::sliderMoveRateState)
-    {
-    case MoveRateState::kClassic:
-       mouseMenuName.append("(Classic)");
-       break;
-    case MoveRateState::kSlow:
-       mouseMenuName.append("(Slow)");
-       break;
-    case MoveRateState::kMedium:
-       mouseMenuName.append("(Medium)");
-       break;
-    case MoveRateState::kExact:
-       mouseMenuName.append("(Exact)");
-       break;
-    default:
-       break;
-    }
+    std::string mouseMenuName = "Mouse Behavior";
 
     settingsMenu->addEntry(mouseSubMenu, mouseMenuName.c_str());
     eid++;
@@ -2760,13 +2754,14 @@ int SurgeGUIEditor::findLargestFittingZoomBetween(int zoomLow, // bottom of rang
     return result;
 }
 
-void SurgeGUIEditor::addCallbackMenu(VSTGUI::COptionMenu* toThis,
-                                     std::string label,
-                                     std::function<void()> op)
+VSTGUI::CCommandMenuItem* SurgeGUIEditor::addCallbackMenu(VSTGUI::COptionMenu* toThis,
+                                                          std::string label,
+                                                          std::function<void()> op)
 {
    CCommandMenuItem* menu = new CCommandMenuItem(CCommandMenuItem::Desc(label.c_str()));
    menu->setActions([op](CCommandMenuItem* m) { op(); });
    toThis->addEntry(menu);
+   return menu;
 }
 
 //------------------------------------------------------------------------------------------------

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -185,6 +185,7 @@ private:
    /*
    ** Utility Function
    */
-   void addCallbackMenu(VSTGUI::COptionMenu* toThis, std::string label, std::function<void()> op);
+   VSTGUI::CCommandMenuItem*
+   addCallbackMenu(VSTGUI::COptionMenu* toThis, std::string label, std::function<void()> op);
 };
 


### PR DESCRIPTION
Behavior' of the sliders to the 'Menu'.

One of 4 slider modes can be selected:

Classic: same as before (0.3 * moverate) = default
Slow:    (0.3)
Medium:  (0.7)
Exact:   (1.0)

On selecting either menu item, the new value get written to the system-
wide 'sliderMoveRateState' value in the defaults file
'SurgeUserDefaults.xml' which is respected when (re)opening Surge.

Note: I also added '*.txt.user' to .gitignore to ignore the
'CMakeLists.txt.user'-file that Qt Creator creates.