### PR TITLE
Initialized state debugging

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -25,6 +25,7 @@ void LfoModulationSource::assign(SurgeStorage* storage,
    env_state = lenv_delay;
    env_val = 0.f;
    env_phase = 0;
+   shuffle_id = 0;
    ratemult = 1.f;
    retrigger_EG = false;
 

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -272,7 +272,9 @@ void DualDelayEffect::init_ctrltypes()
    fxdata->p[11].set_type(ct_decibel_narrow);
 
    fxdata->p[0].posy_offset = 5;
+   fxdata->p[0].temposync = false;
    fxdata->p[1].posy_offset = 5;
+   fxdata->p[1].temposync = false;
 
    fxdata->p[2].posy_offset = 7;
    fxdata->p[3].posy_offset = 7;

--- a/src/headless/HeadlessUtils.cpp
+++ b/src/headless/HeadlessUtils.cpp
@@ -19,6 +19,8 @@ SurgeSynthesizer* createSurge(int sr)
       parent.reset(new HeadlessPluginLayerProxy());
    SurgeSynthesizer* surge = new SurgeSynthesizer(parent.get());
    surge->setSamplerate(sr);
+   surge->time_data.tempo = 120;
+   surge->time_data.ppqPos = 0;
    return surge;
 }
 

--- a/src/headless/Player.cpp
+++ b/src/headless/Player.cpp
@@ -90,6 +90,8 @@ void playAsConfigured(SurgeSynthesizer* surge,
 
    size_t flidx = 0;
 
+   surge->process();
+   
    for (auto i = 0; i < blockCount; ++i)
    {
       int cs = i * BLOCK_SIZE;


### PR DESCRIPTION
These changes do two things
1: Initialize some uninitalized variables in the effect and modulation path
2: Make headless mimic the plugin more by initializing some state which
   the plugin sets naturally in transport

These allow us to continue valgrnd debugging for uninitialized state and leaks