### PR TITLE
Allow channel aftertouch to modulate scene parameters

### DIFF
--- a/src/common/ModulationSource.h
+++ b/src/common/ModulationSource.h
@@ -111,8 +111,7 @@ const int modsource_grid_xy[n_modsources][2] = {
 inline bool isScenelevel(modsources ms)
 {
    return ((ms <= ms_ctrl8) || ((ms >= ms_slfo1) && (ms <= ms_slfo6))) && (ms != ms_velocity) &&
-          (ms != ms_keytrack) && (ms != ms_polyaftertouch) && (ms != ms_timbre) &&
-          (ms != ms_aftertouch);
+          (ms != ms_keytrack) && (ms != ms_polyaftertouch) && (ms != ms_timbre);
 }
 
 inline bool canModulateMonophonicTarget(modsources ms)


### PR DESCRIPTION
Channel aftertouch (as opposed to poly aftertouch) is a scene
level item in both MPE and non-MPE mode. (in MPE mode it is ignored
except on the global channel). As such it should be able to modulate
scene parameters. This change allows that by removing it from the
isSceneLevel exception list.

Closes #814