### PR TITLE
Remove a crash for PC bank messages

### DIFF
--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -137,7 +137,13 @@ void SurgeSynthesizer::incrementCategory(bool nextPrev)
 
 void SurgeSynthesizer::loadPatch(int id)
 {
+   if (id < 0)
+      id = 0;
+   if (id >= storage.patch_list.size())
+      id = id % storage.patch_list.size();
+
    patchid = id;
+
    Patch e = storage.patch_list[id];
 
    FILE* f = fopen(e.path.generic_string().c_str(), "rb");


### PR DESCRIPTION
The patch selected by a bank change was bank << 7 + patch.
In the path to apply this to the synth, there was no bounds check
so you could easily generate a midi message which addressed
storage.patch_list out of bounds. Fix that by doing a bounds
check in loadPatch.

Closes #820