### PR TITLE
Fix a warning on SampleRateCache

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -196,7 +196,7 @@ ComponentResult aulayer::Reset(AudioUnitScope inScope, AudioUnitElement inElemen
       double samplerate = GetOutput(0)->GetStreamFormat().mSampleRate;
       plugin_instance->setSamplerate(samplerate);
       plugin_instance->allNotesOff();
-      sampleRateCache == samplerate;
+      sampleRateCache = samplerate;
    }
    return noErr;
 }


### PR DESCRIPTION
In ::reset we used == rather than = to update the sampleRateCache
which could, in rare cases, lead to sample rate switches being
mis-configured in the AU