### PR TITLE
sweetspot-819: Fixed slider overshoot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ src/linux/ScalablePiggy*
 
 # Qt Creator
 *.txt.user
+*.txt.user.*
 
 # cmake
 build/

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -63,7 +63,7 @@ public:
       has_modulation_current = b;
       invalid();
    } // - " " - for the currently selected modsource
-   virtual void bounceValue();
+   virtual void bounceValue(const bool keeprest = false);
 
    virtual bool isInMouseInteraction();
 
@@ -105,4 +105,6 @@ private:
    VSTGUI::CPoint lastpoint, sourcepoint;
    float oldVal, *edit_value;
    int drawcount_debug;
+
+   float restvalue, restmodval;
 };


### PR DESCRIPTION
This commit fixes the 'overshoot'-issue with the sliders.
CSurgeSlider::bounceValue() now remains a restvalue at the end of the value range, making the sliders more stable.

Classic mode hasn't been altered to keep the Windows version intact.

Fixed reset on 2nd slider action:

When ending a slider action outside of its range, its restvalue and restmodval were not reset.
Starting a 2nd slider action would use these -now obsolete- values, resulting in
unexpected behavior. This is now fixed; restvalue and restmodval are now reset (to 0.0f) in CSurgeSlider::onMouseDown().

Update: initialized restvalue and restmodval in CSurgeSlider constructor.