### PR TITLE
Rescan All Data Folders

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2706,10 +2706,19 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
     addCallbackMenu(settingsMenu, "Open User Data Folder", [this]() {
        Surge::UserInteractions::openFolderInFileBrowser(this->synth->storage.userDataPath);
     });
+    eid++;
 
     addCallbackMenu(settingsMenu, "Open Factory Data Folder", [this]() {
        Surge::UserInteractions::openFolderInFileBrowser(this->synth->storage.datapath);
     });
+    eid++;
+
+    addCallbackMenu(settingsMenu, "Rescan All Data Folders", [this]() {
+       this->synth->storage.refresh_wtlist();
+       this->synth->storage.refresh_patchlist();
+    });
+    eid++;
+    settingsMenu->addSeparator(eid++);
 
     addCallbackMenu(settingsMenu, "SurgeManual", []() {
        Surge::UserInteractions::openURL("https://surge-synthesizer.github.io/manual/");


### PR DESCRIPTION
Prior to this the only way to rescan data folders for wt and
fxp was to restart surge (for both) or to save a patch (for fxp).
Add an explict menu item to accomplish this as well.

Closes #836