### PR TITLE
Fix headless build for SVG

### DIFF
--- a/src/common/gui/CEffectSettings.cpp
+++ b/src/common/gui/CEffectSettings.cpp
@@ -1,6 +1,7 @@
 #include "globals.h"
 #include "SurgeStorage.h"
 #include "CEffectSettings.h"
+#include "CScalableBitmap.h"
 #include "SurgeBitmaps.h"
 
 using namespace VSTGUI;

--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -3,6 +3,7 @@
 #include "MouseCursorControl.h"
 #include "globals.h"
 #include "ModulationSource.h"
+#include "CScalableBitmap.h"
 #include "SurgeBitmaps.h"
 #include <vt_dsp/basic_dsp.h>
 

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -2,6 +2,7 @@
 #include "DspUtilities.h"
 #include "CSnapshotMenu.h"
 #include "effect/Effect.h"
+#include "CScalableBitmap.h"
 #include "SurgeBitmaps.h"
 #include "SurgeStorage.h" // for TINYXML macro
 

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -5,6 +5,7 @@
 #include "resource.h"
 #include "DspUtilities.h"
 #include "MouseCursorControl.h"
+#include "CScalableBitmap.h"
 #include "SurgeBitmaps.h"
 
 using namespace VSTGUI;

--- a/src/common/gui/SurgeBitmaps.h
+++ b/src/common/gui/SurgeBitmaps.h
@@ -3,7 +3,8 @@
 #include "resource.h"
 #include <vstgui/vstgui.h>
 #include <map>
-#include "CScalableBitmap.h"
+
+class CScalableBitmap;
 
 class SurgeBitmaps
 {


### PR DESCRIPTION
Mac Headless didn't build with SVG; fix this by removing an
uneeded link.