### PR TITLE
Add a "TARGET_RACK" around assembly

### DIFF
--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -97,7 +97,7 @@ inline unsigned int BigMULr16(unsigned int a, unsigned int b)
 #if _M_X64
    unsigned __int64 c = __emulu(a, b);
    return c >> 16;
-#elif LINUX
+#elif LINUX || TARGET_RACK
    uint64_t c = (uint64_t)a * (uint64_t)b;
    return c >> 16;
 #else

--- a/src/common/vt_dsp/basic_dsp.cpp
+++ b/src/common/vt_dsp/basic_dsp.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 int Min(int a, int b)
 {
-#if _M_X64 || LINUX
+#if _M_X64 || LINUX || TARGET_RACK
    return min(a, b);
 #else
    __asm
@@ -23,7 +23,7 @@ int Min(int a, int b)
 }
 int Max(int a, int b)
 {
-#if _M_X64 || LINUX
+#if _M_X64 || LINUX || TARGET_RACK
    return max(a, b);
 #else
    __asm
@@ -50,7 +50,7 @@ double Max(double a, double b)
 
 unsigned int Min(unsigned int a, unsigned int b)
 {
-#if _M_X64 || LINUX
+#if _M_X64 || LINUX || TARGET_RACK
    return min(a, b);
 #else
    __asm
@@ -64,7 +64,7 @@ unsigned int Min(unsigned int a, unsigned int b)
 }
 unsigned int Max(unsigned int a, unsigned int b)
 {
-#if _M_X64 || LINUX
+#if _M_X64 || LINUX || TARGET_RACK
    return max(a, b);
 #else
    __asm
@@ -97,7 +97,7 @@ int limit_range(int x, int l, int h)
 
 int Wrap(int x, int L, int H)
 {
-#if _M_X64 || LINUX
+#if _M_X64 || LINUX || TARGET_RACK
    // don't remember what this was anymore...
    // int diff = H - L;
    // if(x > H) x = x-H;
@@ -129,7 +129,7 @@ int Wrap(int x, int L, int H)
 
 int Sign(int x)
 {
-#if _M_X64 || LINUX
+#if _M_X64 || LINUX || TARGET_RACK
    return (x < 0) ? -1 : 1;
 #else
    __asm
@@ -145,7 +145,7 @@ int Sign(int x)
 
 unsigned int limit_range(unsigned int x, unsigned int l, unsigned int h)
 {
-#if _M_X64 || LINUX
+#if _M_X64 || LINUX || TARGET_RACK
    return max(min(x, h), l);
 #else
    __asm


### PR DESCRIPTION
Some of the older DSP code in mac contains explicit assembly
code. VCVRack builds with gcc so this syntax doesn't work;
but there are equiavlent C++ builtins which compile on linux.
So add a TARGET_RACK which is defined nowhere in surge project
itself which is used to condition out the assembly on all platforms,
not just linux.

Partly addresses #849 but this code should be checked to see if it is
even used and stuff still.