### PR TITLE
More Rack Build Changes

### DIFF
--- a/src/common/Sample.cpp
+++ b/src/common/Sample.cpp
@@ -5,7 +5,7 @@
 //	Copyright 2004 Claes Johanson
 //
 //-------------------------------------------------------------------------------------------------------
-#if WINDOWS
+#if WINDOWS && ! TARGET_RACK
 #include "Sample.h"
 #include <assert.h>
 

--- a/src/common/SampleLoadRiffWave.cpp
+++ b/src/common/SampleLoadRiffWave.cpp
@@ -11,7 +11,7 @@
 #include "SurgeStorage.h"
 #include <assert.h>
 
-#if WINDOWS
+#if WINDOWS && !TARGET_RACK
 
 #include <windows.h>
 #include <mmreg.h>

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -29,6 +29,10 @@
 
 #include <sstream>
 
+#if TARGET_RACK
+#define generic_string string
+#endif
+
 float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
 float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];
 short sinctableI16 alignas(16)[(FIRipol_M + 1) * FIRipolI16_N];
@@ -173,6 +177,9 @@ SurgeStorage::SurgeStorage()
    
    userDataPath = std::string(homePath) + "/Documents/Surge";
 #elif WINDOWS
+#if TARGET_RACK
+   Surge::UserInteractions::promptError("Need to implement in-res paths for rack", "SoftwareError" );
+#else
    PWSTR localAppData;
    if (!SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppData))
    {
@@ -188,6 +195,7 @@ SurgeStorage::SurgeStorage()
       wsprintf(path, "%S\\Surge\\", documentsFolder);
       userDataPath = path;
    }
+#endif
 #endif
 
 #if LINUX

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -16,7 +16,7 @@
 #endif
 #include <tinyxml.h>
 
-#if LINUX
+#if LINUX || ( WINDOWS && TARGET_RACK )
 #include <experimental/filesystem>
 #elif MAC
 #include <filesystem.h>

--- a/src/common/SurgeStorageLoadWavetable.cpp
+++ b/src/common/SurgeStorageLoadWavetable.cpp
@@ -20,7 +20,7 @@ using namespace std;
 
 void SurgeStorage::load_wt_wav(string filename, Wavetable* wt)
 {
-#if WINDOWS
+#if WINDOWS && !TARGET_RACK
    uint32 wave_channels = 0;
    uint32 wave_samplerate = 0;
    uint32 wave_blockalignment = 0;

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -18,6 +18,10 @@
 
 namespace fs = std::experimental::filesystem;
 
+#if TARGET_RACK
+#define generic_string string
+#endif
+
 #if AU
 #include "aulayer.h"
 #endif
@@ -306,7 +310,11 @@ void SurgeSynthesizer::savePatch()
            return;
    }
 
+#if WINDOWS && TARGET_RACK
+   std::ofstream f(filename.c_str(), std::ios::out | std::ios::binary);
+#else
    std::ofstream f(filename, std::ios::out | std::ios::binary);
+#endif
 
    if (!f)
       return;

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -94,7 +94,7 @@ void WindowOscillator::init_default_values()
 inline unsigned int BigMULr16(unsigned int a, unsigned int b)
 {
    // 64-bit unsigned multiply with right shift by 16 bits
-#if _M_X64
+#if _M_X64 && ! TARGET_RACK
    unsigned __int64 c = __emulu(a, b);
    return c >> 16;
 #elif LINUX || TARGET_RACK


### PR DESCRIPTION
On Windows, Rack builds with G++ rather than msvc so the code
behaves more like linux. This creates the right code paths
for WINDOWS && TARGET_RACK combinations.