### PR TITLE
Fix a small RACK error

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -29,7 +29,7 @@
 
 #include <sstream>
 
-#if TARGET_RACK
+#if TARGET_RACK && WINDOWS
 #define generic_string string
 #endif
 

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -18,7 +18,7 @@
 
 namespace fs = std::experimental::filesystem;
 
-#if TARGET_RACK
+#if TARGET_RACK && WINDOWS
 #define generic_string string
 #endif
 


### PR DESCRIPTION
That redefinition in RACK is for Windows only.