### PR TITLE
More Windows Rack moves

### DIFF
--- a/libs/filesystem/filesystem.cpp
+++ b/libs/filesystem/filesystem.cpp
@@ -5,10 +5,13 @@
 //  Created by Keith Zantow on 10/2/18.
 //
 
+#if defined(__APPLE__) || TARGET_RACK
 #ifdef __APPLE__
 #include "TargetConditionals.h"
-#ifdef TARGET_OS_MAC
+#endif
+#if defined(TARGET_OS_MAC) || TARGET_RACK
 
+#include <sys/stat.h>
 #include "filesystem.h"
 
 namespace std::experimental::filesystem {
@@ -91,7 +94,9 @@ namespace std::experimental::filesystem {
     void create_directories(path p) {
         mode_t nMode = 0755; // UNIX style permissions
         int nError = 0;
-#if defined(_WIN32)
+#if ! TARGET_RACK
+	// FIX THAT
+#if defined(_WIN32) 
         nError = _mkdir(p.c_str()); // can be used on Windows
 #else
         // create_directories is recursive so this solution
@@ -110,6 +115,7 @@ namespace std::experimental::filesystem {
         }
         // and clean up the end
         nError = mkdir(file_path, nMode );
+#endif
 #endif
         if (nError != 0) {
             // handle your error here

--- a/libs/filesystem/filesystem.h
+++ b/libs/filesystem/filesystem.h
@@ -10,9 +10,12 @@
 
 #include <functional>
 
+#if defined(__APPLE__) || TARGET_RACK
 #ifdef __APPLE__
 #include "TargetConditionals.h"
-#ifdef TARGET_OS_MAC
+#endif
+
+#if defined(TARGET_OS_MAC) || TARGET_RACK
 
 #include <string>
 #include <vector>

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -29,9 +29,6 @@
 
 #include <sstream>
 
-#if TARGET_RACK && WINDOWS
-#define generic_string string
-#endif
 
 float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
 float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];
@@ -371,7 +368,7 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir,
    for (auto &p : alldirs )
    {
       PatchCategory c;
-#if WINDOWS
+#if WINDOWS && ! TARGET_RACK
       /*
       ** Windows filesystem names are properly wstrings which, if we want them to 
       ** display properly in vstgui, need to be converted to UTF8 using the 
@@ -392,7 +389,7 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir,
             Patch e;
             e.category = category;
             e.path = f.path();
-#if WINDOWS
+#if WINDOWS && ! TARGET_RACK
               std::wstring str = f.path().filename().wstring();
               str = str.substr(0, str.size() - xtn.length());
               e.name = Surge::Storage::wstringToUTF8(str);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -16,9 +16,9 @@
 #endif
 #include <tinyxml.h>
 
-#if LINUX || ( WINDOWS && TARGET_RACK )
+#if LINUX 
 #include <experimental/filesystem>
-#elif MAC
+#elif MAC || (WINDOWS && TARGET_RACK)
 #include <filesystem.h>
 #else
 #include <filesystem>

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -7,7 +7,7 @@
 #include <vt_dsp/vt_dsp_endian.h>
 #if LINUX
 #include <experimental/filesystem>
-#elif MAC
+#elif MAC || TARGET_RACK
 #include <filesystem.h>
 #else
 #include <filesystem>
@@ -17,10 +17,6 @@
 #include "UserInteractions.h"
 
 namespace fs = std::experimental::filesystem;
-
-#if TARGET_RACK && WINDOWS
-#define generic_string string
-#endif
 
 #if AU
 #include "aulayer.h"

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -11,7 +11,7 @@
 
 #if LINUX
 #include <experimental/filesystem>
-#elif MAC
+#elif MAC || TARGET_RACK
 #include <filesystem.h>
 #else
 #include <filesystem>


### PR DESCRIPTION
It's really a pain getting C++17 working with a C++11 non native
compiler on windows! But we are close. This change lets windows
rack use our hand-rolled version of filesystem which exists
inconsistenlty in mingw installs.