### PR TITLE
Fix PitchBend in VST3

### DIFF
--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -272,7 +272,10 @@ void SurgeVst3Processor::processParameterChanges(int sampleOffset,
                         surgeInstance->channelAftertouch(channel, (int)(value * 127.f));
                         break;
                      case kPitchBend:
-                        surgeInstance->pitchBend(channel, (int)(value * 8192.f));
+                        /*
+                        ** VST3 float value is between 0 and 1, pitch bend is between -1 and 1. Center it
+                        */
+                        surgeInstance->pitchBend(channel, (int)((value-0.5)*2 * 8192.f));
                         break;
                      case kCtrlProgramChange:
                         break;


### PR DESCRIPTION
PitchBend in VST3 is between 0 and 1, not -1,1, and so ended up
being mis-centered. This meant FL20 was off by a half step since it
sent a pitch wheel "0" at the start of all playing; and any pitch wheel
use stuck your VST3 out of tune.

Closes #854