### PR TITLE
Fix the 'double wheel' problem

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -58,6 +58,21 @@ public:
 #else
    virtual bool PLUGIN_API open(void* parent, const VSTGUI::PlatformType& platformType = VSTGUI::kDefaultNative);
    virtual void PLUGIN_API close() override;
+
+   virtual Steinberg::tresult PLUGIN_API onWheel( float distance ) override
+   {
+     /*
+     ** in VST3 the VstGuiEditorBase we have - even if the OS has handled it
+     ** a call to the VSTGUIEditor::onWheel (trust me; I put in stack traces
+     ** and prints). That's probably wrong. But when you use VSTGUI Zoom 
+     ** and frame->getCurrentPosition gets screwed up because VSTGUI has transform
+     ** bugs it is definitely wrong. So the mouse wheel event gets mistakenly
+     ** delivered twice (OK) but to the wrong spot (not OK!).
+     ** 
+     ** So stop the superclass from doing that by just making this do nothing.
+     */
+     return Steinberg::kResultFalse;
+   } 
 #endif
 
 


### PR DESCRIPTION
VSTGUI was delivering mouse wheel messages twice, once with erroneous
coordinates when soomed. That's tough to fix in the vst3sdk so
just hammer out an override in VST3 which means we don't get the
problem.