### PR TITLE
Rack interacts with Storage

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -474,7 +474,7 @@ public:
    float audio_in_nonOS alignas(16)[2][BLOCK_SIZE];
    //	float sincoffset alignas(16)[(FIRipol_M)*FIRipol_N];	// deprecated
 
-   SurgeStorage();
+   SurgeStorage(std::string suppliedDataPath="");
    ~SurgeStorage();
 
    std::unique_ptr<SurgePatch> _patch;


### PR DESCRIPTION
SurgeStorage for the standalone synth assumes assets in
a standard OS place. For rack, all assets ship with the plugins
in the zip. So we need to parameterize the location of the assets
datapath.

Also, RACK doesn't care about patches, so don't scan and sort them.