### PR TITLE
Midi Channel 3 Behavior

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -218,6 +218,14 @@ int SurgeSynthesizer::calculateChannelMask(int channel, int key)
          break;
       }
    }
+   else if(storage.getPatch().scenemode.val.i == sm_single)
+   {
+       if (storage.getPatch().scene_active.val.i == 1)
+           channelmask = 2;
+       else
+           channelmask = 1;
+   }
+
    return channelmask;
 }
 


### PR DESCRIPTION
In some cases (MPE disabled, Single mode, Scene A) midi channel
3 seemed to "randomly" not play any notes. That's because in single
mode Surge accidentally still used dual/split routing behavior where
channel 2 went to scene A and channel 3 to scene B.

This fixes that by making 2 and 3 both route to the active channel
in single mode.

Closes #866