### PR TITLE
Unsatisfyingly handle mis-behaving mac hosts

### DIFF
--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -27,7 +27,6 @@ void SurgeBitmaps::setupBitmapsForFrame(VSTGUI::CFrame* f)
    addEntry(IDB_BUTTON_ABOUT, f);
    addEntry(IDB_ABOUT, f);
    addEntry(IDB_FILTERBUTTONS, f);
-   addEntry(IDB_OSCSWITCH, f);
    addEntry(IDB_FILTERSUBTYPE, f);
    addEntry(IDB_RELATIVE_TOGGLE, f);
    addEntry(IDB_OSCSELECT, f);
@@ -47,7 +46,6 @@ void SurgeBitmaps::setupBitmapsForFrame(VSTGUI::CFrame* f)
    addEntry(IDB_ENVSHAPE, f);
    addEntry(IDB_FXBYPASS, f);
    addEntry(IDB_LFOTRIGGER, f);
-   addEntry(IDB_BUTTON_CHECK, f);
    addEntry(IDB_BUTTON_MINUSPLUS, f);
    addEntry(IDB_UNIPOLAR, f);
    addEntry(IDB_CHARACTER, f);


### PR DESCRIPTION
Some mac hosts use their bundle, not the VST bundle, as
the bundle reference for the VST. Notably users report
Live 9.7 appears to do this. There's nothing we can really
do except do a hack and hope you installed in the global
location before bailing. But we might as well try that.

Closes #870