### PR TITLE
Change large wavetable inconsistencies.

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -675,10 +675,23 @@ void SurgeStorage::load_wt_wt(string filename, Wavetable* wt)
    data = malloc(ds);
    fread(data, 1, ds, f);
    CS_WaveTableData.enter();
-   wt->BuildWT(data, wh, false);
+   bool wasBuilt = wt->BuildWT(data, wh, false);
    CS_WaveTableData.leave();
    free(data);
 
+   if (!wasBuilt)
+   {
+       std::ostringstream oss;
+       oss << "Your wavetable was unable to build. This often means that it has too many samples or tables."
+           << " You provided " << wh.n_tables << " tables of size " << wh.n_samples << " vs max limits of "
+           << max_subtables << " tables and " << max_wtable_size << " samples."
+           << " In some cases, Surge detects this situation inconsistently leading to this message. Surge is now"
+           << " in a potentially inconsistent state. We recommend you restart Surge and do not load the wavetable again."
+           << " If you would like, please attach the wavetable which caused this message to a new github issue at "
+           << " https://github.com/surge-synthesizer/surge/";
+       Surge::UserInteractions::promptError( oss.str(),
+                                             "Software Error on WT Load" );
+   }
    fclose(f);
 }
 int SurgeStorage::get_clipboard_type()

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -3,7 +3,10 @@
 const int max_wtable_size = 1024;
 const int max_subtables = 512;
 const int max_mipmap_levels = 16;
-const int max_wtable_samples = 268000; // delay pops 4 uses the most
+// I don't know why your max wtable samples would be less than your max tables * your max sample size. So lets fix that!
+// This size is consistent with the check in WaveTable.cpp // CheckRequiredWTSize with ts and tc at 1024 and 512
+const int max_wtable_samples = 1070592;
+// const int max_wtable_samples =  268000; // delay pops 4 uses the most
 
 #pragma pack(push, 1)
 struct wt_header


### PR DESCRIPTION
Large wavetables interacted with surge inconsistently. Surge undertook
checks against limits and set limits which were inconsistent. This
diff sets the max wt size to the largest size which will pass validation.
It also reports when a table fails to build, rather than just crashing
silently when you move the Morph parameter. This comes at the cost of
a bit more memory used per wavetable oscillator.

Closes #872