### PR TITLE
WaveTable Sub-menu truncation

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -393,7 +393,8 @@ bool COscillatorDisplay::populateMenuForCategory(COptionMenu* contextMenu,
             cidx++;
          }
 
-         selected = selected || populateMenuForCategory(subMenu, cidx, selectedItem);
+         bool subSel = populateMenuForCategory(subMenu, cidx, selectedItem);
+         selected = selected || subSel;
       }
    }
 


### PR DESCRIPTION
WaveTable when selected would not show items after the
selected item in submenus. This fixes the too-clever code
which caused that bug and builds the whole menu.

Closes #873