### PR TITLE
Null terminate ConfigurationXml.S

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -5,6 +5,7 @@
 #include "HeadlessUtils.h"
 #include "Player.h"
 #include "Stress.h"
+#include "SurgeError.h"
 
 void simpleOscillatorToStdOut()
 {
@@ -121,11 +122,19 @@ void playSomeBach()
 */
 int main(int argc, char** argv)
 {
-   // simpleOscillatorToStdOut();
-   // statsFromPlayingEveryPatch();
-   //playSomeBach();
-   //Surge::Headless::createAndDestroyWithScaleAndRandomPatch(20000);
-    Surge::Headless::pullInitSamplesWithNoNotes(1000);
+   try 
+   {
+      // simpleOscillatorToStdOut();
+      statsFromPlayingEveryPatch();
+      //playSomeBach();
+      //Surge::Headless::createAndDestroyWithScaleAndRandomPatch(20000);
+      // Surge::Headless::pullInitSamplesWithNoNotes(1000);
+   }
+   catch( Surge::Error &e )
+   {
+	std::cout << "SurgeError: " << e.getTitle() << "\n" << e.getMessage() << "\n";
+	return 1;
+   }
 
    return 0;
 }

--- a/src/linux/ConfigurationXml.S
+++ b/src/linux/ConfigurationXml.S
@@ -3,3 +3,8 @@
 configurationXmlStart:
     .globl configurationXmlStart
     .incbin "../../resources/data/configuration.xml"
+configurationXmlEnd:
+    .global configurationXmlNullTerminator
+    .type configurationXmlNullTerminator, @object
+configurationXmlNullTerminator:
+    .int 0


### PR DESCRIPTION
ConfigurationXml.S included a string but not a string range nor
a null terminator. We were mostly lucky that in surge this didn't
matter but with the onset of SVG and the build order in headless
we had SVG assets abut the XML configuration in a way which made
a non-parseable XML document. So just add a 0 into the rodata
segment right after the content. Fixes a crash in headless on linux.