### PR TITLE
Linux/package/VST3/813: Fix package-vst3.sh

### DIFF
--- a/scripts/linux/package-vst3.sh
+++ b/scripts/linux/package-vst3.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
 OUTPUT_DIR=products
-BUNDLE_NAME="Surge.vst3"
+
+if [ $config = "debug_x64" ]; then
+    BUNDLE_NAME="Surge-Debug.vst3"
+else
+    BUNDLE_NAME="Surge.vst3"
+fi
 BUNDLE_DIR="$OUTPUT_DIR/$BUNDLE_NAME"
 
 echo "Creating Linux VST3 Bundle..."
@@ -14,4 +19,8 @@ fi
 
 VST_SO_DIR="$BUNDLE_DIR/Contents/x86_64-linux"
 mkdir -p "$VST_SO_DIR"
-cp target/vst3/Release/Surge.so "$VST_SO_DIR"
+if [ $config = debug_x64 ]; then
+    cp target/vst3/Debug/Surge-Debug.so "$VST_SO_DIR"
+else
+    cp target/vst3/Release/Surge.so "$VST_SO_DIR"
+fi


### PR DESCRIPTION
The 'package-vst3.sh' script tried to copy 'target/vst3/Release/Surge.so' disregarding which version (debug_x64 or release_x64) was being built.

It now copies either 'target/vst3/Release/Surge.so' or 'target/vst3/Debug/Surge-Debug.so' depending on $config.