### PR TITLE
Correct a VST3 param behavior

### DIFF
--- a/doc/pauls-debug-fragments.txt
+++ b/doc/pauls-debug-fragments.txt
@@ -1,0 +1,30 @@
+This file contains fragments of code Paul ends up pasting into stuff often to debug. You can ignore it.
+It's just so he can keep it around.
+
+---
+
+FILE *logfp = NULL;
+FILE *lfp() {
+    if( logfp == NULL )
+        logfp = fopen( "/tmp/surgevst3.log", "w" );
+    return logfp;
+}
+#define V2LF(fmt, ...) { fprintf( lfp(),"[%s/%d]" fmt "\n", strrchr("/" __FILE__, '/') + 1, __LINE__, __VA_ARGS__ ); fflush(lfp()); }
+
+---
+#if MAC
+#include <execinfo.h>
+#endif
+
+void stackToInfo()
+{
+#if MAC
+    void* callstack[128];
+    int i, frames = backtrace(callstack, 128);
+    char** strs = backtrace_symbols(callstack, frames);
+    for (i = 0; i < frames; ++i) {
+        printf( "[SurgeRack] StackTrace[%3d]: %s", i, strs[i] );
+    }
+    free(strs);
+#endif
+}

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -239,7 +239,6 @@ void SurgeVst3Processor::processParameterChanges(int sampleOffset,
          {
             int32 offsetSamples;
             double value = 0;
-            ;
             int32 numPoints = paramQueue->getPointCount();
 
             int id = paramQueue->getParameterId();
@@ -289,10 +288,10 @@ void SurgeVst3Processor::processParameterChanges(int sampleOffset,
             else
             {
                int id = paramQueue->getParameterId();
-
                if (numPoints == 1)
                {
                   paramQueue->getPoint(0, offsetSamples, value);
+
                   surgeInstance->setParameter01(id, value, true);
                }
                else
@@ -649,7 +648,16 @@ tresult PLUGIN_API SurgeVst3Processor::setParamNormalized(ParamID tag, ParamValu
       return kInvalidArgument;
    }
 
-   surgeInstance->setParameter01(surgeInstance->remapExternalApiToInternalId(tag), value);
+   /*
+   ** Priod code had this:
+   **
+   ** surgeInstance->setParameter01(surgeInstance->remapExternalApiToInternalId(tag), value);
+   **
+   ** which remaps "control 0" -> 2048. I think that's right for the VST2 but for the VST3 where
+   ** we are specially dealing with midi controls it is the wrong thing to do; it makes the FX
+   ** control and the control 0 the same. So here just pass the tag on directly.
+   */
+   surgeInstance->setParameter01(tag, value);
 
    return kResultOk;
 }


### PR DESCRIPTION
VST3 maps midi in a different method than VST2 so a remap to parameter
types is not needed here. This caused a bug where changing FX blend
also changed control 0 and so on.

Closes #882