### PR TITLE
Handle (kinda) zoom errors in Cakewalk

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -72,7 +72,14 @@ public:
      ** So stop the superclass from doing that by just making this do nothing.
      */
      return Steinberg::kResultFalse;
-   } 
+   }
+
+   virtual Steinberg::tresult PLUGIN_API canResize() override
+   {
+      return Steinberg::kResultTrue;
+   }
+
+   virtual Steinberg::tresult PLUGIN_API onSize(Steinberg::ViewRect* newSize) override;
 #endif
 
 
@@ -138,13 +145,20 @@ private:
    */
    
    int zoomFactor;
- public:
+   bool zoomEnabled = true;
+
+public:
    void setZoomCallback(std::function< void(SurgeGUIEditor *) > f) {
        zoom_callback = f;
        setZoomFactor(getZoomFactor()); // notify the new callback
    }
    int  getZoomFactor() { return zoomFactor; }
    void setZoomFactor(int zf);
+   void disableZoom()
+   {
+      zoomEnabled = false;
+      setZoomFactor(100);
+   }
 
 private:
    /**

--- a/src/vst3/SurgeVst3Processor.h
+++ b/src/vst3/SurgeVst3Processor.h
@@ -137,6 +137,7 @@ protected:
    std::set<SurgeGUIEditor*> viewsSet;
    int blockpos;
 
+   bool disableZoom;
    void handleZoom(SurgeGUIEditor *e);
    
    FpuState _fpuState;


### PR DESCRIPTION
Cakewalk by Bandlab interacts with the VST3 zoom API in a way
which doesn't match the documentation in the VST3SDK; after calling
resizeFrame it calls back onSize() with a smaller frame even though
canResize is true; and even though it has grown its window.
So to avoid broken UIs disable Zoom in this host in Windows.

Closes #816