### PR TITLE
Correct the "Jump-to-zoom" startup

### DIFF
--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -122,7 +122,7 @@ CScalableBitmap::CScalableBitmap(CResourceDescription desc, VSTGUI::CFrame* f)
         fn2 << "/Library/Audio/Plug-Ins/VST3/Surge.vst3/Contents/Resources/" << filename.str();
 #endif
         
-        std::cout << "FailBack from bad module SVG path to best guess: [" << fn2.str() << "]" << std::endl;
+        // std::cout << "FailBack from bad module SVG path to best guess: [" << fn2.str() << "]" << std::endl;
         svgImage = nsvgParseFromFile(fn2.str().c_str(), "px", 96);
     }
 #endif

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -582,14 +582,10 @@ bool Vst2PluginInstance::tryInit()
 void Vst2PluginInstance::handleZoom(SurgeGUIEditor *e)
 {
     ERect *vr;
-    int newW, newH;
-    if (e->getRect(&vr))
-    {
-        float fzf = e->getZoomFactor() / 100.0;
-        newW = (vr->right - vr->left) * fzf;
-        newH = (vr->bottom - vr->top) * fzf;
-        sizeWindow( newW, newH );
-    }
+    float fzf = e->getZoomFactor() / 100.0;
+    int newW = WINDOW_SIZE_X * fzf;
+    int newH = WINDOW_SIZE_Y * fzf;
+    sizeWindow( newW, newH );
 
     VSTGUI::CFrame *frame = e->getFrame();
     if(frame)


### PR DESCRIPTION
The initia zoom dance (show at 100 then go to the zoom you want)
was particularly annoying but, because of the way that VST2 and 3
differe in handling zoom, a little annoying to fix. These changes
make sure that the right size is clobbered onto the frame
at at least the right time, if not more, resulting in all of
AU, VST2 and VST3 opening at your default zoom cleanly.

CLoses #844