### PR TITLE
Increase patch display invalidation aggression

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -304,7 +304,11 @@ void SurgeGUIEditor::idle()
              cnpd->invalid();
       }
 
-      if (queue_refresh || synth->refresh_editor)
+      bool patchChanged = false;
+      if (patchname)
+          patchChanged = ((CPatchBrowser *)patchname)->sel_id != synth->patchid;
+
+      if (queue_refresh || synth->refresh_editor || patchChanged)
       {
          queue_refresh = false;
          synth->refresh_editor = false;
@@ -319,9 +323,11 @@ void SurgeGUIEditor::idle()
          }
          if (patchname)
          {
+            ((CPatchBrowser*)patchname)->sel_id = synth->patchid;
             ((CPatchBrowser*)patchname)->setLabel(synth->storage.getPatch().name);
             ((CPatchBrowser*)patchname)->setCategory(synth->storage.getPatch().category);
             ((CPatchBrowser*)patchname)->setAuthor(synth->storage.getPatch().author);
+            patchname->invalid();
          }
       }
 


### PR DESCRIPTION
The patch display updates when queue_refresh is true but some
users report that it doesn't change when you pudate a patch.
That could happen if there is a race where the idle thread
runs ahead of the patch load thread, using the old version
but also resetting the refresh state. So add a third refresh
state which is "the patch browser id is not the synth id" which
forces a redraw.

May close the issue #817 but need user feedback.