### PR TITLE
Add a process-sample stereo biquad method

### DIFF
--- a/src/common/dsp/BiquadFilter.h
+++ b/src/common/dsp/BiquadFilter.h
@@ -121,6 +121,30 @@ public:
       return (float)op;
    }
 
+   inline void process_sample(float L, float R, float& lOut, float& rOut)
+   {
+      a1.process();
+      a2.process();
+      b0.process();
+      b1.process();
+      b2.process();
+
+      double op;
+      double input = L;
+      op = input * b0.v.d[0] + reg0.d[0];
+      reg0.d[0] = input * b1.v.d[0] - a1.v.d[0] * op + reg1.d[0];
+      reg1.d[0] = input * b2.v.d[0] - a2.v.d[0] * op;
+
+      lOut = op;
+
+      input = R;
+      op = input * b0.v.d[0] + reg0.d[1];
+      reg0.d[1] = input * b1.v.d[0] - a1.v.d[0] * op + reg1.d[1];
+      reg1.d[1] = input * b2.v.d[0] - a2.v.d[0] * op;
+
+      rOut = op;
+   }
+
    inline void process_sample_nolag(float& L, float& R)
    {
       double op;


### PR DESCRIPTION
The BiQuad filter can process in blocks; can process with the lag
not activated; and can process mono running the lag; but it can't
process stero and run the lags for you on a single sample, which I
need for rack. This adds the obvious method.