### PR TITLE
Warning Supression

### DIFF
--- a/libs/xml/tinyxml.cpp
+++ b/libs/xml/tinyxml.cpp
@@ -1160,12 +1160,12 @@ void TiXmlAttribute::SetDoubleValue( double _value )
 	SetValue (buf);
 }
 
-const int TiXmlAttribute::IntValue() const
+int TiXmlAttribute::IntValue() const
 {
 	return atoi (value.c_str ());
 }
 
-const double  TiXmlAttribute::DoubleValue() const
+double  TiXmlAttribute::DoubleValue() const
 {
 	return atof (value.c_str ());
 }

--- a/libs/xml/tinyxml.h
+++ b/libs/xml/tinyxml.h
@@ -698,8 +698,8 @@ public:
 
 	const char*		Name()  const		{ return name.c_str (); }		///< Return the name of this attribute.
 	const char*		Value() const		{ return value.c_str (); }		///< Return the value of this attribute.
-	const int       IntValue() const;									///< Return the value of this attribute, converted to an integer.
-	const double	DoubleValue() const;								///< Return the value of this attribute, converted to a double.
+	int       IntValue() const;									///< Return the value of this attribute, converted to an integer.
+	double	DoubleValue() const;								///< Return the value of this attribute, converted to a double.
 
 	/** QueryIntValue examines the value string. It is an alternative to the
 		IntValue() method with richer error checking.
@@ -749,12 +749,12 @@ public:
 	/*	Attribute parsing starts: first letter of the name
 						 returns: the next char after the value end quote
 	*/
-	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding );
+	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding ) override;
 
 	// Prints this Attribute to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const override;
 
-	virtual void StreamOut( TIXML_OSTREAM * out ) const;
+	virtual void StreamOut( TIXML_OSTREAM * out ) const override;
 	// [internal use]
 	// Set the document pointer so the attribute can report errors.
 	void SetDocument( TiXmlDocument* doc )	{ document = doc; }
@@ -922,14 +922,14 @@ public:
 	TiXmlAttribute* LastAttribute()					{ return attributeSet.Last(); }
 
 	/// Creates a new Element and returns it - the returned element is a copy.
-	virtual TiXmlNode* Clone() const;
+	virtual TiXmlNode* Clone() const override;
 	// Print the Element to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const override;
 
 	/*	Attribtue parsing starts: next char past '<'
 						 returns: next char past '>'
 	*/
-	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding );
+	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding ) override;
 
 protected:
 
@@ -938,9 +938,9 @@ protected:
 
 	// Used to be public [internal use]
 	#ifdef TIXML_USE_STL
-	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag );
+	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag ) override;
 	#endif
-	virtual void StreamOut( TIXML_OSTREAM * out ) const;
+	virtual void StreamOut( TIXML_OSTREAM * out ) const override;
 
 	/*	[internal use]
 		Reads the "value" of the element -- another element, or text.
@@ -967,23 +967,23 @@ public:
 	virtual ~TiXmlComment()	{}
 
 	/// Returns a copy of this Comment.
-	virtual TiXmlNode* Clone() const;
+	virtual TiXmlNode* Clone() const override;
 	/// Write this Comment to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const override;
 
 	/*	Attribtue parsing starts: at the ! of the !--
 						 returns: next char past '>'
 	*/
-	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding );
+	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding ) override;
 
 protected:
 	void CopyTo( TiXmlComment* target ) const;
 
 	// used to be public
 	#ifdef TIXML_USE_STL
-	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag );
+	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag ) override;
 	#endif
-	virtual void StreamOut( TIXML_OSTREAM * out ) const;
+	virtual void StreamOut( TIXML_OSTREAM * out ) const override;
 
 private:
 
@@ -1015,20 +1015,20 @@ public:
 	void operator=( const TiXmlText& base )							 	{ base.CopyTo( this ); }
 
 	/// Write this text object to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const override;
 
-	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding );
+	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding ) override;
 
 protected :
 	///  [internal use] Creates a new Element and returns it.
-	virtual TiXmlNode* Clone() const;
+	virtual TiXmlNode* Clone() const override;
 	void CopyTo( TiXmlText* target ) const;
 
-	virtual void StreamOut ( TIXML_OSTREAM * out ) const;
+	virtual void StreamOut ( TIXML_OSTREAM * out ) const override;
 	bool Blank() const;	// returns true if all white space and new lines
 	// [internal use]
 	#ifdef TIXML_USE_STL
-	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag );
+	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag ) override;
 	#endif
 
 private:
@@ -1079,19 +1079,19 @@ public:
 	const char *Standalone() const		{ return standalone.c_str (); }
 
 	/// Creates a copy of this Declaration and returns it.
-	virtual TiXmlNode* Clone() const;
+	virtual TiXmlNode* Clone() const override;
 	/// Print this declaration to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const override;
 
-	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding );
+	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding ) override;
 
 protected:
 	void CopyTo( TiXmlDeclaration* target ) const;
 	// used to be public
 	#ifdef TIXML_USE_STL
-	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag );
+	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag ) override;
 	#endif
-	virtual void StreamOut ( TIXML_OSTREAM * out) const;
+	virtual void StreamOut ( TIXML_OSTREAM * out) const override;
 
 private:
 
@@ -1118,19 +1118,19 @@ public:
 	void operator=( const TiXmlUnknown& copy )										{ copy.CopyTo( this ); }
 
 	/// Creates a copy of this Unknown and returns it.
-	virtual TiXmlNode* Clone() const;
+	virtual TiXmlNode* Clone() const override;
 	/// Print this Unknown to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const override;
 
-	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding );
+	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding ) override;
 
 protected:
 	void CopyTo( TiXmlUnknown* target ) const;
 
 	#ifdef TIXML_USE_STL
-	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag );
+	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag ) override;
 	#endif
-	virtual void StreamOut ( TIXML_OSTREAM * out ) const;
+	virtual void StreamOut ( TIXML_OSTREAM * out ) const override;
 
 private:
 
@@ -1188,7 +1188,7 @@ public:
 		method (either TIXML_ENCODING_LEGACY or TIXML_ENCODING_UTF8 will force TinyXml
 		to use that encoding, regardless of what TinyXml might otherwise try to detect.
 	*/
-	virtual const char* Parse( const char* p, TiXmlParsingData* data = 0, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING );
+	virtual const char* Parse( const char* p, TiXmlParsingData* data = 0, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING ) override;
 
 	/** Get the root element -- the only top level element -- of the document.
 		In well formed XML, there should only be one. TinyXml is tolerant of
@@ -1210,7 +1210,7 @@ public:
 	/** Generally, you probably want the error string ( ErrorDesc() ). But if you
 		prefer the ErrorId, this function will fetch it.
 	*/
-	const int ErrorId()	const				{ return errorId; }
+	int ErrorId()	const				{ return errorId; }
 
 	/** Returns the location (if known) of the error. The first column is column 1, 
 		and the first row is row 1. A value of 0 means the row and column wasn't applicable
@@ -1260,16 +1260,16 @@ public:
 	void Print() const						{ Print( stdout, 0 ); }
 
 	/// Print this Document to a FILE stream.
-	virtual void Print( FILE* cfile, int depth = 0 ) const;
+	virtual void Print( FILE* cfile, int depth = 0 ) const override;
 	// [internal use]
 	void SetError( int err, const char* errorLocation, TiXmlParsingData* prevData, TiXmlEncoding encoding );
 
 protected :
-	virtual void StreamOut ( TIXML_OSTREAM * out) const;
+	virtual void StreamOut ( TIXML_OSTREAM * out) const override;
 	// [internal use]
-	virtual TiXmlNode* Clone() const;
+	virtual TiXmlNode* Clone() const override;
 	#ifdef TIXML_USE_STL
-	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag );
+	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag ) override;
 	#endif
 
 private:

--- a/src/common/ModulationSource.h
+++ b/src/common/ModulationSource.h
@@ -177,7 +177,7 @@ public:
    virtual void attack(){};
    virtual void release(){};
    virtual void reset(){};
-   virtual float get_output()
+   virtual float get_output() 
    {
       return output;
    }
@@ -234,7 +234,7 @@ public:
          changed = true;
    }
 
-   virtual float get_output01()
+   virtual float get_output01() override
    {
       if (bipolar)
          return 0.5f + 0.5f * output;
@@ -259,13 +259,13 @@ public:
       return false;
    }
 
-   virtual void reset()
+   virtual void reset() override
    {
       target = 0.f;
       output = 0.f;
       bipolar = false;
    }
-   virtual void process_block()
+   virtual void process_block() override
    {
       float b = fabs(target - output);
       float a = 0.4f * b;
@@ -285,11 +285,11 @@ public:
       return true; // continue
    }
 
-   virtual bool is_bipolar()
+   virtual bool is_bipolar() override
    {
       return bipolar;
    }
-   virtual void set_bipolar(bool b)
+   virtual void set_bipolar(bool b) override
    {
       bipolar = b;
    }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -583,7 +583,7 @@ void SurgeSynthesizer::releaseNotePostHoldCheck(int scene, char channel, char ke
             */
             if ((v->state.key == key) && (v->state.channel == channel))
             {
-               int activateVoiceKey, activateVoiceChannel;
+	       int activateVoiceKey = 60, activateVoiceChannel = 0; // these will be overriden
 
                // v->release();
                if (!mpeEnabled)

--- a/src/common/dsp/AdsrEnvelope.h
+++ b/src/common/dsp/AdsrEnvelope.h
@@ -66,7 +66,7 @@ public:
          attack();
    }
 
-   void attack()
+   virtual void attack() override
    {
       phase = 0;
       output = 0;
@@ -82,24 +82,24 @@ public:
       }
    }
 
-   virtual const char* get_title()
+   virtual const char* get_title() override
    {
       return "envelope";
    }
-   virtual int get_type()
+   virtual int get_type() override
    {
       return mst_adsr;
    }
-   virtual bool per_voice()
+   virtual bool per_voice() override
    {
       return true;
    }
-   virtual bool is_bipolar()
+   virtual bool is_bipolar() override
    {
       return false;
    }
 
-   void release()
+   void release() override
    {
       /*if(envstate == s_attack)
       {
@@ -135,7 +135,7 @@ public:
    {
       return (envstate == s_idle) && (idlecount > 0);
    }
-   virtual void process_block()
+   virtual void process_block() override
    {
       if (lc[mode].b)
       {

--- a/src/common/dsp/LfoModulationSource.h
+++ b/src/common/dsp/LfoModulationSource.h
@@ -32,19 +32,19 @@ public:
    float bend1(float x);
    float bend2(float x);
    float bend3(float x);
-   virtual void attack();
-   virtual void release();
-   virtual void process_block();
+   virtual void attack() override;
+   virtual void release() override;
+   virtual void process_block() override;
 
-   virtual const char* get_title()
+   virtual const char* get_title() override
    {
       return "LFO";
    }
-   virtual int get_type()
+   virtual int get_type() override
    {
       return mst_lfo;
    }
-   virtual bool is_bipolar()
+   virtual bool is_bipolar() override
    {
       return true;
    }

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -46,9 +46,9 @@ class osc_sine : public Oscillator
 {
 public:
    osc_sine(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
-   virtual void init(float pitch, bool is_display = false);
+   virtual void init(float pitch, bool is_display = false) override;
    virtual void process_block(
-       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f);
+       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override;
    virtual ~osc_sine();
    quadr_osc sinus;
    double phase;
@@ -60,12 +60,12 @@ class FMOscillator : public Oscillator
 {
 public:
    FMOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
-   virtual void init(float pitch, bool is_display = false);
+   virtual void init(float pitch, bool is_display = false) override;
    virtual void process_block(
-       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f);
+       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override;
    virtual ~FMOscillator();
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
    double phase, lastoutput;
    quadr_osc RM1, RM2, AM;
    float driftlfo, driftlfo2;
@@ -76,12 +76,12 @@ class FM2Oscillator : public Oscillator
 {
 public:
    FM2Oscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
-   virtual void init(float pitch, bool is_display = false);
+   virtual void init(float pitch, bool is_display = false) override;
    virtual void process_block(
-       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f);
+       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override;
    virtual ~FM2Oscillator();
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
    double phase, lastoutput;
    quadr_osc RM1, RM2;
    float driftlfo, driftlfo2;
@@ -92,13 +92,13 @@ class osc_audioinput : public Oscillator
 {
 public:
    osc_audioinput(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
-   virtual void init(float pitch, bool is_display = false);
+   virtual void init(float pitch, bool is_display = false) override;
    virtual void process_block(
-       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f);
+       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override;
    virtual ~osc_audioinput();
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual bool allow_display()
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual bool allow_display() override
    {
       return false;
    }
@@ -134,11 +134,11 @@ private:
 
 public:
    SurgeSuperOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
-   virtual void init(float pitch, bool is_display = false);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
+   virtual void init(float pitch, bool is_display = false) override;
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
    virtual void process_block(
-       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f);
+       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override;
    template <bool FM> void convolute(int voice, bool stereo);
    virtual ~SurgeSuperOscillator();
 
@@ -155,16 +155,18 @@ private:
    float CoefB0, CoefB1, CoefA1;
 };
 
+#if 0
 class osc_pluck : public Oscillator
 {
 public:
    osc_pluck(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
-   virtual void init(float pitch, bool is_display = false);
-   virtual void process_block(float pitch, float drift);
-   virtual void process_block_fm(float pitch, float depth, float drift);
+   virtual void init(float pitch, bool is_display = false) override;
+   virtual void process_block(float pitch, float drift) override;
+   virtual void process_block_fm(float pitch, float depth, float drift) override;
    void process_blockT(float pitch, bool FM, float depth, float drift = 0);
    virtual ~osc_pluck();
 };
+#endif
 
 class SampleAndHoldOscillator : public AbstractBlitOscillator
 {
@@ -173,11 +175,11 @@ private:
 
 public:
    SampleAndHoldOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
-   virtual void init(float pitch, bool is_display = false);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
+   virtual void init(float pitch, bool is_display = false) override;
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
    virtual void process_block(
-       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f);
+       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override;
    virtual ~SampleAndHoldOscillator();
 
 private:
@@ -199,11 +201,11 @@ class WavetableOscillator : public AbstractBlitOscillator
 public:
    lipol_ps li_hpf, li_DC, li_integratormult;
    WavetableOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
-   virtual void init(float pitch, bool is_display = false);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
+   virtual void init(float pitch, bool is_display = false) override;
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
    virtual void process_block(
-       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f);
+       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override; 
    virtual ~WavetableOscillator();
 
 private:
@@ -249,11 +251,11 @@ private:
 
 public:
    WindowOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
-   virtual void init(float pitch, bool is_display = false);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
+   virtual void init(float pitch, bool is_display = false) override;
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
    virtual void process_block(
-       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f);
+       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override;
    virtual ~WindowOscillator();
 
 private:

--- a/src/common/dsp/SurgeSuperOscillator.cpp
+++ b/src/common/dsp/SurgeSuperOscillator.cpp
@@ -255,7 +255,7 @@ template <bool FM> void SurgeSuperOscillator::convolute(int voice, bool stereo)
       t = note_to_pitch_inv(detune + sync);
 
    float t_inv = rcp(t);
-   float g, gR;
+   float g = 0.0, gR = 0.0;
 
    switch (state[voice])
    {

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -31,19 +31,19 @@ class DualDelayEffect : public Effect
 public:
    DualDelayEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~DualDelayEffect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "dualdelay";
    }
-   virtual void init();
-   virtual void process(float* dataL, float* dataR);
-   virtual void suspend();
+   virtual void init() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual void suspend() override;
    void setvars(bool init);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
-   virtual int get_ringout_decay()
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
+   virtual int get_ringout_decay() override
    {
       return ringout_time;
    }
@@ -71,18 +71,18 @@ template <int v> class ChorusEffect : public Effect
 public:
    ChorusEffect<v>(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~ChorusEffect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "chorus";
    }
-   virtual void init();
-   virtual void process(float* dataL, float* dataR);
-   virtual void suspend();
+   virtual void init() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual void suspend() override;
    void setvars(bool init);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
 
 private:
    lag<float, true> time[v];
@@ -101,19 +101,19 @@ public:
    lipol_ps mix alignas(16);
    FreqshiftEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~FreqshiftEffect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "freqshift";
    }
-   virtual void init();
-   virtual void process(float* dataL, float* dataR);
-   virtual void suspend();
+   virtual void init() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual void suspend() override;
    void setvars(bool init);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
-   virtual int get_ringout_decay()
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
+   virtual int get_ringout_decay() override
    {
       return ringout_time;
    }
@@ -135,22 +135,22 @@ class Eq3BandEffect : public Effect
 public:
    Eq3BandEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~Eq3BandEffect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "EQ";
    }
-   virtual void init();
-   virtual void process(float* dataL, float* dataR);
-   virtual int get_ringout_decay()
+   virtual void init() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual int get_ringout_decay() override
    {
       return 500;
    }
-   virtual void suspend();
+   virtual void suspend() override;
    void setvars(bool init);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override; 
+   virtual int group_label_ypos(int id) override;
 
 private:
    BiquadFilter band1, band2, band3;
@@ -166,23 +166,23 @@ class PhaserEffect : public Effect
 public:
    PhaserEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~PhaserEffect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "phaser";
    }
-   virtual void init();
-   virtual void process_only_control();
-   virtual void process(float* dataL, float* dataR);
-   virtual int get_ringout_decay()
+   virtual void init() override;
+   virtual void process_only_control() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual int get_ringout_decay() override
    {
       return 1000;
    }
-   virtual void suspend();
+   virtual void suspend() override;
    void setvars();
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
 
 private:
    lipol<float, true> feedback;
@@ -200,22 +200,22 @@ class RotarySpeakerEffect : public Effect
 public:
    RotarySpeakerEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~RotarySpeakerEffect();
-   virtual void process_only_control();
-   virtual const char* get_effectname()
+   virtual void process_only_control() override;
+   virtual const char* get_effectname() override
    {
       return "rotary";
    }
-   virtual void process(float* dataL, float* dataR);
-   virtual int get_ringout_decay()
+   virtual void process(float* dataL, float* dataR) override;
+   virtual int get_ringout_decay() override
    {
       return max_delay_length >> 5;
    }
-   virtual void suspend();
-   virtual void init();
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
+   virtual void suspend() override;
+   virtual void init() override;
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
 
 protected:
    float buffer[max_delay_length];
@@ -241,22 +241,22 @@ class DistortionEffect : public Effect
 public:
    DistortionEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~DistortionEffect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "distortion";
    }
-   virtual void init();
-   virtual void process(float* dataL, float* dataR);
-   virtual void suspend();
-   virtual int get_ringout_decay()
+   virtual void init() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual void suspend() override;
+   virtual int get_ringout_decay() override
    {
       return 1000;
    }
    void setvars(bool init);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
 
 private:
    BiquadFilter band1, band2, lp1, lp2;
@@ -282,22 +282,22 @@ public:
 
    VocoderEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~VocoderEffect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "vocoder";
    }
-   virtual void init();
-   virtual void process(float* dataL, float* dataR);
-   virtual void suspend();
-   virtual int get_ringout_decay()
+   virtual void init() override;
+   virtual void process(float* dataL, float* dataR) override; 
+   virtual void suspend() override;
+   virtual int get_ringout_decay() override
    {
       return 500;
    }
    void setvars(bool init);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
 
 private:
    VectorizedSvfFilter mCarrierL alignas(16)[NVocoderVec];
@@ -328,22 +328,22 @@ class emphasize : public Effect
 public:
    emphasize(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~emphasize();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "emphasize";
    }
-   virtual void init();
-   virtual void process(float* dataL, float* dataR);
-   virtual void suspend();
-   virtual int get_ringout_decay()
+   virtual void init() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual void suspend() override;
+   virtual int get_ringout_decay() override
    {
       return 50;
    }
    void setvars(bool init);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
 
 private:
    BiquadFilter EQ;
@@ -364,25 +364,25 @@ class ConditionerEffect : public Effect
 public:
    ConditionerEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~ConditionerEffect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "conditioner";
    }
-   virtual void init();
-   virtual void process_only_control();
-   virtual void process(float* dataL, float* dataR);
-   virtual int get_ringout_decay()
+   virtual void init() override;
+   virtual void process_only_control() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual int get_ringout_decay() override
    {
       return 100;
    }
-   virtual void suspend();
+   virtual void suspend() override;
    void setvars(bool init);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual int vu_type(int id);
-   virtual int vu_ypos(int id);
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual int vu_type(int id) override;
+   virtual int vu_ypos(int id) override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
 
 private:
    BiquadFilter band1, band2;
@@ -414,19 +414,19 @@ class Reverb1Effect : public Effect
 public:
    Reverb1Effect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~Reverb1Effect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "reverb";
    }
-   virtual void init();
-   virtual void process(float* dataL, float* dataR);
-   virtual void suspend();
+   virtual void init() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual void suspend() override;
    void setvars(bool init);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
-   virtual int get_ringout_decay()
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
+   virtual int get_ringout_decay() override
    {
       return ringout_time;
    }
@@ -506,20 +506,20 @@ class Reverb2Effect : public Effect
 public:
    Reverb2Effect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~Reverb2Effect();
-   virtual const char* get_effectname()
+   virtual const char* get_effectname() override
    {
       return "reverb2";
    }
-   virtual void init();
-   virtual void process(float* dataL, float* dataR);
-   virtual void suspend();
+   virtual void init() override;
+   virtual void process(float* dataL, float* dataR) override;
+   virtual void suspend() override;
    void setvars(bool init);
    void calc_size(float scale);
-   virtual void init_ctrltypes();
-   virtual void init_default_values();
-   virtual const char* group_label(int id);
-   virtual int group_label_ypos(int id);
-   virtual int get_ringout_decay()
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+   virtual const char* group_label(int id) override;
+   virtual int group_label_ypos(int id) override;
+   virtual int get_ringout_decay() override
    {
       return ringout_time;
    }


### PR DESCRIPTION
This change supresses a few classes of warnings

1. Lack of override on overriden methods
2. Uninitalized variables where the compiler is ambiguous if they would be
   get a default value
3. "const int" is not a return type

with the aim of having surge-rack on linux build with far fewer warnings.
(Also we increased the warrning supression flags on linux separately)