### PR TITLE
Add modes to the SIN oscillator

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -524,6 +524,12 @@ void Parameter::set_type(int ctrltype)
       valtype = vt_int;
       val_default.i = 1;
       break;
+   case ct_sineoscmode:
+      val_min.i = 0;
+      val_max.i = 8;
+      valtype = vt_int;
+      val_default.i = 0;
+      break;
    default:
    case ct_none:
       sprintf(dispname, "-");
@@ -847,6 +853,10 @@ void Parameter::get_display(char* txt, bool external, float ef)
          break;
       case ct_character:
          sprintf(txt, "%s", character_abberations[limit_range(i, 0, (int)n_charactermodes - 1)]);
+         break;
+      case ct_sineoscmode:
+         // FIXME - do better than this of course
+         sprintf(txt, "%d", i);
          break;
       case ct_oscroute:
          switch (i)

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -83,6 +83,7 @@ enum ctrltypes
    ct_stereowidth,
    ct_bool_fm,
    ct_character,
+   ct_sineoscmode,
    num_ctrltypes,
 };
 

--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -62,6 +62,8 @@ void osc_sine::init(float pitch, bool is_display)
    sinus.set_phase(phase);
    driftlfo = 0;
    driftlfo2 = 0;
+
+   id_mode = oscdata->p[0].param_id_in_scene;
 }
 
 osc_sine::~osc_sine()
@@ -77,7 +79,7 @@ void osc_sine::process_block(float pitch, float drift, bool stereo, bool FM, flo
 
       for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
-         output[k] = sin(phase);
+         output[k] = valueFromSinAndCos(sin(phase), cos(phase));
          phase += omega + master_osc[k] * FMdepth.v;
          FMdepth.process();
       }
@@ -90,7 +92,10 @@ void osc_sine::process_block(float pitch, float drift, bool stereo, bool FM, flo
       for (int k = 0; k < BLOCK_SIZE_OS; k++)
       {
          sinus.process();
-         output[k] = sinus.r;
+         float svalue = sinus.r;
+         float cvalue = sinus.i;
+
+         output[k] = valueFromSinAndCos(svalue, cvalue);
 
          // const __m128 scale = _mm_set1_ps(0.000030517578125);
 
@@ -116,6 +121,104 @@ void osc_sine::process_block(float pitch, float drift, bool stereo, bool FM, flo
    }
 }
 
+float osc_sine::valueFromSinAndCos(float svalue, float cvalue)
+{
+   int wfMode = localcopy[id_mode].i;
+   float pvalue = svalue;
+
+   int quadrant;
+   if (svalue > 0)
+      if (cvalue > 0)
+         quadrant = 1;
+      else
+         quadrant = 2;
+   else if (cvalue < 0)
+      quadrant = 3;
+   else
+      quadrant = 4;
+
+   switch (wfMode)
+   {
+   case 1:
+      if (quadrant == 3 || quadrant == 4)
+         pvalue = 0;
+      pvalue = 2 * pvalue - 1;
+      break;
+   case 2:
+      if (quadrant == 1 || quadrant == 3)
+         pvalue = 0;
+      break;
+   case 3:
+      if (quadrant == 2 || quadrant == 4)
+         pvalue = 0;
+      break;
+   case 4:
+      switch (quadrant)
+      {
+      case 1:
+         pvalue = 1 - cvalue;
+         break;
+      case 2:
+         pvalue = 1 + cvalue;
+         break;
+      case 3:
+         pvalue = -1 - cvalue;
+         break;
+      case 4:
+         pvalue = -1 + cvalue;
+         break;
+      }
+      break;
+   case 5:
+      switch (quadrant)
+      {
+      case 1:
+         pvalue = 1 - cvalue;
+         break;
+      case 2:
+         pvalue = 1 + cvalue;
+         break;
+      default:
+         pvalue = 0;
+         break;
+      }
+      pvalue = 2 * pvalue - 1;
+      break;
+   case 6:
+      if (quadrant <= 2)
+         pvalue = 2 * svalue * cvalue; // remember sin 2x = 2 * sinx * cosx
+      else
+         pvalue = 0;
+      break;
+   case 7:
+      pvalue = 2 * svalue * cvalue;
+      if (quadrant == 2 || quadrant == 3)
+         pvalue = -pvalue;
+      break;
+   case 8:
+      pvalue = 2 * svalue * cvalue;
+      if (quadrant == 2 || quadrant == 4)
+         pvalue = 0;
+      if (quadrant == 3)
+         pvalue = -pvalue;
+      break;
+
+   default:
+      break;
+   }
+   return pvalue;
+}
+
+void osc_sine::init_ctrltypes()
+{
+   oscdata->p[0].set_name("WaveShape");
+   oscdata->p[0].set_type(ct_sineoscmode);
+}
+
+void osc_sine::init_default_values()
+{
+   oscdata->p[0].val.i = 0;
+}
 /* audio input osc */
 
 /* add controls:

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -50,10 +50,17 @@ public:
    virtual void process_block(
        float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override;
    virtual ~osc_sine();
+   virtual void init_ctrltypes() override;
+   virtual void init_default_values() override;
+
    quadr_osc sinus;
    double phase;
    float driftlfo, driftlfo2;
    lag<double> FMdepth;
+
+   int id_mode;
+
+   float valueFromSinAndCos(float svalue, float cvalue);
 };
 
 class FMOscillator : public Oscillator


### PR DESCRIPTION
The Sin oscillator, humble and simple, gets a bit of complexity
by adding some quadrant blanking and frequency doubling and
so on, modelled after classic 80s FM synths which started to
add non-sin shaped waves to their patterns.

Closes #896