### PR TITLE
Address two obvious zoom errors

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1341,7 +1341,7 @@ bool PLUGIN_API SurgeGUIEditor::open(void* parent, const PlatformType& platformT
 #if TARGET_VST2   
    CRect wsize(0, 0, WINDOW_SIZE_X * fzf, WINDOW_SIZE_Y * fzf);
 #else
-   CRect wsize( 0, 0, WINDOW_SIZE_Y, WINDOW_SIZE_Y );
+   CRect wsize( 0, 0, WINDOW_SIZE_X, WINDOW_SIZE_Y );
 #endif
    
    CFrame *nframe = new CFrame(wsize, this);

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -62,6 +62,7 @@ tresult PLUGIN_API SurgeVst3Processor::initialize(FUnknown* context)
       size_t nNumCharConverted;
       wcstombs_s(&nNumCharConverted, szString, 256, hostName, 128);
       std::string s(szString);
+      disableZoom = false;
       if (s == "Cakewalk")
          disableZoom = true;
    }


### PR DESCRIPTION
Address two obvious zoom errors

1. DisableZoom is uninitialized
2. I set the window to YxY not XxY in some cases; apparently some
   version of FL listen

I am not sure if this will fix #898 but it will help.