### PR TITLE
Dynamically allocate WaveTables

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -249,7 +249,8 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath)
    getPatch().scene[0].osc[0].wt.dt = 1.0f / 512.f;
    load_wt(0, &getPatch().scene[0].osc[0].wt);
 
-   memset(&WindowWT, 0, sizeof(WindowWT));
+   // WindowWT is a WaveTable which now has a constructor so don't do this
+   // memset(&WindowWT, 0, sizeof(WindowWT));
    load_wt_wt(datapath + "windows.wt", &WindowWT);
 }
 

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -22,9 +22,12 @@ class Wavetable
 {
 public:
    Wavetable();
+   ~Wavetable();
    void Copy(Wavetable* wt);
    bool BuildWT(void* wdata, wt_header& wh, bool AppendSilence);
    void MipMapWT();
+
+   void allocPointers(size_t newSize);
 
 public:
    int size;
@@ -34,8 +37,11 @@ public:
    float dt;
    float* TableF32WeakPointers[max_mipmap_levels][max_subtables];
    short* TableI16WeakPointers[max_mipmap_levels][max_subtables];
-   float TableF32Data[max_wtable_samples];
-   short TableI16Data[max_wtable_samples];
+
+   size_t dataSizes;
+   float *TableF32Data;
+   short *TableI16Data;
+   
    int current_id, queue_id;
    bool refresh_display;
    char queue_filename[256];

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -84,6 +84,7 @@ void statsFromPlayingEveryPatch()
    };
 
    Surge::Headless::playOnEveryPatch(surge, scale, callBack);
+   delete surge;
 }
 
 void playSomeBach()


### PR DESCRIPTION
After fixing #872, some users rightly complained about the expansion
in memory. This changes the Surge protocol to dyanmically allocate and
grow sample storage for wavetables, starting at a lower point than it did
before. Since this is a sensitive change I tested it extensively.

1. headless mac and linux plays every patch without a crash
2. valgrind linux shows no memory leaks
3. A wide variety of windows hosts both 32 and 64 bit tested

I'm going to ask for tests for this on various forums and consider
this plus the last correction as important ones for a candidate 1.6.1
early next week.

Closes #900