### PR TITLE
Fix Logic Zoom Crash in 1.6.1

### DIFF
--- a/src/au/aulayer_cocoaui.mm
+++ b/src/au/aulayer_cocoaui.mm
@@ -96,6 +96,7 @@ void timerCallback( CFRunLoopTimerRef timer, void *info )
 @implementation SurgeNSView
 - (id) initWithSurge: (SurgeGUIEditor *) cont preferredSize: (NSSize) size
 {
+    cont->setZoomCallback( []( SurgeGUIEditor *ed ) {} );
     self = [super initWithFrame: NSMakeRect (0, 0, size.width / 2, size.height / 2)];
 
     idleTimer = nil;


### PR DESCRIPTION
1.6.1 when re-opening a logic window with a zoom would call a
null zoom callback resulting in an NPE because open() can now
call setZoom to avoid the dance; fix this by registereing a noop
zoom callback at the first chance in the aulayer.

Closes #904