### PR TITLE
Allow dataPath as an argument to SurgeSynthesizer

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -37,9 +37,10 @@
 
 using namespace std;
 
-SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent)
+SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedDataPath)
     //: halfband_AL(false),halfband_AR(false),halfband_BL(false),halfband_BR(false),
-    : hpA(&storage)
+    : storage(suppliedDataPath)
+    , hpA(&storage)
    , hpB(&storage)
    , _parent(parent)
    , halfbandA(6, true)

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -58,7 +58,7 @@ public:
 
    // methods
 public:
-   SurgeSynthesizer(PluginLayer* parent);
+   SurgeSynthesizer(PluginLayer* parent, std::string suppliedDataPath="");
    virtual ~SurgeSynthesizer();
    void playNote(char channel, char key, char velocity, char detune);
    void releaseNote(char channel, char key, char velocity);


### PR DESCRIPTION
SurgeSynthesizer has a storage; allow it to use an externally
specified path. This is only used for rack.