### PR TITLE
Change case of windows includes

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -23,8 +23,8 @@
 #include "ConfigurationXml.h"
 #else
 #include <windows.h>
-#include <Shellapi.h>
-#include <Shlobj.h>
+#include <shellapi.h>
+#include <shlobj.h>
 #endif
 
 #include <sstream>


### PR DESCRIPTION
Windows include files in SurgeStorage were included with CamelCase.
This is fine for windows builds, but cross-compile environments
on case sensitive file systems (which is how rack community builds)
failed to build.