### PR TITLE
Remember zoom inside a session VST3

### DIFF
--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -456,6 +456,9 @@ IPlugView* PLUGIN_API SurgeVst3Processor::createView(const char* name)
          editor->disableZoom();
 
       editor->setZoomCallback( [this](SurgeGUIEditor *e) { handleZoom(e); } );
+
+      if( haveZoomed )
+          editor->setZoomFactor(lastZoom);
       
       return editor;
    }
@@ -779,5 +782,8 @@ void SurgeVst3Processor::handleZoom(SurgeGUIEditor *e)
         
         frame->setDirty( true );
         frame->invalid();
+
+        haveZoomed = true;
+        lastZoom = e->getZoomFactor();
     }
 }

--- a/src/vst3/SurgeVst3Processor.h
+++ b/src/vst3/SurgeVst3Processor.h
@@ -138,6 +138,8 @@ protected:
    int blockpos;
 
    bool disableZoom;
+   bool haveZoomed = false;
+   int lastZoom = -1;
    void handleZoom(SurgeGUIEditor *e);
    
    FpuState _fpuState;


### PR DESCRIPTION
With the change in startup path for the 'no-dance' default
size, the memory of last zoom feature of VST3 got dropped.
This restores it in a more sensible point.

Addresses #912