### PR TITLE
Alternate Tunings for Surge (alpha)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SURGE_COMMON_SOURCES
     src/common/SurgeStorageLoadWavetable.cpp
     src/common/SurgeSynthesizer.cpp
     src/common/SurgeSynthesizerIO.cpp
+    src/common/Tunings.cpp
     src/common/UserDefaults.cpp
     libs/xml/tinyxml.cpp
     libs/xml/tinyxmlerror.cpp

--- a/premake5.lua
+++ b/premake5.lua
@@ -231,6 +231,7 @@ function plugincommon()
         "src/common/SurgeStorageLoadWavetable.cpp",
         "src/common/SurgeSynthesizer.cpp",
         "src/common/SurgeSynthesizerIO.cpp",
+        "src/common/Tunings.cpp",
         "src/common/UserDefaults.cpp",
         "libs/xml/tinyxml.cpp",
         "libs/xml/tinyxmlerror.cpp",

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -28,6 +28,8 @@
 #include <iterator>
 #include <functional>
 
+#include "Tunings.h"
+
 namespace fs = std::experimental::filesystem;
 
 #if WINDOWS
@@ -467,14 +469,19 @@ enum sub3_copysource
 
 /* STORAGE layer			*/
 
-class SurgeStorage
+class alignas(16) SurgeStorage
 {
 public:
    float audio_in alignas(16)[2][BLOCK_SIZE_OS];
    float audio_in_nonOS alignas(16)[2][BLOCK_SIZE];
    //	float sincoffset alignas(16)[(FIRipol_M)*FIRipol_N];	// deprecated
 
+
    SurgeStorage(std::string suppliedDataPath="");
+   float table_pitch alignas(16)[512];
+   float table_pitch_inv alignas(16)[512];
+   float table_note_omega alignas(16)[2][512];
+
    ~SurgeStorage();
 
    std::unique_ptr<SurgePatch> _patch;
@@ -543,6 +550,11 @@ public:
    CriticalSection CS_WaveTableData, CS_ModRouting;
    Wavetable WindowWT;
 
+   float note_to_pitch(float x);
+   float note_to_pitch_inv(float x);
+   void note_to_omega(float, float&, float&);
+   void retuneToScale(const Surge::Storage::Scale& s);
+
 private:
    TiXmlDocument snapshotloader;
    std::vector<Parameter> clipboard_p;
@@ -553,9 +565,6 @@ private:
 
 };
 
-float note_to_pitch(float);
-float note_to_pitch_inv(float);
-void note_to_omega(float, float&, float&);
 float db_to_linear(float);
 float lookup_waveshape(int, float);
 float lookup_waveshape_warp(int, float);

--- a/src/common/Tunings.cpp
+++ b/src/common/Tunings.cpp
@@ -1,0 +1,115 @@
+
+#include "Tunings.h"
+
+#include <iostream>
+#include <fstream>
+#include <cstdlib>
+
+/*
+ From: http://huygens-fokker.org/scala/scl_format.html
+ The files are human readable ASCII or 8-bit character text-files.
+ The file type is .scl .
+ There is one scale per file.
+ Lines beginning with an exclamation mark are regarded as comments and are to be ignored.
+ The first (non comment) line contains a short description of the scale, but long lines are possible
+ and should not give a read error. The description is only one line. If there is no description,
+ there should be an empty line. The second line contains the number of notes. This number indicates
+ the number of lines with pitch values that follow. In principle there is no upper limit to this,
+ but it is allowed to reject files exceeding a certain size. The lower limit is 0, which is possible
+ since degree 0 of 1/1 is implicit. Spaces before or after the number are allowed.
+
+ After that come the pitch values, each on a separate line, either as a ratio or as a value in
+ cents. If the value contains a period, it is a cents value, otherwise a ratio. Ratios are written
+ with a slash, and only one. Integer values with no period or slash should be regarded as such, for
+ example "2" should be taken as "2/1". Numerators and denominators should be supported to at least
+ 231-1 = 2147483647. Anything after a valid pitch value should be ignored. Space or horizontal tab
+ characters are allowed and should be ignored. Negative ratios are meaningless and should give a
+ read error. For a description of cents, go here. The first note of 1/1 or 0.0 cents is implicit and
+ not in the files. Files for which Scala gives Error in file format are incorrectly formatted. They
+ should give a read error and be rejected.
+*/
+
+Surge::Storage::Scale Surge::Storage::readSCLFile(std::string fname)
+{
+   std::ifstream inf;
+   inf.open(fname);
+   if (!inf.is_open())
+   {
+      return Scale();
+   }
+
+   std::string line;
+   const int read_header = 0, read_count = 1, read_note = 2;
+   int state = read_header;
+
+   Scale res;
+   res.name = fname;
+   while (std::getline(inf, line))
+   {
+      if (line[0] == '!')
+      {
+         continue;
+      }
+      switch (state)
+      {
+      case read_header:
+         res.description = line;
+         state = read_count;
+         break;
+      case read_count:
+         res.count = atoi(line.c_str());
+         state = read_note;
+         break;
+      case read_note:
+         Tone t;
+         t.stringRep = line;
+         if (line.find(".") != std::string::npos)
+         {
+            t.type = Tone::kToneCents;
+            t.cents = atof(line.c_str());
+            t.floatValue = t.cents / 1200.0 + 1.0;
+         }
+         else
+         {
+            t.type = Tone::kToneRatio;
+            auto slashPos = line.find("/");
+            if (slashPos == std::string::npos)
+            {
+               t.ratio_d = atoi(line.c_str());
+               t.ratio_n = 1;
+            }
+            else
+            {
+               t.ratio_n = atoi(line.substr(0, slashPos).c_str());
+               t.ratio_d = atoi(line.substr(slashPos + 1).c_str());
+            }
+            t.floatValue = 1.0 * t.ratio_n / t.ratio_d;
+         }
+         res.tones.push_back(t);
+
+         break;
+      }
+   }
+
+   return res;
+}
+
+std::ostream& Surge::Storage::operator<<(std::ostream& os, const Surge::Storage::Tone& t)
+{
+   os << (t.type == Tone::kToneCents ? "cents" : "ratio") << "  ";
+   if (t.type == Tone::kToneCents)
+      os << t.cents;
+   else
+      os << t.ratio_n << " / " << t.ratio_d;
+   os << "  (" << t.floatValue << ")";
+   return os;
+}
+
+std::ostream& Surge::Storage::operator<<(std::ostream& os, const Surge::Storage::Scale& sc)
+{
+   os << "Scale\n  " << sc.name << "\n  " << sc.description << "\n  --- " << sc.count
+      << " tones ---\n";
+   for (auto t : sc.tones)
+      os << "    - " << t << "\n";
+   return os;
+}

--- a/src/common/Tunings.h
+++ b/src/common/Tunings.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <iostream>
+
+namespace Surge
+{
+namespace Storage
+{
+struct Tone
+{
+   typedef enum Type
+   {
+      kToneCents,
+      kToneRatio
+   } Type;
+
+   Type type;
+   float cents;
+   int ratio_d, ratio_n;
+   std::string stringRep;
+   float floatValue;
+
+   Tone() : type(kToneRatio), cents(0), ratio_d(1), ratio_n(1), stringRep("1/1"), floatValue(1.0)
+   {
+   }
+};
+
+struct Scale
+{
+   std::string name;
+   std::string description;
+   int count;
+   std::vector<Tone> tones;
+
+   Scale() : name("empty scale"), description(""), count(0)
+   {
+   }
+};
+
+std::ostream& operator<<(std::ostream& os, const Tone& sc);
+std::ostream& operator<<(std::ostream& os, const Scale& sc);
+
+Scale readSCLFile(std::string fname);
+} // namespace Storage
+} // namespace Surge

--- a/src/common/dsp/BiquadFilter.h
+++ b/src/common/dsp/BiquadFilter.h
@@ -194,7 +194,7 @@ public:
    // 440*powf(2,scfreq)*samplerate_inv); }
    double calc_omega(double scfreq)
    {
-      return (2 * 3.14159265358979323846) * 440 * note_to_pitch((float)(12.f * scfreq)) *
+      return (2 * 3.14159265358979323846) * 440 * storage->note_to_pitch((float)(12.f * scfreq)) *
              dsamplerate_inv;
    }
    static double calc_omega_from_Hz(double Hz)

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -11,8 +11,10 @@ FilterCoefficientMaker::FilterCoefficientMaker()
    Reset();
 }
 
-void FilterCoefficientMaker::MakeCoeffs(float Freq, float Reso, int Type, int SubType)
+void FilterCoefficientMaker::MakeCoeffs(
+    float Freq, float Reso, int Type, int SubType, SurgeStorage* storageI)
 {
+   storage = storageI;
    switch (Type)
    {
    case fut_lp12:
@@ -153,7 +155,7 @@ double resoscale4Pole(double reso, int subtype)
 
 void FilterCoefficientMaker::Coeff_SVF(float Freq, float Reso, bool FourPole)
 {
-   double f = 440.f * note_to_pitch(Freq);
+   double f = 440.f * storage->note_to_pitch(Freq);
    double F1 = 2.0 * sin(M_PI * min(0.11, f * (0.25 * samplerate_inv))); // 4x oversampling
    // double Q1 = 2.0 - Reso*2.0;
 
@@ -188,7 +190,7 @@ void FilterCoefficientMaker::Coeff_LP12(float freq, float reso, int subtype)
 
        float cosi,
        sinu;
-   note_to_omega(freq, sinu, cosi);
+   storage->note_to_omega(freq, sinu, cosi);
 
    double alpha = sinu * Map2PoleResonance(reso, freq, subtype);
    if (subtype != st_Smooth)
@@ -225,7 +227,7 @@ void FilterCoefficientMaker::Coeff_LP24(float freq, float reso, int subtype)
 
        double Q2inv = Map4PoleResonance((double)reso, (double)freq, subtype);
    float cosi, sinu;
-   note_to_omega(freq, sinu, cosi);
+   storage->note_to_omega(freq, sinu, cosi);
 
    double alpha = sinu * Q2inv;
    if (subtype != st_Smooth)
@@ -248,7 +250,7 @@ void FilterCoefficientMaker::Coeff_HP12(float freq, float reso, int subtype)
 
        double Q2inv = Map2PoleResonance(reso, freq, subtype);
    float cosi, sinu;
-   note_to_omega(freq, sinu, cosi);
+   storage->note_to_omega(freq, sinu, cosi);
 
    double alpha = sinu * Q2inv;
    if (subtype != 0)
@@ -271,7 +273,7 @@ void FilterCoefficientMaker::Coeff_HP24(float freq, float reso, int subtype)
 
        double Q2inv = Map4PoleResonance((double)reso, (double)freq, subtype);
    float cosi, sinu;
-   note_to_omega(freq, sinu, cosi);
+   storage->note_to_omega(freq, sinu, cosi);
 
    double alpha = sinu * Q2inv;
    if (subtype != 0)
@@ -297,7 +299,7 @@ void FilterCoefficientMaker::Coeff_BP12(float freq, float reso, int subtype)
        double Q2inv = Map2PoleResonance(reso, freq, subtype);
    double Q = 0.5 / Q2inv;
    float cosi, sinu;
-   note_to_omega(freq, sinu, cosi);
+   storage->note_to_omega(freq, sinu, cosi);
 
    double alpha = sinu * Q2inv;
    if (subtype != 0)
@@ -329,7 +331,7 @@ void FilterCoefficientMaker::Coeff_BR12(float freq, float reso, int subtype)
       Q2inv = (2.5 - 2.49 * limit_range((double)(1 - (1 - reso) * (1 - reso)), 0.0, 1.0));
 
    float cosi, sinu;
-   note_to_omega(freq, sinu, cosi);
+   storage->note_to_omega(freq, sinu, cosi);
 
    double alpha = sinu * Q2inv, b0 = 1, b1 = -2 * cosi, b2 = 1, a0 = 1 + alpha, a1 = -2 * cosi,
           a2 = 1 - alpha, a0inv = 1 / a0;
@@ -339,8 +341,8 @@ void FilterCoefficientMaker::Coeff_BR12(float freq, float reso, int subtype)
 
 void FilterCoefficientMaker::Coeff_LP4L(float freq, float reso, int subtype)
 {
-   double gg =
-       limit_range(((double)440 * note_to_pitch(freq) * dsamplerate_os_inv), 0.0, 0.187); // gg
+   double gg = limit_range(((double)440 * storage->note_to_pitch(freq) * dsamplerate_os_inv), 0.0,
+                           0.187); // gg
 
    float t_b1 = 1.f - exp(-2 * M_PI * gg);
    float q = min(2.15f * limit_range(reso, 0.f, 1.f), 0.5f / (t_b1 * t_b1 * t_b1 * t_b1));
@@ -356,7 +358,7 @@ void FilterCoefficientMaker::Coeff_LP4L(float freq, float reso, int subtype)
 
 void FilterCoefficientMaker::Coeff_COMB(float freq, float reso, int subtype)
 {
-   float dtime = (1.f / 440.f) * note_to_pitch(-freq);
+   float dtime = (1.f / 440.f) * storage->note_to_pitch(-freq);
    dtime = dtime * dsamplerate_os -
            FIRoffset; // 1 sample for feedback, 1 sample for the IIR-filter without resonance
    dtime = limit_range(dtime, (float)FIRipol_N, (float)MAX_FB_COMB - FIRipol_N);
@@ -373,7 +375,7 @@ void FilterCoefficientMaker::Coeff_COMB(float freq, float reso, int subtype)
 
 void FilterCoefficientMaker::Coeff_SNH(float freq, float reso, int subtype)
 {
-   float dtime = (1.f / 440.f) * note_to_pitch(-freq) * dsamplerate_os;
+   float dtime = (1.f / 440.f) * storage->note_to_pitch(-freq) * dsamplerate_os;
    double v1 = 1.0 / dtime;
 
    float c[n_cm_coeffs];
@@ -484,4 +486,6 @@ void FilterCoefficientMaker::Reset()
    memset(C, 0, sizeof(float) * n_cm_coeffs);
    memset(dC, 0, sizeof(float) * n_cm_coeffs);
    memset(tC, 0, sizeof(float) * n_cm_coeffs);
+
+   storage = nullptr;
 }

--- a/src/common/dsp/FilterCoefficientMaker.h
+++ b/src/common/dsp/FilterCoefficientMaker.h
@@ -1,11 +1,12 @@
 #pragma once
+#include "SurgeStorage.h"
 
 const int n_cm_coeffs = 8;
 
 class FilterCoefficientMaker
 {
 public:
-   void MakeCoeffs(float Freq, float Reso, int Type, int SubType);
+   void MakeCoeffs(float Freq, float Reso, int Type, int SubType, SurgeStorage* storage);
    void Reset();
    FilterCoefficientMaker();
    float C[n_cm_coeffs], dC[n_cm_coeffs], tC[n_cm_coeffs]; // K1,K2,Q1,Q2,V1,V2,V3,etc
@@ -27,4 +28,6 @@ private:
    void Coeff_SVF(float Freq, float Reso, bool);
 
    bool FirstRun;
+
+   SurgeStorage* storage;
 };

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -30,7 +30,8 @@ public:
    }
    inline float pitch_to_omega(float x)
    {
-      return (float)(M_PI * (16.35159783) * note_to_pitch(x) * dsamplerate_os_inv);
+      // Wondering about that constant 16.35? It is the frequency of C0
+      return (float)(M_PI * (16.35159783) * storage->note_to_pitch(x) * dsamplerate_os_inv);
    }
 
 protected:

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -81,9 +81,9 @@ void SampleAndHoldOscillator::init(float pitch, bool is_display)
          double detune = localcopy[id_detune].f * (detune_bias * float(i) + detune_offset);
          // double t = drand * max(2.0,dsamplerate_os / (16.35159783 *
          // pow((double)1.05946309435,(double)pitch)));
-         double st = drand * note_to_pitch(detune - 12);
+         double st = drand * storage->note_to_pitch(detune - 12);
          drand = (double)rand() / RAND_MAX;
-         double ot = drand * note_to_pitch(detune + l_sync.v);
+         double ot = drand * storage->note_to_pitch(detune + l_sync.v);
          oscstate[i] = st;
          syncstate[i] = st;
       }
@@ -143,7 +143,7 @@ void SampleAndHoldOscillator::convolute(int voice, bool FM, bool stereo)
    if (syncstate[voice] < oscstate[voice])
    {
       ipos = (unsigned int)((float)p24 * (syncstate[voice] * pitchmult_inv));
-      float t = note_to_pitch_inv(detune);
+      float t = storage->note_to_pitch_inv(detune);
       if (state[voice] == 1)
          invertcorrelation = -1.f;
       state[voice] = 0;
@@ -164,9 +164,9 @@ void SampleAndHoldOscillator::convolute(int voice, bool FM, bool stereo)
    // add time until next statechange
    float t;
    if (oscdata->p[5].absolute)
-      t = note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f) + l_sync.v);
+      t = storage->note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f) + l_sync.v);
    else
-      t = note_to_pitch_inv(detune + l_sync.v);
+      t = storage->note_to_pitch_inv(detune + l_sync.v);
 
    float g, gR;
 
@@ -252,8 +252,8 @@ template <bool is_init> void SampleAndHoldOscillator::update_lagvals()
    l_smooth.newValue(localcopy[id_smooth].f);
    l_sub.newValue(localcopy[id_sub].f);
 
-   float invt =
-       4.f * min(1.0, (8.175798915 * note_to_pitch(pitch + l_sync.v)) * dsamplerate_os_inv);
+   float invt = 4.f * min(1.0, (8.175798915 * storage->note_to_pitch(pitch + l_sync.v)) *
+                                   dsamplerate_os_inv);
    float hpf2 = min(integrator_hpf, powf(hpf_cycle_loss, invt));
    // TODO Make a lookup-table
 
@@ -276,7 +276,7 @@ void SampleAndHoldOscillator::process_block(
 {
    this->pitch = min(148.f, pitch0);
    this->drift = drift;
-   pitchmult_inv = max(1.0, dsamplerate_os * (1 / 8.175798915) * note_to_pitch_inv(pitch));
+   pitchmult_inv = max(1.0, dsamplerate_os * (1 / 8.175798915) * storage->note_to_pitch_inv(pitch));
    pitchmult = 1.f / pitchmult_inv;
    // This must be a real division, reciprocal-approximation is not precise enough
    int k, l;

--- a/src/common/dsp/SurgeSuperOscillator.cpp
+++ b/src/common/dsp/SurgeSuperOscillator.cpp
@@ -152,9 +152,9 @@ void SurgeSuperOscillator::init(float pitch, bool is_display)
          double detune = localcopy[id_detune].f * (detune_bias * float(i) + detune_offset);
          // double t = drand * max(2.0,dsamplerate_os / (16.35159783 *
          // pow((double)1.05946309435,(double)pitch)));
-         double st = 0.25 * drand * note_to_pitch_inv(detune - 12);
+         double st = 0.25 * drand * storage->note_to_pitch_inv(detune - 12);
          drand = (double)rand() / RAND_MAX;
-         // double ot = 0.25 * drand * note_to_pitch_inv(detune + l_sync.v);
+         // double ot = 0.25 * drand * storage->note_to_pitch_inv(detune + l_sync.v);
          // HACK test 0.2*
          oscstate[i] = st;
          syncstate[i] = st;
@@ -217,9 +217,9 @@ template <bool FM> void SurgeSuperOscillator::convolute(int voice, bool stereo)
          ipos = (unsigned int)(p24 * (syncstate[voice] * pitchmult_inv * FMmul_inv));
       else
          ipos = (unsigned int)(p24 * (syncstate[voice] * pitchmult_inv));
-      // double t = max(0.5,dsamplerate_os * (1/8.175798915) * note_to_pitch_inv(pitch + detune) *
-      // 2);
-      float t = note_to_pitch_inv(detune) * 2;
+      // double t = max(0.5,dsamplerate_os * (1/8.175798915) * storage->note_to_pitch_inv(pitch +
+      // detune) * 2);
+      float t = storage->note_to_pitch_inv(detune) * 2;
       state[voice] = 0;
       last_level[voice] += dc_uni[voice] * (oscstate[voice] - syncstate[voice]);
 
@@ -250,9 +250,9 @@ template <bool FM> void SurgeSuperOscillator::convolute(int voice, bool stereo)
    float sync = min((float)l_sync.v, (12 + 72 + 72) - pitch);
    float t;
    if (oscdata->p[5].absolute)
-      t = note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f) + sync);
+      t = storage->note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f) + sync);
    else
-      t = note_to_pitch_inv(detune + sync);
+      t = storage->note_to_pitch_inv(detune + sync);
 
    float t_inv = rcp(t);
    float g = 0.0, gR = 0.0;
@@ -374,8 +374,8 @@ template <bool is_init> void SurgeSuperOscillator::update_lagvals()
    l_shape.newValue(limit_range(localcopy[id_shape].f, -1.f, 1.f));
    l_sub.newValue(limit_range(localcopy[id_sub].f, 0.f, 1.f));
 
-   float invt =
-       4.f * min(1.0, (8.175798915 * note_to_pitch(pitch + l_sync.v)) * dsamplerate_os_inv);
+   float invt = 4.f * min(1.0, (8.175798915 * storage->note_to_pitch(pitch + l_sync.v)) *
+                                   dsamplerate_os_inv);
    float hpf2 = min(integrator_hpf, powf(hpf_cycle_loss, invt)); // TODO ACHTUNG/WARNING! Make a lookup table
 
    li_hpf.set_target(hpf2);
@@ -400,7 +400,8 @@ void SurgeSuperOscillator::process_block(
 {
    this->pitch = min(148.f, pitch0);
    this->drift = drift;
-   pitchmult_inv = Max(1.0, dsamplerate_os * (1.f / 8.175798915f) * note_to_pitch_inv(pitch));
+   pitchmult_inv =
+       Max(1.0, dsamplerate_os * (1.f / 8.175798915f) * storage->note_to_pitch_inv(pitch));
 
    pitchmult =
        1.f /

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -763,10 +763,10 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
          cutoffB += cutoffA;
 
       CM[0].MakeCoeffs(cutoffA, localcopy[id_resoa].f, scene->filterunit[0].type.val.i,
-                       scene->filterunit[0].subtype.val.i);
+                       scene->filterunit[0].subtype.val.i, storage);
       CM[1].MakeCoeffs(
           cutoffB, scene->f2_link_resonance.val.b ? localcopy[id_resoa].f : localcopy[id_resob].f,
-          scene->filterunit[1].type.val.i, scene->filterunit[1].subtype.val.i);
+          scene->filterunit[1].type.val.i, scene->filterunit[1].subtype.val.i, storage);
 
       for (int u = 0; u < 2; u++)
       {

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -21,6 +21,7 @@ public:
    lipol_ps osclevels alignas(16)[7];
    pdata localcopy alignas(16)[n_scene_params];
    float fmbuffer alignas(16)[BLOCK_SIZE_OS];
+
    // used for the 2>1<3 FM-mode (Needs the pointer earlier)
 
    SurgeVoice();

--- a/src/common/dsp/WavetableOscillator.cpp
+++ b/src/common/dsp/WavetableOscillator.cpp
@@ -226,9 +226,9 @@ void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
    // add time until next statechange
    float tempt;
    if (oscdata->p[5].absolute)
-      tempt = note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f));
+      tempt = storage->note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f));
    else
-      tempt = note_to_pitch_inv(detune);
+      tempt = storage->note_to_pitch_inv(detune);
    float t;
    float xt = ((float)state[voice] + 0.5f) * dt;
    // xt = (1 - hskew + 2*hskew*xt);
@@ -244,7 +244,7 @@ void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
            t = dt * tempt * wt_inc;
    }	*/
    float ft = block_pos * formant_t + (1.f - block_pos) * formant_last;
-   float formant = note_to_pitch(-ft);
+   float formant = storage->note_to_pitch(-ft);
    dt *= formant * xt;
 
    // if(state[voice] >= (oscdata->wt.size-wt_inc)) dt += (1-formant);
@@ -332,7 +332,7 @@ template <bool is_init> void WavetableOscillator::update_lagvals()
    l_shape.newValue(limit_range(localcopy[id_shape].f, 0.f, 1.f));
    formant_t = max(0.f, localcopy[id_formant].f);
 
-   float invt = min(1.0, (8.175798915 * note_to_pitch(pitch_t)) * dsamplerate_os_inv);
+   float invt = min(1.0, (8.175798915 * storage->note_to_pitch(pitch_t)) * dsamplerate_os_inv);
    float hpf2 = min(integrator_hpf, powf(hpf_cycle_loss, 4 * invt)); // TODO Make a lookup table
 
    hpf_coeff.newValue(hpf2);
@@ -358,7 +358,8 @@ void WavetableOscillator::process_block(
 {
    pitch_last = pitch_t;
    pitch_t = min(148.f, pitch0);
-   pitchmult_inv = max(1.0, dsamplerate_os * (1 / 8.175798915) * note_to_pitch_inv(pitch_t));
+   pitchmult_inv =
+       max(1.0, dsamplerate_os * (1 / 8.175798915) * storage->note_to_pitch_inv(pitch_t));
    pitchmult = 1.f / pitchmult_inv; // This must be a real division, reciprocal-approximation is not
                                     // precise enough
    this->drift = drift;

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -137,7 +137,7 @@ void WindowOscillator::ProcessSubOscs(bool stereo)
        (int)(float)(oscdata->wt.n_tables * localcopy[oscdata->p[0].param_id_in_scene].f), 0,
        (int)oscdata->wt.n_tables - 1);
    int FormantMul =
-       (int)(float)(65536.f * note_to_pitch(localcopy[oscdata->p[1].param_id_in_scene].f));
+       (int)(float)(65536.f * storage->note_to_pitch(localcopy[oscdata->p[1].param_id_in_scene].f));
    FormantMul = std::max(FormantMul >> WindowVsWavePO2, 1);
    {
       // SSE2 path
@@ -231,8 +231,8 @@ void WindowOscillator::process_block(float pitch, float drift, bool stereo, bool
    for (int l = 0; l < ActiveSubOscs; l++)
    {
       Sub.DriftLFO[l][0] = drift_noise(Sub.DriftLFO[l][1]);
-      float f = note_to_pitch((pitch - 57.f) + drift * Sub.DriftLFO[l][0] +
-                              Detune * (DetuneOffset + DetuneBias * (float)l));
+      float f = storage->note_to_pitch((pitch - 57.f) + drift * Sub.DriftLFO[l][0] +
+                                       Detune * (DetuneOffset + DetuneBias * (float)l));
       int Ratio = Float2Int(220.f * 32768.f * f * (float)(storage->WindowWT.size) *
                             samplerate_inv); // (65536.f*0.5f), 0.5 for oversampling
       Sub.Ratio[l] = Ratio;

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -60,19 +60,19 @@ void DualDelayEffect::setvars(bool init)
    if (init)
    {
       timeL.newValue(samplerate * ((fxdata->p[0].temposync ? storage->temposyncratio_inv : 1.f) *
-                                   note_to_pitch(12 * fxdata->p[0].val.f)) +
+                                   storage->note_to_pitch(12 * fxdata->p[0].val.f)) +
                      LFOval - FIRoffset);
       timeR.newValue(samplerate * ((fxdata->p[1].temposync ? storage->temposyncratio_inv : 1.f) *
-                                   note_to_pitch(12 * fxdata->p[1].val.f)) -
+                                   storage->note_to_pitch(12 * fxdata->p[1].val.f)) -
                      LFOval - FIRoffset);
    }
    else
    {
       timeL.newValue(samplerate * ((fxdata->p[0].temposync ? storage->temposyncratio_inv : 1.f) *
-                                   note_to_pitch(12 * *f[0])) +
+                                   storage->note_to_pitch(12 * *f[0])) +
                      LFOval - FIRoffset);
       timeR.newValue(samplerate * ((fxdata->p[1].temposync ? storage->temposyncratio_inv : 1.f) *
-                                   note_to_pitch(12 * *f[1])) -
+                                   storage->note_to_pitch(12 * *f[1])) -
                      LFOval - FIRoffset);
    }
 

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -268,8 +268,8 @@ template <int v> void ChorusEffect<v>::setvars(bool init)
       feedback.set_target_smoothed(0.5f * amp_to_linear(*f[3]));
       float rate =
           envelope_rate_linear(-*f[1]) * (fxdata->p[1].temposync ? storage->temposyncratio : 1.f);
-      float tm =
-          note_to_pitch(12 * *f[0]) * (fxdata->p[0].temposync ? storage->temposyncratio_inv : 1.f);
+      float tm = storage->note_to_pitch(12 * *f[0]) *
+                 (fxdata->p[0].temposync ? storage->temposyncratio_inv : 1.f);
       for (int i = 0; i < v; i++)
       {
          lfophase[i] += rate;

--- a/src/common/dsp/effect/FreqshiftEffect.cpp
+++ b/src/common/dsp/effect/FreqshiftEffect.cpp
@@ -43,11 +43,11 @@ void FreqshiftEffect::setvars(bool init)
 
    if (init)
       time.newValue((fxdata->p[fsp_delay].temposync ? storage->temposyncratio_inv : 1.f) *
-                        samplerate * note_to_pitch(12 * fxdata->p[fsp_delay].val.f) -
+                        samplerate * storage->note_to_pitch(12 * fxdata->p[fsp_delay].val.f) -
                     FIRoffset);
    else
       time.newValue((fxdata->p[fsp_delay].temposync ? storage->temposyncratio_inv : 1.f) *
-                        samplerate * note_to_pitch(12 * *f[fsp_delay]) -
+                        samplerate * storage->note_to_pitch(12 * *f[fsp_delay]) -
                     FIRoffset);
    mix.set_target_smoothed(*f[fsp_mix]);
 

--- a/src/common/dsp/effect/Reverb1Effect.cpp
+++ b/src/common/dsp/effect/Reverb1Effect.cpp
@@ -225,7 +225,7 @@ void Reverb1Effect::process(float* dataL, float* dataR)
    mix.set_target_smoothed(*f[rp_mix]);
    width.set_target_smoothed(db_to_linear(*f[rp_width]));
 
-   int pdtime = (int)(float)samplerate * note_to_pitch(12 * *f[rp_predelay]) *
+   int pdtime = (int)(float)samplerate * storage->note_to_pitch(12 * *f[rp_predelay]) *
                 (fxdata->p[rp_predelay].temposync ? storage->temposyncratio_inv : 1.f);
 
    const __m128 one4 = _mm_set1_ps(1.f);

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2676,7 +2676,7 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
     mpeSubMenu->forget();
 
     // Mouse behavior
-
+    // Mouse behavior
     int mid = 0;
 
     COptionMenu* mouseSubMenu = new COptionMenu(menuRect, 0, 0, 0, 0,
@@ -2733,7 +2733,51 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
     mouseSubMenu->forget();
 
     // End Mouse behavior
+    settingsMenu->addSeparator(eid++);
+    
 
+    int tid=0;
+    COptionMenu *tuningSubMenu = new COptionMenu(menuRect, 0, 0, 0, 0,
+                                                 VSTGUI::COptionMenu::kNoDrawStyle |
+                                                 VSTGUI::COptionMenu::kMultipleCheckStyle);
+
+    addCallbackMenu(tuningSubMenu, "Set to Standard Tuning",
+                    [this]()
+                    {
+                        this->synth->storage.init_tables();
+                    }
+        );
+    tid++;
+
+    addCallbackMenu(tuningSubMenu, "Apply .scl file tuning",
+                    [this]()
+                    {
+                        auto cb = [this](std::string sf)
+                        {
+                            auto sc = Surge::Storage::readSCLFile(sf);
+                            this->synth->storage.retuneToScale(sc);
+                        };
+                        Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.userDataPath,
+                                                                      ".scl",
+                                                                      cb);
+                    }
+        );
+    tid++;
+    tuningSubMenu->addSeparator(tid++);
+    
+    addCallbackMenu(tuningSubMenu, "Apply .kbm file mapping",
+                    [this]()
+                    {
+                        Surge::UserInteractions::promptError("KBM File Mappings are not yet supported in Surge",
+                                                             "Unsupported",
+                                                             this);
+                    }
+        );
+
+    settingsMenu->addEntry(tuningSubMenu, "Tunings (experimental)");
+    eid++;
+    tuningSubMenu->forget();
+    
     settingsMenu->addSeparator(eid++);
 
     addCallbackMenu(settingsMenu, "Open User Data Folder", [this]() {

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -7,6 +7,8 @@
 #include "Stress.h"
 #include "SurgeError.h"
 
+#include "Tunings.h"
+
 void simpleOscillatorToStdOut()
 {
    SurgeSynthesizer* surge = Surge::Headless::createSurge(44100);
@@ -87,6 +89,32 @@ void statsFromPlayingEveryPatch()
    delete surge;
 }
 
+void testTuning()
+{
+   SurgeSynthesizer* surge = Surge::Headless::createSurge(44100);
+
+   Surge::Storage::Scale s = Surge::Storage::readSCLFile("/Users/paul/dev/music/scl/05-22.scl");
+    std::cout << s;
+
+    auto n2f = [surge](int n)
+        {
+            std::cout << "N2F " << n
+            << " " << surge->storage.note_to_pitch(n)
+            << " " << surge->storage.note_to_pitch(n) * 16.35159783
+            << std::endl;
+        };
+   //auto s = Surge::Storage::readSCLFile( "/Users/paul/tmp/scl/temp12k4.scl" );
+   //auto s = Surge::Storage::readSCLFile( "/Users/paul/dev/music/surge/flat.scl" );
+   //auto s = Surge::Storage::readSCLFile("/Users/paul/tmp/scl/lumma_12_strangeion.scl");
+   
+   std::cout << "BEFORE\n";
+   n2f(0); n2f(24); n2f(25); n2f(60); n2f(57); n2f(48);
+   surge->storage.retuneToScale(s);
+
+   std::cout << "AFTER\n";
+   n2f(0); n2f(24); n2f(25);  n2f(60); n2f(57); n2f(48);
+}
+
 void playSomeBach()
 { 
    SurgeSynthesizer* surge = Surge::Headless::createSurge(44100);
@@ -126,16 +154,19 @@ int main(int argc, char** argv)
    try 
    {
       // simpleOscillatorToStdOut();
-      statsFromPlayingEveryPatch();
+       //statsFromPlayingEveryPatch();
       //playSomeBach();
       //Surge::Headless::createAndDestroyWithScaleAndRandomPatch(20000);
       // Surge::Headless::pullInitSamplesWithNoNotes(1000);
+       testTuning();
    }
    catch( Surge::Error &e )
    {
 	std::cout << "SurgeError: " << e.getTitle() << "\n" << e.getMessage() << "\n";
 	return 1;
    }
+
+   // playSomeBach();
 
    return 0;
 }


### PR DESCRIPTION
As part of the feature request in #828, this begins to add
alternate non-uniform tunings to surge. This commit is a good
step along the way to the final feature set but is incomplete.

With this commit, you can return a surge to an .scl file of your
chosing, but you cannot load a kbm, cannot choose a center note
other than C4/261hz, and the scl file you choose does not save
into either the patch or the DAW and is transient.

I am adding this commit, though, so that (1) users more experienced
with tuning can test this in the nightlies, (2) I don't have to
keep rebasing it forward and (3) I am guaranteed to get this feature
properly into 1.6.2