### PR TITLE
Surge UserInteractions stubbed with Zenity

### DIFF
--- a/doc/Developer Guide.md
+++ b/doc/Developer Guide.md
@@ -210,8 +210,8 @@ sudo apt-get install ajmidid
 The run jac and ajmidid in separate terminals
 
 ```
-jack -d alsa -X alsa_midi
-ajmidid -e
+jackd -d alsa -X alsa_midi
+a2jmidid -e
 ```
 
 Now start surge with carla-single

--- a/src/common/gui/PopupEditorDialog.cpp
+++ b/src/common/gui/PopupEditorDialog.cpp
@@ -147,11 +147,27 @@ void spawn_miniedit_text(char* c, int maxchars)
 #elif LINUX
 
 #include "UserInteractions.h"
+#include <string.h>
 
 void spawn_miniedit_text(char* c, int maxchars)
 {
    // FIXME: Implement text edit popup on Linux.
-   Surge::UserInteractions::promptError( "miniedit_text is not implemented on linux", "Unimplemented Feature" );
+   char cmd[1024];
+   snprintf(cmd, 1024, "zenity --entry --entry-text \"%s\"", c );
+   FILE *z = popen( cmd, "r" );
+   if( ! z )
+   {
+      return;
+   }
+   char buffer[ 1024 ];
+   if (!fscanf(z, "%1024s", buffer))
+   {
+      return;
+   }
+   pclose(z);
+
+   strncpy( c, buffer, maxchars);
+
 }
 
 #endif


### PR DESCRIPTION
Surge UserInteractions on Linux should really use
the vst event loop and vstgui and be hand written because
otherwise you have to popen zenity which can cause audio
pauses and pops.

But audio pauses and pops on anciliary actions are better than
nothing, so stick in a crudy zenity implementation which is
a start, and someone inspired to remove it at least has a spec
in the future.

Addresses #562
Closes #637 and #917