### PR TITLE
Refcount assert limit

### DIFF
--- a/src/common/thread/CriticalSection.cpp
+++ b/src/common/thread/CriticalSection.cpp
@@ -32,7 +32,7 @@ void CriticalSection::enter()
 #endif
    refcount++;
    assert(refcount > 0);
-   assert(!(refcount > 5)); // if its >5 there's some crazy *§%* going on ^^
+   assert(!(refcount > 10)); // if its >10 there's some crazy *§%* going on ^^
 }
 
 void CriticalSection::leave()

--- a/src/common/thread/CriticalSection.h
+++ b/src/common/thread/CriticalSection.h
@@ -30,7 +30,7 @@ public:
     pthread_mutex_lock(&mutex);
     refcount++;
     assert(refcount > 0);
-    assert(!(refcount > 5)); // if its >5 there's some crazy *§%* going on ^^
+    assert(!(refcount > 10)); // if its >10 there's some crazy *§%* going on ^^
   }
   void leave(){
     refcount--;


### PR DESCRIPTION
One user, one time, when making a particularly wavetable heavy
set of patches, ran into the refcount limit on the critical
section. We aren't sure how and can't reproduce it. But if
refcounts are going to run away, they will run away to 10
just as easily as they run away to 5, so up the assert limit.

Closes #908