### PR TITLE
Fix two more tuning problems

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1190,11 +1190,9 @@ float envelope_rate_linear(float x)
 
 void SurgeStorage::retuneToScale(const Surge::Storage::Scale& s)
 {
-   int scale0 = 48;  // This is the 1.0 point
-   float value0 = 16; 
-
    float pitches[512];
-   int pos0 = 256 + scale0;
+   int pos0 = 256 + scaleConstantNote();
+   float pitchMod = log(scaleConstantPitch())/log(2) - 1;
    pitches[pos0] = 1.0;
    for (int i=0; i<512; ++i)
    {
@@ -1216,7 +1214,7 @@ void SurgeStorage::retuneToScale(const Surge::Storage::Scale& s)
            float mul = pow( s.tones[s.count-1].floatValue, rounds);
            pitches[i] = s.tones[thisRound].floatValue + rounds * (s.tones[s.count - 1].floatValue - 1.0);
            float otp = table_pitch[i];
-           table_pitch[i] = pow( 2.0, pitches[i] + 3 );
+           table_pitch[i] = pow( 2.0, pitches[i] + pitchMod );
 
 #if DEBUG_SCALES
            if( i > 296 && i < 340 )

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -553,8 +553,11 @@ public:
    float note_to_pitch(float x);
    float note_to_pitch_inv(float x);
    void note_to_omega(float, float&, float&);
-   void retuneToScale(const Surge::Storage::Scale& s);
 
+   void retuneToScale(const Surge::Storage::Scale& s);
+   inline int scaleConstantNote() { return 48; }
+   inline float scaleConstantPitch() { return 16.0; }
+   
 private:
    TiXmlDocument snapshotloader;
    std::vector<Parameter> clipboard_p;

--- a/src/common/dsp/SurgeSuperOscillator.cpp
+++ b/src/common/dsp/SurgeSuperOscillator.cpp
@@ -250,9 +250,11 @@ template <bool FM> void SurgeSuperOscillator::convolute(int voice, bool stereo)
    float sync = min((float)l_sync.v, (12 + 72 + 72) - pitch);
    float t;
    if (oscdata->p[5].absolute)
-      t = storage->note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f) + sync);
+      t = storage->note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f) + sync + storage->scaleConstantNote()) *
+          storage->scaleConstantPitch();
    else
-      t = storage->note_to_pitch_inv(detune + sync);
+      t = storage->note_to_pitch_inv(detune + sync + storage->scaleConstantNote()) *
+          storage->scaleConstantPitch();
 
    float t_inv = rcp(t);
    float g = 0.0, gR = 0.0;


### PR DESCRIPTION
1. The concept of "48" being the center and "16" being its pitch
   were hardcoded. Make those inline functions in storage (which
   right now just return 48 and 16) and use those in the retuneToScale

2. The Classic oscillator convoultion for Square and Triangle
   assumed that note 0 was pitch 1; whereas we know note 48 is pitch
   16 and in regular tuning that is 2^(-48/12) lower. So adjust to
   use the center note as the convlution period time.

All of this is a no-op if you are in standard tuning.

Addresses #828