### PR TITLE
Fix linux file navigation

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2760,6 +2760,7 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
                                 if( sf.compare(sf.length() - sfx.length(), sfx.length(), sfx) != 0 )
                                 {
                                     Surge::UserInteractions::promptError( "Please only select .scl files", "Invalid Choice" );
+                                    std::cout << "FILE is [" << sf << "]" << std::endl;
                                     return;
                                 }
                             }

--- a/src/linux/UserInteractionsLinux.cpp
+++ b/src/linux/UserInteractionsLinux.cpp
@@ -86,10 +86,14 @@ void promptFileOpenDialog(const std::string& initialDirectory,
       return;
    }
    char buffer[ 1024 ];
-   if (!fscanf(z, "%1024s", buffer))
+   if (fgets(buffer, sizeof(buffer), z) == NULL)
    {
       return;
    }
+   for( int i=0; i<1024; ++i )
+      if( buffer[i] == '\n' )
+         buffer[i] = 0;
+   
    pclose(z);
 
    callbackOnOpen(buffer);


### PR DESCRIPTION
Linux file navigation with spaces would truncate the file name.
Fix it with this more hacky approach. There Must Be A Better Way
but This Works.

Closes #924