### PR TITLE
Modval calculation error in mouse extrema

### DIFF
--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -321,7 +321,7 @@ void CSurgeSlider::bounceValue(const bool keeprest)
        modval = 1.f;
    }
    if (modval < -1.f) {
-       restmodval = 1.f - modval;
+       restmodval = modval - (-1.f);
        modval = -1.f;
    }
 }


### PR DESCRIPTION
restmodval was computed incorrectly leading to the
modulation slider jumping to max when scrolled very past min
in extremis. Calculate symmetrically with the restval.

Closes #935