### PR TITLE
Fork VST3SDK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vst3sdk"]
 	path = vst3sdk
-	url = https://github.com/steinbergmedia/vst3sdk.git
+	url = https://github.com/surge-synthesizer/vst3sdk.git
 [submodule "vstgui.surge"]
 	path = vstgui.surge
 	url = https://github.com/surge-synthesizer/vstgui.git

--- a/doc/vst3sdk-fork.md
+++ b/doc/vst3sdk-fork.md
@@ -1,0 +1,5 @@
+Surge uses a fork of vst3sdk. Unlike our fork of vstgui, this is not
+to change code, but rather just to remove the needlessly large doc/
+subdirectory from our checkouts.
+
+The file vst3sdk/SURGE.changes.md explains how it works.

--- a/premake5.lua
+++ b/premake5.lua
@@ -157,7 +157,7 @@ includedirs {
     "libs/nanosvg/src",
     "src/common/vt_dsp",
     "src/common/thread",
-    "vst3sdk/vstgui4",
+    "vstgui.surge",
     "vst3sdk",
     "libs/"
     }

--- a/src/common/gui/CDIBitmap.h
+++ b/src/common/gui/CDIBitmap.h
@@ -7,7 +7,7 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#include <vstgui/vstgui.h>
+#include "vstgui/vstgui.h"
 
 union rgbpixel
 {

--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -5,7 +5,7 @@
 ** load bitmaps at multiple resolutions and draw them scaled accordingly
 */
 
-#include <vstgui/vstgui.h>
+#include "vstgui/vstgui.h"
 
 #include <vector>
 #include <map>

--- a/src/common/gui/Colors.h
+++ b/src/common/gui/Colors.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <vstgui/vstgui.h>
+#include "vstgui/vstgui.h"
 
 const VSTGUI::CColor col_plain_std = VSTGUI::CColor(214, 209, 198, 255);
 const VSTGUI::CColor col_plain_shadow = VSTGUI::CColor(192, 188, 175, 255);

--- a/src/common/gui/SurgeBitmaps.h
+++ b/src/common/gui/SurgeBitmaps.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "resource.h"
-#include <vstgui/vstgui.h>
+#include "vstgui/vstgui.h"
 #include <map>
 
 class CScalableBitmap;

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -7,7 +7,7 @@
 
 #if TARGET_AUDIOUNIT
 //#include "vstkeycode.h"
-#include <vstgui/plugin-bindings/plugguieditor.h>
+#include "vstgui/plugin-bindings/plugguieditor.h"
 typedef VSTGUI::PluginGUIEditor EditorType;
 #elif TARGET_VST3
 #include "public.sdk/source/vst/vstguieditor.h"
@@ -17,11 +17,11 @@ typedef Steinberg::Vst::VSTGUIEditor EditorType;
 #include "../linux/linux-aeffguieditor.h"
 typedef VSTGUI::LinuxAEffGUIEditor EditorType;
 #else
-#include <vstgui/plugin-bindings/aeffguieditor.h>
+#include "vstgui/plugin-bindings/aeffguieditor.h"
 typedef VSTGUI::AEffGUIEditor EditorType;
 #endif
 #else
-#include <vstgui/plugin-bindings/plugguieditor.h>
+#include "vstgui/plugin-bindings/plugguieditor.h"
 typedef VSTGUI::PluginGUIEditor EditorType;
 #endif
 

--- a/src/common/gui/vstcontrols.h
+++ b/src/common/gui/vstcontrols.h
@@ -1,2 +1,2 @@
-#include <vstgui/vstgui.h>
+#include "vstgui/vstgui.h"
 #include <CCursorHidingControl.h>

--- a/src/mac/DisplayInfoMac.mm
+++ b/src/mac/DisplayInfoMac.mm
@@ -2,7 +2,7 @@
 #include "UserInteractions.h"
 #include <CoreFoundation/CoreFoundation.h>
 #include <Cocoa/Cocoa.h>
-#include <vstgui/vstgui.h>
+#include "vstgui/vstgui.h"
 #include "vstgui/lib/platform/mac/cocoa/nsviewframe.h"
 
 namespace Surge

--- a/src/vst2/vstplugsquartz.h
+++ b/src/vst2/vstplugsquartz.h
@@ -24,7 +24,7 @@
 
 #include <Carbon/Carbon.h>
 #include <Accelerate/Accelerate.h>
-#include <vstgui/vstgui.h>
+#include "vstgui/vstgui.h"
 #include "globals.h"
 
 #define stricmp strcmp


### PR DESCRIPTION
This commit moves our vst3sdk from the steinbergmedia/ one to a
fork in surge-synthesizer which is identical in every way, except
for the elimination of the doc/ submodule and the vstgui4/ submodule.
The elimination fo the vstgui4/ submodule showed some places where we
were not using the surge fork for include files; so also correct that
with various source and premake changes

Closes #936
