### PR TITLE
Two changes for RACK

### DIFF
--- a/libs/filesystem/filesystem.cpp
+++ b/libs/filesystem/filesystem.cpp
@@ -138,16 +138,16 @@ namespace std::experimental::filesystem {
     std::vector<file> directory_iterator(path p) {
         std::vector<file> files;
         DIR *dp;
-        struct dirent *dirp;
         if((dp  = opendir(p.c_str())) == NULL) {
 //            std::cout << "Error(" << errno << ") opening " << p.generic_string() << std::endl;
           return files;
         }
         
         // this needs to return the full path not just the relative path
-        while ((dirp = readdir(dp)) != NULL) {
-          string fname(dirp->d_name);
-            // Skip . and .. : https://github.com/kurasu/surge/issues/77
+        struct dirent dirp, *entry;
+        while ( (readdir_r(dp, &dirp, &entry) == 0) && entry != NULL) {
+          string fname(dirp.d_name);
+          // Skip . and .. : https://github.com/kurasu/surge/issues/77
           if (fname.compare(".") == 0 || fname.compare("..") == 0) {
               continue;
           }

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -239,9 +239,9 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath)
    }
 
    load_midi_controllers();
-   refresh_wtlist();
 
 #if !TARGET_RACK   
+   refresh_wtlist();
    refresh_patchlist();
 #endif
    


### PR DESCRIPTION
Two changes for the VCVRack implementation

1. Make the read of the wavetables an on-demand thing in rack, like
   the patches, not an every-storage thing.
2. Use the re-entrant version of readdir in libs/filesystem

Closes #942