### PR TITLE
Implement Param Change Automation

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -753,17 +753,13 @@ bool aulayer::ParameterEndEdit(int p)
 
 bool aulayer::ParameterUpdate(int p)
 {
-   // AUParameterChange_TellListeners(GetComponentInstance(), p);
-   // set up an AudioUnitParameter structure with all of the necessary values
-   AudioUnitParameter dirtyParam;
-   memset(&dirtyParam, 0, sizeof(dirtyParam)); // zero out the struct
-   dirtyParam.mAudioUnit = GetComponentInstance();
-   dirtyParam.mParameterID = p;
-   dirtyParam.mScope = kAudioUnitScope_Global;
-   dirtyParam.mElement = 0;
-
-   AUParameterListenerNotify(NULL, NULL, &dirtyParam);
-
+   AudioUnitEvent event;
+   event.mEventType = kAudioUnitEvent_ParameterValueChange;
+   event.mArgument.mParameter.mAudioUnit = GetComponentInstance();
+   event.mArgument.mParameter.mParameterID = p;
+   event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
+   event.mArgument.mParameter.mElement = 0;
+   AUEventListenerNotify(NULL, NULL, &event);
    return true;
 }
 

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -770,8 +770,7 @@ void SurgeSynthesizer::sendParameterAutomation(long index, float value)
    if (externalparam >= 0)
    {
 #if TARGET_AUDIOUNIT
-      // FIXME!
-      // getParent()->ParameterUpdate(externalparam);
+      getParent()->ParameterUpdate(externalparam);
 #elif TARGET_VST3
       getParent()->setParameterAutomated(externalparam, value);
 #elif TARGET_HEADLESS || TARGET_APP


### PR DESCRIPTION
the AU had never had the param-change notification to the AU
layer enabled. That was partly because the API wasn't the one
we wanted I don't think. So fix the aulayer and restore the call.

Closes #929