### PR TITLE
Return UI for Solo

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1364,7 +1364,7 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
             }
          }
          switch_toggled_queued = true;
-         // need_refresh = true; See github issue #160
+         need_refresh = true; 
          break;
       };
    }


### PR DESCRIPTION
SOLO is real Solo in surge. One at a time. The automation changes
I made way back in December when getting things working with
VST2 external automation broke the display refresh for this and it
has been wrong since. Re-instate it.

Closes #891