### PR TITLE
Initialize lastSeenZoom

### DIFF
--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -162,6 +162,7 @@ CScalableBitmap::CScalableBitmap(CResourceDescription desc, VSTGUI::CFrame* f)
 
     extraScaleFactor = 100;
     currentPhysicalZoomFactor = 100;
+    lastSeenZoom = -1;
 }
 
 #define DUMPR(r)                                                                                   \
@@ -222,8 +223,8 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
           lastSeenZoom = currentPhysicalZoomFactor;
        }
 
-       CGraphicsTransform tf =
-           CGraphicsTransform().scale(lastSeenZoom / 100.0, lastSeenZoom / 100.0);
+       CGraphicsTransform tf = CGraphicsTransform().scale(lastSeenZoom / 100.0, lastSeenZoom / 100.0);
+       
        /*
        ** VSTGUI has this wierdo bug where it shrinks backgrounds properly but doesn't grow them. Sigh.
        ** So asymmetrically treat the extra factor here and only here.
@@ -233,6 +234,7 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
            CGraphicsTransform().scale(exs / 100.0, exs / 100.0);
        CGraphicsTransform itf = tf.inverse();
        CGraphicsTransform ixtf = xtf.inverse();
+
 
        if (offscreenCache.find(offset) == offscreenCache.end())
        {

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -8,12 +8,10 @@ using namespace VSTGUI;
 
 SurgeBitmaps::SurgeBitmaps()
 {
-   std::cout << "Constructing a registry" << std::endl;
 }
 
 SurgeBitmaps::~SurgeBitmaps()
 {
-   std::cout << "Destroying a registry" << std::endl;
    for (auto pair : bitmap_registry)
    {
       pair.second->forget();


### PR DESCRIPTION
CSCalableBitmap didn't initialize this member so the generation of
clean bitmaps was comparing with an unset variable. This may be
what causes #952, although I am having a hard time reproducing it
reliably. But lets push this fix and see if it fixes it for dave.