### PR TITLE
Restore Side-buttons for toggle editing

### DIFF
--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -257,7 +257,7 @@ CMouseEventResult CModulationSourceButton::onMouseDown(CPoint& where, const CBut
    }
 
    if (listener &&
-       buttons & (kAlt | kRButton | kMButton | kShift | kControl | kApple | kDoubleClick))
+       buttons & (kAlt | kRButton | kMButton | kButton4 | kButton5 | kShift | kControl | kApple | kDoubleClick))
    {
       if (listener->controlModifierClicked(this, buttons) != 0)
          return kMouseDownEventHandledButDontNeedMovedOrUpEvents;

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -346,7 +346,7 @@ CMouseEventResult CSurgeSlider::onMouseDown(CPoint& where, const CButtonState& b
    }
 
    if (listener &&
-       buttons & (kAlt | kRButton | kMButton | kShift | kControl | kApple | kDoubleClick))
+       buttons & (kAlt | kRButton | kMButton | kButton4 | kButton5 | kShift | kControl | kApple | kDoubleClick))
    {
       if (listener->controlModifierClicked(this, buttons) != 0)
          return kMouseEventHandled;


### PR DESCRIPTION
The side buttons (button 4 and 5) are bound to toggle mod editing
in SurgeSynthesizer but the method which would do this is
wrapped in a conditional which ignores buttons 4 and 5 in
the slider and modulation source button. Fix that.

Closes #906 