### PR TITLE
Musical TempoSync Values

### DIFF
--- a/scripts/misc/figure-out-times.py
+++ b/scripts/misc/figure-out-times.py
@@ -1,0 +1,107 @@
+# This is a python script so I can figure out how to displya temposync
+
+import math
+
+
+def fVal(inVal):
+    (b, a) = math.modf(inVal)
+    # print("\n", inVal, " ", a, " ", b)
+
+    if (b < 0):
+        b += 1.0
+        a -= 1.0
+
+    # print("B prior is ", b)
+    b = math.pow(2.0, b)
+    # print("B post is ", b)
+
+    if (b > 1.41):
+        # print("SQRT")
+        b = math.log(1.5) / math.log(2.0)
+    elif (b > 1.167):
+        # print("167")
+        b = math.log(1.3333333333) / math.log(2.0)
+    else:
+        # print("ZERO")
+        b = 0.0
+
+    # print("Then b = ", b)
+    res = a + b
+    return res
+
+
+def surgeCurrent(f):
+    if (f > 1):
+        res = "%.3f bars" % (0.5 * math.pow(2.0, f))
+    elif (f > -1):
+        res = "%.3f / 4th" % (2.0 * math.pow(2.0, f))
+    elif (f > -2):
+        res = "%.3f / 8th" % (4.0 * math.pow(2.0, f))
+    elif (f > -3):
+        res = "%.3f / 16th" % (8.0 * math.pow(2.0, f))
+    elif (f > -5):
+        res = "%.3f / 64th" % (32.0 * math.pow(2.0, f))
+    elif (f > -7):
+        res = "%.3f / 128th" % (64.0 * math.pow(2.0, f))
+    else:
+        res = "%.3f / 256th" % (128.0 * math.pow(2.0, f))
+
+    return res
+
+
+def surgeImproved(f):
+    (b, a) = math.modf(f)
+
+    if (b >= 0):
+        b -= 1.0
+        a += 1.0
+
+    if(f >= 1):
+        q = math.pow(2.0, f - 1)
+        nn = "whole"
+        if(q >= 3):
+            return "%.0lf whole notes" % (q)
+        elif(q >= 2):
+            nn = "double whole"
+            q /= 2
+
+        if(q < 1.3):
+            t = "note"
+        elif(q < 1.4):
+            t = "triplet"
+            if (nn == "whole"):
+                nn = "1/2"
+            else:
+                nn = "whole"
+        else:
+            t = "dotted"
+
+    else:
+        d = math.pow(2.0, -(a - 2))
+        q = math.pow(2.0, (b+1))
+        if(q < 1.3):
+            t = "note"
+        elif(q < 1.4):
+            t = "triplet"
+            d = d / 2
+        else:
+            t = "dotted"
+        if d == 1:
+            nn = "whole"
+        else:
+            nn = "1/%0.d" % d
+
+    res = "%s %s" % (nn, t)
+
+    return res
+
+
+dup = {}
+
+for x in range(257):
+    n = x / 256.0
+    y = n * 14 - 11
+    f = fVal(y)
+    if f not in dup:
+        print("%20s ==> %20s" % (surgeCurrent(fVal(y)), surgeImproved(fVal(y))))
+    dup[f] = 1

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -8,6 +8,7 @@
 #include <math.h>
 #include <iomanip>
 #include <sstream>
+#include <string>
 
 Parameter::Parameter()
 {
@@ -673,6 +674,90 @@ float Parameter::get_extended(float f)
    }
 }
 
+std::string Parameter::tempoSyncNotationValue(float f)
+{
+    float a, b = modf(f, &a);
+    
+    if (b >= 0)
+    {
+        b -= 1.0;
+        a += 1.0;
+    }
+
+    float d, q;
+    std::string nn, t;
+    char tmp[1024];
+    
+    if(f >= 1)
+    {
+        q = pow(2.0, f - 1);
+        nn = "whole";
+        if(q >= 3)
+        {
+            snprintf(tmp, 1024, "%.2f whole notes", q);
+            std::string res = tmp;
+            return res;
+        }
+        else if(q >= 2)
+        {
+            nn = "double whole";
+            q /= 2;
+        }
+
+        if(q < 1.3)
+        {
+            t = "note";
+        }
+        else if(q < 1.4)
+        {
+            t = "triplet";
+            if (nn == "whole")
+            {
+                nn = "1/2";
+            }
+            else
+            {
+                nn = "whole";
+            }
+        }
+        else
+        {
+            t = "dotted";
+        }
+    }
+    else
+    {
+        d = pow(2.0, -(a - 2));
+        q = pow(2.0, (b+1));
+        if (q < 1.3)
+        {
+            t = "note";
+        }
+        else if(q < 1.4)
+        {
+            t = "triplet";
+            d = d / 2;
+        }
+        else
+        {
+            t = "dotted";
+        }
+        if ( d == 1 )
+        {
+            nn = "whole";
+        }
+        else
+        {
+            char tmp[1024];
+            snprintf(tmp, 1024, "1/%0.d", (int)d, d );
+            nn = tmp;
+        }
+    }
+    std::string res = nn + " " + t;
+
+    return res;
+}
+
 void Parameter::get_display(char* txt, bool external, float ef)
 {
    if (ctrltype == ct_none)
@@ -707,20 +792,8 @@ void Parameter::get_display(char* txt, bool external, float ef)
          {
             if (temposync)
             {
-               if (f > 1)
-                  sprintf(txt, "%.3f bars", 0.5f * powf(2.0f, f));
-               else if (f > -1)
-                  sprintf(txt, "%.3f / 4th", 2.0f * powf(2.0f, f));
-               else if (f > -2)
-                  sprintf(txt, "%.3f / 8th", 4.0f * powf(2.0f, f));
-               else if (f > -3)
-                  sprintf(txt, "%.3f / 16th", 8.0f * powf(2.0f, f));
-               else if (f > -5)
-                  sprintf(txt, "%.3f / 64th", 32.0f * powf(2.0f, f));
-               else if (f > -7)
-                  sprintf(txt, "%.3f / 128th", 64.0f * powf(2.0f, f));
-               else
-                  sprintf(txt, "%.3f / 256th", 128.0f * powf(2.0f, f));
+               std::string res = tempoSyncNotationValue(f);
+               sprintf( txt, "%s", res.c_str() );
             }
             else if (f == val_min.f)
             {
@@ -735,24 +808,8 @@ void Parameter::get_display(char* txt, bool external, float ef)
       case ct_lforate:
          if (temposync)
          {
-            if (f > 6 )
-                sprintf(txt, "%.3f / 256th", 128.f * powf(2.0, -f));
-            else if (f > 5)
-                sprintf(txt, "%.3f / 128th", 64.f * powf(2.0, -f));
-            else if (f > 4)
-               sprintf(txt, "%.3f / 64th", 32.f * powf(2.0f, -f));
-            else if (f > 3)
-               sprintf(txt, "%.3f / 32th", 16.f * powf(2.0f, -f));
-            else if (f > 2)
-               sprintf(txt, "%.3f / 16th", 8.f * powf(2.0f, -f));
-            else if (f > 1)
-               sprintf(txt, "%.3f / 8th", 4.f * powf(2.0f, -f));
-            else if (f > 0)
-               sprintf(txt, "%.3f / 4th", 2.f * powf(2.0f, -f));
-            else if (f > -1)
-               sprintf(txt, "%.3f / 2th", 1.f * powf(2.0f, -f));
-            else
-               sprintf(txt, "%.3f bars", 0.5f * powf(2.0f, -f));
+            std::string res = tempoSyncNotationValue(-f);
+            sprintf(txt, "%s", res.c_str() );
          }
          else
             sprintf(txt, "%.3f Hz", powf(2.0f, f));

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -3,6 +3,7 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 #include "globals.h"
+#include <string>
 
 union pdata
 {
@@ -148,6 +149,8 @@ public:
    float set_modulation_f01(float v); // used by the gui to set the modulation to match the position
                                       // of the modulated handle
    void bound_value(bool force_integer = false);
+   std::string tempoSyncNotationValue(float f);
+   
    pdata val, val_default, val_min, val_max;
    int id;
    char name[NAMECHARS], dispname[NAMECHARS], name_storage[NAMECHARS], fullname[NAMECHARS];


### PR DESCRIPTION
temposync values used to have odd values like "2.667 1/4th notes"
and so on. We all kinda decided it was better to have musical terms
like "1/8 dotted" rather than "1.500 1/8" (or even better 3.000 1/16).
This change does that. Theres a small python script I used to figure
it all out, then the implementation as a member function in Parameter.

Closes #959