### PR TITLE
Undisable Zoom for Cakewalk

### DIFF
--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -63,8 +63,8 @@ tresult PLUGIN_API SurgeVst3Processor::initialize(FUnknown* context)
       wcstombs_s(&nNumCharConverted, szString, 256, hostName, 128);
       std::string s(szString);
       disableZoom = false;
-      if (s == "Cakewalk")
-         disableZoom = true;
+      //if (s == "Cakewalk")
+      //   disableZoom = true;
    }
 #endif
 


### PR DESCRIPTION
Turns out cakewalk lets you set a default zoom and respects that
so turn off the zoom disable