### PR TITLE
Antialias used consistently in font

### DIFF
--- a/src/common/gui/CEffectLabel.h
+++ b/src/common/gui/CEffectLabel.h
@@ -17,13 +17,15 @@ public:
       VSTGUI::CRect size = getViewSize();
       VSTGUI::CRect bl(size);
       bl.top = bl.bottom - 2;
+
       VSTGUI::CColor gray = {106, 106, 106, 255};
       dc->setFillColor(gray);
       dc->drawRect(bl, VSTGUI::kDrawFilled);
-      dc->setFontColor(gray);
-      // dc->setFont(kNormalFontSmaller,8,kBoldFace);
+
+      dc->setFontColor(VSTGUI::kBlackCColor);
       dc->setFont(displayFont);
-      dc->drawString(label.c_str(), size, VSTGUI::kLeftText, false);
+      dc->drawString(label.c_str(), size, VSTGUI::kLeftText, true);
+
       setDirty(false);
    }
    void setLabel(std::string s)

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -191,7 +191,7 @@ void COscillatorDisplay::draw(CDrawContext* dc)
       dc->setFontColor(kBlackCColor);
       dc->setFont(displayFont);
       // strupr(wttxt);
-      dc->drawString(wttxt, rmenu, kCenterText, false);
+      dc->drawString(wttxt, rmenu, kCenterText, true);
 
       /*CRect wtlbl_status(size);
       wtlbl_status.bottom = wtlbl_status.top + wtbheight;


### PR DESCRIPTION
The wavetable name and effect group name were painted non-antialiased
This change fixes that. It also makes the effect group name black.

Closes #779