### PR TITLE
Remove xcb-util0 as an option in the .deb

### DIFF
--- a/installer_linux/make_deb.sh
+++ b/installer_linux/make_deb.sh
@@ -56,7 +56,7 @@ Package: ${PACKAGE_NAME}
 Version: $DEB_VERSION
 Architecture: amd64
 Maintainer: surgeteam
-Depends: libcairo2, libfontconfig1, libfreetype6, libx11-6, libxcb-cursor0, libxcb-util1 | libxcb-util0, libxcb-xkb1, libxcb1, libxkbcommon-x11-0, libxkbcommon0, fonts-lato
+Depends: libcairo2, libfontconfig1, libfreetype6, libx11-6, libxcb-cursor0, libxcb-util1, libxcb-xkb1, libxcb1, libxkbcommon-x11-0, libxkbcommon0, fonts-lato
 Provides: vst-plugin
 Section: sound
 Priority: optional


### PR DESCRIPTION
Surge will build against xcb util 0 or 1, but we build it against
1 in the binary image, so remove the deceptive "or" in the deb file
for binaries we ship

Closes #931