### PR TITLE
Critical Section Two Changes

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -544,7 +544,7 @@ public:
    std::string userDataPath;
    std::string defaultsig, defaultname;
    // float table_sin[512],table_sin_offset[512];
-   CriticalSection CS_WaveTableData, CS_ModRouting;
+   Surge::CriticalSection CS_WaveTableData, CS_ModRouting;
    Wavetable WindowWT;
 
    float note_to_pitch(float x);

--- a/src/common/thread/CriticalSection.cpp
+++ b/src/common/thread/CriticalSection.cpp
@@ -1,35 +1,25 @@
 #include "CriticalSection.h"
 
-#if !LINUX
+#if WINDOWS
 
 #include "assert.h"
 
+namespace Surge {
+    
 CriticalSection::CriticalSection()
 {
    refcount = 0;
-#if MAC
-   MPCreateCriticalRegion(&cs);
-#else
    InitializeCriticalSection(&cs);
-#endif
 }
 
 CriticalSection::~CriticalSection()
 {
-#if MAC
-   MPDeleteCriticalRegion(cs);
-#else
    DeleteCriticalSection(&cs);
-#endif
 }
 
 void CriticalSection::enter()
 {
-#if MAC
-   MPEnterCriticalRegion(cs, kDurationForever);
-#else
    EnterCriticalSection(&cs);
-#endif
    refcount++;
    assert(refcount > 0);
    assert(!(refcount > 10)); // if its >10 there's some crazy *§%* going on ^^
@@ -43,11 +33,8 @@ void CriticalSection::leave()
       int breakpointme = 0;
    }
    assert(refcount >= 0);
-#if MAC
-   MPExitCriticalRegion(cs);
-#else
    LeaveCriticalSection(&cs);
-#endif
 }
 
+}
 #endif

--- a/src/common/thread/CriticalSection.h
+++ b/src/common/thread/CriticalSection.h
@@ -1,17 +1,17 @@
 #pragma once
 
-#if MAC
-#include <CoreServices/CoreServices.h>
-#elif LINUX
+#if MAC | LINUX
+#include <stdio.h>
+#include <pthread.h>
+#include <assert.h>
+
 #else
 #include "windows.h"
 #endif
 
-#if LINUX
+namespace Surge {
 
-#include <stdio.h>
-#include <pthread.h>
-#include <assert.h>
+#if MAC | LINUX
 
 class CriticalSection
 {
@@ -54,13 +54,9 @@ public:
    void leave();
 
 protected:
-#if MAC
-   MPCriticalRegionID cs;
-#else
    CRITICAL_SECTION cs;
-#endif
    int refcount;
 };
 
 #endif
-
+}


### PR DESCRIPTION
Two key changes to Critical Section

1: On Mac use pthread rather than the (deprecated since OSX 10.7!!)
   MPCriticalSection

2: Put CriticalSection into the Surge namespace since it conflicts with
   JUCE otherwise