### PR TITLE
Make an option to build the FX and include it in the dmg (MacOS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ installer_mac/*.dmg
 installer_osx/installer
 installer_osx/Install_Surge_*.dmg
 build_logs/
+fxbuild/
 .DS_Store
 
 # IntelliJ IDEA

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -40,6 +40,9 @@ Commands are:
         --build-install-vst3     Build and install only the VST3
         --build-headless         Build the headless application
 
+        --get-and-build-fx       Get and build the surge-fx project. This is only needed if you
+                                 want to make a release with that asset included
+
         --package                Creates a .pkg file from current built state in products
         --clean-and-package      Cleans everything; runs all the builds; makes an installer; drops it in products
                                  Equivalent of running --clean-all then --build then --package
@@ -305,7 +308,7 @@ run_clean_all()
     run_clean_builds
 
     echo "Cleaning additional assets (directories, XCode, etc)"
-    rm -rf Surge.xcworkspace *xcodeproj target products build_logs obj build
+    rm -rf Surge.xcworkspace *xcodeproj target products build_logs obj build fxbuild
 }
 
 run_uninstall_surge()
@@ -336,6 +339,21 @@ run_package()
     echo
     echo "Have a lovely day!"
     echo
+}
+
+get_and_build_fx()
+{
+    set -x
+    mkdir -p fxbuild
+    mkdir -p products
+    cd fxbuild
+    git clone https://github.com/surge-synthesizer/surge-fx
+    cd surge-fx
+    git submodule update --init --recursive
+    make build
+    cd Builds/MacOSX/build/Release
+    tar cf - surge-fx.component/* | ( cd ../../../../../../products ; tar xf - )
+	tar cf - surge-fx.vst3/* | ( cd   ../../../../../../products ; tar xf - )
 }
 
 # This is the main section of the script
@@ -402,6 +420,9 @@ case $command in
         ;;
     --uninstall-surge)
         run_uninstall_surge
+        ;;
+    --get-and-build-fx)
+        get_and_build_fx
         ;;
     "")
         default_action

--- a/installer_mac/make_installer.sh
+++ b/installer_mac/make_installer.sh
@@ -30,6 +30,8 @@ PRODUCTS="../products/"
 VST2="Surge.vst"
 VST3="Surge.vst3"
 AU="Surge.component"
+FXAU="surge-fx.component"
+FXVST3="surge-fx.vst3"
 
 RSRCS="../resources/data"
 
@@ -81,6 +83,16 @@ if [[ -d $PRODUCTS/$AU ]]; then
     build_flavor "AU" $AU "com.vemberaudio.au.pkg" "/Library/Audio/Plug-Ins/Components"
 fi
 
+# And the FXen
+
+if [[ -d $PRODUCTS/$FXAU ]]; then
+    build_flavor "FXAU" $FXAU "org.surge-synthesizer.fxau.pkg" "/Library/Audio/Plug-Ins/Components"
+fi
+
+if [[ -d $PRODUCTS/$FXVST3 ]]; then
+    build_flavor "FXVST3" $FXVST3 "org.surge-synthesizer.fxvst3.pkg" "/Library/Audio/Plug-Ins/VST3"
+fi
+
 # write build info to resources folder
 
 echo "Version: ${VERSION}" > "$RSRCS/BuildInfo.txt"
@@ -113,6 +125,16 @@ if [[ -d $PRODUCTS/$AU ]]; then
 	AU_CHOICE='<line choice="com.vemberaudio.au.pkg"/>'
 	AU_CHOICE_DEF="<choice id=\"com.vemberaudio.au.pkg\" visible=\"true\" start_selected=\"true\" title=\"Audio Unit\"><pkg-ref id=\"com.vemberaudio.au.pkg\"/></choice><pkg-ref id=\"com.vemberaudio.au.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_AU.pkg</pkg-ref>"
 fi
+if [[ -d $PRODUCTS/$FXAU ]]; then
+	FXAU_PKG_REF='<pkg-ref id="org.surge-synthesizer.fxau.pkg"/>'
+	FXAU_CHOICE='<line choice="org.surge-synthesizer.fxau.pkg"/>'
+	FXAU_CHOICE_DEF="<choice id=\"org.surge-synthesizer.fxau.pkg\" visible=\"true\" start_selected=\"true\" title=\"Audio Unit for Standalone FX\"><pkg-ref id=\"org.surge-synthesizer.fxau.pkg\"/></choice><pkg-ref id=\"org.surge-synthesizer.fxau.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_FXAU.pkg</pkg-ref>"
+fi
+if [[ -d $PRODUCTS/$FXVST3 ]]; then
+	FXVST3_PKG_REF='<pkg-ref id="org.surge-synthesizer.fxvst3.pkg"/>'
+	FXVST3_CHOICE='<line choice="org.surge-synthesizer.fxvst3.pkg"/>'
+	FXVST3_CHOICE_DEF="<choice id=\"org.surge-synthesizer.fxvst3.pkg\" visible=\"true\" start_selected=\"true\" title=\"VST3 for Standalone FX\"><pkg-ref id=\"org.surge-synthesizer.fxvst3.pkg\"/></choice><pkg-ref id=\"org.surge-synthesizer.fxvst3.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_FXVST3.pkg</pkg-ref>"
+fi
 
 cat > distribution.xml << XMLEND
 <?xml version="1.0" encoding="utf-8"?>
@@ -122,17 +144,23 @@ cat > distribution.xml << XMLEND
     ${VST2_PKG_REF}
     ${VST3_PKG_REF}
     ${AU_PKG_REF}
+    ${FXVST3_PKG_REF}
+    ${FXAU_PKG_REF}
     <pkg-ref id="com.vemberaudio.resources.pkg"/>
     <options require-scripts="false" customize="always" />
     <choices-outline>
         ${VST2_CHOICE}
         ${VST3_CHOICE}
         ${AU_CHOICE}
+        ${FXVST3_CHOICE}
+        ${FXAU_CHOICE}
         <line choice="com.vemberaudio.resources.pkg"/>
     </choices-outline>
     ${VST2_CHOICE_DEF}
     ${VST3_CHOICE_DEF}
     ${AU_CHOICE_DEF}
+    ${FXVST3_CHOICE_DEF}
+    ${FXAU_CHOICE_DEF}
     <choice id="com.vemberaudio.resources.pkg" visible="true" enabled="false" selected="true" title="Install resources">
         <pkg-ref id="com.vemberaudio.resources.pkg"/>
     </choice>


### PR DESCRIPTION
The surge-fx project now builds cleanly macos and makes a working
VST3 and AU. Here we add a set of options so we can make it if
we want using build-osx and if we do, the installer picks it up.