### PR TITLE
TempoSync used the wrong modf

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -676,7 +676,7 @@ float Parameter::get_extended(float f)
 
 std::string Parameter::tempoSyncNotationValue(float f)
 {
-    float a, b = modf(f, &a);
+    float a, b = modff(f, &a);
     
     if (b >= 0)
     {


### PR DESCRIPTION
TempoSync used modf, not modff. In surge-fx JUCE build this
actually mattered.