### PR TITLE
Only build VST3 extensions in the VST3

### DIFF
--- a/src/linux/LinuxVST3Helpers.cpp
+++ b/src/linux/LinuxVST3Helpers.cpp
@@ -2,6 +2,7 @@
 ** The various things we need to help with VST3 Linux
 */
 
+#if TARGET_VST3
 #include <iostream>
 #include <pthread.h>
 #include <unistd.h>
@@ -218,3 +219,4 @@ void LinuxVST3FrameOpen(VSTGUI::CFrame* that, void* parent, const VSTGUI::Platfo
 
    IdleUpdateHandler::start();
 }
+#endif


### PR DESCRIPTION
The LInuxVST3Helpers were not conditionally compiled correctly.
Make it symmetric with the VST2 helpers by using a #ifdef TARGET_VST3

Closes #980