### PR TITLE
Support WAV file generally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SURGE_COMMON_SOURCES
     src/common/SurgeSynthesizerIO.cpp
     src/common/Tunings.cpp
     src/common/UserDefaults.cpp
+    src/common/WavSupport.cpp 
     libs/xml/tinyxml.cpp
     libs/xml/tinyxmlerror.cpp
     libs/xml/tinyxmlparser.cpp

--- a/premake5.lua
+++ b/premake5.lua
@@ -233,6 +233,7 @@ function plugincommon()
         "src/common/SurgeSynthesizerIO.cpp",
         "src/common/Tunings.cpp",
         "src/common/UserDefaults.cpp",
+        "src/common/WavSupport.cpp",
         "libs/xml/tinyxml.cpp",
         "libs/xml/tinyxmlerror.cpp",
         "libs/xml/tinyxmlparser.cpp",

--- a/scripts/wt-tool/raw-chunk-reader.py
+++ b/scripts/wt-tool/raw-chunk-reader.py
@@ -1,0 +1,30 @@
+# Read the raw chunk names from a wav file
+
+
+def toInt(b):
+    return int.from_bytes(b, byteorder='little')
+
+
+def read_raw(fn):
+    print("Opeining :", fn)
+    with open(fn, "rb") as f:
+        bdata = f.read()
+    print("Size in bytes is", len(bdata))
+    print("HEADER0: ", bdata[0:4])
+    print("HEADER1: ", toInt(bdata[4:8]))
+    print("HEADER2: ", bdata[8:12])
+    pos = 12
+    while pos < len(bdata):
+        print("  CHUNK    :", bdata[pos:(pos + 4)])
+        cs = toInt(bdata[(pos + 4):(pos + 8)])
+        print("  CS       :", cs)
+        print(bdata[(pos+4):(pos+8)])
+        if(cs == 48):
+            print(bdata[pos+8:pos+60])
+        pos += cs + 8
+
+
+if __name__ == "__main__":
+    read_raw("/Users/Paul/tmp/Wavetable Example/Wavetable.wav")
+    read_raw("/Users/paul/tmp/SerumWT/Korg MS-2000/SQUARE-C2.wav")
+    read_raw("/Users/paul/tmp/SerumWT/Classic Synths/05_BELL.WAV")

--- a/src/common/SampleLoadRiffWave.cpp
+++ b/src/common/SampleLoadRiffWave.cpp
@@ -6,6 +6,7 @@
 //
 //-------------------------------------------------------------------------------------------------------
 
+
 #include "Sample.h"
 #include "globals.h"
 #include "SurgeStorage.h"
@@ -294,3 +295,4 @@ bool Sample::load_riff_wave_mk2(const char* fname)
 }
 
 #endif
+

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -610,9 +610,7 @@ void SurgeStorage::refresh_wtlistAddDir(bool userDir, std::string subdir)
 {
    std::vector<std::string> supportedTableFileTypes;
    supportedTableFileTypes.push_back(".wt");
-#if WINDOWS
    supportedTableFileTypes.push_back(".wav");
-#endif
 
    refreshPatchOrWTListAddDir(
        userDir, subdir,
@@ -671,10 +669,8 @@ void SurgeStorage::load_wt(string filename, Wavetable* wt)
       extension[i] = tolower(extension[i]);
    if (extension.compare(".wt") == 0)
       load_wt_wt(filename, wt);
-#if !MAC
    else if (extension.compare(".wav") == 0)
-      load_wt_wav(filename, wt);
-#endif
+      load_wt_wav_portable(filename, wt);
 }
 
 void SurgeStorage::load_wt_wt(string filename, Wavetable* wt)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -516,7 +516,8 @@ public:
    void load_wt(int id, Wavetable* wt);
    void load_wt(std::string filename, Wavetable* wt);
    void load_wt_wt(std::string filename, Wavetable* wt);
-   void load_wt_wav(std::string filename, Wavetable* wt);
+   // void load_wt_wav(std::string filename, Wavetable* wt);
+   void load_wt_wav_portable(std::string filename, Wavetable *wt);
    void clipboard_copy(int type, int scene, int entry);
    void clipboard_paste(int type, int scene, int entry);
    int get_clipboard_type();

--- a/src/common/SurgeStorageLoadWavetable.cpp
+++ b/src/common/SurgeStorageLoadWavetable.cpp
@@ -1,6 +1,8 @@
 //-------------------------------------------------------------------------------------------------------
 //	Copyright 2005 Claes Johanson & Vember Audio
 //-------------------------------------------------------------------------------------------------------
+#if 0
+
 #include "SurgeStorage.h"
 #include "DspUtilities.h"
 
@@ -297,3 +299,5 @@ abort:
    fprintf(stderr, "%s: WAV file loading is not implemented.\n", __func__);
 #endif
 }
+
+#endif

--- a/src/common/WavSupport.cpp
+++ b/src/common/WavSupport.cpp
@@ -1,0 +1,285 @@
+/*
+** Portable (using standard fread and so on) support for .wav files generating
+** wavetables. 
+**
+** Two things which matter in addition to the fmt and data block
+**
+**  1: The `smpl` block
+**  2: the `clm ` block - indicates a serum file
+**
+** I read them in this order
+**
+**  1. If there is a clm block that wins, we ignore the smpl block, and you get your 2048 wt
+**  2. If there is no smpl block and you have a smpl block if you have a power of 2 sample length
+**     we interpret you as a wt otherwise as a one shot
+*/
+
+
+#include <stdio.h>
+#include "UserInteractions.h"
+#include "SurgeStorage.h"
+#include <sstream>
+
+// Sigh - lets write a portable ntol by hand
+unsigned int pl_int(char *d)
+{
+    return (unsigned char)d[0] + (((unsigned char)d[1]) << 8) + (((unsigned char)d[2]) << 16) + (((unsigned char)d[3]) << 24);
+}
+
+unsigned short pl_short(char *d)
+{
+    return (unsigned char)d[0] + (((unsigned char)d[1]) << 8);
+}
+
+bool four_chars(char *v, char a, char b, char c, char d)
+{
+    return v[0] == a &&
+        v[1] == b &&
+        v[2] == c &&
+        v[3] == d;
+}
+
+void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
+{
+    std::cout << "Loading wt_wav_portable" << std::endl;
+    std::cout << "  fn='" << fn << "'" << std::endl;
+
+    FILE *fp = fopen(fn.c_str(), "rb");
+    if( ! fp )
+    {
+        std::ostringstream oss;
+        oss << "Unable to open file '" << fn << "'";
+        Surge::UserInteractions::promptError(oss.str(), "WaveTable Error" );
+        return;
+    }
+
+    char riff[4], szd[4], wav[4];
+    if( ! (fread(riff,1,4,fp) +
+           fread(szd,1,4,fp) +
+           fread(wav,1,4,fp) == 12 ) )
+    {
+        return;
+    }
+
+    if( ! four_chars(riff, 'R', 'I', 'F', 'F' ) &&
+        ! four_chars(wav,  'W', 'A', 'V', 'E' ) )
+    {
+        Surge::UserInteractions::promptError("File is not a standard RIFF/WAVE file",
+                                             "WaveTable Error" );
+        return;
+    }
+    
+    // WAV HEADER
+    short audioFormat, numChannels;
+    int sampleRate, byteRate;
+    short blockAlign, bitsPerSample;
+
+    // Result of data read
+    bool hasSMPL = false;
+    bool hasCLM = false;;
+    int clmLEN = 0;
+    int smplLEN = 0;
+    
+    // Now start reading chunks
+    int tbr = 4;
+    char *wavdata = nullptr;
+    int datasz = 0, datasamples;
+    while( true )
+    {
+        char chunkType[4], chunkSzD[4];
+        int br;
+        if( ! ( ( br = fread(chunkType, 1, 4, fp) ) == 4 ) )
+        {
+            break;
+        }
+        fread(chunkSzD, 1, 4, fp);
+        std::cout << "  CHUNK  `"; for( int i=0; i<4; ++i ) std::cout << chunkType[i]; 
+        int cs = pl_int(chunkSzD);
+        std::cout << "`  sz=" << cs << std::endl;
+        tbr += 8 + cs;
+        
+        char* data = (char *)malloc( cs );
+        br = fread( data, 1, cs, fp );
+        if( br != cs )
+        {
+            free(data);
+            
+            break;
+        }
+
+        if( four_chars( chunkType, 'f','m','t',' '))
+        {
+            char *dp = data;
+            audioFormat = pl_short(dp); dp += 2; // 1 is PCM; 3 is IEEE Float
+            numChannels = pl_short(dp); dp += 2;
+            sampleRate = pl_int(dp); dp += 4;
+            byteRate = pl_int(dp); dp += 4;
+            blockAlign = pl_short(dp); dp += 2;
+            bitsPerSample = pl_short(dp); dp += 2;
+
+            free(data);           
+        }
+        else if( four_chars(chunkType, 'c', 'l', 'm', ' '))
+        {
+            // These all begin '<!>dddd' where d is 2048 it seems
+            char *dp = data + 3;
+            if( four_chars(dp, '2', '0', '4', '8' ) )
+            {
+                // 2048 CLM detected
+                hasCLM = true;
+                clmLEN = 2048;
+            }
+            free(data);
+        }
+        else if( four_chars(chunkType, 'd', 'a', 't', 'a' ))
+        {
+            datasz = cs;
+            datasamples = cs * 8 / bitsPerSample / numChannels;
+            wavdata = data;
+        }
+        else if( four_chars(chunkType, 's', 'm', 'p', 'l' ))
+        {
+            char *dp = data;
+            unsigned int samplechunk[9];
+            for( int i=0; i<9; ++i )
+            {
+                samplechunk[i] = pl_int(dp); dp += 4;
+            }
+            unsigned int nloops = samplechunk[7];
+            unsigned int sdsz = samplechunk[8];
+
+            if( nloops != 1 )
+            {
+                // We don't support this. Indicate somehow.
+            }
+            
+            for( int i=0; i<nloops && i < 1; ++i )
+            {
+                unsigned int loopdata[6];
+                for( int j=0; j<6; ++j )
+                {
+                    loopdata[j] = pl_int(dp); dp += 4;
+                }
+                hasSMPL = true;
+                smplLEN = loopdata[3] - loopdata[2] + 1;
+            }
+        }
+        else
+        {
+            free(data);
+        }
+    }
+
+
+    bool loopData = hasSMPL || hasCLM;
+    int loopLen = hasCLM ? clmLEN : smplLEN;
+    int loopCount = datasamples / loopLen;
+    if( loopCount * loopLen != datasz )
+    {
+        // Do somethign about this error state where loops are not integer
+    }
+
+    std::cout << "  samples=" << datasamples << " loopLen=" << loopLen << " loopCount=" << loopCount << std::endl;
+    
+    // wt format header (surge internal)
+    wt_header wh;
+    memset(&wh, 0, sizeof(wt_header));
+    wh.flags = wtf_is_sample;
+
+    int sh = 0;
+    if( loopData )
+    {
+        wh.flags = 0;
+        switch( loopLen )
+        {
+        case 4096:
+            sh = 12;
+            break;
+        case 2048:
+            sh = 11;
+            break;
+        case 1024:
+            sh = 10;
+            break;
+        case 512:
+            sh = 9;
+            break;
+        case 256:
+            sh = 8;
+            break;
+        case 128:
+            sh = 7;
+            break;
+        case 64:
+            sh = 6;
+            break;
+        case 32:
+            sh = 5;
+            break;
+        case 16:
+            sh = 4;
+            break;
+        case 8:
+            sh = 3;
+            break;
+        case 4:
+            sh = 2;
+            break;
+        case 2:
+            sh = 1;
+            break;
+        default:
+            wh.flags = wtf_is_sample;
+            break;
+        }
+    }
+
+    if( sh == 0 )
+    {
+        Surge::UserInteractions::promptError( "Sorry we only can read power of 2 wavetables right now but sample support coming soon!q",
+                                              "Error loading WAV" );
+    }
+    
+    wh.n_samples = 1 << sh;
+    int mask = wt->size - 1;
+    
+    int sample_length = std::min(datasamples, max_wtable_size * max_subtables);
+    
+    wh.n_tables = std::min(max_subtables, (sample_length >> sh));
+    
+    int channels = 1;
+
+    
+    if ((audioFormat == 1 /* WAVE_FORMAT_PCM */) &&
+        (bitsPerSample == 16) &&
+        numChannels == 1)
+    {
+        assert(wh.n_samples * wh.n_tables * 2 <= datasz);
+        wh.flags |= wtf_int16;
+    }
+    else if ((audioFormat == 3 /* WAVE_FORMAT_IEEE_FLOAT */) &&
+             (bitsPerSample == 32) &&
+             numChannels == 1
+        )
+    {
+        assert(wh.n_samples * wh.n_tables * 4 <= datasz);
+    }
+    else
+    {
+        Surge::UserInteractions::promptError( "Sorry, we only support 16 bit mono PCM and 32 bit IEEE float",
+                                              "Wav File Error" );
+        if( wavdata ) free( wavdata );
+        return;
+    }
+
+    if( wavdata && wt )
+    {
+        CS_WaveTableData.enter();
+        
+        wt->BuildWT(wavdata, wh, wh.flags & wtf_is_sample);
+        
+        CS_WaveTableData.leave();
+        free( wavdata );
+    }
+    return;
+}

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <string>
-const int max_wtable_size = 1024;
+const int max_wtable_size = 4096;
 const int max_subtables = 512;
 const int max_mipmap_levels = 16;
 // I don't know why your max wtable samples would be less than your max tables * your max sample size. So lets fix that!
 // This size is consistent with the check in WaveTable.cpp // CheckRequiredWTSize with ts and tc at 1024 and 512
-const int max_wtable_samples = 1070592;
+const int max_wtable_samples = 2097152;
 // const int max_wtable_samples =  268000; // delay pops 4 uses the most
 
 #pragma pack(push, 1)

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -349,6 +349,13 @@ void COscillatorDisplay::populateMenu(COptionMenu* contextMenu, int selectedItem
          populateMenuForCategory(contextMenu, c, selectedItem);
       }
    }
+
+   // Add direct open here
+   contextMenu->addSeparator();
+   auto actionItem = new CCommandMenuItem(CCommandMenuItem::Desc("Open Wave Table from File"));
+   auto action = [this](CCommandMenuItem* item) { this->loadWavetableFromFile(); };
+   actionItem->setActions(action, nullptr);
+   contextMenu->addEntry(actionItem);
 }
 
 bool COscillatorDisplay::populateMenuForCategory(COptionMenu* contextMenu,
@@ -438,6 +445,15 @@ void COscillatorDisplay::loadWavetable(int id)
    {
       oscdata->wt.queue_id = id;
    }
+}
+
+void COscillatorDisplay::loadWavetableFromFile()
+{
+    Surge::UserInteractions::promptFileOpenDialog( "", "", [this](std::string s) {
+            std::cout << "Gonna try and open '" << s << "'" << std::endl;
+            strncpy(this->oscdata->wt.queue_filename, s.c_str(), 255);
+
+        } );
 }
 
 CMouseEventResult COscillatorDisplay::onMouseUp(CPoint& where, const CButtonState& buttons)

--- a/src/common/gui/COscillatorDisplay.h
+++ b/src/common/gui/COscillatorDisplay.h
@@ -24,6 +24,7 @@ public:
    virtual bool onDrop(VSTGUI::IDataPackage* drag, const VSTGUI::CPoint& where);
 
    void loadWavetable(int id);
+   void loadWavetableFromFile();
 
    // virtual void mouse (CDrawContext *pContext, VSTGUI::CPoint &where, long button = -1);
    virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -146,6 +146,18 @@ void playSomeBach()
    Surge::Headless::renderMidiFileToWav(surge, fname, fname + ".wav");
 }
 
+void portableWt()
+{
+    SurgeSynthesizer* surge = Surge::Headless::createSurge(44100);
+    
+    surge->storage.load_wt_wav_portable("/users/Paul/tmp/Wavetable Example/Wavetable.wav", nullptr);
+    surge->storage.load_wt_wav_portable("/Users/paul/tmp/SerumWT/Korg MS-2000/SQUARE-C2.wav", nullptr);
+    surge->storage.load_wt_wav_portable("/Users/paul/tmp/SerumWT/Classic Synths/05_BELL.WAV", nullptr);
+    surge->storage.load_wt_wav_portable("/Users/paul/tmp/SerumWT/Adventure Kid Serum/pluckalgo.wav", nullptr);
+
+    delete surge;
+}
+
 /*
 ** This is a simple main that, for now, you make call out to the application
 ** stub of your choosing. We have two in Applications and we call them both
@@ -159,7 +171,8 @@ int main(int argc, char** argv)
       //playSomeBach();
       //Surge::Headless::createAndDestroyWithScaleAndRandomPatch(20000);
       // Surge::Headless::pullInitSamplesWithNoNotes(1000);
-       testTuning();
+       // testTuning();
+       portableWt();
    }
    catch( Surge::Error &e )
    {


### PR DESCRIPTION
This diff supports WAV file in several important ways

1. Read WAV file portably so mac and linux get them
2. Allow direct open of a wav file so you don't have to move them
   to documents/surge
3. Reliably support the information in the smpl block to allow
   sampler wave files to be wavetables
4. Support the Serum 'clm ' block meaning Serum files work
5. Increase the surge max wavetable size to 4096 and have that
   interact properly with dynamic memory management.

I am going to tag these issues as "addresses" rather than "closes" for
some of them since we want some testing, but I think this gets us
the path to wav done except for 511 and 509.

Addresses #461
Addresses #835
Addresses #198
Addresses #509