### PR TITLE
Reinstate Drag n Drop

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -235,8 +235,14 @@ void COscillatorDisplay::draw(CDrawContext* dc)
    setDirty(false);
 }
 
-bool COscillatorDisplay::onDrop(IDataPackage* drag, const CPoint& where)
+bool COscillatorDisplay::onDrop(VSTGUI::DragEventData data )
 {
+   doingDrag = false;
+   /* invalid();
+      setDirty(true); */
+
+   auto drag = data.drag;
+   auto where = data.pos;
    uint32_t ct = drag->getCount();
    if (ct == 1)
    {

--- a/src/common/gui/COscillatorDisplay.h
+++ b/src/common/gui/COscillatorDisplay.h
@@ -7,7 +7,7 @@
 #include "CDIBitmap.h"
 #include "DspUtilities.h"
 
-class COscillatorDisplay : public VSTGUI::CControl
+class COscillatorDisplay : public VSTGUI::CControl, public VSTGUI::IDropTarget
 {
 public:
    COscillatorDisplay(const VSTGUI::CRect& size, OscillatorStorage* oscdata, SurgeStorage* storage)
@@ -21,7 +21,28 @@ public:
    {
    }
    virtual void draw(VSTGUI::CDrawContext* dc);
-   virtual bool onDrop(VSTGUI::IDataPackage* drag, const VSTGUI::CPoint& where);
+   
+   virtual VSTGUI::DragOperation onDragEnter(VSTGUI::DragEventData data) override
+   {
+       doingDrag = true;
+       /* invalid();
+          setDirty(true); */
+
+       return VSTGUI::DragOperation::Copy;
+   }
+   virtual VSTGUI::DragOperation onDragMove(VSTGUI::DragEventData data) override
+   {
+       return VSTGUI::DragOperation::Copy;
+   }
+   virtual void onDragLeave(VSTGUI::DragEventData data) override
+   {
+       doingDrag = false;
+       /* invalid();
+          setDirty(true); */
+   }
+   virtual bool onDrop(VSTGUI::DragEventData data) override;
+   
+   virtual VSTGUI::SharedPointer<VSTGUI::IDropTarget> getDropTarget () override { return this; }
 
    void loadWavetable(int id);
    void loadWavetableFromFile();
@@ -39,6 +60,7 @@ protected:
    SurgeStorage* storage;
    unsigned controlstate;
 
+   bool doingDrag = false;
    VSTGUI::CRect rnext, rprev, rmenu;
    VSTGUI::CPoint lastpos;
    CLASS_METHODS(COscillatorDisplay, VSTGUI::CControl)


### PR DESCRIPTION
With our VSTGUI upgrade forever ago we lost drag n drop but
since we had only .wt files and they read from ~/Documents
it didn't bother us. With the addition of .wav file reading
we want this back, though. The VSTGUI api changed so this
restores drag n drop.

Closes #520