### PR TITLE
Support WaveTable Table Display

### DIFF
--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -85,6 +85,7 @@ enum ctrltypes
    ct_bool_fm,
    ct_character,
    ct_sineoscmode,
+   ct_countedset_percent, // what % through a counted set are you
    num_ctrltypes,
 };
 
@@ -102,6 +103,17 @@ enum ControlGroup
    cg_ENV = 5,
    cg_LFO = 6,
    cg_FX = 7,
+};
+
+struct ParamUserData
+{
+   virtual ~ParamUserData()
+   {}
+};
+
+struct CountedSetUserData : public ParamUserData
+{
+   virtual int getCountedSetSize() = 0; // A constant time answer to the count of the set
 };
 
 class Parameter
@@ -123,6 +135,7 @@ public:
    bool can_temposync();
    bool can_extend_range();
    bool can_be_absolute();
+   bool can_snap();
    void clear_flags();
    void set_type(int ctrltype);
    void morph(Parameter* a, Parameter* b, float x);
@@ -166,5 +179,8 @@ public:
    bool affect_other_parameters;
    float moverate;
    bool per_voice_processing;
-   bool temposync, extend_range, absolute;
+   bool temposync, extend_range, absolute, snap;
+
+   ParamUserData* user_data;              // I know this is a bit gross but we have a runtime type
+   void set_user_data(ParamUserData* ud); // I take a shallow copy and assume i am referencable
 };

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -293,7 +293,7 @@ struct MidiChannelState
    float timbre;
 };
 
-struct OscillatorStorage
+struct OscillatorStorage : public CountedSetUserData // The counted set is the wt tables
 {
    Parameter type;
    Parameter pitch, octave;
@@ -302,6 +302,11 @@ struct OscillatorStorage
    Wavetable wt;
    void* queue_xmldata;
    int queue_type;
+
+   virtual int getCountedSetSize()
+   {
+      return wt.n_tables;
+   }
 };
 
 struct FilterStorage

--- a/src/common/dsp/WavetableOscillator.cpp
+++ b/src/common/dsp/WavetableOscillator.cpp
@@ -101,7 +101,10 @@ void WavetableOscillator::init(float pitch, bool is_display)
 void WavetableOscillator::init_ctrltypes()
 {
    oscdata->p[0].set_name("Morph");
-   oscdata->p[0].set_type(ct_percent);
+   oscdata->p[0].set_type(ct_countedset_percent);
+   oscdata->p[0].set_user_data(oscdata);
+   oscdata->p[0].snap = false;
+
    oscdata->p[1].set_name("Skew V");
    oscdata->p[1].set_type(ct_percent_bidirectional);
    oscdata->p[2].set_name("Saturate");

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -71,7 +71,10 @@ WindowOscillator::~WindowOscillator()
 void WindowOscillator::init_ctrltypes()
 {
    oscdata->p[0].set_name("Morph");
-   oscdata->p[0].set_type(ct_percent);
+   oscdata->p[0].set_type(ct_countedset_percent);
+   oscdata->p[0].set_user_data(oscdata);
+   oscdata->p[0].snap = false;
+
    oscdata->p[1].set_name("Formant");
    oscdata->p[1].set_type(ct_pitch);
    oscdata->p[2].set_name("Window");

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1892,6 +1892,12 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             contextMenu->checkEntry(eid, p->absolute);
             eid++;
          }
+         if (p->can_snap())
+         {
+            addCallbackMenu(contextMenu, "Snap", [this, p]() { p->snap = !p->snap; });
+            contextMenu->checkEntry(eid, p->snap);
+            eid++;
+         }
 
          {
             if (synth->learn_param > -1)


### PR DESCRIPTION
In the WaveTable and Window oscillator, show the table count in effect
and also allow you to choose a 'snap to table' UI mode vs a 'interpolate
fully' (which is, admittedly, way more useful in the wavetable mode).

Closes #780