### PR TITLE
FClose .wav file; clean up some error paths

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -671,6 +671,12 @@ void SurgeStorage::load_wt(string filename, Wavetable* wt)
       load_wt_wt(filename, wt);
    else if (extension.compare(".wav") == 0)
       load_wt_wav_portable(filename, wt);
+   else
+   {
+       std::ostringstream oss;
+       oss << "Unable to load file with extension '" << extension << "'. Surge only supports .wav and .wt files";
+       Surge::UserInteractions::promptError(oss.str(), "load_wt error" );
+   }
 }
 
 void SurgeStorage::load_wt_wt(string filename, Wavetable* wt)

--- a/src/common/WavSupport.cpp
+++ b/src/common/WavSupport.cpp
@@ -42,6 +42,17 @@ bool four_chars(char *v, char a, char b, char c, char d)
         v[3] == d;
 }
 
+struct FcloseGuard {
+    FILE *fp = nullptr;
+    FcloseGuard( FILE *f ) { fp = f; }
+    ~FcloseGuard() {
+        if( fp )
+        {
+            fclose(fp);
+        }
+    }
+                
+};
 void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
 {
     std::string uitag = "Wav File Load Error";
@@ -56,7 +67,8 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
         Surge::UserInteractions::promptError(oss.str(), uitag );
         return;
     }
-
+    FcloseGuard closeOnReturn(fp);
+    
     char riff[4], szd[4], wav[4];
     auto hds = fread(riff, 1, 4, fp);
     hds += fread(szd, 1, 4, fp);
@@ -144,7 +156,7 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
                 oss << "Sorry, Surge only supports 16-bit PCM or 32-bit IEEE float mono (single channel) wav files. "
                     << " You provided a wav with format=" << audioFormat << " (" << fname << ") "
                     << " bitsPerSample=" << bitsPerSample
-                    << " and channels=" << numChannels;
+                    << " and channels=" << numChannels << (numChannels == 2 ? " (stereo)" : "" );
                 
                 Surge::UserInteractions::promptError( oss.str(), uitag );
                 return;

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -457,7 +457,6 @@ void COscillatorDisplay::loadWavetable(int id)
 void COscillatorDisplay::loadWavetableFromFile()
 {
     Surge::UserInteractions::promptFileOpenDialog( "", "", [this](std::string s) {
-            std::cout << "Gonna try and open '" << s << "'" << std::endl;
             strncpy(this->oscdata->wt.queue_filename, s.c_str(), 255);
 
         } );


### PR DESCRIPTION
This change fcloses the wav file when the reading is done, avoiding
a silly lock on windows and just generally being correct. It also
cleans up a few error messages here and there.

Closes #995
Addresses #994 which is in some strange private state