### PR TITLE
Support Custom User Folders

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -31,6 +31,8 @@
 #include <iomanip>
 #include <sstream>
 
+#include "UserDefaults.h"
+
 
 float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
 float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];
@@ -243,6 +245,15 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath)
 #endif
 #endif
 
+   userDefaultFilePath = userDataPath;
+   
+   std::string userSpecifiedDataPath = Surge::Storage::getUserDefaultValue(this, "userDataPath", "UNSPEC" );
+   if( userSpecifiedDataPath != "UNSPEC" )
+   {
+       std::cout << "Got a custom user data path" << std::endl;
+       userDataPath = userSpecifiedDataPath;
+   }
+   
 #if LINUX
    if (!snapshotloader.Parse((const char*)&configurationXmlStart, 0,
                              TIXML_ENCODING_UTF8)) {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -547,6 +547,8 @@ public:
    std::string wtpath;
    std::string datapath;
    std::string userDataPath;
+   std::string userDefaultFilePath;
+   
    std::string defaultsig, defaultname;
    // float table_sin[512],table_sin_offset[512];
    Surge::CriticalSection CS_WaveTableData, CS_ModRouting;

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -45,7 +45,7 @@ bool haveReadDefaultsFile = false;
 
 std::string defaultsFileName(SurgeStorage *storage)
 {
-    std::string fn = storage->userDataPath + "/SurgeUserDefaults.xml";
+    std::string fn = storage->userDefaultFilePath + "/SurgeUserDefaults.xml";
     return fn;
 }
 
@@ -99,7 +99,7 @@ bool storeUserDefaultValue(SurgeStorage *storage, const std::string &key, const 
     ** See SurgeSytnehsizer::savePatch for instance
     ** and so we have to do the same here
     */
-    fs::create_directories(storage->userDataPath);
+    fs::create_directories(storage->userDefaultFilePath);
 
     
     UserDefaultValue v;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -12,6 +12,7 @@
 ** persist this information.
 */
 
+
 namespace Surge
 {
 namespace Storage

--- a/src/common/UserInteractions.h
+++ b/src/common/UserInteractions.h
@@ -53,6 +53,8 @@ void openFolderInFileBrowser(const std::string& folder);
 void promptFileOpenDialog(const std::string& initialDirectory,
                           const std::string& filterSuffix,
                           std::function<void(std::string)> callbackOnOpen,
+                          bool canSelectDirectories = false,
+                          bool canCreateDirectories = false,
                           SurgeGUIEditor* guiEditor = nullptr);
 };
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2862,7 +2862,23 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
        this->synth->storage.refresh_wtlist();
        this->synth->storage.refresh_patchlist();
     });
+    did++;
 
+    addCallbackMenu( dataSubMenu, "Set Custom User Data Folder", [this]() {
+            auto cb = [this](std::string f) {
+                // FIXME - check if f is a path
+                this->synth->storage.userDataPath = f;
+                Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                                       "userDataPath",
+                                                       f);
+                this->synth->storage.refresh_wtlist();
+                this->synth->storage.refresh_patchlist();
+            };
+            Surge::UserInteractions::promptFileOpenDialog("", "", cb, true, true);
+                                                          
+        });
+    did++;
+    
     settingsMenu->addEntry( dataSubMenu, "Data and Patches");
     eid++;
     dataSubMenu->forget();

--- a/src/headless/UserInteractionsHeadless.cpp
+++ b/src/headless/UserInteractionsHeadless.cpp
@@ -37,6 +37,7 @@ void openURL(const std::string &url)
 void promptFileOpenDialog(const std::string& initialDirectory,
                           const std::string& filterSuffix,
                           std::function<void(std::string)> callbackOnOpen,
+			  bool od, bool cd,
                           SurgeGUIEditor* guiEditor)
 {
    UserInteractions::promptError("OpenFileDialog is unimplemented in this version of Surge. Sorry!",

--- a/src/linux/UserInteractionsLinux.cpp
+++ b/src/linux/UserInteractionsLinux.cpp
@@ -75,6 +75,8 @@ void openFolderInFileBrowser(const std::string& folder)
 void promptFileOpenDialog(const std::string& initialDirectory,
                           const std::string& filterSuffix,
                           std::function<void(std::string)> callbackOnOpen,
+                          bool canSelectDirectories,
+                          bool canCreateDirectories,
                           SurgeGUIEditor* guiEditor)
 {
    /*

--- a/src/mac/UserInteractionsMac.mm
+++ b/src/mac/UserInteractionsMac.mm
@@ -79,10 +79,14 @@ void openFolderInFileBrowser(const std::string& folder)
 void promptFileOpenDialog(const std::string& initialDirectory,
                           const std::string& filterSuffix,
                           std::function<void(std::string)> callbackOnOpen,
+                          bool canSelectDirectories,
+                          bool canCreateDirectories,
                           SurgeGUIEditor* guiEditor)
 {
    // FIXME TODO - support the filterSuffix and initialDirectory
    NSOpenPanel* panel = [NSOpenPanel openPanel];
+   [panel setCanChooseDirectories:canSelectDirectories];
+   [panel setCanCreateDirectories:canCreateDirectories]; 
 
    [panel beginWithCompletionHandler:^(NSInteger result) {
      if (result == NSFileHandlingPanelOKButton)


### PR DESCRIPTION
Support custom user folders as a preference. The system still
requires a well named directory (~/Documents/Surge and so on)
to store the defaults but patches and wavetables can be placed
elsewhere. Provide a UI to select a directory and bind to the data
menu.

Addresses #1001 