### PR TITLE
An expanded vocder implementation

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -565,6 +565,12 @@ void Parameter::set_type(int ctrltype)
       valtype = vt_int;
       val_default.i = 0;
       break;
+   case ct_vocoder_bandcount:
+      val_min.i = 4;
+      val_max.i = 20;
+      valtype = vt_int;
+      val_default.i = 20;
+      break;
    case ct_countedset_percent:
       val_min.f = 0;
       val_max.f = 1;
@@ -630,6 +636,11 @@ void Parameter::bound_value(bool force_integer)
       val.f = 1.0 * intcount / count;
    }
 
+   if( ctrltype == ct_vocoder_bandcount )
+   {
+       val.i = val.i - val.i % 4;
+   }
+   
    switch (valtype)
    {
    case vt_float:
@@ -984,6 +995,10 @@ void Parameter::get_display(char* txt, bool external, float ef)
       case ct_sineoscmode:
          // FIXME - do better than this of course
          sprintf(txt, "%d", i);
+         break;
+      case ct_vocoder_bandcount:
+         // FIXME - do better than this of course
+         sprintf(txt, "%d bands", i);
          break;
       case ct_oscroute:
          switch (i)

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -86,6 +86,7 @@ enum ctrltypes
    ct_character,
    ct_sineoscmode,
    ct_countedset_percent, // what % through a counted set are you
+   ct_vocoder_bandcount,
    num_ctrltypes,
 };
 

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -41,7 +41,10 @@ Effect::Effect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd)
    this->pd = pd;
    ringout = 10000000;
    for (int i = 0; i < n_fx_params; i++)
+   {
       f[i] = &pd[fxdata->p[i].id].f;
+      pdata_ival[i] = &pd[fxdata->p[i].id].i;
+   }
 }
 
 bool Effect::process_ringout(float* dataL, float* dataR, bool indata_present)

--- a/src/common/dsp/effect/Effect.h
+++ b/src/common/dsp/effect/Effect.h
@@ -78,6 +78,7 @@ protected:
    pdata* pd;
    int ringout;
    float* f[n_fx_params];
+   int* pdata_ival[n_fx_params]; // f is not a great choice for a member name, but 'i' woudl be worse!
 };
 
 Effect* spawn_effect(int id, SurgeStorage* storage, FxStorage* fxdata, pdata* pd);

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -278,6 +278,12 @@ public:
       // KUnvoicedThreshold,
       KQuality,
       KShift,
+
+      kNumBands,
+      kFreqLo,
+      kFreqHi,
+      kModExpand,
+      kModCenter,
    };
 
    VocoderEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
@@ -307,7 +313,8 @@ private:
    lipol_ps mGain alignas(16);
 
    int mBI; // block increment (to keep track of events not occurring every n blocks)
-
+   int active_bands;
+   
    /*
    float mVoicedLevel;
    float mUnvoicedLevel;


### PR DESCRIPTION
These changes address issue #864

1. Add the appropriate parameters to do band control to the effect
   and make sure they display properly and save properly in the fxp
2. Make the bands tunable and coutnable (although bands must be %4)
   and respond properly to hi and low band frequency.
3. Implement tuning to reset the frequency bands; also
   implement separate tuning through the center and expand
   for the modulator bands.
4. Bind vocoderbands to multiple of 4.