### PR TITLE
Activate control values from patch stream

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1245,7 +1245,7 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
       {
          if (p->QueryIntAttribute("bipolar", &j) == TIXML_SUCCESS)
             scene[0].modsources[ms_ctrl1 + cont]->set_bipolar(j);
-         if (!is_preset && (p->QueryDoubleAttribute("v", &d) == TIXML_SUCCESS))
+         if (p->QueryDoubleAttribute("v", &d) == TIXML_SUCCESS)
          {
             ((ControllerModulationSource*)scene[0].modsources[ms_ctrl1 + cont])->set_target(d);
          }


### PR DESCRIPTION
As discussed in #915, for some reason the patch unstream doesn't
restore the value of the 8 controls whereas daw unstream does. This
is a conscious choice by the code for no reason any of us can see,
and is counterintuitive, so change it.