### PR TITLE
Consistent UI for Control items

### DIFF
--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -6,6 +6,7 @@
 #include "CScalableBitmap.h"
 #include "SurgeBitmaps.h"
 #include <vt_dsp/basic_dsp.h>
+#include <iostream>
 
 using namespace VSTGUI;
 using namespace std;
@@ -261,6 +262,20 @@ CMouseEventResult CModulationSourceButton::onMouseDown(CPoint& where, const CBut
    {
       if (listener->controlModifierClicked(this, buttons) != 0)
          return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
+
+   if (is_metacontroller && (buttons & kDoubleClick) && MCRect.pointInside(where) && !controlstate)
+   {
+      if (bipolar)
+         value = 0.5;
+      else
+         value = 0;
+
+      invalid();
+      if (listener)
+         listener->valueChanged(this);
+
+      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
    }
 
    if (is_metacontroller && MCRect.pointInside(where) && (buttons & kLButton) && !controlstate)


### PR DESCRIPTION
Every slider in the UI responds with a reset-to-appropriate-zero
on double click except the control sliders in the metacontrol
modulation window. This change fixes that, adding a double click
handler which resets you to the appropriave value based on your
bipolar nature.

Closes #1009