### PR TITLE
Tweak to Mac File Picker

### DIFF
--- a/src/mac/UserInteractionsMac.mm
+++ b/src/mac/UserInteractionsMac.mm
@@ -87,7 +87,7 @@ void promptFileOpenDialog(const std::string& initialDirectory,
    NSOpenPanel* panel = [NSOpenPanel openPanel];
    [panel setCanChooseDirectories:canSelectDirectories];
    [panel setCanCreateDirectories:canCreateDirectories]; 
-
+   [panel makeKeyAndOrderFront:panel];
    [panel beginWithCompletionHandler:^(NSInteger result) {
      if (result == NSFileHandlingPanelOKButton)
      {


### PR DESCRIPTION
Reported by @mortfell in #1001 MacOS Sierra has the open
window not come to front. With Mojave I couldn't reproduce
this, but added a [makeKeyAndOrderFront:self] just to make
sure.

Closes #1001