### PR TITLE
Another try to bring to front on Mac

### DIFF
--- a/src/mac/UserInteractionsMac.mm
+++ b/src/mac/UserInteractionsMac.mm
@@ -86,8 +86,13 @@ void promptFileOpenDialog(const std::string& initialDirectory,
    // FIXME TODO - support the filterSuffix and initialDirectory
    NSOpenPanel* panel = [NSOpenPanel openPanel];
    [panel setCanChooseDirectories:canSelectDirectories];
-   [panel setCanCreateDirectories:canCreateDirectories]; 
+   [panel setCanCreateDirectories:canCreateDirectories];
+
+   // Logic and others have wierd window ordering which can mean this somethimes pops behind.
+   // See #1001.
    [panel makeKeyAndOrderFront:panel];
+   [panel setLevel:CGShieldingWindowLevel()];
+   
    [panel beginWithCompletionHandler:^(NSInteger result) {
      if (result == NSFileHandlingPanelOKButton)
      {


### PR DESCRIPTION
Bring to front of the window for selecting directories worked
on some hosts but not in logic and live and so on. So clobber the
window order a little bit harder.

With this I now get the chooser window on top of surge in Logic 10.4.whatever
and bitwig 2.4.3 with the vst3

Closes #1001. Again. I hope!