### PR TITLE
Offscreen bitmaps should be integral

### DIFF
--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -16,6 +16,8 @@
 #include "vstgui/lib/platform/iplatformresourceinputstream.h"
 #endif
 
+#include <cmath>
+
 #include "resource.h"
 
 #include <stdio.h>
@@ -244,7 +246,7 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
           VSTGUI::CPoint offScreenSz = sz;
           tf.transform(offScreenSz);
 
-          if (auto offscreen = COffscreenContext::create(frame, offScreenSz.x, offScreenSz.y))
+          if (auto offscreen = COffscreenContext::create(frame, ceil(offScreenSz.x), ceil(offScreenSz.y)))
           {
              offscreen->beginDraw();
              VSTGUI::CRect newRect(0, 0, rect.getWidth(), rect.getHeight());


### PR DESCRIPTION
Offscreen bitmap sizes were non-integral leading to unpredictable
clips at the edges of items. This would mean on non-retina displays
at lower non-integral zoom levels (like 1.25) you would get clips and
misdraws at edges of items, for instance, the borders of buttons.

Fix with a simple application of ceil.

Closes #907