### PR TITLE
Implement a variety of small UI changes

### DIFF
--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -343,4 +343,15 @@ double CModulationSourceButton::getMouseDeltaScaling(CPoint& where, const CButto
    return scaling;
 }
 
+bool CModulationSourceButton::onWheel(const VSTGUI::CPoint& where, const float &distance, const VSTGUI::CButtonState& buttons)
+{
+    value += distance / (double)(getWidth());
+    value = limit_range(value, 0.f, 1.f);
+    event_is_drag = true;
+    invalid();
+    if (listener)
+        listener->valueChanged(this);
+    return true;
+}
+
 //------------------------------------------------------------------------------------------------

--- a/src/common/gui/CModulationSourceButton.h
+++ b/src/common/gui/CModulationSourceButton.h
@@ -28,6 +28,7 @@ public:
 
    virtual void onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy);
    virtual double getMouseDeltaScaling(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual bool onWheel(const VSTGUI::CPoint& where, const float &distance, const VSTGUI::CButtonState& buttons);
 
    int state, msid, controlstate;
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2703,7 +2703,17 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
        zoomSubMenu->addEntry(defaultZ);
        zid++;
 
-       settingsMenu->addEntry(zoomSubMenu, "Zoom");
+       addCallbackMenu(zoomSubMenu, "Set default zoom to ...", [this]() {
+               // FIXME! This won't work on linux
+               char c[256];
+               snprintf(c, 256, "%d", this->zoomFactor );
+               spawn_miniedit_text(c, 16);
+               int newVal = ::atoi(c);
+               Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "defaultZoom", newVal);
+           });
+       zid++;
+
+       settingsMenu->addEntry(zoomSubMenu, "Zoom" );
        eid++;
     }
 


### PR DESCRIPTION
1. Mouse wheel adjusts control region (Addressed #1009)
2. Add a "set default zoom to..." option for users on hosts
   where zoom doesn't work. Closes #1013.