### PR TITLE
Support DAW state in the patch

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -525,6 +525,10 @@ ComponentResult aulayer::RestoreState(CFPropertyListRef plist)
       p = CFDataGetBytePtr(data);
       size_t psize = CFDataGetLength(data);
       plugin_instance->loadRaw(p, psize, false);
+
+      plugin_instance->loadFromDawExtraState();
+      if( editor_instance )
+          editor_instance->loadFromDAWExtraState(plugin_instance);
    }
    return noErr;
 }
@@ -545,11 +549,17 @@ ComponentResult aulayer::SaveState(CFPropertyListRef* plist)
 
    CFMutableDictionaryRef dict = (CFMutableDictionaryRef)*plist;
    void* data;
+   
+   plugin_instance->populateDawExtraState();
+   if( editor_instance )
+       editor_instance->populateDawExtraState(plugin_instance);
+   
    CFIndex size = plugin_instance->saveRaw(&data);
    CFDataRef dataref =
        CFDataCreateWithBytesNoCopy(NULL, (const UInt8*)data, size, kCFAllocatorNull);
    CFDictionarySetValue(dict, rawchunkname, dataref);
    CFRelease(dataref);
+
    return noErr;
 }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -387,6 +387,21 @@ struct StepSequencerStorage
    unsigned int trigmask;
 };
 
+/*
+** There are a collection of things we want your DAW to save about your particular instance
+** but don't want saved in your patch. So have this extra structure in the patch which we
+** can activate/populate from the DAW hosts. See #915
+*/
+struct DAWExtraStateStorage
+{
+   bool isPopulated = false;
+    
+   int instanceZoomFactor = -1;
+   bool mpeEnabled = false;
+   bool hasTuning = false;
+   std::string tuningContents = "";
+};
+
 class SurgeStorage;
 
 class SurgePatch
@@ -423,6 +438,8 @@ public:
 
    StepSequencerStorage stepsequences[2][n_lfos];
 
+   DAWExtraStateStorage dawExtraState;
+   
    std::vector<Parameter*> param_ptr;
    std::vector<int> easy_params_id;
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -167,6 +167,26 @@ public:
 
    float vu_peak[8];
 
+   void populateDawExtraState() {
+       storage.getPatch().dawExtraState.isPopulated = true;
+       storage.getPatch().dawExtraState.mpeEnabled = mpeEnabled;
+       storage.getPatch().dawExtraState.hasTuning = !storage.isStandardTuning;
+       if( ! storage.isStandardTuning )
+           storage.getPatch().dawExtraState.tuningContents = storage.currentScale.rawText;
+       else
+           storage.getPatch().dawExtraState.tuningContents = "";
+   }
+   void loadFromDawExtraState() {
+       if( ! storage.getPatch().dawExtraState.isPopulated )
+           return;
+       mpeEnabled = storage.getPatch().dawExtraState.mpeEnabled;
+       if( storage.getPatch().dawExtraState.hasTuning )
+       {
+           auto sc = Surge::Storage::parseSCLData(storage.getPatch().dawExtraState.tuningContents );
+           storage.retuneToScale(sc);
+       }
+   }
+   
 public:
    int CC0, PCH, patchid;
    float masterfade = 0;

--- a/src/common/Tunings.cpp
+++ b/src/common/Tunings.cpp
@@ -31,21 +31,13 @@
  should give a read error and be rejected.
 */
 
-Surge::Storage::Scale Surge::Storage::readSCLFile(std::string fname)
+Surge::Storage::Scale scaleFromStream(std::istream &inf)
 {
-   std::ifstream inf;
-   inf.open(fname);
-   if (!inf.is_open())
-   {
-      return Scale();
-   }
-
    std::string line;
    const int read_header = 0, read_count = 1, read_note = 2;
    int state = read_header;
 
-   Scale res;
-   res.name = fname;
+   Surge::Storage::Scale res;
    std::ostringstream rawOSS;
    while (std::getline(inf, line))
    {
@@ -65,16 +57,16 @@ Surge::Storage::Scale Surge::Storage::readSCLFile(std::string fname)
          state = read_note;
          break;
       case read_note:
-         Tone t;
+         Surge::Storage::Tone t;
          t.stringRep = line;
          if (line.find(".") != std::string::npos)
          {
-            t.type = Tone::kToneCents;
+            t.type = Surge::Storage::Tone::kToneCents;
             t.cents = atof(line.c_str());
          }
          else
          {
-            t.type = Tone::kToneRatio;
+            t.type = Surge::Storage::Tone::kToneRatio;
             auto slashPos = line.find("/");
             if (slashPos == std::string::npos)
             {
@@ -101,6 +93,28 @@ Surge::Storage::Scale Surge::Storage::readSCLFile(std::string fname)
 
    res.rawText = rawOSS.str();
    return res;
+}
+
+Surge::Storage::Scale Surge::Storage::readSCLFile(std::string fname)
+{
+   std::ifstream inf;
+   inf.open(fname);
+   if (!inf.is_open())
+   {
+      return Scale();
+   }
+
+   auto res = scaleFromStream(inf);
+   res.name = fname;
+   return res;
+}
+
+Surge::Storage::Scale Surge::Storage::parseSCLData(const std::string &d)
+{
+    std::istringstream iss(d);
+    auto res = scaleFromStream(iss);
+    res.name = "Scale from Patch";
+    return res;
 }
 
 std::ostream& Surge::Storage::operator<<(std::ostream& os, const Surge::Storage::Tone& t)

--- a/src/common/Tunings.h
+++ b/src/common/Tunings.h
@@ -45,5 +45,6 @@ std::ostream& operator<<(std::ostream& os, const Tone& sc);
 std::ostream& operator<<(std::ostream& os, const Scale& sc);
 
 Scale readSCLFile(std::string fname);
+Scale parseSCLData(const std::string &sclContents);
 } // namespace Storage
 } // namespace Surge

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -97,6 +97,14 @@ SurgeGUIEditor::SurgeGUIEditor(void* effect, SurgeSynthesizer* synth) : super(ef
    // init the size of the plugin
    int userDefaultZoomFactor = Surge::Storage::getUserDefaultValue(&(synth->storage), "defaultZoom", 100);
    float zf = userDefaultZoomFactor / 100.0;
+
+   if( synth->storage.getPatch().dawExtraState.isPopulated &&
+       synth->storage.getPatch().dawExtraState.instanceZoomFactor > 0
+       )
+   {
+       // If I restore state before I am constructed I need to do this
+       zf = synth->storage.getPatch().dawExtraState.instanceZoomFactor / 100.0;
+   }
    
    rect.left = 0;
    rect.top = 0;

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -148,6 +148,20 @@ private:
    bool zoomEnabled = true;
 
 public:
+
+   void populateDawExtraState(SurgeSynthesizer *synth) {
+       synth->storage.getPatch().dawExtraState.isPopulated = true;
+       synth->storage.getPatch().dawExtraState.instanceZoomFactor = zoomFactor;
+   }
+   void loadFromDAWExtraState(SurgeSynthesizer *synth) {
+       if( synth->storage.getPatch().dawExtraState.isPopulated )
+       {
+           auto sz = synth->storage.getPatch().dawExtraState.instanceZoomFactor;
+           if( sz > 0 )
+               setZoomFactor(sz);
+       }
+   }
+   
    void setZoomCallback(std::function< void(SurgeGUIEditor *) > f) {
        zoom_callback = f;
        setZoomFactor(getZoomFactor()); // notify the new callback

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -511,6 +511,10 @@ VstInt32 Vst2PluginInstance::getChunk(void** data, bool isPreset)
    if (!tryInit())
       return 0;
 
+   _instance->populateDawExtraState();
+   if( editor )
+       ((SurgeGUIEditor *)editor)->populateDawExtraState(_instance);
+
    return _instance->saveRaw(data);
    //#endif
 }
@@ -524,6 +528,10 @@ VstInt32 Vst2PluginInstance::setChunk(void* data, VstInt32 byteSize, bool isPres
       return 0;
 
    _instance->loadRaw(data, byteSize, false);
+
+   _instance->loadFromDawExtraState();
+   if( editor )
+       ((SurgeGUIEditor *)editor)->loadFromDAWExtraState(_instance);
 
    return 1;
 }

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -159,6 +159,10 @@ tresult PLUGIN_API SurgeVst3Processor::getState(IBStream* state)
    CHECK_INITIALIZED
 
    void* data = nullptr; // surgeInstance keeps its data in an auto-ptr so we don't need to free it
+   surgeInstance->populateDawExtraState();
+   for( auto e : viewsSet )
+       e->populateDawExtraState(surgeInstance.get());
+
    unsigned int stateSize = surgeInstance->saveRaw(&data);
    state->write(data, stateSize);
 
@@ -179,6 +183,10 @@ tresult PLUGIN_API SurgeVst3Processor::setState(IBStream* state)
    if (result == kResultOk)
    {
       surgeInstance->loadRaw(data, numBytes, false);
+      surgeInstance->loadFromDawExtraState();
+      for( auto e : viewsSet )
+          e->loadFromDAWExtraState(surgeInstance.get());
+
    }
 
    free(data);


### PR DESCRIPTION
Some features of the synth - notably, zoom, MPE Enablement, and
Tuning - are features of the DAW environment you are working in and
were not persisted. This fixes that by adding a dawExtraState section
to the streaming protocol which is only populated and read at DAW time
not at general patch time.

Closes #890
Closes #914
CLoses #915
Mostly wraps up #828