### PR TITLE
Fix up the Sin osc FM channel

### DIFF
--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -58,6 +58,7 @@ public:
    double phase;
    float driftlfo, driftlfo2;
    lag<double> FMdepth;
+   lag<double> FB;
 
    int id_mode, id_fb;
    float lastvalue = 0;


### PR DESCRIPTION
The Sin osc FM channel was totally different than
the FM2 one in a way which was wierdly inconsistent.
So choose to change the behavior of SIN in FM mode.
This may impact the sound of some patches.

Closes #1035