### PR TITLE
VST2 Header Order

### DIFF
--- a/src/common/gui/CStatusPanel.cpp
+++ b/src/common/gui/CStatusPanel.cpp
@@ -1,6 +1,7 @@
+#include "SurgeGUIEditor.h"
 #include "CStatusPanel.h"
 #include "RuntimeFont.h"
-#include "SurgeGUIEditor.h"
+
 
 using namespace VSTGUI;
 


### PR DESCRIPTION
Somewhat concerningly VST2 doesn't like the header order with the
vstcontrol after SurgeGUIEditor. I could fix that I suppose but
instead just reoder headers so it (fragile-y) works.