### PR TITLE
SIN backwards compatibility

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -565,6 +565,12 @@ void Parameter::set_type(int ctrltype)
       valtype = vt_int;
       val_default.i = 0;
       break;
+   case ct_sinefmlegacy:
+      val_min.i = 0;
+      val_max.i = 1;
+      valtype = vt_int;
+      val_default.i = 0;
+      break;
    case ct_vocoder_bandcount:
       val_min.i = 4;
       val_max.i = 20;
@@ -995,6 +1001,12 @@ void Parameter::get_display(char* txt, bool external, float ef)
       case ct_sineoscmode:
          // FIXME - do better than this of course
          sprintf(txt, "%d", i);
+         break;
+      case ct_sinefmlegacy:
+         if( i == 0 )
+             sprintf( txt, "Legacy (1.6.1.1 and earlier)");
+         else
+             sprintf( txt, "Consistent w. FM2/3" );
          break;
       case ct_vocoder_bandcount:
          // FIXME - do better than this of course

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -85,6 +85,7 @@ enum ctrltypes
    ct_bool_fm,
    ct_character,
    ct_sineoscmode,
+   ct_sinefmlegacy,
    ct_countedset_percent, // what % through a counted set are you
    ct_vocoder_bandcount,
    num_ctrltypes,

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -55,6 +55,8 @@ public:
    virtual void init(float pitch, bool is_display = false) override;
    virtual void process_block(
        float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f) override;
+   virtual void process_block_legacy(
+       float pitch, float drift = 0.f, bool stereo = false, bool FM = false, float FMdepth = 0.f);
    virtual ~osc_sine();
    virtual void init_ctrltypes() override;
    virtual void init_default_values() override;
@@ -65,7 +67,7 @@ public:
    lag<double> FMdepth;
    lag<double> FB;
 
-   int id_mode, id_fb;
+   int id_mode, id_fb, id_fmlegacy;
    float lastvalue = 0;
 
    float valueFromSinAndCos(float svalue, float cvalue);


### PR DESCRIPTION
The changes to Sin to make the FM feedback and the like work
properly were too big a change for old patches. So add a mode
where FM is legacy or consistent mode. In legacy mode we exactly
match 1.6.1.1 and earlier; old patches load in legacy mode automatically.
New instances load in consistent mode. Streamed patches at version
11 (this version) and higher save properly.

Addresses #1035