### PR TITLE
Tuning and Oscillators

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -584,6 +584,15 @@ public:
 
    float note_to_pitch(float x);
    float note_to_pitch_inv(float x);
+   inline float note_to_pitch_tuningctr(float x)
+   {
+       return note_to_pitch(x + scaleConstantNote() ) / scaleConstantPitch();
+   }
+   inline float note_to_pitch_inv_tuningctr(float x)
+   {
+       return note_to_pitch_inv( x + scaleConstantNote() ) * scaleConstantPitch();
+   }
+       
    void note_to_omega(float, float&, float&);
 
    void retuneToScale(const Surge::Storage::Scale& s);

--- a/src/common/dsp/WavetableOscillator.cpp
+++ b/src/common/dsp/WavetableOscillator.cpp
@@ -229,9 +229,9 @@ void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
    // add time until next statechange
    float tempt;
    if (oscdata->p[5].absolute)
-      tempt = storage->note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f));
+      tempt = storage->note_to_pitch_inv_tuningctr(detune * pitchmult_inv * (1.f / 440.f));
    else
-      tempt = storage->note_to_pitch_inv(detune);
+      tempt = storage->note_to_pitch_inv_tuningctr(detune);
    float t;
    float xt = ((float)state[voice] + 0.5f) * dt;
    // xt = (1 - hskew + 2*hskew*xt);
@@ -247,7 +247,7 @@ void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
            t = dt * tempt * wt_inc;
    }	*/
    float ft = block_pos * formant_t + (1.f - block_pos) * formant_last;
-   float formant = storage->note_to_pitch(-ft);
+   float formant = storage->note_to_pitch_tuningctr(-ft);
    dt *= formant * xt;
 
    // if(state[voice] >= (oscdata->wt.size-wt_inc)) dt += (1-formant);
@@ -335,7 +335,7 @@ template <bool is_init> void WavetableOscillator::update_lagvals()
    l_shape.newValue(limit_range(localcopy[id_shape].f, 0.f, 1.f));
    formant_t = max(0.f, localcopy[id_formant].f);
 
-   float invt = min(1.0, (8.175798915 * storage->note_to_pitch(pitch_t)) * dsamplerate_os_inv);
+   float invt = min(1.0, (8.175798915 * storage->note_to_pitch_tuningctr(pitch_t)) * dsamplerate_os_inv);
    float hpf2 = min(integrator_hpf, powf(hpf_cycle_loss, 4 * invt)); // TODO Make a lookup table
 
    hpf_coeff.newValue(hpf2);

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -140,7 +140,7 @@ void WindowOscillator::ProcessSubOscs(bool stereo)
        (int)(float)(oscdata->wt.n_tables * localcopy[oscdata->p[0].param_id_in_scene].f), 0,
        (int)oscdata->wt.n_tables - 1);
    int FormantMul =
-       (int)(float)(65536.f * storage->note_to_pitch(localcopy[oscdata->p[1].param_id_in_scene].f));
+       (int)(float)(65536.f * storage->note_to_pitch_tuningctr(localcopy[oscdata->p[1].param_id_in_scene].f));
    FormantMul = std::max(FormantMul >> WindowVsWavePO2, 1);
    {
       // SSE2 path
@@ -234,9 +234,13 @@ void WindowOscillator::process_block(float pitch, float drift, bool stereo, bool
    for (int l = 0; l < ActiveSubOscs; l++)
    {
       Sub.DriftLFO[l][0] = drift_noise(Sub.DriftLFO[l][1]);
-      float f = storage->note_to_pitch((pitch - 57.f) + drift * Sub.DriftLFO[l][0] +
+      /*
+      ** This original code uses note 57 as a center point with a frequency of 220.
+      */
+      
+      float f = storage->note_to_pitch(pitch + drift * Sub.DriftLFO[l][0] +
                                        Detune * (DetuneOffset + DetuneBias * (float)l));
-      int Ratio = Float2Int(220.f * 32768.f * f * (float)(storage->WindowWT.size) *
+      int Ratio = Float2Int(8.175798915f * 32768.f * f * (float)(storage->WindowWT.size) *
                             samplerate_inv); // (65536.f*0.5f), 0.5 for oversampling
       Sub.Ratio[l] = Ratio;
    }


### PR DESCRIPTION
The classic and wavetable/window oscillators were acting
improperly with very compact (like 3 notes to an octave)
tuning. This was because a few points were not centered
on the storage center note.

Among other things, this
- Fix the delay times in SurgeSuperOscillator
- Add StorageAPI for tuning-ctr pitches
- Fix WaveTable and Window Oscillator
- Make a rational choice for a tuned S&H osc

Closes #1051