### PR TITLE
SampleAndHold uses Tuning API

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -586,7 +586,7 @@ public:
    float note_to_pitch_inv(float x);
    inline float note_to_pitch_tuningctr(float x)
    {
-       return note_to_pitch(x + scaleConstantNote() ) / scaleConstantPitch();
+       return note_to_pitch(x + scaleConstantNote() ) * scaleConstantPitchInv();
    }
    inline float note_to_pitch_inv_tuningctr(float x)
    {
@@ -598,6 +598,7 @@ public:
    void retuneToScale(const Surge::Storage::Scale& s);
    inline int scaleConstantNote() { return 48; }
    inline float scaleConstantPitch() { return 16.0; }
+   inline float scaleConstantPitchInv() { return 0.0625; } // Obviously that's the inverse of the above
 
    Surge::Storage::Scale currentScale;
    bool isStandardTuning;

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -81,9 +81,9 @@ void SampleAndHoldOscillator::init(float pitch, bool is_display)
          double detune = localcopy[id_detune].f * (detune_bias * float(i) + detune_offset);
          // double t = drand * max(2.0,dsamplerate_os / (16.35159783 *
          // pow((double)1.05946309435,(double)pitch)));
-         double st = drand * storage->note_to_pitch(detune - 12 + storage->scaleConstantNote()) / storage->scaleConstantPitch();
+         double st = drand * storage->note_to_pitch_tuningctr(detune) * 0.5;
          drand = (double)rand() / RAND_MAX;
-         double ot = drand * storage->note_to_pitch(detune + l_sync.v + storage->scaleConstantNote()) / storage->scaleConstantPitch();
+         double ot = drand * storage->note_to_pitch_tuningctr(detune);
          oscstate[i] = st;
          syncstate[i] = st;
       }
@@ -143,7 +143,7 @@ void SampleAndHoldOscillator::convolute(int voice, bool FM, bool stereo)
    if (syncstate[voice] < oscstate[voice])
    {
       ipos = (unsigned int)((float)p24 * (syncstate[voice] * pitchmult_inv));
-      float t = storage->note_to_pitch_inv(detune + storage->scaleConstantNote()) * storage->scaleConstantPitch();
+      float t = storage->note_to_pitch_inv_tuningctr(detune);
       if (state[voice] == 1)
          invertcorrelation = -1.f;
       state[voice] = 0;
@@ -164,11 +164,9 @@ void SampleAndHoldOscillator::convolute(int voice, bool FM, bool stereo)
    // add time until next statechange
    float t;
    if (oscdata->p[5].absolute)
-       t = storage->note_to_pitch_inv(detune * pitchmult_inv * (1.f / 440.f) + l_sync.v + storage->scaleConstantNote()) *
-           storage->scaleConstantPitch();
+       t = storage->note_to_pitch_inv_tuningctr(detune * pitchmult_inv * (1.f / 440.f) + l_sync.v);
    else
-       t = storage->note_to_pitch_inv(detune + l_sync.v + storage->scaleConstantNote()) *
-           storage->scaleConstantPitch();
+       t = storage->note_to_pitch_inv_tuningctr(detune + l_sync.v);
 
    float g, gR;
 
@@ -254,7 +252,7 @@ template <bool is_init> void SampleAndHoldOscillator::update_lagvals()
    l_smooth.newValue(localcopy[id_smooth].f);
    l_sub.newValue(localcopy[id_sub].f);
 
-   auto pp = storage->note_to_pitch(pitch + l_sync.v + storage->scaleConstantNote()) / storage->scaleConstantPitch();
+   auto pp = storage->note_to_pitch_tuningctr(pitch + l_sync.v);
    float invt = 4.f * min(1.0, (8.175798915 * pp * dsamplerate_os_inv) );
    float hpf2 = min(integrator_hpf, powf(hpf_cycle_loss, invt));
    // TODO Make a lookup-table


### PR DESCRIPTION
Sample and Hold uses the Tuning Note to Pitch API which
recenters; fixes a small start time bug; and the centering
API avoids a division.

Closes #1059