### PR TITLE
Linux VST3 Shutdown; and include in DEB

### DIFF
--- a/installer_linux/make_deb.sh
+++ b/installer_linux/make_deb.sh
@@ -81,7 +81,7 @@ cp -r ../resources/data/* ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/
 cp ../target/vst2/Release/Surge.so ${PACKAGE_NAME}/usr/lib/vst/${SURGE_NAME}.so
 
 # Once VST3 works, this will be ../products/vst3
-# cp ../target/vst3/Release/Surge.so ${PACKAGE_NAME}/usr/lib/vst3/${SURGE_NAME}.so
+cp -r ../products/Surge.vst3 ${PACKAGE_NAME}/usr/lib/vst3/
 
 #build package
 


### PR DESCRIPTION
The LInux VST3 now cleanly shuts down its runloop, meaning
it works completely in reaper linux. I have included it in the
deb file for installation as a result.

Addresses #514