### PR TITLE
Copy the correct oscillator

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1590,7 +1590,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          contextMenu->addEntry(txt, eid++);
          contextMenu->addEntry("-", eid++);
          addCallbackMenu(contextMenu, "Copy",
-                         [this]() { synth->storage.clipboard_copy(cp_osc, current_scene, 0); });
+                         [this, a]() { synth->storage.clipboard_copy(cp_osc, current_scene, a); });
          eid++;
 
          addCallbackMenu(contextMenu, "Copy (with modulation)", [this, a]() {


### PR DESCRIPTION
Way back in 1.6.0 beta 5 we introduced this bug that always copied
oscillator 0.

Closes #1060