### PR TITLE
Only apply Streaming fixes when Streaming

### DIFF
--- a/doc/pauls-debug-fragments.txt
+++ b/doc/pauls-debug-fragments.txt
@@ -22,8 +22,8 @@ void stackToInfo()
     void* callstack[128];
     int i, frames = backtrace(callstack, 128);
     char** strs = backtrace_symbols(callstack, frames);
-    for (i = 0; i < frames; ++i) {
-        printf( "[SurgeRack] StackTrace[%3d]: %s", i, strs[i] );
+    for (i = 1; i < 8; ++i) {
+        printf( "StackTrace[%3d]: %s\n", i, strs[i] );
     }
     free(strs);
 #endif

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -695,8 +695,9 @@ void SurgePatch::copy_globaldata(pdata* d)
 // pdata scenedata[2][n_scene_params];
 
 void SurgePatch::update_controls(bool init,
-                                 void* init_osc) // init_osc is the pointer to the data structure of
-                                                 // a particular osc to be reinitialized
+                                 void* init_osc, // init_osc is the pointer to the data structure of a particular osc to init
+                                 bool from_streaming // we are loading from a patch
+    ) 
 {
    for (auto& sc : scene)
    {
@@ -709,9 +710,12 @@ void SurgePatch::update_controls(bool init,
          if (t_osc)
          {
             t_osc->init_ctrltypes();
-            t_osc->handleStreamingMismatches( streamingRevision, currentSynthStreamingRevision );
+            if (from_streaming)
+                t_osc->handleStreamingMismatches( streamingRevision, currentSynthStreamingRevision );
             if (init || (init_osc == &sc.osc[osc]))
-               t_osc->init_default_values();
+            {
+                t_osc->init_default_values();
+            }
             delete t_osc;
          }
       }

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -417,7 +417,7 @@ public:
    SurgePatch(SurgeStorage* storage);
    ~SurgePatch();
    void init_default_values();
-   void update_controls(bool init = false, void* init_osc = 0);
+   void update_controls(bool init = false, void* init_osc = 0, bool from_stream = false);
    void do_morph();
    void copy_scenedata(pdata*, int scene);
    void copy_globaldata(pdata*);

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -220,7 +220,7 @@ void SurgeSynthesizer::loadRaw(const void* data, int size, bool preset)
 
    storage.getPatch().init_default_values();
    storage.getPatch().load_patch(data, size, preset);
-   storage.getPatch().update_controls(false);
+   storage.getPatch().update_controls(false, nullptr, true);
    for (int i = 0; i < 8; i++)
    {
       memcpy(&fxsync[i], &storage.getPatch().fx[i], sizeof(FxStorage));


### PR DESCRIPTION
Fixes the mis-application of change in #1035 by making sure the
chance to handle old streaming versions only occurs when, you know,
you are actually streaming!

Closes #1035