### PR TITLE
Effects get a chance to react to streaming versions

### DIFF
--- a/scripts/patch-tool/patch-grep.py
+++ b/scripts/patch-tool/patch-grep.py
@@ -28,8 +28,25 @@ def sceneFun(xml):
         return False
 
 
+def containsFX(xml):
+    try:
+        pt = xml.getElementsByTagName("patch")[0]
+        for i in range(8):
+            nm = "fx{}_type".format(i + 1)
+            fx = pt.getElementsByTagName(nm)
+            if len(fx) > 0:
+                fxe = fx[0]
+                fxt = fxe.attributes["value"].nodeValue
+                if fxt == "10":
+                    return True
+
+        return False
+    except:
+        return False
+
+
 def target(xml):
-    return sceneFun(xml)
+    return containsFX(xml)
 
 
 def patchToDom(patch):

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -720,6 +720,20 @@ void SurgePatch::update_controls(bool init,
          }
       }
    }
+
+   if( from_streaming )
+   {
+       for( int i=0; i<8; ++i )
+       {
+           if(fx[i].type.val.i != fxt_off)
+           {
+               Effect *t_fx = spawn_effect(fx[i].type.val.i, nullptr, &(fx[i]), nullptr );
+               t_fx->init_ctrltypes();
+               t_fx->handleStreamingMismatches(streamingRevision, currentSynthStreamingRevision );
+               delete t_fx;
+           }
+       }
+   }
 }
 
 void SurgePatch::do_morph()

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -35,15 +35,18 @@ Effect* spawn_effect(int id, SurgeStorage* storage, FxStorage* fxdata, pdata* pd
 
 Effect::Effect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd)
 {
-   assert(storage);
+   // assert(storage);
    this->fxdata = fxdata;
    this->storage = storage;
    this->pd = pd;
    ringout = 10000000;
-   for (int i = 0; i < n_fx_params; i++)
+   if(pd)
    {
-      f[i] = &pd[fxdata->p[i].id].f;
-      pdata_ival[i] = &pd[fxdata->p[i].id].i;
+       for (int i = 0; i < n_fx_params; i++)
+       {
+           f[i] = &pd[fxdata->p[i].id].f;
+           pdata_ival[i] = &pd[fxdata->p[i].id].i;
+       }
    }
 }
 

--- a/src/common/dsp/effect/Effect.h
+++ b/src/common/dsp/effect/Effect.h
@@ -72,6 +72,11 @@ public:
    }
    float vu[KNumVuSlots]; // stereo pairs, just use every other when mono
 
+   virtual void handleStreamingMismatches(int streamingRevision, int currentSynthStreamingRevision)
+   {
+       // No-op here.
+   }
+
 protected:
    SurgeStorage* storage;
    FxStorage* fxdata;

--- a/src/common/dsp/effect/VocoderEffect.cpp
+++ b/src/common/dsp/effect/VocoderEffect.cpp
@@ -322,4 +322,17 @@ void VocoderEffect::init_ctrltypes()
 
 }
 
+void VocoderEffect::handleStreamingMismatches(int streamingRevision, int currentSynthStreamingRevision)
+{
+    if( streamingRevision <= 10 )
+    {
+        fxdata->p[kNumBands].val.i = n_vocoder_bands;
+        
+        fxdata->p[kFreqLo].val.f = 12.f * log(vocoder_freq_vsm201[0]/440.f)/log(2.f);
+        fxdata->p[kFreqHi].val.f = 12.f * log(vocoder_freq_vsm201[n_vocoder_bands-1]/440.f)/log(2.f);
+        
+        fxdata->p[kModExpand].val.f = 0.f;
+        fxdata->p[kModCenter].val.f = 0.f;
+    }
+}
 //------------------------------------------------------------------------------------------------

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -305,6 +305,8 @@ public:
    virtual const char* group_label(int id) override;
    virtual int group_label_ypos(int id) override;
 
+   virtual void handleStreamingMismatches(int streamingRevision, int currentSynthStreamingRevision) override;
+
 private:
    VectorizedSvfFilter mCarrierL alignas(16)[NVocoderVec];
    VectorizedSvfFilter mCarrierR alignas(16)[NVocoderVec];


### PR DESCRIPTION
With streaming version 11 (version 1.6.2) when I added parameters
to Vocoder and Sine we realized old patches had streamed nonsense
values for those new parameters. So add an opportunity along with
streaming version to reset my values to defaults.

To test this, load any of the vocoder patches in the system and see
that bands == 20 and so on.

Closes #1037