### PR TITLE
Disable Animated OSC

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -31,13 +31,20 @@ void COscillatorDisplay::draw(CDrawContext* dc)
    for (int c = 0; c < 2; ++c)
    {
       osces[c] = nullptr;
+
+#if OSC_MOD_ANIMATION
       if (!is_mod && c > 0 )
          continue;
+#else
+      if (c > 0)
+         continue;
+#endif
 
       tp[c][oscdata->pitch.param_id_in_scene].f = 0;
       for (int i = 0; i < n_osc_params; i++)
          tp[c][oscdata->p[i].param_id_in_scene].i = oscdata->p[i].val.i;
 
+#if OSC_MOD_ANIMATION
       if (c == 1 )
       {
          auto modOut = 1.0;
@@ -101,6 +108,7 @@ void COscillatorDisplay::draw(CDrawContext* dc)
             iter++;
          }
       }
+#endif
 
       osces[c] = spawn_osc(oscdata->type.val.i, storage, oscdata, tp[c]);
    }

--- a/src/common/gui/COscillatorDisplay.h
+++ b/src/common/gui/COscillatorDisplay.h
@@ -7,6 +7,8 @@
 #include "CDIBitmap.h"
 #include "DspUtilities.h"
 
+#define OSC_MOD_ANIMATION 0
+
 class COscillatorDisplay : public VSTGUI::CControl, public VSTGUI::IDropTarget
 {
 public:
@@ -52,6 +54,7 @@ public:
    virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
    virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
 
+#if OSC_MOD_ANIMATION
    void setIsMod(bool b)
    {
       is_mod = b;
@@ -65,6 +68,7 @@ public:
    {
       mod_time += 1.0 / 30.0;
    }
+#endif
 
 protected:
    void populateMenu(VSTGUI::COptionMenu* m, int selectedItem);
@@ -75,9 +79,12 @@ protected:
    unsigned controlstate;
 
    bool doingDrag = false;
+
+#if OSC_MOD_ANIMATION
    bool is_mod = false;
    modsources modsource = ms_original;
    float mod_time = 0;
+#endif
    VSTGUI::CRect rnext, rprev, rmenu;
    VSTGUI::CPoint lastpos;
    CLASS_METHODS(COscillatorDisplay, VSTGUI::CControl)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -309,12 +309,14 @@ void SurgeGUIEditor::idle()
          }
       }
 
+#if OSC_MOD_ANIMATION
       if (mod_editor && oscdisplay)
       {
          ((COscillatorDisplay*)oscdisplay)->tickModTime();
          oscdisplay->setDirty(true);
          oscdisplay->invalid();
       }
+#endif
 
       if (polydisp)
       {
@@ -524,6 +526,7 @@ void SurgeGUIEditor::refresh_mod()
          s->invalid();
       }
    }
+#if OSC_MOD_ANIMATION
    if (oscdisplay)
    {
       ((COscillatorDisplay*)oscdisplay)->setIsMod(mod_editor);
@@ -531,6 +534,8 @@ void SurgeGUIEditor::refresh_mod()
       oscdisplay->invalid();
       oscdisplay->setDirty(true);
    }
+#endif
+
    synth->storage.CS_ModRouting.leave();
    for (int i = 1; i < n_modsources; i++)
    {


### PR DESCRIPTION
The Animated OSC was just too confusing - is it the real LFO; what
rate; what envelope; which modulation. So just disable it and think
about it some other time.

Closes #1017