### PR TITLE
Re-allocation using samples caused Crash; Fix

### DIFF
--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -52,6 +52,7 @@ size_t RequiredWTSize(int TableSize, int TableCount)
 {
    int Size = 0;
 
+   TableCount += 3; // for sample padding. Should match the "3" in the AppendSilence block below.
    while (TableSize > 0)
    {
       Size += TableCount * (TableSize + FIRoffsetI16 + FIRipolI16_N);
@@ -167,7 +168,7 @@ bool Wavetable::BuildWT(void* wdata, wt_header& wh, bool AppendSilence)
 
    if (AppendSilence)
    {
-      n_tables += 3;
+       n_tables += 3; // this "3" should match the "3" in RequiredWTSize
    }
 
 #if WINDOWS


### PR DESCRIPTION
Re-allocating larger wavetables in some very specific size
cases mis-allocated the size required for the silence which
was appended. This left memory mis-aligned causing an immediate
crash on Windows in some cases. Fix by adding the silence pad to the
required size for a given set of tables.

Closes #1087