### PR TITLE
Improving LV2

### DIFF
--- a/src/lv2/SurgeLv2Ui.h
+++ b/src/lv2/SurgeLv2Ui.h
@@ -43,6 +43,9 @@ private:
    static const void* extensionData(const char* uri);
    static int uiIdle(LV2UI_Handle ui);
 
+    // callback from the editor
+    void handleZoom(SurgeGUIEditor* e, const LV2UI_Resize* resizer);
+
 private:
    std::unique_ptr<SurgeGUIEditor> _editor;
    SurgeLv2Wrapper* _instance;

--- a/src/lv2/SurgeLv2Wrapper.cpp
+++ b/src/lv2/SurgeLv2Wrapper.cpp
@@ -251,7 +251,7 @@ void SurgeLv2Wrapper::handleEvent(const LV2_Atom_Event* event)
       };
 
       if (speed)
-         atomGetNumber(beatsPerMinute, &_timePositionSpeed);
+         atomGetNumber(speed, &_timePositionSpeed);
       if (beatsPerMinute)
          atomGetNumber(beatsPerMinute, &_timePositionTempoBpm);
       if (beat)


### PR DESCRIPTION
Hello, I add two things.

1. it's a mistake about taking the wrong variable in a function call, which is able to crash the host if reached.
2. this is window resizing of zoom.

About zoom, it's fine with Carla. With Jalv, the window accepts to make itself larger, but not to shrink back. I'm guessing the problem is probably Jalv's regarding this matter.