### PR TITLE
Make the pthread routine return null

### DIFF
--- a/src/linux/LinuxVST3Helpers.cpp
+++ b/src/linux/LinuxVST3Helpers.cpp
@@ -169,6 +169,7 @@ public:
          gUpdateHandlerInit.get()->triggerDeferedUpdates();
          usleep(1000 / 30.0);
       }
+      return nullptr;
    }
 
    static void stop()


### PR DESCRIPTION
Since I've seen such things be at the origin of crashes before, it's better to be safe.