### PR TITLE
Add SurgeEffectsBank optional to the installer

### DIFF
--- a/installer_win/surge-x86.iss
+++ b/installer_win/surge-x86.iss
@@ -39,10 +39,12 @@ SolidCompression=yes
 Name: Data; Description: Data files; Types: full compact custom; Flags: fixed
 Name: VST2; Description: VST2 Plug-in (32 bit); Types: full custom; Flags: checkablealone
 Name: VST3; Description: VST3 Plug-in (32 bit); Types: full compact custom; Flags: checkablealone
+Name: EffectsVST3; Description: SurgeEffectsBank VST3 Plug-in (32 bit); Types: full compact custom; Flags: checkablealone
 
 [Files]
 Source: ..\target\vst2\Release\Surge_x86.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\target\vst3\Release\Surge_x86.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
+Source: ..\fxbuild\surge-fx\Builds\VisualStudio2017\Win32\ReleaseWin32\VST3\SurgeEffectsBank.vst3; DestDir: {cf}\VST3; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\resources\data\*; DestDir: {localappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
 Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 

--- a/installer_win/surge.iss
+++ b/installer_win/surge.iss
@@ -39,10 +39,12 @@ SolidCompression=yes
 Name: Data; Description: Data files; Types: full compact custom; Flags: fixed
 Name: VST2; Description: VST2 Plug-in (64 bit); Types: full custom; Flags: checkablealone
 Name: VST3; Description: VST3 Plug-in (64 bit); Types: full compact custom; Flags: checkablealone
+Name: EffectsVST3; Description: SurgeEffectsBank VST3 Plug-in (64 bit); Types: full compact custom; Flags: checkablealone
 
 [Files]
 Source: ..\target\vst2\Release\Surge.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\target\vst3\Release\Surge.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
+Source: ..\fxbuild\surge-fx\Builds\VisualStudio2017\x64\Release\VST3\SurgeEffectsBank.vst3; DestDir: {cf}\VST3; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\resources\data\*; DestDir: {localappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
 Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 


### PR DESCRIPTION
The installer, if the SurgeEffectsBank is built in an fxbuild/
subdir, will include it in the installer.

At the same time, the release pipeline builds the effects bank
in the right place.

Addresses #1098