### PR TITLE
Add xdg-open and zenity commands as Debian dependencies

### DIFF
--- a/installer_linux/make_deb.sh
+++ b/installer_linux/make_deb.sh
@@ -57,7 +57,7 @@ Package: ${PACKAGE_NAME}
 Version: $DEB_VERSION
 Architecture: amd64
 Maintainer: surgeteam
-Depends: libcairo2, libfontconfig1, libfreetype6, libx11-6, libxcb-cursor0, libxcb-util1, libxcb-xkb1, libxcb1, libxkbcommon-x11-0, libxkbcommon0, fonts-lato
+Depends: libcairo2, libfontconfig1, libfreetype6, libx11-6, libxcb-cursor0, libxcb-util1, libxcb-xkb1, libxcb1, libxkbcommon-x11-0, libxkbcommon0, fonts-lato, xdg-utils, zenity
 Provides: vst-plugin
 Section: sound
 Priority: optional


### PR DESCRIPTION
These packages have been reported to me as missing dependencies, in the Debian binary package.
It's the commands called by Linux User Interactions.
- https://packages.debian.org/stretch/xdg-utils
- https://packages.debian.org/stretch/zenity