### PR TITLE
Use "Natural Order" for sorting patches and wavetables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SURGE_COMMON_SOURCES
     libs/xml/tinyxml.cpp
     libs/xml/tinyxmlerror.cpp
     libs/xml/tinyxmlparser.cpp
+    libs/strnatcmp/strnatcmp.cpp
     libs/filesystem/filesystem.cpp
 )
 
@@ -59,6 +60,7 @@ set(SURGE_COMMON_INCLUDES
     libs/
     libs/filesystem
     libs/xml
+    libs/strnatcmp
     src/common
     src/common/dsp
     src/common/thread

--- a/libs/strnatcmp/README.md
+++ b/libs/strnatcmp/README.md
@@ -1,0 +1,22 @@
+This library contains strnatcmp from http://sourcefrog.net/projects/natsort/ and is
+zlib-compatible licensed
+
+The only modifications made are
+
+1: Rename from .c to .cpp
+
+---------
+
+This software is copyright by Martin Pool, and made available under the same licence as zlib:
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+This licence applies only to the C implementation. You are free to reimplement the idea fom scratch in any language.

--- a/libs/strnatcmp/strnatcmp.cpp
+++ b/libs/strnatcmp/strnatcmp.cpp
@@ -1,0 +1,178 @@
+/* -*- mode: c; c-file-style: "k&r" -*-
+
+  strnatcmp.c -- Perform 'natural order' comparisons of strings in C.
+  Copyright (C) 2000, 2004 by Martin Pool <mbp sourcefrog net>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+
+/* partial change history:
+ *
+ * 2004-10-10 mbp: Lift out character type dependencies into macros.
+ *
+ * Eric Sosman pointed out that ctype functions take a parameter whose
+ * value must be that of an unsigned int, even on platforms that have
+ * negative chars in their default char type.
+ */
+
+#include <ctype.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+#include "strnatcmp.h"
+
+
+/* These are defined as macros to make it easier to adapt this code to
+ * different characters types or comparison functions. */
+static inline int
+nat_isdigit(nat_char a)
+{
+     return isdigit((unsigned char) a);
+}
+
+
+static inline int
+nat_isspace(nat_char a)
+{
+     return isspace((unsigned char) a);
+}
+
+
+static inline nat_char
+nat_toupper(nat_char a)
+{
+     return toupper((unsigned char) a);
+}
+
+
+
+static int
+compare_right(nat_char const *a, nat_char const *b)
+{
+     int bias = 0;
+     
+     /* The longest run of digits wins.  That aside, the greatest
+	value wins, but we can't know that it will until we've scanned
+	both numbers to know that they have the same magnitude, so we
+	remember it in BIAS. */
+     for (;; a++, b++) {
+	  if (!nat_isdigit(*a)  &&  !nat_isdigit(*b))
+	       return bias;
+	  else if (!nat_isdigit(*a))
+	       return -1;
+	  else if (!nat_isdigit(*b))
+	       return +1;
+	  else if (*a < *b) {
+	       if (!bias)
+		    bias = -1;
+	  } else if (*a > *b) {
+	       if (!bias)
+		    bias = +1;
+	  } else if (!*a  &&  !*b)
+	       return bias;
+     }
+
+     return 0;
+}
+
+
+static int
+compare_left(nat_char const *a, nat_char const *b)
+{
+     /* Compare two left-aligned numbers: the first to have a
+        different value wins. */
+     for (;; a++, b++) {
+	  if (!nat_isdigit(*a)  &&  !nat_isdigit(*b))
+	       return 0;
+	  else if (!nat_isdigit(*a))
+	       return -1;
+	  else if (!nat_isdigit(*b))
+	       return +1;
+	  else if (*a < *b)
+	       return -1;
+	  else if (*a > *b)
+	       return +1;
+     }
+	  
+     return 0;
+}
+
+
+static int strnatcmp0(nat_char const *a, nat_char const *b, int fold_case)
+{
+     int ai, bi;
+     nat_char ca, cb;
+     int fractional, result;
+     
+     assert(a && b);
+     ai = bi = 0;
+     while (1) {
+	  ca = a[ai]; cb = b[bi];
+
+	  /* skip over leading spaces or zeros */
+	  while (nat_isspace(ca))
+	       ca = a[++ai];
+
+	  while (nat_isspace(cb))
+	       cb = b[++bi];
+
+	  /* process run of digits */
+	  if (nat_isdigit(ca)  &&  nat_isdigit(cb)) {
+	       fractional = (ca == '0' || cb == '0');
+
+	       if (fractional) {
+		    if ((result = compare_left(a+ai, b+bi)) != 0)
+			 return result;
+	       } else {
+		    if ((result = compare_right(a+ai, b+bi)) != 0)
+			 return result;
+	       }
+	  }
+
+	  if (!ca && !cb) {
+	       /* The strings compare the same.  Perhaps the caller
+                  will want to call strcmp to break the tie. */
+	       return 0;
+	  }
+
+	  if (fold_case) {
+	       ca = nat_toupper(ca);
+	       cb = nat_toupper(cb);
+	  }
+	  
+	  if (ca < cb)
+	       return -1;
+	  else if (ca > cb)
+	       return +1;
+
+	  ++ai; ++bi;
+     }
+}
+
+
+
+int strnatcmp(nat_char const *a, nat_char const *b) {
+     return strnatcmp0(a, b, 0);
+}
+
+
+/* Compare, recognizing numeric string and ignoring case. */
+int strnatcasecmp(nat_char const *a, nat_char const *b) {
+     return strnatcmp0(a, b, 1);
+}

--- a/libs/strnatcmp/strnatcmp.h
+++ b/libs/strnatcmp/strnatcmp.h
@@ -1,0 +1,31 @@
+/* -*- mode: c; c-file-style: "k&r" -*-
+
+  strnatcmp.c -- Perform 'natural order' comparisons of strings in C.
+  Copyright (C) 2000, 2004 by Martin Pool <mbp sourcefrog net>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+
+/* CUSTOMIZATION SECTION
+ *
+ * You can change this typedef, but must then also change the inline
+ * functions in strnatcmp.c */
+typedef char nat_char;
+
+int strnatcmp(nat_char const *a, nat_char const *b);
+int strnatcasecmp(nat_char const *a, nat_char const *b);

--- a/premake5.lua
+++ b/premake5.lua
@@ -154,6 +154,7 @@ end
 
 includedirs {
     "libs/xml",
+    "libs/strnatcmp",
     "libs/nanosvg/src",
     "src/common/vt_dsp",
     "src/common/thread",
@@ -235,6 +236,7 @@ function plugincommon()
         "libs/xml/tinyxml.cpp",
         "libs/xml/tinyxmlerror.cpp",
         "libs/xml/tinyxmlparser.cpp",
+        "libs/strnatcmp/strnatcmp.cpp",
         "libs/filesystem/filesystem.cpp",
     }
 

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -33,6 +33,8 @@
 
 #include "UserDefaults.h"
 
+#include "strnatcmp.h"
+
 
 float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
 float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];
@@ -344,8 +346,8 @@ void SurgeStorage::refresh_patchlist()
    auto patchCompare =
       [this](const int &i1, const int &i2) -> bool
       {
-         return _stricmp(patch_list[i1].name.c_str(),
-                         patch_list[i2].name.c_str()) < 0;
+         return strnatcasecmp(patch_list[i1].name.c_str(),
+                              patch_list[i2].name.c_str()) < 0;
       };
 
    std::sort(patchOrdering.begin(), patchOrdering.end(), patchCompare);
@@ -359,8 +361,8 @@ void SurgeStorage::refresh_patchlist()
    auto categoryCompare =
       [this](const int &i1, const int &i2) -> bool
       {
-         return _stricmp(patch_category[i1].name.c_str(),
-                         patch_category[i2].name.c_str()) < 0;
+         return strnatcasecmp(patch_category[i1].name.c_str(),
+                              patch_category[i2].name.c_str()) < 0;
       };
 
    int groups[4] = {0, firstThirdPartyCategory, firstUserCategory,
@@ -513,7 +515,7 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir,
    auto catCompare =
        [this](const PatchCategory &c1, const PatchCategory &c2) -> bool
        {
-           return _stricmp(c1.name.c_str(),c2.name.c_str()) < 0;
+           return strnatcasecmp(c1.name.c_str(),c2.name.c_str()) < 0;
        };
    for (auto& pc : local_categories)
    {
@@ -583,7 +585,7 @@ void SurgeStorage::refresh_wtlist()
    std::iota(wtCategoryOrdering.begin(), wtCategoryOrdering.end(), 0);
 
    auto categoryCompare = [this](const int& i1, const int& i2) -> bool {
-      return _stricmp(wt_category[i1].name.c_str(), wt_category[i2].name.c_str()) < 0;
+      return strnatcasecmp(wt_category[i1].name.c_str(), wt_category[i2].name.c_str()) < 0;
    };
 
    int groups[4] = {0, firstThirdPartyWTCategory, firstUserWTCategory, (int)wt_category.size()};
@@ -598,7 +600,7 @@ void SurgeStorage::refresh_wtlist()
    wtOrdering = std::vector<int>();
 
    auto wtCompare = [this](const int& i1, const int& i2) -> bool {
-      return _stricmp(wt_list[i1].name.c_str(), wt_list[i2].name.c_str()) < 0;
+      return strnatcasecmp(wt_list[i1].name.c_str(), wt_list[i2].name.c_str()) < 0;
    };
 
    // Sort wavetables per category in the category order.


### PR DESCRIPTION
"Natural Order" means "foo 1, foo 2, foo 12" rather than
"foo 1, foo 12, foo 2" which is strict per-char alpha order.
Implement by using a zlib licsense C implementation as
described in libs/strnatcmp/README.md

Closes #1120