### PR TITLE
When exporting LV2 manifest, avoid error dialog situations

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -287,8 +287,16 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath)
    load_midi_controllers();
 
 #if !TARGET_RACK   
-   refresh_wtlist();
-   refresh_patchlist();
+   bool loadWtAndPatch = true;
+#if TARGET_LV2
+   // skip loading during export, it pops up an irrelevant error dialog
+   loadWtAndPatch = !skipLoadWtAndPatch;
+#endif
+   if (loadWtAndPatch)
+   {
+      refresh_wtlist();
+      refresh_patchlist();
+   }
 #endif
    
    getPatch().scene[0].osc[0].wt.dt = 1.0f / 512.f;
@@ -1299,6 +1307,10 @@ bool SurgeStorage::retuneToScale(const Surge::Storage::Scale& s)
 
    return true;
 }
+
+#if TARGET_LV2
+bool SurgeStorage::skipLoadWtAndPatch = false;
+#endif
 
 namespace Surge
 {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -611,6 +611,11 @@ private:
    std::vector<ModulationRouting> clipboard_modulation_scene, clipboard_modulation_voice;
    Wavetable clipboard_wt[n_oscs];
 
+#if TARGET_LV2
+public:
+   // whether to skip loading, desired while exporting manifests
+   static bool skipLoadWtAndPatch;
+#endif
 };
 
 float db_to_linear(float);

--- a/src/lv2/SurgeLv2Export.cpp
+++ b/src/lv2/SurgeLv2Export.cpp
@@ -20,6 +20,8 @@ void lv2_generate_ttl(const char* baseName)
    const LV2_Descriptor* desc = lv2_descriptor(0);
    const LV2UI_Descriptor* uidesc = lv2ui_descriptor(0);
 
+   SurgeStorage::skipLoadWtAndPatch = true;
+
    SurgeLv2Wrapper defaultInstance(44100.0);
    SurgeSynthesizer* defaultSynth = defaultInstance.synthesizer();
 


### PR DESCRIPTION
As discussed in the previous PR.
Don't load the WT, nor patches. Both are sources of error messages.