### PR TITLE
Move Version Numbers to 1.6.2

### DIFF
--- a/doc/versions.md
+++ b/doc/versions.md
@@ -1,0 +1,13 @@
+# Version Numbers
+
+This document is a reminder list of all the places you need to update when you have a version 
+number tick.
+
+So version numbers live in
+
+* src/common/surge_auversion.h
+* resource/osx-*/Info.plist
+* src/windows/surge.rc (in several places in for 1,6,0,0)
+* src/common/version.h
+* src/common/version.h also contains a copyright year as does the AU info.plist
+* src/lv2/SurgeLv2Export.cpp generates minor and micro version

--- a/resources/osx-au/Info.plist
+++ b/resources/osx-au/Info.plist
@@ -40,7 +40,7 @@
 	<key>CFBundleSignature</key>
 	<string>VmbA</string>
 	<key>CFBundleVersion</key>
-	<string>1.6.0</string>
+	<string>1.6.2</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>CFBundleSupportedPlatforms</key>
@@ -50,6 +50,6 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>2018</string>
+	<string>2019</string>
 </dict>
 </plist>

--- a/resources/osx-vst2/Info.plist
+++ b/resources/osx-vst2/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleSignature</key>
 	<string>VmbA</string>
 	<key>CFBundleVersion</key>
-	<string>1.6.0</string>
+	<string>1.6.2</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>VSTWindowCompositing</key>

--- a/resources/osx-vst3/Info.plist
+++ b/resources/osx-vst3/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleSignature</key>
 	<string>VmbA</string>
 	<key>CFBundleVersion</key>
-	<string>1.6.0</string>
+	<string>1.6.2</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>VSTWindowCompositing</key>

--- a/src/common/surge_auversion.h
+++ b/src/common/surge_auversion.h
@@ -1,2 +1,2 @@
 #define kComponentManuf 'VmbA'
-#define kVersionNumber 0x00010600
+#define kVersionNumber 0x00010602

--- a/src/common/version.h
+++ b/src/common/version.h
@@ -11,8 +11,8 @@
 #define SUB_VERSION_STR "6"
 #define SUB_VERSION_INT 6
 
-#define RELEASE_NUMBER_STR "0"
-#define RELEASE_NUMBER_INT 0
+#define RELEASE_NUMBER_STR "2"
+#define RELEASE_NUMBER_INT 2
 
 #define BUILD_NUMBER_STR "100" // Build number to be sure that each result could identified.
 #define BUILD_NUMBER_INT 100

--- a/src/lv2/SurgeLv2Export.cpp
+++ b/src/lv2/SurgeLv2Export.cpp
@@ -147,9 +147,9 @@ void lv2_generate_ttl(const char* baseName)
       }
       osDsp << " ;\n";
 
-      // TODO LV2: implement an adequate version number scheme
-      osDsp << "    lv2:microVersion 0 ;\n"
-               "    lv2:minorVersion 0 .\n";
+      // TODO LV2: implement an adequate version number scheme. For now, make it the last two (so 1.6.2 gets 6 2)
+      osDsp << "    lv2:minorVersion 6 ;\n"
+               "    lv2:microVersion 2 .\n";
    }
 
    {

--- a/src/windows/surge.rc
+++ b/src/windows/surge.rc
@@ -116,9 +116,10 @@ LANGUAGE LANG_NEUTRAL,
         // Version
         //
 
-        VS_VERSION_INFO VERSIONINFO FILEVERSION 1,
-    6, 0, 0 PRODUCTVERSION 1, 6, 0,
-    0 FILEFLAGSMASK 0x17L
+        VS_VERSION_INFO VERSIONINFO
+        FILEVERSION 1, 6, 2, 0
+        PRODUCTVERSION 1, 6, 2, 0
+        FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
     FILEFLAGS 0x1L
 #else
@@ -127,10 +128,10 @@ LANGUAGE LANG_NEUTRAL,
     FILEOS 0x4L FILETYPE 0x2L FILESUBTYPE 0x0L BEGIN BLOCK "StringFileInfo" BEGIN BLOCK
                                                            "000004b0" BEGIN VALUE "Comments",
     "http://www.vemberaudio.se" VALUE "CompanyName", "Vember Audio" VALUE "FileDescription",
-    "Surge VSTi instrument" VALUE "FileVersion", "1, 6, 0, 0" VALUE "InternalName",
-    "surge" VALUE "LegalCopyright", "Copyright (C) 2005-2014 Vember Audio" VALUE "OriginalFilename",
+    "Surge VSTi instrument" VALUE "FileVersion", "1, 6, 2, 0" VALUE "InternalName",
+    "surge" VALUE "LegalCopyright", "Copyright (C) 2005-2019 Authors as described in github" VALUE "OriginalFilename",
     "surge.dll" VALUE "ProductName", "Surge" VALUE "ProductVersion",
-    "1, 6, 0, 0" END END BLOCK "VarFileInfo" BEGIN VALUE "Translation", 0x0,
+    "1, 6, 2, 0" END END BLOCK "VarFileInfo" BEGIN VALUE "Translation", 0x0,
     1200 END END
 
         /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Ahead of the 1.6.2 release, move the DLL and Plugin version
nubmers from 1.6.0 (since we had never moved these before)
to 1.6.2. Also add a doc on where they all live.

Closes #1116