### PR TITLE
Prevent overflowing VST2 program name buffers

### DIFF
--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -305,10 +305,8 @@ bool Vst2PluginInstance::getProgramNameIndexed (VstInt32 category, VstInt32 inde
    if (tryInit())
    {
        SurgeSynthesizer* s = (SurgeSynthesizer*)_instance;
-       /*
-       ** The original surge had this 63. Presume it is documented somewhere in vst land.
-       */
-       strncpy(text, s->storage.getPatch().name.c_str(), 63);
+       strncpy(text, s->storage.getPatch().name.c_str(), kVstMaxProgNameLen);
+       text[kVstMaxProgNameLen - 1] = '\0';
    }
    return true;
 }


### PR DESCRIPTION
This truncates the name to the 24 byte limit.
I spend the last byte for the null-character because Qtractor requires it to be present.
