### PR TITLE
Fix problem with transport and tuning in Logic

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -194,9 +194,12 @@ ComponentResult aulayer::Reset(AudioUnitScope inScope, AudioUnitElement inElemen
    if ((inScope == kAudioUnitScope_Global) && (inElement == 0) && plugin_instance)
    {
       double samplerate = GetOutput(0)->GetStreamFormat().mSampleRate;
-      plugin_instance->setSamplerate(samplerate);
+      if( samplerate != sampleRateCache )
+      {
+          plugin_instance->setSamplerate(samplerate);
+          sampleRateCache = samplerate;
+      }
       plugin_instance->allNotesOff();
-      sampleRateCache = samplerate;
    }
    return noErr;
 }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1120,6 +1120,11 @@ void SurgeSynthesizer::allNotesOff()
 
 void SurgeSynthesizer::setSamplerate(float sr)
 {
+   // If I am changing my sample rate I will change my internal tables, so this
+   // needs to be tuning aware and reapply tuning if needed
+   auto s = storage.currentScale;
+   bool wasST = storage.isStandardTuning;
+
    samplerate = sr;
    dsamplerate = sr;
    samplerate_inv = 1.0 / sr;
@@ -1128,6 +1133,11 @@ void SurgeSynthesizer::setSamplerate(float sr)
    dsamplerate_os_inv = 1.0 / dsamplerate_os;
    storage.init_tables();
    sinus.set_rate(1000.0 * dsamplerate_inv);
+
+   if( ! wasST )
+   {
+       storage.retuneToScale(s);
+   }
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
LogicProX sends an AU Reset when play begins and ends; which does
a set sample rate. set sample rate was not tuning aware so would
drop tuning. Fix this problem by (1) makeing setsamplerate preserve
tuning and (2) making the au call setsamplerate only at the appropriate
time

Closes #1163