### PR TITLE
Add an option to use non-vector LFO display

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -3,6 +3,7 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CLFOGui.h"
 #include "LfoModulationSource.h"
+#include "UserDefaults.h"
 
 using namespace VSTGUI;
 using namespace std;
@@ -37,12 +38,19 @@ void CLFOGui::draw(CDrawContext* dc)
    /*
    ** As of 1.6.2, the linux vectorized drawing is slow and scales imporoperly with zoom, so
    ** return to the original bitmap drawing until we resolve. See issue #1103.
+   ** 
+   ** Also some older machines report performance problems so make it switchable
    */
-#if LINUX
-   drawBitmap(dc);
-#else
-   drawVectorized(dc);
-#endif
+
+   auto useBitmap = Surge::Storage::getUserDefaultValue(storage, "useBitmapLFO", 0 );
+   if( useBitmap )
+   {
+        drawBitmap(dc);
+   }
+   else
+   {
+        drawVectorized(dc);
+   }
 }
 
 void CLFOGui::drawVectorized(CDrawContext* dc)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2868,6 +2868,9 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
     eid++;
     mpeSubMenu->forget();
 
+    COptionMenu *uiOptionsMenu = new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle |
+                                                 VSTGUI::COptionMenu::kMultipleCheckStyle );
+    
     // Mouse behavior
     // Mouse behavior
     int mid = 0;
@@ -2921,9 +2924,22 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
 
     std::string mouseMenuName = "Mouse Behavior";
 
-    settingsMenu->addEntry(mouseSubMenu, mouseMenuName.c_str());
-    eid++;
+    uiOptionsMenu->addEntry(mouseSubMenu, mouseMenuName.c_str() );
     mouseSubMenu->forget();
+
+    auto useBitmap = Surge::Storage::getUserDefaultValue(&(this->synth->storage), "useBitmapLFO", 0 );
+    auto bitmapMenu = useBitmap ? "Use Vector LFO Display" : "Use Bitmap LFO Display";
+    addCallbackMenu( uiOptionsMenu, bitmapMenu, [this, useBitmap]() {
+            Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                                   "useBitmapLFO",
+                                                   useBitmap ? 0 : 1 );
+            this->synth->refresh_editor = true;
+        });
+
+    
+    settingsMenu->addEntry(uiOptionsMenu, "UI Options" );
+    uiOptionsMenu->forget();
+    eid++;
 
     auto tuningSubMenu = makeTuningMenu(menuRect);
     settingsMenu->addEntry(tuningSubMenu, "Tuning" );


### PR DESCRIPTION
Add a menu option for non-vector LFO display (for now only a user
option). Soon make this auto-toggle based on draw time or LFO
frequency.

Addresses #1167