### PR TITLE
LFO Display Resolution Finalized

### DIFF
--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -106,6 +106,7 @@ protected:
    VSTGUI::CRect ss_shift_left, ss_shift_right;
    bool edit_trigmask;
    int controlstate;
-
+   bool ignore_bitmap_pref = false; // if this is true, we always use the bitmap
+   
    CLASS_METHODS(CLFOGui, VSTGUI::CControl)
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2927,12 +2927,9 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
     uiOptionsMenu->addEntry(mouseSubMenu, mouseMenuName.c_str() );
     mouseSubMenu->forget();
 
+#if !LINUX
     auto useBitmap = Surge::Storage::getUserDefaultValue(&(this->synth->storage), "useBitmapLFO",
-#if LINUX
-                                                         1
-#else
                                                          0
-#endif
         );
     auto bitmapMenu = useBitmap ? "Use Vector LFO Display" : "Use Bitmap LFO Display";
     addCallbackMenu( uiOptionsMenu, bitmapMenu, [this, useBitmap]() {
@@ -2941,7 +2938,7 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
                                                    useBitmap ? 0 : 1 );
             this->synth->refresh_editor = true;
         });
-
+#endif
     
     settingsMenu->addEntry(uiOptionsMenu, "UI Options" );
     uiOptionsMenu->forget();


### PR DESCRIPTION
1. The LFO display is always bitmap on Linux
2. The LFO display defaults vector but is user siwtchabe Mac and Win
3. If the LFO display takes > 0.1 seconds to draw, switch to bitmap

Closes #1167