### PR TITLE
Apply param changes when presets change

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2137,6 +2137,9 @@ DWORD WINAPI loadPatchInBackgroundThread(LPVOID lpParam)
    synth->patchid_queue = -1;
    synth->allNotesOff();
    synth->loadPatch(patchid);
+#if TARGET_LV2
+   synth->getParent()->patchChanged();
+#endif
    synth->halt_engine = false;
    return 0;
 }
@@ -2149,6 +2152,9 @@ void SurgeSynthesizer::processThreadunsafeOperations()
       if (patchid_queue >= 0)
       {
          loadPatch(patchid_queue);
+#if TARGET_LV2
+         getParent()->patchChanged();
+#endif
          patchid_queue = -1;
       }
 

--- a/src/lv2/SurgeLv2Wrapper.cpp
+++ b/src/lv2/SurgeLv2Wrapper.cpp
@@ -28,6 +28,20 @@ void SurgeLv2Wrapper::setParameterAutomated(int externalparam, float value)
    _editor->setParameterAutomated(externalparam, value);
 }
 
+void SurgeLv2Wrapper::patchChanged(void)
+{
+   if( _editor == nullptr ) return;
+
+   SurgeSynthesizer *s = _synthesizer.get();
+
+   for (unsigned int i = 0; i < n_total_params; i++)
+   {
+      unsigned index = s->remapExternalApiToInternalId(i);
+      float value = s->getParameter01(index);
+      _editor->setParameterAutomated(i, value);
+   }
+}
+
 LV2_Handle SurgeLv2Wrapper::instantiate(const LV2_Descriptor* descriptor,
                                         double sample_rate,
                                         const char* bundle_path,

--- a/src/lv2/SurgeLv2Wrapper.h
+++ b/src/lv2/SurgeLv2Wrapper.h
@@ -47,6 +47,7 @@ public:
    // PluginLayer
    void updateDisplay();
    void setParameterAutomated(int externalparam, float value);
+   void patchChanged(void);
 
 private:
    static LV2_Handle instantiate(const LV2_Descriptor* descriptor,


### PR DESCRIPTION
A diff from IRC user CrystalMath which notifies the LV2
parameter set when the editor initiatest a patch change.

Closes #1176