### PR TITLE
VST3 cleanups; stdout cleanups

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -255,7 +255,6 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath)
    std::string userSpecifiedDataPath = Surge::Storage::getUserDefaultValue(this, "userDataPath", "UNSPEC" );
    if( userSpecifiedDataPath != "UNSPEC" )
    {
-       std::cout << "Got a custom user data path" << std::endl;
        userDataPath = userSpecifiedDataPath;
    }
    

--- a/src/vst3/SurgeVst3Processor.h
+++ b/src/vst3/SurgeVst3Processor.h
@@ -6,6 +6,7 @@
 #include <util/FpuState.h>
 #include <memory>
 #include <set>
+#include <map>
 
 using namespace Steinberg;
 
@@ -135,6 +136,7 @@ protected:
 
    std::unique_ptr<SurgeSynthesizer> surgeInstance;
    std::set<SurgeGUIEditor*> viewsSet;
+   std::map<int, int> beginEditGuard;
    int blockpos;
 
    bool disableZoom;


### PR DESCRIPTION
Fix 3 VST3 problems

1. getParamNormalized when called out of range returns 0 since it is Param
2. begin/end edit nest guard, and a comment explaining where the silly nesting
   comes from in the vst3
3. set parameter automated sets external to true to do UI animation

Also remove a specious stdout in Storage as I cleaned up to 0 stdout

Closes #1179
Closes #1180