### PR TITLE
Add a content menu to both the patch browser and WT browser.

### DIFF
--- a/src/common/dsp/AdsrEnvelope.h
+++ b/src/common/dsp/AdsrEnvelope.h
@@ -3,6 +3,7 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
+#include <algorithm> // for std::min
 #include "DspUtilities.h"
 #include "SurgeStorage.h"
 #include "SurgeVoiceState.h"

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "SurgeStorage.h"
 #include "DspUtilities.h"
 #include <vt_dsp/lipol.h>

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -1,6 +1,7 @@
 //-------------------------------------------------------------------------------------------------------
 //	Copyright 2005 Claes Johanson & Vember Audio
 //-------------------------------------------------------------------------------------------------------
+#include "SurgeGUIEditor.h"
 #include "COscillatorDisplay.h"
 #include "Oscillator.h"
 #include <time.h>
@@ -692,6 +693,14 @@ void COscillatorDisplay::populateMenu(COptionMenu* contextMenu, int selectedItem
    auto action = [this](CCommandMenuItem* item) { this->loadWavetableFromFile(); };
    actionItem->setActions(action, nullptr);
    contextMenu->addEntry(actionItem);
+
+   auto contentItem = new CCommandMenuItem(CCommandMenuItem::Desc("Download Additional Content"));
+   auto contentAction = [](CCommandMenuItem *item)
+   {
+       Surge::UserInteractions::openURL(SurgeGUIEditor::additionalContentURL);
+   };
+   contentItem->setActions(contentAction,nullptr);
+   contextMenu->addEntry(contentItem);
 }
 
 bool COscillatorDisplay::populateMenuForCategory(COptionMenu* contextMenu,

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -2,7 +2,8 @@
 //	Copyright 2005 Claes Johanson & Vember Audio
 //-------------------------------------------------------------------------------------------------------
 #include "CPatchBrowser.h"
-
+#include "UserInteractions.h"
+#include "SurgeGUIEditor.h"
 #include <vector>
 
 using namespace VSTGUI;
@@ -109,6 +110,16 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint& where, const CButtonState& 
    }
    // contextMenu->addEntry("refresh list");
 
+
+   contextMenu->addSeparator();
+   auto contentItem = new CCommandMenuItem(CCommandMenuItem::Desc("Download Additional Content"));
+   auto contentAction = [](CCommandMenuItem *item)
+   {
+       Surge::UserInteractions::openURL(SurgeGUIEditor::additionalContentURL);
+   };
+   contentItem->setActions(contentAction,nullptr);
+   contextMenu->addEntry(contentItem);
+   
    getFrame()->addView(contextMenu); // add to frame
    contextMenu->setDirty();
    contextMenu->popup();

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3003,8 +3003,8 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
         });
     eid++;
 
-    addCallbackMenu(settingsMenu, "Download Extra Content", []() {
-            Surge::UserInteractions::openURL("https://github.com/surge-synthesizer/surge-synthesizer.github.io/wiki/Additional-Content");
+    addCallbackMenu(settingsMenu, "Download Additional Content", []() {
+            Surge::UserInteractions::openURL(SurgeGUIEditor::additionalContentURL);
     });
     eid++;
 
@@ -3172,5 +3172,8 @@ Steinberg::tresult PLUGIN_API SurgeGUIEditor::onSize(Steinberg::ViewRect* newSiz
 }
 
 #endif
+
+std::string SurgeGUIEditor::additionalContentURL = "https://github.com/surge-synthesizer/surge-synthesizer.github.io/wiki/Additional-Content";
+;
 
 //------------------------------------------------------------------------------------------------

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -33,6 +33,7 @@ typedef VSTGUI::PluginGUIEditor EditorType;
 #include "SurgeSynthesizer.h"
 
 #include <vector>
+#include <string>
 
 class SurgeGUIEditor : public EditorType, public VSTGUI::IControlListener, public VSTGUI::IKeyboardHook
 {
@@ -183,6 +184,12 @@ public:
    void showTuningMenu(VSTGUI::CPoint &where);
    void tuningFileDropped(std::string fn);
    std::string tuningCacheForToggle = "";
+
+   /*
+   ** Menu and Manual URLs
+   */
+public:
+   static std::string additionalContentURL;
    
 private:
    /**


### PR DESCRIPTION
Seems like a simple change, but I wanted the URL in one location
so had to clean up some fragile headers when I changed the link pattern
of SurgeGUIEditor also

Closes #1182