### PR TITLE
Disable absolute mode for Global pitch

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -177,7 +177,7 @@ bool Parameter::can_be_absolute()
    switch (ctrltype)
    {
    case ct_oscspread:
-   case ct_pitch_semi7bp:
+   case ct_pitch_semi7bp_absolutable:
       return true;
    }
    return false;
@@ -256,6 +256,7 @@ void Parameter::set_type(int ctrltype)
       val_default.i = 2;
       break;
    case ct_pitch_semi7bp:
+   case ct_pitch_semi7bp_absolutable:
       valtype = vt_float;
       val_min.f = -7;
       val_max.f = 7;
@@ -746,6 +747,7 @@ float Parameter::get_extended(float f)
    case ct_freq_shift:
       return 100.f * f;
    case ct_pitch_semi7bp:
+   case ct_pitch_semi7bp_absolutable:
       return 12.f * f;
    default:
       return f;
@@ -953,6 +955,9 @@ void Parameter::get_display(char* txt, bool external, float ef)
          sprintf(txt, "%.2f semitones", f);
          break;
       case ct_pitch_semi7bp:
+          sprintf(txt, "%.2f", get_extended(f));
+          break;
+      case ct_pitch_semi7bp_absolutable:
          if(absolute)
              sprintf(txt, "%.1f Hz", 10 * get_extended(f));
          else

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -26,6 +26,7 @@ enum ctrltypes
    ct_percent_bidirectional,
    ct_pitch_octave,
    ct_pitch_semi7bp,
+   ct_pitch_semi7bp_absolutable,
    ct_pitch,
    ct_fmratio,
    ct_fmratio_int,

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -161,7 +161,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                                        cg_OSC, osc, false, Surge::ParamConfig::kHorizontal | kNoPopup));
          py = gui_mainsec_slider_y;
          a->push_back(scene[sc].osc[osc].pitch.assign(p_id++, id_s++, "pitch", "Pitch",
-                                                      ct_pitch_semi7bp, px, py, sc_id, cg_OSC, osc,
+                                                      ct_pitch_semi7bp_absolutable, px, py, sc_id, cg_OSC, osc,
                                                       true, Surge::ParamConfig::kHorizontal | kSemitone | sceasy));
          py += gui_hfader_dist;
          for (int i = 0; i < n_osc_params; i++)


### PR DESCRIPTION
With the intro of 'absolute' pitch shift for the oscillators
the global shift had the mode, which gave it the UI of doing
absolute pitch, but not the DSP code. So split the pitch
control types and apply correctly.

Closes #1188