### PR TITLE
Fix two minor 1.6.2 errors

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -166,6 +166,7 @@ bool Parameter::can_extend_range()
    switch (ctrltype)
    {
    case ct_pitch_semi7bp:
+   case ct_pitch_semi7bp_absolutable:
    case ct_freq_shift:
       return true;
    }

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -455,6 +455,7 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir,
 #else
       c.name = p.generic_string().substr(patchpathSubstrLength);
 #endif
+      c.internalid = category;
 
       c.numberOfPatchesInCatgory = 0;
       for (auto& f : fs::directory_iterator(p))

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -482,6 +482,7 @@ struct PatchCategory
    std::vector<PatchCategory> children;
    bool isRoot;
 
+   int internalid;
    int numberOfPatchesInCatgory;
    int numberOfPatchesInCategoryAndChildren;
 };

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -188,7 +188,7 @@ bool CPatchBrowser::populatePatchMenuForCategory( int c, COptionMenu *contextMen
             int idx = 0;
             for (auto &cc : storage->patch_category)
             {
-                if (cc.name == childcat.name) break;
+                if (cc.name == childcat.name && cc.internalid == childcat.internalid) break;
                 idx++;
             }
             bool checkedKid = populatePatchMenuForCategory( idx, subMenu, false, main_e, false );


### PR DESCRIPTION
1. I removed the 'extend' option on the osc pitch menu. Closes #1193
2. Menu bulding found the wrong parent menu when names were duped. Closes #1191