### PR TITLE
Cosmetic changes for menus; XCode 11 import corrected

### DIFF
--- a/src/au/aulayer_cocoaui.mm
+++ b/src/au/aulayer_cocoaui.mm
@@ -31,6 +31,7 @@
 #include <objc/runtime.h>
 #import <CoreFoundation/CoreFoundation.h>
 #import <AudioUnit/AUCocoaUIView.h>
+#import <AppKit/AppKit.h>
 #include "aulayer.h"
 #include "aulayer_cocoaui.h"
 

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -688,12 +688,12 @@ void COscillatorDisplay::populateMenu(COptionMenu* contextMenu, int selectedItem
 
    // Add direct open here
    contextMenu->addSeparator();
-   auto actionItem = new CCommandMenuItem(CCommandMenuItem::Desc("Open Wave Table from File"));
+   auto actionItem = new CCommandMenuItem(CCommandMenuItem::Desc("Open Wave Table from File..."));
    auto action = [this](CCommandMenuItem* item) { this->loadWavetableFromFile(); };
    actionItem->setActions(action, nullptr);
    contextMenu->addEntry(actionItem);
    
-   auto contentItem = new CCommandMenuItem(CCommandMenuItem::Desc("Download Additional Content"));
+   auto contentItem = new CCommandMenuItem(CCommandMenuItem::Desc("Download Additional Content..."));
    auto contentAction = [](CCommandMenuItem *item)
        {
            Surge::UserInteractions::openURL("https://github.com/surge-synthesizer/surge-synthesizer.github.io/wiki/Additional-Content");

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -111,7 +111,7 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint& where, const CButtonState& 
    // contextMenu->addEntry("refresh list");
 
    contextMenu->addSeparator();
-   auto contentItem = new CCommandMenuItem(CCommandMenuItem::Desc("Download Additional Content"));
+   auto contentItem = new CCommandMenuItem(CCommandMenuItem::Desc("Download Additional Content..."));
    auto contentAction = [](CCommandMenuItem *item)
        {
            Surge::UserInteractions::openURL("https://github.com/surge-synthesizer/surge-synthesizer.github.io/wiki/Additional-Content");


### PR DESCRIPTION
Add a "..." to the menus in the patch and osc browser. Closes #1196.
Add a missing import that xcode 11 catches.