### PR TITLE
Handle Channel AT in MPE mode

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -422,7 +422,7 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
          new (nvoice) SurgeVoice(&storage, &storage.getPatch().scene[scene],
                                  storage.getPatch().scenedata[scene], key, velocity, channel, scene,
                                  detune, &channelState[channel].keyState[key],
-                                 &channelState[mpeMainChannel], &channelState[channel]);
+                                 &channelState[mpeMainChannel], &channelState[channel], mpeEnabled);
       }
       break;
    }
@@ -457,7 +457,7 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
          new (nvoice) SurgeVoice(&storage, &storage.getPatch().scene[scene],
                                  storage.getPatch().scenedata[scene], key, velocity, channel, scene,
                                  detune, &channelState[channel].keyState[key],
-                                 &channelState[mpeMainChannel], &channelState[channel]);
+                                 &channelState[mpeMainChannel], &channelState[channel], mpeEnabled);
       }
    }
    break;
@@ -503,7 +503,7 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
             new (nvoice) SurgeVoice(&storage, &storage.getPatch().scene[scene],
                                     storage.getPatch().scenedata[scene], key, velocity, channel,
                                     scene, detune, &channelState[channel].keyState[key],
-                                    &channelState[mpeMainChannel], &channelState[channel]);
+                                    &channelState[mpeMainChannel], &channelState[channel], mpeEnabled);
          }
       }
    }

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -35,7 +35,9 @@ public:
               float detune,
               MidiKeyState* keyState,
               MidiChannelState* mainChannelState,
-              MidiChannelState* voiceChannelState);
+              MidiChannelState* voiceChannelState,
+              bool mpeEnabled
+       );
    ~SurgeVoice();
 
    void release();
@@ -173,4 +175,7 @@ private:
    // filterblock stuff
    int id_cfa, id_cfb, id_kta, id_ktb, id_emoda, id_emodb, id_resoa, id_resob, id_drive, id_vca,
        id_vcavel, id_fbalance, id_feedback;
+
+   // MPE special cases
+   bool mpeEnabled;
 };


### PR DESCRIPTION
In MPE mode the Roli and Linnstrument send their aftertouch as
channel aftertouch per channel rather than poly after touch.
Surge in non-mpe-mode treats channelAT as a scene level not a
voice level parameter. So in MPE mode when we get channel AT
on non-channel-0 the voice needs to iterate and apply it. This change
does that.

Closes #1214