### PR TITLE
Allow to build the Linux x86 configuration

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -83,7 +83,7 @@ elseif (os.istarget("linux")) then
 
     buildoptions { "-std=c++17" }
 
-    platforms { "x64" }
+    platforms { "x64", "x86" }
 
     files
     {


### PR DESCRIPTION
Hi, this allows to package Surge for Linux in x86 configuration.
The current problem is, under 32bit, running premake5 does not create any targets.

cc @trebmuh
Surge x86 is buildable by `config=release_x86` on the `make` line.