### PR TITLE
VST3 Midi Mapping

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,12 @@
+((nil . ((indent-tabs-mode . nil)))
+
+ (c-mode . ((c-file-style . "linux")
+            (tab-width . 3)
+            (c-basic-offset . 3)
+            ))
+
+ (c++-mode . ((c-file-style . "linux")
+              (tab-width . 3)
+              (c-basic-offset . 3)
+              ))
+ )

--- a/src/vst3/SurgeVst3Processor.h
+++ b/src/vst3/SurgeVst3Processor.h
@@ -3,6 +3,7 @@
 #include "public.sdk/source/vst/vstsinglecomponenteffect.h"
 #include "public.sdk/source/vst/vsteditcontroller.h"
 #include "pluginterfaces/vst/ivstevents.h"
+#include "pluginterfaces/vst/ivstmidicontrollers.h"
 #include <util/FpuState.h>
 #include <memory>
 #include <set>
@@ -104,10 +105,6 @@ public:
                                Steinberg::Vst::CtrlNumber midiControllerNumber,
                                Steinberg::Vst::ParamID& id /*out*/) override;
 
-   //! when true, surge exports all normal 128 CC parameters, aftertouch and pitch bend as
-   //! parameters (but not automatable)
-   bool exportAllMidiControllers();
-
    void updateDisplay();
    void setParameterAutomated(int externalparam, float value);
 
@@ -146,6 +143,9 @@ protected:
    
    FpuState _fpuState;
 
+   int midi_controller_0, midi_controller_max;
+   const int n_midi_controller_params = 16 * Steinberg::Vst::ControllerNumbers::kCountCtrlNumber;
+   
 public:
    OBJ_METHODS(SurgeVst3Processor, Steinberg::Vst::SingleComponentEffect)
    DEFINE_INTERFACES


### PR DESCRIPTION
VST3 Midi Mapipng was outside the range of parameters so strict VST3
hosts - notably cubase - dropped mod wheel, pitch wheel, etc...

Addresses #1050 and subject to further testing may close it.