### PR TITLE
Expand the distortion effect

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -168,6 +168,7 @@ bool Parameter::can_extend_range()
    case ct_pitch_semi7bp:
    case ct_pitch_semi7bp_absolutable:
    case ct_freq_shift:
+   case ct_decibel_extendable:
       return true;
    }
    return false;
@@ -309,6 +310,7 @@ void Parameter::set_type(int ctrltype)
       val_default.f = 1;
       break;
    case ct_decibel:
+   case ct_decibel_extendable:
       valtype = vt_float;
       val_min.f = -48;
       val_max.f = 48;
@@ -486,7 +488,7 @@ void Parameter::set_type(int ctrltype)
    case ct_wstype:
       valtype = vt_int;
       val_min.i = 0;
-      val_max.i = n_ws_type - 1;
+      val_max.i = n_ws_type - 1; 
       val_default.i = 0;
       break;
    case ct_midikey:
@@ -590,6 +592,12 @@ void Parameter::set_type(int ctrltype)
       val_max.i = 20;
       valtype = vt_int;
       val_default.i = 20;
+      break;
+   case ct_distortion_waveshape:
+      val_min.i = 0;
+      val_max.i = n_ws_type - 2; // we want to skip none also
+      valtype = vt_int;
+      val_default.i = 0;
       break;
    case ct_countedset_percent:
       val_min.f = 0;
@@ -750,6 +758,8 @@ float Parameter::get_extended(float f)
    case ct_pitch_semi7bp:
    case ct_pitch_semi7bp_absolutable:
       return 12.f * f;
+   case ct_decibel_extendable:
+      return 3.f * f;
    default:
       return f;
    }
@@ -909,6 +919,9 @@ void Parameter::get_display(char* txt, bool external, float ef)
       case ct_decibel_extra_narrow:
          sprintf(txt, "%.2f dB", f);
          break;
+      case ct_decibel_extendable:
+         sprintf(txt, "%.2f dB", get_extended(f));
+         break;
       case ct_bandwidth:
          sprintf(txt, "%.2f octaves", f);
          break;
@@ -1029,8 +1042,32 @@ void Parameter::get_display(char* txt, bool external, float ef)
              sprintf( txt, "Consistent w. FM2/3" );
          break;
       case ct_vocoder_bandcount:
-         // FIXME - do better than this of course
          sprintf(txt, "%d bands", i);
+         break;
+      case ct_distortion_waveshape:
+         // FIXME - do better than this of course
+         switch( i + 1 )
+         {
+         case wst_tanh:
+            sprintf(txt,"tanh");
+            break;
+         case wst_hard:
+            sprintf(txt,"hard");
+            break;
+         case wst_asym:
+            sprintf(txt,"asym");
+            break;
+         case wst_sinus:
+            sprintf(txt,"sin");
+            break;
+         case wst_digi:
+            sprintf(txt,"digi");
+            break;
+         default:
+         case wst_none:
+            sprintf(txt,"none");
+            break;
+         }
          break;
       case ct_oscroute:
          switch (i)

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -40,6 +40,7 @@ enum ctrltypes
    ct_decibel_attenuation,
    ct_decibel_attenuation_large,
    ct_decibel_fmdepth,
+   ct_decibel_extendable,
    ct_freq_audible,
    ct_freq_mod,
    ct_freq_hpf,
@@ -91,6 +92,7 @@ enum ctrltypes
    ct_sinefmlegacy,
    ct_countedset_percent, // what % through a counted set are you
    ct_vocoder_bandcount,
+   ct_distortion_waveshape,
    num_ctrltypes,
 };
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -50,7 +50,8 @@ const int gui_mid_topbar_y = 17;
 // than ctrl7 by +1), custom controllers have names (guess for pre-rev9 patches)
 // 9 -> 10 added character parameter
 // 10 -> 11 (1.6.2 release) added DAW Extra State
-const int ff_revision = 11;
+// 11 -> 12 (1.6.3 release) added new parameters to the Distortion effect
+const int ff_revision = 12;
 
 SurgePatch::SurgePatch(SurgeStorage* storage)
 {

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -258,6 +258,8 @@ public:
    virtual const char* group_label(int id) override;
    virtual int group_label_ypos(int id) override;
 
+   virtual void handleStreamingMismatches(int streamingRevision, int currentSynthStreamingRevision) override;
+
 private:
    BiquadFilter band1, band2, lp1, lp2;
    int bi; // block increment (to keep track of events not occurring every n blocks)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -825,6 +825,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          case ct_decibel:
          case ct_decibel_narrow:
          case ct_decibel_extra_narrow:
+         case ct_decibel_extendable:
          case ct_freq_mod:
          case ct_percent_bidirectional:
          case ct_freq_shift:


### PR DESCRIPTION
Two additions to the distortion effect

1. You can pick your wavetable
2. The "gain" controls have an extended range which drive them
   well beyond the stable regime

Addresses issue #1213