### PR TITLE
When drag-zooming in VST3 don't trigger the too-big constraint

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -169,6 +169,7 @@ public:
    }
    int  getZoomFactor() { return zoomFactor; }
    void setZoomFactor(int zf);
+   bool doesZoomFitToScreen(int zf, int &correctedZf); // returns true if it fits; false if not; sets correctedZF to right size in either case
    void disableZoom()
    {
       zoomEnabled = false;


### PR DESCRIPTION
The doesn't-fit-screen popup was really counterintuitive when
drag resizing. Just don't size beyond the max in the drag callback.

Addresses #1212