### PR TITLE
More VST3 Fake MIDI mapping

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -67,7 +67,7 @@ const int n_scene_params = 271;
 const int n_global_params = 113;
 const int n_global_postparams = 1;
 const int n_total_params = n_global_params + 2 * n_scene_params + n_global_postparams;
-const int metaparam_offset = 2048;
+const int metaparam_offset = 20480; // has to be bigger than total + 16 * 130 for fake VST3 mapping
 
 enum sub3_scenemode
 {

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -17,7 +17,6 @@
 #include <codecvt>
 #include <string.h>
 
-
 using namespace Steinberg::Vst;
 
 #define CHECK_INITIALIZED                                                                          \
@@ -287,10 +286,16 @@ void SurgeVst3Processor::processParameterChanges(int sampleOffset,
                int cont = chancont >> 4;
                
 
-               for (int i = 0; i < numPoints && cont != 45; ++i)
+               for (int i = 0; i < numPoints; ++i)
                {
                   paramQueue->getPoint(0, offsetSamples, value);
-                  // std::cout << "MIDI id=" << id << " chancont=" << chancont << " channel=" << channel << " controller=" << cont << " value=" << value << std::endl;
+                  /*
+                  if( i == 0 ) 
+                  {
+                     std::cout << "MIDI id=" << id << " chancont=" << chancont << " channel=" << channel << " controller=" << cont << " value=" << value << std::endl;
+                  }
+                  */
+                  
                   if (cont < 128)
                   {
                      if (cont == ControllerNumbers::kCtrlAllSoundsOff ||
@@ -502,7 +507,7 @@ tresult SurgeVst3Processor::beginEdit(ParamID id)
    }
    if( id >= getParameterCountWithoutMappings() )
    {
-      return Steinberg::Vst::SingleComponentEffect::beginEdit(id);
+      return kResultOk;
    }
 
    int mappedId =
@@ -525,7 +530,7 @@ tresult SurgeVst3Processor::performEdit(ParamID id, Steinberg::Vst::ParamValue v
    }
    if( id >= getParameterCountWithoutMappings() )
    {
-      return Steinberg::Vst::SingleComponentEffect::performEdit(id, valueNormalized);
+      return kResultOk;
    }
 
    int mappedId =
@@ -555,14 +560,7 @@ tresult SurgeVst3Processor::endEdit(ParamID id)
 
    if( id > getParameterCountWithoutMappings() )
    {
-      if( endcount == 0 )
-      {
-         return Steinberg::Vst::SingleComponentEffect::endEdit(id);
-      }
-      else
-      {
-         return kResultOk;
-      }
+      return kResultOk;
    }
    else
    {


### PR DESCRIPTION
This stops the metacontroller conflicting with fake midi which
made some synths learn controllers in the 80s for controllers in
the 40s. (that is CC#, not duran duran vs benny goodman).