### PR TITLE
Fix Automation, VST3, and Layout issues

### DIFF
--- a/src/common/ModulationSource.h
+++ b/src/common/ModulationSource.h
@@ -102,10 +102,10 @@ const char modsource_abberations_short[n_modsources][32] = {
 const int modsource_grid_xy[n_modsources][2] = {
     {0, 0}, {0, 0}, {1, 0}, {2, 0},  {3, 0}, {4, 0}, {5, 0},          // vel -> mw
     {7, 0}, {8, 0}, {9, 0}, {10, 0}, {7, 3}, {8, 3}, {9, 3}, {10, 3}, // ctrl 1-8
-    {6, 0}, {6, 2},                                                   // EGs
+    {6, 2}, {6, 4},                                                   // EGs
     {0, 2}, {1, 2}, {2, 2}, {3, 2},  {4, 2}, {5, 2},                  // LFO
     {0, 4}, {1, 4}, {2, 4}, {3, 4},  {4, 4}, {5, 4},                  // SLFO
-    {6, 4}                                                            // Timbre
+    {6, 0}                                                            // Timbre
 };
 
 inline bool isScenelevel(modsources ms)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -292,6 +292,7 @@ struct MidiChannelState
    float timbre;
 };
 
+// I have used the ordering here in SurgeGUIEditor to iterate. Be careful if tyoe or retrigger move from first/last position.
 struct OscillatorStorage : public CountedSetUserData // The counted set is the wt tables
 {
    Parameter type;
@@ -331,6 +332,7 @@ struct ADSRStorage
    Parameter mode;
 };
 
+// I have used the ordering here in CLFOGui to iterate. Be careful if rate or release move from first/last position.
 struct LFOStorage
 {
    Parameter rate, shape, start_phase, magnitude, deform;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1377,7 +1377,6 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
             storage.getPatch().scene[s].filterunit[1].cutoff.set_type(ct_freq_audible);
             storage.getPatch().scene[s].filterunit[1].cutoff.set_name("Cutoff");
          }
-
          need_refresh = true;
       }
       break;

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -959,3 +959,23 @@ CMouseEventResult CLFOGui::onMouseMoved(CPoint& where, const CButtonState& butto
    }
    return kMouseEventHandled;
 }
+
+void CLFOGui::invalidateIfIdIsInRange(int id)
+{
+   bool inRange = false;
+   if( ! lfodata ) return;
+   
+   auto *c = &lfodata->rate;
+   auto *e = &lfodata->release;
+   while( c <= e && ! inRange )
+   {
+      if( id == c->id )
+         inRange = true;
+      ++c;
+   }
+
+   if (inRange)
+   {
+      invalid();
+   }
+}

--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -93,6 +93,8 @@ public:
    void drawVectorized(VSTGUI::CDrawContext* dc);
    void drawBitmap(VSTGUI::CDrawContext* dc);
 
+   void invalidateIfIdIsInRange(int id);
+
 protected:
    LFOStorage* lfodata;
    StepSequencerStorage* ss;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -441,6 +441,29 @@ void SurgeGUIEditor::idle()
             {
                param[j]->setValue(synth->getParameter01(j));
                frame->invalidRect(param[j]->getViewSize());
+               auto *currOsc = &synth->storage.getPatch().scene[current_scene].osc[current_osc].type;
+               auto *endOsc = &synth->storage.getPatch().scene[current_scene].osc[current_osc].retrigger;
+
+               bool oscInvalid = false, lfoInvalid = false;
+               if( oscdisplay )
+               {
+                  while( currOsc <= endOsc && ! oscInvalid )
+                  {
+                     if( currOsc->id == j )
+                        oscInvalid = true;
+                     currOsc++;
+                  }
+                  
+                  if( oscInvalid  )
+                  {
+                     oscdisplay->invalid();
+                  }
+               }
+
+               if( lfodisplay )
+               {
+                  ((CLFOGui*)lfodisplay)->invalidateIfIdIsInRange(j);
+               }
             }
             else if ((j >= metaparam_offset) && (j < (metaparam_offset + n_customcontrollers)))
             {

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -332,16 +332,19 @@ void SurgeVst3Processor::processParameterChanges(int sampleOffset,
             else
             {
                int id = paramQueue->getParameterId();
-               if (numPoints == 1 && id < getParameterCountWithoutMappings() )
+               if ( id < getParameterCountWithoutMappings() )
                {
-                  paramQueue->getPoint(0, offsetSamples, value);
+                  // Make a choice to use the latest point not the earliest. I think that's right. (I actually
+                  // don't think it matters all that much but hey...)
+                  paramQueue->getPoint(numPoints - 1, offsetSamples, value);
 
-                  surgeInstance->setParameter01(id, value, true);
+                  // VST3 wants to send me these events a LOT
+                  if( surgeInstance->getParameter01(id) != value )
+                     surgeInstance->setParameter01(id, value, true);
                }
                else
                {
-                  // Unclear what to do here
-                  std::cerr << "Unable to handle parameter " << id << " with npoints " << numPoints << std::endl;
+                  // std::cerr << "Unable to handle parameter " << id << " with npoints " << numPoints << std::endl;
                }
             }
          }
@@ -789,7 +792,8 @@ tresult PLUGIN_API SurgeVst3Processor::setParamNormalized(ParamID tag, ParamValu
    ** we are specially dealing with midi controls it is the wrong thing to do; it makes the FX
    ** control and the control 0 the same. So here just pass the tag on directly.
    */
-   surgeInstance->setParameter01(tag, value, true);
+   if( value != surgeInstance->getParameter01(tag) )
+      surgeInstance->setParameter01(tag, value, true);
 
    return kResultOk;
 }


### PR DESCRIPTION
Fix a variety of issues ahead of 1.6.3

1. Automation of OSC or LFO params for on-display OSC or LFO
   repaints the waveform
2. multi-point vst3 events handled by choosing latest.
3. VST3 supresses non-change events sent in some situations by REAPER
4. Relocate the TIMRBRE button

Closes #1232
Closes #1234
Closes #1083