### PR TITLE
Fix Cubase mis-behaving low-id controls (like Master)

### DIFF
--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -757,7 +757,7 @@ ParamValue PLUGIN_API SurgeVst3Processor::plainParamToNormalized(ParamID tag, Pa
 
 ParamValue PLUGIN_API SurgeVst3Processor::getParamNormalized(ParamID tag)
 {
-   ABORT_IF_NOT_INITIALIZED
+   ABORT_IF_NOT_INITIALIZED;
 
    if (tag >= getParameterCountWithoutMappings())
    {
@@ -766,7 +766,7 @@ ParamValue PLUGIN_API SurgeVst3Processor::getParamNormalized(ParamID tag)
       return 0;
    }
 
-   auto res = surgeInstance->getParameter01(surgeInstance->remapExternalApiToInternalId(tag));
+   auto res = surgeInstance->getParameter01(tag);
    return res;
 }
 


### PR DESCRIPTION
We were remapping incorrectly in "getParam" and cubase calls
"getParam" at the end of any gesture so for the inaccurately remapped
params that forced them to zero, leading to an apparent "one touch
to dead" behavior on FX sends, Master, etc.. in the VST3 Cubase.

Closes #1052