### PR TITLE
OSC and LFO redraw on midi-cc slider move

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -818,3 +818,21 @@ CMouseEventResult COscillatorDisplay::onMouseMoved(CPoint& where, const CButtonS
    }
    return kMouseEventHandled;
 }
+
+void COscillatorDisplay::invalidateIfIdIsInRange(int id)
+{
+   auto *currOsc = &oscdata->type;
+   auto *endOsc = &oscdata->retrigger;
+   bool oscInvalid = false;
+   while( currOsc <= endOsc && ! oscInvalid )
+   {
+      if( currOsc->id == id )
+         oscInvalid = true;
+      currOsc++;
+   }
+   
+   if( oscInvalid  )
+   {
+      invalid();
+   }
+}

--- a/src/common/gui/COscillatorDisplay.h
+++ b/src/common/gui/COscillatorDisplay.h
@@ -99,6 +99,8 @@ public:
    virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
    virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
 
+   void invalidateIfIdIsInRange(int id);
+   
 #if OSC_MOD_ANIMATION
    void setIsMod(bool b)
    {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -428,6 +428,17 @@ void SurgeGUIEditor::idle()
                param[j]->setValue(synth->refresh_ctrl_queue_value[i]);
                frame->invalidRect(param[j]->getViewSize());
                // oscdisplay->invalid();
+
+               if( oscdisplay )
+               {
+                  ((COscillatorDisplay*)oscdisplay)->invalidateIfIdIsInRange(j);
+               }
+
+               if( lfodisplay )
+               {
+                  ((CLFOGui*)lfodisplay)->invalidateIfIdIsInRange(j);
+               }
+
             }
          }
       }
@@ -441,23 +452,10 @@ void SurgeGUIEditor::idle()
             {
                param[j]->setValue(synth->getParameter01(j));
                frame->invalidRect(param[j]->getViewSize());
-               auto *currOsc = &synth->storage.getPatch().scene[current_scene].osc[current_osc].type;
-               auto *endOsc = &synth->storage.getPatch().scene[current_scene].osc[current_osc].retrigger;
 
-               bool oscInvalid = false, lfoInvalid = false;
                if( oscdisplay )
                {
-                  while( currOsc <= endOsc && ! oscInvalid )
-                  {
-                     if( currOsc->id == j )
-                        oscInvalid = true;
-                     currOsc++;
-                  }
-                  
-                  if( oscInvalid  )
-                  {
-                     oscdisplay->invalid();
-                  }
+                  ((COscillatorDisplay*)oscdisplay)->invalidateIfIdIsInRange(j);
                }
 
                if( lfodisplay )


### PR DESCRIPTION
If a slider maps to an LFO or OSC which is on display and
is midi cc learned, redraw the osc or lfo display just like
we do with param changes. Refactor the OSC check into a function
like I did for LFO (and should have done for OSC in the first place).

Closes #1232