### PR TITLE
In TANH mode use TANH

### DIFF
--- a/src/common/dsp/effect/DistortionEffect.cpp
+++ b/src/common/dsp/effect/DistortionEffect.cpp
@@ -91,11 +91,8 @@ void DistortionEffect::process(float* dataL, float* dataR)
          L = Lin + fb * L;
          R = Rin + fb * R;
          lp1.process_sample_nolag(L, R);
-         if( ws != 0 )
-         {
-            L = lookup_waveshape(ws, L);
-            R = lookup_waveshape(ws, R);
-         }
+         L = lookup_waveshape(ws, L);
+         R = lookup_waveshape(ws, R);
          L += a;
          R += a; // denormal
          lp2.process_sample_nolag(L, R);


### PR DESCRIPTION
I had left an if in from an early version which had 'none' in
the mix of parameters; that de-facto meant that tanh mode
(the default) had no waveshaper. Remove the specious if
and restore the default behavior to the 1.6.2.1 behavior

Addresess #1213