### PR TITLE
Provide a cleaner error message for windows.wt

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -550,7 +550,7 @@ public:
 
    void load_wt(int id, Wavetable* wt);
    void load_wt(std::string filename, Wavetable* wt);
-   void load_wt_wt(std::string filename, Wavetable* wt);
+   bool load_wt_wt(std::string filename, Wavetable* wt);
    // void load_wt_wav(std::string filename, Wavetable* wt);
    void load_wt_wav_portable(std::string filename, Wavetable *wt);
    void clipboard_copy(int type, int scene, int entry);


### PR DESCRIPTION
If Windows.wt is missing, surge can go horribly awry. We
issued no error message in this case. So do so now.

Closes #1247