### PR TITLE
Distortion Drive is also Extendible

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -169,6 +169,7 @@ bool Parameter::can_extend_range()
    case ct_pitch_semi7bp_absolutable:
    case ct_freq_shift:
    case ct_decibel_extendable:
+   case ct_decibel_narrow_extendable:
       return true;
    }
    return false;
@@ -335,6 +336,7 @@ void Parameter::set_type(int ctrltype)
       val_default.f = 0;
       break;
    case ct_decibel_narrow:
+   case ct_decibel_narrow_extendable:
       valtype = vt_float;
       val_min.f = -24;
       val_max.f = 24;
@@ -760,6 +762,8 @@ float Parameter::get_extended(float f)
       return 12.f * f;
    case ct_decibel_extendable:
       return 3.f * f;
+   case ct_decibel_narrow_extendable:
+      return 5.f * f;
    default:
       return f;
    }
@@ -920,6 +924,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
          sprintf(txt, "%.2f dB", f);
          break;
       case ct_decibel_extendable:
+      case ct_decibel_narrow_extendable:
          sprintf(txt, "%.2f dB", get_extended(f));
          break;
       case ct_bandwidth:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -36,6 +36,7 @@ enum ctrltypes
    ct_reverbshape,
    ct_decibel,
    ct_decibel_narrow,
+   ct_decibel_narrow_extendable,
    ct_decibel_extra_narrow,
    ct_decibel_attenuation,
    ct_decibel_attenuation_large,

--- a/src/common/dsp/effect/DistortionEffect.cpp
+++ b/src/common/dsp/effect/DistortionEffect.cpp
@@ -68,7 +68,7 @@ void DistortionEffect::process(float* dataL, float* dataR)
    bi = (bi + 1) & slowrate_m1;
 
    band1.process_block(dataL, dataR);
-   drive.set_target_smoothed(db_to_linear(*f[4]));
+   drive.set_target_smoothed(db_to_linear(fxdata->p[4].get_extended(*f[4])));
    outgain.set_target_smoothed(db_to_linear(*f[10]));
    float fb = *f[5];
    int ws = *pdata_ival[11];
@@ -181,7 +181,7 @@ void DistortionEffect::init_ctrltypes()
    fxdata->p[3].set_type(ct_freq_audible);
 
    fxdata->p[4].set_name("Drive");
-   fxdata->p[4].set_type(ct_decibel_narrow);
+   fxdata->p[4].set_type(ct_decibel_narrow_extendable);
    fxdata->p[5].set_name("Feedback");
    fxdata->p[5].set_type(ct_percent_bidirectional);
    fxdata->p[11].set_name("WaveShape");

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -845,6 +845,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          {
          case ct_decibel:
          case ct_decibel_narrow:
+         case ct_decibel_narrow_extendable:
          case ct_decibel_extra_narrow:
          case ct_decibel_extendable:
          case ct_freq_mod:


### PR DESCRIPTION
I had decided to not do this in 1.6.3 but after discussing
with the original requestor, they wanted to try it. So
push this into the nightly now. I think this is only useful if
we get different waveshapers also, but we will see.