### PR TITLE
Alternate-modsource-state survives openOrRecreate

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -219,6 +219,9 @@ SurgeGUIEditor::SurgeGUIEditor(void* effect, SurgeSynthesizer* synth, void* user
    {
        throw new Surge::Error("Software Error: Param MisMaptch" );
    }
+
+   for( int i=0; i<n_modsources; ++i )
+      modsource_is_alternate[i] = false;
 }
 
 SurgeGUIEditor::~SurgeGUIEditor()
@@ -747,6 +750,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          {
             ((CModulationSourceButton*)gui_modsrc[ms])->setAlternate(ms_releasevelocity,
                                                                      modsource_abberations_button[ms_releasevelocity]);
+            ((CModulationSourceButton*)gui_modsrc[ms])->setUseAlternate(modsource_is_alternate[ms]);
          }
       }
       frame->addView(gui_modsrc[ms]);
@@ -1761,8 +1765,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             bool activeMod = (cms->state & 3) == 2;
             
             auto *mi = addCallbackMenu(
-               contextMenu, offLab, [cms]() {
+               contextMenu, offLab, [this, modsource, cms]() {
                                        cms->setUseAlternate( ! cms->useAlternate );
+                                       modsource_is_alternate[modsource] = cms->useAlternate;
                                     }
                );
             if( activeMod )

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -211,6 +211,8 @@ private:
 
    std::shared_ptr<SurgeBitmaps> bitmapStore = nullptr;
 
+   bool modsource_is_alternate[n_modsources];
+
    VSTGUI::CControl* vu[16];
    VSTGUI::CControl *infowindow, *patchname, *ccfxconf = nullptr, *statuspanel = nullptr;
    VSTGUI::CControl* aboutbox = nullptr;


### PR DESCRIPTION
The modsource gui state didn't survive recreating the GUI, which
Surge does surpisingly often. Fix that by keeping the alternate state
and applying it at create time.