### PR TITLE
Name the S++ LV2 distinctly.

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -700,11 +700,11 @@ includedirs {
 }
 
 configuration { "Debug" }
-targetdir "target/lv2/Debug/Surge.lv2"
+targetdir "target/lv2/Debug/Surge++.lv2"
 targetsuffix "-Debug"
 
 configuration { "Release" }
-targetdir "target/lv2/Release/Surge.lv2"
+targetdir "target/lv2/Release/Surge++.lv2"
 
 configuration {}
 

--- a/src/lv2/SurgeLv2Export.cpp
+++ b/src/lv2/SurgeLv2Export.cpp
@@ -45,10 +45,10 @@ void lv2_generate_ttl(const char* baseName)
       writePrefix(osDsp);
 
       osDsp << "<" << desc->URI << ">\n"
-               "    doap:name \"Surge\" ;\n"
+               "    doap:name \"Surge++\" ;\n"
                "    doap:license <GPL-3.0-only> ;\n"
                "    doap:maintainer [\n"
-               "        foaf:name \"Vember Audio\" ;\n"
+               "        foaf:name \"Surge Synth Team\" ;\n"
                "        foaf:homepage <https://surge-synthesizer.github.io/> ;\n"
                "    ] ;\n"
                "    ui:ui <" << uidesc->URI << "> ;\n"


### PR DESCRIPTION
Finalize the S++ LV2 modifications. It is unclear exactly how
well these work, but they won't conclift with surge classic
at least with this diff