### PR TITLE
Give clean message on invalid XML

### DIFF
--- a/PaulTODO.md
+++ b/PaulTODO.md
@@ -11,8 +11,9 @@ Here's my sort of running todo as I think of it, in rough order
   * Alignment of Text (MONO STFP?)
 * Slider Parameterization and Work
   * Handle and BG SVGs
-  * API for painting ticks on sliders; and sizing sliders
-  * SVG for slider handles
+    - hiroz is 133 x 14
+    - vertical is ...
+
 * Modulation Button Properties for Colors exposed
   * including hover, background blink, font, etc...
 * VU Meter and VU Meter Optimization for Background

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -6,6 +6,8 @@
 #
 # ./build-osx.sh --help
 
+set -o xtrace
+
 
 help_message()
 {

--- a/resources/data/layouts/original.layout/SVG/hslider/BiModTickTray.svg
+++ b/resources/data/layouts/original.layout/SVG/hslider/BiModTickTray.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 133 14" xmlns="http://www.w3.org/2000/svg">
+  <polygon id="Triangle" fill="#9899EE" points="70.189 -50.255 76.189 60.745 70.189 60.745" transform="matrix(0, -1, 1, 0, 67.944004, 78.434002)"/>
+  <rect id="Rectangle" fill="#000000" x="128" y="0" width="1" height="14"/>
+  <polygon id="polygon-1" fill="#9899EE" points="57.026 -46.524 63.026 64.476 57.026 64.476" transform="matrix(0, 1, -1, 0, 69.002003, -51.049999)"/>
+  <rect id="Rectangle" fill="#000000" x="5" y="6" width="123" height="2"/>
+  <rect id="Rectangle" fill="#000000" x="4" y="0" width="1" height="14"/>
+  <rect id="rect-1" fill="#000000" x="128" y="0" width="1" height="14"/>
+  <rect id="rect-2" fill="#000000" x="94.462" y="2.347" width="0.753" height="8.493" style=""/>
+  <rect id="rect-3" fill="#000000" x="63.43" y="2.266" width="1.028" height="9.494" style=""/>
+  <rect id="rect-4" fill="#000000" x="31.372" y="3.051" width="1.087" height="8.424" style=""/>
+</svg>

--- a/resources/data/layouts/original.layout/SVG/hslider/BiModTray.svg
+++ b/resources/data/layouts/original.layout/SVG/hslider/BiModTray.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 133 14" xmlns="http://www.w3.org/2000/svg">
+  <polygon id="Triangle" fill="#9899EE" points="70.189 -50.255 76.189 60.745 70.189 60.745" transform="matrix(0, -1, 1, 0, 67.944004, 78.434002)"/>
+  <rect id="Rectangle" fill="#000000" x="128" y="0" width="1" height="14"/>
+  <polygon id="polygon-1" fill="#9899EE" points="57.026 -46.524 63.026 64.476 57.026 64.476" transform="matrix(0, 1, -1, 0, 69.002003, -51.049999)"/>
+  <rect id="Rectangle" fill="#000000" x="5" y="6" width="123" height="2"/>
+  <rect id="Rectangle" fill="#000000" x="4" y="0" width="1" height="14"/>
+</svg>

--- a/resources/data/layouts/original.layout/SVG/hslider/BiTickTray.svg
+++ b/resources/data/layouts/original.layout/SVG/hslider/BiTickTray.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 133 14" xmlns="http://www.w3.org/2000/svg">
+  <polygon id="Triangle" fill="#98999B" points="70.189 -50.255 76.189 60.745 70.189 60.745" transform="matrix(0, -1, 1, 0, 67.944004, 78.434002)"/>
+  <rect id="Rectangle" fill="#000000" x="128" y="0" width="1" height="14"/>
+  <polygon id="polygon-1" fill="#98999B" points="57.026 -46.524 63.026 64.476 57.026 64.476" transform="matrix(0, 1, -1, 0, 69.002003, -51.049999)"/>
+  <rect id="Rectangle" fill="#000000" x="5" y="6" width="123" height="2"/>
+  <rect id="Rectangle" fill="#000000" x="4" y="0" width="1" height="14"/>
+  <rect id="rect-1" fill="#000000" x="128" y="0" width="1" height="14"/>
+  <rect id="rect-2" fill="#000000" x="94.462" y="2.347" width="0.753" height="8.493" style=""/>
+  <rect id="rect-3" fill="#000000" x="63.43" y="2.266" width="1.028" height="9.494" style=""/>
+  <rect id="rect-4" fill="#000000" x="31.372" y="3.051" width="1.087" height="8.424" style=""/>
+</svg>

--- a/resources/data/layouts/original.layout/SVG/hslider/BiTray.svg
+++ b/resources/data/layouts/original.layout/SVG/hslider/BiTray.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 133 14" xmlns="http://www.w3.org/2000/svg">
+  <polygon id="Triangle" fill="#98999B" points="70.189 -50.255 76.189 60.745 70.189 60.745" transform="matrix(0, -1, 1, 0, 67.944004, 78.434002)"/>
+  <rect id="Rectangle" fill="#000000" x="128" y="0" width="1" height="14"/>
+  <polygon id="polygon-1" fill="#98999B" points="57.026 -46.524 63.026 64.476 57.026 64.476" transform="matrix(0, 1, -1, 0, 69.002003, -51.049999)"/>
+  <rect id="Rectangle" fill="#000000" x="5" y="6" width="123" height="2"/>
+  <rect id="Rectangle" fill="#000000" x="4" y="0" width="1" height="14"/>
+</svg>

--- a/resources/data/layouts/original.layout/SVG/hslider/Handle.svg
+++ b/resources/data/layouts/original.layout/SVG/hslider/Handle.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 20 14" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient x1="0.49999313354492186" y1="0" x2="0.49999313354492186" y2="1" id="linearGradient-1">
+      <stop stop-color="#D4D4D4" offset="0"/>
+      <stop stop-color="#A5A5A5" offset="0.2876"/>
+      <stop stop-color="#A6A6A6" offset="0.7299"/>
+      <stop stop-color="#5F5F5F" offset="1"/>
+    </linearGradient>
+  </defs>
+  <g id="Group-2" transform="matrix(1, 0, 0, 1, 0.81739, 0.153148)">
+    <rect id="Rectangle" stroke="#262626" fill="url(#linearGradient-1)" x="0.5" y="0.5" width="18" height="13" rx="5"/>
+    <rect id="Rectangle" fill-opacity="0.1" fill="#FFFFFF" x="8" y="3" width="1" height="8"/>
+    <rect id="Rectangle" fill="#5D6286" x="9" y="2" width="1" height="10"/>
+  </g>
+</svg>

--- a/resources/data/layouts/original.layout/SVG/hslider/HandleMod.svg
+++ b/resources/data/layouts/original.layout/SVG/hslider/HandleMod.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 20 14" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient x1="0.49999313354492186" y1="0" x2="0.49999313354492186" y2="1" id="linearGradient-1">
+      <stop stop-color="#F4D4F4" offset="0"/>
+      <stop stop-color="#A5E5A5" offset="0.2876"/>
+      <stop stop-color="#A6A6E6" offset="0.7299"/>
+      <stop stop-color="#5F5F3F" offset="1"/>
+    </linearGradient>
+  </defs>
+  <g id="Group-2" transform="matrix(1, 0, 0, 1, 0.81739, 0.153148)">
+    <rect id="Rectangle" stroke="#262626" fill="url(#linearGradient-1)" x="0.5" y="0.5" width="18" height="13" rx="5"/>
+    <rect id="Rectangle" fill-opacity="0.1" fill="#FFFFFF" x="8" y="3" width="1" height="8"/>
+    <rect id="Rectangle" fill="#5D6286" x="9" y="2" width="1" height="10"/>
+  </g>
+</svg>

--- a/resources/data/layouts/original.layout/SVG/hslider/UniModTray.svg
+++ b/resources/data/layouts/original.layout/SVG/hslider/UniModTray.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 133 14" xmlns="http://www.w3.org/2000/svg">
+  <polygon id="Triangle" fill="#9899EE" points="69.48 -52.266 75.48 58.734 69.48 58.734" transform="matrix(0, -1, 1, 0, 69.246002, 75.714005)"/>
+  <rect id="Rectangle" fill="#000000" x="128" y="0" width="1" height="14"/>
+  <rect id="Rectangle" fill="#000000" x="5" y="6" width="123" height="2"/>
+  <rect id="Rectangle" fill="#000000" x="4" y="0" width="1" height="14"/>
+</svg>

--- a/resources/data/layouts/original.layout/SVG/hslider/UniTray.svg
+++ b/resources/data/layouts/original.layout/SVG/hslider/UniTray.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 133 14" xmlns="http://www.w3.org/2000/svg">
+  <polygon id="Triangle" fill="#98999B" points="69.48 -52.266 75.48 58.734 69.48 58.734" transform="matrix(0, -1, 1, 0, 69.246002, 75.714005)"/>
+  <rect id="Rectangle" fill="#000000" x="128" y="0" width="1" height="14"/>
+  <rect id="Rectangle" fill="#000000" x="5" y="6" width="123" height="2"/>
+  <rect id="Rectangle" fill="#000000" x="4" y="0" width="1" height="14"/>
+</svg>

--- a/resources/data/layouts/original.layout/layout.xml
+++ b/resources/data/layouts/original.layout/layout.xml
@@ -81,6 +81,15 @@
 
   <components>
     <component name="hslider" class="CSurgeSlider" width="140" height="26">
+      <componentproperties
+          unipolar_background="SVG/hslider/UniTray.svg"
+          unipolar_modulated_background="SVG/hslider/UniModTray.svg"
+          bipolar_background="SVG/hslider/BiTray.svg"
+          bipolar_modulated_background="SVG/hslider/BiModTray.svg"
+          bipolar_ticked_background="SVG/hslider/BiTickTray.svg"
+          bipolar_modulated_ticked_background="SVG/hslider/BiModTickTray.svg"
+          handle="SVG/hslider/Handle.svg"
+          handle_modulated="SVG/hslider/HandleMod.svg"/>
     </component>
     <component name="hslider.light" class="CSurgeSlider" width="140" height="26">
       <componentproperties white="true"/>

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -32,7 +32,7 @@ CSurgeSlider::CSurgeSlider(const CPoint& loc,
    this->style = stylee;
    this->is_mod = is_mod;
 
-   for( int i=0; i<n_bitmaps; ++i )
+   for( int i=0; i<n_stateBitmaps; ++i )
       stateBitmaps[i] = nullptr;
    
    modmode = 0;

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -6,6 +6,7 @@
 #include "SurgeBitmaps.h"
 #include "SurgeParamConfig.h"
 #include "ISliderKnobInterface.h"
+#include "CScalableBitmap.h"
 
 class CSurgeSlider : public CCursorHidingControl, public virtual Surge::ISliderKnobInterface
 {
@@ -17,6 +18,7 @@ public:
                 bool is_mod,
                 std::shared_ptr<SurgeBitmaps> bitmapStore);
    ~CSurgeSlider();
+      
    virtual void draw(VSTGUI::CDrawContext*);
    // virtual void mouse (VSTGUI::CDrawContext *pContext, VSTGUI::CPoint &where, long buttons = -1);
    // virtual bool onWheel (VSTGUI::CDrawContext *pContext, const VSTGUI::CPoint &where, float distance);
@@ -98,28 +100,47 @@ public:
    }
 
 
-   enum BitmapIdentities {
-      bmap_Handle,
-      bmap_ModHandle,
-      bmap_Tray,
-      bmap_BipolarTray,
-      bmap_BipolarTickTray,
-      bmap_ModTray,
-      bmap_ModBipolarTray,
-      bmap_ModBipolarTickTray,
-      n_bitmaps
-   };
+   typedef enum BitmapMode {
+      Surge16_Bitmaps,
+      Individual_Bitmaps
+   } BitmapMode;
+   BitmapMode bitmapmode = Surge16_Bitmaps;
 
-   void setBitmapForIdentity(BitmapIdentities identity, VSTGUI::CBitmap *bm) {
-      stateBitmaps[identity] = bm;
+   typedef enum StateBitmaps {
+      UnipolarBackground,
+      UnipolarModulatedBackground,
+
+      /* These two states could be here logically but actually aren't used so leave them out
+      UnipolarTickedBackground,
+      UnipolarTickedModulatedBackground,
+      */
+      
+      BipolarBackground,
+      BipolarModulatedBackground,
+      BipolarTickedBackground,
+      BipolarTickedModulatedBackground,
+
+      ValueHandle,
+      ModulationHandle,
+
+      n_stateBitmaps
+   } StateBitmaps;
+      
+
+   void setBitmapForState( StateBitmaps b, VSTGUI::CBitmap *bm ) {
+      bitmapmode = Individual_Bitmaps;
+      stateBitmaps[b] = bm;
    }
+
+   
    
 private:
    // For ContainsMultitudes mode
    VSTGUI::CBitmap *pHandle, *pTray, *pModHandle;
 
+   VSTGUI::CBitmap *stateBitmaps[n_stateBitmaps];
+   
    // For BitmapPerState mode
-   VSTGUI::CBitmap *stateBitmaps[n_bitmaps];
    VSTGUI::CRect handle_rect, handle_rect_orig;
    VSTGUI::CPoint offsetHandle;
    int range;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -721,8 +721,8 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
    {
       auto* oscswitch = layout->addLayoutControl("osc.switch", this, tag_osc_select, this);
-      // FIX THIS
-      oscswitch->setValue((float)current_osc / (n_oscs - 1));
+      if( oscswitch )
+         oscswitch->setValue((float)current_osc / (n_oscs - 1));
    }
 
    {
@@ -799,7 +799,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
       }
       else
       {
-         std::cout << "SOFTWARE ERROR IN DYNCAST" << std::endl;
+         // std::cout << "SOFTWARE ERROR IN DYNCAST" << std::endl;
       }
    }
 
@@ -1016,7 +1016,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
                   hsw->setValue(p->get_value_f01());
 
                bool bprop;
-               if( hsw->getAttribute(Surge::LayoutEngine::kSurgeShowPopup, bprop) )
+               if( hsw && hsw->getAttribute(Surge::LayoutEngine::kSurgeShowPopup, bprop) )
                {
                   if( ! bprop ) // explicitly don't show the popup
                   {

--- a/src/common/layoutengine/LayoutEngineControlFactory.cpp
+++ b/src/common/layoutengine/LayoutEngineControlFactory.cpp
@@ -282,6 +282,22 @@ void LayoutEngine::setupControlFactory()
 
       auto res = new CSurgeSlider(nopoint, style,
                                   listener, tag, true, bitmapStore);
+
+      std::vector<std::string> propNamesForSVG = { "unipolar_background",
+                                                   "unipolar_modulated_background",
+                                                   "bipolar_background",
+                                                   "bipolar_modulated_background",
+                                                   "bipolar_ticked_background",
+                                                   "bipolar_modulated_ticked_background",
+                                                   "handle",
+                                                   "handle_modulated" };
+      for( int i=0; i<CSurgeSlider::n_stateBitmaps; ++i )
+      {
+         if( props[propNamesForSVG[i]] != "" )
+         {
+            // LayoutLog::info() << "Item '" << i << "' name '" << props[propNamesForSVG[i]] << "' value '" << propNamesForSVG[i] << "'" << std::endl;
+         }
+      }
       /*
       ** SO MUCH to fix here; like horizontal and vertical; and like the bitmaps we choose and the
       *background.


### PR DESCRIPTION
Invalid XML used to cause a segfault. Now it causes a black 100x100 GUI
along with a clean Surge::UserInteractions::promptError. This change also
contains an incomplete slider parameterization, since that's what I was
working on when I screwed up the XML, but I want to get this into other devs
hands.