### PR TITLE
Reset modulation state when modulations are cleared

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -591,13 +591,15 @@ void SurgeGUIEditor::refresh_mod()
          state = mod_editor ? 2 : 1;
       if (i == modsource_editor)
          state |= 4;
+
       if( gui_modsrc[i] )
       {
+         // this could change if I cleared the last one
+         ((CModulationSourceButton*)gui_modsrc[i])->used = synth->isModsourceUsed( (modsources)i );
          ((CModulationSourceButton*)gui_modsrc[i])->state = state;
          ((CModulationSourceButton*)gui_modsrc[i])->invalid();
       }
    }
-
    // ctnvg	frame->redraw();
    // frame->setDirty();
 }
@@ -1849,6 +1851,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                                     
                                     synth->clearModulation(md, thisms);
                                     refresh_mod();
+                                    control->setDirty();
+                                    control->invalid();
                                     
                                     if (resetName)
                                     {
@@ -1885,7 +1889,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                                                         for (int md = 1; md < n_total_md; md++)
                                                            synth->clearModulation(md, thisms);
                                                         refresh_mod();
-                                                        
+
                                                         // Also blank out the name and rebuild the UI
                                                         if (within_range(ms_ctrl1, thisms, ms_ctrl1 + n_customcontrollers - 1))
                                                         {
@@ -1895,11 +1899,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                                                            synth->storage.getPatch().CustomControllerLabel[ccid][1] = 0;
                                                            ((CModulationSourceButton*)control)
                                                               ->setlabel(synth->storage.getPatch().CustomControllerLabel[ccid]);
-                                                           control->setDirty();
-                                                           control->invalid();
-                                                           
-                                                           synth->updateDisplay();
                                                         }
+                                                        control->setDirty(true);
+                                                        control->invalid();
+                                                        synth->updateDisplay();
+
                                                      });
                eid++;
             }


### PR DESCRIPTION
If you RMB/Clear a modulation the item wouldn't repaint properly
until a later time (when update_lagvals were called). This corrects
that.

Closes #1329