### PR TITLE
Temporary workarond for n_osc WT streaming

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -773,7 +773,7 @@ void SurgePatch::do_morph()
 struct patch_header
 {
    char tag[4];
-   unsigned int xmlsize, wtsize[2][n_oscs];
+   unsigned int xmlsize, wtsize[2][3]; // n_oscs]; FIXME deal with patch header for n_osc > 3
 };
 #pragma pack(pop)
 
@@ -885,7 +885,7 @@ void SurgePatch::load_patch(const void* data, int datasize, bool preset)
 
       for (int sc = 0; sc < 2; sc++)
       {
-         for (int osc = 0; osc < n_oscs; osc++)
+         for (int osc = 0; osc < 3 /* n_oscs FIXME deal with patch streaming for n_osc != 3 */; osc++)
          {
             ph->wtsize[sc][osc] = vt_read_int32LE(ph->wtsize[sc][osc]);
             if (ph->wtsize[sc][osc])

--- a/src/headless/UnitTests.cpp
+++ b/src/headless/UnitTests.cpp
@@ -145,20 +145,17 @@ TEST_CASE( "Simple Single Oscillator is Constant", "[dsp]" )
 
 TEST_CASE( "All Patches are Loadable", "[patch]" )
 {
-#if 0
    // FIXME - why doesn't this work?
    SurgeSynthesizer* surge = Surge::Headless::createSurge(44100);
    REQUIRE( surge );
    int i=0;
    for( auto p : surge->storage.patch_list )
    {
-      std::cout << i << " " << p.name << " " << p.path.generic_string() << std::endl;
       surge->loadPatch(i);
       ++i;
    }
    
    delete surge;
-#endif   
 }
 
 TEST_CASE( "lipol_ps class", "[dsp]" )


### PR DESCRIPTION
Linked to #1337, the patch format assumes 3 oscillators per stream
and has binary offsets. With 6 oscillators per stream (that is using
n_osc rather than 3) things go wrong at unstream of 1.6.4 patches.
We need to fix this, but for now I made a couple of spots just have
'3' so we don't get segfaults.