### PR TITLE
Filter and FM Config; Readonly Nodes

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -216,6 +216,7 @@ function plugincommon()
         "src/common/gui/CSnapshotMenu.cpp",
         "src/common/gui/CSurgeSlider.cpp",
         "src/common/gui/CSurgeVuMeter.cpp",
+        "src/common/gui/CSVGValueDisplay.cpp",
         "src/common/gui/CSwitchControl.cpp",
         "src/common/gui/PopupEditorDialog.cpp",
         "src/common/gui/SurgeBitmaps.cpp",

--- a/resources/data/layouts/original.layout/layout.xml
+++ b/resources/data/layouts/original.layout/layout.xml
@@ -257,7 +257,34 @@
         </array>
       </componentproperties>
     </component>
+
+    <component name="Filter Config Display" class="CSVGValueDisplay" width="120" height="70">
+      <componentproperties>
+        <array name="images">
+          <element value="SVG/filterconfig/s1.svg"/>
+          <element value="SVG/filterconfig/s2.svg"/>
+          <element value="SVG/filterconfig/s3.svg"/>
+          <element value="SVG/filterconfig/d1.svg"/>
+          <element value="SVG/filterconfig/d2.svg"/>
+          <element value="SVG/filterconfig/lr.svg"/>
+          <element value="SVG/filterconfig/rng.svg"/>
+          <element value="SVG/filterconfig/w.svg"/>
+        </array>
+      </componentproperties>
+    </component>
+
     
+    <component name="FM Config Display" class="CSVGValueDisplay" width="120" height="70">
+      <componentproperties>
+        <array name="images">
+          <element value="SVG/fmconfig/none.svg"/>
+          <element value="SVG/fmconfig/a.svg"/>
+          <element value="SVG/fmconfig/b.svg"/>
+          <element value="SVG/fmconfig/c.svg"/> <!-- rename and make obviously -->
+        </array>
+      </componentproperties>
+    </component>
+
     <component name="Mute Emoji Switch" class="CSwitchControl" width="22" height="22">
       <componentproperties subPixmaps="2"
                            svgPerState="true"
@@ -465,10 +492,18 @@
         <layout width="auto" height="auto" mode="vlist" style="blank" label="midparent">
           <layout height="150" width="auto" mode="hlist" style="blank" label="ofoparent">
             <layout height="auto" width="auto" style="roundedlabel" bgcolor="$mixenv.bg" fgcolor="$mixenv.fg" label="FM">
-              <node guiid="fm.depth" xoff="center"   yoff="20" component="hslider.light"/>
+              <readonlynode guiid="scene.fmconfig" xoff="center" yoff="10" component="FM Config Display"/>
+              <node component="15x15 UnTabbed Multi" guiid="scene.fmconfig" width="60" height="15" xoff="center" yoff="90">
+                <nodeproperties rows="1" cols="4" fontsize="8" choices="0|21|321|312"/>
+              </node>
+              <node guiid="fm.depth" xoff="center"   yoff="110" component="hslider.light"/>
             </layout>
             <layout height="auto" width="auto" style="roundedlabel" bgcolor="$mixenv.bg" fgcolor="$mixenv.fg" label="Filter Cfg">
-                <node guiid="filters.feedback" xoff="center"   yoff="20" component="hslider.light"/>
+              <readonlynode guiid="filters.config" xoff="center" yoff="10" component="Filter Config Display"/>
+              <node component="15x15 UnTabbed Multi" guiid="filters.config" width="120" height="15" xoff="center" yoff="90">
+                <nodeproperties rows="1" cols="8" fontsize="8" choices="s1|s2|s3|d1|d2|lr|rng|w"/>
+              </node>
+              <node guiid="filters.feedback" xoff="center"   yoff="110" component="hslider.light"/>
             </layout>
             <layout height="auto" width="auto" style="roundedlabel" bgcolor="$mixenv.bg" fgcolor="$mixenv.fg" label="Output">
                 <node guiid="scene.output.volume" xoff="center"   yoff="23" component="hslider.light"/>
@@ -482,15 +517,15 @@
           <layout height="100" width="auto" mode="hlist" style="blank" label="filtparent">
             <layout height="auto" width="auto" mode="vlist" style="roundedlabel" bgcolor="$ctrl.bg" fgcolor="$ctrl.fg" label="Filt 1">
               <node guiid="filters.filter0.type" component="Filter Selector"/>
-              <node guiid="filter0.cutoff" xoff="center"   yoff="10" component="hslider.light"/>
-              <node guiid="filter0.resonance" xoff="center"   yoff="27" component="hslider.light"/>
+              <node guiid="filter0.cutoff" xoff="center"   yoff="10" component="hslider"/>
+              <node guiid="filter0.resonance" xoff="center"   yoff="27" component="hslider"/>
               
             </layout>
             <layout height="100" width="175" style="svg" svg="SVG/175x100_BG.svg" label="Filt Mix"/>
             <layout height="auto" width="auto" mode="vlist" style="roundedlabel" bgcolor="$ctrl.bg" fgcolor="$ctrl.fg" label="Filt 2">
               <node guiid="filters.filter1.type" component="Filter Selector"/>
-              <node guiid="filter1.cutoff" xoff="center"   yoff="10" component="hslider.light"/>
-              <node guiid="filter1.resonance" xoff="center"   yoff="27" component="hslider.light"/>
+              <node guiid="filter1.cutoff" xoff="center"   yoff="10" component="hslider"/>
+              <node guiid="filter1.resonance" xoff="center"   yoff="27" component="hslider"/>
               
             </layout>
           </layout>

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -192,9 +192,9 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       a->push_back(scene[sc].polymode.assign(p_id.next(), id_s++,
                                              "polymode", "Polymode", "scene.polymode",
                                              ct_polymode, sc_id, cg_GLOBAL, 0, false )); // FIXME kWhite kNoPopup
-      a->push_back(scene[sc].fm_switch.assign(p_id.next(), id_s++, "fm_switch", "FM Routing",
-                                              ct_fmconfig, gui_col3_x + 3, gui_topbar + 25, sc_id,
-                                              cg_GLOBAL, 0, false));
+      a->push_back(scene[sc].fm_switch.assign(p_id.next(), id_s++, "fm_switch", "FM Routing", "scene.fmconfig",
+                                              ct_fmconfig, sc_id, cg_GLOBAL, 0, false));
+      
       a->push_back(scene[sc].fm_depth.assign(
                       p_id.next(), id_s++, "fm_depth", "FM Depth", "fm.depth",
                       ct_decibel_fmdepth, sc_id, cg_GLOBAL, 0, true ));
@@ -334,8 +334,9 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       py += gui_hfader_dist;
 
       a->push_back(scene[sc].filterblock_configuration.assign(
-          p_id.next(), id_s++, "fb_config", "Filter Configuration", ct_fbconfig, gui_col4_x - 1,
-          gui_topbar + 25, sc_id, cg_GLOBAL, 0, false, Surge::ParamConfig::kHorizontal));
+                      p_id.next(), id_s++, "fb_config", "Filter Configuration", "filters.config",
+                      ct_fbconfig, sc_id, cg_GLOBAL, 0, false));
+      
       a->push_back(scene[sc].filter_balance.assign(
           p_id.next(), id_s++, "f_balance", "Filter Balance", ct_percent_bidirectional, gui_col4_x,
           gui_mainsec_slider_y + 11, sc_id, cg_GLOBAL, 0, true,

--- a/src/common/gui/CGlyphSwitch.cpp
+++ b/src/common/gui/CGlyphSwitch.cpp
@@ -24,6 +24,12 @@ void CGlyphSwitch::setValue(float f)
    auto scale = (rows > 1 ? rows - 1 : 1 ) * ( cols > 1 ? cols - 1 : 1 );
    multiValue = std::round( f * scale );
    invalid();
+
+   for( auto c : readOnlyPartners )
+   {
+      c->setValue(f);
+      c->invalid();
+   }
 }
 
 void CGlyphSwitch::setMultiValue(int i)

--- a/src/common/gui/CGlyphSwitch.h
+++ b/src/common/gui/CGlyphSwitch.h
@@ -2,6 +2,7 @@
 
 #include "vstcontrols.h"
 #include "CScalableBitmap.h"
+#include "IUpdateReadOnlyPartner.h"
 
 /*
 ** A switch which paints its background and draws a glyph over the front.
@@ -9,7 +10,7 @@
 ** value is 0.
 */
 
-class CGlyphSwitch : public VSTGUI::CControl
+class CGlyphSwitch : public VSTGUI::CControl, public IUpdateReadOnlyPartner
 {
 public:
    CGlyphSwitch( const VSTGUI::CRect &size,
@@ -20,6 +21,8 @@ public:
    ~CGlyphSwitch() {
       if( glyph )
          glyph->forget();
+      for( auto c : readOnlyPartners )
+         c->forget();
    }
 
    // Use this later
@@ -153,12 +156,18 @@ public:
                                                      const VSTGUI::CButtonState &buttons) override;
 
    void setMousedRowAndCol(VSTGUI::CPoint &where);
+
+   void addReadOnlyPartner(VSTGUI::CControl *c) {
+      c->remember();
+      readOnlyPartners.push_back(c);
+   }
    
 private:
    CScalableBitmap *bgBitmap[n_drawstates];
    VSTGUI::CColor bgColor[n_drawstates], fgColor[n_drawstates];
    CScalableBitmap *glyph = nullptr;
    std::vector<CScalableBitmap *> glyphChoices;
+   std::vector<VSTGUI::CControl *> readOnlyPartners;
    
    std::vector<std::string> choiceLabels;
    

--- a/src/common/gui/CSVGValueDisplay.cpp
+++ b/src/common/gui/CSVGValueDisplay.cpp
@@ -1,0 +1,31 @@
+#include "CSVGValueDisplay.h"
+#include <iostream>
+
+CSVGValueDisplay::CSVGValueDisplay(const VSTGUI::CRect &size,
+                                   VSTGUI::IControlListener *listener,
+                                   long tag)
+   : VSTGUI::CControl( size, listener, tag )
+{
+}
+   
+   // virtual void setValue(float f) override;
+void CSVGValueDisplay::draw( VSTGUI::CDrawContext *dc )
+{
+   auto r = getViewSize();
+   dc->setFillColor(VSTGUI::kYellowCColor);
+   dc->drawRect(r, VSTGUI::kDrawFilled);
+
+   char txt[256];
+   sprintf( txt, "v=%f", getValue() );
+
+   auto stringR = r;
+   
+   VSTGUI::SharedPointer<VSTGUI::CFontDesc> labelFont = new VSTGUI::CFontDesc("Lato", 14);
+   dc->setFont(labelFont);
+   dc->setFontColor(VSTGUI::kBlackCColor);
+
+   stringR.top = r.getHeight() / 2 - 10;
+   stringR.bottom = r.getHeight() / 2 + 10;
+   dc->drawString(txt, stringR, VSTGUI::kCenterText, true);
+
+}

--- a/src/common/gui/CSVGValueDisplay.h
+++ b/src/common/gui/CSVGValueDisplay.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "vstcontrols.h"
+#include "CScalableBitmap.h"
+
+/*
+** A switch which paints its background and draws a glyph over the front.
+** When selected the value is the given value; when unselected the
+** value is 0.
+*/
+
+class CSVGValueDisplay : public VSTGUI::CControl
+{
+public:
+   CSVGValueDisplay(const VSTGUI::CRect &size,
+                    VSTGUI::IControlListener *listener,
+                    long tag);
+   
+   // virtual void setValue(float f) override;
+   virtual void draw( VSTGUI::CDrawContext *dc ) override;
+
+private:
+   CLASS_METHODS( CSVGValueDisplay, VSTGUI::CControl );
+};

--- a/src/common/gui/IUpdateReadOnlyPartner.h
+++ b/src/common/gui/IUpdateReadOnlyPartner.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "vstcontrols.h"
+
+class IUpdateReadOnlyPartner {
+public:
+   virtual void addReadOnlyPartner( VSTGUI::CControl *c ) = 0;
+};

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1010,6 +1010,8 @@ void SurgeGUIEditor::openOrRecreateEditor()
          case ct_filtertype:
          case ct_character:
          case ct_fxbypass:
+         case ct_fbconfig:
+         case ct_fmconfig:
          {
             CControl *hsw = nullptr;
             if( p->hasLayoutEngineID )
@@ -1039,6 +1041,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
                std::cout << "ERROR: No layoutEngineID for switch type " << std::endl;
             }
             nonmod_param[i] = hsw;
+
+            if( p->ctrltype == ct_fbconfig )
+               filterblock_tag = p->id + start_paramtags;
          }
          break;
          case ct_bool_relative_switch:
@@ -1100,29 +1105,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
             rect(0, 0, 28, 47);
             rect.offset(p->posx, p->posy);
             hsw->setMouseableArea(rect);
-            hsw->setValue(p->get_value_f01());
-            if(legacy != nullptr) legacy->addView(hsw);
-            nonmod_param[i] = hsw;
-         }
-         break;
-         case ct_fbconfig:
-         {
-            CRect rect(0, 0, 134, 52);
-            rect.offset(p->posx, p->posy);
-            CControl* hsw = new CHSwitch2(rect, this, p->id + start_paramtags, 8, 52, 1, 8,
-                                          bitmapStore->getBitmap(IDB_FBCONFIG), nopoint, true);
-            hsw->setValue(p->get_value_f01());
-            if(legacy != nullptr) legacy->addView(hsw);
-            nonmod_param[i] = hsw;
-            filterblock_tag = p->id + start_paramtags;
-         }
-         break;
-         case ct_fmconfig:
-         {
-            CRect rect(0, 0, 134, 52);
-            rect.offset(p->posx, p->posy);
-            CControl* hsw = new CHSwitch2(rect, this, p->id + start_paramtags, 4, 52, 1, 4,
-                                          bitmapStore->getBitmap(IDB_FMCONFIG), nopoint, true);
             hsw->setValue(p->get_value_f01());
             if(legacy != nullptr) legacy->addView(hsw);
             nonmod_param[i] = hsw;
@@ -2535,7 +2517,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
       filtersubtype[idx]->invalid();
    }
 
-   if (tag == filterblock_tag)
+   if (tag == filterblock_tag) 
    {
       // pan2 control
       int i = synth->storage.getPatch().scene[current_scene].width.id;

--- a/src/common/layoutengine/LayoutEngine.h
+++ b/src/common/layoutengine/LayoutEngine.h
@@ -54,12 +54,23 @@ public:
    virtual control_t* addLayoutControl(const guiid_t& guiid,
                                        VSTGUI::IControlListener* listener,
                                        long tag,
+                                       SurgeGUIEditor* editor) {
+      return addLayoutControl(nodeMap[guiid], listener, tag, editor);
+   }
+
+   virtual control_t* addLayoutControl(LayoutElement *node,
+                                       VSTGUI::IControlListener* listener,
+                                       long tag,
                                        SurgeGUIEditor* editor);
 
    std::shared_ptr<SurgeBitmaps> bitmapStore = nullptr;
    std::unique_ptr<LayoutElement> rootLayoutElement = nullptr;
    std::unordered_map<std::string, std::shared_ptr<LayoutComponent>> components;
+
+   // These are shallow copies of the pointer
    std::unordered_map<std::string, LayoutElement*> nodeMap;
+   std::unordered_map<std::string, std::vector<LayoutElement*>> readonlyNodeMap;
+   
    std::unordered_map<std::string, controlGenerator_t> controlFactory;
    frame_t* frame = nullptr;
 
@@ -107,6 +118,7 @@ public:
    {
       Layout,
       Node,
+      ReadOnlyNode,
       Label
    } ElementType;
    ElementType type;

--- a/src/common/layoutengine/LayoutEngineControlFactory.cpp
+++ b/src/common/layoutengine/LayoutEngineControlFactory.cpp
@@ -4,6 +4,7 @@
 #include "CHSwitch2.h"
 #include "COscillatorDisplay.h"
 #include "CGlyphSwitch.h"
+#include "CSVGValueDisplay.h"
 #include "CScalableBitmap.h"
 #include "CSurgeSlider.h"
 #include "CSurgeKnob.h"
@@ -137,7 +138,7 @@ void LayoutEngine::setupControlFactory()
 
       rect.offset(p->xoff, p->yoff);
 
-      auto res = new CGlyphSwitch(rect, listener, tag, 7);
+      auto res = new CGlyphSwitch(rect, listener, tag, 7); // FIXME - 7. WTH?
 
       auto rows = std::max(1,std::atoi(props["rows"].c_str()));
       auto cols = std::max(1,std::atoi(props["cols"].c_str()));
@@ -258,6 +259,21 @@ void LayoutEngine::setupControlFactory()
          res->setFont( props["font"] );
 
       this->commonFactoryMethods(res, props);
+      return res;
+   };
+
+   controlFactory["CSVGValueDisplay"] = [this](const guiid_t& guiid, VSTGUI::IControlListener* listener,
+                                           long tag, SurgeGUIEditor* editor, LayoutElement* p) {
+      auto pprops = p->properties;
+      auto comp = components[p->component];
+      auto props = Surge::mergeProperties(comp->properties, pprops);
+
+      point_t nopoint(0, 0);
+      rect_t rect(0, 0, p->width, p->height);
+
+      rect.offset(p->xoff, p->yoff);
+      
+      auto res = new CSVGValueDisplay(rect, listener, tag);
       return res;
    };
 


### PR DESCRIPTION
The Filter and FM Config move over but in doing so we added a cool
new feature - a readonly node which can pair with a readwrite node
for alternate displays. In this case we just have an idealized SVG
display that doesn't paint yet, but will soon with images showing the
routings.