### PR TITLE
Fix MacOS Catalina PostInstall

### DIFF
--- a/installer_mac/ResourcesPackageScript/postinstall
+++ b/installer_mac/ResourcesPackageScript/postinstall
@@ -1,4 +1,4 @@
 #!/bin/bash
-rsync -r --delete "$DSTVOLUME/tmp/Surge" /Library/Application\ Support/
+rsync -r --delete "/tmp/Surge" /Library/Application\ Support/
 chown -R $USER:staff /Library/Application\ Support/Surge
-rm -rf "$DSTVOLUME/tmp/Surge"
+rm -rf "/tmp/Surge"


### PR DESCRIPTION
DSTVOLUME was misused but also not set in mojave and earlier.
In catalina it is set in a way which broke our postinstall.
Checked with install on mojave and catalina both.

Addressed #1344