### PR TITLE
Move multi switches to XML

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ The Emu (J Riley Hill)
 EvilDragon 
 Erik-Jan Maalderink <fonkle@gmx.com>
 Kjetil Matheussen <k.s.matheussen@notam02.no>
+Andrew Palm <andrewtpalm@gmail.com>
 Dave Palmer <itsmedavep@gmail.com>
 Adam Raisbeck <sense@i2pi.com>
 Esa Juhani Ruoho <esaruoho@gmail.com>

--- a/resources/data/layouts/original.layout/layout.xml
+++ b/resources/data/layouts/original.layout/layout.xml
@@ -688,7 +688,7 @@
 
       </layout>
       <layout height="auto" width="auto" style="roundedlabel" bgcolor="$mod.bg" fgcolor="$mod.fg" label="Modulator">
-        <node component="60x12 Multi" guiid="filter.env.mode" xoff="170" yoff="20" width="60" height="36">
+        <node component="60x12 Multi" guiid="lfo.trigmode" xoff="170" yoff="20" width="60" height="36">
           <nodeproperties rows="3" cols="1" choices="$freerun|$keytrigger|$random"/>
         </node>
         <node component="60x18 Switch" xoff="170" yoff="65" guiid="lfo.unipolar">

--- a/resources/data/layouts/original.layout/layout.xml
+++ b/resources/data/layouts/original.layout/layout.xml
@@ -566,7 +566,9 @@
               <node guiid="filter0.resonance" xoff="center"   yoff="27" component="hslider"/>
               
             </layout>
-            <layout height="100" width="175" style="svg" svg="SVG/175x100_BG.svg" label="Filt Mix"/>
+            <layout height="auto" width="auto" mode="vlist" style="roundedlabel" bgcolor="$ctrl.bg" fgcolor="$ctrl.fg">
+              <node guiid="filters.balance" component="hslider" xoff="center" yoff="center"/>
+            </layout>
             <layout height="auto" width="auto" mode="vlist" style="roundedlabel" bgcolor="$ctrl.bg" fgcolor="$ctrl.fg" label="Filt 2">
               <node guiid="filters.filter1.type" component="Filter Selector"/>
               <node guiid="filter1.cutoff" xoff="center"   yoff="10" component="hslider"/>
@@ -593,9 +595,12 @@
 
                 <layout mode="vlist" width="auto" height="auto" bgcolor="$waveshapersection.bg">
                   <label string="$waveshaper" fgcolor="$waveshapersection.fg" height="12" width="auto"/>
-                  <node guiid="global.waveshaper_type" component="60x12 Multi" xoff="10" yoff="0" width="60" height="60">
-                    <nodeproperties rows="6" cols="1" choices="$off|$soft|$hard|$asym|$sine|$digi"/>
-                  </node>
+                  <layout mode="hlist" width="auto" height="auto" style="blank">
+                    <node guiid="global.waveshaper_type" component="60x12 Multi" xoff="10" yoff="0" width="60" height="60">
+                      <nodeproperties rows="6" cols="1" choices="$off|$soft|$hard|$asym|$sine|$digi"/>
+                    </node>
+                    <node guiid="global.waveshaper_drive" component="vslider" xoff="10"/>
+                  </layout>
                 </layout>
               </layout>
               

--- a/resources/data/layouts/original.layout/layout.xml
+++ b/resources/data/layouts/original.layout/layout.xml
@@ -23,7 +23,30 @@
       <string name="warm" value="Warm"/>
       <string name="neutral" value="Neutral"/>
       <string name="bright" value="Bright"/>
-      
+
+      <string name="freerun" value="Freerun"/>
+      <string name="keytrigger" value="Keytrigger"/>
+      <string name="random" value="Random"/>
+
+      <string name="waveshaper" value="Waveshaper"/>
+      <string name="off" value="OFF"/>
+      <string name="soft" value="SOFT"/>
+      <string name="hard" value="HARD"/>
+      <string name="asym" value="ASYM"/>
+      <string name="sine" value="SINE"/>
+      <string name="digi" value="DIGI"/>
+
+      <string name="digital" value="DIGITAL"/>
+      <string name="analog" value="ANALOG"/>
+
+      <string name="triangle" value="Triangle"/>
+      <string name="square" value="Square"/>
+      <string name="ramp" value="Ramp"/>
+      <string name="noise" value="Noise"/>
+      <string name="s_h" value="S&amp;H"/>
+      <string name="envelope" value="Envelope"/>
+      <string name="stepseq" value="Step Seq"/>
+
     </stringmap>
 
     <stringmap language="fr">
@@ -64,6 +87,9 @@
 
       <color name="switchsection.bg" value="#000000"/>
       <color name="switchsection.fg" value="#111111"/>
+
+      <color name="waveshapersection.bg" value="#5e616a"/>
+      <color name="waveshapersection.fg" value="#cfced4"/>
 
       <color name="switch.onfg" value="#ff9000"/>
       <color name="switch.offfg" value="#ccaa99"/>
@@ -564,10 +590,20 @@
               <layout mode="hlist" width="auto" height="150" style="blank">
                 <node guiid="filter0.keytrack" xoff="10"   component="vslider"/>
                 <node guiid="filter1.keytrack" xoff="30"   component="vslider"/>
+
+                <layout mode="vlist" width="auto" height="auto" bgcolor="$waveshapersection.bg">
+                  <label string="$waveshaper" fgcolor="$waveshapersection.fg" height="12" width="auto"/>
+                  <node guiid="global.waveshaper_type" component="60x12 Multi" xoff="10" yoff="0" width="60" height="60">
+                    <nodeproperties rows="6" cols="1" choices="$off|$soft|$hard|$asym|$sine|$digi"/>
+                  </node>
+                </layout>
               </layout>
               
             </layout>
             <layout height="auto" width="auto" style="roundedlabel" bgcolor="$mixenv.bg" fgcolor="$mixenv.fg" label="FEG">
+              <node guiid="filter.env.mode" component="60x12 Multi" xoff="80" yoff="20" width="60" height="24">
+                <nodeproperties rows="2" cols="1" choices="$digital|$analog"/>
+              </node>
                 <node guiid="filter.env.attack" xoff="23"   yoff="center" component="vslider"/>
                 <node guiid="filter.env.decay" xoff="40"   yoff="center" component="vslider"/>
                 <node guiid="filter.env.sustain" xoff="57"   yoff="center" component="vslider"/>
@@ -578,6 +614,9 @@
             </layout>
                 
             <layout height="auto" width="auto" style="roundedlabel" bgcolor="$mixenv.bg" fgcolor="$mixenv.fg" label="AEG">
+              <node guiid="amp.env.mode" component="60x12 Multi" xoff="80" yoff="20" width="60" height="24">
+                <nodeproperties rows="2" cols="1" choices="$digital|$analog"/>
+              </node>
               <node guiid="amp.env.attack" xoff="23"   yoff="center" component="vslider"/>
               <node guiid="amp.env.decay" xoff="40"   yoff="center" component="vslider"/>
               <node guiid="amp.env.sustain" xoff="57"   yoff="center" component="vslider"/>
@@ -644,10 +683,15 @@
 
       </layout>
       <layout height="auto" width="auto" style="roundedlabel" bgcolor="$mod.bg" fgcolor="$mod.fg" label="Modulator">
-        <node component="60x18 Switch" xoff="20" yoff="20" guiid="lfo.unipolar">
+        <node component="60x12 Multi" guiid="filter.env.mode" xoff="170" yoff="20" width="60" height="36">
+          <nodeproperties rows="3" cols="1" choices="$freerun|$keytrigger|$random"/>
+        </node>
+        <node component="60x18 Switch" xoff="170" yoff="65" guiid="lfo.unipolar">
           <nodeproperties label="$unipolar" fontsize="9"/>
         </node>
-        <node component="hslider" xoff="20" yoff="37" guiid="lfo.shape"/>
+        <node component="60x12 Multi" guiid="lfo.shape" xoff="240" yoff="20" width="60" height="96">
+          <nodeproperties rows="8" cols="1" choices="$sine|$triangle|$square|$ramp|$noise|$s_h|$envelope|$stepseq"/>
+        </node>
         <node component="hslider" xoff="20" yoff="54" guiid="lfo.rate"/>
         <node component="hslider" xoff="20" yoff="71" guiid="lfo.phase"/>
         <node component="hslider" xoff="20" yoff="88" guiid="lfo.magnitude"/>

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -347,9 +347,8 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                            Surge::ParamConfig::kVertical | kWhite | sceasy));
 
       a->push_back(scene[sc].wsunit.type.assign(p_id.next(), id_s++, "ws_type", "Waveshaper Type",
-                                                ct_wstype, gui_envsec_x + gui_vfader_dist * 4 - 1,
-                                                gui_envsec_y + 13, sc_id, cg_GLOBAL, 0, false,
-                                                kNoPopup));
+                                                "global.waveshaper_type", ct_wstype, sc_id,
+                                                cg_GLOBAL, 0, false));
       a->push_back(scene[sc].wsunit.drive.assign(
           p_id.next(), id_s++, "ws_drive", "Waveshaper Drive", ct_decibel_narrow,
           gui_envsec_x + gui_vfader_dist * 5 + 10, gui_envsec_y, sc_id, cg_GLOBAL, 0, true,
@@ -450,9 +449,9 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                                    cg_ENV, e, false, kNoPopup));
          px += gui_vfader_dist; 
 
-         a->push_back(scene[sc].adsr[e].mode.assign(p_id.next(), id_s++, "mode", "Mode", ct_envmode,
-                                                    px + 13, py - 31, sc_id, cg_ENV, e, false,
-                                                    kNoPopup));
+         sprintf(gname, "%s.env.mode", gpfx);
+         a->push_back(scene[sc].adsr[e].mode.assign(p_id.next(), id_s++, "mode", "Mode", gname,
+                                                    ct_envmode, sc_id, cg_ENV, e, false));
       }
 
       for (int l = 0; l < n_lfos; l++)
@@ -492,9 +491,8 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                 py = gui_modsec_y;
                  
                 sprintf(label, "lfo%i_trigmode", l);
-                a->push_back(scene[sc].lfo[l].trigmode.assign(p_id.next(), id_s++, label, "Trigger Mode",
-                                                              ct_lfotrigmode, px + 5, py - 4, sc_id,
-                                                              cg_LFO, ms_lfo1 + l, false, kNoPopup));
+                a->push_back(scene[sc].lfo[l].trigmode.assign(p_id.next(), id_s++, label, "Trigger Mode", "lfo.trigmode",
+                                                              ct_lfotrigmode, sc_id, cg_LFO, ms_lfo1 + l, false));
                 py += 44;
                  
                 sprintf(label, "lfo%i_unipolar", l);

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -337,9 +337,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                       ct_fbconfig, sc_id, cg_GLOBAL, 0, false));
       
       a->push_back(scene[sc].filter_balance.assign(
-          p_id.next(), id_s++, "f_balance", "Filter Balance", ct_percent_bidirectional, gui_col4_x,
-          gui_mainsec_slider_y + 11, sc_id, cg_GLOBAL, 0, true,
-          Surge::ParamConfig::kHorizontal | sceasy));
+          p_id.next(), id_s++, "f_balance", "Filter Balance", "filters.balance", ct_percent_bidirectional, sc_id, cg_GLOBAL, 0, true));
 
       a->push_back(scene[sc].lowcut.assign(p_id.next(), id_s++, "lowcut", "High Pass", ct_freq_hpf,
                                            gui_envsec_x + gui_vfader_dist * 2 + 5, gui_envsec_y,
@@ -350,9 +348,8 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                                 "global.waveshaper_type", ct_wstype, sc_id,
                                                 cg_GLOBAL, 0, false));
       a->push_back(scene[sc].wsunit.drive.assign(
-          p_id.next(), id_s++, "ws_drive", "Waveshaper Drive", ct_decibel_narrow,
-          gui_envsec_x + gui_vfader_dist * 5 + 10, gui_envsec_y, sc_id, cg_GLOBAL, 0, true,
-          Surge::ParamConfig::kVertical | kWhite | sceasy));
+          p_id.next(), id_s++, "ws_drive", "Waveshaper Drive", "global.waveshaper_drive", ct_decibel_narrow,
+          sc_id, cg_GLOBAL, 0, true));
 
       for (int f = 0; f < 2; f++)
       {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -974,29 +974,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
             }
          }
          break;
-         case ct_envmode:
-         {
-            CRect rect(0, 0, 34, 15);
-            rect.offset(p->posx, p->posy);
-            CHSwitch2* hsw = new CHSwitch2(rect, this, p->id + start_paramtags, 2, 15, 2, 1,
-                                           bitmapStore->getBitmap(IDB_ENVMODE), nopoint, false);
-            hsw->setValue(p->get_value_f01());
-
-            if(legacy != nullptr) legacy->addView(hsw);
-            nonmod_param[i] = hsw;
-         }
-         break;
-         case ct_lfotrigmode:
-         {
-            CRect rect(0, 0, 51, 39);
-            rect.offset(p->posx, p->posy);
-            CControl* hsw = new CHSwitch2(rect, this, p->id + start_paramtags, 3, 39, 3, 1,
-                                          bitmapStore->getBitmap(IDB_LFOTRIGGER), nopoint, true);
-            hsw->setValue(p->get_value_f01());
-            if(legacy != nullptr) legacy->addView(hsw);
-            nonmod_param[i] = hsw;
-         }
-         break;
          case ct_bool_mute:
          case ct_bool_solo:
          case ct_oscroute:
@@ -1015,6 +992,10 @@ void SurgeGUIEditor::openOrRecreateEditor()
          case ct_pbdepth:
          case ct_midikey:
          case ct_polylimit:
+         case ct_wstype:
+         case ct_envmode:
+         case ct_lfotrigmode:
+         case ct_lfoshape:
          {
             CControl *hsw = nullptr;
             if( p->hasLayoutEngineID )
@@ -1099,37 +1080,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
                                       &synth->fxsync[current_fx], current_fx);
             m->setValue(p->get_value_f01());
             if(legacy != nullptr) legacy->addView(m);
-         }
-         break;
-         case ct_wstype:
-         {
-            CRect rect(0, 0, 28, 47);
-            rect.offset(p->posx, p->posy);
-            CControl* hsw = new CHSwitch2(rect, this, p->id + start_paramtags, 6, 47, 6, 1,
-                                          bitmapStore->getBitmap(IDB_WAVESHAPER), nopoint, true);
-            rect(0, 0, 28, 47);
-            rect.offset(p->posx, p->posy);
-            hsw->setMouseableArea(rect);
-            hsw->setValue(p->get_value_f01());
-            if(legacy != nullptr) legacy->addView(hsw);
-            nonmod_param[i] = hsw;
-         }
-         break;
-         case ct_lfoshape:
-         {
-            CRect rect(0, 0, 359, 85);
-            rect.offset(p->posx, p->posy - 2);
-            int lfo_id = p->ctrlgroup_entry - ms_lfo1;
-            if ((lfo_id >= 0) && (lfo_id < n_lfos))
-            {
-               CControl* slfo = new CLFOGui(
-                   rect, lfo_id == 0, this, p->id + start_paramtags,
-                   &synth->storage.getPatch().scene[current_scene].lfo[lfo_id], &synth->storage,
-                   &synth->storage.getPatch().stepsequences[current_scene][lfo_id]);
-               lfodisplay = slfo;
-               if(legacy != nullptr) legacy->addView(slfo);
-               nonmod_param[i] = slfo;
-            }
          }
          break;
          default:


### PR DESCRIPTION
This PR addresses https://github.com/surge-synthesizer/surge/issues/1316.

It moves the following to XML:

* waveshaper type
* filter envelope mode
* amp envelope mode
* LFO shape
* LFO trigger mode

<img width="1664" alt="Screen Shot 2019-12-01 at 10 35 19" src="https://user-images.githubusercontent.com/4495237/69916493-9c7eed00-1429-11ea-9e5f-c321695af0fb.png">


One issue is that the `Filter EG` section doesn't show the envelope mode multi switch; I'm not sure why.


Since https://github.com/surge-synthesizer/surge/issues/1316 states "once the sliders are moved", I also moved a few more sliders:

* waveshaper drive
* filter balance

However, if you prefer that the slider moves aren't part of this PR, I can back them out.