### PR TITLE
Improve the LFO display with TempoSync

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -398,6 +398,16 @@ ComponentResult aulayer::Render(AudioUnitRenderActionFlags& ioActionFlags,
       plugin_instance->time_data.tempo = 120;
    }
 
+   UInt32 oDS;
+   Float32 otsNum;
+   UInt32 otsDen;
+   Float64 ocmD;
+   if( CallHostMusicalTimeLocation(&oDS, &otsNum, &otsDen, &ocmD ) >= 0 )
+   {
+      plugin_instance->time_data.timeSigNumerator = (int)otsNum;
+      plugin_instance->time_data.timeSigDenominator = (int)otsDen;
+   }
+
    unsigned int events_processed = 0;
 
    unsigned int i;

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -35,6 +35,7 @@ class PluginLayer;
 struct timedata
 {
    double ppqPos, tempo;
+   int timeSigNumerator = 4, timeSigDenominator = 4;
 };
 
 struct parametermeta

--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -94,6 +94,12 @@ public:
    void drawBitmap(VSTGUI::CDrawContext* dc);
 
    void invalidateIfIdIsInRange(int id);
+   void invalidateIfAnythingIsTemposynced();
+
+   void setTimeSignature(int n, int d ) {
+      tsNum = n;
+      tsDen = d;
+   }
 
 protected:
    LFOStorage* lfodata;
@@ -101,6 +107,9 @@ protected:
    SurgeStorage* storage;
    unsigned int coltable[256];
    CDIBitmap* cdisurf;
+   int tsNum = 4, tsDen = 4;
+   
+   
    VSTGUI::CRect shaperect[n_lfoshapes];
    VSTGUI::CRect steprect[n_stepseqsteps];
    VSTGUI::CRect gaterect[n_stepseqsteps];

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -458,6 +458,23 @@ void SurgeGUIEditor::idle()
             }
          }
       }
+
+      if(lastTempo != synth->time_data.tempo ||
+         lastTSNum != synth->time_data.timeSigNumerator ||
+         lastTSDen != synth->time_data.timeSigDenominator
+         )
+      {
+         lastTempo = synth->time_data.tempo;
+         lastTSNum = synth->time_data.timeSigNumerator;
+         lastTSDen = synth->time_data.timeSigDenominator;
+         if( lfodisplay )
+         {
+            ((CLFOGui*)lfodisplay)->setTimeSignature(synth->time_data.timeSigNumerator,
+                                                     synth->time_data.timeSigDenominator);
+            ((CLFOGui*)lfodisplay)->invalidateIfAnythingIsTemposynced();
+         }
+      }
+      
       for (int i = 0; i < 8; i++)
       {
          if (synth->refresh_parameter_queue[i] >= 0)
@@ -2067,7 +2084,16 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             if (p->can_temposync())
             {
                addCallbackMenu(contextMenu, "Temposync",
-                               [this, p]() { p->temposync = !p->temposync; });
+                               [this, p, control]() {
+                                  p->temposync = !p->temposync;
+                                  if( p->temposync )
+                                     p->bound_value();
+                                  else if( control )
+                                     p->set_value_f01( control->getValue() );
+
+                                  if( this->lfodisplay )
+                                     this->lfodisplay->invalid();
+                               });
                contextMenu->checkEntry(eid, p->temposync);
                eid++;
             }

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -127,6 +127,8 @@ private:
    unsigned int idleinc = 0;
    int fxbypass_tag = 0, resolink_tag = 0, f1resotag = 0, f1subtypetag = 0, f2subtypetag = 0,
        filterblock_tag = 0;
+   double lastTempo = 0;
+   int lastTSNum = 0, lastTSDen = 0;
    void draw_infowindow(int ptag, VSTGUI::CControl* control, bool modulate, bool forceMB = false);
 
    bool showPatchStoreDialog(patchdata* p,

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -405,6 +405,17 @@ tresult PLUGIN_API SurgeVst3Processor::process(ProcessData& data)
             surgeInstance->time_data.tempo = tempo;
             surgeInstance->time_data.ppqPos +=
                 (double)BLOCK_SIZE * tempo / (60. * data.processContext->sampleRate);
+
+            if (data.processContext->state & ProcessContext::kTimeSigValid)
+            {
+               surgeInstance->time_data.timeSigNumerator = data.processContext->timeSigNumerator;
+               surgeInstance->time_data.timeSigDenominator = data.processContext->timeSigDenominator;
+            }
+            else
+            {
+               surgeInstance->time_data.timeSigNumerator = 4;
+               surgeInstance->time_data.timeSigDenominator = 4;
+            }
          }
 
          processEvents(i, data.inputEvents, noteEventIndex);


### PR DESCRIPTION
1. If BPM changes and anything is temposynced, invalidate the change
2; Invalidate things on TempoSync swap of a parameter
3: If temposync is on, draw beat markers
3. Support time signature through the VST3 and AU and draw ticks
based on DAW signature setting.
4. Handle display change properly on temposync toggle, including
   value change
5: Labe the ticks properly
6: Scale in and out the beat display

Closes 1388