### PR TITLE
Show Sidechain in Cubase

### DIFF
--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -68,7 +68,7 @@ tresult PLUGIN_API SurgeVst3Processor::initialize(FUnknown* context)
 
    //---create Audio In/Out busses------
    // we want a stereo Input and a Stereo Output
-   addAudioInput(STR16("Stereo In"), SpeakerArr::kStereo);
+   addAudioInput(STR16("Stereo In"), SpeakerArr::kStereo, kAux );
    addAudioOutput(STR16("Stereo Out"), SpeakerArr::kStereo);
 
    //---create Event In/Out busses (1 bus with 16 channels)------


### PR DESCRIPTION
SideChains in Cubase require the VST3 to show a "kAux" input.
This does that.

Closes #379