### PR TITLE
Implement Patch Wavetable Export

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -553,6 +553,7 @@ public:
    bool load_wt_wt(std::string filename, Wavetable* wt);
    // void load_wt_wav(std::string filename, Wavetable* wt);
    void load_wt_wav_portable(std::string filename, Wavetable *wt);
+   void export_wt_wav_portable(std::string fbase, Wavetable *wt);
    void clipboard_copy(int type, int scene, int entry);
    void clipboard_paste(int type, int scene, int entry);
    int get_clipboard_type();

--- a/src/common/UserInteractions.h
+++ b/src/common/UserInteractions.h
@@ -32,6 +32,10 @@ void promptError(const std::string &message, const std::string &title,
 // And a convenience version which does the same from a Surge::Error
 void promptError(const Surge::Error &error, SurgeGUIEditor *guiEditor = nullptr);
 
+// Show the user an Info dialog with an OK button; and wait for them to press it
+void promptInfo(const std::string &message, const std::string &title,
+                SurgeGUIEditor *guiEditor = nullptr);
+
 // Prompt the user with an OK/Cance
 typedef enum MessageResult
 {

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -692,7 +692,38 @@ void COscillatorDisplay::populateMenu(COptionMenu* contextMenu, int selectedItem
    auto action = [this](CCommandMenuItem* item) { this->loadWavetableFromFile(); };
    actionItem->setActions(action, nullptr);
    contextMenu->addEntry(actionItem);
-   
+
+   auto exportItem = new CCommandMenuItem(CCommandMenuItem::Desc("Export Wave Table to File..."));
+   auto exportAction = [this](CCommandMenuItem *item)
+       {
+          // FIXME - we need to find the scene and osc by iterating (gross).
+          int oscNum = -1;
+          int scene = -1;
+          for( int sc=0;sc<2;sc++ )
+          {
+             auto s = &(storage->getPatch().scene[sc]);
+             for( int o=0;o<n_oscs; ++o )
+             {
+                if( &( s->osc[o] ) == this->oscdata )
+                {
+                   oscNum = o;
+                   scene = sc;
+                }
+             }
+          }
+          if( scene == -1 || oscNum == -1 )
+          {
+             Surge::UserInteractions::promptError( "Unable to determine which osc I have data for in export", "Export" );
+          }
+          else
+          {
+             std::string baseName = storage->getPatch().name + "_osc" + std::to_string(oscNum + 1) + "_scene" + (scene == 0 ? "A" : "B" );
+             storage->export_wt_wav_portable( baseName, &( oscdata->wt ) );
+          }
+       };
+   exportItem->setActions(exportAction,nullptr);
+   contextMenu->addEntry(exportItem);
+
    auto contentItem = new CCommandMenuItem(CCommandMenuItem::Desc("Download Additional Content..."));
    auto contentAction = [](CCommandMenuItem *item)
        {

--- a/src/headless/UserInteractionsHeadless.cpp
+++ b/src/headless/UserInteractionsHeadless.cpp
@@ -20,6 +20,15 @@ void promptError(const Surge::Error &error, SurgeGUIEditor *guiEditor)
     promptError(error.getMessage(), error.getTitle());
 }
 
+void promptInfo(const std::string &message, const std::string &title,
+                SurgeGUIEditor *guiEditor)
+{
+    std::cerr << "Surge Info\n"
+              << title << "\n"
+              << message << "\n" << std::flush;
+}
+
+
 MessageResult promptOKCancel(const std::string &message, const std::string &title,
                              SurgeGUIEditor *guiEditor)
 {

--- a/src/linux/UserInteractionsLinux.cpp
+++ b/src/linux/UserInteractionsLinux.cpp
@@ -74,6 +74,25 @@ void promptError(const Surge::Error &error, SurgeGUIEditor *guiEditor)
     promptError(error.getMessage(), error.getTitle());
 }
 
+void promptInfo(const std::string &message, const std::string &title,
+                SurgeGUIEditor *guiEditor)
+{
+   if (vfork()==0)
+   {
+      if (execlp("zenity", "zenity",
+                 "--info",
+                 "--text", message.c_str(),
+                 "--title", title.c_str(),
+                 (char*)nullptr) < 0)
+      {
+         _exit(0);
+      }
+   }
+   std::cerr << "Surge Error\n"
+             << title << "\n"
+             << message << "\n" << std::flush;
+}
+
 MessageResult promptOKCancel(const std::string &message, const std::string &title,
                              SurgeGUIEditor *guiEditor)
 {

--- a/src/mac/UserInteractionsMac.mm
+++ b/src/mac/UserInteractionsMac.mm
@@ -42,6 +42,30 @@ void promptError(const Surge::Error& error, SurgeGUIEditor* guiEditor)
    promptError(error.getMessage(), error.getTitle());
 }
 
+void promptInfo(const std::string& message, const std::string& title, SurgeGUIEditor* guiEditor)
+{
+   CFStringRef cfT =
+       CFStringCreateWithCString(kCFAllocatorDefault, title.c_str(), kCFStringEncodingUTF8);
+   CFStringRef cfM =
+       CFStringCreateWithCString(kCFAllocatorDefault, message.c_str(), kCFStringEncodingUTF8);
+
+   SInt32 nRes = 0;
+   CFUserNotificationRef pDlg = NULL;
+   const void* keys[] = {kCFUserNotificationAlertHeaderKey, kCFUserNotificationAlertMessageKey};
+   const void* vals[] = {cfT, cfM};
+
+   CFDictionaryRef dict =
+       CFDictionaryCreate(0, keys, vals, sizeof(keys) / sizeof(*keys),
+                          &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+   pDlg = CFUserNotificationCreate(kCFAllocatorDefault, 0, kCFUserNotificationNoteAlertLevel, &nRes,
+                                   dict);
+
+   CFRelease(cfT);
+   CFRelease(cfM);
+}
+
+
 MessageResult
 promptOKCancel(const std::string& message, const std::string& title, SurgeGUIEditor* guiEditor)
 {

--- a/src/windows/UserInteractionsWin.cpp
+++ b/src/windows/UserInteractionsWin.cpp
@@ -28,6 +28,16 @@ void promptError(const Surge::Error &error, SurgeGUIEditor *guiEditor)
     promptError(error.getMessage(), error.getTitle());
 }
 
+void promptInfo(const std::string &message, const std::string &title,
+                SurgeGUIEditor *guiEditor)
+{
+    MessageBox(::GetActiveWindow(),
+               message.c_str(),
+               title.c_str(),
+               MB_OK | MB_ICONINFORMATION );
+}
+
+
 MessageResult promptOKCancel(const std::string &message, const std::string &title,
                              SurgeGUIEditor *guiEditor)
 {


### PR DESCRIPTION
Given a Patch, it was impossible to save the wavetable as a
.wav which you could use elsewhere. You could copy and paste but
you couldn't extract. SO this adds code which exports the wav
into your library for you and lets you know, including doing smart
things with srge tags and the like so surge can use it in other contexts.

Closes #1341