### PR TITLE
Delay unstreams TempoSync correctly

### DIFF
--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -272,9 +272,7 @@ void DualDelayEffect::init_ctrltypes()
    fxdata->p[11].set_type(ct_decibel_narrow);
 
    fxdata->p[0].posy_offset = 5;
-   fxdata->p[0].temposync = false;
    fxdata->p[1].posy_offset = 5;
-   fxdata->p[1].temposync = false;
 
    fxdata->p[2].posy_offset = 7;
    fxdata->p[3].posy_offset = 7;


### PR DESCRIPTION
In commit a1f187a trying to clean up uninitialized memory I left
in a specious override in the Delay only of temposync. That's
been there since April 2019 but meant that Delay temposync didn't
unstream! So remove that, since the temposync is initlaized in
Parameter::assign properly now, and now it unstreams.

Closes #1401