### PR TITLE
Fix logic pro size restore

### DIFF
--- a/src/au/aulayer_cocoaui.mm
+++ b/src/au/aulayer_cocoaui.mm
@@ -297,6 +297,7 @@ ComponentResult aulayer::GetProperty(AudioUnitPropertyID iID, AudioUnitScope iSc
                 if( editor_instance == NULL )
                 {
                     editor_instance = new SurgeGUIEditor( this, plugin_instance );
+                    editor_instance->loadFromDAWExtraState(plugin_instance);
                 }
                 void** pThis = (void**)(outData);
                 *pThis = (void*)editor_instance;


### PR DESCRIPTION
Either this never worked or Logic Pro has changed its startup
sequence in a recent update, but the DAW was restored onto a
plugin with no editor instance so the editor specific DAW streams
in the AU in Logic weren't restored. Now they are.

Closes #1407