### PR TITLE
LFO1 Envelope Lanes

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <thread/CriticalSection.h>
 #include <memory>
+#include <stdint.h>
 
 #ifndef TIXML_USE_STL
 #define TIXML_USE_STL
@@ -386,7 +387,7 @@ struct StepSequencerStorage
    float steps[n_stepseqsteps];
    int loop_start, loop_end;
    float shuffle;
-   unsigned int trigmask;
+   uint64_t trigmask;
 };
 
 /*

--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -27,7 +27,8 @@ void LfoModulationSource::assign(SurgeStorage* storage,
    env_phase = 0;
    shuffle_id = 0;
    ratemult = 1.f;
-   retrigger_EG = false;
+   retrigger_FEG = false;
+   retrigger_AEG = false;
 
    rate = lfo->rate.param_id_in_scene;
    magn = lfo->magnitude.param_id_in_scene;
@@ -231,7 +232,8 @@ void LfoModulationSource::release()
 
 void LfoModulationSource::process_block()
 {
-   retrigger_EG = false;
+   retrigger_FEG = false;
+   retrigger_AEG = false;
    int s = lfo->shape.val.i;
 
    float frate = envelope_rate_linear(-localcopy[rate].f);
@@ -364,8 +366,24 @@ void LfoModulationSource::process_block()
       }
       break;
       case ls_stepseq:
-         if (ss->trigmask & (1 << step))
-            retrigger_EG = true;
+         /*
+         ** You might thing we don't need this and technically we don't
+         ** but I wanted to keep it here to retain compatability with 
+         ** versions of trigmask which were streamed in older sessions
+         */
+         if (ss->trigmask & (1L << step))
+         {
+            retrigger_FEG = true;
+            retrigger_AEG = true;
+         }
+         if (ss->trigmask & (1L << (16+step)))
+         {
+            retrigger_FEG = true;
+         }
+         if (ss->trigmask & (1L << (32+step)))
+         {
+            retrigger_AEG = true;
+         }
          step++;
          shuffle_id = (shuffle_id + 1) & 1;
          if (shuffle_id)

--- a/src/common/dsp/LfoModulationSource.h
+++ b/src/common/dsp/LfoModulationSource.h
@@ -50,7 +50,8 @@ public:
    }
    float env_val;
    int env_state;
-   bool retrigger_EG;
+   bool retrigger_FEG;
+   bool retrigger_AEG;
 
 private:
    LFOStorage* lfo;

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -362,9 +362,12 @@ template <bool first> void SurgeVoice::calc_ctrldata(QuadFilterChainState* Q, in
          lfo[i].process_block();
    }
 
-   if (lfo[0].retrigger_EG)
+   if (lfo[0].retrigger_AEG)
    {
       ((AdsrEnvelope*)modsources[ms_ampeg])->retrigger();
+   }
+   if (lfo[0].retrigger_FEG)
+   {
       ((AdsrEnvelope*)modsources[ms_filtereg])->retrigger();
    }
 


### PR DESCRIPTION
The LFO1 Step Sequencer can retrigger the A and F envelope but
can't do so separately. This change allows it to do so.

- Separate the trigger_EG into _FEG and _AEG
- Handle multi-length trig state to trigger AEG or FEG separately
- A reasonable switching UI driven on shift-click to select only one
- Stream the full uint64

Addresses #1385. Not closing it yet since I want user feedback first.