### PR TITLE
Re-factor the keysplit code; remove crash

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -18,15 +18,6 @@ Parameter::Parameter()
 
 Parameter::~Parameter()
 {
-   {
-      if( owns_user_data && user_data != nullptr )
-      {
-         std::cout << "Deleting User Data on DTOR" << std::endl;
-         delete user_data;
-         user_data = nullptr;
-         owns_user_data = false;
-      }
-   }
 }
 
 void get_prefix(char* txt, ControlGroup ctrlgroup, int ctrlgroup_entry, int scene)
@@ -211,14 +202,6 @@ bool Parameter::can_snap()
 
 void Parameter::set_user_data(ParamUserData* ud)
 {
-   if( owns_user_data && user_data != nullptr )
-   {
-      std::cout << "Deleting User Data on Set" << std::endl;
-      delete user_data;
-      user_data = nullptr;
-      owns_user_data = false;
-   }
-   
    switch (ctrltype)
    {
    case ct_countedset_percent:
@@ -230,9 +213,6 @@ void Parameter::set_user_data(ParamUserData* ud)
       {
          user_data = nullptr;
       }
-      break;
-   case ct_midikey_or_channel:
-      user_data = ud;
       break;
    default:
       std::cerr << "Setting userdata on a non-supporting param ignored" << std::endl;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -76,6 +76,7 @@ enum ctrltypes
    ct_scenesel,
    ct_polymode,
    ct_polylimit,
+   ct_midikey,
    ct_midikey_or_channel,
    ct_bool,
    ct_bool_relative_switch,
@@ -122,15 +123,6 @@ struct ParamUserData
 struct CountedSetUserData : public ParamUserData
 {
    virtual int getCountedSetSize() = 0; // A constant time answer to the count of the set
-};
-
-struct KeyOrChannelState : public ParamUserData
-{
-   bool key = true;
-   virtual bool getIsKey() { return key; }
-   virtual bool getIsChannel() { return ! key; }
-   virtual void setIsKey() { key = true; }
-   virtual void setIsChannel() { key = false; }
 };
 
 class Parameter
@@ -200,11 +192,6 @@ public:
    bool per_voice_processing;
    bool temposync, extend_range, absolute, snap;
 
-   bool owns_user_data = false;
    ParamUserData* user_data;              // I know this is a bit gross but we have a runtime type
    void set_user_data(ParamUserData* ud); // I take a shallow copy and don't assume ownership and assume i am referencable
-   void set_user_data_owned(ParamUserData *ud) { // I take ownership
-      set_user_data(ud);
-      owns_user_data = true;
-   }
 };

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -87,7 +87,6 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
    param_ptr.push_back(splitkey.assign(p_id++, 0, "splitkey", "Split Key", ct_midikey_or_channel, 8 + 91,
                                        gui_mid_topbar_y - 3, 0, cg_GLOBAL, 0, false,
                                        Surge::ParamConfig::kHorizontal | kNoPopup));
-   param_ptr.back()->set_user_data_owned(new KeyOrChannelState() );
    
    param_ptr.push_back(fx_disable.assign(p_id++, 0, "fx_disable", "FX Disable", ct_none, 0, 0, 0,
                                          cg_GLOBAL, 0, false));
@@ -214,7 +213,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
           gui_uppersec_y + gui_hfader_dist * 4, sc_id, cg_GLOBAL, 0, true,
           Surge::ParamConfig::kHorizontal | kWhite | sceasy));
       a->push_back(scene[sc].keytrack_root.assign(p_id++, id_s++, "ktrkroot", "Keytrack Root Key",
-                                                  ct_midikey_or_channel, 180 + 127, gui_topbar + 78 + 106 + 24,
+                                                  ct_midikey, 180 + 127, gui_topbar + 78 + 106 + 24,
                                                   sc_id, cg_GLOBAL, 0, false));
       // ct_midikey
       // drift,keytrack_root

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1280,6 +1280,19 @@ void SurgeGUIEditor::openOrRecreateEditor()
             key->setControlMode(cm_notename);
             // key->altlook = true;
             key->setValue(p->get_value_f01());
+            splitkeyControl = key;
+            frame->addView(key);
+            nonmod_param[i] = key;
+         }
+         break;
+         case ct_midikey:
+         {
+            CRect rect(0, 0, 43, 14);
+            rect.offset(p->posx, p->posy);
+            CNumberField* key = new CNumberField(rect, this, p->id + start_paramtags);
+            key->setControlMode(cm_notename);
+            // key->altlook = true;
+            key->setValue(p->get_value_f01());
             frame->addView(key);
             nonmod_param[i] = key;
          }
@@ -2636,23 +2649,11 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                /*
                ** Now I also need to toggle the split key state
                */
-               auto koc = dynamic_cast<KeyOrChannelState *>(synth->storage.getPatch().splitkey.user_data);
-               if( koc )
+               auto nf = dynamic_cast<CNumberField *>(splitkeyControl);
+               if( nf )
                {
-                  if( koc->getIsKey() && im == sm_chsplit )
-                  {
-                     koc->setIsChannel();
-                     synth->refresh_editor = true;
-                  }
-                  else if( koc->getIsChannel() && im != sm_chsplit )
-                  {
-                     koc->setIsKey();
-                     synth->refresh_editor = true;
-                  }
-               }
-               else
-               {
-                  std::cout << "NULL STATE AFTER CAST of " << synth->storage.getPatch().splitkey.user_data << std::endl;
+
+                  std::cout << "Would whack SKC " << im << std::endl;
                }
             }
             // synth->storage.getPatch().param_ptr[ptag]->set_value_f01(val);

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -227,6 +227,7 @@ private:
    VSTGUI::CTextLabel* patchTuningLabel = nullptr;
    VSTGUI::CControl* polydisp = nullptr;
    VSTGUI::CControl* oscdisplay = nullptr;
+   VSTGUI::CControl* splitkeyControl = nullptr;
    VSTGUI::CControl* param[1024] = {};
    VSTGUI::CControl* nonmod_param[1024] = {}; 
    VSTGUI::CControl* gui_modsrc[n_modsources] = {};


### PR DESCRIPTION
The helper I introduced to handle KeySplit UI changing was
both wrong and unnecessary. So remove it, thereby killing a crash
and also making the code ready to finish the split mode.

Addresses #1413
Closes #1425