### PR TITLE
Finish the ChSplit mode

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -498,6 +498,7 @@ void Parameter::set_type(int ctrltype)
       val_default.i = 0;
       break;
    case ct_midikey_or_channel:
+   case ct_midikey:
       valtype = vt_int;
       val_min.i = 0;
       val_max.i = 127;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -226,7 +226,7 @@ int SurgeSynthesizer::calculateChannelMask(int channel, int key)
             channelmask = 2;
          break;
       case sm_chsplit:
-         if( channel <= 8 )
+         if( channel <= ( (int)( storage.getPatch().splitkey.val.i / 8 ) + 1 ) )
             channelmask = 1;
          else
             channelmask = 2;
@@ -540,9 +540,6 @@ void SurgeSynthesizer::releaseScene(int s)
 
 void SurgeSynthesizer::releaseNote(char channel, char key, char velocity)
 {
-   int channelmask =
-       ((channel == 0) ? 3 : 0) || ((channel == 1) ? 1 : 0) || ((channel == 2) ? 2 : 0);
-
    for( int s=0; s<2; ++s )
    {
       for( auto *v : voices[s] )

--- a/src/common/gui/CNumberField.cpp
+++ b/src/common/gui/CNumberField.cpp
@@ -317,6 +317,12 @@ void CNumberField::draw(CDrawContext* pContext)
    case cm_polyphony:
       sprintf(the_text, "%i / %i", i_poly, i_value);
       break;
+   case cm_midichannel_from_127:
+   {
+      int mc = i_value / 8 + 1;
+      sprintf(the_text, "Ch. %i", mc );
+   }
+   break;
    case cm_notename:
    {
       int octave = (i_value / 12) - 2;
@@ -478,7 +484,7 @@ void CNumberField::draw(CDrawContext* pContext)
          sprintf(the_text, "no");
       break;
    case cm_none:
-      sprintf(the_text, "---");
+      sprintf(the_text, "-");
       break;
    }
 

--- a/src/common/gui/CNumberField.h
+++ b/src/common/gui/CNumberField.h
@@ -23,6 +23,7 @@ enum ctrl_mode
    cm_envelopetime,
    cm_lforate,
    cm_midichannel,
+   cm_midichannel_from_127,
    cm_mutegroup,
    cm_lag,
    cm_pbdepth,
@@ -164,6 +165,7 @@ public:
    }
 
    void setControlMode(int mode);
+   int getControlMode() { return controlmode; }
    void setPoly(int p)
    {
       if (i_poly != p)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1207,7 +1207,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             rect.offset(p->posx, p->posy);
             CControl* hsw = new CHSwitch2(rect, this, p->id + start_paramtags, 4, 33, 4, 1,
                                           bitmapStore->getBitmap(IDB_SCENEMODE), nopoint, true);
-            rect(1, 1, 35, 27);
+            rect(1, 1, 35, 32);
             rect.offset(p->posx, p->posy);
             hsw->setMouseableArea(rect);
 
@@ -1277,7 +1277,22 @@ void SurgeGUIEditor::openOrRecreateEditor()
             CRect rect(0, 0, 43, 14);
             rect.offset(p->posx, p->posy);
             CNumberField* key = new CNumberField(rect, this, p->id + start_paramtags);
-            key->setControlMode(cm_notename);
+            auto sm = this->synth->storage.getPatch().scenemode.val.i;
+
+            switch(sm)
+            {
+            case sm_single:
+            case sm_dual:
+               key->setControlMode(cm_none);
+               break;
+            case sm_split:
+               key->setControlMode(cm_notename);
+               break;
+            case sm_chsplit:
+               key->setControlMode(cm_midichannel_from_127);
+               break;
+            }
+
             // key->altlook = true;
             key->setValue(p->get_value_f01());
             splitkeyControl = key;
@@ -2652,8 +2667,21 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                auto nf = dynamic_cast<CNumberField *>(splitkeyControl);
                if( nf )
                {
-
-                  std::cout << "Would whack SKC " << im << std::endl;
+                  int cm = nf->getControlMode();
+                  if( im == sm_chsplit && cm != cm_midichannel_from_127 )
+                  {
+                     nf->setControlMode(cm_midichannel_from_127);
+                     nf->invalid();
+                  }
+                  else if( im == sm_split && cm != cm_notename ) {
+                     nf->setControlMode(cm_notename);
+                     nf->invalid();
+                  }
+                  else if( (im == sm_single || im == sm_dual ) && cm != cm_none ) {
+                     nf->setControlMode(cm_none);
+                     nf->invalid();
+                  }
+                  
                }
             }
             // synth->storage.getPatch().param_ptr[ptag]->set_value_f01(val);


### PR DESCRIPTION
Fix the display of the split; fix the problem with the mousable area;
make it so the split is read at synth time; and fix some display things
to be more coherent.

AFAICS the only thing left to close the issue is to do some extensive
testing

Addresses #1413.