### PR TITLE
FrameClose on editor::close

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -29,7 +29,6 @@
 #include <iomanip>
 #include <strstream>
 
-
 #if TARGET_VST3
 #include "pluginterfaces/vst/ivstcontextmenu.h"
 #include "pluginterfaces/base/ustring.h"
@@ -51,6 +50,7 @@
 #endif
 
 namespace fs = std::experimental::filesystem;
+
 
 #if LINUX && TARGET_LV2
 namespace SurgeLv2
@@ -1631,6 +1631,16 @@ bool PLUGIN_API SurgeGUIEditor::open(void* parent, const PlatformType& platformT
 
 void SurgeGUIEditor::close()
 {
+#if TARGET_VST2
+   // We may need this in other hosts also; but for now 
+   if (frame);
+   {
+      getFrame()->unregisterKeyboardHook(this);
+      frame->close();
+      frame = nullptr;
+   }
+#endif
+
 #if !TARGET_VST3
    super::close();
 #endif


### PR DESCRIPTION
As noted in #1406 we don't handle the frame close cycle properly
which most DAWS compensate for, improperly probably, but which
FreeStyle rightly didn't, leading to a crash.

For now, before the holidays, put in this fix as VST2 only so we
can get some testing. But keep the issue open to do a careful review
of the close lifecycle in the editors in VST3 AU and maybe LV2 also.