### PR TITLE
VS2019 std::filesystem name change

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -30,7 +30,13 @@
 
 #include "Tunings.h"
 
+
+#if WINDOWS && ( _MSC_VER >= 1920 )
+// vs2019
+namespace fs = std::filesystem;
+#else
 namespace fs = std::experimental::filesystem;
+#endif
 
 #if WINDOWS
 #define PATH_SEPARATOR '\\'

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -16,7 +16,12 @@
 #include <iterator>
 #include "UserInteractions.h"
 
+#if WINDOWS && ( _MSC_VER >= 1920 )
+// vs2019
+namespace fs = std::filesystem;
+#else
 namespace fs = std::experimental::filesystem;
+#endif
 
 #if AU
 #include "aulayer.h"

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -17,7 +17,12 @@
 #include <filesystem>
 #endif
 
+#if WINDOWS && ( _MSC_VER >= 1920 )
+// vs2019
+namespace fs = std::filesystem;
+#else
 namespace fs = std::experimental::filesystem;
+#endif
 
 namespace Surge
 {

--- a/src/common/WavSupport.cpp
+++ b/src/common/WavSupport.cpp
@@ -32,7 +32,12 @@
 #include <filesystem>
 #endif
 
+#if WINDOWS && ( _MSC_VER >= 1920 )
+// vs2019
+namespace fs = std::filesystem;
+#else
 namespace fs = std::experimental::filesystem;
+#endif
 
 // Sigh - lets write a portable ntol by hand
 unsigned int pl_int(char *d)

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -16,7 +16,12 @@
 
 using namespace VSTGUI;
 
+#if WINDOWS && ( _MSC_VER >= 1920 )
+// vs2019
+namespace fs = std::filesystem;
+#else
 namespace fs = std::experimental::filesystem;
+#endif
 
 const float disp_pitch = 90.15f - 48.f;
 const int wtbheight = 12;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -49,7 +49,12 @@
 #include <filesystem>
 #endif
 
+#if WINDOWS && ( _MSC_VER >= 1920 )
+// vs2019
+namespace fs = std::filesystem;
+#else
 namespace fs = std::experimental::filesystem;
+#endif
 
 
 #if LINUX && TARGET_LV2


### PR DESCRIPTION
VS2019 changed std::experimental::filesystme to std::filesystem
so condition on windows on MSC_VER to use a different name.

Closes #1433