### PR TITLE
Fixed new parameter messages sent to host, Fixed scrolling on buttons.

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -85,7 +85,7 @@ enum sub3_scenemode
    n_scenemodes,
 };
 
-const char scenemode_abberations[n_scenemodes][16] = {"Single", "Split", "Dual"};
+const char scenemode_abberations[n_scenemodes][16] = {"Single", "Key Split", "Dual", "Channel Split"};
 
 enum sub3_polymode
 {

--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -116,12 +116,12 @@ bool CHSwitch2::onWheel(const CPoint& where, const float& distance, const CButto
       float range = getRange();
       if (columns >1)
       {
-         rate = range / (float)columns;
+         rate = range / (float)(columns-1); // Colums-1 = number of scroll steps
          newVal += rate * distance;
       }
       else
       {
-         rate = range / (float)rows;
+         rate = range / (float)(rows-1); // Rows-1 = Number of scroll steps
          newVal += rate * -distance; // flip distance (==direction) because it makes more sense when wheeling
       }
       beginEdit();


### PR DESCRIPTION
- Fixed the parameter message that is sent to the host for the new Channel Split scene mode. (it sent **"Scene Mode: 1.00"** before, it now sends **"Scene Mode: Channel Split"**).
- Fixed inconsistent scrolling behavior on buttons. It now works correctly every time.

Closes #1440.