### PR TITLE
Fix the shift without mouse down behavior on buttons

### DIFF
--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -76,7 +76,7 @@ CMouseEventResult CHSwitch2::onMouseUp(CPoint& where, const CButtonState& button
 }
 CMouseEventResult CHSwitch2::onMouseMoved(CPoint& where, const CButtonState& buttons)
 {
-   if (dragable && ( buttons.getButtonState() || ( buttons.getModifierState() & kShift ) ) )
+   if (dragable && ( buttons.getButtonState() ))
    {
       auto mouseableArea = getMouseableArea();
       double coefX, coefY;


### PR DESCRIPTION
This fixes a bug where you could just slide across buttons while holding down "Shift" without left-clicking.

Closes #1447 