### PR TITLE
Fix an Init Delay Timing Condition

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -109,6 +109,8 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath)
    last_key[0] = 60;
    last_key[1] = 60;
    temposyncratio = 1.f;
+   temposyncratio_inv = 0.0f; // Use this as a sentinel (since it was not initialized prior to 1.6.5 this was the value at least win and mac had). #1444
+   
    songpos = 0;
 
    for (int i = 0; i < n_customcontrollers; i++)

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -29,10 +29,22 @@ void DualDelayEffect::init()
    lp.suspend();
    hp.suspend();
    setvars(true);
+   inithadtempo = true;
+   // See issue #1444 and the fix for this stuff
+   if( storage->temposyncratio_inv == 0 )
+   {
+      inithadtempo = false;
+   }
 }
 
 void DualDelayEffect::setvars(bool init)
 {
+   if( ! inithadtempo && storage->temposyncratio_inv != 0 )
+   {
+      init = true;
+      inithadtempo = true;
+   }
+   
    float fb = amp_to_linear(*f[2]);
    float cf = amp_to_linear(*f[3]);
 

--- a/src/common/dsp/effect/FreqshiftEffect.cpp
+++ b/src/common/dsp/effect/FreqshiftEffect.cpp
@@ -35,10 +35,24 @@ void FreqshiftEffect::init()
    fi.reset();
    ringout = 10000000;
    setvars(true);
+
+   inithadtempo = true;
+   // See issue #1444 and the fix for this stuff
+   if( storage->temposyncratio_inv == 0 )
+   {
+      inithadtempo = false;
+   }
+
 }
 
 void FreqshiftEffect::setvars(bool init)
 {
+   if( ! inithadtempo && storage->temposyncratio_inv != 0 )
+   {
+      init = true;
+      inithadtempo = true;
+   }
+
    feedback.newValue(amp_to_linear(*f[fsp_feedback]));
 
    if (init)

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -50,6 +50,7 @@ public:
 
 private:
    lag<float, true> timeL, timeR;
+   bool inithadtempo;
    float envf;
    int wpos;
    BiquadFilter lp, hp;
@@ -121,6 +122,7 @@ public:
 private:
    lipol<float, true> feedback;
    lag<float, true> time, shiftL, shiftR;
+   bool inithadtempo;
    float buffer[2][max_delay_length];
    int wpos;
    // CHalfBandFilter<6> frL,fiL,frR,fiR;


### PR DESCRIPTION
Init on Delay with temposync could happen before the global
tempo was set when you unstreamed in a DAW. As a result the
lag for the time would catch up on the first and only first
play leading to glitches. To fix it, detect if setvars(true)
(the init condition) is called when temposync hasn't been set
yet and defer the initialization if so.

The frequency shifter would have the same bug so fix that also.

Closes #1444.