### PR TITLE
Some Slider Cleanups

### DIFF
--- a/assets/original-vector/SVG/exported/bmp00105.svg
+++ b/assets/original-vector/SVG/exported/bmp00105.svg
@@ -1,127 +1,126 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="48px" height="300px" viewBox="0 0 48 300" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 53.1 (72631) - https://sketchapp.com -->
-    <title>bmp00105</title>
-    <desc>Created with Sketch.</desc>
-    <g id="bmp00105" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Group" transform="translate(1.000000, 0.000000)">
-            <g id="Group-2" fill="#D9DADC">
-                <rect id="Rectangle" x="6" y="0" width="2" height="73"></rect>
-                <rect id="Rectangle" x="0" y="9" width="6" height="1"></rect>
-                <rect id="Rectangle" x="8" y="9" width="6" height="1"></rect>
-                <polygon id="Triangle" opacity="0.504952567" points="8 65 8 10 14 10"></polygon>
-                <rect id="Rectangle" x="0" y="65" width="6" height="1"></rect>
-                <rect id="Rectangle" x="8" y="65" width="6" height="1"></rect>
-            </g>
-            <g id="Group-2" transform="translate(16.000000, 0.000000)">
-                <rect id="Rectangle" fill="#99A7DB" x="6" y="0" width="2" height="73"></rect>
-                <rect id="Rectangle" fill="#9AA7DB" x="0" y="9" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#9AA7DB" x="8" y="9" width="6" height="1"></rect>
-                <polygon id="Triangle" fill="#99A7DB" opacity="0.500837054" points="8 65 8 10 14 10"></polygon>
-                <rect id="Rectangle" fill="#9AA7DB" x="0" y="65" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#9AA7DB" x="8" y="65" width="6" height="1"></rect>
-            </g>
-            <g id="Group-2" transform="translate(32.000000, 0.000000)">
-                <rect id="Rectangle" fill="#4766D3" x="6" y="0" width="2" height="73"></rect>
-                <rect id="Rectangle" fill="#4766D3" x="0" y="9" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#4766D3" x="8" y="9" width="6" height="1"></rect>
-                <polygon id="Triangle" fill="#4662C8" opacity="0.498883929" points="8 65 8 10 14 10"></polygon>
-                <rect id="Rectangle" fill="#4766D3" x="0" y="65" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#4766D3" x="8" y="65" width="6" height="1"></rect>
-            </g>
-        </g>
-        <rect id="Rectangle" fill="#D9DADC" x="7" y="0" width="2" height="73"></rect>
-        <rect id="Rectangle" fill="#D9DADC" x="1" y="9" width="6" height="1"></rect>
-        <rect id="Rectangle" fill="#D9DADC" x="9" y="9" width="6" height="1"></rect>
-        <polygon id="Triangle" fill="#D9DADC" opacity="0.504952567" points="9 65 9 10 15 10"></polygon>
-        <rect id="Rectangle" fill="#D9DADC" x="1" y="65" width="6" height="1"></rect>
-        <rect id="Rectangle" fill="#D9DADC" x="9" y="65" width="6" height="1"></rect>
-        <rect id="Rectangle" fill="#99A7DB" x="23" y="0" width="2" height="73"></rect>
-        <rect id="Rectangle" fill="#9AA7DB" x="17" y="9" width="6" height="1"></rect>
-        <rect id="Rectangle" fill="#9AA7DB" x="25" y="9" width="6" height="1"></rect>
-        <polygon id="Triangle" fill="#99A7DB" opacity="0.500837054" points="25 65 25 10 31 10"></polygon>
-        <rect id="Rectangle" fill="#9AA7DB" x="17" y="65" width="6" height="1"></rect>
-        <rect id="Rectangle" fill="#9AA7DB" x="25" y="65" width="6" height="1"></rect>
-        <rect id="Rectangle" fill="#4766D3" x="39" y="0" width="2" height="73"></rect>
-        <rect id="Rectangle" fill="#4766D3" x="33" y="9" width="6" height="1"></rect>
-        <rect id="Rectangle" fill="#4766D3" x="41" y="9" width="6" height="1"></rect>
-        <polygon id="Triangle" fill="#4662C8" opacity="0.498883929" points="41 65 41 10 47 10"></polygon>
-        <rect id="Rectangle" fill="#4766D3" x="33" y="65" width="6" height="1"></rect>
-        <rect id="Rectangle" fill="#4766D3" x="41" y="65" width="6" height="1"></rect>
-        <g id="Group" transform="translate(1.000000, 75.000000)">
-            <g id="Group-2" fill="#D9DADC">
-                <rect id="Rectangle" x="6" y="0" width="2" height="73"></rect>
-                <rect id="Rectangle" x="0" y="9" width="6" height="1"></rect>
-                <rect id="Rectangle" x="8" y="9" width="6" height="1"></rect>
-                <polygon id="Triangle" opacity="0.503162202" transform="translate(11.000000, 24.000000) scale(1, -1) translate(-11.000000, -24.000000) " points="8 10 14 38 8 38"></polygon>
-                <polygon id="Triangle" opacity="0.503162202" transform="translate(3.000000, 51.000000) scale(1, -1) rotate(-180.000000) translate(-3.000000, -51.000000) " points="0 37 6 65 0 65"></polygon>
-                <rect id="Rectangle" x="0" y="65" width="6" height="1"></rect>
-                <rect id="Rectangle" x="8" y="65" width="6" height="1"></rect>
-                <rect id="Rectangle" x="4" y="37" width="2" height="1"></rect>
-                <rect id="Rectangle" x="8" y="37" width="2" height="1"></rect>
-            </g>
-            <g id="Group-2" transform="translate(16.000000, 0.000000)">
-                <rect id="Rectangle" fill="#93A0D2" x="6" y="0" width="2" height="73"></rect>
-                <rect id="Rectangle" fill="#93A0D2" x="0" y="9" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#93A0D2" x="8" y="9" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#93A0D2" x="4" y="37" width="2" height="1"></rect>
-                <rect id="Rectangle" fill="#93A0D2" x="8" y="37" width="2" height="1"></rect>
-                <polygon id="Triangle" fill="#575F79" transform="translate(11.000000, 24.000000) scale(1, -1) translate(-11.000000, -24.000000) " points="8 10 14 38 8 38"></polygon>
-                <polygon id="Triangle" fill="#575F79" transform="translate(3.000000, 51.000000) scale(1, -1) rotate(-180.000000) translate(-3.000000, -51.000000) " points="0 37 6 65 0 65"></polygon>
-                <rect id="Rectangle" fill="#93A0D2" x="0" y="65" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#93A0D2" x="8" y="65" width="6" height="1"></rect>
-            </g>
-            <g id="Group-2" transform="translate(32.000000, 0.000000)">
-                <rect id="Rectangle" fill="#4766D3" x="6" y="0" width="2" height="73"></rect>
-                <rect id="Rectangle" fill="#4766D3" x="0" y="9" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#4766D3" x="8" y="9" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#4766D3" x="4" y="37" width="2" height="1"></rect>
-                <rect id="Rectangle" fill="#4766D3" x="8" y="37" width="2" height="1"></rect>
-                <polygon id="Triangle" fill="#4662C8" opacity="0.500651042" transform="translate(11.000000, 24.000000) scale(1, -1) translate(-11.000000, -24.000000) " points="8 10 14 38 8 38"></polygon>
-                <polygon id="Triangle" fill="#4662C8" opacity="0.500651042" transform="translate(3.000000, 51.000000) scale(1, -1) rotate(-180.000000) translate(-3.000000, -51.000000) " points="0 37 6 65 0 65"></polygon>
-                <rect id="Rectangle" fill="#4766D3" x="0" y="65" width="6" height="1"></rect>
-                <rect id="Rectangle" fill="#4766D3" x="8" y="65" width="6" height="1"></rect>
-            </g>
-        </g>
-        <g id="Group-4" transform="translate(1.000000, 150.000000)">
-            <g id="Group-3">
-                <rect id="Rectangle" fill="#000000" x="6" y="0" width="2" height="56"></rect>
-                <rect id="Rectangle" fill="#000000" x="0" y="9" width="14" height="1"></rect>
-                <polygon id="Triangle" fill="#98999B" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"></polygon>
-                <rect id="Rectangle" fill="#000000" x="0" y="48" width="14" height="1"></rect>
-            </g>
-            <g id="Group-3" transform="translate(16.000000, 0.000000)">
-                <rect id="Rectangle" fill="#5E72BA" x="6" y="0" width="2" height="56"></rect>
-                <rect id="Rectangle" fill="#5E72BA" x="0" y="9" width="14" height="1"></rect>
-                <polygon id="Triangle" fill="#405CBF" opacity="0.497558594" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"></polygon>
-                <rect id="Rectangle" fill="#5E72BA" x="0" y="48" width="14" height="1"></rect>
-            </g>
-            <g id="Group-3" transform="translate(32.000000, 0.000000)">
-                <rect id="Rectangle" fill="#1437B8" x="6" y="0" width="2" height="56"></rect>
-                <rect id="Rectangle" fill="#1437B8" x="0" y="9" width="14" height="1"></rect>
-                <polygon id="Triangle" fill="#3356D5" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"></polygon>
-                <rect id="Rectangle" fill="#1437B8" x="0" y="48" width="14" height="1"></rect>
-            </g>
-        </g>
-        <g id="Group-4" transform="translate(1.000000, 225.000000)">
-            <g id="Group-3">
-                <rect id="Rectangle" fill="#000000" x="6" y="0" width="2" height="56"></rect>
-                <rect id="Rectangle" fill="#000000" x="0" y="9" width="14" height="1"></rect>
-                <polygon id="Triangle" fill="#98999B" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"></polygon>
-                <rect id="Rectangle" fill="#000000" x="0" y="48" width="14" height="1"></rect>
-            </g>
-            <g id="Group-3" transform="translate(16.000000, 0.000000)">
-                <rect id="Rectangle" fill="#5E72BA" x="6" y="0" width="2" height="56"></rect>
-                <rect id="Rectangle" fill="#5E72BA" x="0" y="9" width="14" height="1"></rect>
-                <polygon id="Triangle" fill="#405CBF" opacity="0.498232887" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"></polygon>
-                <rect id="Rectangle" fill="#5E72BA" x="0" y="48" width="14" height="1"></rect>
-            </g>
-            <g id="Group-3" transform="translate(32.000000, 0.000000)">
-                <rect id="Rectangle" fill="#1438B8" x="6" y="0" width="2" height="56"></rect>
-                <rect id="Rectangle" fill="#1438B8" x="0" y="9" width="14" height="1"></rect>
-                <polygon id="Triangle" fill="#3357D4" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"></polygon>
-                <rect id="Rectangle" fill="#1438B8" x="0" y="48" width="14" height="1"></rect>
-            </g>
-        </g>
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="48px" height="300px" viewBox="0 0 48 300" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <title>bmp00105</title>
+  <desc>Created with Sketch.</desc>
+  <g id="bmp00105" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Group" transform="translate(1.000000, 0.000000)">
+      <g id="Group-2" fill="#D9DADC">
+        <rect id="Rectangle" x="6" y="0" width="2" height="73"/>
+        <rect id="Rectangle" x="0" y="9" width="6" height="1"/>
+        <rect id="Rectangle" x="8" y="9" width="6" height="1"/>
+        <polygon id="Triangle" opacity="0.504952567" points="8 65 8 10 14 10"/>
+        <rect id="Rectangle" x="0" y="65" width="6" height="1"/>
+        <rect id="Rectangle" x="8" y="65" width="6" height="1"/>
+      </g>
+      <g id="Group-2" transform="translate(16.000000, 0.000000)">
+        <rect id="Rectangle" fill="#99A7DB" x="6" y="0" width="2" height="73"/>
+        <rect id="Rectangle" fill="#9AA7DB" x="0" y="9" width="6" height="1"/>
+        <rect id="Rectangle" fill="#9AA7DB" x="8" y="9" width="6" height="1"/>
+        <polygon id="Triangle" fill="#99A7DB" opacity="0.500837054" points="8 65 8 10 14 10"/>
+        <rect id="Rectangle" fill="#9AA7DB" x="0" y="65" width="6" height="1"/>
+        <rect id="Rectangle" fill="#9AA7DB" x="8" y="65" width="6" height="1"/>
+      </g>
+      <g id="Group-2" transform="translate(32.000000, 0.000000)">
+        <rect id="Rectangle" fill="#BBC4f6" x="6" y="0" width="2" height="73"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="0" y="9" width="6" height="1"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="8" y="9" width="6" height="1"/>
+        <polygon id="Triangle" fill="#4662C8" opacity="0.498883929" points="8 65 8 10 14 10"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="0" y="65" width="6" height="1"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="8" y="65" width="6" height="1"/>
+      </g>
     </g>
+    <rect id="Rectangle" fill="#D9DADC" x="7" y="0" width="2" height="73"/>
+    <rect id="Rectangle" fill="#D9DADC" x="1" y="9" width="6" height="1"/>
+    <rect id="Rectangle" fill="#D9DADC" x="9" y="9" width="6" height="1"/>
+    <polygon id="Triangle" fill="#D9DADC" opacity="0.504952567" points="9 65 9 10 15 10"/>
+    <rect id="Rectangle" fill="#D9DADC" x="1" y="65" width="6" height="1"/>
+    <rect id="Rectangle" fill="#D9DADC" x="9" y="65" width="6" height="1"/>
+    <rect id="Rectangle" fill="#99A7DB" x="23" y="0" width="2" height="73"/>
+    <rect id="Rectangle" fill="#9AA7DB" x="17" y="9" width="6" height="1"/>
+    <rect id="Rectangle" fill="#9AA7DB" x="25" y="9" width="6" height="1"/>
+    <polygon id="Triangle" fill="#99A7DB" opacity="0.500837054" points="25 65 25 10 31 10"/>
+    <rect id="Rectangle" fill="#9AA7DB" x="17" y="65" width="6" height="1"/>
+    <rect id="Rectangle" fill="#9AA7DB" x="25" y="65" width="6" height="1"/>
+    <rect id="Rectangle" fill="#BBC4f6" x="39" y="0" width="2" height="73"/>
+    <rect id="Rectangle" fill="#BBC4f6" x="33" y="9" width="6" height="1"/>
+    <rect id="Rectangle" fill="#BBC4f6" x="41" y="9" width="6" height="1"/>
+    <polygon id="Triangle" fill="#297be6" opacity="0.7" points="41 65 41 10 47 10"/>
+    <rect id="Rectangle" fill="#BBC4f6" x="33" y="65" width="6" height="1"/>
+    <rect id="Rectangle" fill="#BBC4f6" x="41" y="65" width="6" height="1"/>
+    <g id="Group" transform="translate(1.000000, 75.000000)">
+      <g id="Group-2" fill="#D9DADC">
+        <rect id="Rectangle" x="6" y="0" width="2" height="73"/>
+        <rect id="Rectangle" x="0" y="9" width="6" height="1"/>
+        <rect id="Rectangle" x="8" y="9" width="6" height="1"/>
+        <polygon id="Triangle" opacity="0.503162202" transform="translate(11.000000, 24.000000) scale(1, -1) translate(-11.000000, -24.000000) " points="8 10 14 38 8 38"/>
+        <polygon id="Triangle" opacity="0.503162202" transform="translate(3.000000, 51.000000) scale(1, -1) rotate(-180.000000) translate(-3.000000, -51.000000) " points="0 37 6 65 0 65"/>
+        <rect id="Rectangle" x="0" y="65" width="6" height="1"/>
+        <rect id="Rectangle" x="8" y="65" width="6" height="1"/>
+        <rect id="Rectangle" x="4" y="37" width="2" height="1"/>
+        <rect id="Rectangle" x="8" y="37" width="2" height="1"/>
+      </g>
+      <g id="Group-2" transform="translate(16.000000, 0.000000)">
+        <rect id="Rectangle" fill="#93A0D2" x="6" y="0" width="2" height="73"/>
+        <rect id="Rectangle" fill="#93A0D2" x="0" y="9" width="6" height="1"/>
+        <rect id="Rectangle" fill="#93A0D2" x="8" y="9" width="6" height="1"/>
+        <rect id="Rectangle" fill="#93A0D2" x="4" y="37" width="2" height="1"/>
+        <rect id="Rectangle" fill="#93A0D2" x="8" y="37" width="2" height="1"/>
+        <polygon id="Triangle" fill="#575F79" transform="translate(11.000000, 24.000000) scale(1, -1) translate(-11.000000, -24.000000) " points="8 10 14 38 8 38"/>
+        <polygon id="Triangle" fill="#575F79" transform="translate(3.000000, 51.000000) scale(1, -1) rotate(-180.000000) translate(-3.000000, -51.000000) " points="0 37 6 65 0 65"/>
+        <rect id="Rectangle" fill="#93A0D2" x="0" y="65" width="6" height="1"/>
+        <rect id="Rectangle" fill="#93A0D2" x="8" y="65" width="6" height="1"/>
+      </g>
+      <g id="Group-2" transform="translate(32.000000, 0.000000)">
+        <rect id="Rectangle" fill="#BBC4f6" x="6" y="0" width="2" height="73"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="0" y="9" width="6" height="1"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="8" y="9" width="6" height="1"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="4" y="37" width="2" height="1"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="8" y="37" width="2" height="1"/>
+        <polygon id="Triangle" fill="#297be6" opacity="0.7" transform="translate(11.000000, 24.000000) scale(1, -1) translate(-11.000000, -24.000000) " points="8 10 14 38 8 38"/>
+        <polygon id="Triangle" fill="#297be6" opacity="0.7" transform="translate(3.000000, 51.000000) scale(1, -1) rotate(-180.000000) translate(-3.000000, -51.000000) " points="0 37 6 65 0 65"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="0" y="65" width="6" height="1"/>
+        <rect id="Rectangle" fill="#BBC4f6" x="8" y="65" width="6" height="1"/>
+      </g>
+    </g>
+    <g id="Group-4" transform="translate(1.000000, 150.000000)">
+      <g id="Group-3">
+        <rect id="Rectangle" fill="#000000" x="6" y="0" width="2" height="56"/>
+        <rect id="Rectangle" fill="#000000" x="0" y="9" width="14" height="1"/>
+        <polygon id="Triangle" fill="#98999B" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"/>
+        <rect id="Rectangle" fill="#000000" x="0" y="48" width="14" height="1"/>
+      </g>
+      <g id="Group-3" transform="translate(16.000000, 0.000000)">
+        <rect id="Rectangle" fill="#5E72BA" x="6" y="0" width="2" height="56"/>
+        <rect id="Rectangle" fill="#5E72BA" x="0" y="9" width="14" height="1"/>
+        <polygon id="Triangle" fill="#405CBF" opacity="0.497558594" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"/>
+        <rect id="Rectangle" fill="#5E72BA" x="0" y="48" width="14" height="1"/>
+      </g>
+      <g id="Group-3" transform="translate(32.000000, 0.000000)">
+        <rect id="Rectangle" fill="#1437B8" x="6" y="0" width="2" height="56"/>
+        <rect id="Rectangle" fill="#1437B8" x="0" y="9" width="14" height="1"/>
+        <polygon id="Triangle" fill="#3356D5" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"/>
+        <rect id="Rectangle" fill="#1437B8" x="0" y="48" width="14" height="1"/>
+      </g>
+    </g>
+    <g id="Group-4" transform="translate(1.000000, 225.000000)">
+      <g id="Group-3">
+        <rect id="Rectangle" fill="#000000" x="6" y="0" width="2" height="56"/>
+        <rect id="Rectangle" fill="#000000" x="0" y="9" width="14" height="1"/>
+        <polygon id="Triangle" fill="#98999B" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"/>
+        <rect id="Rectangle" fill="#000000" x="0" y="48" width="14" height="1"/>
+      </g>
+      <g id="Group-3" transform="translate(16.000000, 0.000000)">
+        <rect id="Rectangle" fill="#5E72BA" x="6" y="0" width="2" height="56"/>
+        <rect id="Rectangle" fill="#5E72BA" x="0" y="9" width="14" height="1"/>
+        <polygon id="Triangle" fill="#405CBF" opacity="0.498232887" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"/>
+        <rect id="Rectangle" fill="#5E72BA" x="0" y="48" width="14" height="1"/>
+      </g>
+      <g id="Group-3" transform="translate(32.000000, 0.000000)">
+        <rect id="Rectangle" fill="#1438B8" x="6" y="0" width="2" height="56"/>
+        <rect id="Rectangle" fill="#1438B8" x="0" y="9" width="14" height="1"/>
+        <polygon id="Triangle" fill="#3357D4" transform="translate(11.000000, 29.500000) rotate(-180.000000) translate(-11.000000, -29.500000) " points="14 10 14 49 8 49"/>
+        <rect id="Rectangle" fill="#1438B8" x="0" y="48" width="14" height="1"/>
+      </g>
+    </g>
+  </g>
 </svg>

--- a/assets/original-vector/SVG/exported/bmp00154.svg
+++ b/assets/original-vector/SVG/exported/bmp00154.svg
@@ -1,222 +1,222 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="399px" height="84px" viewBox="0 0 399 84" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g id="bmp00154" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="Triangle" fill="#5E72BA" opacity="0.5" points="334 76 388 73 388 76"></polygon>
-        <polygon id="Triangle" fill="#5E72BA" opacity="0.5" points="331 78 277 81 277 78"></polygon>
-        <polygon id="Triangle" fill="#B6C4F6" opacity="0.423897879" points="201 76 255 73 255 76"></polygon>
-        <polygon id="Triangle" fill="#B6C4F6" opacity="0.423897879" points="198 78 144 81 144 78"></polygon>
-        <rect id="Rectangle" fill="#000000" x="10" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="5" y="34" width="123" height="2"></rect>
-        <polygon id="Triangle" fill="#98999B" points="68 34 122 31 122 34"></polygon>
-        <polygon id="Triangle" fill="#98999B" points="65 36 11 39 11 36"></polygon>
-        <rect id="Rectangle" fill="#000000" x="65" y="28" width="3" height="14"></rect>
-        <rect id="Rectangle" fill="#000000" x="18" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="26" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="34" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="42" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="90" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="98" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="106" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="114" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="122" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="65" y="28" width="3" height="14"></rect>
-        <rect id="Rectangle" fill="#000000" x="122" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="5" y="20" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="66" y="18" width="1" height="6"></rect>
-        <rect id="Rectangle" fill="#000000" x="122" y="0" width="1" height="28"></rect>
-        <rect id="Rectangle" fill="#000000" x="5" y="6" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="10" y="0" width="1" height="28"></rect>
-        <polygon id="Triangle" fill="#98999B" transform="translate(66.500000, 3.000000) rotate(-90.000000) translate(-66.500000, -3.000000) " points="63.5 -52.5 69.5 58.5 63.5 58.5"></polygon>
-        <polygon id="Triangle" fill="#98999B" transform="translate(94.500000, 17.000000) rotate(-90.000000) translate(-94.500000, -17.000000) " points="91.5 -10.5 97.5 44.5 91.5 44.5"></polygon>
-        <polygon id="Triangle" fill="#98999B" transform="translate(38.500000, 25.000000) rotate(-270.000000) translate(-38.500000, -25.000000) " points="35.5 -2.5 41.5 52.5 35.5 52.5"></polygon>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="50" y="78" width="1" height="1"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="58" y="78" width="1" height="1"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="74" y="75" width="1" height="1"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="82" y="75" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#F5F5F6" x="5" y="76" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#F5F5F6" x="65" y="70" width="3" height="6"></rect>
-        <rect id="Rectangle" fill="#F5F5F6" x="65" y="78" width="3" height="6"></rect>
-        <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" points="68 76 122 73 122 76"></polygon>
-        <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" points="65 78 11 81 11 78"></polygon>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="18" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="11" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="26" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="34" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="42" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="90" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="98" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="106" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="114" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#FFFFFF" x="122" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#F5F5F6" x="5" y="62" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#F5F5F6" x="66" y="60" width="1" height="6"></rect>
-        <rect id="Rectangle" fill="#F5F5F6" x="122" y="42" width="1" height="28"></rect>
-        <rect id="Rectangle" fill="#F5F5F6" x="5" y="48" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#F5F5F6" x="10" y="42" width="1" height="28"></rect>
-        <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" transform="translate(66.500000, 45.000000) rotate(-90.000000) translate(-66.500000, -45.000000) " points="63.5 -10.5 69.5 100.5 63.5 100.5"></polygon>
-        <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" transform="translate(94.500000, 59.000000) rotate(-90.000000) translate(-94.500000, -59.000000) " points="91.5 31.5 97.5 86.5 91.5 86.5"></polygon>
-        <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" transform="translate(38.500000, 67.000000) rotate(-270.000000) translate(-38.500000, -67.000000) " points="35.5 39.5 41.5 94.5 35.5 94.5"></polygon>
-        <rect id="Rectangle" fill="#2B3E80" x="143" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="183" y="36" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="191" y="36" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="207" y="33" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#000000" x="215" y="33" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="138" y="34" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="198" y="28" width="3" height="14"></rect>
-        <rect id="Rectangle" fill="#000000" x="151" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="159" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="167" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="175" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="223" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="231" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#000000" x="239" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#000000" x="247" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="255" y="31" width="1" height="3"></rect>
-        <polygon id="Triangle" fill="#8395D1" points="201 34 255 31 255 34"></polygon>
-        <polygon id="Triangle" fill="#8395D1" points="198 36 144 39 144 36"></polygon>
-        <rect id="Rectangle" fill="#2B3E80" x="138" y="20" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="199" y="18" width="1" height="6"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="255" y="0" width="1" height="28"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="138" y="6" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="143" y="0" width="1" height="28"></rect>
-        <polygon id="Triangle" fill="#7B8ECE" transform="translate(199.500000, 3.000000) rotate(-90.000000) translate(-199.500000, -3.000000) " points="196.5 -52.5 202.5 58.5 196.5 58.5"></polygon>
-        <polygon id="Triangle" fill="#7B8ECE" transform="translate(227.500000, 17.000000) rotate(-90.000000) translate(-227.500000, -17.000000) " points="224.5 -10.5 230.5 44.5 224.5 44.5"></polygon>
-        <polygon id="Triangle" fill="#7B8ECE" transform="translate(171.500000, 25.000000) rotate(-270.000000) translate(-171.500000, -25.000000) " points="168.5 -2.5 174.5 52.5 168.5 52.5"></polygon>
-        <rect id="Rectangle" fill="#B6C4F6" x="143" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#C1CEFF" x="191" y="78" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="207" y="75" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="215" y="75" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="138" y="76" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="198" y="70" width="3" height="14"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="255" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="151" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="159" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="167" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="175" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="191" y="78" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="183" y="78" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="223" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="231" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="239" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="247" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="138" y="62" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="199" y="60" width="1" height="6"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="255" y="42" width="1" height="28"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="138" y="48" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#B6C4F6" x="143" y="42" width="1" height="28"></rect>
-        <polygon id="Triangle" fill="#B6C4F6" opacity="0.497721354" transform="translate(199.500000, 45.000000) rotate(-90.000000) translate(-199.500000, -45.000000) " points="196.5 -10.5 202.5 100.5 196.5 100.5"></polygon>
-        <polygon id="Triangle" fill="#B6C4F6" opacity="0.497721354" transform="translate(227.500000, 59.000000) rotate(-90.000000) translate(-227.500000, -59.000000) " points="224.5 31.5 230.5 86.5 224.5 86.5"></polygon>
-        <polygon id="Triangle" fill="#B6C4F6" opacity="0.497721354" transform="translate(171.500000, 67.000000) rotate(-270.000000) translate(-171.500000, -67.000000) " points="168.5 39.5 174.5 94.5 168.5 94.5"></polygon>
-        <rect id="Rectangle" fill="#5E72BA" x="276" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="388" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="316" y="78" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="324" y="78" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="340" y="75" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="348" y="75" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="271" y="76" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="271" y="62" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="332" y="60" width="1" height="6"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="388" y="42" width="1" height="28"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="271" y="48" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="276" y="42" width="1" height="28"></rect>
-        <polygon id="Triangle" fill="#5E72BA" opacity="0.5" transform="translate(332.500000, 45.000000) rotate(-90.000000) translate(-332.500000, -45.000000) " points="329.5 -10.5 335.5 100.5 329.5 100.5"></polygon>
-        <polygon id="Triangle" fill="#5E72BA" opacity="0.5" transform="translate(360.500000, 59.000000) rotate(-90.000000) translate(-360.500000, -59.000000) " points="357.5 31.5 363.5 86.5 357.5 86.5"></polygon>
-        <polygon id="Triangle" fill="#637FE3" opacity="0.5" transform="translate(304.500000, 67.000000) rotate(-270.000000) translate(-304.500000, -67.000000) " points="301.5 39.5 307.5 94.5 301.5 94.5"></polygon>
-        <rect id="Rectangle" fill="#1437B8" x="276" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#C1CEFF" x="324" y="36" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="340" y="33" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="348" y="33" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="271" y="34" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="331" y="28" width="3" height="14"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="331" y="70" width="3" height="14"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="388" y="31" width="1" height="3"></rect>
-        <polygon id="Triangle" fill="#1437B8" opacity="0.494094122" points="334 34 388 31 388 34"></polygon>
-        <polygon id="Triangle" fill="#1437B8" opacity="0.494094122" points="331 36 277 39 277 36"></polygon>
-        <rect id="Rectangle" fill="#1437B8" x="271" y="20" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="332" y="18" width="1" height="6"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="388" y="0" width="1" height="28"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="271" y="6" width="123" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="276" y="0" width="1" height="28"></rect>
-        <polygon id="Triangle" fill="#1437B8" opacity="0.494094122" transform="translate(332.500000, 3.000000) rotate(-90.000000) translate(-332.500000, -3.000000) " points="329.5 -52.5 335.5 58.5 329.5 58.5"></polygon>
-        <polygon id="Triangle" fill="#1437B8" opacity="0.494094122" transform="translate(360.500000, 17.000000) rotate(-90.000000) translate(-360.500000, -17.000000) " points="357.5 -10.5 363.5 44.5 357.5 44.5"></polygon>
-        <polygon id="Triangle" fill="#1437B8" opacity="0.494094122" transform="translate(304.500000, 25.000000) rotate(-270.000000) translate(-304.500000, -25.000000) " points="301.5 -2.5 307.5 52.5 301.5 52.5"></polygon>
-        <rect id="Rectangle" fill="#1437B8" x="284" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="292" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="300" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="308" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="324" y="36" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="316" y="36" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="356" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="364" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="372" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="380" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="284" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="292" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="300" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="308" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="324" y="36" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="316" y="36" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="356" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="364" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="372" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="380" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="284" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="292" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="300" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="308" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="324" y="36" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="316" y="36" width="1" height="1"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="356" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="364" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="372" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#1437B8" x="380" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="151" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="159" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="167" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="175" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="223" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="231" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="239" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="247" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="151" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="159" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="167" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="175" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="223" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="231" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="239" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="247" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="151" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="159" y="36" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="167" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="175" y="36" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="223" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="231" y="32" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="239" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#2B3E80" x="247" y="31" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="284" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="292" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="300" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="308" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="356" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="364" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="372" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="380" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="284" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="292" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="300" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="308" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="356" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="364" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="372" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#405CBF" x="380" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="284" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="292" y="78" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="300" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="308" y="78" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="356" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="364" y="74" width="1" height="2"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="372" y="73" width="1" height="3"></rect>
-        <rect id="Rectangle" fill="#5E72BA" x="380" y="73" width="1" height="3"></rect>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="399px" height="84px" viewBox="0 0 399 84" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <g id="bmp00154" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <polygon id="Triangle" fill="#297be6" opacity="0.7" points="334 76 388 73 388 76"/>
+    <polygon id="Triangle" fill="#297be6" opacity="0.7" points="331 78 277 81 277 78"/>
+    <polygon id="Triangle" fill="#B6C4F6" opacity="0.423897879" points="201 76 255 73 255 76"/>
+    <polygon id="Triangle" fill="#B6C4F6" opacity="0.423897879" points="198 78 144 81 144 78"/>
+    <rect id="Rectangle" fill="#000000" x="10" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="5" y="34" width="123" height="2"/>
+    <polygon id="Triangle" fill="#98999B" points="68 34 122 31 122 34"/>
+    <polygon id="Triangle" fill="#98999B" points="65 36 11 39 11 36"/>
+    <rect id="Rectangle" fill="#000000" x="65" y="28" width="3" height="14"/>
+    <rect id="Rectangle" fill="#000000" x="18" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="26" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="34" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="42" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="90" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="98" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="106" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="114" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="122" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="65" y="28" width="3" height="14"/>
+    <rect id="Rectangle" fill="#000000" x="122" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="5" y="20" width="123" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="66" y="18" width="1" height="6"/>
+    <rect id="Rectangle" fill="#000000" x="122" y="0" width="1" height="28"/>
+    <rect id="Rectangle" fill="#000000" x="5" y="6" width="123" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="10" y="0" width="1" height="28"/>
+    <polygon id="Triangle" fill="#98999B" transform="translate(66.500000, 3.000000) rotate(-90.000000) translate(-66.500000, -3.000000) " points="63.5 -52.5 69.5 58.5 63.5 58.5"/>
+    <polygon id="Triangle" fill="#98999B" transform="translate(94.500000, 17.000000) rotate(-90.000000) translate(-94.500000, -17.000000) " points="91.5 -10.5 97.5 44.5 91.5 44.5"/>
+    <polygon id="Triangle" fill="#98999B" transform="translate(38.500000, 25.000000) rotate(-270.000000) translate(-38.500000, -25.000000) " points="35.5 -2.5 41.5 52.5 35.5 52.5"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="50" y="78" width="1" height="1"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="58" y="78" width="1" height="1"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="74" y="75" width="1" height="1"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="82" y="75" width="1" height="1"/>
+    <rect id="Rectangle" fill="#F5F5F6" x="5" y="76" width="123" height="2"/>
+    <rect id="Rectangle" fill="#F5F5F6" x="65" y="70" width="3" height="6"/>
+    <rect id="Rectangle" fill="#F5F5F6" x="65" y="78" width="3" height="6"/>
+    <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" points="68 76 122 73 122 76"/>
+    <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" points="65 78 11 81 11 78"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="18" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="11" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="26" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="34" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="42" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="90" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="98" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="106" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill-opacity="0.854478034" fill="#FFFFFF" x="114" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#FFFFFF" x="122" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#F5F5F6" x="5" y="62" width="123" height="2"/>
+    <rect id="Rectangle" fill="#F5F5F6" x="66" y="60" width="1" height="6"/>
+    <rect id="Rectangle" fill="#F5F5F6" x="122" y="42" width="1" height="28"/>
+    <rect id="Rectangle" fill="#F5F5F6" x="5" y="48" width="123" height="2"/>
+    <rect id="Rectangle" fill="#F5F5F6" x="10" y="42" width="1" height="28"/>
+    <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" transform="translate(66.500000, 45.000000) rotate(-90.000000) translate(-66.500000, -45.000000) " points="63.5 -10.5 69.5 100.5 63.5 100.5"/>
+    <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" transform="translate(94.500000, 59.000000) rotate(-90.000000) translate(-94.500000, -59.000000) " points="91.5 31.5 97.5 86.5 91.5 86.5"/>
+    <polygon id="Triangle" fill="#F5F5F6" opacity="0.503557478" transform="translate(38.500000, 67.000000) rotate(-270.000000) translate(-38.500000, -67.000000) " points="35.5 39.5 41.5 94.5 35.5 94.5"/>
+    <rect id="Rectangle" fill="#2B3E80" x="143" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="183" y="36" width="1" height="1"/>
+    <rect id="Rectangle" fill="#2B3E80" x="191" y="36" width="1" height="1"/>
+    <rect id="Rectangle" fill="#2B3E80" x="207" y="33" width="1" height="1"/>
+    <rect id="Rectangle" fill="#000000" x="215" y="33" width="1" height="1"/>
+    <rect id="Rectangle" fill="#2B3E80" x="138" y="34" width="123" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="198" y="28" width="3" height="14"/>
+    <rect id="Rectangle" fill="#000000" x="151" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="159" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="167" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="175" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="223" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="231" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#000000" x="239" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#000000" x="247" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="255" y="31" width="1" height="3"/>
+    <polygon id="Triangle" fill="#8395D1" points="201 34 255 31 255 34"/>
+    <polygon id="Triangle" fill="#8395D1" points="198 36 144 39 144 36"/>
+    <rect id="Rectangle" fill="#2B3E80" x="138" y="20" width="123" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="199" y="18" width="1" height="6"/>
+    <rect id="Rectangle" fill="#2B3E80" x="255" y="0" width="1" height="28"/>
+    <rect id="Rectangle" fill="#2B3E80" x="138" y="6" width="123" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="143" y="0" width="1" height="28"/>
+    <polygon id="Triangle" fill="#7B8ECE" transform="translate(199.500000, 3.000000) rotate(-90.000000) translate(-199.500000, -3.000000) " points="196.5 -52.5 202.5 58.5 196.5 58.5"/>
+    <polygon id="Triangle" fill="#7B8ECE" transform="translate(227.500000, 17.000000) rotate(-90.000000) translate(-227.500000, -17.000000) " points="224.5 -10.5 230.5 44.5 224.5 44.5"/>
+    <polygon id="Triangle" fill="#7B8ECE" transform="translate(171.500000, 25.000000) rotate(-270.000000) translate(-171.500000, -25.000000) " points="168.5 -2.5 174.5 52.5 168.5 52.5"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="143" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#C1CEFF" x="191" y="78" width="1" height="1"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="207" y="75" width="1" height="1"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="215" y="75" width="1" height="1"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="138" y="76" width="123" height="2"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="198" y="70" width="3" height="14"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="255" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="151" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="159" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="167" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="175" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="191" y="78" width="1" height="1"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="183" y="78" width="1" height="1"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="223" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="231" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="239" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="247" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="138" y="62" width="123" height="2"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="199" y="60" width="1" height="6"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="255" y="42" width="1" height="28"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="138" y="48" width="123" height="2"/>
+    <rect id="Rectangle" fill="#B6C4F6" x="143" y="42" width="1" height="28"/>
+    <polygon id="Triangle" fill="#B6C4F6" opacity="0.497721354" transform="translate(199.500000, 45.000000) rotate(-90.000000) translate(-199.500000, -45.000000) " points="196.5 -10.5 202.5 100.5 196.5 100.5"/>
+    <polygon id="Triangle" fill="#B6C4F6" opacity="0.497721354" transform="translate(227.500000, 59.000000) rotate(-90.000000) translate(-227.500000, -59.000000) " points="224.5 31.5 230.5 86.5 224.5 86.5"/>
+    <polygon id="Triangle" fill="#B6C4F6" opacity="0.497721354" transform="translate(171.500000, 67.000000) rotate(-270.000000) translate(-171.500000, -67.000000) " points="168.5 39.5 174.5 94.5 168.5 94.5"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="276" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="388" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="316" y="78" width="1" height="1"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="324" y="78" width="1" height="1"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="340" y="75" width="1" height="1"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="348" y="75" width="1" height="1"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="271" y="76" width="123" height="2"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="271" y="62" width="123" height="2"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="332" y="60" width="1" height="6"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="388" y="42" width="1" height="28"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="271" y="48" width="123" height="2"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="276" y="42" width="1" height="28"/>
+    <polygon id="Triangle" fill="#297be6" opacity="0.7" transform="translate(332.500000, 45.000000) rotate(-90.000000) translate(-332.500000, -45.000000) " points="329.5 -10.5 335.5 100.5 329.5 100.5"/>
+    <polygon id="Triangle" fill="#297be6" opacity="0.7" transform="translate(360.500000, 59.000000) rotate(-90.000000) translate(-360.500000, -59.000000) " points="357.5 31.5 363.5 86.5 357.5 86.5"/>
+    <polygon id="Triangle" fill="#297be6" opacity="0.7" transform="translate(304.500000, 67.000000) rotate(-270.000000) translate(-304.500000, -67.000000) " points="301.5 39.5 307.5 94.5 301.5 94.5"/>
+    <rect id="Rectangle" fill="#1437B8" x="276" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#C1CEFF" x="324" y="36" width="1" height="1"/>
+    <rect id="Rectangle" fill="#1437B8" x="340" y="33" width="1" height="1"/>
+    <rect id="Rectangle" fill="#1437B8" x="348" y="33" width="1" height="1"/>
+    <rect id="Rectangle" fill="#1437B8" x="271" y="34" width="123" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="331" y="28" width="3" height="14"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="331" y="70" width="3" height="14"/>
+    <rect id="Rectangle" fill="#1437B8" x="388" y="31" width="1" height="3"/>
+    <polygon id="Triangle" fill="#297be6" opacity="1" points="334 34 388 31 388 34"/>
+    <polygon id="Triangle" fill="#297be6" opacity="1" points="331 36 277 39 277 36"/>
+    <rect id="Rectangle" fill="#1437B8" x="271" y="20" width="123" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="332" y="18" width="1" height="6"/>
+    <rect id="Rectangle" fill="#1437B8" x="388" y="0" width="1" height="28"/>
+    <rect id="Rectangle" fill="#1437B8" x="271" y="6" width="123" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="276" y="0" width="1" height="28"/>
+    <polygon id="Triangle" fill="#297be6" opacity="1" transform="translate(332.500000, 3.000000) rotate(-90.000000) translate(-332.500000, -3.000000) " points="329.5 -52.5 335.5 58.5 329.5 58.5"/>
+    <polygon id="Triangle" fill="#297be6" opacity="1" transform="translate(360.500000, 17.000000) rotate(-90.000000) translate(-360.500000, -17.000000) " points="357.5 -10.5 363.5 44.5 357.5 44.5"/>
+    <polygon id="Triangle" fill="#297be6" opacity="1" transform="translate(304.500000, 25.000000) rotate(-270.000000) translate(-304.500000, -25.000000) " points="301.5 -2.5 307.5 52.5 301.5 52.5"/>
+    <rect id="Rectangle" fill="#1437B8" x="284" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="292" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="300" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="308" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="324" y="36" width="1" height="1"/>
+    <rect id="Rectangle" fill="#1437B8" x="316" y="36" width="1" height="1"/>
+    <rect id="Rectangle" fill="#1437B8" x="356" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="364" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="372" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="380" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="284" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="292" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="300" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="308" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="324" y="36" width="1" height="1"/>
+    <rect id="Rectangle" fill="#1437B8" x="316" y="36" width="1" height="1"/>
+    <rect id="Rectangle" fill="#1437B8" x="356" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="364" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="372" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="380" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="284" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="292" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="300" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="308" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="324" y="36" width="1" height="1"/>
+    <rect id="Rectangle" fill="#1437B8" x="316" y="36" width="1" height="1"/>
+    <rect id="Rectangle" fill="#1437B8" x="356" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="364" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#1437B8" x="372" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#1437B8" x="380" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="151" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="159" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="167" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="175" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="223" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="231" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="239" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="247" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="151" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="159" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="167" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="175" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="223" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="231" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="239" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="247" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="151" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="159" y="36" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="167" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="175" y="36" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="223" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="231" y="32" width="1" height="2"/>
+    <rect id="Rectangle" fill="#2B3E80" x="239" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#2B3E80" x="247" y="31" width="1" height="3"/>
+    <rect id="Rectangle" fill="#405CBF" x="284" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#405CBF" x="292" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#405CBF" x="300" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill="#405CBF" x="308" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill="#405CBF" x="356" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill="#405CBF" x="364" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill="#405CBF" x="372" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#405CBF" x="380" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#405CBF" x="284" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#405CBF" x="292" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#405CBF" x="300" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill="#405CBF" x="308" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill="#405CBF" x="356" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill="#405CBF" x="364" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill="#405CBF" x="372" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#405CBF" x="380" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="284" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="292" y="78" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="300" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="308" y="78" width="1" height="2"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="356" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="364" y="74" width="1" height="2"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="372" y="73" width="1" height="3"/>
+    <rect id="Rectangle" fill="#B6C4f6" x="380" y="73" width="1" height="3"/>
+  </g>
 </svg>

--- a/src/common/gui/CCursorHidingControl.cpp
+++ b/src/common/gui/CCursorHidingControl.cpp
@@ -59,12 +59,19 @@ CMouseEventResult CCursorHidingControl::onMouseMoved(CPoint& where, const CButto
 #if WINDOWS
    if (_isDetatched)
    {
-      double ddx = where.x - _detachPos.x;
-      double ddy = where.y - _detachPos.y;
-      double d = sqrt(ddx * ddx + ddy * ddy);
-      if (d > 10 && SetCursorPos(_hideX, _hideY))
+      // test for touch. If we are in a touch screen this cursor reset seems like a messy flip. See #1443
+      int value = GetSystemMetrics(SM_DIGITIZER);
+      bool hasTouch = ( value & ( NID_INTEGRATED_TOUCH | NID_EXTERNAL_TOUCH ) ) ? true : false;
+      
+      if (!hasTouch)
       {
-         _lastPos = _detachPos;
+         double ddx = where.x - _detachPos.x;
+         double ddy = where.y - _detachPos.y;
+         double d = sqrt(ddx * ddx + ddy * ddy);
+         if (d > 10 && SetCursorPos(_hideX, _hideY))
+         {
+            _lastPos = _detachPos;
+         }
       }
    }
 #endif


### PR DESCRIPTION
1. Increase the contrast between moduated-by-anything and
   modulated-by-current-source sliders. Closes #1455
2. Add touch compensation on windows, per contribution from
   @nathankopp. Addresses #1443, but need final user confirmation.