### PR TITLE
UP threhold on analog release unit test

### DIFF
--- a/src/headless/UnitTests.cpp
+++ b/src/headless/UnitTests.cpp
@@ -1083,7 +1083,7 @@ TEST_CASE( "ADSR Envelope Behaviour", "[mod]" )
          auto a = rand() * 1.0 / RAND_MAX + 0.03;
          auto d = rand() * 1.0 / RAND_MAX + 0.03;
          auto s = 0.7 * rand() * 1.0 / RAND_MAX + 0.2; // we have tested the s=0 case above
-         auto r = rand() * 1.0 / RAND_MAX;
+         auto r = rand() * 1.0 / RAND_MAX + 0.03;
          testAnalog( a, d, s, r);
       }
       


### PR DESCRIPTION
The analog release unit test was sometimes too fast to pass in
some random regimes. Make the floor a bit longer.