### PR TITLE
Refresh editor when clearing a modulation

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2319,6 +2319,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                      addCallbackMenu(contextMenu, tmptxt, [this, ms, ptag]() {
                                                              synth->clearModulation(ptag, (modsources)ms);
                                                              refresh_mod();
+                                                             /*
+                                                             ** FIXME - this is a pretty big hammer to deal with
+                                                             ** #1477 - can we be more parsimonious?
+                                                             */
+                                                             synth->refresh_editor = true;
                                                           });
                      eid++;
                   }


### PR DESCRIPTION
Some modulations in the LFO section don't repaint properly
when odulation is cleared. I can't figure out why so just
make that equivalent to an LFO swap or scene swap by
rebuilding. It's infrequent enough that we can afford it.

Closes #1477