### PR TITLE
Better Slider Modulation Visualization

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1647,6 +1647,36 @@ bool SurgeSynthesizer::isActiveModulation(long ptag, modsources modsource)
    return false;
 }
 
+bool SurgeSynthesizer::isBipolarModulation(modsources tms)
+{
+   // HERE
+   int scene_ms = storage.getPatch().scene_active.val.i;
+   /* You would think you could just do this nad ask for is_bipolar but remember the LFOs are made at voice time so... */
+   // auto ms = storage.getPatch().scene[scene_ms].modsources.at(tms);
+
+   // FIX - this will break in S++
+   if( tms >= ms_lfo1 && tms <= ms_slfo6 )
+   {
+      bool isup = storage.getPatch().scene[scene_ms].lfo[tms-ms_lfo1].unipolar.val.i;
+      // For now
+      return !isup;
+   }
+   if( tms >= ms_ctrl1 && tms <= ms_ctrl8 )
+   {
+      // Controls can also be bipolar
+      auto ms = storage.getPatch().scene[scene_ms].modsources[tms];
+      if( ms )
+         return ms->is_bipolar();
+      else
+         return false;
+   }
+   else
+   {
+      return false;
+   }
+}
+
+
 bool SurgeSynthesizer::isModDestUsed(long ptag)
 {
    int scene_ms = storage.getPatch().scene_active.val.i;

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -128,6 +128,7 @@ public:
    //	float getParameter (long index);
    bool isValidModulation(long ptag, modsources modsource);
    bool isActiveModulation(long ptag, modsources modsource);
+   bool isBipolarModulation(modsources modsources);
    bool isModsourceUsed(modsources modsource);
    bool isModDestUsed(long moddest);
    ModulationRouting* getModRouting(long ptag, modsources modsource);

--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -142,8 +142,8 @@ void CModulationSourceButton::draw(CDrawContext* dc)
    FontCol = UsedOrActive ? ColEdge : ColSemiTint;
    if (ActiveModSource)
    {
-      FrameCol = blink ? ColBlink : ColTint;
-      FillCol = blink ? ColBlink : ColTint;
+      FrameCol = ColBlink; // blink ? ColBlink : ColTint;
+      FillCol = ColBlink; // blink ? ColBlink : ColTint;
       FontCol = ColBG;
    }
    else if (SelectedModSource)

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -49,9 +49,10 @@ public:
    {
       has_modulation = b;
    } // true if the slider has modulation routings assigned to it
-   virtual void setModCurrent(bool b)
+   virtual void setModCurrent(bool isCurrent, bool isBipolarModulator)
    {
-      has_modulation_current = b;
+      has_modulation_current = isCurrent;
+      modulation_is_bipolar = isBipolarModulator;
       invalid();
    } // - " " - for the currently selected modsource
    virtual void bounceValue(const bool keeprest = false);
@@ -94,7 +95,7 @@ private:
    float moverate, statezoom;
    int typex, typey;
    int typehx, typehy;
-   bool has_modulation, has_modulation_current;
+   bool has_modulation, has_modulation_current, modulation_is_bipolar = false;
    bool is_temposync = false;
    VSTGUI::CPoint lastpoint, sourcepoint;
    float oldVal, *edit_value;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -606,7 +606,7 @@ void SurgeGUIEditor::refresh_mod()
          {
             s->setModMode(mod_editor ? 1 : 0);
             s->setModPresent(synth->isModDestUsed(i));
-            s->setModCurrent(synth->isActiveModulation(i, thisms));
+            s->setModCurrent(synth->isActiveModulation(i, thisms), synth->isBipolarModulation(thisms));
          }
          // s->setDirty();
          s->setModValue(synth->getModulation(i, thisms));
@@ -1369,7 +1369,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
                hs->setModMode(mod_editor ? 1 : 0);
                hs->setModValue(synth->getModulation(p->id, modsource));
                hs->setModPresent(synth->isModDestUsed(p->id));
-               hs->setModCurrent(synth->isActiveModulation(p->id, modsource));
+               hs->setModCurrent(synth->isActiveModulation(p->id, modsource), synth->isBipolarModulation(modsource));
                hs->setValue(p->get_value_f01());
                hs->setLabel(p->get_name());
                hs->setMoveRate(p->moverate);
@@ -2413,7 +2413,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             synth->clearModulation(ptag, thisms);
             ((CSurgeSlider*)control)->setModValue(synth->getModulation(p->id, thisms));
             ((CSurgeSlider*)control)->setModPresent(synth->isModDestUsed(p->id));
-            ((CSurgeSlider*)control)->setModCurrent(synth->isActiveModulation(p->id, thisms));
+            ((CSurgeSlider*)control)->setModCurrent(synth->isActiveModulation(p->id, thisms), synth->isBipolarModulation(thisms));
             // control->setGhostValue(p->get_value_f01());
             oscdisplay->invalid();
             return 1;
@@ -2717,7 +2717,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
             }
             synth->setModulation(ptag, thisms, ((CSurgeSlider*)control)->getModValue());
             ((CSurgeSlider*)control)->setModPresent(synth->isModDestUsed(p->id));
-            ((CSurgeSlider*)control)->setModCurrent(synth->isActiveModulation(p->id, thisms));
+            ((CSurgeSlider*)control)->setModCurrent(synth->isActiveModulation(p->id, thisms), synth->isBipolarModulation(thisms));
 
             synth->getParameterName(ptag, txt);
             sprintf(pname, "%s -> %s", modsource_abberations_short[thisms], txt);


### PR DESCRIPTION
The sliders are always confusing as to exactly how far you are
modulationg, especially with hidden bi- and uni-polar stuff. So
draw a distance line which acts accordingly under the handles in
modulation mode. Also, remove the annoying modulation blink