### PR TITLE
Streaming and MPE Changes

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1442,10 +1442,15 @@ bool SurgeStorage::remapToKeyboard(const Surge::Storage::KeyboardMapping& k)
       tuningPitch = k.tuningFrequency / 8.175798915;
       tuningPitchInv = 1.0 / tuningPitch;
    }
-   // The mapping will change all the cached pitches.
-   if( ! currentScale.isValid() )
+   // The mapping will change all the cached pitches so we need to redo
+   if( isStandardMapping && isStandardTuning )
    {
-      // We need to set the current scale to a default scale
+      retuneToStandardTuning();
+   }
+   else if( !isStandardMapping && !currentScale.isValid() )
+   {
+      // We need to set the current scale to a default scale so we can remap the keyboard.
+      // This is an odd edge case but we do need to support it.
       retuneToScale(Surge::Storage::Scale::evenTemperament12NoteScale());
    }
    else

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -837,6 +837,9 @@ void SurgeSynthesizer::onRPN(int channel, int lsbRPN, int msbRPN, int lsbValue, 
      
      for each channel. Which seems unrelated to the spec. But as a result the original onRPN code
      means you get no MPE with a Roli Seaboard.
+
+     Hey one year later an edit: Those aren't coming from ROLI they are coming from Logic PRO and
+     now that I correct modify and stream MPE state, we should not listen to those messages.
      */
     
    if (lsbRPN == 0 && msbRPN == 0) // PITCH BEND RANGE
@@ -854,17 +857,26 @@ void SurgeSynthesizer::onRPN(int channel, int lsbRPN, int msbRPN, int lsbValue, 
    {
       mpeEnabled = msbValue > 0;
       mpeVoices = msbValue & 0xF;
-      mpePitchBendRange = Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
+      if( mpePitchBendRange < 0 )
+         mpePitchBendRange = Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
       mpeGlobalPitchBendRange = 0;
       return;
    }
    else if (lsbRPN == 4 && msbRPN == 0 && channel != 0 && channel != 0xF )
    {
+      /*
+      ** This is code sent by logic in all cases for some reason. In ancient times
+      ** I thought it came from a roli. But I since changed the MPE state management so
+      ** with 1.6.5 do this:
+      */
+#if 0      
        // This is the invalid message which the ROLI sends. Rather than have the Roli not work
        mpeEnabled = true;
        mpeVoices = msbValue & 0xF;
        mpePitchBendRange = Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
+       std::cout << __LINE__ << " " << __FILE__ << " MPEE=" << mpeEnabled << " MPEPBR=" << mpePitchBendRange << std::endl;
        mpeGlobalPitchBendRange = 0;
+#endif       
        return;
    }
 }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3461,8 +3461,20 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMpeMenu(VSTGUI::CRect &menuRect)
                     [this]() { this->synth->mpeEnabled = !this->synth->mpeEnabled; });
 
     std::ostringstream oss;
-    oss << "Change default pitch bend range (" << synth->mpePitchBendRange << ")";
+    oss << "Change pitch bend range (range=" << synth->mpePitchBendRange << ")";
     addCallbackMenu(mpeSubMenu, oss.str().c_str(), [this]() {
+       // FIXME! This won't work on linux
+       char c[256];
+       snprintf(c, 256, "%d", synth->mpePitchBendRange);
+       spawn_miniedit_text(c, 16);
+       int newVal = ::atoi(c);
+       this->synth->mpePitchBendRange = newVal;
+    });
+
+    std::ostringstream oss2;
+    int def = Surge::Storage::getUserDefaultValue( &(synth->storage), "mpePitchBendRange", 48 );
+    oss2 << "Change default pitch bend range (range=" << synth->mpePitchBendRange <<" default=" << def << ")";
+    addCallbackMenu(mpeSubMenu, oss2.str().c_str(), [this]() {
        // FIXME! This won't work on linux
        char c[256];
        snprintf(c, 256, "%d", synth->mpePitchBendRange);

--- a/src/headless/UnitTestsIO.cpp
+++ b/src/headless/UnitTestsIO.cpp
@@ -83,7 +83,7 @@ TEST_CASE( "All Patches are Loadable", "[io]" )
    }
 }
 
-TEST_CASE( "DAW Streaming and Unstreaming", "[io]" )
+TEST_CASE( "DAW Streaming and Unstreaming", "[io][mpe][tun]" )
 {
    // The basic plan of attack is, in a section, set up two surges,
    // stream onto data on the first and off of data on the second
@@ -155,6 +155,19 @@ TEST_CASE( "DAW Streaming and Unstreaming", "[io]" )
       fromto( surgeSrc, surgeDest );
       REQUIRE( surgeDest->mpePitchBendRange == v2 );
    }
+   
+   SECTION( "Everything Standard Stays Standard" )
+   {
+      auto surgeSrc = Surge::Headless::createSurge(44100);
+      auto surgeDest = Surge::Headless::createSurge(44100);
+      REQUIRE( surgeSrc->storage.isStandardTuning );
+      REQUIRE( surgeSrc->storage.isStandardMapping );
+      fromto(surgeSrc, surgeDest );
+      REQUIRE( surgeSrc->storage.isStandardTuning );
+      REQUIRE( surgeSrc->storage.isStandardMapping );
+      REQUIRE( surgeDest->storage.isStandardTuning );
+      REQUIRE( surgeDest->storage.isStandardMapping );
+   }
 
    SECTION( "SCL State Saves" )
    {
@@ -212,6 +225,5 @@ TEST_CASE( "DAW Streaming and Unstreaming", "[io]" )
       REQUIRE( surgeDest->storage.isStandardMapping );
 
    }
-
 
 }


### PR DESCRIPTION
- The KBM restore meant tuning was activated for standard tuned
  elements when saving and restoring. Fix that. Closes #1504
- Add MPE menus to distinguish between the default and current
  synth state and stream them properly. Closes #1355
- Remove the confusion about MPE-activating midi messages
  which over-triggered MPE in Logic Pro. Closes #1505