### PR TITLE
Move Windows Assets to ProgramData

### DIFF
--- a/installer_win/surge-x86.iss
+++ b/installer_win/surge-x86.iss
@@ -45,7 +45,7 @@ Name: EffectsVST3; Description: SurgeEffectsBank VST3 Plug-in (32 bit); Types: f
 Source: ..\target\vst2\Release\Surge_x86.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\target\vst3\Release\Surge_x86.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
 Source: ..\fxbuild\surge-fx\Builds\VisualStudio2017\Win32\ReleaseWin32\VST3\SurgeEffectsBank.vst3; DestDir: {cf}\VST3; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist
-Source: ..\resources\data\*; DestDir: {localappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
+Source: ..\resources\data\*; DestDir: {commonappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
 Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 
 [Languages]

--- a/installer_win/surge.iss
+++ b/installer_win/surge.iss
@@ -45,7 +45,7 @@ Name: EffectsVST3; Description: SurgeEffectsBank VST3 Plug-in (64 bit); Types: f
 Source: ..\target\vst2\Release\Surge.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\target\vst3\Release\Surge.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
 Source: ..\fxbuild\surge-fx\Builds\VisualStudio2017\x64\Release\VST3\SurgeEffectsBank.vst3; DestDir: {cf}\VST3; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist
-Source: ..\resources\data\*; DestDir: {localappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
+Source: ..\resources\data\*; DestDir: {commonappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
 Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 
 [Languages]

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -235,12 +235,28 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath)
 #if TARGET_RACK
    datapath = suppliedDataPath;
 #else
-   PWSTR localAppData;
-   if (!SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppData))
+   bool foundSurge = false;
+   PWSTR commonAppData;
+   if (!SHGetKnownFolderPath(FOLDERID_ProgramData, 0, nullptr, &commonAppData))
    {
       CHAR path[4096];
-      wsprintf(path, "%S\\Surge\\", localAppData);
+      wsprintf(path, "%S\\Surge\\", commonAppData);
       datapath = path;
+      if( fs::is_directory( fs::path( datapath ) ) )
+         foundSurge = true;
+      else
+         datapath = "";
+   }
+
+   if( ! foundSurge ) {
+      PWSTR localAppData;
+      if (!SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppData))
+      {
+         CHAR path[4096];
+         wsprintf(path, "%S\\Surge\\", localAppData);
+         datapath = path;
+         foundSurge = true;
+      }
    }
 
    PWSTR documentsFolder;

--- a/src/common/gui/CAboutBox.cpp
+++ b/src/common/gui/CAboutBox.cpp
@@ -68,8 +68,9 @@ void CAboutBox::draw(CDrawContext* pContext)
       std::vector< std::string > msgs = { {
               std::string() + "Version " + SURGE_STR(SURGE_VERSION) + " (" + bittiness + " " + platform + " " + flavor + ". Built " +
               __DATE__ + " " + __TIME__ + ")",
+              std::string() + "Resources: dataPath=" + dataPath + " userData=" + userPath,
               "Released under the GNU General Public License, v3",
-              "Copyright 2005-2019 by individual contributors",
+              "Copyright 2005-2020 by individual contributors",
               "Source, contributors and other information at https://github.com/surge-synthesizer/surge",
               "VST Plug-in technology by Steinberg, AU Plugin Technology by Apple Computer"
           } };
@@ -103,8 +104,10 @@ bool CAboutBox::hitTest(const CPoint& where, const CButtonState& buttons)
 
 //------------------------------------------------------------------------
 
-void CAboutBox::boxShow()
+void CAboutBox::boxShow(std::string dataPath, std::string userPath)
 {
+   this->dataPath = dataPath;
+   this->userPath = userPath;
    setViewSize(toDisplay);
    setMouseableArea(toDisplay);
    value = 1.f;

--- a/src/common/gui/CAboutBox.h
+++ b/src/common/gui/CAboutBox.h
@@ -30,7 +30,7 @@ public:
                const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
    virtual void unSplash();
 
-   void boxShow();
+   void boxShow(std::string dataPath, std::string userPath);
    void boxHide(bool invalidateframe = true);
 
    CLASS_METHODS(CAboutBox, VSTGUI::CControl)
@@ -41,6 +41,7 @@ protected:
    VSTGUI::CPoint offset;
    VSTGUI::SharedPointer<VSTGUI::CBitmap> _aboutBitmap;
    bool bvalue;
+   std::string dataPath, userPath;
 
    static VSTGUI::SharedPointer<VSTGUI::CFontDesc> infoFont;
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3439,7 +3439,7 @@ void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)
 
     addCallbackMenu(settingsMenu, "About", [this]() {
        if (aboutbox)
-          ((CAboutBox*)aboutbox)->boxShow();
+          ((CAboutBox*)aboutbox)->boxShow(this->synth->storage.datapath, this->synth->storage.userDataPath);
     });
     eid++;
 


### PR DESCRIPTION
Move windows assets to ProgramData, failing back to LocalAppData.
Show paths in the About screen. Modify the installers.

Addresses #1289