### PR TITLE
Add a "ParameterAlt" display for tooltip; use for Freq

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -858,6 +858,41 @@ std::string Parameter::tempoSyncNotationValue(float f)
     return res;
 }
 
+void Parameter::get_display_alt(char* txt, bool external, float ef)
+{
+   
+   txt[0] = 0;
+   switch( ctrltype )
+   {
+   case ct_freq_hpf:
+   case ct_freq_audible:
+   case ct_freq_vocoder_low:
+   case ct_freq_vocoder_high:
+   {
+      float f = val.f;
+      int i_value = (int)( f + 0.5 ) + 69; // that 1/2th centers us
+      if( i_value < 0 ) i_value = 0; 
+      int octave = (i_value / 12) - 1;
+      char notenames[12][3] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+      sprintf(txt, "~%s%d", notenames[i_value % 12], octave);
+      break;
+   }
+   case ct_countedset_percent:
+      if (user_data != nullptr)
+      {
+         // We check when set so the reinterpret cast is safe and fast
+         float f = val.f;
+         CountedSetUserData* cs = reinterpret_cast<CountedSetUserData*>(user_data);
+         auto count = cs->getCountedSetSize();
+         auto tl = count * f;
+         sprintf(txt, "%.1f / %d", tl, count);
+      }
+
+      break;
+
+   }
+}
+
 void Parameter::get_display(char* txt, bool external, float ef)
 {
    if (ctrltype == ct_none)
@@ -940,22 +975,8 @@ void Parameter::get_display(char* txt, bool external, float ef)
          break;
       case ct_percent:
       case ct_percent_bidirectional:
-         sprintf(txt, "%.1f %c", f * 100.f, '%');
-         break;
       case ct_countedset_percent:
-         if (user_data == nullptr)
-         {
-            sprintf(txt, "%.1f %c", f * 100.f, '%');
-         }
-         else
-         {
-            // We check when set so the reinterpret cast is safe and fast
-            CountedSetUserData* cs = reinterpret_cast<CountedSetUserData*>(user_data);
-            auto count = cs->getCountedSetSize();
-            auto tl = count * f;
-            sprintf(txt, "%.1f%% (%.1f / %d)", f * 100.f, tl, count);
-         }
-
+         sprintf(txt, "%.1f %c", f * 100.f, '%');
          break;
       case ct_oscspread:
          if (absolute)
@@ -974,11 +995,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
       case ct_freq_vocoder_low:
       case ct_freq_vocoder_high:
       {
-         int i_value = (int)( f + 0.5 ) + 69; // that 1/2th centers us
-         if( i_value < 0 ) i_value = 0; 
-         int octave = (i_value / 12) - 1;
-         char notenames[12][3] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
-         sprintf(txt, "%.3f Hz (~%s%d)", 440.f * powf(2.0f, f / 12.f),  notenames[i_value % 12], octave);
+         sprintf(txt, "%.3f Hz", 440.f * powf(2.0f, f / 12.f) );
          break;
       }
       case ct_freq_mod:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -159,6 +159,7 @@ public:
    const char* get_storage_name();
    const wchar_t* getUnit() const;
    void get_display(char* txt, bool external = false, float ef = 0.f);
+   void get_display_alt(char* txt, bool external = false, float ef = 0.f);
    char* get_storage_value(char*);
    void set_storage_value(int i);
    void set_storage_value(float f);

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2002,6 +2002,18 @@ void SurgeSynthesizer::getParameterDisplay(long index, char* text)
       sprintf(text, "-");
 }
 
+void SurgeSynthesizer::getParameterDisplayAlt(long index, char* text)
+{
+   if ((index >= 0) && (index < storage.getPatch().param_ptr.size()))
+   {
+      storage.getPatch().param_ptr[index]->get_display_alt(text);
+   }
+   else 
+   {
+      text[0] = 0;
+   }
+}
+
 void SurgeSynthesizer::getParameterDisplay(long index, char* text, float x)
 {
    if ((index >= 0) && (index < storage.getPatch().param_ptr.size()))

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -142,6 +142,7 @@ public:
    int remapInternalToExternalApiId(unsigned int x);
    void getParameterDisplay(long index, char* text);
    void getParameterDisplay(long index, char* text, float x);
+   void getParameterDisplayAlt(long index, char* text);
    void getParameterName(long index, char* text);
    void getParameterMeta(long index, parametermeta& pm);
    void getParameterNameW(long index, wchar_t* ptr);

--- a/src/common/gui/CParameterTooltip.h
+++ b/src/common/gui/CParameterTooltip.h
@@ -3,6 +3,7 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 #include "vstcontrols.h"
+#include <iostream>
 
 class CParameterTooltip : public VSTGUI::CControl
 {
@@ -15,7 +16,7 @@ public:
       last_tag = -1;
    }
 
-   void setLabel(const char* txt1, const char* txt2)
+   void setLabel(const char* txt1, const char* txt2, const char* txt2left = nullptr)
    {
       if (txt1)
          strncpy(label[0], txt1, 256);
@@ -25,6 +26,11 @@ public:
          strncpy(label[1], txt2, 256);
       else
          label[1][0] = 0;
+      if (txt2left)
+         strncpy(label2left, txt2left, 256);
+      else
+         label2left[0] = 0;
+      
       setDirty(true);
    }
 
@@ -91,6 +97,8 @@ public:
              dc->drawString(label[0], tupper, VSTGUI::kLeftText, true);
          // dc->drawString(label[1],tlower,false,label[0][0]?kRightText:kCenterText);
          dc->drawString(label[1], tlower, VSTGUI::kRightText, true);
+         if( label2left[0] )
+            dc->drawString(label2left, tlower, VSTGUI::kLeftText, true);
          // dc->copyFrom(dc1,smaller);
          // dc->forget();
       }
@@ -98,7 +106,7 @@ public:
    }
 
 protected:
-   char label[2][256];
+   char label[2][256], label2left[256];
    bool visible;
    int last_tag;
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2799,7 +2799,9 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                   control->invalid();
                synth->getParameterName(ptag, pname);
                synth->getParameterDisplay(ptag, pdisp);
-               ((CParameterTooltip*)infowindow)->setLabel(0, pdisp);
+               char pdispalt[256];
+               synth->getParameterDisplayAlt(ptag, pdispalt);
+               ((CParameterTooltip*)infowindow)->setLabel(0, pdisp, pdispalt);
                if (p->ctrltype == ct_polymode)
                   modulate = true;
             }


### PR DESCRIPTION
The addition of a note to the frequency display meant the percentage bounced
around like crazy. So add the capability to ahve an alternate parameter display
which is only used on the tooltip (not sent to the DAW/Automation) and left
aligns. Use that for the note approximation of frequency and for the position
in a wavetable.

Closes #447