### PR TITLE
A Collection of 1.6.5 fixes and cleanups

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -114,8 +114,10 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       {
          char label[16];
          sprintf(label, "p%i", p);
+         char dawlabel[32];
+         sprintf(dawlabel, "param %i", p);
          param_ptr.push_back(
-             this->fx[fx].p[p].assign(p_id++, 0, label, "param", ct_none, px, py, 0, cg_FX, fx,
+             this->fx[fx].p[p].assign(p_id++, 0, label, dawlabel, ct_none, px, py, 0, cg_FX, fx,
                                       true, Surge::ParamConfig::kHorizontal | kHide | ((fx == 0) ? kEasy : 0)));
          py += 20;
       }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1674,7 +1674,9 @@ bool SurgeSynthesizer::isBipolarModulation(modsources tms)
    // FIX - this will break in S++
    if( tms >= ms_lfo1 && tms <= ms_slfo6 )
    {
-      bool isup = storage.getPatch().scene[scene_ms].lfo[tms-ms_lfo1].unipolar.val.i;
+      bool isup = storage.getPatch().scene[scene_ms].lfo[tms-ms_lfo1].unipolar.val.i ||
+         storage.getPatch().scene[scene_ms].lfo[tms-ms_lfo1].shape.val.i == ls_constant1;
+      
       // For now
       return !isup;
    }
@@ -1686,6 +1688,10 @@ bool SurgeSynthesizer::isBipolarModulation(modsources tms)
          return ms->is_bipolar();
       else
          return false;
+   }
+   if( tms == ms_keytrack )
+   {
+      return true;
    }
    else
    {

--- a/src/common/Tunings.cpp
+++ b/src/common/Tunings.cpp
@@ -406,3 +406,29 @@ R"HTML(
   return htmls.str();
 
 }
+
+Surge::Storage::KeyboardMapping Surge::Storage::KeyboardMapping::tuneA69To(double freq)
+{
+   // There's a couple of ways to do this but since I want it to stream I will syntheitcally create
+   // a KBM file
+   std::ostringstream oss;
+   oss << R"KBM(! Surge Synthetic Keyboard Tuning to Retune A69
+!
+! Map Size
+0
+! First note
+0
+! Last note
+127
+! First mapping
+60
+! Reference Note
+69
+! Reference Freqency
+)KBM" << freq << R"KBM(
+! Scale Degree
+0
+! Mapping)KBM";
+   std::cout << oss.str() << std::endl;;
+   return parseKBMData( oss.str() );
+}

--- a/src/common/Tunings.h
+++ b/src/common/Tunings.h
@@ -78,6 +78,8 @@ struct KeyboardMapping
             keys.push_back(i);
       }
 
+   static KeyboardMapping tuneA69To(double freq);
+   
    // TODO
    // std::string toHtml(); 
 };

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -4,6 +4,7 @@
 #include "CLFOGui.h"
 #include "LfoModulationSource.h"
 #include "UserDefaults.h"
+#include "SurgeGUIEditor.h"
 #include <chrono>
 
 using namespace VSTGUI;
@@ -997,6 +998,14 @@ CMouseEventResult CLFOGui::onMouseMoved(CPoint& where, const CButtonState& butto
             {
                lfodata->shape.val.i = i;
                invalid();
+
+               // This is such a hack
+               auto sge = dynamic_cast<SurgeGUIEditor *>(listener);
+               if( sge )
+               {
+                  sge->refresh_mod();
+               }
+               
             }
          }
       }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2862,7 +2862,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                   modulate = true;
             }
 
-            if( p->ctrltype == ct_bool_unipolar )
+            if( p->ctrltype == ct_bool_unipolar || p->ctrltype == ct_lfoshape )
             {
                // The green line might change so...
                refresh_mod();
@@ -3645,6 +3645,29 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect)
         );
     tid++;
 
+    addCallbackMenu( tuningSubMenu, "ReMap A4 (midi #69) frequency directly to...",
+                     [this]()
+                        {
+                           char c[256];
+                           snprintf(c, 256, "440.0");
+                           spawn_miniedit_text(c, 16);
+                           float freq = ::atof(c);
+                           if( freq == 440.0 )
+                           {
+                              this->synth->storage.remapToStandardKeyboard();
+                           }
+                           else
+                           {
+                              auto kb = Surge::Storage::KeyboardMapping::tuneA69To(freq);
+                              if( ! this->synth->storage.remapToKeyboard(kb) )
+                              {
+                                 Surge::UserInteractions::promptError( "This .kbm file is not valid", "File format error" );
+                                 return;
+                              }
+                           }
+                        }
+       );
+    
     tuningSubMenu->addSeparator();
     tid++;
     auto *sct = addCallbackMenu(tuningSubMenu, "Show current tuning",

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -100,6 +100,7 @@ protected:
    void controlBeginEdit(VSTGUI::CControl* pControl) override;
    void controlEndEdit(VSTGUI::CControl* pControl) override;
 
+public:
    void refresh_mod();
 
 #if TARGET_VST3


### PR DESCRIPTION
- Keytrack is bipolar on greenline. Closes #1529
- Envelope LFO is unipolar on greenline. Cloese #1527
- FX VST Display Names have slot number. Closes #1528
- Allow a remap to a note other than 440 without a KBM
  Closes #1526 but still succeptible to the bug in #1533