### PR TITLE
Fix VST2 build error

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -1,10 +1,10 @@
 //-------------------------------------------------------------------------------------------------------
 //	Copyright 2005 Claes Johanson & Vember Audio
 //-------------------------------------------------------------------------------------------------------
+#include "SurgeGUIEditor.h"
 #include "CLFOGui.h"
 #include "LfoModulationSource.h"
 #include "UserDefaults.h"
-#include "SurgeGUIEditor.h"
 #include <chrono>
 
 using namespace VSTGUI;


### PR DESCRIPTION
VST2 is fragile header ordered with VSTGUI, and also we don't build it in our
PR pipeline, so I broke it. This unbreaks it.