### PR TITLE
Correct errors in Mac Live / VST3

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2070,14 +2070,19 @@ void SurgeSynthesizer::getParameterNameW(long index, wchar_t* ptr)
    else if (index >= metaparam_offset)
    {
       int c = index - metaparam_offset;
+      // For a reason I don't understand, on windows, we need to sprintf then swprinf just the short char
+      // to make just these names work. :shrug:
+      char wideHack[256];
+       
       if (c >= num_metaparameters)
       {
-         swprintf(ptr, 128, L"C%i:ERROR");
+         snprintf(wideHack, 255, "C:ERROR");
       }
       else
       {
-         swprintf(ptr, 128, L"C%i:%s", c + 1, storage.getPatch().CustomControllerLabel[c]);
+         snprintf(wideHack, 255, "C%d:%s", c+1, storage.getPatch().CustomControllerLabel[c]);
       }
+      swprintf(ptr, 128, L"%s", wideHack);
    }
    else
    {
@@ -2093,15 +2098,7 @@ void SurgeSynthesizer::getParameterShortNameW(long index, wchar_t* ptr)
    }
    else if (index >= metaparam_offset)
    {
-      int c = index - metaparam_offset;
-      if (c >= num_metaparameters)
-      {
-         swprintf(ptr, 128, L"C%i:ERROR", c + 1);
-      }
-      else
-      {
-         swprintf(ptr, 128, L"C%i:%s", c + 1, storage.getPatch().CustomControllerLabel[c]);
-      }
+       getParameterNameW( index, ptr );
    }
    else
    {
@@ -2204,6 +2201,8 @@ float SurgeSynthesizer::normalizedToValue(long index, float value)
 {
    if (index < 0)
       return 0.f;
+   if (index >= metaparam_offset)
+      return value;
    if (index < storage.getPatch().param_ptr.size())
       return storage.getPatch().param_ptr[index]->normalized_to_value(value);
    return 0.f;
@@ -2213,6 +2212,8 @@ float SurgeSynthesizer::valueToNormalized(long index, float value)
 {
    if (index < 0)
       return 0.f;
+   if (index >= metaparam_offset)
+      return value;
    if (index < storage.getPatch().param_ptr.size())
       return storage.getPatch().param_ptr[index]->value_to_normalized(value);
    return 0.f;

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -747,14 +747,17 @@ tresult PLUGIN_API SurgeVst3Processor::getParamStringByValue(ParamID tag,
                                                              ParamValue valueNormalized,
                                                              String128 ontostring)
 {
+   // std::cout << __LINE__ << " " << __func__ << " " << tag << std::endl;
    CHECK_INITIALIZED;
 
-   if (tag >= getParameterCount() )
+   if( tag >= metaparam_offset && tag <= metaparam_offset + num_metaparameters ) 
+   {
+   }
+   else if (tag >= getParameterCount() )
    {
       return kInvalidArgument;
    }
-
-   if( tag >= getParameterCountWithoutMappings() )
+   else if( tag >= getParameterCountWithoutMappings() )
    {
       return kResultOk;
    }
@@ -774,6 +777,7 @@ tresult PLUGIN_API SurgeVst3Processor::getParamValueByString(ParamID tag,
                                                              TChar* string,
                                                              ParamValue& valueNormalized)
 {
+   // std::cout << __LINE__ << " " << __func__ << " " << tag << std::endl;
    CHECK_INITIALIZED;
       
    if (tag >= getParameterCount())
@@ -787,13 +791,17 @@ tresult PLUGIN_API SurgeVst3Processor::getParamValueByString(ParamID tag,
 ParamValue PLUGIN_API SurgeVst3Processor::normalizedParamToPlain(ParamID tag,
                                                                  ParamValue valueNormalized)
 {
+   // std::cout << __LINE__ << " " << __func__ << " " << tag << std::endl;
    ABORT_IF_NOT_INITIALIZED;
 
-   if (tag >= getParameterCount())
+   if( tag >= metaparam_offset && tag <= metaparam_offset + num_metaparameters ) 
+   {
+   }
+   else if (tag >= getParameterCount())
    {
       return kInvalidArgument;
    }
-   if( tag >= getParameterCountWithoutMappings())
+   else if( tag >= getParameterCountWithoutMappings())
    {
       return 0;
    }
@@ -803,21 +811,27 @@ ParamValue PLUGIN_API SurgeVst3Processor::normalizedParamToPlain(ParamID tag,
 
 ParamValue PLUGIN_API SurgeVst3Processor::plainParamToNormalized(ParamID tag, ParamValue plainValue)
 {
+   // std::cout << __LINE__ << " " << __func__ << " " << tag << " " << plainValue << std::endl;
    ABORT_IF_NOT_INITIALIZED
 
-   if (tag >= getParameterCountWithoutMappings())
+   if( tag >= metaparam_offset && tag <= metaparam_offset + num_metaparameters ) 
+   {
+   }
+   else if (tag >= getParameterCountWithoutMappings())
    {
        // return kInvalidArgument;
        // kInvalidArgument is not a ParamValue. In this case just
        return 0;
    }
 
-   return surgeInstance->valueToNormalized(tag, plainValue);
+   auto res = surgeInstance->valueToNormalized(tag, plainValue);
+   // std::cout << __LINE__ << " " << __func__ << " " << tag << " " << plainValue << " = " << res << std::endl;
+   return res;
 }
 
 ParamValue PLUGIN_API SurgeVst3Processor::getParamNormalized(ParamID tag)
 {
-   //std::cout << __LINE__ << " getParamNormalized " << tag << std::endl;
+   // std::cout << __LINE__ << " getParamNormalized " << tag << std::endl;
    ABORT_IF_NOT_INITIALIZED;
 
    if(tag >= getParameterCountWithoutMappings() &&
@@ -837,6 +851,7 @@ ParamValue PLUGIN_API SurgeVst3Processor::getParamNormalized(ParamID tag)
 
 tresult PLUGIN_API SurgeVst3Processor::setParamNormalized(ParamID tag, ParamValue value)
 {
+   // std::cout << __LINE__ << " " << __func__ << " " << tag << std::endl;
    CHECK_INITIALIZED;
 
    if( tag >= metaparam_offset && tag <= metaparam_offset + num_metaparameters ) 


### PR DESCRIPTION
The CC thing still wasn't quite right. This gets it working in
Live at least on my demo version on my mac.

Also address a windows-only wide string issue with CC names

Addresses #1531