### PR TITLE
Add FM for the Window Oscillator

### DIFF
--- a/doc/pauls-debug-fragments.txt
+++ b/doc/pauls-debug-fragments.txt
@@ -28,3 +28,5 @@ void stackToInfo()
     free(strs);
 #endif
 }
+---
+#define _D(x) " " << (#x) << "=" << x

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -265,6 +265,8 @@ private:
                                                // per-sample scheduling)
       unsigned char Gain[wt2_suboscs][2];
       float DriftLFO[wt2_suboscs][2];
+
+      int FMRatio[wt2_suboscs][BLOCK_SIZE_OS];
    } Sub alignas(16);
 
 public:
@@ -277,7 +279,9 @@ public:
    virtual ~WindowOscillator();
 
 private:
-   void ProcessSubOscs(bool);
+   void ProcessSubOscs(bool stereo, bool FM);
+   lag<double> FMdepth[wt2_suboscs];
+
    float OutAttenuation;
    float DetuneBias, DetuneOffset;
    int ActiveSubOscs;


### PR DESCRIPTION
The Window Oscillator didn't support FM. Now it does. I chose the
depth callibration to match the FM2 and Sin-non-legacy FM callibration.

Closes #1171

But I want to add another issue to think about if
or how I can regtest this.