### PR TITLE
Apply the WideHack to CC %

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2129,7 +2129,11 @@ void SurgeSynthesizer::getParameterStringW(long index, float value, wchar_t* ptr
    }
    else if (index >= metaparam_offset)
    {
-      swprintf(ptr, 128, L"%.2f %%", 100.f * value);
+      // For a reason I don't understand, on windows, we need to sprintf then swprinf just the short char
+      // to make just these names work. :shrug:
+      char wideHack[256];
+      snprintf(wideHack, 256, "%.2f %%", 100.f * value ); 
+      swprintf(ptr, 128, L"%s", wideHack);
    }
    else
    {

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -232,7 +232,6 @@ void SurgeVoice::switch_toggled()
          osc[i].reset(spawn_osc(scene->osc[i].type.val.i, storage, &scene->osc[i], localcopy));
          if (osc[i])
          {
-            std::cout << __LINE__ << " init" << std::endl;
             osc[i]->init(state.pitch);
          }
          osctype[i] = scene->osc[i].type.val.i;


### PR DESCRIPTION
The CC % was cursed by the same wierd wide string problem
as the metaparam name. I don't understand why this fix
fixes it, but I also haven't invested enough in windows
wide strings to be too bothered, since this does work.

Closes #1553