### PR TITLE
Send ValueChanged on MouseDown, showing Window

### DIFF
--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -562,6 +562,11 @@ CMouseEventResult CSurgeSlider::onMouseDown(CPoint& where, const CButtonState& b
       restvalue = 0.f;
       restmodval = 0.f;
 
+      // Show the infowindow. Bit heavy handed
+      bounceValue();
+      if( listener )
+         listener->valueChanged( this );
+      
       detachCursor(where);
       return kMouseEventHandled;
    }


### PR DESCRIPTION
We used to send Value Changed (and show InfoWindow) only
on mouse moved. Now send it on MouseDown. That's an idempotent
change since we are just setting value to the value, but it
makes the UI far more consistent.

Closes #1549