### PR TITLE
Add "Refresh" options to patch and wavetable menu

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -736,6 +736,12 @@ void COscillatorDisplay::populateMenu(COptionMenu* contextMenu, int selectedItem
        };
    contentItem->setActions(contentAction,nullptr);
    contextMenu->addEntry(contentItem);
+
+   auto refreshItem = new CCommandMenuItem(CCommandMenuItem::Desc("Refresh Wavetable List"));
+   auto refresh = [this](CCommandMenuItem* item) { this->storage->refresh_wtlist(); };
+   refreshItem->setActions(refresh, nullptr);
+   contextMenu->addEntry(refreshItem);
+
 }
 
 bool COscillatorDisplay::populateMenuForCategory(COptionMenu* contextMenu,

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -118,7 +118,15 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint& where, const CButtonState& 
        };
    contentItem->setActions(contentAction,nullptr);
    contextMenu->addEntry(contentItem);
-   
+
+   auto refreshItem = new CCommandMenuItem(CCommandMenuItem::Desc("Refresh Patch List"));
+   auto refreshAction = [this](CCommandMenuItem *item)
+                           {
+                              this->storage->refresh_patchlist();
+                           };
+   refreshItem->setActions(refreshAction,nullptr);
+   contextMenu->addEntry(refreshItem);
+
    getFrame()->addView(contextMenu); // add to frame
    contextMenu->setDirty();
    contextMenu->popup();


### PR DESCRIPTION
As well as having refresh all data in the user/data menu
add refresh patch and refresh wave lists to the places where
you open waves and patches.

Closes #1197