### PR TITLE
Start changing internal datastructures

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -10,7 +10,9 @@
 #include <sstream>
 #include <string>
 
-Parameter::Parameter()
+Parameter::Parameter() : posx( PositionHolder::Axis::X ),
+                         posy( PositionHolder::Axis::Y ),
+                         posy_offset( PositionHolder::Axis::YOFF )
 {
    val.i = 0;
    posy_offset = 0;
@@ -129,11 +131,13 @@ void Parameter::set_name(const char* n)
    create_fullname(dispname, fullname, ctrlgroup, ctrlgroup_entry);
 }
 
-Parameter* Parameter::assign(int id,
+Parameter* Parameter::assign(ParameterIDCounter::promise_t idp,
                              int pid,
                              const char* name,
                              const char* dispname,
                              int ctrltype,
+
+                             std::string ui_identifier,
                              int posx,
                              int posy,
                              int scene,
@@ -142,7 +146,8 @@ Parameter* Parameter::assign(int id,
                              bool modulateable,
                              int ctrlstyle)
 {
-   this->id = id;
+   this->id_promise = idp.get();
+   this->id = -1;
    this->param_id_in_scene = pid;
    this->ctrlgroup = ctrlgroup;
    this->ctrlgroup_entry = ctrlgroup_entry;
@@ -151,6 +156,7 @@ Parameter* Parameter::assign(int id,
    this->modulateable = modulateable;
    this->scene = scene;
    this->ctrlstyle = ctrlstyle;
+   strncpy(this->ui_identifier, ui_identifier.c_str(), NAMECHARS );
 
    strncpy(this->name, name, NAMECHARS);
    set_name(dispname);

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -58,45 +58,56 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
    this->storage = storage;
    patchptr = nullptr;
 
-   int p_id = 0;
+   ParameterIDCounter p_id;
    {
       int px = gui_col6_x, py = gui_sendfx_y;
 
-      param_ptr.push_back(fx[4].return_level.assign(p_id++, 0, "volume_FX1", "FX1 Return",
-                                                    ct_amplitude, px, py, 0, cg_GLOBAL, 0, true,
+      param_ptr.push_back(fx[4].return_level.assign(p_id.next(), 0, "volume_FX1", "FX1 Return",
+                                                    ct_amplitude,
+                                                    "global.fx1_return", px, py,
+                                                    0, cg_GLOBAL, 0, true,
                                                     Surge::ParamConfig::kHorizontal));
       py += gui_hfader_dist;
-      param_ptr.push_back(fx[5].return_level.assign(p_id++, 0, "volume_FX2", "FX2 Return",
-                                                    ct_amplitude, px, py, 0, cg_GLOBAL, 0, true,
+      param_ptr.push_back(fx[5].return_level.assign(p_id.next(), 0, "volume_FX2", "FX2 Return",
+                                                    ct_amplitude,
+                                                    "global.fx2_return", px, py,
+                                                    0, cg_GLOBAL, 0, true,
                                                     Surge::ParamConfig::kHorizontal));
       py += gui_hfader_dist;
 
       // TODO don't store in the patch ?
       param_ptr.push_back(volume.assign(
-          p_id++, 0, "volume", "Master Volume", ct_decibel_attenuation, hmargin + gui_sec_width * 5,
-          gui_mid_topbar_y + 12, 0, cg_GLOBAL, 0, true, Surge::ParamConfig::kHorizontal | kEasy));
+          p_id.next(), 0, "volume", "Master Volume", ct_decibel_attenuation,
+          "global.master_volume", hmargin + gui_sec_width * 5, gui_mid_topbar_y + 12,
+          0, cg_GLOBAL, 0, true, Surge::ParamConfig::kHorizontal | kEasy));
    }
-   param_ptr.push_back(scene_active.assign(p_id++, 0, "scene_active", "Active Scene", ct_scenesel,
-                                           7, gui_mid_topbar_y - 2, 0, cg_GLOBAL, 0, false,
+   param_ptr.push_back(scene_active.assign(p_id.next(), 0, "scene_active", "Active Scene", ct_scenesel,
+                                           "global.active_scene", 7, gui_mid_topbar_y - 2,
+                                           0, cg_GLOBAL, 0, false,
                                            Surge::ParamConfig::kHorizontal));
-   param_ptr.push_back(scenemode.assign(p_id++, 0, "scenemode", "Scene Mode", ct_scenemode,
-                                        8 + 51 + 3, gui_mid_topbar_y - 4, 0, cg_GLOBAL, 0, false,
+   param_ptr.push_back(scenemode.assign(p_id.next(), 0, "scenemode", "Scene Mode", ct_scenemode,
+                                        "global.scene_mode", 8 + 51 + 3, gui_mid_topbar_y - 4,
+                                        0, cg_GLOBAL, 0, false,
                                         Surge::ParamConfig::kHorizontal | kNoPopup));
-   // param_ptr.push_back(scenemorph.assign(p_id++,0,"scenemorph","scenemorph",ct_percent,hmargin+gui_sec_width,gui_mid_topbar_y,0,0,0,false,Surge::ParamConfig::kHorizontal));
+   // param_ptr.push_back(scenemorph.assign(p_id.next(),0,"scenemorph","scenemorph",ct_percent,hmargin+gui_sec_width,gui_mid_topbar_y,0,0,0,false,Surge::ParamConfig::kHorizontal));
 
-   param_ptr.push_back(splitkey.assign(p_id++, 0, "splitkey", "Split Key", ct_midikey_or_channel, 8 + 91,
-                                       gui_mid_topbar_y - 3, 0, cg_GLOBAL, 0, false,
+   param_ptr.push_back(splitkey.assign(p_id.next(), 0, "splitkey", "Split Key", ct_midikey_or_channel,
+                                       "global.splitkey", 8 + 91, gui_mid_topbar_y - 3,
+                                       0, cg_GLOBAL, 0, false,
                                        Surge::ParamConfig::kHorizontal | kNoPopup));
    
-   param_ptr.push_back(fx_disable.assign(p_id++, 0, "fx_disable", "FX Disable", ct_none, 0, 0, 0,
-                                         cg_GLOBAL, 0, false));
+   param_ptr.push_back(fx_disable.assign(p_id.next(), 0, "fx_disable", "FX Disable", ct_none,
+                                         "global.fx_disable", 0, 0,
+                                         0, cg_GLOBAL, 0, false));
 
    // shouldnt't be stored in the patch
-   param_ptr.push_back(polylimit.assign(p_id++, 0, "polylimit", "Poly Limit", ct_polylimit, 8 + 91,
-                                        gui_mid_topbar_y + 13, 0, cg_GLOBAL, 0, false,
+   param_ptr.push_back(polylimit.assign(p_id.next(), 0, "polylimit", "Poly Limit", ct_polylimit,
+                                        "global.polylimit", 8 + 91, gui_mid_topbar_y + 13,
+                                        0, cg_GLOBAL, 0, false,
                                         Surge::ParamConfig::kHorizontal | kNoPopup));
-   param_ptr.push_back(fx_bypass.assign(p_id++, 0, "fx_bypass", "FX Bypass", ct_fxbypass, 607,
-                                        gui_mid_topbar_y - 6, 0, cg_GLOBAL, 0, false,
+   param_ptr.push_back(fx_bypass.assign(p_id.next(), 0, "fx_bypass", "FX Bypass", ct_fxbypass,
+                                        "global.fx_bypass", 607, gui_mid_topbar_y - 6,
+                                        0, cg_GLOBAL, 0, false,
                                         Surge::ParamConfig::kHorizontal | kNoPopup));
 
    polylimit.val.i = 8;
@@ -107,8 +118,9 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
    {
       int px = gui_col6_x, py = gui_sendfx_y + 20 * 3;
 
-      param_ptr.push_back(this->fx[fx].type.assign(p_id++, 0, "type", "FX type", ct_fxtype, px,
-                                                   py - 2, 0, cg_FX, fx, false, Surge::ParamConfig::kHorizontal));
+      param_ptr.push_back(this->fx[fx].type.assign(p_id.next(), 0, "type", "FX type", ct_fxtype,
+                                                   "FX.fxtype", px, py - 2,
+                                                   0, cg_FX, fx, false, Surge::ParamConfig::kHorizontal));
       py += 20;
       for (int p = 0; p < n_fx_params; p++)
       {
@@ -117,13 +129,16 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          char dawlabel[32];
          sprintf(dawlabel, "Param %i", p + 1);
          param_ptr.push_back(
-             this->fx[fx].p[p].assign(p_id++, 0, label, dawlabel, ct_none, px, py, 0, cg_FX, fx,
+             this->fx[fx].p[p].assign(p_id.next(), 0, label, dawlabel, ct_none,
+                                      "FX.param_" + std::to_string(p), px, py,
+                                      0, cg_FX, fx,
                                       true, Surge::ParamConfig::kHorizontal | kHide | ((fx == 0) ? kEasy : 0)));
          py += 20;
       }
    }
 
-   int globparams = p_id;
+   ParameterIDCounter::promise_t globparams_promise = p_id.tail;
+   ParameterIDCounter::promise_t scene_start_promise[2];
 
    for (int sc = 0; sc < 2; sc++)
    {
@@ -137,20 +152,24 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
 
       int sc_id = (sc & 1) + 1;
 
-      scene_start[sc] = p_id;
+      scene_start_promise[sc] = p_id.tail;
 
       px = gui_col2_x;
       py = gui_mainsec_y;
-      a->push_back(scene[sc].octave.assign(p_id++, id_s++, "octave", "Octave", ct_pitch_octave,
-                                           px + 46, py + 1, sc_id, cg_GLOBAL, 0, false,
+      a->push_back(scene[sc].octave.assign(p_id.next(), id_s++, "octave", "Octave", ct_pitch_octave,
+                                           "global.octave", px + 46, py + 1,
+                                           sc_id, cg_GLOBAL, 0, false,
                                            Surge::ParamConfig::kHorizontal | kNoPopup));
       py = gui_mainsec_slider_y;
-      a->push_back(scene[sc].pitch.assign(p_id++, id_s++, "pitch", "Pitch", ct_pitch_semi7bp, px,
-                                          py, sc_id, cg_GLOBAL, 0, true,
+      a->push_back(scene[sc].pitch.assign(p_id.next(), id_s++, "pitch", "Pitch", ct_pitch_semi7bp,
+                                          "global.pitch", px, py,
+                                          sc_id, cg_GLOBAL, 0, true,
                                           Surge::ParamConfig::kHorizontal | kSemitone | sceasy));
       py += gui_hfader_dist;
-      a->push_back(scene[sc].portamento.assign(p_id++, id_s++, "portamento", "Portamento",
-                                               ct_portatime, px, py, sc_id, cg_GLOBAL, 0, true,
+      a->push_back(scene[sc].portamento.assign(p_id.next(), id_s++, "portamento", "Portamento",
+                                               ct_portatime,
+                                               "global.portatime", px, py,
+                                               sc_id, cg_GLOBAL, 0, true,
                                                Surge::ParamConfig::kHorizontal | sceasy));
       py += gui_hfader_dist;
       for (int osc = 0; osc < n_oscs; osc++)
@@ -158,33 +177,42 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          px = gui_col1_x;
          py = gui_mainsec_y;
 
-         a->push_back(scene[sc].osc[osc].type.assign(p_id++, id_s++, "type", "Type", ct_osctype,
-                                                     px + 3, py + 1, sc_id, cg_OSC, osc, false));
-         a->push_back(scene[sc].osc[osc].octave.assign(p_id++, id_s++, "octave", "Octave",
-                                                       ct_pitch_octave, px - 3, py + 1, sc_id,
-                                                       cg_OSC, osc, false, Surge::ParamConfig::kHorizontal | kNoPopup));
+         a->push_back(scene[sc].osc[osc].type.assign(p_id.next(), id_s++, "type", "Type", ct_osctype,
+                                                     "osc.osctype", px + 3, py + 1,
+                                                     sc_id, cg_OSC, osc, false));
+         a->push_back(scene[sc].osc[osc].octave.assign(p_id.next(), id_s++, "octave", "Octave",
+                                                       ct_pitch_octave,
+                                                       "osc.octave", px - 3, py + 1,
+                                                       sc_id, cg_OSC, osc, false, Surge::ParamConfig::kHorizontal | kNoPopup));
          py = gui_mainsec_slider_y;
-         a->push_back(scene[sc].osc[osc].pitch.assign(p_id++, id_s++, "pitch", "Pitch",
-                                                      ct_pitch_semi7bp_absolutable, px, py, sc_id, cg_OSC, osc,
+         a->push_back(scene[sc].osc[osc].pitch.assign(p_id.next(), id_s++, "pitch", "Pitch",
+                                                      ct_pitch_semi7bp_absolutable,
+                                                      "osc.pitch", px, py,
+                                                      sc_id, cg_OSC, osc,
                                                       true, Surge::ParamConfig::kHorizontal | kSemitone | sceasy));
          py += gui_hfader_dist;
          for (int i = 0; i < n_osc_params; i++)
          {
             char label[16];
             sprintf(label, "param%i", i);
-            a->push_back(scene[sc].osc[osc].p[i].assign(p_id++, id_s++, label, "-", ct_none, px, py,
+            a->push_back(scene[sc].osc[osc].p[i].assign(p_id.next(), id_s++, label, "-", ct_none,
+                                                        "osc.param_" + std::to_string(i), px, py,
                                                         sc_id, cg_OSC, osc, true,
                                                         Surge::ParamConfig::kHorizontal | ((i < 6) ? sceasy : 0)));
             py += gui_hfader_dist;
          }
          py = gui_mainsec_y - 7;
-         a->push_back(scene[sc].osc[osc].keytrack.assign(p_id++, id_s++, "keytrack", "Keytrack",
-                                                         ct_bool_keytrack, px + 2, py, sc_id,
+         a->push_back(scene[sc].osc[osc].keytrack.assign(p_id.next(), id_s++, "keytrack", "Keytrack",
+                                                         ct_bool_keytrack,
+                                                         "osc.keytrack", px + 2, py,
+                                                         sc_id,
                                                          cg_OSC, osc, false, Surge::ParamConfig::kHorizontal));
-         a->push_back(scene[sc].osc[osc].retrigger.assign(p_id++, id_s++, "retrigger", "Retrigger",
-                                                          ct_bool_retrigger, px + 50, py, sc_id,
+         a->push_back(scene[sc].osc[osc].retrigger.assign(p_id.next(), id_s++, "retrigger", "Retrigger",
+                                                          ct_bool_retrigger,
+                                                          "osc.retrigger", px + 50, py,
+                                                          sc_id,
                                                           cg_OSC, osc, false, Surge::ParamConfig::kHorizontal));
-         // a->push_back(scene[sc].osc[osc].startphase.assign(p_id++,id_s++,"startphase","start
+         // a->push_back(scene[sc].osc[osc].startphase.assign(p_id.next(),id_s++,"startphase","start
          // phase",ct_none,0,0,sc_id,2,osc,false));
 
          /*scene[sc].osc[osc].wt.n_tables = 8;
@@ -196,50 +224,63 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          + 1.0) * M_PI * x);
          }*/
       }
-      a->push_back(scene[sc].polymode.assign(p_id++, id_s++, "polymode", "Polymode", ct_polymode,
-                                             gui_col2_x + 83, gui_uppersec_y + 9, sc_id, cg_GLOBAL,
+      a->push_back(scene[sc].polymode.assign(p_id.next(), id_s++, "polymode", "Polymode", ct_polymode,
+                                             "global.polymode", gui_col2_x + 83, gui_uppersec_y + 9,
+                                             sc_id, cg_GLOBAL,
                                              0, false, Surge::ParamConfig::kVertical | kWhite | kNoPopup));
-      a->push_back(scene[sc].fm_switch.assign(p_id++, id_s++, "fm_switch", "FM Routing",
-                                              ct_fmconfig, gui_col3_x + 3, gui_topbar + 25, sc_id,
+      a->push_back(scene[sc].fm_switch.assign(p_id.next(), id_s++, "fm_switch", "FM Routing",
+                                              ct_fmconfig,
+                                              "global.fmrouting", gui_col3_x + 3, gui_topbar + 25,
+                                              sc_id,
                                               cg_GLOBAL, 0, false));
-      a->push_back(scene[sc].fm_depth.assign(p_id++, id_s++, "fm_depth", "FM Depth",
-                                             ct_decibel_fmdepth, gui_col3_x,
-                                             gui_uppersec_y + gui_hfader_dist * 4, sc_id, cg_GLOBAL,
+      a->push_back(scene[sc].fm_depth.assign(p_id.next(), id_s++, "fm_depth", "FM Depth",
+                                             ct_decibel_fmdepth,
+                                             "global.fmdepth", gui_col3_x, gui_uppersec_y + gui_hfader_dist * 4,
+                                             sc_id, cg_GLOBAL,
                                              0, true, Surge::ParamConfig::kHorizontal | kWhite | sceasy));
 
-      a->push_back(scene[sc].drift.assign(p_id++, id_s++, "drift", "Osc Drift", ct_percent,
-                                          gui_col2_x, gui_uppersec_y + gui_hfader_dist * 3, sc_id,
+      a->push_back(scene[sc].drift.assign(p_id.next(), id_s++, "drift", "Osc Drift", ct_percent,
+                                          "global.drift", gui_col2_x, gui_uppersec_y + gui_hfader_dist * 3,
+                                          sc_id,
                                           cg_GLOBAL, 0, true, Surge::ParamConfig::kHorizontal | kWhite));
       a->push_back(scene[sc].noise_colour.assign(
-          p_id++, id_s++, "noisecol", "Noise Color", ct_percent_bidirectional, gui_col2_x,
-          gui_uppersec_y + gui_hfader_dist * 4, sc_id, cg_GLOBAL, 0, true,
+          p_id.next(), id_s++, "noisecol", "Noise Color", ct_percent_bidirectional,
+          "global.noise_color", gui_col2_x, gui_uppersec_y + gui_hfader_dist * 4, sc_id, cg_GLOBAL, 0, true,
           Surge::ParamConfig::kHorizontal | kWhite | sceasy));
-      a->push_back(scene[sc].keytrack_root.assign(p_id++, id_s++, "ktrkroot", "Keytrack Root Key",
-                                                  ct_midikey, 180 + 127, gui_topbar + 78 + 106 + 24,
+      a->push_back(scene[sc].keytrack_root.assign(p_id.next(), id_s++, "ktrkroot", "Keytrack Root Key",
+                                                  ct_midikey,
+                                                  "global.keytrack_root", 180 + 127, gui_topbar + 78 + 106 + 24,
                                                   sc_id, cg_GLOBAL, 0, false));
       // ct_midikey
       // drift,keytrack_root
 
       px = gui_col5_x;
       py = gui_uppersec_y;
-      a->push_back(scene[sc].volume.assign(p_id++, id_s++, "volume", "Volume", ct_amplitude, px, py,
+      a->push_back(scene[sc].volume.assign(p_id.next(), id_s++, "volume", "Volume", ct_amplitude,
+                                           "global.volume", px, py,
                                            sc_id, cg_GLOBAL, 0, true,
                                            Surge::ParamConfig::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
-      a->push_back(scene[sc].pan.assign(p_id++, id_s++, "pan", "Pan", ct_percent_bidirectional, px,
-                                        py, sc_id, cg_GLOBAL, 0, true,
+      a->push_back(scene[sc].pan.assign(p_id.next(), id_s++, "pan", "Pan", ct_percent_bidirectional,
+                                        "global.pan", px, py,
+                                        sc_id, cg_GLOBAL, 0, true,
                                         Surge::ParamConfig::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
-      a->push_back(scene[sc].width.assign(p_id++, id_s++, "pan2", "Width", ct_percent_bidirectional,
-                                          px, py, sc_id, cg_GLOBAL, 0, true,
+      a->push_back(scene[sc].width.assign(p_id.next(), id_s++, "pan2", "Width", ct_percent_bidirectional,
+                                          "global.width", px, py,
+                                          sc_id, cg_GLOBAL, 0, true,
                                           Surge::ParamConfig::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
-      a->push_back(scene[sc].send_level[0].assign(p_id++, id_s++, "send_fx_1", "FX1 Send",
-                                                  ct_amplitude, px, py, sc_id, cg_GLOBAL, 0, true,
+      a->push_back(scene[sc].send_level[0].assign(p_id.next(), id_s++, "send_fx_1", "FX1 Send",
+                                                  ct_amplitude,
+                                                  "global.send_fx_1", px, py,
+                                                  sc_id, cg_GLOBAL, 0, true,
                                                   Surge::ParamConfig::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
-      a->push_back(scene[sc].send_level[1].assign(p_id++, id_s++, "send_fx_2", "FX2 Send",
-                                                  ct_amplitude, px, py, sc_id, cg_GLOBAL, 0, true,
+      a->push_back(scene[sc].send_level[1].assign(p_id.next(), id_s++, "send_fx_2", "FX2 Send",
+                                                  ct_amplitude,
+                                                  "global.send_fx_2", px, py,
+                                                  sc_id, cg_GLOBAL, 0, true,
                                                   Surge::ParamConfig::kHorizontal | kWhite | sceasy));
       scene[sc].send_level[0].val_max.f = 1.5874f;
       scene[sc].send_level[1].val_max.f = 1.5874f;
@@ -247,124 +288,143 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       px = gui_oscmix_x;
       py = gui_oscmix_y;
       int mof = -36, sof = mof + 10, rof = mof + 20;
-      a->push_back(scene[sc].level_o1.assign(p_id++, id_s++, "level_o1", "Osc1 Level", ct_amplitude,
-                                             px, py, sc_id, cg_MIX, 0, true,
+      a->push_back(scene[sc].level_o1.assign(p_id.next(), id_s++, "level_o1", "Osc1 Level", ct_amplitude,
+                                             "mix.level_o1", px, py, sc_id, cg_MIX, 0, true,
                                              Surge::ParamConfig::kVertical | kWhite | sceasy));
-      a->push_back(scene[sc].mute_o1.assign(p_id++, id_s++, "mute_o1", "Osc1 Mute", ct_bool_mute,
-                                            px, py + mof, sc_id, cg_MIX, 0, false));
-      a->push_back(scene[sc].solo_o1.assign(p_id++, id_s++, "solo_o1", "Osc1 Solo", ct_bool_solo,
-                                            px, py + sof, sc_id, cg_MIX, 0, false, kMeta));
-      a->push_back(scene[sc].route_o1.assign(p_id++, id_s++, "route_o1", "Osc1 Route", ct_oscroute,
-                                             px, py + rof, sc_id, cg_MIX, 0, false));
+      a->push_back(scene[sc].mute_o1.assign(p_id.next(), id_s++, "mute_o1", "Osc1 Mute", ct_bool_mute,
+                                            "mix.mute_o1", px, py + mof,
+                                            sc_id, cg_MIX, 0, false));
+      a->push_back(scene[sc].solo_o1.assign(p_id.next(), id_s++, "solo_o1", "Osc1 Solo", ct_bool_solo,
+                                            "mix.solo_o1", px, py + sof, sc_id, cg_MIX, 0, false, kMeta));
+      a->push_back(scene[sc].route_o1.assign(p_id.next(), id_s++, "route_o1", "Osc1 Route", ct_oscroute,
+                                             "mix.route_o1", px, py + rof, sc_id, cg_MIX, 0, false));
       px += gui_vfader_dist;
-      a->push_back(scene[sc].level_o2.assign(p_id++, id_s++, "level_o2", "Osc2 Level", ct_amplitude,
-                                             px, py, sc_id, cg_MIX, 0, true,
+      a->push_back(scene[sc].level_o2.assign(p_id.next(), id_s++, "level_o2", "Osc2 Level", ct_amplitude,
+                                             "mix.level_o2", px, py, sc_id, cg_MIX, 0, true,
                                              Surge::ParamConfig::kVertical | kWhite | sceasy));
-      a->push_back(scene[sc].mute_o2.assign(p_id++, id_s++, "mute_o2", "Osc2 Mute", ct_bool_mute,
-                                            px, py + mof, sc_id, cg_MIX, 0, false));
-      a->push_back(scene[sc].solo_o2.assign(p_id++, id_s++, "solo_o2", "Osc2 Solo", ct_bool_solo,
-                                            px, py + sof, sc_id, cg_MIX, 0, false, kMeta));
-      a->push_back(scene[sc].route_o2.assign(p_id++, id_s++, "route_o2", "Osc2 Route", ct_oscroute,
-                                             px, py + rof, sc_id, cg_MIX, 0, false));
+      a->push_back(scene[sc].mute_o2.assign(p_id.next(), id_s++, "mute_o2", "Osc2 Mute", ct_bool_mute,
+                                            "mix.mute_o2", px, py + mof, sc_id, cg_MIX, 0, false));
+      a->push_back(scene[sc].solo_o2.assign(p_id.next(), id_s++, "solo_o2", "Osc2 Solo", ct_bool_solo,
+                                            "mix.solo_o2", px, py + sof, sc_id, cg_MIX, 0, false, kMeta));
+      a->push_back(scene[sc].route_o2.assign(p_id.next(), id_s++, "route_o2", "Osc2 Route", ct_oscroute,
+                                             "mix.route_o2", px, py + rof, sc_id, cg_MIX, 0, false));
       px += gui_vfader_dist;
-      a->push_back(scene[sc].level_o3.assign(p_id++, id_s++, "level_o3", "Osc3 Level", ct_amplitude,
-                                             px, py, sc_id, cg_MIX, 0, true,
+      a->push_back(scene[sc].level_o3.assign(p_id.next(), id_s++, "level_o3", "Osc3 Level", ct_amplitude,
+                                             "mix.level_o3", px, py, sc_id, cg_MIX, 0, true,
                                              Surge::ParamConfig::kVertical | kWhite | sceasy));
-      a->push_back(scene[sc].mute_o3.assign(p_id++, id_s++, "mute_o3", "Osc3 Mute", ct_bool_mute,
-                                            px, py + mof, sc_id, cg_MIX, 0, false));
-      a->push_back(scene[sc].solo_o3.assign(p_id++, id_s++, "solo_o3", "Osc3 Solo", ct_bool_solo,
-                                            px, py + sof, sc_id, cg_MIX, 0, false, kMeta));
-      a->push_back(scene[sc].route_o3.assign(p_id++, id_s++, "route_o3", "Osc3 Route", ct_oscroute,
-                                             px, py + rof, sc_id, cg_MIX, 0, false));
+      a->push_back(scene[sc].mute_o3.assign(p_id.next(), id_s++, "mute_o3", "Osc3 Mute", ct_bool_mute,
+                                            "mix.mute_o3", px, py + mof, sc_id, cg_MIX, 0, false));
+      a->push_back(scene[sc].solo_o3.assign(p_id.next(), id_s++, "solo_o3", "Osc3 Solo", ct_bool_solo,
+                                            "mix.solo_o3", px, py + sof, sc_id, cg_MIX, 0, false, kMeta));
+      a->push_back(scene[sc].route_o3.assign(p_id.next(), id_s++, "route_o3", "Osc3 Route", ct_oscroute,
+                                             "mix.route_o3", px, py + rof, sc_id, cg_MIX, 0, false));
       px += gui_vfader_dist;
-      a->push_back(scene[sc].level_ring_12.assign(p_id++, id_s++, "level_ring12", "Ring Level 1x2",
-                                                  ct_amplitude, px, py, sc_id, cg_MIX, 0, true,
+      a->push_back(scene[sc].level_ring_12.assign(p_id.next(), id_s++, "level_ring12", "Ring Level 1x2",
+                                                  ct_amplitude,
+                                                  "mix.level_ring12", px, py, sc_id, cg_MIX, 0, true,
                                                   Surge::ParamConfig::kVertical | kWhite | sceasy));
-      a->push_back(scene[sc].mute_ring_12.assign(p_id++, id_s++, "mute_ring12", "Ring Mute 1x2",
-                                                 ct_bool_mute, px, py + mof, sc_id, cg_MIX, 0,
+      a->push_back(scene[sc].mute_ring_12.assign(p_id.next(), id_s++, "mute_ring12", "Ring Mute 1x2",
+                                                 ct_bool_mute,
+                                                 "mix.mute_ring12", px, py + mof, sc_id, cg_MIX, 0,
                                                  false));
-      a->push_back(scene[sc].solo_ring_12.assign(p_id++, id_s++, "solo_ring12", "Ring Solo 1x2",
-                                                 ct_bool_solo, px, py + sof, sc_id, cg_MIX, 0,
+      a->push_back(scene[sc].solo_ring_12.assign(p_id.next(), id_s++, "solo_ring12", "Ring Solo 1x2",
+                                                 ct_bool_solo,
+                                                 "mix.solo_ring12", px, py + sof, sc_id, cg_MIX, 0,
                                                  false, kMeta));
-      a->push_back(scene[sc].route_ring_12.assign(p_id++, id_s++, "route_ring12", "Ring Route 1x2",
-                                                  ct_oscroute, px, py + rof, sc_id, cg_MIX, 0,
+      a->push_back(scene[sc].route_ring_12.assign(p_id.next(), id_s++, "route_ring12", "Ring Route 1x2",
+                                                  ct_oscroute,
+                                                  "mix.route_ring12", px, py + rof, sc_id, cg_MIX, 0,
                                                   false));
       px += gui_vfader_dist;
-      a->push_back(scene[sc].level_ring_23.assign(p_id++, id_s++, "level_ring23", "Ring Level 2x3",
-                                                  ct_amplitude, px, py, sc_id, cg_MIX, 0, true,
+      a->push_back(scene[sc].level_ring_23.assign(p_id.next(), id_s++, "level_ring23", "Ring Level 2x3",
+                                                  ct_amplitude,
+                                                  "mix.level_ring23", px, py, sc_id, cg_MIX, 0, true,
                                                   Surge::ParamConfig::kVertical | kWhite | sceasy));
-      a->push_back(scene[sc].mute_ring_23.assign(p_id++, id_s++, "mute_ring23", "Ring Mute 2x3",
-                                                 ct_bool_mute, px, py + mof, sc_id, cg_MIX, 0,
+      a->push_back(scene[sc].mute_ring_23.assign(p_id.next(), id_s++, "mute_ring23", "Ring Mute 2x3",
+                                                 ct_bool_mute,
+                                                 "mix.mute_ring23", px, py + mof, sc_id, cg_MIX, 0,
                                                  false));
-      a->push_back(scene[sc].solo_ring_23.assign(p_id++, id_s++, "solo_ring23", "Ring Solo 2x3",
-                                                 ct_bool_solo, px, py + sof, sc_id, cg_MIX, 0,
+      a->push_back(scene[sc].solo_ring_23.assign(p_id.next(), id_s++, "solo_ring23", "Ring Solo 2x3",
+                                                 ct_bool_solo,
+                                                 "mix.solo_ring23", px, py + sof, sc_id, cg_MIX, 0,
                                                  false, kMeta));
-      a->push_back(scene[sc].route_ring_23.assign(p_id++, id_s++, "route_ring23", "Ring Route 2x3",
-                                                  ct_oscroute, px, py + rof, sc_id, cg_MIX, 0,
+      a->push_back(scene[sc].route_ring_23.assign(p_id.next(), id_s++, "route_ring23", "Ring Route 2x3",
+                                                  ct_oscroute,
+                                                  "mix.route_ring23", px, py + rof, sc_id, cg_MIX, 0,
                                                   false));
       px += gui_vfader_dist;
-      a->push_back(scene[sc].level_noise.assign(p_id++, id_s++, "level_noise", "Noise Level",
-                                                ct_amplitude, px, py, sc_id, cg_MIX, 0, true,
+      a->push_back(scene[sc].level_noise.assign(p_id.next(), id_s++, "level_noise", "Noise Level",
+                                                ct_amplitude,
+                                                "mix.level_noise", px, py, sc_id, cg_MIX, 0, true,
                                                 Surge::ParamConfig::kVertical | kWhite | sceasy));
-      a->push_back(scene[sc].mute_noise.assign(p_id++, id_s++, "mute_noise", "Noise Mute",
-                                               ct_bool_mute, px, py + mof, sc_id, cg_MIX, 0,
+      a->push_back(scene[sc].mute_noise.assign(p_id.next(), id_s++, "mute_noise", "Noise Mute",
+                                               ct_bool_mute,
+                                               "mix.mute_noise", px, py + mof, sc_id, cg_MIX, 0,
                                                false));
-      a->push_back(scene[sc].solo_noise.assign(p_id++, id_s++, "solo_noise", "Noise Solo",
-                                               ct_bool_solo, px, py + sof, sc_id, cg_MIX, 0, false,
+      a->push_back(scene[sc].solo_noise.assign(p_id.next(), id_s++, "solo_noise", "Noise Solo",
+                                               ct_bool_solo,
+                                               "mix.solo_noise", px, py + sof, sc_id, cg_MIX, 0, false,
                                                kMeta));
-      a->push_back(scene[sc].route_noise.assign(p_id++, id_s++, "route_noise", "Noise Route",
-                                                ct_oscroute, px, py + rof, sc_id, cg_MIX, 0,
+      a->push_back(scene[sc].route_noise.assign(p_id.next(), id_s++, "route_noise", "Noise Route",
+                                                ct_oscroute,
+                                                "mix.route_noise", px, py + rof, sc_id, cg_MIX, 0,
                                                 false));
       px += gui_vfader_dist;
-      a->push_back(scene[sc].level_pfg.assign(p_id++, id_s++, "level_pfg", "Pre-Filter Gain",
-                                              ct_decibel, px, py, sc_id, cg_MIX, 0, true,
+      a->push_back(scene[sc].level_pfg.assign(p_id.next(), id_s++, "level_pfg", "Pre-Filter Gain",
+                                              ct_decibel,
+                                              "mix.level_prefiltergain", px, py, sc_id, cg_MIX, 0, true,
                                               Surge::ParamConfig::kVertical | kWhite | sceasy));
       px += gui_vfader_dist;
 
       int pbx = 164, pby = 112;
-      a->push_back(scene[sc].pbrange_up.assign(p_id++, id_s++, "pbrange_up",
-                                               "Pitch Bend Range (up)", ct_pbdepth, pbx + 25, pby,
+      a->push_back(scene[sc].pbrange_up.assign(p_id.next(), id_s++, "pbrange_up",
+                                               "Pitch Bend Range (up)", ct_pbdepth,
+                                               "global.pbrange_up", pbx + 25, pby,
                                                sc_id, cg_GLOBAL, 0, true, kNoPopup));
-      a->push_back(scene[sc].pbrange_dn.assign(p_id++, id_s++, "pbrange_dn",
-                                               "Pitch Bend Range (down)", ct_pbdepth, pbx, pby,
+      a->push_back(scene[sc].pbrange_dn.assign(p_id.next(), id_s++, "pbrange_dn",
+                                               "Pitch Bend Range (down)", ct_pbdepth,
+                                               "global.pbrange_dn", pbx, pby,
                                                sc_id, cg_GLOBAL, 0, true, kNoPopup));
 
       px = gui_envsec_x + gui_vfader_dist * 19 + 10;
       py = gui_envsec_y;
-      a->push_back(scene[sc].vca_level.assign(p_id++, id_s++, "vca_level", "Gain", ct_decibel, px,
-                                              py, sc_id, cg_GLOBAL, 0, true,
+      a->push_back(scene[sc].vca_level.assign(p_id.next(), id_s++, "vca_level", "Gain", ct_decibel,
+                                              "global.gain", px, py, sc_id, cg_GLOBAL, 0, true,
                                               Surge::ParamConfig::kVertical | kWhite | sceasy));
       px += gui_vfader_dist;
-      a->push_back(scene[sc].vca_velsense.assign(p_id++, id_s++, "vca_velsense", "Velocity > Gain",
-                                                 ct_decibel_attenuation, px, py, sc_id, cg_GLOBAL,
+      a->push_back(scene[sc].vca_velsense.assign(p_id.next(), id_s++, "vca_velsense", "Velocity > Gain",
+                                                 ct_decibel_attenuation,
+                                                 "global.velocity_sensitivity", px, py, sc_id, cg_GLOBAL,
                                                  0, false, Surge::ParamConfig::kVertical | kWhite));
       px += gui_vfader_dist;
 
       px = gui_col3_x + gui_sec_width + 1;
       py = gui_uppersec_y + gui_hfader_dist * 4;
-      a->push_back(scene[sc].feedback.assign(p_id++, id_s++, "feedback", "Feedback",
-                                             ct_percent_bidirectional, px, py, sc_id, cg_GLOBAL, 0,
+      a->push_back(scene[sc].feedback.assign(p_id.next(), id_s++, "feedback", "Feedback",
+                                             ct_percent_bidirectional,
+                                             "global.feedback", px, py, sc_id, cg_GLOBAL, 0,
                                              true, Surge::ParamConfig::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
 
       a->push_back(scene[sc].filterblock_configuration.assign(
-          p_id++, id_s++, "fb_config", "Filter Configuration", ct_fbconfig, gui_col4_x - 1,
-          gui_topbar + 25, sc_id, cg_GLOBAL, 0, false, Surge::ParamConfig::kHorizontal));
+          p_id.next(), id_s++, "fb_config", "Filter Configuration", ct_fbconfig,
+          "filter.config", gui_col4_x - 1, gui_topbar + 25, sc_id, cg_GLOBAL, 0, false, Surge::ParamConfig::kHorizontal));
       a->push_back(scene[sc].filter_balance.assign(
-          p_id++, id_s++, "f_balance", "Filter Balance", ct_percent_bidirectional, gui_col4_x,
-          gui_mainsec_slider_y + 11, sc_id, cg_GLOBAL, 0, true, Surge::ParamConfig::kHorizontal | sceasy));
+          p_id.next(), id_s++, "f_balance", "Filter Balance", ct_percent_bidirectional,
+          "filter.balance", gui_col4_x, gui_mainsec_slider_y + 11, sc_id, cg_GLOBAL, 0, true, Surge::ParamConfig::kHorizontal | sceasy));
 
-      a->push_back(scene[sc].lowcut.assign(p_id++, id_s++, "lowcut", "High Pass", ct_freq_hpf,
-                                           gui_envsec_x + gui_vfader_dist * 2 + 5, gui_envsec_y,
+      a->push_back(scene[sc].lowcut.assign(p_id.next(), id_s++, "lowcut", "High Pass", ct_freq_hpf,
+                                           "global.highpassfilter", gui_envsec_x + gui_vfader_dist * 2 + 5, gui_envsec_y,
                                            sc_id, cg_GLOBAL, 0, true, Surge::ParamConfig::kVertical | kWhite | sceasy));
 
-      a->push_back(scene[sc].wsunit.type.assign(p_id++, id_s++, "ws_type", "Waveshaper Type",
-                                                ct_wstype, gui_envsec_x + gui_vfader_dist * 4 - 1,
+      a->push_back(scene[sc].wsunit.type.assign(p_id.next(), id_s++, "ws_type", "Waveshaper Type",
+                                                ct_wstype,
+                                                "global.waveshaper_type", gui_envsec_x + gui_vfader_dist * 4 - 1,
                                                 gui_envsec_y + 13, sc_id, cg_GLOBAL, 0, false,
                                                 kNoPopup));
       a->push_back(scene[sc].wsunit.drive.assign(
-          p_id++, id_s++, "ws_drive", "Waveshaper Drive", ct_decibel_narrow,
-          gui_envsec_x + gui_vfader_dist * 5 + 10, gui_envsec_y, sc_id, cg_GLOBAL, 0, true,
+          p_id.next(), id_s++, "ws_drive", "Waveshaper Drive", ct_decibel_narrow,
+          "global.waveshaper_drive", gui_envsec_x + gui_vfader_dist * 5 + 10, gui_envsec_y, sc_id, cg_GLOBAL, 0, true,
           Surge::ParamConfig::kVertical | kWhite | sceasy));
 
       for (int f = 0; f < 2; f++)
@@ -372,27 +432,33 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          px = gui_col3_x + gui_sec_width * 2 * f;
          py = gui_mainsec_y;
 
-         a->push_back(scene[sc].filterunit[f].type.assign(p_id++, id_s++, "type", "Filter Type",
-                                                          ct_filtertype, px - 2, py + 1, sc_id,
+         a->push_back(scene[sc].filterunit[f].type.assign(p_id.next(), id_s++, "type", "Filter Type",
+                                                          ct_filtertype,
+                                                          "filter.type_" + std::to_string(f), px - 2, py + 1, sc_id,
                                                           cg_FILTER, f, false, Surge::ParamConfig::kHorizontal));
          a->push_back(scene[sc].filterunit[f].subtype.assign(
-             p_id++, id_s++, "subtype", "Filter Subtype", ct_filtersubtype, px - 3, py + 1, sc_id,
+             p_id.next(), id_s++, "subtype", "Filter Subtype", ct_filtersubtype,
+             "filter.subtype_" + std::to_string(f), px - 3, py + 1, sc_id,
              cg_FILTER, f, false, Surge::ParamConfig::kHorizontal));
          py = gui_mainsec_slider_y;
          a->push_back(scene[sc].filterunit[f].cutoff.assign(
-             p_id++, id_s++, "cutoff", "Cutoff", ct_freq_audible, px, py, sc_id, cg_FILTER, f, true,
+             p_id.next(), id_s++, "cutoff", "Cutoff", ct_freq_audible,
+             "filter.cutoff_" + std::to_string(f), px, py, sc_id, cg_FILTER, f, true,
              Surge::ParamConfig::kHorizontal | sceasy));
          if (f == 1)
             a->push_back(scene[sc].f2_cutoff_is_offset.assign(
-                p_id++, id_s++, "f2_cf_is_offset", "Is Offset to F1", ct_bool_relative_switch, px,
+                p_id.next(), id_s++, "f2_cf_is_offset", "Is Offset to F1", ct_bool_relative_switch,
+                "filter.f2_cf_is_offset", px,
                 py, sc_id, cg_GLOBAL, 0, false, kMeta));
          py += gui_hfader_dist;
          a->push_back(scene[sc].filterunit[f].resonance.assign(
-             p_id++, id_s++, "resonance", "Resonance", ct_percent, px, py, sc_id, cg_FILTER, f,
+             p_id.next(), id_s++, "resonance", "Resonance", ct_percent,
+             "filter.resonance_" + std::to_string(f), px, py, sc_id, cg_FILTER, f,
              true, Surge::ParamConfig::kHorizontal | sceasy));
          if (f == 1)
             a->push_back(scene[sc].f2_link_resonance.assign(
-                p_id++, id_s++, "f2_link_resonance", "Link Resonance", ct_bool_link_switch, px, py,
+                p_id.next(), id_s++, "f2_link_resonance", "Link Resonance", ct_bool_link_switch,
+                "filter.f2_link_resonance", px, py,
                 sc_id, cg_GLOBAL, 0, false, kMeta));
 
          // py += gui_hfader_dist2;
@@ -400,51 +466,58 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          px = gui_envsec_x + gui_vfader_dist * (5 + f) - 10;
          py = gui_envsec_y;
          a->push_back(scene[sc].filterunit[f].envmod.assign(
-             p_id++, id_s++, "envmod", "Envmod", ct_freq_mod, px + gui_sec_width, py, sc_id,
+             p_id.next(), id_s++, "envmod", "Envmod", ct_freq_mod,
+             "filter.envmod_" + std::to_string(f), px + gui_sec_width, py, sc_id,
              cg_FILTER, f, true, Surge::ParamConfig::kVertical | kWhite | sceasy));
          px += 3 * gui_vfader_dist - gui_sec_width;
          a->push_back(scene[sc].filterunit[f].keytrack.assign(
-             p_id++, id_s++, "keytrack", "Keytrack", ct_percent_bidirectional, px, py, sc_id,
+             p_id.next(), id_s++, "keytrack", "Keytrack", ct_percent_bidirectional,
+             "filter.keytrack_" + std::to_string(f), px, py, sc_id,
              cg_FILTER, f, true, Surge::ParamConfig::kVertical | kWhite));
       }
 
       // scene[sc].filterunit[0].type.val.i = 1;
       for (int e = 0; e < 2; e++)
       {
+         std::string envs = "FEG.";
+         if( e == 1 )
+            envs = "AEG.";
+         
          px = gui_envsec_x + gui_sec_width + (gui_sec_width) * (1 - e);
          py = gui_envsec_y;
          const int so = -30;
-         a->push_back(scene[sc].adsr[e].a.assign(p_id++, id_s++, "attack", "Attack", ct_envtime, px,
-                                                 py, sc_id, cg_ENV, e, true,
+         a->push_back(scene[sc].adsr[e].a.assign(p_id.next(), id_s++, "attack", "Attack", ct_envtime,
+                                                 envs + "attack", px, py, sc_id, cg_ENV, e, true,
                                                  Surge::ParamConfig::kVertical | kWhite | sceasy));
-         a->push_back(scene[sc].adsr[e].a_s.assign(p_id++, id_s++, "attack_shape", "Attack Shape",
-                                                   ct_envshape, px, py + so, sc_id, cg_ENV, e,
+         a->push_back(scene[sc].adsr[e].a_s.assign(p_id.next(), id_s++, "attack_shape", "Attack Shape",
+                                                   ct_envshape,
+                                                   envs + "attack_shape", px, py + so, sc_id, cg_ENV, e,
                                                    false, kNoPopup));
          px += gui_vfader_dist;
 
-         a->push_back(scene[sc].adsr[e].d.assign(p_id++, id_s++, "decay", "Decay", ct_envtime, px,
-                                                 py, sc_id, cg_ENV, e, true,
+         a->push_back(scene[sc].adsr[e].d.assign(p_id.next(), id_s++, "decay", "Decay", ct_envtime,
+                                                 envs + "decay", px, py, sc_id, cg_ENV, e, true,
                                                  Surge::ParamConfig::kVertical | kWhite | sceasy));
-         a->push_back(scene[sc].adsr[e].d_s.assign(p_id++, id_s++, "decay_shape", "Decay Shape",
-                                                   ct_envshape, px, py + so, sc_id, cg_ENV, e,
+         a->push_back(scene[sc].adsr[e].d_s.assign(p_id.next(), id_s++, "decay_shape", "Decay Shape",
+                                                   ct_envshape, envs + "decay_shape", px, py + so, sc_id, cg_ENV, e,
                                                    false, kNoPopup));
          px += gui_vfader_dist;
 
-         a->push_back(scene[sc].adsr[e].s.assign(p_id++, id_s++, "sustain", "Sustain", ct_percent,
-                                                 px, py, sc_id, cg_ENV, e, true,
+         a->push_back(scene[sc].adsr[e].s.assign(p_id.next(), id_s++, "sustain", "Sustain", ct_percent,
+                                                 envs + "sustain", px, py, sc_id, cg_ENV, e, true,
                                                  Surge::ParamConfig::kVertical | kWhite | sceasy));
          px += gui_vfader_dist;
 
-         a->push_back(scene[sc].adsr[e].r.assign(p_id++, id_s++, "release", "Release", ct_envtime,
-                                                 px, py, sc_id, cg_ENV, e, true,
+         a->push_back(scene[sc].adsr[e].r.assign(p_id.next(), id_s++, "release", "Release", ct_envtime,
+                                                 envs + "release", px, py, sc_id, cg_ENV, e, true,
                                                  Surge::ParamConfig::kVertical | kWhite | sceasy));
-         a->push_back(scene[sc].adsr[e].r_s.assign(p_id++, id_s++, "release_shape", "Release Shape",
-                                                   ct_envshape, px, py + so, sc_id, cg_ENV, e,
+         a->push_back(scene[sc].adsr[e].r_s.assign(p_id.next(), id_s++, "release_shape", "Release Shape",
+                                                   ct_envshape, envs + "release_shape",  px, py + so, sc_id, cg_ENV, e,
                                                    false, kNoPopup));
          px += gui_vfader_dist;
 
-         a->push_back(scene[sc].adsr[e].mode.assign(p_id++, id_s++, "mode", "Mode", ct_envmode,
-                                                    px + 13, py - 31, sc_id, cg_ENV, e, false,
+         a->push_back(scene[sc].adsr[e].mode.assign(p_id.next(), id_s++, "mode", "Mode", ct_envmode,
+                                                    envs + "mode", px + 13, py - 31, sc_id, cg_ENV, e, false,
                                                     kNoPopup));
       }
 
@@ -455,86 +528,100 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          char label[32];
 
          sprintf(label, "lfo%i_shape", l);
-         a->push_back(scene[sc].lfo[l].shape.assign(p_id++, id_s++, label, "Shape", ct_lfoshape, px,
-                                                    py, sc_id, cg_LFO, ms_lfo1 + l, true,
+         a->push_back(scene[sc].lfo[l].shape.assign(p_id.next(), id_s++, label, "Shape", ct_lfoshape,
+                                                    "lfo.shape", px, py, sc_id, cg_LFO, ms_lfo1 + l, true,
                                                     Surge::ParamConfig::kHorizontal));
 
          px = gui_modsec_x;
          py = gui_modsec_y - 10;
 
          sprintf(label, "lfo%i_rate", l);
-         a->push_back(scene[sc].lfo[l].rate.assign(p_id++, id_s++, label, "Rate", ct_lforate, px,
-                                                   py, sc_id, cg_LFO, ms_lfo1 + l, true,
+         a->push_back(scene[sc].lfo[l].rate.assign(p_id.next(), id_s++, label, "Rate", ct_lforate,
+                                                   "lfo.rate", px, py, sc_id, cg_LFO, ms_lfo1 + l, true,
                                                    Surge::ParamConfig::kHorizontal | sceasy));
          py += gui_hfader_dist;
          sprintf(label, "lfo%i_phase", l);
-         a->push_back(scene[sc].lfo[l].start_phase.assign(p_id++, id_s++, label, "Phase / Shuffle",
-                                                          ct_percent, px, py, sc_id, cg_LFO,
+         a->push_back(scene[sc].lfo[l].start_phase.assign(p_id.next(), id_s++, label, "Phase / Shuffle",
+                                                          ct_percent,
+                                                          "lfo.phase", px, py,
+                                                          sc_id, cg_LFO,
                                                           ms_lfo1 + l, true, Surge::ParamConfig::kHorizontal));
          py += gui_hfader_dist;
          sprintf(label, "lfo%i_magnitude", l);
-         a->push_back(scene[sc].lfo[l].magnitude.assign(p_id++, id_s++, label, "Magnitude",
-                                                        ct_percent, px, py, sc_id, cg_LFO,
+         a->push_back(scene[sc].lfo[l].magnitude.assign(p_id.next(), id_s++, label, "Magnitude",
+                                                        ct_percent,
+                                                        "lfo.magnitude", px, py, sc_id, cg_LFO,
                                                         ms_lfo1 + l, true, Surge::ParamConfig::kHorizontal | sceasy));
          py += gui_hfader_dist;
          sprintf(label, "lfo%i_deform", l);
-         a->push_back(scene[sc].lfo[l].deform.assign(p_id++, id_s++, label, "Deform",
-                                                     ct_percent_bidirectional, px, py, sc_id,
+         a->push_back(scene[sc].lfo[l].deform.assign(p_id.next(), id_s++, label, "Deform",
+                                                     ct_percent_bidirectional, "lfo.deform", px, py, sc_id,
                                                      cg_LFO, ms_lfo1 + l, true, Surge::ParamConfig::kHorizontal));
 
          px += gui_sec_width;
          py = gui_modsec_y;
          sprintf(label, "lfo%i_trigmode", l);
-         a->push_back(scene[sc].lfo[l].trigmode.assign(p_id++, id_s++, label, "Trigger Mode",
-                                                       ct_lfotrigmode, px + 5, py - 4, sc_id,
+         a->push_back(scene[sc].lfo[l].trigmode.assign(p_id.next(), id_s++, label, "Trigger Mode",
+                                                       ct_lfotrigmode, "lfo.triggermode", px + 5, py - 4, sc_id,
                                                        cg_LFO, ms_lfo1 + l, false, kNoPopup));
          py += 44;
          sprintf(label, "lfo%i_unipolar", l);
-         a->push_back(scene[sc].lfo[l].unipolar.assign(p_id++, id_s++, label, "Unipolar",
-                                                       ct_bool_unipolar, px + 5, py - 4, sc_id,
+         a->push_back(scene[sc].lfo[l].unipolar.assign(p_id.next(), id_s++, label, "Unipolar",
+                                                       ct_bool_unipolar, "lfo.unipolar", px + 5, py - 4, sc_id,
                                                        cg_LFO, ms_lfo1 + l, false));
 
          px += 3 * gui_sec_width + 8;
          py = gui_modsec_y + 5;
          sprintf(label, "lfo%i_delay", l);
-         a->push_back(scene[sc].lfo[l].delay.assign(p_id++, id_s++, label, "Delay", ct_envtime, px,
+         a->push_back(scene[sc].lfo[l].delay.assign(p_id.next(), id_s++, label, "Delay", ct_envtime, "lfo.delay", px,
                                                     py, sc_id, cg_LFO, ms_lfo1 + l, true,
                                                     Surge::ParamConfig::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_attack", l);
-         a->push_back(scene[sc].lfo[l].attack.assign(p_id++, id_s++, label, "Attack", ct_envtime,
-                                                     px, py, sc_id, cg_LFO, ms_lfo1 + l, true,
+         a->push_back(scene[sc].lfo[l].attack.assign(p_id.next(), id_s++, label, "Attack", ct_envtime,
+                                                     "lfo.attack", px, py, sc_id, cg_LFO, ms_lfo1 + l, true,
                                                      Surge::ParamConfig::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_hold", l);
-         a->push_back(scene[sc].lfo[l].hold.assign(p_id++, id_s++, label, "Hold", ct_envtime, px,
+         a->push_back(scene[sc].lfo[l].hold.assign(p_id.next(), id_s++, label, "Hold", ct_envtime, "lfo.hold", px,
                                                    py, sc_id, cg_LFO, ms_lfo1 + l, true,
                                                    Surge::ParamConfig::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_decay", l);
-         a->push_back(scene[sc].lfo[l].decay.assign(p_id++, id_s++, label, "Decay", ct_envtime, px,
+         a->push_back(scene[sc].lfo[l].decay.assign(p_id.next(), id_s++, label, "Decay", ct_envtime, "lfo.decay", px,
                                                     py, sc_id, cg_LFO, ms_lfo1 + l, true,
                                                     Surge::ParamConfig::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_sustain", l);
-         a->push_back(scene[sc].lfo[l].sustain.assign(p_id++, id_s++, label, "Sustain", ct_percent,
-                                                      px, py, sc_id, cg_LFO, ms_lfo1 + l, true,
+         a->push_back(scene[sc].lfo[l].sustain.assign(p_id.next(), id_s++, label, "Sustain", ct_percent,
+                                                      "lfo.sustain", px, py, sc_id, cg_LFO, ms_lfo1 + l, true,
                                                       Surge::ParamConfig::kVertical | kMini));
          px += gui_vfader_dist;
          sprintf(label, "lfo%i_release", l);
-         a->push_back(scene[sc].lfo[l].release.assign(p_id++, id_s++, label, "Release",
-                                                      ct_envtime_lfodecay, px, py, sc_id, cg_LFO,
+         a->push_back(scene[sc].lfo[l].release.assign(p_id.next(), id_s++, label, "Release",
+                                                      ct_envtime_lfodecay, "lfo.release", px, py, sc_id, cg_LFO,
                                                       ms_lfo1 + l, true, Surge::ParamConfig::kVertical | kMini));
          px += gui_vfader_dist;
       }
    }
 
-   param_ptr.push_back(character.assign(p_id++, 0, "character", "Character", ct_character, 607,
+   param_ptr.push_back(character.assign(p_id.next(), 0, "character", "Character", ct_character, "global.character", 607,
                                         gui_mid_topbar_y + 24, 0, cg_GLOBAL, 0, false, kNoPopup));
+
+   // Resolve the promise chain
+   p_id.resolve();
+   for (unsigned int i = 0; i < param_ptr.size(); i++)
+   {
+      param_ptr[i]->id = param_ptr[i]->id_promise->value;
+      param_ptr[i]->id_promise = nullptr; // we only hold it transiently since we have a direct pointer copy to keep the class size fixed
+   }
+
+   scene_start[0] = scene_start_promise[0]->value;
+   scene_start[1] = scene_start_promise[1]->value;
 
    scene_size = scene_start[1] - scene_start[0];
    assert(scene_size == n_scene_params);
-   assert(globparams == n_global_params);
+   assert(globparams_promise->value == n_global_params);
    init_default_values();
    update_controls(true);
 

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -255,5 +255,6 @@ private:
    addCallbackMenu(VSTGUI::COptionMenu* toThis, std::string label, std::function<void()> op);
    VSTGUI::COptionMenu* makeMpeMenu(VSTGUI::CRect &rect);
    VSTGUI::COptionMenu* makeTuningMenu(VSTGUI::CRect &rect);
+   VSTGUI::COptionMenu* makeDevMenu(VSTGUI::CRect &rect);
 };
 

--- a/src/headless/UnitTestsTUN.cpp
+++ b/src/headless/UnitTestsTUN.cpp
@@ -180,9 +180,10 @@ TEST_CASE( "KBM File Remaps Center", "[tun]" )
    auto surge = surgeOnSine();
    REQUIRE( surge.get() );
 
-   float unmapped[3];
-   SECTION( "Marvel 12 unmapped" )
+   SECTION( "Marvel 12 mapped and unmapped" )
    {
+      float unmapped[3];
+      
       Surge::Storage::Scale s = Surge::Storage::readSCLFile("test-data/scl/marvel12.scl" );
       surge->storage.retuneToScale(s);
       auto f60 = frequencyForNote( surge, 60 );
@@ -195,19 +196,14 @@ TEST_CASE( "KBM File Remaps Center", "[tun]" )
       unmapped[0] = f60;
       unmapped[1] = f72;
       unmapped[2] = f69;
-   }
 
-   SECTION( "And remap to 440" )
-   {
-      Surge::Storage::Scale s = Surge::Storage::readSCLFile("test-data/scl/marvel12.scl" );
       auto k = Surge::Storage::readKBMFile( "test-data/scl/mapping-a440-constant.kbm" );
 
-      surge->storage.retuneToScale(s);
       surge->storage.remapToKeyboard(k);
       
-      auto f60 = frequencyForNote( surge, 60 );
-      auto f72 = frequencyForNote( surge, 72 );
-      auto f69 = frequencyForNote( surge, 69 );
+      f60 = frequencyForNote( surge, 60 );
+      f72 = frequencyForNote( surge, 72 );
+      f69 = frequencyForNote( surge, 69 );
       REQUIRE( f69 == Approx( 440.0 ).margin(.1) );
       REQUIRE( unmapped[2]/440.0 == Approx( unmapped[0] / f60 ).margin(.001) );
       REQUIRE( unmapped[2]/440.0 == Approx( unmapped[1] / f72 ).margin(.001) );


### PR DESCRIPTION
Port three changes - two from the (probably abandoned) surge-experimental
branch and one new - into the mainline

1. Use a "promise" rather than an "int" for parameters so we can,
   at a later date, interleave parameter ID assignment inside the
   SurgePatch

2. Give each parameter a "ui_identifier" in addition to a px,py so
   at a later date we can look up px and py.

3. Make posx, posy, and posy_offset classes where we can
   in the future add a bit of indirection