### PR TITLE
Update deb file ownerships

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Alec DiAstra <alecdiastra@gmail.com>
 Rich Elmes <richie@juic3.com>
 The Emu (J Riley Hill)
 EvilDragon 
+Brian Ginsburg
 Nathan Kopp <nk.sg@nathankopp.com>
 Jacky Ligon
 Erik-Jan Maalderink <fonkle@gmx.com>

--- a/installer_linux/make_deb.sh
+++ b/installer_linux/make_deb.sh
@@ -90,7 +90,7 @@ cp -r ../target/lv2/Release/Surge.lv2 ${PACKAGE_NAME}/usr/lib/lv2/
 #build package
 
 mkdir -p product
-dpkg-deb --build ${PACKAGE_NAME} product/${PACKAGE_NAME}-linux-x64-${VERSION}.deb
+dpkg-deb --root-owner-group --build ${PACKAGE_NAME} product/${PACKAGE_NAME}-linux-x64-${VERSION}.deb
 rm -rf ${PACKAGE_NAME}
 
 echo "Built DEB Package"


### PR DESCRIPTION
This PR adds the `--root-owner-group` flag to make root the owner and group on installed files on Linux. Addresses surge-synthesizer/surge#1579.