### PR TITLE
lv2: reload parameters in host after editor loads a patch

### DIFF
--- a/src/lv2/SurgeLv2Wrapper.cpp
+++ b/src/lv2/SurgeLv2Wrapper.cpp
@@ -28,18 +28,9 @@ void SurgeLv2Wrapper::setParameterAutomated(int externalparam, float value)
    _editor->setParameterAutomated(externalparam, value);
 }
 
-void SurgeLv2Wrapper::patchChanged(void)
+void SurgeLv2Wrapper::patchChanged()
 {
-   if( _editor == nullptr ) return;
-
-   SurgeSynthesizer *s = _synthesizer.get();
-
-   for (unsigned int i = 0; i < n_total_params; i++)
-   {
-      unsigned index = s->remapExternalApiToInternalId(i);
-      float value = s->getParameter01(index);
-      _editor->setParameterAutomated(i, value);
-   }
+   _editorMustReloadPatch.store(true);
 }
 
 LV2_Handle SurgeLv2Wrapper::instantiate(const LV2_Descriptor* descriptor,

--- a/src/lv2/SurgeLv2Wrapper.h
+++ b/src/lv2/SurgeLv2Wrapper.h
@@ -2,6 +2,7 @@
 #include "SurgeSynthesizer.h"
 #include "AllLv2.h"
 #include "util/FpuState.h"
+#include <atomic>
 #include <memory>
 
 class SurgeLv2Ui;
@@ -47,7 +48,7 @@ public:
    // PluginLayer
    void updateDisplay();
    void setParameterAutomated(int externalparam, float value);
-   void patchChanged(void);
+   void patchChanged();
 
 private:
    static LV2_Handle instantiate(const LV2_Descriptor* descriptor,
@@ -96,4 +97,8 @@ private:
    LV2_URID _uridSurgePatch;
 
    SurgeLv2Ui* _editor = nullptr;
+
+public:
+   // tells the editor it must take parameters from synth and update itself
+   std::atomic<bool> _editorMustReloadPatch{false};
 };


### PR DESCRIPTION
#1577 

This is a better fix for updating patch after reloading, although still hackish.
In particular, this one is thread-safe and will possibly help with some crash reports I received. (@alcomposer)

```
   // if a patch was loaded from storage, the plugin atomically sets a bit to
   // indicate it. In this case, write the control value again using UI's write
   // interface, in order to update the host side.
```

From what I can tell, this works in Ardour, Jalv.

However it still fails in Carla, for some reasons I can't explain. On saving, it doesn't pick up the parameters which have been set by UI's write function. (cc @falkTX)

Note: Carla was `1:2.1.b1.test1.r210.gd17c94b3f-1`
I've checked control ports values in and out, after saving closing carla, and reloading. It was different values.