### PR TITLE
Backout #1406 change on Linux for VST2

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1653,7 +1653,7 @@ bool PLUGIN_API SurgeGUIEditor::open(void* parent, const PlatformType& platformT
 
 void SurgeGUIEditor::close()
 {
-#if TARGET_VST2
+#if TARGET_VST2 && WINDOWS
    // We may need this in other hosts also; but for now 
    if (frame);
    {


### PR DESCRIPTION
VST2 frame management got screwed up in bitwig
when we pushed this. So back it out for linux for now

Addresses #1572