### PR TITLE
Select OSC Display pitch in a tuning-aware way

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -154,6 +154,33 @@ void COscillatorDisplay::drawVector(CDrawContext* dc)
       if (osc)
       {
          float disp_pitch_rs = disp_pitch + 12.0 * log2(dsamplerate / 44100.0);
+         if(! storage->isStandardTuning )
+         {
+            // OK so in this case we need to find a better version of the note which gets us
+            // that pitch. Sigh.
+            auto pit = storage->note_to_pitch_ignoring_tuning(disp_pitch_rs);
+            int bracket = -1;
+            for( int i=0; i<128; ++i )
+            {
+               if( storage->note_to_pitch(i) < pit && storage->note_to_pitch(i+1) > pit )
+               {
+                  bracket = i;
+                  break;
+               }
+            }
+            if( bracket >= 0 )
+            {
+               float f1 = storage->note_to_pitch(bracket);
+               float f2 = storage->note_to_pitch(bracket+1);
+               float frac = (pit - f1)/ (f2-f1);
+               float newp = storage->note_to_pitch(bracket + frac);
+               disp_pitch_rs = bracket + frac;
+            }
+            else
+            {
+               // What the hell type of scale is this folks! But this is just UI code so just punt
+            }
+         }
          bool use_display = osc->allow_display();
 
          // Mis-install check #2

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3166,6 +3166,8 @@ void SurgeGUIEditor::toggleTuning()
 
     if( statuspanel )
         ((CStatusPanel *)statuspanel)->setDisplayFeature(CStatusPanel::tuningMode, !this->synth->storage.isStandardTuning );
+
+    this->synth->refresh_editor = true;
 }
 void SurgeGUIEditor::showTuningMenu(VSTGUI::CPoint &where)
 {
@@ -3182,11 +3184,13 @@ void SurgeGUIEditor::showTuningMenu(VSTGUI::CPoint &where)
 void SurgeGUIEditor::tuningFileDropped(std::string fn)
 {
     this->synth->storage.retuneToScale(Surge::Storage::readSCLFile(fn));
+    this->synth->refresh_editor = true;
 }
 
 void SurgeGUIEditor::mappingFileDropped(std::string fn)
 {
     this->synth->storage.remapToKeyboard(Surge::Storage::readKBMFile(fn));
+    this->synth->refresh_editor = true;
 }
 
 bool SurgeGUIEditor::doesZoomFitToScreen(int zf, int &correctedZf)


### PR DESCRIPTION
The OSC display pitch is a note but that note gives a radically
different frequency on short and long scales, improperly changing the
oscillator display. Instead search for a note which has the pitch
we want when in non-standard tuning.

Closes #1590