### PR TITLE
Update deb package and linux storage location

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Alec DiAstra <alecdiastra@gmail.com>
 Rich Elmes <richie@juic3.com>
 The Emu (J Riley Hill)
 EvilDragon 
+Brian Ginsburg
 Nathan Kopp <nk.sg@nathankopp.com>
 Jacky Ligon
 Erik-Jan Maalderink <fonkle@gmx.com>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,7 +177,7 @@ jobs:
       echo "Running HeadlessTest $(linuxProject)"
       export XDG_DATA_HOME=$AGENT_TEMPDIRECTORY/XH
       mkdir -p $XDG_DATA_HOME
-      rsync -r --delete "resources/data/" "$XDG_DATA_HOME/Surge/"
+      rsync -r --delete "resources/data/" "$XDG_DATA_HOME/surge/"
 
       ./target/headless/Release/Surge/Surge-Headless
 

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -325,13 +325,13 @@ if [[ ! -z "$option_local" ]]; then
     vst3_dest_path="$HOME/.vst3"
     lv2_dest_path="$HOME/.lv2"
     headless_dest_path="$HOME/bin"
-    data_path="$HOME/.local/share/Surge"
+    data_path="$HOME/.local/share/surge"
 else
     vst2_dest_path="/usr/lib/vst"
     vst3_dest_path="/usr/lib/vst3"
     lv2_dest_path="/usr/lib/lv2"
     headless_dest_path="/usr/bin"
-    data_path="/usr/share/Surge"
+    data_path="/usr/share/surge"
 fi
 
 case $1 in

--- a/installer_linux/make_deb.sh
+++ b/installer_linux/make_deb.sh
@@ -31,7 +31,7 @@ fi
 
 
 # Names
-SURGE_NAME=Surge
+SURGE_NAME=surge
 PACKAGE_NAME="$SURGE_NAME"
 # SURGE_NAME=surge-synthesizer
 
@@ -53,20 +53,23 @@ if [[ -f ${PACKAGE_NAME}/DEBIAN/control ]]; then
 fi
 touch ${PACKAGE_NAME}/DEBIAN/control
 cat <<EOT >> ${PACKAGE_NAME}/DEBIAN/control
+Source: ${PACKAGE_NAME}
 Package: ${PACKAGE_NAME}
 Version: $DEB_VERSION
 Architecture: amd64
-Maintainer: surgeteam
+Maintainer: surgeteam <noreply@github.com>
 Depends: libcairo2, libfontconfig1, libfreetype6, libx11-6, libxcb-cursor0, libxcb-util1, libxcb-xkb1, libxcb1, libxkbcommon-x11-0, libxkbcommon0, fonts-lato, xdg-utils, zenity
 Provides: vst-plugin
 Section: sound
 Priority: optional
-Description: Surge Synthesizer plugin
+Description: Subtractive hybrid synthesizer virtual instrument
+ Surge includes VST2, VST3, and LV2 virtual instrument formats for use in compatible hosts.
 EOT
 
-DATE=`date`
+touch ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc/changelog.Debian
+DATE=`date --rfc-email`
 MSG=`git log -n 1 --pretty="%s (git hash %H)"`
-cat <<EOT > ${PACKAGE_NAME}/DEBIAN/changelog
+cat <<EOT > ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc/changelog.Debian
 ${PACKAGE_NAME} (${DEB_VERSION}) stable; urgency=medium
 
   * ${MSG}
@@ -74,20 +77,26 @@ ${PACKAGE_NAME} (${DEB_VERSION}) stable; urgency=medium
 
  -- Surge Synthesizer Team <noreply@github.com>  ${DATE}
 EOT
+gzip -9 -n ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc/changelog.Debian
 
 #copy data and vst plugins
 
-cp ../LICENSE ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc
+cp ../LICENSE ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc/copyright
 cp -r ../resources/data/* ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/
 cp ../target/vst2/Release/Surge.so ${PACKAGE_NAME}/usr/lib/vst/${SURGE_NAME}.so
 
 # Once VST3 works, this will be ../products/vst3
 cp -r ../products/Surge.vst3 ${PACKAGE_NAME}/usr/lib/vst3/
 
-#copy the lv2 bundle
+# copy the lv2 bundle
 cp -r ../target/lv2/Release/Surge.lv2 ${PACKAGE_NAME}/usr/lib/lv2/
 
-#build package
+# set permissions on shared libraries
+chmod -R 0644 ${PACKAGE_NAME}/usr/lib/vst/${SURGE_NAME}.so
+find ${PACKAGE_NAME}/usr/lib/vst3/ -type f -iname "*.so" | xargs chmod 0644
+find ${PACKAGE_NAME}/usr/lib/lv2/ -type f -iname "*.so" | xargs chmod 0644
+
+# build package
 
 mkdir -p product
 dpkg-deb --build ${PACKAGE_NAME} product/${PACKAGE_NAME}-linux-x64-${VERSION}.deb

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -180,18 +180,31 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath)
    if(!hasSuppliedDataPath)
    {
        const char* xdgDataPath = getenv("XDG_DATA_HOME");
+       std::string localDataPath = std::string(homePath) + "/.local/share/surge/";
        if (xdgDataPath)
-           datapath = std::string(xdgDataPath) + "/Surge/";
+       {
+           datapath = std::string(xdgDataPath) + "/surge/";
+       }
+       else if ( fs::is_directory(localDataPath) )
+       {
+           datapath = localDataPath;
+       }
        else
-           datapath = std::string(homePath) + "/.local/share/Surge/";
+       {
+          datapath = std::string(homePath) + "/.local/share/Surge/";
+       }
        
        /*
        ** If local directory doesn't exists - we probably came here through an installer -
-       ** use /usr/share/Surge as our last guess
+       ** check for /usr/share/surge and use /usr/share/Surge as our last guess
        */
        if (! fs::is_directory(datapath))
        {
-           datapath = "/usr/share/Surge/";
+          std::string systemDataPath = "/usr/share/surge/";
+          if ( fs::is_directory(systemDataPath) )
+             datapath = systemDataPath;
+          else
+             datapath = "/usr/share/Surge/";
        }
    }
    else


### PR DESCRIPTION
This PR updates the deb package to address Lintian errors and warnings. The package description has also been updated.

The storage location on Linux has been changed from "Surge" to "surge" to conform with debian guidelines and to enable GDebi to remove and reinstall the package.
