### PR TITLE
Fix "Open Tuning Library" on Windows

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3698,13 +3698,15 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect)
     auto *tfl = addCallbackMenu(tuningSubMenu, "Factory Tuning Library...",
                     [this]()
                     {
-                       Surge::UserInteractions::openFolderInFileBrowser(this->synth->storage.datapath +
+                       auto dpath = this->synth->storage.datapath;
+                       std::string sep = "/";
 #if WINDOWS
-                                                                        "\\"
-#else
-                                                                        "/"
-#endif                                                                        
-                          + "tuning-library");
+                       sep = "\\";
+                       if( dpath.back() == '\\' || dpath.back() == '/' )
+                         sep = "";
+#endif
+                       Surge::UserInteractions::openFolderInFileBrowser(
+                          dpath + sep + "tuning-library");
                     }
         );
 


### PR DESCRIPTION
Tuning Library contained a double back slash forcing shell open
to fail. Fix that by looking for trailing slash at path creation time.

Closes #1589