### PR TITLE
LV2 State Adjustments

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1603,7 +1603,7 @@ bool SurgeSynthesizer::loadOscalgos()
    {
       for (int i = 0; i < n_oscs; i++)
       {
-
+         bool resend = false;
          if (storage.getPatch().scene[s].osc[i].queue_type > -1)
          {
             storage.getPatch().scene[s].osc[i].type.val.i =
@@ -1612,12 +1612,14 @@ bool SurgeSynthesizer::loadOscalgos()
             storage.getPatch().scene[s].osc[i].queue_type = -1;
             switch_toggled_queued = true;
             refresh_editor = true;
+            resend = true;
          }
 
          TiXmlElement* e = (TiXmlElement*)storage.getPatch().scene[s].osc[i].queue_xmldata;
 
          if (e)
          {
+            resend = true;
             for (int k = 0; k < n_osc_params; k++)
             {
                double d;
@@ -1636,6 +1638,18 @@ bool SurgeSynthesizer::loadOscalgos()
                }
             }
             storage.getPatch().scene[s].osc[i].queue_xmldata = 0;
+         }
+         if (resend)
+         {
+#if TARGET_LV2
+            auto tp = &(storage.getPatch().scene[s].osc[i].type);
+            sendParameterAutomation(tp->id, getParameter01(tp->id) );
+            for (int k = 0; k < n_osc_params; k++)
+            {
+               auto pp = &(storage.getPatch().scene[s].osc[i].p[k]);
+               sendParameterAutomation(pp->id, getParameter01(pp->id) );
+            }
+#endif            
          }
       }
    }

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -1004,6 +1004,7 @@ CMouseEventResult CLFOGui::onMouseMoved(CPoint& where, const CButtonState& butto
                if( sge )
                {
                   sge->refresh_mod();
+                  sge->forceautomationchangefor(&(lfodata->shape));
                }
                
             }

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -1,4 +1,5 @@
 #include "globals.h"
+#include "SurgeGUIEditor.h"
 #include "DspUtilities.h"
 #include "CSnapshotMenu.h"
 #include "effect/Effect.h"
@@ -334,6 +335,16 @@ void CFxMenu::loadSnapshot(int type, TiXmlElement* e)
              ((e->QueryIntAttribute(sublbl, &j) == TIXML_SUCCESS) && (j == 1));
       }
    }
+#if TARGET_LV2
+   auto *sge = dynamic_cast<SurgeGUIEditor *>(listener);
+   if( sge )
+   {
+      sge->forceautomationchangefor( &(fxbuffer->type) );
+      for( int i=0; i<n_fx_params; ++i )
+         sge->forceautomationchangefor( &(fxbuffer->p[i] ) );
+   }
+#endif
+   
 }
 void CFxMenu::saveSnapshot(TiXmlElement* e, const char* name)
 {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3809,4 +3809,11 @@ Steinberg::tresult PLUGIN_API SurgeGUIEditor::checkSizeConstraint(Steinberg::Vie
 
 #endif
 
+void SurgeGUIEditor::forceautomationchangefor(Parameter *p)
+{
+#if TARGET_LV2
+   // revisit this for non-LV2 outside 1.6.6
+   synth->sendParameterAutomation(p->id, synth->getParameter01(p->id));
+#endif   
+}
 //------------------------------------------------------------------------------------------------

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -102,7 +102,8 @@ protected:
 
 public:
    void refresh_mod();
-
+   void forceautomationchangefor(Parameter *p);
+   
 #if TARGET_VST3
 public:
    /**


### PR DESCRIPTION
The LV2 takes the ports, not the synth, as authoritative
so some UI actions which change multiple values - notably
changing an FX or Oscillator or LFO Type - need to send
bulk parameter automation messages to make the LV2 consistent.

This may be useful/nice-to-have in the VST2/3/AU also but since
they capture values from the synth at all times, it won't make
an inconsistency. After the 1.6.6 release, go back to this diff
and consider activating it for the other hosts also, just
for consistency.

Addresses #1577