### PR TITLE
Fix problem with KBM outside of range

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1384,7 +1384,24 @@ bool SurgeStorage::retuneToScale(const Surge::Storage::Scale& s)
    if( scalePositionOfTuningNote == 0 )
       tuningCenterPitchOffset = 0;
    else
-      tuningCenterPitchOffset = s.tones[scalePositionOfTuningNote-1].floatValue - 1.0;
+   {
+      int tshift = 0;
+      while( scalePositionOfTuningNote < 0 )
+      {
+         scalePositionOfTuningNote += s.count;
+         tshift ++;
+      }
+      while( scalePositionOfTuningNote > s.count )
+      {
+         scalePositionOfTuningNote -= s.count;
+         tshift --;
+      }
+      
+      if( scalePositionOfTuningNote == 0 )
+         tuningCenterPitchOffset = -tshift;
+      else
+         tuningCenterPitchOffset = s.tones[scalePositionOfTuningNote-1].floatValue - 1.0 - tshift;
+   }
 
    pitches[posPitch0] = 1.0;
    for (int i=0; i<512; ++i)

--- a/src/common/Tunings.cpp
+++ b/src/common/Tunings.cpp
@@ -334,11 +334,11 @@ R"HTML(
             <th>#</th><th>Datum</th><th>Cents</th><th>Float</th>
           </tr>
           <tr>
-            <td>1</td><td>1</td><td>0</td><td>1</td>
+            <td>0</td><td>1</td><td>0</td><td>1</td>
           </tr>
     )HTML";
 
-    int ct = 2;
+    int ct = 1;
     for( auto & t : tones )
     {
        htmls << "<tr><td> " << ct++ << "</td><td>";

--- a/src/headless/UnitTestsTUN.cpp
+++ b/src/headless/UnitTestsTUN.cpp
@@ -625,6 +625,139 @@ TEST_CASE( "Non-Monotonic Tunings", "[tun]" )
    }
 }
 
+TEST_CASE( "Mapping below and outside of count" )
+{
+   SECTION( "A bit below" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge.get() );
+
+      auto k = Surge::Storage::readKBMFile( "test-data/scl/mapping-note54-to-259-6.kbm" );
+
+      surge->storage.remapToKeyboard(k);
+      REQUIRE( surge->storage.table_pitch[54+256] == Approx( 259.6 / 8.175798915 ).margin( 1e-4 ) );
+      
+      for( int i=256 ; i < 256 + 128; ++i ) {
+         REQUIRE( surge->storage.table_pitch[i] > surge->storage.table_pitch[i-1] );
+      }
+   }
+
+   SECTION( "Twelve below" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge.get() );
+
+      auto k = Surge::Storage::readKBMFile( "test-data/scl/mapping-note48-to-100.kbm" );
+
+      surge->storage.remapToKeyboard(k);
+      REQUIRE( surge->storage.table_pitch[48+256] == Approx( 100.0 / 8.175798915 ).margin( 1e-4 ) );
+      
+      for( int i=256 ; i < 256 + 128; ++i ) {
+         REQUIRE( surge->storage.table_pitch[i] > surge->storage.table_pitch[i-1] );
+      }
+   }
+
+   SECTION( "A lot below" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge.get() );
+
+      auto k = Surge::Storage::readKBMFile( "test-data/scl/mapping-note42-to-100.kbm" );
+
+      surge->storage.remapToKeyboard(k);
+      REQUIRE( surge->storage.table_pitch[42+256] == Approx( 100.0 / 8.175798915 ).margin( 1e-4 ) );
+
+      for( int i=256 ; i < 256 + 128; ++i ) {
+         REQUIRE( surge->storage.table_pitch[i] > surge->storage.table_pitch[i-1] );
+      }
+   }
+
+   SECTION( "Twelve above" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge.get() );
+
+      auto k = Surge::Storage::readKBMFile( "test-data/scl/mapping-note72-to-500.kbm" );
+
+      surge->storage.remapToKeyboard(k);
+      REQUIRE( surge->storage.table_pitch[72+256] == Approx( 500.0 / 8.175798915 ).margin( 1e-4 ) );
+      
+      for( int i=256 ; i < 256 + 128; ++i ) {
+         REQUIRE( surge->storage.table_pitch[i] > surge->storage.table_pitch[i-1] );
+      }
+   }
+
+   SECTION( "A lot above" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge.get() );
+
+      auto k = Surge::Storage::readKBMFile( "test-data/scl/mapping-note80-to-1000.kbm" );
+
+      surge->storage.remapToKeyboard(k);
+      REQUIRE( surge->storage.table_pitch[80+256] == Approx( 1000.0 / 8.175798915 ).margin( 1e-4 ) );
+      
+      for( int i=256 ; i < 256 + 128; ++i ) {
+         REQUIRE( surge->storage.table_pitch[i] > surge->storage.table_pitch[i-1] );
+      }
+   }
+
+   SECTION( "A bit below with 6ns" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge.get() );
+
+      auto s = Surge::Storage::readSCLFile( "test-data/scl/6-exact.scl" );
+      surge->storage.retuneToScale(s);
+      
+      auto k = Surge::Storage::readKBMFile( "test-data/scl/mapping-note54-to-259-6.kbm" );
+      surge->storage.remapToKeyboard(k);
+      
+      REQUIRE( surge->storage.table_pitch[54+256] == Approx( 259.6 / 8.175798915 ).margin( 1e-4 ) );
+      
+      for( int i=256 ; i < 256 + 128; ++i ) {
+         REQUIRE( surge->storage.table_pitch[i] > surge->storage.table_pitch[i-1] );
+      }
+   }
+
+   SECTION( "A lot below witn 6ns" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge.get() );
+
+      auto s = Surge::Storage::readSCLFile( "test-data/scl/6-exact.scl" );
+      surge->storage.retuneToScale(s);
+
+      auto k = Surge::Storage::readKBMFile( "test-data/scl/mapping-note42-to-100.kbm" );
+
+      surge->storage.remapToKeyboard(k);
+      REQUIRE( surge->storage.table_pitch[42+256] == Approx( 100.0 / 8.175798915 ).margin( 1e-4 ) );
+
+      for( int i=256 ; i < 256 + 128; ++i ) {
+         REQUIRE( surge->storage.table_pitch[i] > surge->storage.table_pitch[i-1] );
+      }
+   }
+
+   SECTION( "A lot above with 6ns" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge.get() );
+
+      auto s = Surge::Storage::readSCLFile( "test-data/scl/6-exact.scl" );
+      surge->storage.retuneToScale(s);
+
+      auto k = Surge::Storage::readKBMFile( "test-data/scl/mapping-note80-to-1000.kbm" );
+
+      surge->storage.remapToKeyboard(k);
+      REQUIRE( surge->storage.table_pitch[80+256] == Approx( 1000.0 / 8.175798915 ).margin( 1e-4 ) );
+      
+      for( int i=256 ; i < 256 + 128; ++i ) {
+         REQUIRE( surge->storage.table_pitch[i] > surge->storage.table_pitch[i-1] );
+      }
+   }
+
+}
+
 TEST_CASE( "HPF Ignores Tuning Properly", "[tun][dsp]" )
 {
    INFO( "Testing condition reported in #1545" );

--- a/test-data/scl/mapping-note42-to-100.kbm
+++ b/test-data/scl/mapping-note42-to-100.kbm
@@ -1,0 +1,21 @@
+! Template for a keyboard mapping
+!
+! Size of map. The pattern repeats every so many keys:
+0
+! First MIDI note number to retune:
+0
+! Last MIDI note number to retune:
+127
+! Middle note where the first entry of the mapping is mapped to:
+60
+! Reference note for which frequency is given:
+42
+! Frequency to tune the above note to (floating point e.g. 440.0):
+100
+! Scale degree to consider as formal octave (determines difference in pitch
+! between adjacent mapping patterns):
+0
+! Mapping.
+! The numbers represent scale degrees mapped to keys. The first entry is for
+! the given middle note, the next for subsequent higher keys.
+! For an unmapped key, put in an "x". At the end, unmapped keys may be left out.

--- a/test-data/scl/mapping-note48-to-100.kbm
+++ b/test-data/scl/mapping-note48-to-100.kbm
@@ -1,0 +1,21 @@
+! Template for a keyboard mapping
+!
+! Size of map. The pattern repeats every so many keys:
+0
+! First MIDI note number to retune:
+0
+! Last MIDI note number to retune:
+127
+! Middle note where the first entry of the mapping is mapped to:
+60
+! Reference note for which frequency is given:
+48
+! Frequency to tune the above note to (floating point e.g. 440.0):
+100
+! Scale degree to consider as formal octave (determines difference in pitch
+! between adjacent mapping patterns):
+0
+! Mapping.
+! The numbers represent scale degrees mapped to keys. The first entry is for
+! the given middle note, the next for subsequent higher keys.
+! For an unmapped key, put in an "x". At the end, unmapped keys may be left out.

--- a/test-data/scl/mapping-note53-to-430-408.kbm
+++ b/test-data/scl/mapping-note53-to-430-408.kbm
@@ -1,0 +1,21 @@
+! Template for a keyboard mapping
+!
+! Size of map. The pattern repeats every so many keys:
+0
+! First MIDI note number to retune:
+0
+! Last MIDI note number to retune:
+127
+! Middle note where the first entry of the mapping is mapped to:
+60
+! Reference note for which frequency is given:
+53
+! Frequency to tune the above note to (floating point e.g. 440.0):
+430.408
+! Scale degree to consider as formal octave (determines difference in pitch
+! between adjacent mapping patterns):
+0
+! Mapping.
+! The numbers represent scale degrees mapped to keys. The first entry is for
+! the given middle note, the next for subsequent higher keys.
+! For an unmapped key, put in an "x". At the end, unmapped keys may be left out.

--- a/test-data/scl/mapping-note54-to-259-6.kbm
+++ b/test-data/scl/mapping-note54-to-259-6.kbm
@@ -1,0 +1,21 @@
+! Template for a keyboard mapping
+!
+! Size of map. The pattern repeats every so many keys:
+0
+! First MIDI note number to retune:
+0
+! Last MIDI note number to retune:
+127
+! Middle note where the first entry of the mapping is mapped to:
+60
+! Reference note for which frequency is given:
+54
+! Frequency to tune the above note to (floating point e.g. 440.0):
+259.6
+! Scale degree to consider as formal octave (determines difference in pitch
+! between adjacent mapping patterns):
+0
+! Mapping.
+! The numbers represent scale degrees mapped to keys. The first entry is for
+! the given middle note, the next for subsequent higher keys.
+! For an unmapped key, put in an "x". At the end, unmapped keys may be left out.

--- a/test-data/scl/mapping-note72-to-500.kbm
+++ b/test-data/scl/mapping-note72-to-500.kbm
@@ -1,0 +1,21 @@
+! Template for a keyboard mapping
+!
+! Size of map. The pattern repeats every so many keys:
+0
+! First MIDI note number to retune:
+0
+! Last MIDI note number to retune:
+127
+! Middle note where the first entry of the mapping is mapped to:
+60
+! Reference note for which frequency is given:
+72
+! Frequency to tune the above note to (floating point e.g. 440.0):
+500
+! Scale degree to consider as formal octave (determines difference in pitch
+! between adjacent mapping patterns):
+0
+! Mapping.
+! The numbers represent scale degrees mapped to keys. The first entry is for
+! the given middle note, the next for subsequent higher keys.
+! For an unmapped key, put in an "x". At the end, unmapped keys may be left out.

--- a/test-data/scl/mapping-note80-to-1000.kbm
+++ b/test-data/scl/mapping-note80-to-1000.kbm
@@ -1,0 +1,21 @@
+! Template for a keyboard mapping
+!
+! Size of map. The pattern repeats every so many keys:
+0
+! First MIDI note number to retune:
+0
+! Last MIDI note number to retune:
+127
+! Middle note where the first entry of the mapping is mapped to:
+60
+! Reference note for which frequency is given:
+80
+! Frequency to tune the above note to (floating point e.g. 440.0):
+1000
+! Scale degree to consider as formal octave (determines difference in pitch
+! between adjacent mapping patterns):
+0
+! Mapping.
+! The numbers represent scale degrees mapped to keys. The first entry is for
+! the given middle note, the next for subsequent higher keys.
+! For an unmapped key, put in an "x". At the end, unmapped keys may be left out.


### PR DESCRIPTION
If the KBM was set so the tuning note was
outside of the range centerNote, centerNote+s.length the
tuning mapped incorrectly. This fixes that case and also
adds a regtest to make sure the tuning which results is both
centered correctly and strictly monotonic