### PR TITLE
Handle VST3 poly aftertouch as real value

### DIFF
--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -258,9 +258,11 @@ void SurgeVst3Processor::processEvent(const Event& e)
    }
 
    case Event::kPolyPressureEvent:
-      getSurge()->polyAftertouch(e.polyPressure.channel, e.polyPressure.pitch,
-                                 e.polyPressure.pressure);
+   {
+      char cPres = value01ToMidi7Bit(e.polyPressure.pressure);
+      getSurge()->polyAftertouch(e.polyPressure.channel, e.polyPressure.pitch, cPres);
       break;
+   }
    }
 }
 


### PR DESCRIPTION
This is supposed to fix incorrect interpretation of the poly aftertouch.
It's just as is, I have not tried.
I have noticed this while studying how VST3 works.

fixes #1610 