### PR TITLE
Support Default Skins

### DIFF
--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -119,10 +119,12 @@ private:
    ~SkinDB();
    SkinDB(const SkinDB&) = delete; 
    SkinDB& operator=(const SkinDB&) = delete; 
-
+   SurgeStorage *storage;
+   
    std::vector<Entry> availableSkins;
    std::unordered_map<Entry,std::shared_ptr<Skin>, Entry::hash> skins;
    Entry defaultSkinEntry;
+   bool foundDefaultSkinEntry = false;
    
    static std::shared_ptr<SkinDB> instance;
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3782,6 +3782,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeSkinMenu(VSTGUI::CRect &menuRect)
                           this->currentSkin->reloadSkin(this->bitmapStore);
                           reloadFromSkin();
                           this->synth->refresh_editor = true;
+                          Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "defaultSkin", entry.name );
                        });
        tid++;
     }


### PR DESCRIPTION
When you select a skin, it automatically becomes your
default for all future surges until you choose anotherone
or remove your Defaults file. If your skin is missing it
reverts to the default skin.

Closes #1621