### PR TITLE
Add a Skin-optional button glyph for status panel

### DIFF
--- a/src/common/gui/CStatusPanel.cpp
+++ b/src/common/gui/CStatusPanel.cpp
@@ -1,5 +1,6 @@
 #include "SurgeGUIEditor.h"
 #include "CStatusPanel.h"
+#include "CScalableBitmap.h"
 #include "RuntimeFont.h"
 
 
@@ -8,6 +9,8 @@ using namespace VSTGUI;
 void CStatusPanel::draw( VSTGUI::CDrawContext *dc )
 {
     auto size = getViewSize();
+
+    auto statusButtonGlyph = bitmapStore->getBitmapByStringID( "STATUS_BUTTON" );
 
     dc->setFont(displayFont);
     auto sw = dc->getStringWidth("Status");
@@ -29,7 +32,7 @@ void CStatusPanel::draw( VSTGUI::CDrawContext *dc )
            mpeBox = CRect(xp,yp,xp+w,yp+h);
        if( i == tuningMode )
            tuningBox = CRect(xp,yp,xp+w,yp+h);
-       
+
        auto hlbg = true;
        auto ol = skin->getColor( "mpetunstatus.button.outline", CColor(0x97, 0x97, 0x97 ) );
        auto bg = skin->getColor( "mpetunstatus.button.background", CColor(0xe3, 0xe3, 0xe3 ) );
@@ -41,21 +44,34 @@ void CStatusPanel::draw( VSTGUI::CDrawContext *dc )
            hlbg = false;
        }
 
-       dc->setDrawMode(VSTGUI::kAntiAliasing);
-       dc->setFrameColor(bg);;
-       auto p = dc->createRoundRectGraphicsPath(CRect(xp,yp,xp+w,yp+h), 5 );
-       dc->setFillColor(bg);;
-       dc->drawGraphicsPath(p, CDrawContext::kPathFilled);
-       dc->setFrameColor(ol);
-       dc->drawGraphicsPath(p, CDrawContext::kPathStroked);
-       p->forget();
+       if( statusButtonGlyph != nullptr )
+       {
+          CRect wr = CRect(xp,yp,xp+w,yp+h);
+
+          statusButtonGlyph->draw( dc, wr, CPoint( 0, h * ( hlbg ? 1 : 0 ) ), 0xff );
+       }
+       else
+       {
+          dc->setDrawMode(VSTGUI::kAntiAliasing);
+          dc->setFrameColor(bg);;
+          auto p = dc->createRoundRectGraphicsPath(CRect(xp,yp,xp+w,yp+h), 5 );
+          dc->setFillColor(bg);;
+          dc->drawGraphicsPath(p, CDrawContext::kPathFilled);
+          dc->setFrameColor(ol);
+          dc->drawGraphicsPath(p, CDrawContext::kPathStroked);
+          p->forget();
+          
+          if( hlbg )
+          {
+             auto p = dc->createRoundRectGraphicsPath(CRect(xp+2,yp+2,xp+w-2,yp+h-2), 3 );
+             dc->setFillColor(hl);
+             dc->drawGraphicsPath(p, CDrawContext::kPathFilled);
+             p->forget();
+          }
+       }
 
        if( hlbg )
        {
-           auto p = dc->createRoundRectGraphicsPath(CRect(xp+2,yp+2,xp+w-2,yp+h-2), 3 );
-           dc->setFillColor(hl);
-           dc->drawGraphicsPath(p, CDrawContext::kPathFilled);
-           p->forget();
            dc->setFontColor(fg);
        }
        else

--- a/src/common/gui/CStatusPanel.h
+++ b/src/common/gui/CStatusPanel.h
@@ -5,6 +5,7 @@
 #include "SurgeStorage.h"
 #include "vstcontrols.h"
 #include "SkinSupport.h"
+#include "SurgeBitmaps.h"
 
 class SurgeGUIEditor;
 
@@ -18,8 +19,9 @@ public:
         numDisplayFeatures
     } DisplayFeatures;
     
-    CStatusPanel(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, SurgeStorage* storage)
-        : VSTGUI::CControl(size, listener, tag, 0) {
+    CStatusPanel(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag,
+                 SurgeStorage* storage, std::shared_ptr<SurgeBitmaps> ibms)
+       : VSTGUI::CControl(size, listener, tag, 0), bitmapStore(ibms) {
         for( auto i=0; i<numDisplayFeatures; ++i )
             dispfeatures[i] = false;
         doingDrag = false;
@@ -63,7 +65,7 @@ protected:
     SurgeStorage* storage = nullptr;
     SurgeGUIEditor *editor = nullptr;
     VSTGUI::CRect mpeBox, tuningBox, tuningLock;
-    
+    std::shared_ptr<SurgeBitmaps> bitmapStore;
     
     CLASS_METHODS(CStatusPanel, VSTGUI::CControl)
 };

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -349,7 +349,12 @@ void Skin::reloadSkin(std::shared_ptr<SurgeBitmaps> bitmapStore)
          {
             if (id.size() > 0)
             {
-               bitmapStore->loadBitmapByPathForID(resourceName(res), imageIds[id]);
+               if( imageIds.find(id) != imageIds.end() )
+                  bitmapStore->loadBitmapByPathForID(resourceName(res), imageIds[id]);
+               else
+               {
+                  bitmapStore->loadBitmapByPathForStringID(resourceName(res), id );
+               }
             }
             else
             {

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -16,6 +16,14 @@ SurgeBitmaps::~SurgeBitmaps()
    {
       pair.second->forget();
    }
+   for (auto pair : bitmap_file_registry)
+   {
+      pair.second->forget();
+   }
+   for (auto pair : bitmap_stringid_registry)
+   {
+      pair.second->forget();
+   }
    bitmap_registry.clear();
 }
 
@@ -82,6 +90,13 @@ CScalableBitmap* SurgeBitmaps::getBitmapByPath(std::string path)
    return bitmap_file_registry.at(path);
 }
 
+CScalableBitmap* SurgeBitmaps::getBitmapByStringID(std::string id)
+{
+   if( bitmap_stringid_registry.find(id) == bitmap_stringid_registry.end() )
+      return nullptr;
+   return bitmap_stringid_registry[id];
+}
+
 CScalableBitmap* SurgeBitmaps::loadBitmapByPath(std::string path )
 {
    bitmap_file_registry[path] = new CScalableBitmap(path, frame);
@@ -99,11 +114,24 @@ CScalableBitmap* SurgeBitmaps::loadBitmapByPathForID(std::string path, int id)
    return bitmap_registry[id];
 }
 
+CScalableBitmap* SurgeBitmaps::loadBitmapByPathForStringID(std::string path, std::string id)
+{
+   if( bitmap_stringid_registry.find(id) != bitmap_stringid_registry.end() )
+   {
+      // FIXME - think about ownership here
+      bitmap_stringid_registry[id]->forget();
+   }
+   bitmap_stringid_registry[id] = new CScalableBitmap( path, frame );
+   return bitmap_stringid_registry[id];
+}
+
 void SurgeBitmaps::setPhysicalZoomFactor(int pzf)
 {
    for (auto pair : bitmap_registry)
       pair.second->setPhysicalZoomFactor(pzf);
    for (auto pair : bitmap_file_registry)
+      pair.second->setPhysicalZoomFactor(pzf);
+   for (auto pair : bitmap_stringid_registry)
       pair.second->setPhysicalZoomFactor(pzf);
 }
 

--- a/src/common/gui/SurgeBitmaps.h
+++ b/src/common/gui/SurgeBitmaps.h
@@ -17,12 +17,16 @@ public:
 
    CScalableBitmap* getBitmap(int id);
    CScalableBitmap* getBitmapByPath(std::string filename);
+   CScalableBitmap* getBitmapByStringID(std::string id);
+   
    CScalableBitmap* loadBitmapByPath(std::string filename);
    CScalableBitmap* loadBitmapByPathForID(std::string filename, int id);
+   CScalableBitmap* loadBitmapByPathForStringID(std::string filename, std::string id);
    
 protected:
    void addEntry(int id, VSTGUI::CFrame* f);
    std::map<int, CScalableBitmap*> bitmap_registry;
    std::map<std::string, CScalableBitmap*> bitmap_file_registry;
+   std::map<std::string, CScalableBitmap*> bitmap_stringid_registry;
    VSTGUI::CFrame *frame;
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -887,7 +887,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
    ((CPatchBrowser*)patchname)->setAuthor(synth->storage.getPatch().author);
    frame->addView(patchname);
 
-   statuspanel = new CStatusPanel(CRect( 560, 1, 595, 54 ), this, tag_statuspanel, &synth->storage);
+   statuspanel = new CStatusPanel(CRect( 560, 1, 595, 54 ), this, tag_statuspanel, &synth->storage, bitmapStore);
    {
        CStatusPanel *pb = (CStatusPanel *)statuspanel;
        pb->setSkin( currentSkin );


### PR DESCRIPTION
The status panel button is drawn in code. Make it so that
you can also draw the button with a 2 state button. The button
is 31x11 so the sprite glyph is 31x22 with the off state first.
It is specified in a skin with <image id="STATUS_BUTTON" resource=".."/>

Addresses #1634