### PR TITLE
Implement "lfo.waveform.fill"

### DIFF
--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -4,7 +4,7 @@
     <defaultimage directory="SVG/"/>
 
     
-    <color id="lfo.waveform.fill" value="#303030"/> <!-- Only used in the bitmap mode (linux; slow windows) -->
+    <color id="lfo.waveform.fill" value="#303030"/> 
     <color id="lfo.waveform.font" value="#FF9000"/>
     <color id="lfo.waveform.rules" value="#FF9000"/>
     <color id="lfo.waveform.envelope" value="#FF9000"/>
@@ -13,6 +13,7 @@
     <color id="lfo.type.unselected.foreground" value="#B4B4B4"/>
 
     <color id="lfo.stepseq.background" value="#202020"/>
+    
     <color id="lfo.stepseq.stepmarker" value="#ff9000"/>
     <color id="lfo.stepseq.loopregionlo" value="#151515"/>
     <color id="lfo.stepseq.loopregionhi" value="#202020"/>

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -154,6 +154,15 @@ void CLFOGui::drawVectorized(CDrawContext* dc)
       tlfo->attack();
       CRect boxo(maindisp);
       boxo.offset(-size.left - splitpoint, -size.top);
+
+      if( skin->hasColor( "lfo.waveform.fill" ) )
+      {
+         CRect boxI(size);
+         boxI.left += lpsize + 4 + 15;
+
+         dc->setFillColor( skin->getColor( "lfo.waveform.fill", CColor( 0xFF, 0x90, 0x00 ) ) );
+         dc->drawRect(boxI, CDrawStyle::kDrawFilled);
+      }
       
       int minSamples = ( 1 << 3 ) * (int)( boxo.right - boxo.left );
       int totalSamples = std::max( (int)minSamples, (int)(totalEnvTime * samplerate / BLOCK_SIZE) );
@@ -481,7 +490,7 @@ void CLFOGui::drawBitmap(CDrawContext* dc)
    maindisp.bottom -= 1;
 
    cdisurf->begin();
-   auto col = skin->getColor( "lfo.stepseq.background", CColor( 0xFF, 0x90, 0x00 ) );
+   auto col = skin->getColor( "lfo.waveform.fill", CColor( 0xFF, 0x90, 0x00 ) );
    int r = col.red;
    int g = col.green;
    int b = col.blue;
@@ -498,6 +507,17 @@ void CLFOGui::drawBitmap(CDrawContext* dc)
 
    if (ss && lfodata->shape.val.i == ls_stepseq)
    {
+      auto col = skin->getColor( "lfo.stepseq.background", CColor( 0xFF, 0x90, 0x00 ) );
+      int r = col.red;
+      int g = col.green;
+      int b = col.blue;
+#if MAC
+      int c = ( b << 24 ) + ( g << 16 ) + ( r << 8 ) + 255;
+      cdisurf->clear(c);
+#else
+      int c = ( b ) + ( g << 8 ) + ( r << 16 ) + ( 255 << 24 );
+      cdisurf->clear(c);
+#endif
       drawStepSeq(dc, maindisp, leftpanel);
    }
    else


### PR DESCRIPTION
Color "lfo.waveform.fill" fills the waveform section of the LFO
display. Otherwise it is left transparent to the background.

Addresses #1635