### PR TITLE
Leak checkers; and clean up offscreen caches

### DIFF
--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <map>
+#include <atomic>
 
 #include "nanosvg.h"
 
@@ -17,6 +18,7 @@ class CScalableBitmap : public VSTGUI::CBitmap
 public:
    CScalableBitmap(VSTGUI::CResourceDescription d, VSTGUI::CFrame* f);
    CScalableBitmap(std::string fname, VSTGUI::CFrame* f);
+   ~CScalableBitmap();
 
    virtual void draw(VSTGUI::CDrawContext* context,
                      const VSTGUI::CRect& rect,
@@ -60,10 +62,12 @@ private:
    };
 
    std::map<VSTGUI::CPoint, VSTGUI::CBitmap*, CPointCompare> offscreenCache;
-
+   static std::atomic<int> instances;
+   
    int lastSeenZoom, bestFitScaleGroup;
    int extraScaleFactor;
    int resourceID;
+   std::string fname;
 
    VSTGUI::CFrame* frame;
 

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -207,15 +207,19 @@ std::unordered_map<std::string, int> createIdNameMap()
    return res;
 }
 
+std::atomic<int> Skin::instances( 0 );
+
 Skin::Skin(std::string root, std::string name) : root(root), name(name)
 {
-   std::cout << "Constructing a skin " << _D(root) << _D(name) << std::endl;
+   instances++;
+   std::cout << "Constructing a skin " << _D(root) << _D(name) << _D(instances) << std::endl;
    imageIds = createIdNameMap();
 }
 
 Skin::~Skin()
 {
-   std::cout << "Destroying a skin" << std::endl;
+   instances--;
+   std::cout << "Destroying a skin " << _D(instances) << std::endl;
 }
 
 #if !defined(TINYXML_SAFE_TO_ELEMENT)

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <memory>
+#include <atomic>
 
 #include "vstgui/lib/ccolor.h"
 
@@ -82,6 +83,7 @@ public:
    std::unordered_set<std::string> getQueriedColors() { return queried_colors; }
    
 private:
+   static std::atomic<int> instances;
    std::vector<std::pair<std::string, props_t>> globals;
 
    std::unordered_map<std::string, VSTGUI::CColor> colors;

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -6,8 +6,11 @@
 
 using namespace VSTGUI;
 
+std::atomic<int> SurgeBitmaps::instances( 0 );
 SurgeBitmaps::SurgeBitmaps()
 {
+   instances++;
+   std::cout << "Constructing a SurgeBitmaps; Instances is " << instances << std::endl;
 }
 
 SurgeBitmaps::~SurgeBitmaps()
@@ -25,6 +28,10 @@ SurgeBitmaps::~SurgeBitmaps()
       pair.second->forget();
    }
    bitmap_registry.clear();
+   bitmap_file_registry.clear();
+   bitmap_stringid_registry.clear();
+   instances --;
+   std::cout << "Destroying a SurgeBitmaps; Instances is " << instances << std::endl;
 }
 
 void SurgeBitmaps::setupBitmapsForFrame(VSTGUI::CFrame* f)

--- a/src/common/gui/SurgeBitmaps.h
+++ b/src/common/gui/SurgeBitmaps.h
@@ -3,6 +3,7 @@
 #include "resource.h"
 #include "vstgui/vstgui.h"
 #include <map>
+#include <atomic>
 
 class CScalableBitmap;
 
@@ -24,6 +25,8 @@ public:
    CScalableBitmap* loadBitmapByPathForStringID(std::string filename, std::string id);
    
 protected:
+   static std::atomic<int> instances;
+   
    void addEntry(int id, VSTGUI::CFrame* f);
    std::map<int, CScalableBitmap*> bitmap_registry;
    std::map<std::string, CScalableBitmap*> bitmap_file_registry;


### PR DESCRIPTION
In #1647 we had a report that the skin engine seemed to increase
load time as the run went on, probably due to a leak. This change
adds some leak checkers I can use, and also closes one leak
in the CScalableBitmap offscreenCache which was never forgotten.

Addresses #1647