### PR TITLE
Add a BG Bitmap for the LFO Wave Section

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -163,6 +163,13 @@ void CLFOGui::drawVectorized(CDrawContext* dc)
          dc->setFillColor( skin->getColor( "lfo.waveform.fill", CColor( 0xFF, 0x90, 0x00 ) ) );
          dc->drawRect(boxI, CDrawStyle::kDrawFilled);
       }
+      auto lfoBgGlyph = bitmapStore->getBitmapByStringID( "LFO_WAVE_BACKGROUND" );
+      if( lfoBgGlyph != nullptr )
+      {
+         CRect boxI(size);
+         boxI.left += lpsize + 4 + 15;
+         lfoBgGlyph->draw( dc, boxI, CPoint( 0, 0 ), 0xff );
+      }
       
       int minSamples = ( 1 << 3 ) * (int)( boxo.right - boxo.left );
       int totalSamples = std::max( (int)minSamples, (int)(totalEnvTime * samplerate / BLOCK_SIZE) );

--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -7,7 +7,8 @@
 #include "CDIBitmap.h"
 #include "DspUtilities.h"
 #include "SkinSupport.h"
-
+#include "SurgeBitmaps.h"
+#include "CScalableBitmap.h"
 
 
 class CLFOGui : public VSTGUI::CControl, public Surge::UI::SkinConsumingComponnt
@@ -29,8 +30,10 @@ public:
            long tag = 0,
            LFOStorage* lfodata = 0,
            SurgeStorage* storage = 0,
-           StepSequencerStorage* ss = 0)
-       : VSTGUI::CControl(size, listener, tag, 0)
+           StepSequencerStorage* ss = 0,
+           std::shared_ptr<SurgeBitmaps> ibms = nullptr)
+      : VSTGUI::CControl(size, listener, tag, 0),
+        bitmapStore( ibms )
    {
       this->lfodata = lfodata;
       this->storage = storage;
@@ -123,6 +126,7 @@ protected:
    SurgeStorage* storage;
    unsigned int coltable[256];
    CDIBitmap* cdisurf;
+   std::shared_ptr<SurgeBitmaps> bitmapStore;
    int tsNum = 4, tsDen = 4;
    
    

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1279,7 +1279,8 @@ void SurgeGUIEditor::openOrRecreateEditor()
                CLFOGui* slfo = new CLFOGui(
                    rect, lfo_id == 0, this, p->id + start_paramtags,
                    &synth->storage.getPatch().scene[current_scene].lfo[lfo_id], &synth->storage,
-                   &synth->storage.getPatch().stepsequences[current_scene][lfo_id]);
+                   &synth->storage.getPatch().stepsequences[current_scene][lfo_id],
+                   bitmapStore);
                slfo->setSkin( currentSkin );
                lfodisplay = slfo;
                frame->addView(slfo);


### PR DESCRIPTION
The LFO Wave Section can have its own independent bitmap.
Currently this is all too size dependent and static but it
will allow us wiggle in the future. Provide a 280x85
bitmap as LFO_WAVE_BACKGROUND.

Closes #1657