### PR TITLE
Fix 3 memory issues in the skin parser

### DIFF
--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -205,6 +205,10 @@ CScalableBitmap::~CScalableBitmap()
    }
    offscreenCache.clear();
 
+   if( svgImage )
+   {
+      nsvgDelete( svgImage );
+   }
    instances--;
    //std::cout << "  Destroy CScalableBitmap. instances=" << instances << " id=" << resourceID << " fn=" << fname << std::endl;
 }
@@ -457,6 +461,7 @@ void CScalableBitmap::drawSVG(CDrawContext* dc,
             VSTGUI::CPoint p1 = gradXform.inverse().transform(s1);
 
             dc->fillLinearGradient(gp, *cg, p0, p1, evenOdd);
+            cg->forget();
          }
          else
          {

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -151,6 +151,8 @@ private:
 
 class SkinConsumingComponnt {
 public:
+   virtual ~SkinConsumingComponnt() {
+   }
    virtual void setSkin( Skin::ptr_t s ) { skin = s; }
 protected:
    Skin::ptr_t skin;

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -106,6 +106,10 @@ CScalableBitmap* SurgeBitmaps::getBitmapByStringID(std::string id)
 
 CScalableBitmap* SurgeBitmaps::loadBitmapByPath(std::string path )
 {
+   if( bitmap_file_registry.find(path) != bitmap_file_registry.end() )
+   {
+      bitmap_file_registry[path]->forget();
+   }
    bitmap_file_registry[path] = new CScalableBitmap(path, frame);
    return bitmap_file_registry[path];
 }
@@ -114,7 +118,6 @@ CScalableBitmap* SurgeBitmaps::loadBitmapByPathForID(std::string path, int id)
 {
    if( bitmap_registry.find(id) != bitmap_registry.end() )
    {
-      // FIXME - think about ownership here
       bitmap_registry[id]->forget();
    }
    bitmap_registry[id] = new CScalableBitmap( path, frame );
@@ -125,7 +128,6 @@ CScalableBitmap* SurgeBitmaps::loadBitmapByPathForStringID(std::string path, std
 {
    if( bitmap_stringid_registry.find(id) != bitmap_stringid_registry.end() )
    {
-      // FIXME - think about ownership here
       bitmap_stringid_registry[id]->forget();
    }
    bitmap_stringid_registry[id] = new CScalableBitmap( path, frame );


### PR DESCRIPTION
1. (Major) - leaked the SVG parse tree all the time
2. (Medium) - leaked a reference to a Gradient when drawing
3. (Small) - didn't forget images when reloading by path, although that
   API was unused

Addresses #1647