### PR TITLE
Zoom Oversample on Windows

### DIFF
--- a/src/windows/DisplayInfoWin.cpp
+++ b/src/windows/DisplayInfoWin.cpp
@@ -27,11 +27,11 @@ float getDisplayBackingScaleFactor(CFrame *f)
         GetScaleFactorForMonitor(hMon,&pScale);
         // At this point we would convert this painfully to a float with a big switch. But until
         // we implement scalable bitmaps it doesn't matter, so:
-        return 1.0;
+        return 2.0;
     }
 #endif
 
-    return 1.0;
+    return 2.0;
 }
     
 CRect getScreenDimensions(CFrame *)


### PR DESCRIPTION
Set the default backing factor on windows to 2, not 1.

Addresses #1650