### PR TITLE
Set ringout for Reverb2

### DIFF
--- a/src/common/dsp/effect/Reverb2Effect.cpp
+++ b/src/common/dsp/effect/Reverb2Effect.cpp
@@ -168,10 +168,21 @@ void Reverb2Effect::setvars(bool init)
    calc_size(1.f);
 }
 
+void Reverb2Effect::update_rtime()
+{
+   float t = BLOCK_SIZE_INV * ( samplerate * powf(2.f, *f[r2p_decay_time]) * 2.f); // *2 is to get the db120 time
+   ringout_time = (int)t;
+}
+
 void Reverb2Effect::process(float* dataL, float* dataR)
 {
    float scale = powf(2.f, 1.f * *f[r2p_room_size]);
    calc_size(scale);
+
+   if (fabs(*f[r2p_decay_time] - last_decay_time) > 0.001f)
+      update_rtime();
+
+   last_decay_time = *f[r2p_decay_time];
 
    float wetL alignas(16)[BLOCK_SIZE],
          wetR alignas(16)[BLOCK_SIZE];

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -537,7 +537,9 @@ public:
       return ringout_time;
    }
 
+
 private:
+   void update_rtime();
    int ringout_time;
    allpass _input_allpass[NUM_INPUT_ALLPASSES];
    allpass _allpass[NUM_BLOCKS][NUM_ALLPASSES_PER_BLOCK];
@@ -556,4 +558,5 @@ private:
    lipol<float, true> _lf_damp_coefficent;
    lipol<float, true> _modulation;
    quadr_osc _lfo;
+   float last_decay_time = -1.0;
 };


### PR DESCRIPTION
As we go around restoring Reverb2, the ringout parameter was
uninitialized leading to a clean 0 on mac (infinite ringout)
but a random value on windows (random ringout). Set it to
a reasonable approximation of the right time.

Closes #1689
Addresses #881