### PR TITLE
Add a timing hook to UI Instrumentation; Fix a Globals quadratic

### DIFF
--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -7,6 +7,7 @@
 #include "SurgeBitmaps.h"
 #include "UserInteractions.h"
 #include "UserDefaults.h"
+#include "UIInstrumentation.h"
 
 #if LINUX
 #include <experimental/filesystem>
@@ -34,6 +35,9 @@ SkinDB& Surge::UI::SkinDB::get(SurgeStorage* s)
 
 SkinDB::SkinDB(SurgeStorage* s)
 {
+#ifdef INSTRUMENT_UI
+   Surge::Debug::record( "SkinDB::SkinDB" );
+#endif   
    std::cout << "Constructing SkinDB" << std::endl;
    rescanForSkins(s);
    this->storage = s;
@@ -41,6 +45,9 @@ SkinDB::SkinDB(SurgeStorage* s)
 
 SkinDB::~SkinDB()
 {
+#ifdef INSTRUMENT_UI
+   Surge::Debug::record( "SkinDB::~SkinDB" );
+#endif   
    skins.clear(); // Not really necessary but means the skins are destroyed before the rest of the
                   // dtor runs
    std::cout << "Destroying SkinDB" << std::endl;
@@ -73,6 +80,9 @@ std::shared_ptr<Skin> SkinDB::getSkin(const Entry& skinEntry)
 
 void SkinDB::rescanForSkins(SurgeStorage* storage)
 {
+#ifdef INSTRUMENT_UI
+   Surge::Debug::record( "SkinDB::rescanForSkins" );
+#endif   
    availableSkins.clear();
 
    std::vector<std::string> paths = {storage->datapath, storage->userDataPath};
@@ -211,6 +221,9 @@ std::atomic<int> Skin::instances( 0 );
 
 Skin::Skin(std::string root, std::string name) : root(root), name(name)
 {
+#ifdef INSTRUMENT_UI
+   Surge::Debug::record( "Skin::Skin" );
+#endif   
    instances++;
    std::cout << "Constructing a skin " << _D(root) << _D(name) << _D(instances) << std::endl;
    imageIds = createIdNameMap();
@@ -218,6 +231,9 @@ Skin::Skin(std::string root, std::string name) : root(root), name(name)
 
 Skin::~Skin()
 {
+#ifdef INSTRUMENT_UI
+   Surge::Debug::record( "Skin::~Skin" );
+#endif   
    instances--;
    std::cout << "Destroying a skin " << _D(instances) << std::endl;
 }
@@ -228,6 +244,10 @@ Skin::~Skin()
 
 void Skin::reloadSkin(std::shared_ptr<SurgeBitmaps> bitmapStore)
 {
+#ifdef INSTRUMENT_UI
+   Surge::Debug::record( "Skin::reloadSkin" );
+   Surge::Debug::TimeThisBlock _trs_( "Skin::reloadSkin" );
+#endif   
    std::cout << "Reloading skin " << _D(name) << std::endl;
    TiXmlDocument doc;
    // Obviously fix this
@@ -248,7 +268,6 @@ void Skin::reloadSkin(std::shared_ptr<SurgeBitmaps> bitmapStore)
       FIXMEERROR << "There is no top level suge-skin node in skin.xml" << std::endl;
       return;
    }
-
    const char* a;
    displayName = name;
    author = "";
@@ -279,6 +298,7 @@ void Skin::reloadSkin(std::shared_ptr<SurgeBitmaps> bitmapStore)
    /*
    ** Parse the globals section
    */
+   globals.clear();
    for (auto gchild = globalsxml->FirstChild(); gchild; gchild = gchild->NextSibling())
    {
       auto lkid = TINYXML_SAFE_TO_ELEMENT(gchild);

--- a/src/common/gui/UIInstrumentation.cpp
+++ b/src/common/gui/UIInstrumentation.cpp
@@ -35,6 +35,18 @@ namespace Debug
       oss << "</table></body></html>\n";
       Surge::UserInteractions::showHTML( oss.str() );
    }
+
+   TimeThisBlock::TimeThisBlock(std::string i ) : tag( i ) {
+      start = std::chrono::high_resolution_clock::now();
+   }
+
+   TimeThisBlock::~TimeThisBlock() {
+      auto end = std::chrono::high_resolution_clock::now();
+      auto duration = end - start;
+      auto durationFloat = duration.count();
+      // std::cout << "Block in " << tag << " took " << durationFloat << std::endl;
+      // FIX - record this so I can report
+   }
 }
 }
 #endif

--- a/src/common/gui/UIInstrumentation.h
+++ b/src/common/gui/UIInstrumentation.h
@@ -1,14 +1,36 @@
 // -*-c++-*-
 #pragma once
 #include <string>
+#include <chrono>
 
 #define INSTRUMENT_UI
 
 #ifdef INSTRUMENT_UI
 namespace Surge {
 namespace Debug {
+   /*
+   ** Just count how many times we hit this function 
+   */
    void record( std::string tag );
+
+   /*
+   ** Pop up the timing report in a browser 
+   */
    void report();
+
+   /*
+   ** A little structure which records the time for a block. Like
+   ** {
+   **    Surge::Debug::TimeThisBlock( "howlong" )
+   **    // do something slow
+   ** }
+   */
+   struct TimeThisBlock {
+      TimeThisBlock( std::string tag );
+      ~TimeThisBlock();
+      std::string tag;
+      std::chrono::time_point<std::chrono::high_resolution_clock> start;
+   };
 };
 };
 #endif


### PR DESCRIPTION
I was not clearing Globals when I reloaded an existing skin, leading
to massive blow out in scan of the default directory which was totally
uneeded. Fix that.

And in path to fixing that, introduce a little timer guard thing.