### PR TITLE
ED's Renaming spree, take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ packages/
 target/
 *.pdb
 packages.config
+CMakeSettings.json
 
 # XCode
 Surge.xcworkspace/

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -108,9 +108,9 @@ void SampleAndHoldOscillator::init_ctrltypes()
    oscdata->p[3].set_type(ct_none);
    oscdata->p[4].set_name("Sync");
    oscdata->p[4].set_type(ct_syncpitch);
-   oscdata->p[5].set_name("Uni Spread");
+   oscdata->p[5].set_name("Unison Detune");
    oscdata->p[5].set_type(ct_oscspread);
-   oscdata->p[6].set_name("Uni Count");
+   oscdata->p[6].set_name("Unison Voices");
    oscdata->p[6].set_type(ct_osccount);
 }
 void SampleAndHoldOscillator::init_default_values()

--- a/src/common/dsp/SurgeSuperOscillator.cpp
+++ b/src/common/dsp/SurgeSuperOscillator.cpp
@@ -293,16 +293,16 @@ void SurgeSuperOscillator::init_ctrltypes()
    oscdata->p[1].set_name("Width");
    oscdata->p[1].set_type(ct_percent);
    oscdata->p[1].val_default.f = 0.5f;
-   oscdata->p[2].set_name("Sub Width");
+   oscdata->p[2].set_name("Sub Osc Width");
    oscdata->p[2].set_type(ct_percent);
    oscdata->p[2].val_default.f = 0.5f;
-   oscdata->p[3].set_name("Sub Level");
+   oscdata->p[3].set_name("Sub Osc Level");
    oscdata->p[3].set_type(ct_percent);
    oscdata->p[4].set_name("Sync");
    oscdata->p[4].set_type(ct_syncpitch);
-   oscdata->p[5].set_name("Uni Spread");
+   oscdata->p[5].set_name("Unison Detune");
    oscdata->p[5].set_type(ct_oscspread);
-   oscdata->p[6].set_name("Uni Count");
+   oscdata->p[6].set_name("Unison Voices");
    oscdata->p[6].set_type(ct_osccount);
 }
 void SurgeSuperOscillator::init_default_values()

--- a/src/common/dsp/WavetableOscillator.cpp
+++ b/src/common/dsp/WavetableOscillator.cpp
@@ -105,17 +105,17 @@ void WavetableOscillator::init_ctrltypes()
    oscdata->p[0].set_user_data(oscdata);
    oscdata->p[0].snap = false;
 
-   oscdata->p[1].set_name("Skew V");
+   oscdata->p[1].set_name("Skew Vertical");
    oscdata->p[1].set_type(ct_percent_bidirectional);
    oscdata->p[2].set_name("Saturate");
    oscdata->p[2].set_type(ct_percent);
    oscdata->p[3].set_name("Formant");
    oscdata->p[3].set_type(ct_syncpitch);
-   oscdata->p[4].set_name("Skew H");
+   oscdata->p[4].set_name("Skew Horizontal");
    oscdata->p[4].set_type(ct_percent_bidirectional);
-   oscdata->p[5].set_name("Uni Spread");
+   oscdata->p[5].set_name("Unison Detune");
    oscdata->p[5].set_type(ct_oscspread);
-   oscdata->p[6].set_name("Uni Count");
+   oscdata->p[6].set_name("Unison Voices");
    oscdata->p[6].set_type(ct_osccountWT);
 }
 void WavetableOscillator::init_default_values()

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -80,9 +80,9 @@ void WindowOscillator::init_ctrltypes()
    oscdata->p[2].set_name("Window");
    oscdata->p[2].set_type(ct_wt2window);
 
-   oscdata->p[5].set_name("Uni Spread");
+   oscdata->p[5].set_name("Unison Detune");
    oscdata->p[5].set_type(ct_oscspread);
-   oscdata->p[6].set_name("Uni Count");
+   oscdata->p[6].set_name("Unison Voices");
    oscdata->p[6].set_type(ct_osccountWT);
 }
 void WindowOscillator::init_default_values()

--- a/src/common/dsp/effect/ConditionerEffect.cpp
+++ b/src/common/dsp/effect/ConditionerEffect.cpp
@@ -192,6 +192,8 @@ const char* ConditionerEffect::group_label(int id)
       return "Stereo";
    case 2:
       return "Limiter";
+   case 3:
+      return "Output";
    }
    return 0;
 }
@@ -205,6 +207,8 @@ int ConditionerEffect::group_label_ypos(int id)
       return 7;
    case 2:
       return 13;
+   case 3:
+      return 27;
    }
    return 0;
 }
@@ -230,11 +234,11 @@ void ConditionerEffect::init_ctrltypes()
 
    fxdata->p[4].set_name("Threshold");
    fxdata->p[4].set_type(ct_decibel_attenuation);
-   fxdata->p[5].set_name("A Rate");
+   fxdata->p[5].set_name("Attack Rate");
    fxdata->p[5].set_type(ct_percent_bidirectional);
-   fxdata->p[6].set_name("R Rate");
+   fxdata->p[6].set_name("Release Rate");
    fxdata->p[6].set_type(ct_percent_bidirectional);
-   fxdata->p[7].set_name("Output");
+   fxdata->p[7].set_name("Gain");
    fxdata->p[7].set_type(ct_decibel_attenuation);
 
    fxdata->p[0].posy_offset = 1;
@@ -246,7 +250,7 @@ void ConditionerEffect::init_ctrltypes()
    fxdata->p[4].posy_offset = 11;
    fxdata->p[5].posy_offset = 11;
    fxdata->p[6].posy_offset = 11;
-   fxdata->p[7].posy_offset = 11;
+   fxdata->p[7].posy_offset = 13;
 }
 void ConditionerEffect::init_default_values()
 {}

--- a/src/common/dsp/effect/DistortionEffect.cpp
+++ b/src/common/dsp/effect/DistortionEffect.cpp
@@ -173,9 +173,9 @@ void DistortionEffect::init_ctrltypes()
 
    fxdata->p[0].set_name("Gain");
    fxdata->p[0].set_type(ct_decibel_extendable);
-   fxdata->p[1].set_name("Freq");
+   fxdata->p[1].set_name("Frequency");
    fxdata->p[1].set_type(ct_freq_audible);
-   fxdata->p[2].set_name("BW");
+   fxdata->p[2].set_name("Bandwidth");
    fxdata->p[2].set_type(ct_bandwidth);
    fxdata->p[3].set_name("High Cut");
    fxdata->p[3].set_type(ct_freq_audible);
@@ -189,9 +189,9 @@ void DistortionEffect::init_ctrltypes()
 
    fxdata->p[6].set_name("Gain");
    fxdata->p[6].set_type(ct_decibel_extendable);
-   fxdata->p[7].set_name("Freq");
+   fxdata->p[7].set_name("Frequency");
    fxdata->p[7].set_type(ct_freq_audible);
-   fxdata->p[8].set_name("BW");
+   fxdata->p[8].set_name("Bandwidth");
    fxdata->p[8].set_type(ct_bandwidth);
    fxdata->p[9].set_name("High Cut");
    fxdata->p[9].set_type(ct_freq_audible);

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -224,13 +224,13 @@ const char* DualDelayEffect::group_label(int id)
    case 0:
       return "Input";
    case 1:
-      return "Delay time";
+      return "Delay Time";
    case 2:
       return "Feedback/EQ";
    case 3:
       return "Modulation";
    case 4:
-      return "Mix";
+      return "Output";
    }
    return 0;
 }

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -181,25 +181,25 @@ void Eq3BandEffect::init_ctrltypes()
 {
    Effect::init_ctrltypes();
 
-   fxdata->p[0].set_name("L Gain");
+   fxdata->p[0].set_name("Gain 1");
    fxdata->p[0].set_type(ct_decibel);
-   fxdata->p[1].set_name("L Freq");
+   fxdata->p[1].set_name("Frequency 1");
    fxdata->p[1].set_type(ct_freq_audible);
-   fxdata->p[2].set_name("L BW");
+   fxdata->p[2].set_name("Bandwidth 1");
    fxdata->p[2].set_type(ct_bandwidth);
 
-   fxdata->p[3].set_name("M Gain");
+   fxdata->p[3].set_name("Gain 2");
    fxdata->p[3].set_type(ct_decibel);
-   fxdata->p[4].set_name("M Freq");
+   fxdata->p[4].set_name("Frequency 2");
    fxdata->p[4].set_type(ct_freq_audible);
-   fxdata->p[5].set_name("M BW");
+   fxdata->p[5].set_name("Bandwidth 2");
    fxdata->p[5].set_type(ct_bandwidth);
 
-   fxdata->p[6].set_name("H Gain");
+   fxdata->p[6].set_name("Gain 3");
    fxdata->p[6].set_type(ct_decibel);
-   fxdata->p[7].set_name("H Freq");
+   fxdata->p[7].set_name("Frequency 3");
    fxdata->p[7].set_type(ct_freq_audible);
-   fxdata->p[8].set_name("H BW");
+   fxdata->p[8].set_name("Bandwidth 3");
    fxdata->p[8].set_type(ct_bandwidth);
 
    fxdata->p[9].set_name("Gain");

--- a/src/common/dsp/effect/FreqshiftEffect.cpp
+++ b/src/common/dsp/effect/FreqshiftEffect.cpp
@@ -211,9 +211,9 @@ const char* FreqshiftEffect::group_label(int id)
    case 0:
       return "Shift";
    case 1:
-      return "Parameters";
+      return "Delay";
    case 2:
-      return "Mix";
+      return "Output";
    }
    return 0;
 }
@@ -239,7 +239,7 @@ void FreqshiftEffect::init_ctrltypes()
    fxdata->p[fsp_shift].set_type(ct_freq_shift);
    fxdata->p[fsp_rmult].set_name("Right");
    fxdata->p[fsp_rmult].set_type(ct_percent_bidirectional);
-   fxdata->p[fsp_delay].set_name("Delay");
+   fxdata->p[fsp_delay].set_name("Time");
    fxdata->p[fsp_delay].set_type(ct_envtime);
    fxdata->p[fsp_feedback].set_name("Feedback");
    fxdata->p[fsp_feedback].set_type(ct_amplitude);

--- a/src/common/dsp/effect/PhaserEffect.cpp
+++ b/src/common/dsp/effect/PhaserEffect.cpp
@@ -149,7 +149,7 @@ const char* PhaserEffect::group_label(int id)
    case 1:
       return "Modulation";
    case 2:
-      return "Mix";
+      return "Output";
    }
    return 0;
 }
@@ -171,7 +171,7 @@ void PhaserEffect::init_ctrltypes()
 {
    Effect::init_ctrltypes();
 
-   fxdata->p[pp_base].set_name("Base Freq");
+   fxdata->p[pp_base].set_name("Base Frequency");
    fxdata->p[pp_base].set_type(ct_percent_bidirectional);
    fxdata->p[pp_feedback].set_name("Feedback");
    fxdata->p[pp_feedback].set_type(ct_percent_bidirectional);

--- a/src/common/dsp/effect/Reverb1Effect.cpp
+++ b/src/common/dsp/effect/Reverb1Effect.cpp
@@ -319,7 +319,7 @@ const char* Reverb1Effect::group_label(int id)
    case 2:
       return "EQ";
    case 3:
-      return "Mix";
+      return "Output";
    }
    return 0;
 }
@@ -360,9 +360,9 @@ void Reverb1Effect::init_ctrltypes()
 
    fxdata->p[rp_locut].set_name("Low Cut");
    fxdata->p[rp_locut].set_type(ct_freq_audible);
-   fxdata->p[rp_freq1].set_name("Band1 Freq");
+   fxdata->p[rp_freq1].set_name("Peak Freq");
    fxdata->p[rp_freq1].set_type(ct_freq_audible);
-   fxdata->p[rp_gain1].set_name("Band1 Gain");
+   fxdata->p[rp_gain1].set_name("Peak Gain");
    fxdata->p[rp_gain1].set_type(ct_decibel);
    fxdata->p[rp_hicut].set_name("High Cut");
    fxdata->p[rp_hicut].set_type(ct_freq_audible);

--- a/src/common/dsp/effect/Reverb2Effect.cpp
+++ b/src/common/dsp/effect/Reverb2Effect.cpp
@@ -289,7 +289,7 @@ const char* Reverb2Effect::group_label(int id)
    case 2:
       return "EQ";
    case 3:
-      return "Mix";
+      return "Output";
    }
    return 0;
 }

--- a/src/common/dsp/effect/RotarySpeakerEffect.cpp
+++ b/src/common/dsp/effect/RotarySpeakerEffect.cpp
@@ -86,9 +86,9 @@ const char* RotarySpeakerEffect::group_label(int id)
    switch (id)
    {
    case 0:
-      return "Rate";
+      return "Horn";
    case 1:
-      return "Depth";
+      return "Modulation";
    }
    return 0;
 }
@@ -108,11 +108,11 @@ void RotarySpeakerEffect::init_ctrltypes()
 {
    Effect::init_ctrltypes();
 
-   fxdata->p[0].set_name("Horn Rate");
+   fxdata->p[0].set_name("Rate");
    fxdata->p[0].set_type(ct_lforate);
    fxdata->p[1].set_name("Doppler");
    fxdata->p[1].set_type(ct_percent);
-   fxdata->p[2].set_name("Amp Mod");
+   fxdata->p[2].set_name("Tremolo");
    fxdata->p[2].set_type(ct_percent);
 
    fxdata->p[0].posy_offset = 1;

--- a/src/common/dsp/effect/VocoderEffect.cpp
+++ b/src/common/dsp/effect/VocoderEffect.cpp
@@ -261,11 +261,13 @@ const char* VocoderEffect::group_label(int id)
    switch (id)
    {
    case 0:
-      return "Levels";
+      return "Input";
    case 1:
-      return "Filterbank";
+      return "Filter Bank";
    case 2:
-       return "Bands";
+       return "Carrier";
+   case 3:
+       return "Modulator";
    }
    return 0;
 }
@@ -282,6 +284,8 @@ int VocoderEffect::group_label_ypos(int id)
       return 7;
    case 2:
        return 13;
+   case 3:
+       return 22;
    }
    return 0;
 }
@@ -300,7 +304,7 @@ void VocoderEffect::init_ctrltypes()
    fxdata->p[KGateLevel].set_type(ct_decibel_attenuation_large);
    fxdata->p[KGateLevel].posy_offset = 1;
 
-   fxdata->p[KRate].set_name("Rate");
+   fxdata->p[KRate].set_name("Env Follow");
    fxdata->p[KRate].set_type(ct_percent);
    fxdata->p[KRate].posy_offset = 3;
 
@@ -312,25 +316,25 @@ void VocoderEffect::init_ctrltypes()
    fxdata->p[KQuality].set_type(ct_percent_bidirectional);
    fxdata->p[KQuality].posy_offset = 3;
 
-   fxdata->p[kNumBands].set_name("# Bands");
+   fxdata->p[kNumBands].set_name("Bands");
    fxdata->p[kNumBands].set_type(ct_vocoder_bandcount);
    fxdata->p[kNumBands].posy_offset = 3;
 
-   fxdata->p[kFreqLo].set_name("Low band");
+   fxdata->p[kFreqLo].set_name("Min Frequency");
    fxdata->p[kFreqLo].set_type(ct_freq_vocoder_low);
    fxdata->p[kFreqLo].posy_offset = 3;
 
-   fxdata->p[kFreqHi].set_name("High band");
+   fxdata->p[kFreqHi].set_name("Max Frequency");
    fxdata->p[kFreqHi].set_type(ct_freq_vocoder_high);
    fxdata->p[kFreqHi].posy_offset = 3;
 
-   fxdata->p[kModExpand].set_name("Mod XPand");
+   fxdata->p[kModExpand].set_name("Mod Range");
    fxdata->p[kModExpand].set_type(ct_percent_bidirectional);
-   fxdata->p[kModExpand].posy_offset = 3;
+   fxdata->p[kModExpand].posy_offset = 6;
    
    fxdata->p[kModCenter].set_name("Mod Center");
    fxdata->p[kModCenter].set_type(ct_percent_bidirectional);
-   fxdata->p[kModCenter].posy_offset = 3;
+   fxdata->p[kModCenter].posy_offset = 6;
 
 }
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2276,7 +2276,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                cancellearn = true;
 
             std::string learnTag =
-                cancellearn ? "Abort learn controller" : "Learn controller [MIDI]";
+                cancellearn ? "Abort controller MIDI learn" : "MIDI learn controller...";
             addCallbackMenu(contextMenu, learnTag, [this, cancellearn, ccid] {
                if (cancellearn)
                   synth->learn_param = -1;
@@ -2289,7 +2289,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             {
                char txt4[128];
                decode_controllerid(txt4, synth->storage.controllers[ccid]);
-               sprintf(txt, "Clear controller [currently %s]", txt4);
+               sprintf(txt, "Clear controller [%s]", txt4);
                addCallbackMenu(contextMenu, txt, [this, ccid]() {
                   synth->storage.controllers[ccid] = -1;
                   synth->storage.save_midi_controllers();
@@ -2327,7 +2327,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
 
             contextMenu->addEntry("-", eid++);
 
-            // Construct submenus for expicit controller mapping
+            // Construct submenus for explicit controller mapping
             COptionMenu* midiSub =
                 new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
             COptionMenu* currentSub;
@@ -2423,7 +2423,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             // if(p->can_temposync() || p->can_extend_range())	contextMenu->addEntry("-",eid++);
             if (p->can_temposync())
             {
-               addCallbackMenu(contextMenu, "Temposync",
+               addCallbackMenu(contextMenu, "Tempo sync",
                                [this, p, control]() {
                                   p->temposync = !p->temposync;
                                   if( p->temposync )
@@ -2447,7 +2447,6 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                {
                   char lab[256];
                   char prefix[256];
-                  char un[5];
 
                   // WARNING - this won't work with Surge++
                   int a = p->ctrlgroup_entry + 1 - ms_lfo1;
@@ -2459,16 +2458,15 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                   bool setTSTo;
                   if( p->temposync )
                   {
-                     un[0] = 'U'; un[1] = 'n'; un[2] = '-', un[3] = 0;;
+                     snprintf(lab, 256, "Disable tempo sync for all %s parameters", prefix);
                      setTSTo = false;
                   }
                   else
                   {
-                     un[0] = 0;
+                     snprintf(lab, 256, "Enable tempo sync for all %s parameters", prefix);
                      setTSTo = true;
                   }
 
-                  snprintf(lab, 256, "%sTempoSync all %s Params", un, prefix );
                   addCallbackMenu( contextMenu, lab,
                                    [this, p, setTSTo](){
                                       // There is surely a more efficient way but this is fine
@@ -2515,7 +2513,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                if (synth->learn_param > -1)
                   cancellearn = true;
                std::string learnTag =
-                  cancellearn ? "Abort learn controller" : "Learn controller [MIDI]";
+                  cancellearn ? "Abort parameter MIDI learn" : "MIDI learn parameter...";
                addCallbackMenu(contextMenu, learnTag, [this, cancellearn, p] {
                                                          if (cancellearn)
                                                             synth->learn_param = -1;
@@ -2529,7 +2527,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             {
                char txt4[128];
                decode_controllerid(txt4, p->midictrl);
-               sprintf(txt, "Clear controller [currently %s]", txt4);
+               sprintf(txt, "Clear learned MIDI [%s]", txt4);
                addCallbackMenu(contextMenu, txt,
                                [this, p, ptag]() {
                                   // p->midictrl = -1;


### PR DESCRIPTION
* tweaked names of some sections and parameters for most FX
* added Output section for Conditioner
* added Modulator section for Vocoder (renamed Bands to Carrier)
* renamed Sub Width/Level to Sub Osc Width/Level
* renamed Uni Spread/Count to Unison Detune/Voices
* renamed Skew V/H to Skew Vertical/Horizontal
* reworded tempo sync LFO option to read more nicely