### PR TITLE
Add some warnings as errors in macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,11 @@ if( APPLE )
     -msse2
     "-D_aligned_malloc(x,a)=malloc(x)"
     "-D_aligned_free(x)=free(x)"
+    -Wno-deprecated-declarations
+    -Werror=inconsistent-missing-override
+    -Werror=logical-op-parentheses
+    -Werror=dynamic-class-memaccess
+    -Werror=undefined-bool-conversion
     ) 
   set(OS_INCLUDE_DIRECTORIES
     src/mac
@@ -486,11 +491,11 @@ if( BUILD_VST3 )
   if( APPLE )
     target_sources(surge-vst3 PRIVATE vst3sdk/public.sdk/source/main/macmain.cpp)
   elseif( UNIX AND NOT APPLE )
-    target_sources(surge-vst3 PUBLIC
+    target_sources(surge-vst3 PRIVATE
          vst3sdk/public.sdk/source/main/linuxmain.cpp
          src/linux/LinuxVST3Helpers.cpp)
   elseif( WIN32 )
-    target_sources(surge-vst3 PUBLIC vst3sdk/public.sdk/source/main/dllmain.cpp)
+    target_sources(surge-vst3 PRIVATE vst3sdk/public.sdk/source/main/dllmain.cpp)
     target_link_options( surge-vst3 PUBLIC  "/DEF:..\\resources\\windows-vst3\\surge.def" )
   endif()
 
@@ -735,8 +740,8 @@ if( BUILD_HEADLESS )
 
   find_package(LibSndFile ${PACKAGE_OPTION})
   if(NOT LIBSNDFILE_FOUND)
-    message(WARNING "LibSndFile not installed; building without wav support")
-    message(WARNING "You can 'brew install libsndfile' or 'apt-get install libsndfile1-dev'")
+    message("-- LibSndFile not installed; building without wav support")
+    message("-- You can 'brew install libsndfile' or 'apt-get install libsndfile1-dev'")
   else()
     target_compile_definitions(surge-headless
       PRIVATE

--- a/libs/xml/tinyxml.h
+++ b/libs/xml/tinyxml.h
@@ -603,19 +603,25 @@ public:
 	/// Returns true if this node has no children.
 	bool NoChildren() const						{ return !firstChild; }
 
-	const TiXmlDocument* ToDocument()	const		{ return ( this && type == DOCUMENT ) ? (const TiXmlDocument*) this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	const TiXmlElement*  ToElement() const			{ return ( this && type == ELEMENT  ) ? (const TiXmlElement*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	const TiXmlComment*  ToComment() const			{ return ( this && type == COMMENT  ) ? (const TiXmlComment*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	const TiXmlUnknown*  ToUnknown() const			{ return ( this && type == UNKNOWN  ) ? (const TiXmlUnknown*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	const TiXmlText*	   ToText()    const		{ return ( this && type == TEXT     ) ? (const TiXmlText*)     this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	const TiXmlDeclaration* ToDeclaration() const	{ return ( this && type == DECLARATION ) ? (const TiXmlDeclaration*) this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+#if INEEDTHISAND
+#define THISAND this &&
+#else
+#define THISAND
+#endif   
+   
+	const TiXmlDocument* ToDocument()	const		{ return ( THISAND type == DOCUMENT ) ? (const TiXmlDocument*) this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	const TiXmlElement*  ToElement() const			{ return ( THISAND type == ELEMENT  ) ? (const TiXmlElement*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	const TiXmlComment*  ToComment() const			{ return ( THISAND type == COMMENT  ) ? (const TiXmlComment*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	const TiXmlUnknown*  ToUnknown() const			{ return ( THISAND type == UNKNOWN  ) ? (const TiXmlUnknown*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	const TiXmlText*	   ToText()    const		{ return ( THISAND type == TEXT     ) ? (const TiXmlText*)     this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	const TiXmlDeclaration* ToDeclaration() const	{ return ( THISAND type == DECLARATION ) ? (const TiXmlDeclaration*) this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
 
-	TiXmlDocument* ToDocument()			{ return ( this && type == DOCUMENT ) ? (TiXmlDocument*) this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	TiXmlElement*  ToElement()			{ return ( this && type == ELEMENT  ) ? (TiXmlElement*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	TiXmlComment*  ToComment()			{ return ( this && type == COMMENT  ) ? (TiXmlComment*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	TiXmlUnknown*  ToUnknown()			{ return ( this && type == UNKNOWN  ) ? (TiXmlUnknown*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	TiXmlText*	   ToText()   			{ return ( this && type == TEXT     ) ? (TiXmlText*)     this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
-	TiXmlDeclaration* ToDeclaration()	{ return ( this && type == DECLARATION ) ? (TiXmlDeclaration*) this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	TiXmlDocument* ToDocument()			{ return ( THISAND type == DOCUMENT ) ? (TiXmlDocument*) this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	TiXmlElement*  ToElement()			{ return ( THISAND type == ELEMENT  ) ? (TiXmlElement*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	TiXmlComment*  ToComment()			{ return ( THISAND type == COMMENT  ) ? (TiXmlComment*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	TiXmlUnknown*  ToUnknown()			{ return ( THISAND type == UNKNOWN  ) ? (TiXmlUnknown*)  this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	TiXmlText*	   ToText()   			{ return ( THISAND type == TEXT     ) ? (TiXmlText*)     this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
+	TiXmlDeclaration* ToDeclaration()	{ return ( THISAND type == DECLARATION ) ? (TiXmlDeclaration*) this : 0; } ///< Cast to a more defined type. Will return null not of the requested type.
 
 	/** Create an exact duplicate of this node and return it. The memory must be deleted
 		by the caller. 

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -911,7 +911,7 @@ std::string Parameter::tempoSyncNotationValue(float f)
         else
         {
             char tmp[1024];
-            snprintf(tmp, 1024, "1/%0.d", (int)d, d );
+            snprintf(tmp, 1024, "1/%d", (int)d );
             nn = tmp;
         }
     }
@@ -1405,14 +1405,14 @@ void Parameter::morph(Parameter* a, Parameter* b, float x)
 {
    if ((a->valtype == vt_float) && (b->valtype == vt_float) && (a->ctrltype == b->ctrltype))
    {
-      memcpy(this, a, sizeof(Parameter));
+      memcpy((void*)this, (void*)a, sizeof(Parameter));
       val.f = (1 - x) * a->val.f + x * b->val.f;
    }
    else
    {
       if (x > 0.5)
-         memcpy(this, b, sizeof(Parameter));
+         memcpy((void*)this, (void*)b, sizeof(Parameter));
       else
-         memcpy(this, a, sizeof(Parameter));
+         memcpy((void*)this, (void*)a, sizeof(Parameter));
    }
 }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -69,10 +69,10 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
    memset(storage.getPatch().scenedata[1], 0, sizeof(pdata) * n_scene_params);
    memset(storage.getPatch().globaldata, 0, sizeof(pdata) * n_global_params);
    memset(mControlInterpolatorUsed, 0, sizeof(bool) * num_controlinterpolators);
-   memset(fxsync, 0, sizeof(FxStorage) * 8);
+   memset((void*)fxsync, 0, sizeof(FxStorage) * 8);
    for (int i = 0; i < 8; i++)
    {
-      memcpy(&fxsync[i], &storage.getPatch().fx[i], sizeof(FxStorage));
+      memcpy((void*)&fxsync[i], (void*)&storage.getPatch().fx[i], sizeof(FxStorage));
       fx_reload[i] = false;
    }
 
@@ -1558,7 +1558,7 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
          }
 
          if (/*!force_reload_all && */ storage.getPatch().fx[s].type.val.i)
-            memcpy(&storage.getPatch().fx[s].p, &fxsync[s].p, sizeof(Parameter) * n_fx_params);
+            memcpy((void*)&storage.getPatch().fx[s].p, (void*)&fxsync[s].p, sizeof(Parameter) * n_fx_params);
 
          fx[s].reset(spawn_effect(storage.getPatch().fx[s].type.val.i, &storage,
                               &storage.getPatch().fx[s], storage.getPatch().globaldata));
@@ -1581,7 +1581,7 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
       }
       else if (fx_reload[s])
       {
-         memcpy(&storage.getPatch().fx[s].p, &fxsync[s].p, sizeof(Parameter) * n_fx_params);
+         memcpy((void*)&storage.getPatch().fx[s].p, (void*)&fxsync[s].p, sizeof(Parameter) * n_fx_params);
          if (fx[s])
          {
             fx[s]->suspend();

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -252,7 +252,7 @@ void SurgeSynthesizer::loadRaw(const void* data, int size, bool preset)
    storage.getPatch().update_controls(false, nullptr, true);
    for (int i = 0; i < 8; i++)
    {
-      memcpy(&fxsync[i], &storage.getPatch().fx[i], sizeof(FxStorage));
+      memcpy((void*)&fxsync[i], (void*)&storage.getPatch().fx[i], sizeof(FxStorage));
       fx_reload[i] = true;
    }
 

--- a/src/common/WavSupport.cpp
+++ b/src/common/WavSupport.cpp
@@ -175,9 +175,9 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
             free(data);
 
             // Do a format check here to bail out
-            if (! ( numChannels == 1 &&
-                    ( (audioFormat == 1 /* WAVE_FORMAT_PCM */) && (bitsPerSample == 16) ) ||
-                    ( (audioFormat == 3 /* IEEE_FLOAT */ ) && (bitsPerSample == 32) ) ) )
+            if (! ( ( numChannels == 1 ) &&
+                    ( ( (audioFormat == 1 /* WAVE_FORMAT_PCM */) && (bitsPerSample == 16) ) ||
+                      ( (audioFormat == 3 /* IEEE_FLOAT */ ) && (bitsPerSample == 32) ) ) ) )
             {
                 std::string formname = "Unknown (" + std::to_string(audioFormat) + ")";
                 if( audioFormat == 1 ) formname = "PCM";

--- a/src/common/gui/CAboutBox.h
+++ b/src/common/gui/CAboutBox.h
@@ -23,12 +23,12 @@ public:
              VSTGUI::CBitmap* aboutBitmap);
    virtual ~CAboutBox();
 
-   virtual void draw(VSTGUI::CDrawContext*);
-   virtual bool hitTest(const VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons = -1);
+   virtual void draw(VSTGUI::CDrawContext*) override;
+   virtual bool hitTest(const VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons = -1) override;
    // virtual void mouse (VSTGUI::CDrawContext *pContext, VSTGUI::CPoint &where, long button = -1);
    virtual VSTGUI::CMouseEventResult
    onMouseDown(VSTGUI::CPoint& where,
-               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
+               const VSTGUI::CButtonState& buttons) override; ///< called when a mouse down event occurs
    virtual void unSplash();
 
    void boxShow(std::string dataPath, std::string userPath);

--- a/src/common/gui/CCursorHidingControl.h
+++ b/src/common/gui/CCursorHidingControl.h
@@ -13,9 +13,9 @@ protected:
                         VSTGUI::CBitmap* pBackground);
    virtual ~CCursorHidingControl();
 
-   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
 
    virtual void
    onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy) = 0;

--- a/src/common/gui/CEffectLabel.h
+++ b/src/common/gui/CEffectLabel.h
@@ -13,7 +13,7 @@ public:
    CEffectLabel(const VSTGUI::CRect& size) : VSTGUI::CControl(size, 0, 0, 0)
    {}
 
-   virtual void draw(VSTGUI::CDrawContext* dc)
+   virtual void draw(VSTGUI::CDrawContext* dc) override
    {
       VSTGUI::CRect size = getViewSize();
       VSTGUI::CRect bl(size);

--- a/src/common/gui/CEffectSettings.h
+++ b/src/common/gui/CEffectSettings.h
@@ -13,12 +13,12 @@ public:
                    long tag,
                    int current,
                    std::shared_ptr<SurgeBitmaps> bitmapStore);
-   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
    virtual VSTGUI::CMouseEventResult
    onMouseDown(VSTGUI::CPoint& where,
-               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
+               const VSTGUI::CButtonState& buttons) override; ///< called when a mouse down event occurs
    virtual VSTGUI::CMouseEventResult
-   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons); ///< called when a mouse up event occurs
+   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override; ///< called when a mouse up event occurs
 
    int current;
    VSTGUI::CBitmap *bg, *labels;

--- a/src/common/gui/CHSwitch2.h
+++ b/src/common/gui/CHSwitch2.h
@@ -35,17 +35,17 @@ public:
    bool dragable;
    bool usesMouseWheel;
 
-   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
    virtual VSTGUI::CMouseEventResult
    onMouseDown(VSTGUI::CPoint& where,
-               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
+               const VSTGUI::CButtonState& buttons) override; ///< called when a mouse down event occurs
    virtual VSTGUI::CMouseEventResult
-   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons); ///< called when a mouse up event occurs
+   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override; ///< called when a mouse up event occurs
    virtual VSTGUI::CMouseEventResult
    onMouseMoved(VSTGUI::CPoint& where,
-                const VSTGUI::CButtonState& buttons); ///< called when a mouse move event occurs
+                const VSTGUI::CButtonState& buttons) override; ///< called when a mouse move event occurs
    virtual bool
-   onWheel (const VSTGUI::CPoint& where, const float& distance, const VSTGUI::CButtonState& buttons); ///< called when scrollwheel events occurs    
+   onWheel (const VSTGUI::CPoint& where, const float& distance, const VSTGUI::CButtonState& buttons) override; ///< called when scrollwheel events occurs    
    CLASS_METHODS(CHSwitch2, VSTGUI::CControl)
    void setUsesMouseWheel(bool wheel);
 };

--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -94,9 +94,9 @@ public:
 #endif      
    }
    // virtual void mouse (CDrawContext *pContext, VSTGUI::CPoint &where, long buttons = -1);
-   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
 
    virtual void setSkin( Surge::UI::Skin::ptr_t s ) override {
       SkinConsumingComponnt::setSkin(s);
@@ -107,7 +107,7 @@ public:
    {
       delete cdisurf;
    }
-   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
    void drawVectorized(VSTGUI::CDrawContext* dc);
    void drawBitmap(VSTGUI::CDrawContext* dc);
    void drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp, VSTGUI::CRect &leftpanel);

--- a/src/common/gui/CModulationSourceButton.h
+++ b/src/common/gui/CModulationSourceButton.h
@@ -21,16 +21,16 @@ public:
                            std::shared_ptr<SurgeBitmaps> bitmapStore);
    ~CModulationSourceButton();
 
-   virtual void setValue(float val)
+   virtual void setValue(float val) override
    {
       if (value != val)
          invalid();
       value = val;
    }
 
-   virtual void onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy);
-   virtual double getMouseDeltaScaling(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual bool onWheel(const VSTGUI::CPoint& where, const float &distance, const VSTGUI::CButtonState& buttons);
+   virtual void onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy) override;
+   virtual double getMouseDeltaScaling(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual bool onWheel(const VSTGUI::CPoint& where, const float &distance, const VSTGUI::CButtonState& buttons) override;
 
    int state, msid, controlstate;
 
@@ -66,9 +66,9 @@ public:
    bool useAlternate = false;
    void setUseAlternate( bool f ) { useAlternate = f; if( hasAlternate ) { invalid(); setDirty(); } }
    
-   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
    // virtual void mouse (VSTGUI::CDrawContext *pContext, VSTGUI::CPoint &where, long button = -1);
-   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
    CLASS_METHODS(CModulationSourceButton, VSTGUI::CControl)
 };

--- a/src/common/gui/CNumberField.h
+++ b/src/common/gui/CNumberField.h
@@ -145,9 +145,9 @@ public:
       envColor = bgcol;
    }
 
-   virtual void bounceValue();
+   virtual void bounceValue() override;
 
-   virtual void setValue(float val);
+   virtual void setValue(float val) override;
 
    void setIntValue(int ival)
    {
@@ -221,12 +221,12 @@ public:
    virtual void setLabel(char* newlabel);
    virtual void setLabelPlacement(int placement);
 
-   virtual void draw(VSTGUI::CDrawContext*);
+   virtual void draw(VSTGUI::CDrawContext*) override;
    // virtual void mouse (VSTGUI::CDrawContext *pContext, VSTGUI::CPoint &where, long buttons = -1);
-   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual bool onWheel(const VSTGUI::CPoint& where, const float& distance, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual bool onWheel(const VSTGUI::CPoint& where, const float& distance, const VSTGUI::CButtonState& buttons) override;
    bool altlook;
 
 private:

--- a/src/common/gui/COscillatorDisplay.h
+++ b/src/common/gui/COscillatorDisplay.h
@@ -66,7 +66,7 @@ public:
    {
       delete cdisurf;
    }
-   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
    void drawBitmap(VSTGUI::CDrawContext* dc);
    void drawVector(VSTGUI::CDrawContext* dc);
 
@@ -96,9 +96,9 @@ public:
    void loadWavetableFromFile();
 
    // virtual void mouse (CDrawContext *pContext, VSTGUI::CPoint &where, long button = -1);
-   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
 
    void invalidateIfIdIsInRange(int id);
    

--- a/src/common/gui/CParameterTooltip.h
+++ b/src/common/gui/CParameterTooltip.h
@@ -57,7 +57,7 @@ public:
       return visible;
    }
 
-   virtual void draw(VSTGUI::CDrawContext* dc)
+   virtual void draw(VSTGUI::CDrawContext* dc) override
    {
       if (visible)
       {

--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -55,8 +55,8 @@ public:
       setDirty(true);
    }
 
-   virtual void draw(VSTGUI::CDrawContext* dc);
-   VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
+   VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
    void loadPatch(int id);
    int sel_id = 0;
 

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -444,7 +444,7 @@ void CFxMenu::copyFX()
         fxCopyPaste[tp] = fx->p[i].temposync;
         fxCopyPaste[xp] = fx->p[i].extend_range;
     }
-    memcpy(fxbuffer,fx,sizeof(FxStorage));
+    memcpy((void*)fxbuffer,(void*)fx,sizeof(FxStorage));
     
 }
 

--- a/src/common/gui/CSnapshotMenu.h
+++ b/src/common/gui/CSnapshotMenu.h
@@ -13,7 +13,7 @@ class CSnapshotMenu : public VSTGUI::COptionMenu, public Surge::UI::SkinConsumin
 public:
    CSnapshotMenu(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, SurgeStorage* storage);
    virtual ~CSnapshotMenu();
-   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
    // virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
    virtual void populate();
    virtual void loadSnapshot(int type, TiXmlElement* e){};
@@ -35,8 +35,8 @@ public:
             SurgeStorage* storage,
             OscillatorStorage* osc,
             std::shared_ptr<SurgeBitmaps>);
-   virtual void draw(VSTGUI::CDrawContext* dc);
-   virtual void loadSnapshot(int type, TiXmlElement* e);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
+   virtual void loadSnapshot(int type, TiXmlElement* e) override;
 
 protected:
    OscillatorStorage* osc = nullptr;
@@ -55,13 +55,13 @@ public:
            FxStorage* fx,
            FxStorage* fxbuffer,
            int slot);
-   virtual void draw(VSTGUI::CDrawContext* dc);
-   virtual bool canSave()
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
+   virtual bool canSave() override
    {
       return true;
    }
-   virtual void loadSnapshot(int type, TiXmlElement* e);
-   virtual void saveSnapshot(TiXmlElement* e, const char* name);
+   virtual void loadSnapshot(int type, TiXmlElement* e) override;
+   virtual void saveSnapshot(TiXmlElement* e, const char* name) override;
    virtual void populate() override;
    
 protected:

--- a/src/common/gui/CStatusPanel.h
+++ b/src/common/gui/CStatusPanel.h
@@ -40,8 +40,8 @@ public:
         editor = e;
     }
     
-    virtual void draw(VSTGUI::CDrawContext* dc);
-    VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button);
+    virtual void draw(VSTGUI::CDrawContext* dc) override;
+    VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
 
     virtual VSTGUI::DragOperation onDragEnter(VSTGUI::DragEventData data) override
     {

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -17,23 +17,23 @@ public:
                 bool is_mod,
                 std::shared_ptr<SurgeBitmaps> bitmapStore);
    ~CSurgeSlider();
-   virtual void draw(VSTGUI::CDrawContext*);
+   virtual void draw(VSTGUI::CDrawContext*) override;
    // virtual void mouse (VSTGUI::CDrawContext *pContext, VSTGUI::CPoint &where, long buttons = -1);
    // virtual bool onWheel (VSTGUI::CDrawContext *pContext, const VSTGUI::CPoint &where, float distance);
    virtual bool 
-   onWheel(const VSTGUI::CPoint& where, const float &distane, const VSTGUI::CButtonState& buttons);
+   onWheel(const VSTGUI::CPoint& where, const float &distane, const VSTGUI::CButtonState& buttons) override;
 
    virtual VSTGUI::CMouseEventResult
    onMouseDown(VSTGUI::CPoint& where,
-               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
+               const VSTGUI::CButtonState& buttons) override; ///< called when a mouse down event occurs
    virtual VSTGUI::CMouseEventResult
-   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons); ///< called when a mouse up event occurs
+   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override; ///< called when a mouse up event occurs
 
    virtual VSTGUI::CMouseEventResult
    onMouseExited(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
    
-   virtual double getMouseDeltaScaling(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
-   virtual void onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy);
+   virtual double getMouseDeltaScaling(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;
+   virtual void onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy) override;
 
    virtual void setLabel(const char* txt);
    virtual void setModValue(float val);
@@ -63,7 +63,7 @@ public:
 
    virtual bool isInMouseInteraction();
 
-   virtual void setValue(float val);
+   virtual void setValue(float val) override;
    virtual void setBipolar(bool);
 
    virtual void setTempoSync( bool b ) { is_temposync = b; }

--- a/src/common/gui/CSurgeVuMeter.h
+++ b/src/common/gui/CSurgeVuMeter.h
@@ -10,7 +10,7 @@ class CSurgeVuMeter : public VSTGUI::CControl, public Surge::UI::SkinConsumingCo
 {
 public:
    CSurgeVuMeter(const VSTGUI::CRect& size);
-   virtual void draw(VSTGUI::CDrawContext* dc);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
    void setType(int vutype);
    // void setSecondaryValue(float v);
    void setValueR(float f);

--- a/src/common/gui/CSwitchControl.h
+++ b/src/common/gui/CSwitchControl.h
@@ -8,16 +8,16 @@ class CSwitchControl : public VSTGUI::CControl
 {
 public:
    CSwitchControl(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, VSTGUI::CBitmap* background);
-   virtual void draw(VSTGUI::CDrawContext* dc);
-   virtual void setValue(float f);
+   virtual void draw(VSTGUI::CDrawContext* dc) override;
+   virtual void setValue(float f) override;
    virtual VSTGUI::CMouseEventResult
    onMouseDown(VSTGUI::CPoint& where,
-               const VSTGUI::CButtonState& buttons); ///< called when a mouse down event occurs
+               const VSTGUI::CButtonState& buttons) override; ///< called when a mouse down event occurs
    virtual VSTGUI::CMouseEventResult
-   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons); ///< called when a mouse up event occurs
+   onMouseUp(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override; ///< called when a mouse up event occurs
    virtual VSTGUI::CMouseEventResult
    onMouseMoved(VSTGUI::CPoint& where,
-                const VSTGUI::CButtonState& buttons); ///< called when a mouse move event occurs
+                const VSTGUI::CButtonState& buttons) override; ///< called when a mouse move event occurs
    int ivalue, imax;
    bool is_itype;
 

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -44,7 +44,11 @@ private:
 public:
    SurgeGUIEditor(void* effect, SurgeSynthesizer* synth, void* userdata = nullptr);
    virtual ~SurgeGUIEditor();
+#if TARGET_AUDIOUNIT
+   void idle() override;
+#else
    void idle();
+#endif   
    bool queue_refresh;
    virtual void toggle_mod_editing();
 
@@ -58,7 +62,7 @@ public:
    bool open(void* parent) override;
    void close() override;
 #else
-   virtual bool PLUGIN_API open(void* parent, const VSTGUI::PlatformType& platformType = VSTGUI::kDefaultNative);
+   virtual bool PLUGIN_API open(void* parent, const VSTGUI::PlatformType& platformType = VSTGUI::kDefaultNative) override;
    virtual void PLUGIN_API close() override;
 
    virtual Steinberg::tresult PLUGIN_API onWheel( float distance ) override

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -194,7 +194,7 @@ TEST_CASE( "ADSR Envelope Behaviour", "[mod]" )
                               REQUIRE( sturns[2].second == 0 );
                               REQUIRE( sturns[3].first == Approx( a + d + sustime ).margin( 0.01 ) );
                               REQUIRE( sturns[3].second == -1 );
-                              if( r_s == 0 || s > 0.1 && r > 0.05 ) // if we are in the non-linear releases at low sustain we get there early
+                              if( r_s == 0 || ( s > 0.1 && r > 0.05 ) ) // if we are in the non-linear releases at low sustain we get there early
                               {
                                  REQUIRE( sturns[4].first == Approx( a + d + sustime + r ).margin( ( r_s == 0 ? 0.01 : ( r * 0.1 ) ) ) );
                                  REQUIRE( sturns[4].second == 0 );

--- a/src/vst3/SurgeVst3Processor.h
+++ b/src/vst3/SurgeVst3Processor.h
@@ -116,10 +116,10 @@ public:
                                Steinberg::Vst::ParamValue valueNormalized);
    virtual tresult endEdit(Steinberg::Vst::ParamID id);
 #else
-   virtual tresult PLUGIN_API beginEdit(Steinberg::Vst::ParamID id);
+   virtual tresult PLUGIN_API beginEdit(Steinberg::Vst::ParamID id) override;
    virtual tresult PLUGIN_API performEdit(Steinberg::Vst::ParamID id,
-                               Steinberg::Vst::ParamValue valueNormalized);
-   virtual tresult PLUGIN_API endEdit(Steinberg::Vst::ParamID id);
+                               Steinberg::Vst::ParamValue valueNormalized) override;
+   virtual tresult PLUGIN_API endEdit(Steinberg::Vst::ParamID id) override;
 #endif
     
 protected:


### PR DESCRIPTION
Turn on the following for macOS, also clearning up
quite a few clang errorss on freebsd apparently

 -Werror=inconsistent-missing-override
 -Werror=logical-op-parentheses
 -Werror=dynamic-class-memaccess
 -Werror=undefined-bool-conversion

This addresses #1731