### PR TITLE
Correct GUI Modulation Rebuild on Scene B

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -241,8 +241,10 @@ private:
    VSTGUI::CControl* polydisp = nullptr;
    VSTGUI::CControl* oscdisplay = nullptr;
    VSTGUI::CControl* splitkeyControl = nullptr;
-   VSTGUI::CControl* param[1024] = {};
-   VSTGUI::CControl* nonmod_param[1024] = {}; 
+
+   static const int n_paramslots = 1024;
+   VSTGUI::CControl* param[n_paramslots] = {};
+   VSTGUI::CControl* nonmod_param[n_paramslots] = {}; 
    VSTGUI::CControl* gui_modsrc[n_modsources] = {};
    VSTGUI::CControl* metaparam[n_customcontrollers] = {};
    VSTGUI::CControl* lfodisplay = nullptr;


### PR DESCRIPTION
refresh_mod only refreshed 512 params and with scene b we
have more control slots; we were defaulting to scene 0 in
a few places; together this meant you couldn't control
modulate scene B LFO 2-6, and now you can

Closes #1748