### PR TITLE
Begin implementation of HoverStates

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ It's what the primary Mac developers use day to day. The simplest approach is to
 ./build-osx.sh
 ```
 
+`build-osx.sh` will give you better output if you first `gem install xcpretty`, the xcodebuild formatter, 
+and you have your gem environment running. If that doesn't work don't worry - you can still build.
+
 this command will build, but not install, the VST3 and AU components. It has a variety of options which
 are documented in the `./build-osx.sh --help` screen but a few key ones are:
 

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -87,6 +87,7 @@ NC=`tput init`
 
 prerequisite_check()
 {
+
     if [ ! -f vst3sdk/LICENSE.txt ]; then
         echo
         echo ${RED}ERROR: You have not gotten the submodules required to build Surge. Run the following command to get them.${NC}
@@ -100,10 +101,17 @@ prerequisite_check()
         echo
         echo ${RED}ERROR: You do not have cmake on your path${NC}
         echo
-	echo Please install cmake. "brew install cmake" or visit https://cmake.org
+  	    echo Please install cmake. "brew install cmake" or visit https://cmake.org
         echo
         exit 1
     fi
+
+    if [ ! $(which xcpretty) ]; then
+        echo
+        echo ${GREEN}You will get better output if you `brew install xcpretty`${NC}
+        echo
+    fi
+
 }
 
 
@@ -124,7 +132,14 @@ run_cmake_build()
     # Don't let TEE eat my return status
     mkdir -p build
     cmake -GXcode -Bbuild
-    xcodebuild build -configuration Release -project build/Surge.xcodeproj -target ${target}
+
+    if [ $(which xcpretty) ]; then
+        set -o pipefail && xcodebuild build -configuration Release -project build/Surge.xcodeproj -target ${target} | xcpretty
+    else
+        xcodebuild build -configuration Release -project build/Surge.xcodeproj -target ${target}
+    fi
+
+
 
     build_suc=$?
 

--- a/resources/data/skins/default.surge-skin/SVG/hover00108.svg
+++ b/resources/data/skins/default.surge-skin/SVG/hover00108.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="129px" height="180px" viewBox="0 0 129 180" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient x1="50%" y1="2.35729769%" x2="50%" y2="100%" id="linearGradient-2">
+      <stop offset="0" stop-color="#DDDDFF" stop-opacity="0.4"/>
+      <stop offset="0.1631" stop-color="#AAAAFF" stop-opacity="0.4"/>
+      <stop offset="0.188" stop-color="#BBBBFF" stop-opacity="0.4"/>
+      <stop offset="1" stop-color="#DDEEFF" stop-opacity="0.4"/>
+    </linearGradient>
+  </defs>
+  <g id="bmp00108" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="4" y="2" width="11" height="11"/>
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="112" y="164" width="11" height="11"/>
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="64" y="92" width="11" height="11"/>
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="52" y="74" width="11" height="11"/>
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="40" y="56" width="11" height="11"/>
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="28" y="38" width="11" height="11"/>
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="16" y="20" width="11" height="11"/>
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="100" y="146" width="11" height="11"/>
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="88" y="128" width="11" height="11"/>
+    <rect id="Rectangle" fill="url(#linearGradient-2)" x="76" y="110" width="11" height="11"/>
+  </g>
+</svg>

--- a/resources/data/skins/default.surge-skin/SVG/hover00120.svg
+++ b/resources/data/skins/default.surge-skin/SVG/hover00120.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="28px" height="282px" viewBox="0 0 28 282" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <title>bmp00120</title>
+  <desc>Created with Sketch.</desc>
+  <g id="bmp00120" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Group" transform="translate(1.000000, 0.000000)">
+      <rect id="Rectangle" fill="#BBCCFF" fill-opacity="0.5" x="0" y="-1.55431223e-14" width="26" height="7"/>
+    </g>
+    <g id="Group" transform="translate(1.000000, 48.000000)">
+      <rect id="Rectangle" fill="#BBCCFF" fill-opacity="0.5" x="0" y="7" width="26" height="7"/>
+    </g>
+    <g id="Group" transform="translate(1.000000, 95.000000)">
+      <rect id="Rectangle" fill="#BBCCFF" fill-opacity="0.5" x="0" y="15" width="26" height="7"/>
+    </g>
+    <g id="Group" transform="translate(1.000000, 142.000000)">
+      <rect id="Rectangle" fill="#BBCCFF" fill-opacity="0.5" x="0" y="23" width="26" height="7"/>
+    </g>
+    <g id="Group" transform="translate(1.000000, 189.000000)">
+      <rect id="Rectangle" fill="#BBCCFF" fill-opacity="0.5" x="0" y="31" width="26" height="7"/>
+    </g>
+    <g id="Group" transform="translate(1.000000, 236.000000)">
+      <rect id="Rectangle" fill="#BBCCFF" fill-opacity="0.5" x="0" y="39" width="26" height="7"/>
+    </g>
+  </g>
+</svg>

--- a/resources/data/skins/default.surge-skin/skin.xml
+++ b/resources/data/skins/default.surge-skin/skin.xml
@@ -1,6 +1,7 @@
 <surge-skin name="Surge Default Skin" author="Surge Synth Team" authorURL="https://surge-synth-team.org/">
   <!-- This skin exists to make sure we can fall back on defaults with no assets and an empty XML. The defaults are built into the DLL -->
   <globals>
+    <defaultimage directory="SVG/"/>
   </globals>
   <component-classes>
   </component-classes>

--- a/src/common/gui/CHSwitch2.h
+++ b/src/common/gui/CHSwitch2.h
@@ -3,8 +3,9 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 #include "vstcontrols.h"
+#include "SkinSupport.h"
 
-class CHSwitch2 : public VSTGUI::CHorizontalSwitch
+class CHSwitch2 : public VSTGUI::CHorizontalSwitch, public Surge::UI::SkinConsumingComponnt
 {
 public:
    CHSwitch2(const VSTGUI::CRect& size,
@@ -35,6 +36,11 @@ public:
    bool dragable;
    bool usesMouseWheel;
 
+   bool lookedForHover = false;
+   CScalableBitmap *hoverBmp = nullptr;
+   bool doingHover = false;
+   float hoverValue = 0.0f;
+   
    virtual void draw(VSTGUI::CDrawContext* dc) override;
    virtual VSTGUI::CMouseEventResult
    onMouseDown(VSTGUI::CPoint& where,
@@ -49,10 +55,13 @@ public:
 
    virtual VSTGUI::CMouseEventResult onMouseEntered (VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override {
       getFrame()->setCursor( VSTGUI::kCursorHand );
+      doingHover = true;
       return VSTGUI::kMouseEventHandled;
    }
    virtual VSTGUI::CMouseEventResult onMouseExited (VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override {
       getFrame()->setCursor( VSTGUI::kCursorDefault );
+      doingHover = false;
+      invalid();
       return VSTGUI::kMouseEventHandled;
    }
 

--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -50,6 +50,8 @@ public:
       extraScaleFactor = a;
    }
 
+   int resourceID;
+
 private:
    struct CPointCompare
    {
@@ -66,7 +68,6 @@ private:
    
    int lastSeenZoom, bestFitScaleGroup;
    int extraScaleFactor;
-   int resourceID;
    std::string fname;
 
    VSTGUI::CFrame* frame;

--- a/src/common/gui/CSwitchControl.h
+++ b/src/common/gui/CSwitchControl.h
@@ -3,8 +3,9 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 #include "vstcontrols.h"
+#include "SkinSupport.h"
 
-class CSwitchControl : public VSTGUI::CControl
+class CSwitchControl : public VSTGUI::CControl, public Surge::UI::SkinConsumingComponnt
 {
 public:
    CSwitchControl(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, VSTGUI::CBitmap* background);

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -8,6 +8,7 @@
 #include "UserInteractions.h"
 #include "UserDefaults.h"
 #include "UIInstrumentation.h"
+#include "CScalableBitmap.h"
 
 #if LINUX
 #include <experimental/filesystem>
@@ -27,6 +28,9 @@ namespace Surge
 {
 namespace UI
 {
+
+const std::string Skin::defaultImageIDPrefix = "DEFAULT/";
+   
 SkinDB& Surge::UI::SkinDB::get(SurgeStorage* s)
 {
    static SkinDB instance(s);
@@ -384,6 +388,11 @@ void Skin::reloadSkin(std::shared_ptr<SurgeBitmaps> bitmapStore)
                int idx = std::atoi(d.path().generic_string().c_str() + pos + 3);
                bitmapStore->loadBitmapByPathForID(d.path().generic_string(), idx);
             }
+            else
+            {
+               std::string id = defaultImageIDPrefix + d.path().filename().generic_string();
+               bitmapStore->loadBitmapByPathForStringID(d.path().generic_string(), id);
+            }
          }
       }
    }
@@ -589,6 +598,29 @@ CScalableBitmap *Skin::backgroundBitmapForControl( Skin::Control::ptr_t c, std::
       }
    }
    return bmp;
+}
+
+CScalableBitmap *Skin::hoverBitmapOverlayForBackgroundBitmap( Skin::Control::ptr_t c, CScalableBitmap *b, std::shared_ptr<SurgeBitmaps> bitmapStore )
+{
+   if( ! bitmapStore.get() )
+   {
+      return nullptr;
+   }
+   if( c.get() )
+   {
+      std::cout << "should ask control if it has an opinoin" << std::endl;
+   }
+   if( ! b )
+   {
+      return nullptr;
+   }
+   std::ostringstream sid;
+   sid << defaultImageIDPrefix << "hover" << std::setw(5) << std::setfill('0') << b->resourceID << ".svg";
+   auto bmp = bitmapStore->getBitmapByStringID( sid.str() );
+   if( bmp )
+      return bmp;
+
+   return nullptr;
 }
 
 } // namespace UI

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -176,6 +176,9 @@ public:
    }
 
    CScalableBitmap *backgroundBitmapForControl( Skin::Control::ptr_t c, std::shared_ptr<SurgeBitmaps> bitmapStore );
+   CScalableBitmap *hoverBitmapOverlayForBackgroundBitmap( Skin::Control::ptr_t c, CScalableBitmap *b, std::shared_ptr<SurgeBitmaps> bitmapStore );
+
+   static const std::string defaultImageIDPrefix;
    
 private:
    static std::atomic<int> instances;
@@ -253,8 +256,16 @@ public:
    virtual ~SkinConsumingComponnt() {
    }
    virtual void setSkin( Skin::ptr_t s ) { skin = s; }
+   virtual void setSkin( Skin::ptr_t s, std::shared_ptr<SurgeBitmaps> b ) {
+      skin = s;
+      associatedBitmapStore = b;
+   }
+   virtual void setAssociatedSkinControl( Skin::Control::ptr_t c ) { skinControl = c; };
+   virtual void setAssociatedBitmapStore( std::shared_ptr<SurgeBitmaps> b ) { associatedBitmapStore = b; }
 protected:
-   Skin::ptr_t skin;
+   Skin::ptr_t skin = nullptr;
+   Skin::Control::ptr_t skinControl = nullptr;
+   std::shared_ptr<SurgeBitmaps> associatedBitmapStore = nullptr;
 };
 }
 }


### PR DESCRIPTION
Begin implementation of HoverStates. This change

1. Plubms through hover state API on the skin engine
2. Implements a default hover state
3. Makes CHSwitch2 an accurate client of that
4. Adds bad hover graphics for filter and waveshaper switches

Committing here so designers can start using this feature on the
switches while we code up other elements.

Addresses #1752