### PR TITLE
FX Prev/Next buttons wrap properly

### DIFF
--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -111,6 +111,10 @@ bool CSnapshotMenu::loadSnapshotByIndex( int idx )
             typeD.push( next );
       }
    }
+   if( idx < 0 && cidx + idx > 0 ) {
+      // I've gone off the end
+      return( loadSnapshotByIndex( cidx + idx ) );
+   }
    return false;
 }
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2940,7 +2940,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
    {
       CFxMenu *fxm = dynamic_cast<CFxMenu*>(fxmenu);
       auto jog = [this, fxm](int byThis ) {
-                    this->selectedFX[this->current_fx] += byThis;
+                    this->selectedFX[this->current_fx] = std::max( this->selectedFX[this->current_fx] + byThis, -1 );
                     if( ! fxm->loadSnapshotByIndex( this->selectedFX[this->current_fx] ) )
                     {
                        // Try and go back to 0. This is the wrong behavior for negative jog


### PR DESCRIPTION
The buttons would wrap forward, but not backwards. Since
we don't know the count, handle this a bit oddly but
it works.

Closes #1754