### PR TITLE
Tiny Linux Fix for Ubuntu 20.04 and Forgotten header

### DIFF
--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <iostream>
+#include <iomanip>
 
 #if !WINDOWS
 namespace fs = std::experimental::filesystem;


### PR DESCRIPTION
Forgot an iomanip in skinsupport. Meant u20.04 didn't build