### PR TITLE
WIP: LV2 using patch extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ set( SURGE_LV2_SOURCES
   src/lv2/SurgeLv2Util.cpp
   src/lv2/SurgeLv2Vstgui.cpp
   src/lv2/SurgeLv2Wrapper.cpp
+  src/lv2/SurgeLv2Helpers.cpp
   vstgui.surge/vstgui/plugin-bindings/plugguieditor.cpp
 )
 

--- a/src/lv2/AllLv2.h
+++ b/src/lv2/AllLv2.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <lv2/core/lv2.h>
 #include <lv2/atom/atom.h>
+#include <lv2/atom/forge.h>
 #include <lv2/atom/util.h>
 #include <lv2/instance-access/instance-access.h>
 #include <lv2/data-access/data-access.h>
@@ -12,6 +13,7 @@
 #include <lv2/midi/midi.h>
 #include <lv2/time/time.h>
 #include <lv2/state/state.h>
+#include <lv2/patch/patch.h>
 
 #define SURGE_PLUGIN_URI "https://surge-synthesizer.github.io/lv2/surge"
 #define SURGE_UI_URI     SURGE_PLUGIN_URI "#UI"

--- a/src/lv2/SurgeLv2Helpers.cpp
+++ b/src/lv2/SurgeLv2Helpers.cpp
@@ -1,0 +1,3 @@
+#include "SurgeLv2Helpers.h"
+
+thread_local CallerType callerType = kCallerNone;

--- a/src/lv2/SurgeLv2Helpers.h
+++ b/src/lv2/SurgeLv2Helpers.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// Tracking of the caller of `sendParameterAutomated`
+//  it determines which logic to use in order to handle parameter sends
+enum CallerType { kCallerNone, kCallerDsp, kCallerUi };
+extern thread_local CallerType callerType;
+
+// RAII wrapper for the caller type
+class ScopedCallerType {
+public:
+   explicit ScopedCallerType(CallerType ct) : prevCt(callerType) { callerType = ct; }
+   ~ScopedCallerType() { callerType = prevCt; }
+private:
+   ScopedCallerType(const ScopedCallerType &) = delete;
+   ScopedCallerType &operator=(const ScopedCallerType &) = delete;
+private:
+   CallerType prevCt;
+};

--- a/src/lv2/SurgeLv2Ui.cpp
+++ b/src/lv2/SurgeLv2Ui.cpp
@@ -2,6 +2,7 @@
 #include "SurgeLv2Util.h"
 #include "SurgeLv2Vstgui.h"
 #include "SurgeLv2Wrapper.h"
+#include "SurgeLv2Helpers.h"
 #include "SurgeGUIEditor.h"
 #include <cassert>
 
@@ -71,6 +72,7 @@ LV2UI_Handle SurgeLv2Ui::instantiate(const LV2UI_Descriptor* descriptor,
                                      LV2UI_Widget* widget,
                                      const LV2_Feature* const* features)
 {
+   ScopedCallerType callerType(kCallerUi);
    SurgeLv2Wrapper* instance =
        (SurgeLv2Wrapper*)SurgeLv2::requireFeature(LV2_INSTANCE_ACCESS_URI, features);
    void* parentWindow = (void*)SurgeLv2::findFeature(LV2_UI__parent, features);
@@ -84,6 +86,7 @@ LV2UI_Handle SurgeLv2Ui::instantiate(const LV2UI_Descriptor* descriptor,
 
 void SurgeLv2Ui::cleanup(LV2UI_Handle ui)
 {
+   ScopedCallerType callerType(kCallerUi);
    SurgeLv2Ui* self = (SurgeLv2Ui*)ui;
    delete self;
 }
@@ -91,6 +94,7 @@ void SurgeLv2Ui::cleanup(LV2UI_Handle ui)
 void SurgeLv2Ui::portEvent(
     LV2UI_Handle ui, uint32_t port_index, uint32_t buffer_size, uint32_t format, const void* buffer)
 {
+   ScopedCallerType callerType(kCallerUi);
    SurgeLv2Ui* self = (SurgeLv2Ui*)ui;
    SurgeSynthesizer* s = self->_instance->synthesizer();
 
@@ -108,6 +112,7 @@ void SurgeLv2Ui::portEvent(
 
 const void* SurgeLv2Ui::extensionData(const char* uri)
 {
+   ScopedCallerType callerType(kCallerUi);
    if (!strcmp(uri, LV2_UI__idleInterface))
    {
       static const LV2UI_Idle_Interface idle = {&uiIdle};
@@ -122,6 +127,7 @@ const void* SurgeLv2Ui::extensionData(const char* uri)
 
 int SurgeLv2Ui::uiIdle(LV2UI_Handle ui)
 {
+   ScopedCallerType callerType(kCallerUi);
    SurgeLv2Ui* self = (SurgeLv2Ui*)ui;
    SurgeLv2Wrapper* instance = self->_instance;
 

--- a/src/lv2/SurgeLv2Ui.h
+++ b/src/lv2/SurgeLv2Ui.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "AllLv2.h"
+#include "SurgeStorage.h"
 #include "vstgui/lib/vstguibase.h"
 #include <memory>
 
@@ -54,4 +55,14 @@ private:
 #endif
    LV2UI_Write_Function _writeFn;
    LV2UI_Controller _controller;
+
+   LV2_Atom_Forge _eventsForge;
+
+   LV2_URID _uridAtom_eventTransfer;
+   LV2_URID _uridPatchSet;
+   LV2_URID _uridPatch_property;
+   LV2_URID _uridPatch_value;
+
+   // mappings between URID and Parameter
+   LV2_URID _uridSurgeParameter[n_total_params];
 };

--- a/src/lv2/SurgeLv2Wrapper.h
+++ b/src/lv2/SurgeLv2Wrapper.h
@@ -109,9 +109,12 @@ private:
    LV2_URID _uridPatch_value;
 
    LV2_URID _uridSurgePatch;
+
+   // mappings between URID and Parameter
    LV2_URID _uridSurgeParameter[n_total_params];
    std::unordered_map<LV2_URID, unsigned> _surgeParameterUrid;
 
+private:
    SurgeLv2Ui* _editor = nullptr;
 
 public:


### PR DESCRIPTION
#1619

Hello it's the work in progress of lv2 patch extensions that help to resolve current problems.
~~This is not working yet, I think there is a blocking in carla, where the output port indicates an overflow problem regardless of the capacity I give it (?)~~
The state does not restore right among things, hence making it a WIP.

This sets up at least the framework to handle events according to semantics of LV2 patch.
The `sendParameterAutomated` logic is different whether it's UI or DSP that makes the call.

@baconpaul sorry that I'm a bit destroyed at the moment, I hope also that things are going well at your side, thanks.
