### PR TITLE
Default bounds on FX CP and FX Retore

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1568,6 +1568,25 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
             fx[s]->init_ctrltypes();
             if (initp)
                fx[s]->init_default_values();
+            else
+            {
+               for(int j=0; j<n_fx_params; j++)
+               {
+                  auto p = &( storage.getPatch().fx[s].p[j] );
+                  if( p->valtype == vt_float )
+                  {
+                     if( p->val.f < p->val_min.f )
+                     {
+                        p->val.f = p->val_min.f;
+                     }
+                     if( p->val.f > p->val_max.f )
+                     {
+                        p->val.f = p->val_max.f;
+                     }
+                  }
+               }
+
+            }
             /*for(int j=0; j<n_fx_params; j++)
             {
                 storage.getPatch().globaldata[storage.getPatch().fx[s].p[j].id].f =

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -538,8 +538,18 @@ void CFxMenu::pasteFX()
         switch( fxbuffer->p[i].valtype )
         {
         case vt_float:
+        {
             fxbuffer->p[i].val.f = fxCopyPaste[vp];
-            break;
+            if( fxbuffer->p[i].val.f < fxbuffer->p[i].val_min.f )
+            {
+               fxbuffer->p[i].val.f = fxbuffer->p[i].val_min.f;
+            }
+            if( fxbuffer->p[i].val.f > fxbuffer->p[i].val_max.f )
+            {
+               fxbuffer->p[i].val.f = fxbuffer->p[i].val_max.f;
+            }
+        }
+        break;
         case vt_int:
             fxbuffer->p[i].val.i = (int)fxCopyPaste[vp];
             break;


### PR DESCRIPTION
The default boundson params were ignored in FX C&P and FX Restore.
That meant some wedged states could stream bad values which then
restored into incorrect settings, blowing up sensitive FX like
Reverb2

Closes #1756