### PR TITLE
Linux Cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ cmake-stamp
 
 # cmake
 build/
+buildlin/
+buildmac/
+buildwin/
 
 # Reaper
 *.RPP-bak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,11 @@ elseif( UNIX AND NOT APPLE )
 
   file(GLOB LINUX_VSTGUI_GLOB vstgui.surge/vstgui/lib/platform/linux/*.cpp )
 
+  # Our friends at steinberg have this maddening habig of using #warning DEPRECATED in linux code
+  set_source_files_properties(${SURGE_VST3_GLOB} PROPERTIES COMPILE_FLAGS -Wno-cpp)
+  set_source_files_properties(${LINUX_VSTGUI_GLOB} PROPERTIES COMPILE_FLAGS -Wno-cpp)
+
+
   set(SURGE_OS_GUI_SOURCES
     src/linux/DisplayInfoLinux.cpp
     src/linux/RuntimeFontLinux.cpp
@@ -322,6 +327,7 @@ elseif( UNIX AND NOT APPLE )
     -msse2
     "-D_aligned_malloc(x,a)=malloc(x)"
     "-D_aligned_free(x)=free(x)"
+    -Werror
     -Wno-multichar
     -fvisibility=hidden
     -fvisibility-inlines-hidden
@@ -576,7 +582,7 @@ if( BUILD_VST2 )
     )
 
   if( UNIX AND NOT APPLE )
-    target_sources(surge-vst2 PUBLIC src/linux/linux-aeffguieditor.cpp )
+    target_sources(surge-vst2 PRIVATE src/linux/linux-aeffguieditor.cpp )
 
     # Ideally we wouldn't define __cdecl on linux. It's not needed
     # Alas, the VST2 SDK has in aeffgui a _GNUC define which requires
@@ -712,9 +718,9 @@ if( BUILD_LV2 )
       POST_BUILD
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND echo "Packaging up LV2 component"
-      COMMAND mkdir -p products/Surge.lv2
-      COMMAND cp build/libsurge-lv2.so products/Surge.lv2/Surge.so
-      COMMAND python scripts/linux/generate-lv2-ttl.py products/Surge.lv2/Surge.so
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_SOURCE_DIR}/products/Surge.lv2
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/libsurge-lv2.so ${CMAKE_CURRENT_SOURCE_DIR}/products/Surge.lv2/Surge.so
+      COMMAND python scripts/linux/generate-lv2-ttl.py ${CMAKE_CURRENT_SOURCE_DIR}/products/Surge.lv2/Surge.so
       )
   endif()
 
@@ -781,7 +787,7 @@ if( BUILD_HEADLESS )
 
   if( UNIX AND NOT APPLE )
     find_package(Threads REQUIRED)
-    target_sources( surge-headless PUBLIC src/linux/ConfigurationXml.S )
+    target_sources( surge-headless PRIVATE src/linux/ConfigurationXml.S )
     target_link_libraries(surge-headless
       PRIVATE
       stdc++fs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ jobs:
       mkdir -p $XDG_DATA_HOME
       rsync -r --delete "resources/data/" "$XDG_DATA_HOME/surge/"
 
-      ./build/surge-headless
+      ./buildlin/surge-headless
 
 
     condition: and(variables.isLinux,variables.runHeadless)

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -35,6 +35,7 @@ EOHELP
 RED=`tput setaf 1`
 GREEN=`tput setaf 2`
 NC=`tput sgr0`
+DEF_BUILD_DIR="buildlin"
 
 prerequisite_check()
 {
@@ -50,35 +51,30 @@ prerequisite_check()
 
 run_cmake()
 {
-    mkdir -p build
-    cmake . -Bbuild
+    cmake . -B${DEF_BUILD_DIR}
 }
 
 run_cmake_if()
 {
-    if [[ ! -f build/CMakeCache.txt ]]; then
+    if [[ ! -f ${DEF_BUILD_DIR}/CMakeCache.txt ]]; then
         run_cmake
     fi
-    if [[ CMakeLists.txt -nt build/CMakeCache.txt ]]; then
+    if [[ CMakeLists.txt -nt ${DEF_BUILD_DIR}/CMakeCache.txt ]]; then
         run_cmake
     fi
 }
 
 run_clean()
 {
-    if [[ -d build ]]; then
-        pushd build 
-        make clean
-        popd
+    if [[ -d ${DEF_BUILD_DIR} ]]; then
+	cmake --build ${DEF_BUILD_DIR} --target clean --config Release
     fi
 }
 
 run_build()
 {
     local flavor=$1
-    pushd build
-    make -j 2 $flavor
-    popd
+    cmake --build ${DEF_BUILD_DIR} --config Release --target $flavor --parallel 2
 
     build_suc=$?
     if [[ $build_suc = 0 ]]; then
@@ -156,7 +152,7 @@ run_clean_all()
     run_clean_builds
 
     echo "Cleaning additional assets"
-    rm -rf target products build
+    rm -rf target products ${DEF_BUILD_DIR}
 }
 
 run_uninstall()
@@ -235,7 +231,7 @@ if [ -z "$option_debug" ]; then
     vst3_src_path="products/Surge.vst3"
     lv2_bundle_name="Surge.lv2"
     lv2_src_path="products/$lv2_bundle_name"
-    headless_src_path="build/surge-headless"
+    headless_src_path="${DEF_BUILD_DIR}/surge-headless"
     dest_plugin_name="Surge.so"
     dest_headless_name="Surge-Headless"
 else

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -56,7 +56,7 @@ void get_prefix(char* txt, ControlGroup ctrlgroup, int ctrlgroup_entry, int scen
 
 void create_fullname(char* dn, char* fn, ControlGroup ctrlgroup, int ctrlgroup_entry)
 {
-   char prefix[16];
+   char prefix[32];
    bool useprefix = true;
    switch (ctrlgroup)
    {
@@ -119,10 +119,13 @@ void create_fullname(char* dn, char* fn, ControlGroup ctrlgroup, int ctrlgroup_e
       break;
    };
 
+   char tfn[256];
    if (useprefix)
-      sprintf(fn, "%s %s", prefix, dn);
+      sprintf(tfn, "%s %s", prefix, dn);
    else
-      sprintf(fn, "%s", dn);
+      sprintf(tfn, "%s", dn);
+   memset(fn, 0, NAMECHARS * sizeof(char));
+   strncpy(fn, tfn, NAMECHARS - 1 );
 }
 
 void Parameter::set_name(const char* n)

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -817,7 +817,9 @@ bool SurgeStorage::load_wt_wt(string filename, Wavetable* wt)
       ds = sizeof(float) * vt_read_int16LE(wh.n_tables) * vt_read_int32LE(wh.n_samples);
 
    data = malloc(ds);
-   fread(data, 1, ds, f);
+   read = fread(data, 1, ds, f);
+   // FIXME - error if read != ds
+   
    CS_WaveTableData.enter();
    bool wasBuilt = wt->BuildWT(data, wh, false);
    CS_WaveTableData.leave();

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -159,7 +159,8 @@ bool SurgeSynthesizer::loadPatchByPath( const char* fxpPath, int categoryId, con
    if (!f)
       return false;
    fxChunkSetCustom fxp;
-   fread(&fxp, sizeof(fxChunkSetCustom), 1, f);
+   auto read = fread(&fxp, sizeof(fxChunkSetCustom), 1, f);
+   // FIXME - error if read != chunk size
    if ((vt_read_int32BE(fxp.chunkMagic) != 'CcnK') || (vt_read_int32BE(fxp.fxMagic) != 'FPCh') ||
        (vt_read_int32BE(fxp.fxID) != 'cjs3'))
    {

--- a/src/common/WavSupport.cpp
+++ b/src/common/WavSupport.cpp
@@ -138,7 +138,8 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
         {
             break;
         }
-        fread(chunkSzD, 1, 4, fp);
+        br = fread(chunkSzD, 1, 4, fp);
+        // FIXME - deal with br
         int cs = pl_int(chunkSzD);
 
 #if WAV_STDOUT_INFO

--- a/src/common/gui/CNumberField.cpp
+++ b/src/common/gui/CNumberField.cpp
@@ -425,8 +425,9 @@ void CNumberField::draw(CDrawContext* pContext)
       else
       {
          float t = powf(2, value);
-         unit_prefix(t, the_text, true, false);
-         sprintf(the_text, "%ss", the_text);
+         char tmp_text[28];
+         unit_prefix(t, tmp_text, true, false);
+         sprintf(the_text, "%ss", tmp_text);
       }
       break;
    }
@@ -467,15 +468,17 @@ void CNumberField::draw(CDrawContext* pContext)
    case cm_frequency1hz:
    {
       float freq = powf(2, value);
-      unit_prefix(freq, the_text, false, false);
-      sprintf(the_text, "%sHz", the_text);
+      char tmp_text[28];
+      unit_prefix(freq, tmp_text, false, false);
+      sprintf(the_text, "%sHz", tmp_text);
       break;
    }
    case cm_time1s:
    {
       float t = powf(2, value);
-      unit_prefix(t, the_text, true, false);
-      sprintf(the_text, "%ss", the_text);
+      char tmp_text[28];
+      unit_prefix(t, tmp_text, true, false);
+      sprintf(the_text, "%ss", tmp_text);
       break;
    }
    case cm_noyes:

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -30,7 +30,7 @@
 
 #include <iostream>
 #include <iomanip>
-#include <strstream>
+#include <sstream>
 #include <stack>
 
 #if TARGET_VST3
@@ -2516,7 +2516,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                if( p->ctrlgroup == cg_LFO )
                {
                   char lab[256];
-                  char prefix[256];
+                  char prefix[32];
 
                   // WARNING - this won't work with Surge++
                   int a = p->ctrlgroup_entry + 1 - ms_lfo1;

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -70,7 +70,7 @@ void playSomeBach()
    if (!tf)
    {
       std::string cmd = "curl -o " + fname + " http://www.jsbach.net/midi/bwv988/988-v05.mid";
-      system(cmd.c_str()); 
+      auto res = system(cmd.c_str()); 
    }
    else
       fclose(tf);


### PR DESCRIPTION
1. Cleanup some errors with the LV2 cmake file for outofsource
2. Turn on warnings-are-errors
3. Fix some warnings; and turn off warnings-are-errors for some vstgui

Closes #1783