### PR TITLE
Lifecycle of the Storage object mishandled by Skin

### DIFF
--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -32,20 +32,18 @@ namespace UI
 
 const std::string Skin::defaultImageIDPrefix = "DEFAULT/";
    
-SkinDB& Surge::UI::SkinDB::get(SurgeStorage* s)
+SkinDB& Surge::UI::SkinDB::get()
 {
-   static SkinDB instance(s);
+   static SkinDB instance;
    return instance;
 }
 
-SkinDB::SkinDB(SurgeStorage* s)
+SkinDB::SkinDB()
 {
 #ifdef INSTRUMENT_UI
    Surge::Debug::record( "SkinDB::SkinDB" );
 #endif   
    std::cout << "Constructing SkinDB" << std::endl;
-   rescanForSkins(s);
-   this->storage = s;
 }
 
 SkinDB::~SkinDB()
@@ -58,8 +56,9 @@ SkinDB::~SkinDB()
    std::cout << "Destroying SkinDB" << std::endl;
 }
 
-std::shared_ptr<Skin> SkinDB::defaultSkin()
+std::shared_ptr<Skin> SkinDB::defaultSkin(SurgeStorage *storage)
 {
+   rescanForSkins(storage);
    auto uds = Surge::Storage::getUserDefaultValue( storage, "defaultSkin", "" );
    if( uds == "" )
       return getSkin(defaultSkinEntry);

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -217,7 +217,7 @@ private:
 class SkinDB
 {
 public:
-   static SkinDB& get(SurgeStorage *);
+   static SkinDB& get();
 
    struct Entry {
       std::string root;
@@ -239,14 +239,13 @@ public:
    void rescanForSkins(SurgeStorage *);
    std::vector<Entry> getAvailableSkins() { return availableSkins; }
    Skin::ptr_t getSkin( const Entry &skinEntry );
-   Skin::ptr_t defaultSkin();
+   Skin::ptr_t defaultSkin(SurgeStorage *);
 
 private:
-   SkinDB(SurgeStorage *);
+   SkinDB();
    ~SkinDB();
    SkinDB(const SkinDB&) = delete; 
    SkinDB& operator=(const SkinDB&) = delete; 
-   SurgeStorage *storage;
    
    std::vector<Entry> availableSkins;
    std::unordered_map<Entry,std::shared_ptr<Skin>, Entry::hash> skins;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -310,7 +310,7 @@ SurgeGUIEditor::SurgeGUIEditor(void* effect, SurgeSynthesizer* synth, void* user
    for( int i=0; i<n_modsources; ++i )
       modsource_is_alternate[i] = false;
 
-   currentSkin = Surge::UI::SkinDB::get(&(this->synth->storage)).defaultSkin();
+   currentSkin = Surge::UI::SkinDB::get().defaultSkin(&(this->synth->storage));
 }
 
 SurgeGUIEditor::~SurgeGUIEditor()
@@ -4145,7 +4145,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeSkinMenu(VSTGUI::CRect &menuRect)
 
     auto defaultNoOp = []() { Surge::UserInteractions::promptError( "Rescanning the skins folder is not implemented yet!", "Error" ); };
 
-    auto &db = Surge::UI::SkinDB::get(&(synth->storage));
+    auto &db = Surge::UI::SkinDB::get();
     bool hasTests = false;
     for( auto &entry : db.getAvailableSkins() )
     {


### PR DESCRIPTION
The SkinDB captures the Storage object beyond its lfiecycle.
Adjust the API so the storage is handed just when needed.