### PR TITLE
Reorder audio inputs

### DIFF
--- a/resources/data/configuration.xml
+++ b/resources/data/configuration.xml
@@ -13,8 +13,8 @@
     <type i="3" name="SH Noise" />
     <type i="4" name="Audio Input">
         <snapshot name="Left" p0="-1.0" p1="6.0" />
-        <snapshot name="Both/Stereo" p0="0.0" p1="6.0" />
         <snapshot name="Right" p0="1.0" p1="6.0" />
+        <snapshot name="Stereo" p0="0.0" p1="6.0" />
     </type>
 </osc>
 <fx>


### PR DESCRIPTION
* makes more sense to first have left, then right, then stereo
* also removed "Both/", it's enough to just say "Stereo"