### PR TITLE
Fix Phase Overflow in sin/fm2/fm3

### DIFF
--- a/src/common/dsp/FMOscillator.cpp
+++ b/src/common/dsp/FMOscillator.cpp
@@ -58,6 +58,8 @@ void FMOscillator::process_block(float pitch, float drift, bool stereo, bool FM,
       output[k] = sin(output[k]);
       lastoutput = output[k] * FeedbackDepth.v;
       phase += omega;
+      if( phase > 2.0 * M_PI )
+         phase -= 2.0 * M_PI;
       RelModDepth1.process();
       RelModDepth2.process();
       AbsModDepth.process();
@@ -162,6 +164,9 @@ void FM2Oscillator::process_block(float pitch, float drift, bool stereo, bool FM
       output[k] = sin(output[k]);
       lastoutput = output[k] * FeedbackDepth.v;
       phase += omega;
+      if( phase > 2.0 * M_PI )
+         phase -= 2.0 * M_PI;
+
       RelModDepth1.process();
       RelModDepth2.process();
       FeedbackDepth.process();

--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -94,6 +94,9 @@ void osc_sine::process_block(float pitch, float drift, bool stereo, bool FM, flo
          p += FMdepth.v * master_osc[k];
       output[k] = valueFromSinAndCos(sin(p), cos(p));
       phase += omega;
+      if( phase > 2.0 * M_PI )
+         phase -= 2.0 * M_PI;
+
       lastvalue = output[k] * FB.v;
       FMdepth.process();
       FB.process();
@@ -117,6 +120,9 @@ void osc_sine::process_block_legacy(float pitch, float drift, bool stereo, bool 
       {
          output[k] = valueFromSinAndCos(sin(phase), cos(phase));
          phase += omega + master_osc[k] * FMdepth.v;
+         if( phase > 2.0 * M_PI )
+            phase -= 2.0 * M_PI;
+
          FMdepth.process();
       }
    }


### PR DESCRIPTION
The fm/sin oscillators had form (roughly)

phase += omega
out = sin(phase)

so very very long notes would overflow the sizeof float and
add aliases because of float truncation. So mod phase down
by 2PI and voila

Closes #1805