### PR TITLE
Added more waveforms to Sine oscillator, more nitpick renames

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -629,7 +629,7 @@ void Parameter::set_type(int ctrltype)
       break;
    case ct_sineoscmode:
       val_min.i = 0;
-      val_max.i = 8;
+      val_max.i = 14;
       valtype = vt_int;
       val_default.i = 0;
       break;
@@ -1003,7 +1003,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
       case ct_delaymodtime:
          if ((ctrltype == ct_envtime_lfodecay) && (f == val_max.f))
          {
-            sprintf(txt, "forever");
+            sprintf(txt, "Forever");
          }
          else
          {
@@ -1150,14 +1150,41 @@ void Parameter::get_display(char* txt, bool external, float ef)
          sprintf(txt, "%s", character_abberations[limit_range(i, 0, (int)n_charactermodes - 1)]);
          break;
       case ct_sineoscmode:
-         // FIXME - do better than this of course
-         sprintf(txt, "%d", i);
+         switch (i)
+         {
+         case 0:
+            sprintf(txt, "Wave %d (TX 1)", i + 1);
+            break;
+         case 4:
+            sprintf(txt, "Wave %d (TX 2)", i + 1);
+            break;
+         case 6:
+            sprintf(txt, "Wave %d (TX 5)", i + 1);
+            break;
+         case 9:
+            sprintf(txt, "Wave %d (TX 3)", i + 1);
+            break;
+         case 10:
+            sprintf(txt, "Wave %d (TX 4)", i + 1);
+            break;
+         case 11:
+            sprintf(txt, "Wave %d (TX 6)", i + 1);
+            break;
+         case 12:
+            sprintf(txt, "Wave %d (TX 7)", i + 1);
+            break;
+         case 13:
+            sprintf(txt, "Wave %d (TX 8)", i + 1);
+            break;
+         default:
+            sprintf(txt, "Wave %d", i + 1);
+         }
          break;
       case ct_sinefmlegacy:
          if( i == 0 )
-             sprintf( txt, "Legacy (1.6.1.1 and earlier)");
+             sprintf( txt, "Legacy (before v1.6.2)");
          else
-             sprintf( txt, "Consistent w. FM2/3" );
+             sprintf( txt, "Consistent with FM2/3" );
          break;
       case ct_vocoder_bandcount:
          sprintf(txt, "%d bands", i);
@@ -1167,23 +1194,23 @@ void Parameter::get_display(char* txt, bool external, float ef)
          switch( i + 1 )
          {
          case wst_tanh:
-            sprintf(txt,"soft");
+            sprintf(txt,"Soft");
             break;
          case wst_hard:
-            sprintf(txt,"hard");
+            sprintf(txt,"Hard");
             break;
          case wst_asym:
-            sprintf(txt,"asym");
+            sprintf(txt,"Asymmetric");
             break;
          case wst_sinus:
-            sprintf(txt,"sine");
+            sprintf(txt,"Sine");
             break;
          case wst_digi:
-            sprintf(txt,"digi");
+            sprintf(txt,"Digital");
             break;
          default:
          case wst_none:
-            sprintf(txt,"none");
+            sprintf(txt,"None");
             break;
          }
          break;
@@ -1191,13 +1218,13 @@ void Parameter::get_display(char* txt, bool external, float ef)
          switch (i)
          {
          case 0:
-            sprintf(txt, "filter 1");
+            sprintf(txt, "Filter 1");
             break;
          case 1:
-            sprintf(txt, "both");
+            sprintf(txt, "Both");
             break;
          case 2:
-            sprintf(txt, "filter 2");
+            sprintf(txt, "Filter 2");
             break;
          }
          break;
@@ -1211,29 +1238,29 @@ void Parameter::get_display(char* txt, bool external, float ef)
          switch( mtype )
          {
          case 0:
-            types = "classic";
+            types = "Classic";
             break;
          case 1:
-            types = "vibrato";
+            types = "Vibrato";
             break;
          case 2:
-            types = "arp";
+            types = "Arp";
             break;
          }
          std::string typew;
          switch( mwave )
          {
          case 0:
-            typew = "sin";
+            typew = "Sine";
             break;
          case 1:
-            typew = "tri";
+            typew = "Triangle";
             break;
          case 2:
-            typew = "saw";
+            typew = "Sawtooth";
             break;
          case 3:
-            typew = "s+h";
+            typew = "S&H";
             break;
          }
          sprintf( txt, "%s %s", types.c_str(), typew.c_str() );
@@ -1247,43 +1274,43 @@ void Parameter::get_display(char* txt, bool external, float ef)
          switch( mode )
          {
          case 0:
-            types = "unison";
+            types = "Unison";
             break;
          case 1:
-            types = "octaves";
+            types = "Octaves";
             break;
          case 2:
-            types = "min 2nds";
+            types = "Minor 2nds";
             break;
          case 3:
-            types = "2nds";
+            types = "Major 2nds";
             break;
          case 4:
-            types = "diminished";
+            types = "Diminished";
             break;
          case 5:
-            types = "augmented";
+            types = "Augmented";
             break;
          case 6:
             types = "4ths";
             break;
          case 7:
-            types = "tritones";
+            types = "Tritones";
             break;
          case 8:
             types = "5ths";
             break;
          case 9:
-            types = "major";
+            types = "Major";
             break;
          case 10:
-            types = "minor";
+            types = "Minor";
             break;
          case 11:
-            types = "dominant";
+            types = "Dominant";
             break;
          case 12:
-            types = "maj 7";
+            types = "Major 7th";
             break;
          }
          sprintf( txt, "%s", types.c_str() );
@@ -1300,9 +1327,9 @@ void Parameter::get_display(char* txt, bool external, float ef)
       else
          b = val.b;
       if (b)
-         sprintf(txt, "true");
+         sprintf(txt, "On");
       else
-         sprintf(txt, "false");
+         sprintf(txt, "Off");
       break;
    };
 }

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -16,7 +16,7 @@
 #endif
 #include <tinyxml.h>
 
-#if LINUX 
+#if LINUX
 #include <experimental/filesystem>
 #elif MAC || (WINDOWS && TARGET_RACK)
 #include <filesystem.h>
@@ -134,11 +134,12 @@ enum sub3_osctypes
    ot_WT2,
    num_osctypes,
 };
-const char osctype_abberations[num_osctypes][16] = {"Classic",  "Sine", "Wavetable", "S/H Noise",
+const char osctype_abberations[num_osctypes][16] = {"Classic",  "Sine", "Wavetable", "S&H Noise",
                                                     "Audio In", "FM3",  "FM2",       "Window"};
-const char window_abberations[9][16] = {"Triangular", "Cosine",       "Blend 1",
-                                        "Blend 2",    "Blend 3",      "Ramp",
-                                        "Sine Cycle", "Square Cycle", "Rectangular"};
+
+const char window_abberations[9][16] = {"Triangle", "Cosine",       "Blend 1",
+                                        "Blend 2",    "Blend 3",      "Sawtooth",
+                                        "Sine", "Square", "Rectangle"};
 
 inline bool uses_wavetabledata(int i)
 {
@@ -171,7 +172,7 @@ enum sub3_fxtypes
 };
 const char fxtype_abberations[num_fxtypes][16] = {
     "Off", "Delay",     "Reverb 1",      "Phaser", "Rotary",  "Distortion",
-    "EQ",  "Freqshift", "Conditioner", "Chorus", "Vocoder", "Reverb 2", "Flanger" };
+    "EQ",  "Freq Shift", "Conditioner", "Chorus", "Vocoder", "Reverb 2", "Flanger" };
 
 enum fx_bypass
 {
@@ -225,7 +226,7 @@ enum lfoshapes
    n_lfoshapes
 };
 
-const char ls_abberations[n_lfoshapes][16] = {"Sine",  "Triangle", "Square",   "Ramp",
+const char ls_abberations[n_lfoshapes][16] = {"Sine",  "Triangle", "Square",   "Sawtooth",
                                               "Noise", "S&H",      "Envelope", "Step Seq"};
 
 enum fu_type
@@ -407,7 +408,7 @@ struct StepSequencerStorage
 struct DAWExtraStateStorage
 {
    bool isPopulated = false;
-    
+
    int instanceZoomFactor = -1;
    bool mpeEnabled = false;
    int mpePitchBendRange = -1;
@@ -426,7 +427,7 @@ struct PatchTuningStorage
    std::string tuningContents = "";
    std::string mappingContents = "";
 };
-    
+
 class SurgeStorage;
 
 class SurgePatch
@@ -465,7 +466,7 @@ public:
 
    PatchTuningStorage patchTuning;
    DAWExtraStateStorage dawExtraState;
-   
+
    std::vector<Parameter*> param_ptr;
    std::vector<int> easy_params_id;
 
@@ -532,7 +533,7 @@ public:
    float table_pitch_ignoring_tuning alignas(16)[512];
    float table_pitch_inv_ignoring_tuning alignas(16)[512];
    float table_note_omega_ignoring_tuning alignas(16)[2][512];
-   
+
    ~SurgeStorage();
 
    std::unique_ptr<SurgePatch> _patch;
@@ -599,7 +600,7 @@ public:
    std::string datapath;
    std::string userDataPath;
    std::string userDefaultFilePath;
-   
+
    std::string defaultsig, defaultname;
    // float table_sin[512],table_sin_offset[512];
    Surge::CriticalSection CS_WaveTableData, CS_ModRouting;
@@ -617,15 +618,15 @@ public:
    {
        return note_to_pitch_inv( x + scaleConstantNote() ) * scaleConstantPitch();
    }
-       
+
    void note_to_omega(float, float&, float&);
    void note_to_omega_ignoring_tuning(float, float&, float&);
 
    bool retuneToScale(const Tunings::Scale& s);
    bool retuneToStandardTuning() { init_tables(); return true; }
-   
+
    bool remapToKeyboard(const Tunings::KeyboardMapping &k);
-   bool remapToStandardKeyboard(); 
+   bool remapToStandardKeyboard();
    inline int scaleConstantNote() { return currentMapping.tuningConstantNote; }
    inline float scaleConstantPitch() { return tuningPitch; }
    inline float scaleConstantPitchInv() { return tuningPitchInv; } // Obviously that's the inverse of the above
@@ -635,8 +636,8 @@ public:
 
    Tunings::KeyboardMapping currentMapping;
    bool isStandardMapping = true;
-   float tuningPitch = 32.0f, tuningPitchInv = 0.03125f; 
-   
+   float tuningPitch = 32.0f, tuningPitchInv = 0.03125f;
+
 private:
    TiXmlDocument snapshotloader;
    std::vector<Parameter> clipboard_p;

--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -157,18 +157,23 @@ void osc_sine::process_block_legacy(float pitch, float drift, bool stereo, bool 
    }
 }
 
-float osc_sine::valueFromSinAndCos(float svalue, float cvalue)
+float osc_sine::valueFromSinAndCos(float sinx, float cosx)
 {
    int wfMode = localcopy[id_mode].i;
-   float pvalue = svalue;
+   float pvalue = sinx;
+
+   float sin2x = 2 * sinx * cosx;
+   float cos2x = 1 - (2 * sinx * sinx);
 
    int quadrant;
-   if (svalue > 0)
-      if (cvalue > 0)
+   int octant;
+
+   if (sinx > 0)
+      if (cosx > 0)
          quadrant = 1;
       else
          quadrant = 2;
-   else if (cvalue < 0)
+   else if (cosx < 0)
       quadrant = 3;
    else
       quadrant = 4;
@@ -176,7 +181,7 @@ float osc_sine::valueFromSinAndCos(float svalue, float cvalue)
    switch (wfMode)
    {
    case 1:
-      if (quadrant == 3 || quadrant == 4)
+      if (quadrant > 2)
          pvalue = 0;
       pvalue = 2 * pvalue - 1;
       break;
@@ -192,16 +197,16 @@ float osc_sine::valueFromSinAndCos(float svalue, float cvalue)
       switch (quadrant)
       {
       case 1:
-         pvalue = 1 - cvalue;
+         pvalue = 1 - cosx;
          break;
       case 2:
-         pvalue = 1 + cvalue;
+         pvalue = 1 + cosx;
          break;
       case 3:
-         pvalue = -1 - cvalue;
+         pvalue = -1 - cosx;
          break;
       case 4:
-         pvalue = -1 + cvalue;
+         pvalue = -1 + cosx;
          break;
       }
       break;
@@ -209,10 +214,10 @@ float osc_sine::valueFromSinAndCos(float svalue, float cvalue)
       switch (quadrant)
       {
       case 1:
-         pvalue = 1 - cvalue;
+         pvalue = 1 - cosx;
          break;
       case 2:
-         pvalue = 1 + cvalue;
+         pvalue = 1 + cosx;
          break;
       default:
          pvalue = 0;
@@ -222,21 +227,91 @@ float osc_sine::valueFromSinAndCos(float svalue, float cvalue)
       break;
    case 6:
       if (quadrant <= 2)
-         pvalue = 2 * svalue * cvalue; // remember sin 2x = 2 * sinx * cosx
+         pvalue = sin2x;
       else
          pvalue = 0;
       break;
    case 7:
-      pvalue = 2 * svalue * cvalue;
+      pvalue = sin2x;
       if (quadrant == 2 || quadrant == 3)
          pvalue = -pvalue;
       break;
    case 8:
-      pvalue = 2 * svalue * cvalue;
+      pvalue = sin2x;
       if (quadrant == 2 || quadrant == 4)
          pvalue = 0;
       if (quadrant == 3)
          pvalue = -pvalue;
+      break;
+   case 9:
+      if (quadrant > 2)
+         pvalue = 0;
+      break;
+   case 10:
+      switch (quadrant)
+      {
+      case 1:
+         pvalue = 1 - cosx;
+         break;
+      case 2:
+         pvalue = 1 + cosx;
+         break;
+      default:
+         pvalue = 0;
+         break;
+      }
+      break;
+   case 11:
+   case 13:
+      if (sin2x > 0)
+         if (cos2x > 0)
+            octant = 1;
+         else
+            octant = 2;
+      else if (cos2x < 0)
+         octant = 3;
+      else
+         octant = 4;
+
+      if (quadrant > 2)
+         octant += 4;
+
+      switch (octant)
+      {
+      case 1:
+      case 5:
+         pvalue = 1 - cos2x;
+         break;
+      case 2:
+      case 6:
+         pvalue = 1 + cos2x;
+         break;
+      case 3:
+      case 7:
+         pvalue = -1 - cos2x;
+         break;
+      case 4:
+      case 8:
+         pvalue = -1 + cos2x;
+         break;
+      }
+
+      if (wfMode == 13)
+         pvalue = abs(pvalue);
+
+      if (quadrant > 2)
+         pvalue = 0;
+
+      break;
+   case 12:
+      pvalue = abs(sin2x);
+      if (quadrant > 2)
+         pvalue = 0;
+      break;
+   case 14:
+      pvalue = abs(cos2x);
+      if (quadrant > 2)
+         pvalue = 0;
       break;
 
    default:


### PR DESCRIPTION
* Sine waveforms which match TX81Z are marked in the tooltip as "TX <1-8>"
* renamed svalue and cvalue to sinx/cosx for clarity/readability
* capitalized various tooltips that were all lowercase
* true/false value for buttons is now On/Off instead
* renamed LFO Ramp (and Window oscillator window mode) to Sawtooth for consistency across the board
* couple more renames in SurgeStorage.h