### PR TITLE
Add separate sceneout for VST3

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2569,7 +2569,6 @@ void SurgeSynthesizer::process()
       clear_block_antidenormalnoise(storage.audio_in_nonOS[1], BLOCK_SIZE_QUAD);
    }
 
-   float sceneout alignas(16)[2][2][BLOCK_SIZE_OS];
    float fxsendout alignas(16)[2][2][BLOCK_SIZE];
    bool play_scene[2];
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -50,6 +50,8 @@ class alignas(16) SurgeSynthesizer
 {
 public:
    float output alignas(16)[N_OUTPUTS][BLOCK_SIZE];
+   float sceneout alignas(16)[2][N_OUTPUTS][BLOCK_SIZE_OS]; // this is blocksize_os but has been downsampled by the end of process into block_size
+
    float input alignas(16)[N_INPUTS][BLOCK_SIZE];
    timedata time_data;
    bool audio_processing_active;

--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -500,10 +500,16 @@ void LfoModulationSource::process_block()
    float io2 = iout;
 
    if (lfo->unipolar.val.b)
+   {
       if (s != ls_stepseq)
+      {
          io2 = 0.5f + 0.5f * io2;
+      }
       else if (io2 < 0.f)
+      {
          io2 = 0.f;
+      }
+   }
 
    output = env_val * localcopy[magn].f * io2;
 }

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -72,6 +72,8 @@ tresult PLUGIN_API SurgeVst3Processor::initialize(FUnknown* context)
    // we want a SideChain Input and a Stereo Output
    addAudioInput(STR16("SideChain In"), SpeakerArr::kStereo, kAux );
    addAudioOutput(STR16("Stereo Out"), SpeakerArr::kStereo);
+   addAudioOutput(STR16("Scene A Out"), SpeakerArr::kStereo);
+   addAudioOutput(STR16("Scene B Out"), SpeakerArr::kStereo);
 
    //---create Event In/Out busses (1 bus with 16 channels)------
    addEventInput(USTRING("MIDI In"));
@@ -445,6 +447,16 @@ tresult PLUGIN_API SurgeVst3Processor::process(ProcessData& data)
       {
          out[outp][i] = (float)surgeInstance->output[outp][blockpos];
       }
+      if( numOutputs == 3 )
+      {
+         float** outA = data.outputs[1].channelBuffers32;
+         float** outB = data.outputs[2].channelBuffers32;
+         for(int c=0;c<2;++c)
+         {
+            outA[c][i] = (float)surgeInstance->sceneout[0][c][blockpos];
+            outB[c][i] = (float)surgeInstance->sceneout[1][c][blockpos];
+         }
+      }
 
       blockpos++;
       if (blockpos >= BLOCK_SIZE)
@@ -458,6 +470,11 @@ tresult PLUGIN_API SurgeVst3Processor::process(ProcessData& data)
 
    // mark as not silent
    data.outputs[0].silenceFlags = 0;
+   if( numOutputs == 3 )
+   {
+      data.outputs[1].silenceFlags = 0;
+      data.outputs[2].silenceFlags = 0;
+   }
 
    _fpuState.restore();
 


### PR DESCRIPTION
The VST3 now has 3 stereo outputs, allowing scene A and B
to be separately routed.