### PR TITLE
The Path to Float Typeins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,6 +774,7 @@ if( BUILD_HEADLESS )
     src/headless/UnitTestsIO.cpp
     src/headless/UnitTestsMIDI.cpp
     src/headless/UnitTestsMOD.cpp
+    src/headless/UnitTestsPARAM.cpp
     src/headless/UnitTestsTUN.cpp
     )
   add_dependencies(surge-headless surge-shared)

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -9,6 +9,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <cstdlib>
 
 Parameter::Parameter() : posx( PositionHolder::Axis::X ),
                          posy( PositionHolder::Axis::Y ),
@@ -1513,4 +1514,43 @@ void Parameter::morph(Parameter* a, Parameter* b, float x)
       else
          memcpy((void*)this, (void*)a, sizeof(Parameter));
    }
+}
+
+bool Parameter::can_setvalue_from_string()
+{
+   switch( ctrltype )
+   {
+   case ct_percent:
+   case ct_percent_bidirectional:
+      return true;
+      break;
+   }
+   return false;
+}
+
+bool Parameter::set_value_from_string( std::string s )
+{
+   const char* c = s.c_str();
+   switch( valtype )
+   {
+   case ct_percent:
+   {
+      auto nv = std::atof(c);
+      if( nv < 0 || nv > 100 )
+         return false;
+      val.f = nv / 100.0;
+   }
+   break;
+   case ct_percent_bidirectional:
+   {
+      auto nv = std::atof(c);
+      if( nv < -100 || nv > 100 )
+         return false;
+      val.f = nv / 100.0;
+   }
+   break;
+   default:
+      return false;
+   }
+   return true;
 }

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -241,6 +241,7 @@ public:
    bool can_extend_range();
    bool can_be_absolute();
    bool can_snap();
+   bool can_setvalue_from_string();
    void clear_flags();
    void set_type(int ctrltype);
    void morph(Parameter* a, Parameter* b, float x);
@@ -263,6 +264,7 @@ public:
    float value_to_normalized(float value);
    float get_default_value_f01();
    void set_value_f01(float v, bool force_integer = false);
+   bool set_value_from_string(std::string s);
    float
    get_modulation_f01(float mod);     // used by the gui to get the position of the modulated handle
    float set_modulation_f01(float v); // used by the gui to set the modulation to match the position

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -243,6 +243,7 @@ private:
    VSTGUI::CViewContainer* typeinDialog = nullptr;
    VSTGUI::CTextEdit* typeinValue = nullptr;
    VSTGUI::CTextLabel* typeinLabel = nullptr;
+   Parameter *typeinEditTarget = nullptr;
    
    VSTGUI::CControl* polydisp = nullptr;
    VSTGUI::CControl* oscdisplay = nullptr;

--- a/src/headless/UnitTestsPARAM.cpp
+++ b/src/headless/UnitTestsPARAM.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <algorithm>
+
+#include "HeadlessUtils.h"
+#include "Player.h"
+#include "SurgeError.h"
+
+#include "catch2.hpp"
+
+#include "UnitTestUtilities.h"
+
+using namespace Surge::Test;
+
+TEST_CASE( "Param String Inversion", "[parm]" )
+{
+#if 0   
+   SECTION( "Inverting" )
+   {
+      Parameter pq;
+      std::vector<int> supportedTypes;
+      for( int i=0; i<num_ctrltypes; ++i )
+      {
+         pq.set_type(i);
+         if( pq.can_setvalue_from_string() && pq.valtype == vt_float )
+         {
+            supportedTypes.push_back( i );
+         }
+      }
+      REQUIRE( supportedTypes.size() > 0 );
+      
+      for( auto type : supportedTypes )
+      {
+         INFO( "Testing " << type );
+         REQUIRE( p.can_setvalue_from_string() );
+         for( int i=0; i<25000; ++i )
+         {
+            Parameter p;
+            p.set_type(type);
+            
+            auto val = 1.f * rand() / RAND_MAX;
+            p.set_value_f01(val);
+            auto preval = p.val.f;
+            char txt[256];
+            p.get_display(txt);
+            REQUIRE( p.set_value_from_string( std::string( txt ) ) );
+            auto v01 = p.get_value_f01();
+
+            INFO( "Type " << type << " val01=" << val << " val.f=" << preval << " txt=" << txt << " roundtrip=" << p.val.f << " roundtrip01=" << v01 );
+            REQUIRE( v01 == Approx( val ).margin( .01 ) );
+         }
+      }
+   }
+#endif   
+}


### PR DESCRIPTION
This starts us on the path to float typeins. It includes

1. All the prototypes in Parameter to do an string inverse
2. Implementations of those for ct_percent and ct_percent_bidirectional
3. Regetest of those inversions
4. A UI in SurgeGUIEditor which is terrible but plumbs through.

Addresses #1071