### PR TITLE
Initialize the audio_playing bool

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -51,6 +51,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
    , halfbandIN(6, true)
 {
    switch_toggled_queued = false;
+   audio_processing_active = true;
    halt_engine = false;
    release_if_latched[0] = true;
    release_if_latched[1] = true;


### PR DESCRIPTION
The boolean for if audio was active was uninitialized.
Init it to true.