### PR TITLE
VST2 Init Sequence Change

### DIFF
--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -604,6 +604,8 @@ bool Vst2PluginInstance::tryInit()
       std::unique_ptr<SurgeGUIEditor> editorTmp(new SurgeGUIEditor(this, synthTmp.get()));
 
       _instance = synthTmp.release();
+      _instance->audio_processing_active = true;
+
       editor = editorTmp.release();
    } catch (std::bad_alloc err) {
       Surge::UserInteractions::promptError(err.what(), "Out of memory");


### PR DESCRIPTION
FL20 in VST2 doesn't show patch changes which is consistent
with audio running with the audio processing variable set wrong.
I bet it doesn't call resume ever.