### PR TITLE
SCL/KBM load dialogs open in respective factory folders

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4129,7 +4129,11 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect)
                            scl_folder = "tuning-library/SCL";
                         #endif
                         Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.datapath + scl_folder,
-                                                                      "Scala microtuning files (*.scl)",
+                                                                      #ifdef WINDOWS
+                                                                         "Scala microtuning files (*.scl)",
+                                                                      #else
+                                                                         ".scl",
+                                                                      #endif
                                                                       cb);
                     }
         );
@@ -4173,7 +4177,11 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect)
                            kbm_folder = "tuning-library/KBM Concert Pitch";
                         #endif
                         Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.datapath + kbm_folder,
-                                                                      "Scala keyboard mapping files (*.kbm)",
+                                                                      #ifdef WINDOWS
+                                                                         "Scala keyboard mapping files (*.kbm)",
+                                                                      #else
+                                                                         ".kbm",
+                                                                      #endif
                                                                       cb);
                     }
         );

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4122,8 +4122,14 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect)
                                Surge::UserInteractions::promptError( e.what(), "Error Loading .scl" );
                             }
                         };
-                        Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.userDataPath,
-                                                                      ".scl",
+                        std::string scl_folder;
+                        #if WINDOWS
+                           scl_folder = "tuning-library\\SCL";
+                        #else
+                           scl_folder = "tuning-library/SCL";
+                        #endif
+                        Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.datapath + scl_folder,
+                                                                      "Scala microtuning files (*.scl)",
                                                                       cb);
                     }
         );
@@ -4160,8 +4166,14 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect)
                             }
 
                         };
-                        Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.userDataPath,
-                                                                      ".kbm",
+                        std::string kbm_folder;
+                        #if WINDOWS
+                           kbm_folder = "tuning-library\\KBM Concert Pitch";
+                        #else
+                           kbm_folder = "tuning-library/KBM Concert Pitch";
+                        #endif
+                        Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.datapath + kbm_folder,
+                                                                      "Scala keyboard mapping files (*.kbm)",
                                                                       cb);
                     }
         );

--- a/src/windows/UserInteractionsWin.cpp
+++ b/src/windows/UserInteractionsWin.cpp
@@ -148,11 +148,11 @@ void promptFileOpenDialog(const std::string& initialDirectory,
    ofn.lpstrFile = szFile;
    ofn.lpstrFile[0] = '\0';
    ofn.nMaxFile = sizeof(szFile);
-   ofn.lpstrFilter = "All\0*.*\0";
+   ofn.lpstrFilter = filterSuffix.c_str();
    ofn.nFilterIndex = 0;
    ofn.lpstrFileTitle = NULL;
    ofn.nMaxFileTitle = 0;
-   ofn.lpstrInitialDir = NULL;
+   ofn.lpstrInitialDir = initialDirectory.c_str();
    ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
 
    if (GetOpenFileName(&ofn))


### PR DESCRIPTION
* partial implementation of #840
* passing initialDirectory to promptFileOpenDialog will work now, but filterSuffix doesn't, for to me unknown reason
* TODO: fallback if those factory folders aren't found - open Surge factory data folder root (pointers welcome!)