### PR TITLE
Force a more aggressive update on patch change

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -832,6 +832,7 @@ void SurgeSynthesizer::updateDisplay()
 #if ! TARGET_AUDIOUNIT
    getParent()->updateDisplay();
 #endif
+   refresh_editor = true;
 }
 
 void SurgeSynthesizer::sendParameterAutomation(long index, float value)


### PR DESCRIPTION
On patch change the synth properly invalidates, but
FL20 with VST2 has some sort of wierd thread-order bug
that means it didn't catch the update. Only FL20 and only
VST2. But hammer a change request at the end of patch
udpate for all hosts just to be sure.

Closes #817 as well, I bet