### PR TITLE
Fix typein bug; test it with frequency

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1522,6 +1522,10 @@ bool Parameter::can_setvalue_from_string()
    {
    case ct_percent:
    case ct_percent_bidirectional:
+   case ct_freq_hpf:
+   case ct_freq_audible:
+   case ct_freq_vocoder_low:
+   case ct_freq_vocoder_high:
       return true;
       break;
    }
@@ -1531,7 +1535,7 @@ bool Parameter::can_setvalue_from_string()
 bool Parameter::set_value_from_string( std::string s )
 {
    const char* c = s.c_str();
-   switch( valtype )
+   switch( ctrltype )
    {
    case ct_percent:
    {
@@ -1549,6 +1553,18 @@ bool Parameter::set_value_from_string( std::string s )
       val.f = nv / 100.0;
    }
    break;
+   case ct_freq_hpf:
+   case ct_freq_audible:
+   case ct_freq_vocoder_low:
+   case ct_freq_vocoder_high:
+   {
+      // these are 440 * 2 ^ ( f / 12 ) = c
+      // so log2( c / 440 ) * 12 = f;
+      auto nv = std::atof(c);
+      val.f = limit_range( log2f( nv / 440.0 ) * 12.0f, val_min.f, val_max.f );
+      return true;
+   }
+
    default:
       return false;
    }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4849,7 +4849,7 @@ void SurgeGUIEditor::promptForUserValueEntry( Parameter *p, CControl *c )
       if( ! p->can_setvalue_from_string() )
       {
          typeinValue->setFontColor( VSTGUI::kRedCColor );
-         typeinLabel->setText( "COMING SOON" );
+         typeinValue->setText( "edit coming soon" );
       }
       inner->addView(typeinValue);
 

--- a/src/headless/UnitTestsPARAM.cpp
+++ b/src/headless/UnitTestsPARAM.cpp
@@ -15,7 +15,6 @@ using namespace Surge::Test;
 
 TEST_CASE( "Param String Inversion", "[parm]" )
 {
-#if 0   
    SECTION( "Inverting" )
    {
       Parameter pq;
@@ -29,15 +28,15 @@ TEST_CASE( "Param String Inversion", "[parm]" )
          }
       }
       REQUIRE( supportedTypes.size() > 0 );
-      
+#if 0      
       for( auto type : supportedTypes )
       {
          INFO( "Testing " << type );
-         REQUIRE( p.can_setvalue_from_string() );
          for( int i=0; i<25000; ++i )
          {
             Parameter p;
             p.set_type(type);
+            REQUIRE( p.can_setvalue_from_string() );
             
             auto val = 1.f * rand() / RAND_MAX;
             p.set_value_f01(val);
@@ -51,6 +50,6 @@ TEST_CASE( "Param String Inversion", "[parm]" )
             REQUIRE( v01 == Approx( val ).margin( .01 ) );
          }
       }
+#endif      
    }
-#endif   
 }


### PR DESCRIPTION
The typein case statement was on valtype not ctrltype
which is why it wasn't quite working. Fix that, and to make
sure it is fixed, do the simpler frequencies too.

Addresses #1071