### PR TITLE
Implement lv2ui:scaleFactor

### DIFF
--- a/src/lv2/AllLv2.h
+++ b/src/lv2/AllLv2.h
@@ -13,6 +13,10 @@
 #include <lv2/time/time.h>
 #include <lv2/state/state.h>
 
+#ifndef LV2_UI__scaleFactor
+#define LV2_UI__scaleFactor LV2_UI_PREFIX "scaleFactor"
+#endif
+
 #define SURGE_PLUGIN_URI "https://surge-synthesizer.github.io/lv2/surge"
 #define SURGE_UI_URI     SURGE_PLUGIN_URI "#UI"
 #define SURGE_PATCH_URI  SURGE_PLUGIN_URI "#PatchData"

--- a/src/lv2/SurgeLv2Export.cpp
+++ b/src/lv2/SurgeLv2Export.cpp
@@ -154,6 +154,7 @@ void lv2_generate_ttl(const char* baseName)
               "                        ui:noUserResize ;\n"
               "    lv2:requiredFeature ui:idleInterface ,\n"
               "                        <" LV2_INSTANCE_ACCESS_URI "> ;\n"
+              "    opts:supportedOption ui:scaleFactor ;\n";
               "    lv2:extensionData ui:idleInterface .\n";
    }
 }

--- a/src/lv2/SurgeLv2Ui.cpp
+++ b/src/lv2/SurgeLv2Ui.cpp
@@ -12,14 +12,17 @@ SurgeLv2Ui::SurgeLv2Ui(SurgeLv2Wrapper* instance,
                        const LV2_URID_Map* uridMapper,
                        const LV2UI_Resize* uiResizer,
                        LV2UI_Write_Function writeFn,
-                       LV2UI_Controller controller)
+                       LV2UI_Controller controller,
+                       float uiScaleFactor)
     : _editor(new SurgeGUIEditor(instance, instance->synthesizer(), this)), _instance(instance),
-      _writeFn(writeFn), _controller(controller)
+      _writeFn(writeFn), _controller(controller),
+      _uiScaleFactor(uiScaleFactor), _uiInitialized(false)
 {
    instance->setEditor(this);
 
    if (uiResizer)
    {
+      _editor->setZoomFactor(uiScaleFactor * 100);
       _editor->setZoomCallback(
          [this, uiResizer](SurgeGUIEditor* editor) { handleZoom(editor, uiResizer); });
    }
@@ -30,8 +33,12 @@ SurgeLv2Ui::SurgeLv2Ui(SurgeLv2Wrapper* instance,
    {
       VSTGUI::ERect* rect = nullptr;
       _editor->getRect(&rect);
-      uiResizer->ui_resize(uiResizer->handle, rect->right - rect->left, rect->bottom - rect->top);
+      uiResizer->ui_resize(uiResizer->handle,
+                           (rect->right - rect->left) * uiScaleFactor,
+                           (rect->bottom - rect->top) * uiScaleFactor);
    }
+
+   _uiInitialized = true;
 }
 
 SurgeLv2Ui::~SurgeLv2Ui()
@@ -76,9 +83,22 @@ LV2UI_Handle SurgeLv2Ui::instantiate(const LV2UI_Descriptor* descriptor,
    void* parentWindow = (void*)SurgeLv2::findFeature(LV2_UI__parent, features);
    auto* featureUridMap = (const LV2_URID_Map*)SurgeLv2::requireFeature(LV2_URID__map, features);
    auto* featureResize = (const LV2UI_Resize*)SurgeLv2::findFeature(LV2_UI__resize, features);
+   auto* featureOptions = (const LV2_Options_Option*)SurgeLv2::findFeature(LV2_OPTIONS__options, features);
+
+   auto uriScaleFactor = featureUridMap->map(featureUridMap->handle, LV2_UI__scaleFactor);
+   float uiScaleFactor = 1.0f;
+   for (int i=0; featureOptions[i].key != 0; ++i)
+   {
+        if (featureOptions[i].key == uriScaleFactor)
+        {
+            if (featureOptions[i].type == featureUridMap->map(featureUridMap->handle, LV2_ATOM__Float))
+                uiScaleFactor = *(const float*)featureOptions[i].value;
+            break;
+        }
+   }
 
    std::unique_ptr<SurgeLv2Ui> ui(new SurgeLv2Ui(instance, parentWindow, featureUridMap,
-                                                 featureResize, write_function, controller));
+                                                 featureResize, write_function, controller, uiScaleFactor));
    return (LV2UI_Handle)ui.release();
 }
 
@@ -156,12 +176,13 @@ void SurgeLv2Ui::handleZoom(SurgeGUIEditor *e, const LV2UI_Resize* resizer)
     int newH = WINDOW_SIZE_Y * fzf;
 
     // identical implementation to VST2, except for here
-    resizer->ui_resize(resizer->handle, newW, newH);
+    if (_uiInitialized)
+        resizer->ui_resize(resizer->handle, newW, newH);
 
     VSTGUI::CFrame *frame = e->getFrame();
     if(frame)
     {
-        frame->setZoom(e->getZoomFactor() / 100.0);
+        frame->setZoom(fzf);
         /*
         ** cframe::setZoom uses prior size and integer math which means repeated resets drift
         ** look at the "oroginWidth" math around in CFrame::setZoom. So rather than let those

--- a/src/lv2/SurgeLv2Ui.h
+++ b/src/lv2/SurgeLv2Ui.h
@@ -17,7 +17,8 @@ public:
                        const LV2_URID_Map* uridMapper,
                        const LV2UI_Resize* uiResizer,
                        LV2UI_Write_Function writeFn,
-                       LV2UI_Controller controller);
+                       LV2UI_Controller controller,
+                       float uiScaleFactor);
    ~SurgeLv2Ui();
 
    void setParameterAutomated(int externalparam, float value);
@@ -54,4 +55,6 @@ private:
 #endif
    LV2UI_Write_Function _writeFn;
    LV2UI_Controller _controller;
+   float _uiScaleFactor;
+   bool _uiInitialized;
 };


### PR DESCRIPTION
As discussed in #1846

Some screenshots to demonstrate (I do not manually set anything, just open the UI from Carla)

With 1.0 scale:
![Screenshot_20200509_221228](https://user-images.githubusercontent.com/1334853/81485040-47e66600-9242-11ea-9025-f8e2d268bd87.png)

With 1.5 scale:
![Screenshot_20200509_221417](https://user-images.githubusercontent.com/1334853/81485062-75331400-9242-11ea-983e-22c7a62b5e2a.png)

Cannot test with 2x scale since surge gives warning about window not fitting on screen, which is indeed the case :joy: 
