### PR TITLE
Finessed Ctrl+drag feature, param unit fixes for certain FX

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -791,7 +791,7 @@ void Parameter::bound_value(bool force_integer)
          break;
       case ct_chorusmodtime:
          val.f = limit_range(
-                    log2(round(powf(2.0f, val.f) * 100) / 100.f),
+                    (float) log2(round(powf(2.0f, val.f) * 100) / 100.f),
                             val_min.f, val_max.f);
          break;
       case ct_portatime:
@@ -811,7 +811,7 @@ void Parameter::bound_value(bool force_integer)
             val.f = floor(val.f + 0.5f);
          else if (val.f < 0)
             val.f = limit_range(
-                      log2((round(powf(2.0f, val.f) * 10) / 10.f)),
+                      (float) log2(round(powf(2.0f, val.f) * 10) / 10.f),
                                val_min.f, val_max.f);
          else
             val.f = log2(round(powf(2.0f, val.f)));

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -730,8 +730,6 @@ void Parameter::bound_value(bool force_integer)
       val.f = a + b;
    }
 
-   printf("ctrltype: %d  > ", ctrltype);
-
    if (force_integer && (valtype == vt_float))
    {
       switch (ctrltype)
@@ -842,7 +840,6 @@ void Parameter::bound_value(bool force_integer)
          break;
       }
    }
-   printf("%.8f\n", val.f);
 
    if (ctrltype == ct_vocoder_bandcount)
    {

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -407,6 +407,7 @@ void Parameter::set_type(int ctrltype)
       val_default.f = 0;
       break;
    case ct_delaymodtime:
+   case ct_chorusmodtime:
       valtype = vt_float;
       val_min.f = -11;
       val_max.f = -3;
@@ -713,16 +714,13 @@ void Parameter::bound_value(bool force_integer)
       }
       b = powf(2.0f, b);
 
-      // b = min(floor(b*2.f) / 2.f,floor(b*3.f) / 3.f);
-
       if (b > 1.41f)
       {
-         b = log(1.5f) / log(2.f);
-          
+         b = log2(1.5f);
       }
       else if (b > 1.167f)
       {
-         b = log(1.3333333333f) / log(2.f);
+         b = log2(1.3333333333f);
       }
       else
       {
@@ -730,25 +728,123 @@ void Parameter::bound_value(bool force_integer)
       }
 
       val.f = a + b;
-      // val.f = floor(val.f * 4.f + 0.5f) / 4.f;
    }
+
+   printf("ctrltype: %d  > ", ctrltype);
 
    if (force_integer && (valtype == vt_float))
    {
-      val.f = floor(val.f + 0.5f);
-   }
+      switch (ctrltype)
+      {
+      case ct_percent:
+      case ct_percent_bidirectional:
+      case ct_osc_feedback:
+      case ct_detuning:
+         val.f = floor(val.f * 100) / 100.0;
+         break;
+      case ct_pitch:
+      case ct_pitch_semi7bp:
+      case ct_syncpitch: {
+         if (!extend_range)
+            val.f = floor(val.f + 0.5f);
+         break;
+      }
+      case ct_oscspread: {
+         if (absolute)
+            if (extend_range)
+               val.f = floor(val.f * 192) / 192.0;
+            else
+               val.f = floor(val.f * 16) / 16.0;
+         else if (extend_range)
+            val.f = floor(val.f * 120) / 120.0;
+         else
+            val.f = floor(val.f * 100) / 100.0;
+         break;
+      }
+      case ct_pitch_semi7bp_absolutable: {
+         if (absolute)
+            if (extend_range)
+               val.f = floor(val.f * 120) / 120.0;
+            else
+               val.f = floor(val.f * 12) / 12.0;
+         else
+            val.f = floor(val.f + 0.5f);
+         break;
+      }
+      case ct_amplitude:
+         if (val.f != 0)
+            val.f = db_to_amp(
+                round(amp_to_db(val.f))); // we use round instead of floor because with some params
+                                          // it wouldn't snap to max value (i.e. send levels)
+         else
+            val.f = -INFINITY; // this is so that the popup shows -inf proper instead of -192.0
+         break;
+      case ct_decibel:
+      case ct_decibel_narrow:
+      case ct_decibel_narrow_extendable:
+      case ct_decibel_extra_narrow:
+      case ct_decibel_attenuation:
+      case ct_decibel_attenuation_large:
+      case ct_decibel_fmdepth:
+      case ct_decibel_extendable:
+         val.f = floor(val.f);
+         break;
+      case ct_chorusmodtime:
+         val.f = limit_range(
+                    log2(round(powf(2.0f, val.f) * 100) / 100.f),
+                            val_min.f, val_max.f);
+         break;
+      case ct_portatime:
+      case ct_envtime:
+      case ct_envtime_lfodecay:
+      case ct_reverbtime:
+      case ct_reverbpredelaytime:
+      case ct_delaymodtime:
+         if (temposync)
+             val.f = floor(val.f + 0.5f);
+         else
+             val.f = log2(round(powf(2.0f, val.f) * 10) / 10.f);
+         break;
+      case ct_lforate:
+      {
+         if (temposync)
+            val.f = floor(val.f + 0.5f);
+         else if (val.f < 0)
+            val.f = limit_range(
+                      log2((round(powf(2.0f, val.f) * 10) / 10.f)),
+                               val_min.f, val_max.f);
+         else
+            val.f = log2(round(powf(2.0f, val.f)));
 
-   if (snap && ctrltype == ct_countedset_percent && user_data)
-   {
-      CountedSetUserData* cs = reinterpret_cast<CountedSetUserData*>(user_data);
-      auto count = cs->getCountedSetSize();
-      // OK so now val.f is between 0 and 1. So
-      auto fraccount = val.f * count;
-      auto intcount = (int)fraccount;
-      val.f = 1.0 * intcount / count;
+         break;
+      }
+      case ct_bandwidth:
+         val.f = floor(val.f * 10) / 10.0;
+         break;
+      case ct_freq_shift:
+         if (extend_range)
+            val.f = floor(val.f * 100) / 100.0;
+         else
+            val.f = floor(val.f + 0.5f);
+         break;
+      case ct_countedset_percent:
+      {
+         CountedSetUserData* cs = reinterpret_cast<CountedSetUserData*>(user_data);
+         auto count = cs->getCountedSetSize();
+         // OK so now val.f is between 0 and 1. So
+         auto fraccount = val.f * count;
+         auto intcount = (int)fraccount;
+         val.f = 1.0 * intcount / count;
+         break;
+      }
+      default:
+         val.f = floor(val.f + 0.5f);
+         break;
+      }
    }
+   printf("%.8f\n", val.f);
 
-   if( ctrltype == ct_vocoder_bandcount )
+   if (ctrltype == ct_vocoder_bandcount)
    {
        val.i = val.i - val.i % 4;
    }
@@ -1010,6 +1106,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
       case ct_envtime_lfodecay:
       case ct_reverbtime:
       case ct_reverbpredelaytime:
+      case ct_chorusmodtime:
       case ct_delaymodtime:
          if ((ctrltype == ct_envtime_lfodecay) && (f == val_max.f))
          {
@@ -1020,7 +1117,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
             if (temposync)
             {
                std::string res = tempoSyncNotationValue(f);
-               sprintf( txt, "%s", res.c_str() );
+               sprintf(txt, "%s", res.c_str() );
             }
             else if (f == val_min.f)
             {
@@ -1063,25 +1160,35 @@ void Parameter::get_display(char* txt, bool external, float ef)
          sprintf(txt, "%.2f octaves", f);
          break;
       case ct_freq_shift:
+      {
          sprintf(txt, "%.2f Hz", get_extended(f));
          break;
+      }
       case ct_percent:
       case ct_percent_bidirectional:
       case ct_countedset_percent:
+      {
          sprintf(txt, "%.1f %c", f * 100.f, '%');
          break;
+      }
       case ct_oscspread:
+      {
          if (absolute)
             sprintf(txt, "%.1f Hz", 16.f * get_extended( f ));
          else
             sprintf(txt, "%.1f cents", get_extended( f ) * 100.f);
          break;
+      }
       case ct_detuning:
+      {
          sprintf(txt, "%.1f cents", f * 100.f);
          break;
+      }
       case ct_stereowidth:
+      {
          sprintf(txt, "%.1fº", f);
          break;
+      }
       case ct_freq_hpf:
       case ct_freq_audible:
       case ct_freq_vocoder_low:
@@ -1090,24 +1197,36 @@ void Parameter::get_display(char* txt, bool external, float ef)
          sprintf(txt, "%.3f Hz", 440.f * powf(2.0f, f / 12.f) );
          break;
       }
+      case ct_pitch:
+      case ct_syncpitch:
       case ct_freq_mod:
+      {
          sprintf(txt, "%.2f semitones", f);
          break;
+      }
       case ct_pitch_semi7bp:
-          sprintf(txt, "%.2f", get_extended(f));
+      {
+          sprintf(txt, "%.2f semitones", get_extended(f));
           break;
+      }
       case ct_pitch_semi7bp_absolutable:
+      {
          if(absolute)
-             sprintf(txt, "%.1f Hz", 10 * get_extended(f));
+             sprintf(txt, "%.1f Hz", 10.f * get_extended(f));
          else
-             sprintf(txt, "%.2f", get_extended(f));
+             sprintf(txt, "%.2f semitones", get_extended(f));
          break;
+      }
       case ct_flangerpitch:
+      {
          sprintf(txt, "%.2f", f);
          break;
+      }
       case ct_osc_feedback:
+      {
          sprintf(txt, "%.1f %c", get_extended(f) * 100.f, '%');
          break;
+      }
       default:
          sprintf(txt, "%.2f", f);
          break;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -102,6 +102,7 @@ enum ctrltypes
    ct_flangervoices,
    ct_flangerchord,
    ct_osc_feedback,
+   ct_chorusmodtime,
    num_ctrltypes,
 };
 

--- a/src/common/dsp/DspUtilities.h
+++ b/src/common/dsp/DspUtilities.h
@@ -266,11 +266,11 @@ inline float linear_to_amp(float x)
 }
 inline float amp_to_db(float x)
 {
-   return limit_range((float)(6.f * 3.f * log(x) / log(2.f)), -192.f, 96.f);
+   return limit_range((float)(18.f * log2(x)), -192.f, 96.f);
 }
 inline float db_to_amp(float x)
 {
-   return limit_range(powf((10.f / 3.f), 0.05f * x), 0.f, 1.f);
+   return limit_range(powf(2.f, x / 18.f), 0.f, 2.f);
 }
 
 inline double sincf(double x)

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -261,7 +261,7 @@ void DualDelayEffect::init_ctrltypes()
    fxdata->p[1].set_name("Right");
    fxdata->p[1].set_type(ct_envtime);
    fxdata->p[2].set_name("Feedback");
-   fxdata->p[2].set_type(ct_amplitude);
+   fxdata->p[2].set_type(ct_percent);
    fxdata->p[3].set_name("Crossfeed");
    fxdata->p[3].set_type(ct_amplitude);
    fxdata->p[4].set_name("Low Cut");

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -386,13 +386,13 @@ template <int v> void ChorusEffect<v>::init_ctrltypes()
    Effect::init_ctrltypes();
 
    fxdata->p[0].set_name("Time");
-   fxdata->p[0].set_type(ct_delaymodtime);
+   fxdata->p[0].set_type(ct_chorusmodtime);
    fxdata->p[1].set_name("Rate");
    fxdata->p[1].set_type(ct_lforate);
    fxdata->p[2].set_name("Depth");
    fxdata->p[2].set_type(ct_percent);
    fxdata->p[3].set_name("Feedback");
-   fxdata->p[3].set_type(ct_amplitude);
+   fxdata->p[3].set_type(ct_percent);
    fxdata->p[4].set_name("Low Cut");
    fxdata->p[4].set_type(ct_freq_audible);
    fxdata->p[5].set_name("High Cut");

--- a/src/common/dsp/effect/FreqshiftEffect.cpp
+++ b/src/common/dsp/effect/FreqshiftEffect.cpp
@@ -242,7 +242,7 @@ void FreqshiftEffect::init_ctrltypes()
    fxdata->p[fsp_delay].set_name("Time");
    fxdata->p[fsp_delay].set_type(ct_envtime);
    fxdata->p[fsp_feedback].set_name("Feedback");
-   fxdata->p[fsp_feedback].set_type(ct_amplitude);
+   fxdata->p[fsp_feedback].set_type(ct_percent);
    fxdata->p[fsp_mix].set_name("Mix");
    fxdata->p[fsp_mix].set_type(ct_percent);
 


### PR DESCRIPTION
* all (if I got them all!) parameters now have a lot more sensible Ctrl+drag behavior, usually rounded to an integer unit
* fixed db_to_amp() function in DspUtilities.h
* delay, chorus and frequency shifter Feedback parameters were in dB rather than % like other Feedback parameters - made more consistent
* this PR effectively closes #1593!