### PR TITLE
Handle invalid string ranges

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -243,6 +243,9 @@ private:
    VSTGUI::CViewContainer* typeinDialog = nullptr;
    VSTGUI::CTextEdit* typeinValue = nullptr;
    VSTGUI::CTextLabel* typeinLabel = nullptr;
+   int typeinResetCounter = -1;
+   std::string typeinResetLabel = "";
+   
    Parameter *typeinEditTarget = nullptr;
    
    VSTGUI::CControl* polydisp = nullptr;


### PR DESCRIPTION
If an entered value does not match an acceptable string,
for now keep the dialog visible with a brief invalid
entry message