### PR TITLE
Fix temposync labels

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1005,9 +1005,17 @@ std::string Parameter::tempoSyncNotationValue(float f)
         nn = "whole";
         if (q >= 3)
         {
-            snprintf(tmp, 1024, "%.2f whole notes", q);
-            std::string res = tmp;
-            return res;
+           if( abs( q - floor(q + 0.01 ) ) < 0.01 )
+           {
+              snprintf(tmp, 1024, "%d whole notes", (int)floor(q + 0.01));
+           }
+           else
+           {
+              // this is the triplet case
+              snprintf(tmp, 1024, "%d whole triplets", (int)floor(q * 3.0 / 2.0 + 0.02 ));
+           }
+           std::string res = tmp;
+           return res;
         }
         else if (q >= 2)
         {
@@ -1024,11 +1032,14 @@ std::string Parameter::tempoSyncNotationValue(float f)
             t = "triplet";
             if (nn == "whole")
             {
-                nn = "1/2";
+               nn = "double whole";
             }
             else
             {
-                nn = "whole";
+               q = pow(2.0, f - 1);
+               snprintf(tmp, 1024, "%d whole triplets", (int)floor(q * 3.0 / 2.0 + 0.02 ));
+               std::string res = tmp;
+               return res;
             }
         }
         else

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2512,9 +2512,17 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                for( int i=p->val_min.f; i <= p->val_max.f; ++i )
                {
                   float mul = 1.0;
+                  float triplaboff = log2(1.33333333);
+                  float tripoff = triplaboff;
+                  float dotlaboff = log2(1.5);
+                  float dotoff = dotlaboff;
                   if( p->ctrltype == ct_lforate )
                   {
                      mul = -1.0;
+                     triplaboff = log2(1.5);
+                     tripoff = triplaboff;
+                     dotlaboff = log2(1.3333333333);
+                     dotoff = dotlaboff;
                   }
                   addCallbackMenu( tsMenuR, p->tempoSyncNotationValue( mul * (  (float) i  ) ),
                                    [p, i, this]() {
@@ -2522,26 +2530,24 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                                       p->bound_value();
                                       this->synth->refresh_editor = true;
                                    } );
-                  addCallbackMenu( tsMenuD, p->tempoSyncNotationValue( mul * (  (float) i  + log2( 1.333333333 ) ) ),
-                                   [p, i, this]() {
-                                      p->val.f = (float)i + log2( 1.33333333333 ) ;
+                  addCallbackMenu( tsMenuD, p->tempoSyncNotationValue( mul * (  (float) i  + dotlaboff ) ),
+                                   [p, i, dotoff, this]() {
+                                      p->val.f = (float)i + dotoff;
                                       p->bound_value();
                                       this->synth->refresh_editor = true;
                                    } );
-                  addCallbackMenu( tsMenuT, p->tempoSyncNotationValue( mul * (  (float) i  + log2( 1.5 ) ) ),
-                                   [p, i, this]() {
-                                      p->val.f = (float)i + log2( 1.5 );
+                  addCallbackMenu( tsMenuT, p->tempoSyncNotationValue( mul * (  (float) i  + triplaboff ) ),
+                                   [p, i, tripoff, this]() {
+                                      p->val.f = (float)i + tripoff;
                                       p->bound_value();
                                       this->synth->refresh_editor = true;
                                    } );
-                  p->tempoSyncNotationValue( mul * ( (float) i  + log2f( 1.3333333 ) ) );
-                  p->tempoSyncNotationValue( mul * ( (float) i  + log2f( 1.5 ) ) );
                }
                contextMenu->addEntry( txt2 ); eid++;
                contextMenu->addSeparator(); eid++;
-               contextMenu->addEntry( tsMenuR, "Notes" ); tsMenuR->forget(); eid++;
-               contextMenu->addEntry( tsMenuD, "Dotted Notes" ); tsMenuD->forget(); eid++;
-               contextMenu->addEntry( tsMenuT, "Triplets" ); tsMenuT->forget(); eid++;
+               contextMenu->addEntry( tsMenuR, "Straight" ); tsMenuR->forget(); eid++;
+               contextMenu->addEntry( tsMenuD, "Dotted" ); tsMenuD->forget(); eid++;
+               contextMenu->addEntry( tsMenuT, "Triplet" ); tsMenuT->forget(); eid++;
                contextMenu->addSeparator(); eid++;
             }
             else


### PR DESCRIPTION
Temposync labels, especially near triplets, were wrong in
one case and confusing in several. Improve.

Addresses #1071