### PR TITLE
Fix a TypeIn crash on rebuild

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -834,6 +834,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
    polydisp = 0;
    lfodisplay = 0;
    fxmenu = 0;
+   typeinDialog = nullptr;
    for( int i=0; i<16; ++i ) vu[i] = 0;
    
    current_scene = synth->storage.getPatch().scene_active.val.i;


### PR DESCRIPTION
We keep a weak (non-reference-increasing) pointer to the
typein control and use its nullness and resetting to null
for state. So rebuild needs to null it when it is removed.

Addresses #1071
Closes #1875