### PR TITLE
Internationalization for Streaming

### DIFF
--- a/src/common/dsp/DspUtilities.h
+++ b/src/common/dsp/DspUtilities.h
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "globals.h"
+#include "unitconversion.h"
 #include <vt_dsp/basic_dsp.h>
 #include <vt_dsp/halfratefilter.h>
 
@@ -353,6 +354,7 @@ inline char* float_to_str(float value, char* str)
 {
    if (!str)
       return 0;
+   Surge::ScopedLocale localGuard;
    sprintf(str, "%f", value);
    return str;
 }

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -509,12 +509,12 @@ void COscillatorDisplay::drawBitmap(CDrawContext* dc)
                column_d[y]--;
             }
          }
-         column[midline] = max((unsigned int)64 << aa_bs, column[midline]);
-         column[topline] = max((unsigned int)32 << aa_bs, column[topline]);
-         column[bottomline] = max((unsigned int)32 << aa_bs, column[bottomline]);
+         column[midline] = std::max((unsigned int)64 << aa_bs, column[midline]);
+         column[topline] = std::max((unsigned int)32 << aa_bs, column[topline]);
+         column[bottomline] = std::max((unsigned int)32 << aa_bs, column[bottomline]);
          for (int y = 0; y < h2; y++)
          {
-            cdisurf->setPixel(x, y, coltable[min((unsigned int)255, (column[y] >> aa_bs))]);
+            cdisurf->setPixel(x, y, coltable[std::min((unsigned int)255, (column[y] >> aa_bs))]);
          }
       }
       delete osc;

--- a/src/common/unitconversion.h
+++ b/src/common/unitconversion.h
@@ -1,13 +1,10 @@
+#pragma once
 #include <stdio.h>
 #include <algorithm>
+#include <clocale>
 
 static float env_phasemulti = 1000 / 44100.f;
 static float lfo_range = 1000;
-
-#if MAC
-#define min(x, y) std::min(x, y)
-#define max(x, y) std::max(x, y)
-#endif
 
 inline float lfo_phaseincrement(int samples, float rate)
 {
@@ -18,8 +15,8 @@ inline float lfo_phaseincrement(int samples, float rate)
 inline float dB_to_scamp(float in) // ff rev2
 {
    float v = powf(10.f, -0.05f * in);
-   v = max(0.f, v);
-   v = min(1.f, v);
+   v = std::max(0.f, v);
+   v = std::min(1.f, v);
    return v;
 }
 
@@ -46,8 +43,8 @@ inline float timecent_to_seconds(float in)
 inline float seconds_to_envtime(float in) // ff rev2
 {
    float v = powf(in / 30.f, 1.f / 3.f);
-   v = max(0.f, v);
-   v = min(1.f, v);
+   v = std::max(0.f, v);
+   v = std::min(1.f, v);
    return v;
 }
 
@@ -63,4 +60,32 @@ inline float timecent_to_envtime(float in)
 {
    // return seconds_to_envtime(timecent_to_seconds(in));
    return (in / 1200.f);
+}
+
+/*
+** Locales are kinda units aren't they? Anyway thanks to @falktx for this
+** handy little guard class, as shown in issue #1900
+*/
+namespace Surge
+{
+class ScopedLocale {
+public:
+    ScopedLocale() noexcept
+        : locale(::strdup(::setlocale(LC_NUMERIC, nullptr)))
+    {
+        ::setlocale(LC_NUMERIC, "C");
+    }
+
+    ~ScopedLocale() noexcept
+    {
+        if (locale != nullptr)
+        {
+            ::setlocale(LC_NUMERIC, locale);
+            ::free(locale);
+        }
+    }
+
+private:
+    char* const locale;
+};
 }


### PR DESCRIPTION
Forever, it seems, we've had a bug in our XML streaming
if you have a . , internationalization swap. Fix that here
by forcing "C" locale when we stream the XML (even though
this doesn't touch the streaming; it touches float_to-str).

Thanks to @falktx for help

Closes #1900