### PR TITLE
Tuning button behavior tweak, setEnabled for Set to std map refers to mapping cache

### DIFF
--- a/src/common/gui/CStatusPanel.cpp
+++ b/src/common/gui/CStatusPanel.cpp
@@ -29,9 +29,9 @@ void CStatusPanel::draw( VSTGUI::CDrawContext *dc )
        int yp = size.top + y0 + i * boxSize + (2 * i);
        int w = size.getWidth() - 4;;
        int h = boxSize - 2;
-       if( i == mpeMode )
+       if ( i == mpeMode )
            mpeBox = CRect(xp,yp,xp+w,yp+h);
-       if( i == tuningMode )
+       if ( i == tuningMode )
            tuningBox = CRect(xp,yp,xp+w,yp+h);
        if (i == zoomOptions)
            zoomBox = CRect(xp,yp,xp+w,yp+h);
@@ -42,12 +42,12 @@ void CStatusPanel::draw( VSTGUI::CDrawContext *dc )
        auto fg = skin->getColor( "mpetunstatus.button.selected.foreground", kBlackCColor );
        auto ufg = skin->getColor( "mpetunstatus.button.unselected.foreground", kBlackCColor );
        auto hl = skin->getColor( "mpetunstatus.buttun.highlight", CColor(0xff, 0x9A, 0x10 ) );
-       if( ! dispfeatures[i] )
+       if ( ! dispfeatures[i] )
        {
            hlbg = false;
        }
 
-       if( statusButtonGlyph != nullptr )
+       if ( statusButtonGlyph != nullptr )
        {
           CRect wr = CRect(xp,yp,xp+w,yp+h);
 
@@ -64,7 +64,7 @@ void CStatusPanel::draw( VSTGUI::CDrawContext *dc )
           dc->drawGraphicsPath(p, CDrawContext::kPathStroked);
           p->forget();
           
-          if( hlbg )
+          if ( hlbg )
           {
              auto p = dc->createRoundRectGraphicsPath(CRect(xp+2,yp+2,xp+w-2,yp+h-2), 3 );
              dc->setFillColor(hl);
@@ -73,7 +73,7 @@ void CStatusPanel::draw( VSTGUI::CDrawContext *dc )
           }
        }
 
-       if( hlbg )
+       if ( hlbg )
        {
            dc->setFontColor(fg);
        }
@@ -90,35 +90,39 @@ void CStatusPanel::draw( VSTGUI::CDrawContext *dc )
 
 VSTGUI::CMouseEventResult CStatusPanel::onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button)
 {
-    if( mpeBox.pointInside(where) && editor )
+    if ( mpeBox.pointInside(where) && editor )
     {
-        if( button & kLButton )
+        if ( button & kLButton )
         {
-            editor->toggleMPE();
+             editor->toggleMPE();
         }
-        else if( button & kRButton )
+        else if ( button & kRButton )
         {
-            editor->showMPEMenu(where);
+             editor->showMPEMenu(where);
         }
         return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
     }
 
-    if( tuningBox.pointInside(where) && editor )
+    if ( tuningBox.pointInside(where) && editor )
     {
-        if( button & kLButton )
+        if ( button & kLButton )
         {
-           editor->toggleTuning();
+            if (!storage->isStandardTuning  || editor->tuningCacheForToggle.size() > 0 ||
+                !storage->isStandardMapping || editor->mappingCacheForToggle.size() > 0)
+                editor->toggleTuning();
+            else
+                editor->showTuningMenu(where);
         }
-        else if( button & kRButton )
+        else if ( button & kRButton )
         {
             editor->showTuningMenu(where);
         }
         return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
     }
 
-    if( zoomBox.pointInside(where) && editor )
+    if ( zoomBox.pointInside(where) && editor )
     {
-        if( button & kLButton )
+        if ( button & kLButton )
         {
             editor->showZoomMenu(where);
         }
@@ -130,7 +134,7 @@ VSTGUI::CMouseEventResult CStatusPanel::onMouseDown(VSTGUI::CPoint& where, const
 }
 
 VSTGUI::CMouseEventResult CStatusPanel::onMouseMoved(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) {
-   if( mpeBox.pointInside(where) || tuningBox.pointInside(where) || zoomBox.pointInside(where) )
+   if ( mpeBox.pointInside(where) || tuningBox.pointInside(where) || zoomBox.pointInside(where) )
       getFrame()->setCursor( VSTGUI::kCursorHand );
    else
       getFrame()->setCursor( VSTGUI::kCursorDefault );
@@ -156,13 +160,13 @@ bool CStatusPanel::onDrop(VSTGUI::DragEventData data )
          fs::path fPath(fName);
          if ((_stricmp(fPath.extension().generic_string().c_str(), ".scl") == 0))
          {
-             if( editor )
-                 editor->tuningFileDropped(fName);
+            if ( editor )
+               editor->tuningFileDropped(fName);
          }
          if ((_stricmp(fPath.extension().generic_string().c_str(), ".kbm") == 0))
          {
-             if( editor )
-                 editor->mappingFileDropped(fName);
+            if ( editor )
+               editor->mappingFileDropped(fName);
          }
       }
    }

--- a/src/common/gui/CStatusPanel.h
+++ b/src/common/gui/CStatusPanel.h
@@ -26,6 +26,7 @@ public:
         for( auto i=0; i<numDisplayFeatures; ++i )
             dispfeatures[i] = false;
         doingDrag = false;
+        this->storage = storage;
     }
     
     void setDisplayFeature( DisplayFeatures df, bool v ) {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4143,6 +4143,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect)
                     [this]()
                     {
                         this->synth->storage.init_tables();
+                        tuningCacheForToggle = "";
                     }
         );
     st->setEnabled(!this->synth->storage.isStandardTuning || tuningCacheForToggle.size() > 0);
@@ -4152,9 +4153,10 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect)
                     [this]()
                     {
                         this->synth->storage.remapToStandardKeyboard();
+                        mappingCacheForToggle = "";
                     }
         );
-    kst->setEnabled(!this->synth->storage.isStandardMapping || tuningCacheForToggle.size() > 0);
+    kst->setEnabled(!this->synth->storage.isStandardMapping || mappingCacheForToggle.size() > 0);
     tid++;
 
     tuningSubMenu->addSeparator();


### PR DESCRIPTION
* by default left mouse now pops up context menu that's on right click
* "Set to standard tuning/mapping" options now also clear the cache, so that we get a true reset to 12-TET
* "Set to standard mapping" menu setEnabled function was referring to tuningCacheForToggle which was wrong
* closes #1907