### PR TITLE
Thread Storage into Parameter; use it for semis/keys

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -18,6 +18,7 @@ Parameter::Parameter() : posx( PositionHolder::Axis::X ),
 {
    val.i = 0;
    posy_offset = 0;
+   storage = nullptr;
 }
 
 Parameter::~Parameter()
@@ -161,6 +162,7 @@ Parameter* Parameter::assign(ParameterIDCounter::promise_t idp,
    this->modulateable = modulateable;
    this->scene = scene;
    this->ctrlstyle = ctrlstyle;
+   this->storage = nullptr;
    strncpy(this->ui_identifier, ui_identifier.c_str(), NAMECHARS );
 
    strncpy(this->name, name, NAMECHARS);
@@ -1224,16 +1226,16 @@ void Parameter::get_display(char* txt, bool external, float ef)
       case ct_pitch:
       case ct_syncpitch:
       case ct_freq_mod:
-         sprintf(txt, "%.2f semitones", f);
+         sprintf(txt, "%.2f %s", f, (storage && ! storage->isStandardTuning ? "keys" : "semitones" ));
          break;
       case ct_pitch_semi7bp:
-          sprintf(txt, "%.2f semitones", get_extended(f));
+          sprintf(txt, "%.2f %s", get_extended(f), (storage && ! storage->isStandardTuning ? "keys" : "semitones" ) );
           break;
       case ct_pitch_semi7bp_absolutable:
          if(absolute)
              sprintf(txt, "%.1f Hz", 10.f * get_extended(f));
          else
-             sprintf(txt, "%.2f semitones", get_extended(f));
+             sprintf(txt, "%.2f %s", get_extended(f), (storage && ! storage->isStandardTuning ? "keys" : "semitones" ) );
          break;
       case ct_fmratio:
          sprintf(txt, "C : %.2f", f);

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -217,6 +217,8 @@ private:
    int val;
 };
 
+class SurgeStorage;
+
 class Parameter
 {
 public:
@@ -297,4 +299,14 @@ public:
    
    ParamUserData* user_data;              // I know this is a bit gross but we have a runtime type
    void set_user_data(ParamUserData* ud); // I take a shallow copy and don't assume ownership and assume i am referencable
+
+   /*
+   ** Parameter has a pointer to the storage that manages the patch that contains it
+   ** *if* this parameter was thus constructed. There are real and legitimate uses
+   ** of the Parameter class where this pointer will be null so if you use it you
+   ** have to check the nullity
+   **
+   ** if( storage && storage->isStandardTuning ) { }
+   */
+   SurgeStorage *storage = nullptr;
 };

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -617,6 +617,12 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
    {
       param_ptr[i]->id = param_ptr[i]->id_promise->value;
       param_ptr[i]->id_promise = nullptr; // we only hold it transiently since we have a direct pointer copy to keep the class size fixed
+
+      /*
+      ** Give the param a weak pointer to the storage, since we know this patch will last the
+      ** lifetime of the storage which created it. See comment in Parameter.h
+      */
+      param_ptr[i]->storage = storage;
    }
 
    scene_start[0] = scene_start_promise[0]->value;


### PR DESCRIPTION
We want to make formating decisiosn based on the state of the synth
so parameters need storages. They don't always have them so add
a weak reference to storage to the parameter.

Demosntrate this by changing 'semitones' labels to 'keys' when
you have an alternate tuning. Closes #1848