### PR TITLE
Draw Performance problems on LInux; Vector LFO

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -37,15 +37,6 @@ void CLFOGui::drawtri(CRect r, CDrawContext* context, int orientation)
 
 void CLFOGui::draw(CDrawContext* dc)
 {
-#if LINUX
-   /*
-   ** As of 1.6.2, the linux vectorized drawing is slow and scales imporoperly with zoom, so
-   ** return to the original bitmap drawing until we resolve. See issue #1103.
-   ** 
-   ** Also some older machines report performance problems so make it switchable
-   */
-   drawBitmap(dc);
-#else
    auto useBitmap = Surge::Storage::getUserDefaultValue(storage, "useBitmapLFO", 0 );
 
    if( ignore_bitmap_pref || useBitmap )
@@ -63,7 +54,6 @@ void CLFOGui::draw(CDrawContext* dc)
        if( elapsed_seconds.count() > 0.1 )
            ignore_bitmap_pref = true;
    }
-#endif
 }
 
 void CLFOGui::drawVectorized(CDrawContext* dc)
@@ -423,7 +413,7 @@ void CLFOGui::drawVectorized(CDrawContext* dc)
 
 
 #if LINUX
-      dc->setLineWidth(100.0);
+      dc->setLineWidth(40.0);
 #else
       dc->setLineWidth(1.0);
 #endif
@@ -433,7 +423,7 @@ void CLFOGui::drawVectorized(CDrawContext* dc)
       dc->drawGraphicsPath(edpath, VSTGUI::CDrawContext::PathDrawMode::kPathStroked, &tfpath );
 
 #if LINUX
-      dc->setLineWidth(100.0);
+      dc->setLineWidth(50.0);
 #else
       dc->setLineWidth(1.3);
 #endif

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4439,15 +4439,13 @@ VSTGUI::COptionMenu* SurgeGUIEditor::makeUIOptionsMenu(VSTGUI::CRect& menuRect)
    uiOptionsMenu->addEntry(mouseSubMenu, mouseMenuName.c_str());
    mouseSubMenu->forget();
 
-#if !LINUX
-   auto useBitmap = Surge::Storage::getUserDefaultValue(&(this->synth->storage), "useBitmapLFO", 0);
+   auto useBitmap = Surge::Storage::getUserDefaultValue(&(this->synth->storage), "useBitmapLFO", 0 );
    auto bitmapMenu = useBitmap ? "Use Vectorized LFO Display" : "Use Bitmap LFO Display";
    addCallbackMenu(uiOptionsMenu, Surge::UI::toOSCaseForMenu(bitmapMenu), [this, useBitmap]() {
       Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "useBitmapLFO",
                                              useBitmap ? 0 : 1);
       this->synth->refresh_editor = true;
    });
-#endif
 
    uiOptionsMenu->addSeparator(mid++);
 


### PR DESCRIPTION
Fix a VSTGUI draw performance problem on LInux
That allows us to turn on the Vector LFO on Linux
Yay!

Addresses #1103