### PR TITLE
Change the Installers for JUCE6 Surge-FX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ buildwin/
 
 # Reaper
 *.RPP-bak
+
+surge-fx

--- a/installer_linux/make_deb.sh
+++ b/installer_linux/make_deb.sh
@@ -87,11 +87,14 @@ cp -r ../resources/data/* ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/
 # Copy the VST3 bundld 
 cp -r ../products/Surge.vst3 ${PACKAGE_NAME}/usr/lib/vst3/
 
+if [[ -d ../surge-fx/build/product/ ]]; then
+    cp -r ../surge-fx/build/product/*vst3 ${PACKAGE_NAME}/usr/lib/vst3/
+fi
+
 # copy the lv2 bundle
 cp -r ../products/Surge.lv2 ${PACKAGE_NAME}/usr/lib/lv2/
 
 # set permissions on shared libraries
-chmod -R 0644 ${PACKAGE_NAME}/usr/lib/vst/${SURGE_NAME}.so
 find ${PACKAGE_NAME}/usr/lib/vst3/ -type f -iname "*.so" | xargs chmod 0644
 find ${PACKAGE_NAME}/usr/lib/lv2/ -type f -iname "*.so" | xargs chmod 0644
 
@@ -103,4 +106,3 @@ rm -rf ${PACKAGE_NAME}
 
 echo "Built DEB Package"
 pwd
-ls -l product

--- a/installer_mac/Resources/Readme.rtf
+++ b/installer_mac/Resources/Readme.rtf
@@ -39,5 +39,5 @@ Surge is maintained by a group of volunteers and is distributed as an AU and VST
 \f1\i0 \cf3 The Mac team regularly tests surge in Reaper, Bitwig, Logic, Hosting AU and Cubase. \
 \
 None of us are regular Mac Live users.
-\f2\i \cf2  \cf3 Ableton Live 10.1.14 does not work properly with the Surge VST3. The synth does not load and the effect bank can make incorrect sounds. If you use Live we strongly suggest you do not install the VST3. 
-\f1\i0 If you would like to help us fix this, we can always use developers on the team. Check out our GitHub.}
+\f2\i \cf2  \cf3 Ableton Live 10.1.14 does not work properly with the Surge VST3. The synth does not load and the effect bank can make incorrect sounds. If you use Live we strongly suggest you do not use the VST3 (although install it if you have other DAWs). 
+\f1\i0 If you would like to help us fix this, we can always use developers on the team. Check out our GitHub or Slack!}

--- a/installer_mac/make_installer.sh
+++ b/installer_mac/make_installer.sh
@@ -26,6 +26,7 @@ fi
 # locations
 
 PRODUCTS="../products/"
+FXPRODUCTS="../surge-fx/build/product/"
 
 VST3="Surge.vst3"
 AU="Surge.component"
@@ -45,6 +46,7 @@ build_flavor()
     flavorprod=$2
     ident=$3
     loc=$4
+    proddir=$5
 
     echo --- BUILDING Surge_${flavor}.pkg ---
     
@@ -56,11 +58,11 @@ build_flavor()
     # by moving the product to a tmp dir
 
     mkdir -p $TMPDIR
-    mv $PRODUCTS/$flavorprod $TMPDIR
+    mv $proddir/$flavorprod $TMPDIR
 
     pkgbuild --root $TMPDIR --identifier $ident --version $VERSION --install-location $loc Surge_${flavor}.pkg || exit 1
 
-    mv $TMPDIR/${flavorprod} $PRODUCTS
+    mv $TMPDIR/${flavorprod} $proddir
     rmdir $TMPDIR
 }
 
@@ -68,23 +70,23 @@ build_flavor()
 # try to build VST3 package
 
 if [[ -d $PRODUCTS/$VST3 ]]; then
-    build_flavor "VST3" $VST3 "com.vemberaudio.vst3.pkg" "/Library/Audio/Plug-Ins/VST3"
+    build_flavor "VST3" $VST3 "com.vemberaudio.vst3.pkg" "/Library/Audio/Plug-Ins/VST3" $PRODUCTS
 fi
 
 # try to build AU package
 
 if [[ -d $PRODUCTS/$AU ]]; then
-    build_flavor "AU" $AU "com.vemberaudio.au.pkg" "/Library/Audio/Plug-Ins/Components"
+    build_flavor "AU" $AU "com.vemberaudio.au.pkg" "/Library/Audio/Plug-Ins/Components" $PRODUCTS
 fi
 
 # And the FXen
 
-if [[ -d $PRODUCTS/$FXAU ]]; then
-    build_flavor "FXAU" $FXAU "org.surge-synthesizer.fxau.pkg" "/Library/Audio/Plug-Ins/Components"
+if [[ -d $FXPRODUCTS/$FXAU ]]; then
+    build_flavor "FXAU" $FXAU "org.surge-synthesizer.fxau.pkg" "/Library/Audio/Plug-Ins/Components" $FXPRODUCTS
 fi
 
-if [[ -d $PRODUCTS/$FXVST3 ]]; then
-    build_flavor "FXVST3" $FXVST3 "org.surge-synthesizer.fxvst3.pkg" "/Library/Audio/Plug-Ins/VST3"
+if [[ -d $FXPRODUCTS/$FXVST3 ]]; then
+    build_flavor "FXVST3" $FXVST3 "org.surge-synthesizer.fxvst3.pkg" "/Library/Audio/Plug-Ins/VST3" $FXPRODUCTS
 fi
 
 # write build info to resources folder
@@ -96,6 +98,7 @@ echo "Commit: $(git rev-parse HEAD)" >> "$RSRCS/BuildInfo.txt"
 
 # build resources package
 
+echo --- BUILDING Resources pkg ---
 pkgbuild --root "$RSRCS" --identifier "com.vemberaudio.resources.pkg" --version $VERSION --scripts ResourcesPackageScript --install-location "/tmp/Surge" Surge_Resources.pkg
 
 # remove build info from resource folder
@@ -114,12 +117,12 @@ if [[ -d $PRODUCTS/$AU ]]; then
 	AU_CHOICE='<line choice="com.vemberaudio.au.pkg"/>'
 	AU_CHOICE_DEF="<choice id=\"com.vemberaudio.au.pkg\" visible=\"true\" start_selected=\"true\" title=\"Audio Unit\"><pkg-ref id=\"com.vemberaudio.au.pkg\"/></choice><pkg-ref id=\"com.vemberaudio.au.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_AU.pkg</pkg-ref>"
 fi
-if [[ -d $PRODUCTS/$FXAU ]]; then
+if [[ -d $FXPRODUCTS/$FXAU ]]; then
 	FXAU_PKG_REF='<pkg-ref id="org.surge-synthesizer.fxau.pkg"/>'
 	FXAU_CHOICE='<line choice="org.surge-synthesizer.fxau.pkg"/>'
 	FXAU_CHOICE_DEF="<choice id=\"org.surge-synthesizer.fxau.pkg\" visible=\"true\" start_selected=\"true\" title=\"Audio Unit for Standalone FX\"><pkg-ref id=\"org.surge-synthesizer.fxau.pkg\"/></choice><pkg-ref id=\"org.surge-synthesizer.fxau.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_FXAU.pkg</pkg-ref>"
 fi
-if [[ -d $PRODUCTS/$FXVST3 ]]; then
+if [[ -d $FXPRODUCTS/$FXVST3 ]]; then
 	FXVST3_PKG_REF='<pkg-ref id="org.surge-synthesizer.fxvst3.pkg"/>'
 	FXVST3_CHOICE='<line choice="org.surge-synthesizer.fxvst3.pkg"/>'
 	FXVST3_CHOICE_DEF="<choice id=\"org.surge-synthesizer.fxvst3.pkg\" visible=\"true\" start_selected=\"true\" title=\"VST3 for Standalone FX\"><pkg-ref id=\"org.surge-synthesizer.fxvst3.pkg\"/></choice><pkg-ref id=\"org.surge-synthesizer.fxvst3.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_FXVST3.pkg</pkg-ref>"

--- a/installer_win/surge-x86.iss
+++ b/installer_win/surge-x86.iss
@@ -34,6 +34,8 @@ SetupIconFile=surge.ico
 UsePreviousAppDir=no
 Compression=lzma
 SolidCompression=yes
+UninstallFilesDir={{commmonappdata}\Surge\uninsx86}
+
 
 [Components]
 Name: Data; Description: Data files; Types: full compact custom; Flags: fixed
@@ -41,10 +43,10 @@ Name: VST3; Description: VST3 Plug-in (32 bit); Types: full compact custom; Flag
 Name: EffectsVST3; Description: SurgeEffectsBank VST3 Plug-in (32 bit); Types: full compact custom; Flags: checkablealone
 
 [Files]
-Source: ..\target\vst3\Release\Surge_x86.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
-Source: ..\fxbuild\surge-fx\Builds\VisualStudio2017\Win32\ReleaseWin32\VST3\SurgeEffectsBank.vst3; DestDir: {cf}\VST3; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\resources\data\*; DestDir: {commonappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
 Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
+Source: ..\target\vst3\Release\Surge_x86.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
+Source: ..\surge-fx\build\product\SurgeEffectsBank.vst3\*; DestDir: {cf}\VST3\SurgeEffectsBank_x86.vst3; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist recursesubdirs
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/installer_win/surge.iss
+++ b/installer_win/surge.iss
@@ -34,6 +34,7 @@ SetupIconFile=surge.ico
 UsePreviousAppDir=no
 Compression=lzma
 SolidCompression=yes
+UninstallFilesDir={{commmonappdata}\Surge}
 
 [Components]
 Name: Data; Description: Data files; Types: full compact custom; Flags: fixed
@@ -41,10 +42,10 @@ Name: VST3; Description: VST3 Plug-in (64 bit); Types: full compact custom; Flag
 Name: EffectsVST3; Description: SurgeEffectsBank VST3 Plug-in (64 bit); Types: full compact custom; Flags: checkablealone
 
 [Files]
-Source: ..\target\vst3\Release\Surge.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
-Source: ..\fxbuild\surge-fx\Builds\VisualStudio2017\x64\Release\VST3\SurgeEffectsBank.vst3; DestDir: {cf}\VST3; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist
 Source: ..\resources\data\*; DestDir: {commonappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
 Source: ..\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
+Source: ..\target\vst3\Release\Surge.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
+Source: ..\surge-fx\build\product\SurgeEffectsBank.vst3\*; DestDir: {cf}\VST3\SurgeEffectsBank.vst3; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist recursesubdirs
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/src/common/unitconversion.h
+++ b/src/common/unitconversion.h
@@ -71,7 +71,11 @@ namespace Surge
 class ScopedLocale {
 public:
     ScopedLocale() noexcept
-        : locale(::strdup(::setlocale(LC_NUMERIC, nullptr)))
+#if WINDOWS
+    : locale(::_strdup(::setlocale(LC_NUMERIC, nullptr)))
+#else    
+    : locale(::strdup(::setlocale(LC_NUMERIC, nullptr)))
+#endif
     {
         ::setlocale(LC_NUMERIC, "C");
     }


### PR DESCRIPTION
Now that Surge-FX is on Juce6, upgrade the installer scritps
to grab it from a uniform place (and of course upgrade the
release pipeline too)