### PR TITLE
Implement Portable Mode

### DIFF
--- a/doc/pauls-debug-fragments.txt
+++ b/doc/pauls-debug-fragments.txt
@@ -32,3 +32,9 @@ void stackToInfo()
 #define _D(x) " " << (#x) << "=" << x
 ---
 leaks `ps -ef | grep Hosting | grep Surge | awk '{ print $2 }'`
+---
+   FILE *fp;
+   // Allocate a console for this app
+   AllocConsole();
+   freopen_s(&fp, "CONOUT$", "w", stdout);
+   

--- a/installer_win/surge.iss
+++ b/installer_win/surge.iss
@@ -57,3 +57,9 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Icons]
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 
+[Run]
+Filename: "{cmd}"; \
+    WorkingDir: "{cf}\VST3"; \
+    Parameters: "/C mklink /D /J  ""{cf}\VST3\SurgeData"" ""{commonappdata}\Surge"""; \
+    Description: "Install Surge portable by hard linking resources to VST3 Directory"; \
+    Flags: postinstall unchecked runascurrentuser


### PR DESCRIPTION
Inasmuch as I understand it, this diff implements a portable mode
for surge. Here is exactly what happens

1. The SurgeStorage startup path will find your dll name
2. It will replace the dllname string ".vst3" with "Data\" so
   c:\Program Files\Common\VST3\SurgeData
3. If that is a readable directory, that is your data path
4. Otherwise we fall back to ProgramData

Moreover the installer gives an option to make a junction from
c:\programdata\Surge to {cf}\VST3\SurgeData at the end of the isntaller

Closes #16