### PR TITLE
Fixed scrolling behavior on Number Fields

### DIFF
--- a/src/common/gui/CNumberField.cpp
+++ b/src/common/gui/CNumberField.cpp
@@ -687,13 +687,17 @@ CMouseEventResult CNumberField::onMouseMoved(CPoint& where, const CButtonState& 
 bool CNumberField::onWheel(const CPoint& where, const float& distance, const CButtonState& buttons)
 {
    beginEdit();
-   double mouseFactor = 0.01;
-   if( controlmode == cm_midichannel )
-   {
-      mouseFactor = 0.6; // these are all just empirical from trying them on my mbp
-   }
+   double mouseFactor = 1;
 
-   value += distance * mouseFactor;
+   if (controlmode == cm_midichannel_from_127)
+      mouseFactor = 7.5;
+  
+   if (buttons & kControl)
+      value += distance * 0.01;  
+   else
+      value += distance / (i_max - i_min) * mouseFactor;
+   
+
    i_value = (int)((1.f / 0.99f) * (value - 0.005f) * (float)(i_max - i_min) + 0.5) + i_min;
    bounceValue();
    invalid();


### PR DESCRIPTION
Scrolling speed on number fields is now fixed (by default) instead of being proportional to the amount of possible values in the number field. This makes it so that 1 scroll wheel notch will always increase or decrease the value by 1, no matter the number of values in the number field.

I also kept the old behavior. Holding Ctrl while scrolling will make it proportional. Because why not. :)

This fixes the Number Field part of #1931.