### PR TITLE
VST3 Remembers HostMenu to make sure it can call it

### DIFF
--- a/src/common/dsp/effect/RingModulatorEffect.cpp
+++ b/src/common/dsp/effect/RingModulatorEffect.cpp
@@ -160,6 +160,7 @@ int RingModulatorEffect::group_label_ypos(int id)
    case 3:
       return 19;
    }
+   return 0;
 }
 
 void RingModulatorEffect::init_ctrltypes()


### PR DESCRIPTION
Fixes VST3 extension menus failing on bitwig linux.
Closes #1952