### PR TITLE
Increase scrolling speed to correct speed

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -1079,12 +1079,12 @@ bool CLFOGui::onWheel( const VSTGUI::CPoint &where, const float &distance, const
                     }
 
                  };
-      if( accumDist > 1.0 )
+      if( accumDist > 0.5 )
       {
          jog(-1);
          accumDist = 0;
       }
-      else if( accumDist < -1.0 )
+      else if( accumDist < -0.5 )
       {
          jog(+1);
          accumDist = 0;


### PR DESCRIPTION
This just fixes the new scrolling feature on LFO shape. It was 2x too slow, meaning it took 2 wheel notches to increase or decrease by 1 type. It's now 2x faster, meaning it only takes 1 notch to increase or decrease, bringing it exactly like all the other button rows and columns in the GUI.

Let me know if there would be a more elegant way to fix this, btw.