### PR TITLE
User FX Presets; A Mostly Complete Implementation

### DIFF
--- a/libs/filesystem/filesystem.h
+++ b/libs/filesystem/filesystem.h
@@ -27,6 +27,7 @@
 namespace std::experimental::filesystem {
     class path {
     public:
+        static constexpr char preferred_separator = '/';
         std::string p;
         
         path();

--- a/src/common/gui/CSnapshotMenu.h
+++ b/src/common/gui/CSnapshotMenu.h
@@ -37,6 +37,10 @@ protected:
    void populateSubmenuFromTypeElement(TiXmlElement *typeElement, VSTGUI::COptionMenu *parent, int &main, int &sub, const long &max_sub, int &idx);
    SurgeStorage* storage = nullptr;
    char mtype[16] = {0};
+
+   // The parent class is too chatty with the listener, calling a value changed every time I close which means non-swapping
+   // menus like copy and paste do the wrong thing
+   VSTGUI::IControlListener *listenerNotForParent;
 };
 
 class COscMenu : public CSnapshotMenu
@@ -84,6 +88,29 @@ protected:
 
    void copyFX();
    void pasteFX();
+   void saveFX();
 
+   // We know this runs on the UI thread to populate always so we can use a static for user presets
+   struct UserPreset {
+      UserPreset() {
+         for( int i=0; i<n_fx_params; ++i )
+         {
+            p[i] = 0.0;
+            ts[i] = false;
+            er[i] = false;
+         }
+      }
+      std::string file;
+      std::string name;
+      int type;
+      float p[n_fx_params];
+      bool ts[n_fx_params], er[n_fx_params];
+   };
+   static std::vector<UserPreset> userPresets;
+   static bool scanForUserPresets;
+   
+   void rescanUserPresets();
+   void loadUserPreset( const UserPreset &p );
+   
    CLASS_METHODS(CFxMenu, VSTGUI::CControl)
 };

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -200,6 +200,8 @@ public:
    std::string tuningCacheForToggle = "";
    std::string mappingCacheForToggle = "";
    std::string tuningToHtml();
+
+   void queueRebuildUI() { queue_refresh = true; synth->refresh_editor = true; }
    
 private:
    /**


### PR DESCRIPTION
This implements user FX presets
1. You can save an FX as a user preset
2. You can load old user presets from the menu
3. The presets stream as little files into Documents/Surge

Still todo is to make the name-the-preset UI a bit better

Addresses #378