### PR TITLE
Move to a fast approximation of sin

### DIFF
--- a/src/common/dsp/FastMath.h
+++ b/src/common/dsp/FastMath.h
@@ -1,0 +1,41 @@
+#pragma once
+
+/*
+** Fast Math Approximations to various Functions
+**
+** Documentation on each one
+*/
+
+
+/*
+** These are directly copied from JUCE6 modules/juce_dsp/mathos/juce_FastMathApproximations.h
+**
+** Since JUCE6 is GPL3 and Surge is GPL3 that copy is fine, but I did want to explicitly
+** acknowledge it
+*/
+
+namespace Surge
+{
+namespace DSP
+{
+
+// JUCE6 Pade approximation of sin valid from -PI to PI with max error of 1e-5 and average error of 5e-7
+inline float fastsin( float x ) noexcept
+{
+   auto x2 = x * x;
+   auto numerator = -x * (-11511339840 + x2 * (1640635920 + x2 * (-52785432 + x2 * 479249)));
+   auto denominator = 11511339840 + x2 * (277920720 + x2 * (3177720 + x2 * 18361));
+   return numerator / denominator;
+}
+
+// JUCE6 Pade approximation of cos valid from -PI to PI with max error of 1e-5 and average error of 5e-7
+inline float fastcos( float x ) noexcept
+{
+   auto x2 = x * x;
+   auto numerator = -(-39251520 + x2 * (18471600 + x2 * (-1075032 + 14615 * x2)));
+   auto denominator = 39251520 + x2 * (1154160 + x2 * (16632 + x2 * 127));
+   return numerator / denominator;
+}
+
+}
+}

--- a/src/common/dsp/effect/RingModulatorEffect.cpp
+++ b/src/common/dsp/effect/RingModulatorEffect.cpp
@@ -2,6 +2,7 @@
 #include "Tunings.h"
 #include "Oscillator.h"
 #include "DebugHelpers.h"
+#include "FastMath.h"
 
 // http://recherche.ircam.fr/pub/dafx11/Papers/66_e.pdf
 
@@ -88,7 +89,9 @@ void RingModulatorEffect::process(float* dataL, float* dataR)
       for( int u=0; u<uni; ++u )
       {
          // TODO efficiency of course
-         auto vc = osc_sine::valueFromSinAndCos( sin( 2.0 * M_PI * phase[u] ), cos( 2.0 * M_PI * phase[u] ), *pdata_ival[rm_carriershape] );
+         auto vc = osc_sine::valueFromSinAndCos( Surge::DSP::fastsin( 2.0 * M_PI * ( phase[u] - 0.5 ) ),
+                                                 Surge::DSP::fastcos( 2.0 * M_PI * ( phase[u] - 0.5 ) ),
+                                                 *pdata_ival[rm_carriershape] );
          phase[u] += dphase[u];
          if( phase[u] > 1 )
          {


### PR DESCRIPTION
Taking the Pade approximation of sin from JUCE and Wikipedia
(https://en.wikipedia.org/wiki/Padé_approximant and JUCE6 dsp fastmath
classes), introduce a fast approximation of sin and cos which is
valid in -PI,PI; Use it in the sin oscillator and ring modulator
to reduce CPU in high unison counts.

Closes #1858