### PR TITLE
Fix LFO Modulation / Deform bug

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -1,4 +1,5 @@
 #include "LfoModulationSource.h"
+#include <cmath>
 
 using namespace std;
 
@@ -189,6 +190,8 @@ void LfoModulationSource::attack()
    {
       // fire up the engines
       wf_history[1] = ss->steps[step & (n_stepseqsteps - 1)];
+      wf_history[2] = ss->steps[(step+n_stepseqsteps-1) & (n_stepseqsteps - 1)];
+      wf_history[3] = ss->steps[(step+n_stepseqsteps-2) & (n_stepseqsteps - 1)];
 
       step++;
 
@@ -382,7 +385,16 @@ void LfoModulationSource::process_block()
 
    if (phase > 1)
    {
-      phase -= 1;
+      if( phase >= 2 )
+      {
+         float ipart;
+         phase = modf( phase, &ipart );
+      }
+      else
+      {
+         phase -= 1;
+      }
+
       switch (s)
       {
       case ls_snh:


### PR DESCRIPTION
When LFOs modulate other LFOs especially their rates the phase
can go not only >1 but also >2 and then the -=1 takes too
long to come back down, causing random noise and glitches
(and things like cubic interpolation to 'phase 74' which tives
you modulators like '1e6'. Fix by using fmod in extreme cases.

CLoses #2016