### PR TITLE
Tiny fixes for here and there

### DIFF
--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -198,7 +198,7 @@ void osc_sine::process_block(float pitch, float drift, bool stereo, bool FM, flo
           
           phase[u] += omega[u];
           // phase in range -PI to PI
-          if ( phase[u] > M_PI )
+          while ( phase[u] > M_PI )
           {
              phase[u] -= 2.0 * M_PI;
           }
@@ -267,8 +267,8 @@ void osc_sine::process_block_legacy(float pitch, float drift, bool stereo, bool 
                 playingramp[u] = 1;
 
              phase[u] += omega[u] + master_osc[k] * FMdepth.v;
-             // phase in range -PI to PI
-             if (phase[u] > M_PI)
+             // phase in range -PI to PI. Since there's FM here we can go beyond so if -> while for now. FIX for CPU
+             while (phase[u] > M_PI)
              {
                 phase[u] -= 2.0 * M_PI;
              }

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -946,6 +946,7 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp, VST
    // draw the RMB drag line
    if (controlstate == cs_linedrag)
    {
+      dc->setLineWidth( 1.0 );
       dc->setFrameColor(skin->getColor("lfo.stepseq.drag.line", VSTGUI::CColor(0xdd, 0xdd, 0xff)));
       dc->setFillColor(skin->getColor("lfo.stepseq.drag.line", VSTGUI::CColor(0xdd, 0xdd, 0xff)));
       dc->drawLine(rmStepStart, rmStepCurr);
@@ -964,7 +965,7 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp, VST
          float ds = sqrt(dd);
          dx /= ds;
          dy /= ds;
-         dx *= 8;
+         dx *= 6;
          dy *= 6;
 
          const double cosv = 0.866;
@@ -981,6 +982,9 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp, VST
          pl.push_back(e2);
 
          dc->drawPolygon(pl, kDrawFilled);
+         dc->drawLine( rmStepCurr, e1 );
+         dc->drawLine( e1, e2 );
+         dc->drawLine( e2, rmStepCurr );
       }
    }
 }


### PR DESCRIPTION
1. LFO on Linux draws a line not a bog
2. Arrow gets outline drawn to symmetrize
3. legacy under extreme FM stays in place (but see #2021)