### PR TITLE
Begin work on quantized drag for modulation

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1087,6 +1087,12 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
    sprintf(txt, "%.*f", (detailedMode ? 6 : 2), modulationDepth);
 }
 
+float Parameter::quantize_modulation( float inputval )
+{
+   float res = (float) ( (int)( inputval * 20 ) / 20.f ); // sure why not
+   return res;
+}
+
 void Parameter::get_display_alt(char* txt, bool external, float ef)
 {
    

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -275,6 +275,7 @@ public:
                                       // of the modulated handle
    void bound_value(bool force_integer = false);
    std::string tempoSyncNotationValue(float f);
+   float quantize_modulation(float modvalue); // given a mod-value hand it back rounded to a 'reasonable' step size (used in ctrl-drag)
    
    pdata val, val_default, val_min, val_max;
    // You might be tempted to use a non-fixed-size member here, like a std::string, but

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3542,7 +3542,15 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                if( cms->hasAlternate && cms->useAlternate )
                   thisms = (modsources) cms->alternateId;
             }
-            synth->setModulation(ptag, thisms, ((CSurgeSlider*)control)->getModValue());
+            bool quantize_mod = frame->getCurrentMouseButtons() & kControl;
+            float mv = ((CSurgeSlider*)control)->getModValue();
+            if( quantize_mod )
+            {
+               mv = p->quantize_modulation(mv);
+               // maybe setModValue here
+            }
+            
+            synth->setModulation(ptag, thisms, mv );
             ((CSurgeSlider*)control)->setModPresent(synth->isModDestUsed(p->id));
             ((CSurgeSlider*)control)->setModCurrent(synth->isActiveModulation(p->id, thisms), synth->isBipolarModulation(thisms));
 


### PR DESCRIPTION
As discussed in #1024, we want quantized drag for modulation.
This diff does two things, but leaves some stuff undone

1. Puts in place a quantization hook in Parameter, snapped to 0.05
2. Uses it for modulation on the slider when appropriate button pressed

There's some things we still need to do

1. Snap-jump the slider (it is continuous graphcis with quantized value)
2. Handle different type based modulation