### PR TITLE
Deal with a dissapearing cursor on windows

### DIFF
--- a/src/common/gui/PopupEditorDialog.cpp
+++ b/src/common/gui/PopupEditorDialog.cpp
@@ -64,6 +64,7 @@ void spawn_miniedit_text(char* c, int maxchars, const char* prompt, const char* 
    if (me.updated)
    {
       strncpy(c, me.textdata, maxchars);
+      c[maxchars-1] = 0;
    }
 }
 #elif LINUX

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -39,6 +39,8 @@
 #include "pluginterfaces/vst/ivstcontextmenu.h"
 #include "pluginterfaces/base/ustring.h"
 
+#include "vstgui/lib/cvstguitimer.h"
+
 template< typename T >
 struct RememberForgetGuard { 
    RememberForgetGuard( T *tg )
@@ -2534,12 +2536,18 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             eid++;
 
             addCallbackMenu(contextMenu, "Rename", [this, control, ccid]() {
-                                                      spawn_miniedit_text(synth->storage.getPatch().CustomControllerLabel[ccid], 16, "Enter a new name for macro controller:", "Rename Macro");
-                                                      ((CModulationSourceButton*)control)
-                                                         ->setlabel(synth->storage.getPatch().CustomControllerLabel[ccid]);
-                                                      control->setDirty();
-                                                      control->invalid();
-                                                      synth->updateDisplay();
+                                                      VSTGUI::Call::later( [this, control, ccid]() {
+                                                                              spawn_miniedit_text(synth->storage.getPatch().CustomControllerLabel[ccid] , 16,
+                                                                                                  "Enter a new name for macro controller:", "Rename Macro");
+                                                                              
+                                                                              ((CModulationSourceButton*)control)
+                                                                                 ->setlabel(synth->storage.getPatch().CustomControllerLabel[ccid]);
+                                                                              
+                                                                              control->setDirty();
+                                                                              control->invalid();
+                                                                              synth->refresh_editor = true;
+                                                                              synth->updateDisplay();
+                                                                           }, 1 );
                                                    });
             eid++;
 


### PR DESCRIPTION
I was calling spawn_miniedit_text modally inside an already modal
loop so the modal loops unwound improperly in some cases not restoring
cursor. This meant controller name on windows would eat the cursor

Fix it by haing the menu defer the call in a VSTGUI::Call::later

did a quick review and the other spots with miniedit are already
deferred it seems or are called from different parts of the event
loop

Closes #1465