### PR TITLE
dllcheck and other Debug Helper shifts for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,12 @@ elseif( WIN32 )
     user32
     ../libs/libpng/win/x64/lib/libpng16_static
   )
+
+  add_executable( dllcheck 
+     src/windows/dllcheck/dllcheck.cpp
+     ${CMAKE_BINARY_DIR}/geninclude/version.cpp 
+  )
+  target_include_directories( dllcheck PRIVATE src/common )
 else()
   message(FATAL_ERROR "UNKNOWN OS. Please use lin mac or win" )
 endif()

--- a/src/common/DebugHelpers.cpp
+++ b/src/common/DebugHelpers.cpp
@@ -10,29 +10,50 @@
 #include <cstdlib>
 #endif
 
+#include "version.h"
+#include <iostream>
+#include <iomanip>
+
+#if WINDOWS
+static bool winconinitialized = false;
+static FILE *confp;
+#endif
+
+bool Surge::Debug::openConsole()
+{
+#if WINDOWS   
+    if( ! winconinitialized )
+    {
+        winconinitialized = true;
+        AllocConsole();
+        freopen_s(&confp, "CONOUT$", "w", stdout);
+        std::cout << "Surge Debugging Console\n"
+                  << "This console shows stdout from the surge plugin. If you close it with X you might crash.\n"
+                  << "Version: " << Build::FullVersionStr << " built at " << Build::BuildDate << " " << Build::BuildTime
+                  << "\n\n" << std::endl;
+    }
+    return winconinitialized;
+#else
+    return true;
+#endif    
+}
 bool Surge::Debug::toggleConsole()
 {
 #if WINDOWS
-    static bool initialized = false;
-
-    static FILE *fp;
-
-    if (!initialized)
+    
+    
+    if (!winconinitialized)
     {
-        initialized = true;
-
-        AllocConsole();
-        freopen_s(&fp, "CONOUT$", "w", stdout);
-        printf("SURGE DEBUG CONSOLE\nThis console is for debug output. If you close it all bets are off!\n\n");
+        openConsole();
     }
     else
     {
-        initialized = false;
-        fclose(fp);
+        winconinitialized = false;
+        fclose(confp);
         FreeConsole();
     }
 
-    return initialized;
+    return winconinitialized;
 #else
     return false;
 #endif

--- a/src/common/DebugHelpers.h
+++ b/src/common/DebugHelpers.h
@@ -13,6 +13,8 @@
 namespace Surge {
 namespace Debug {
 
+
+bool openConsole(); // no-op on Linux and macOS; force console open on Windows
 bool toggleConsole(); // no-op on Linux and macOS; shows or closes console on Windows
 
 void stackTraceToStdout(); // no-op on Windows; shows stack trace on macOS and Linunx

--- a/src/windows/dllcheck/dllcheck.cpp
+++ b/src/windows/dllcheck/dllcheck.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <iomanip>
+#include "version.h"
+#include <windows.h>
+#include <string>
+
+/*
+** This is a little standalone C++ program which tries to load a dll and give you
+** error messages, specifically it tries to load the vst3 dll
+*/
+
+void showError( DWORD e, const char* pfx )
+{
+    std::cout << "  | " << pfx << " (" << std::hex << e << std::dec << ")\n";
+
+    LPSTR messageBuffer = nullptr;
+    size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                                 NULL, e, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+    std::string message(messageBuffer, size);
+    LocalFree(messageBuffer);
+
+    std::cout << "  | Message: " << message << std::endl;
+
+}
+
+int main( int argc, char **argv )
+{
+    std::cout << "dllcheck\n"
+            << "Built against codebase with " << Surge::Build::FullVersionStr << "\n";
+    if( argc != 2 )
+    {
+        std::cout << "Usage: dllcheck (vst3name)\n";
+        exit(1);
+    }
+    std::cout << "Trying to load '" << argv[1] << "'" << std::endl;
+
+    auto h = LoadLibrary( argv[1] );
+    if( h == NULL )
+    {
+        showError( GetLastError(), "LoadLibrary failed" );
+        exit(1);
+    }
+    std::cout << "Able to load library : " << h << std::endl;
+
+    auto pa = GetProcAddress( h, "GetPluginFactory" );
+    if( pa == NULL ) {
+        showError( GetLastError(), "GetPluginFactory not loadable" );
+        exit( 1 );
+    }
+    std::cout << "GetPluginFactory was loadable. Things looking good" << std::endl;
+
+    auto pf = (pa)();
+    if( pf == NULL ) {
+        showError( GetLastError(), "Unable to run GetPluginFactory" );
+        exit( 1 );
+    }
+    std::cout << "Able to run GetPluginFactory - return value is " << std::hex << pf << std::endl;
+
+}


### PR DESCRIPTION
Add a target 'dllcheck' which makes a little exe that lets us at least
try to dlopen and find the poit in the vst3 on windows. Off by default of course