### PR TITLE
Clamp the Dampers in Rev1/2

### DIFF
--- a/src/common/dsp/effect/Reverb1Effect.cpp
+++ b/src/common/dsp/effect/Reverb1Effect.cpp
@@ -229,7 +229,9 @@ void Reverb1Effect::process(float* dataL, float* dataR)
                 (fxdata->p[rp_predelay].temposync ? storage->temposyncratio_inv : 1.f);
 
    const __m128 one4 = _mm_set1_ps(1.f);
-   __m128 damp4 = _mm_load1_ps(f[rp_damping]);
+   float dv = *(f[rp_damping]);
+   dv = limit_range( dv, 0.01f, 0.99f ); // this is a simple onepole damper, w * y[n] + ( 1-w ) y[n-1] so to be stable has to stay in range
+   __m128 damp4 = _mm_load1_ps(&dv);
    __m128 damp4m1 = _mm_sub_ps(one4, damp4);
 
    for (int k = 0; k < BLOCK_SIZE; k++)

--- a/src/common/dsp/effect/Reverb2Effect.cpp
+++ b/src/common/dsp/effect/Reverb2Effect.cpp
@@ -231,6 +231,8 @@ void Reverb2Effect::process(float* dataL, float* dataR)
       lfos[2] = -_lfo.r;
       lfos[3] = -_lfo.i;
 
+      auto hdc = limit_range( _hf_damp_coefficent.v, 0.01f, 0.99f );
+      auto ldc = limit_range( _hf_damp_coefficent.v, 0.01f, 0.99f );
       for (int b = 0; b < NUM_BLOCKS; b++)
       {
          x = x + in;
@@ -239,8 +241,8 @@ void Reverb2Effect::process(float* dataL, float* dataR)
             x = _allpass[b][c].process(x, _buildup.v);
          }
 
-         x = _hf_damper[b].process_lowpass(x, _hf_damp_coefficent.v);
-         x = _lf_damper[b].process_highpass(x, _lf_damp_coefficent.v);
+         x = _hf_damper[b].process_lowpass(x, hdc );
+         x = _lf_damper[b].process_highpass(x, ldc );
 
          int modulation = (int)(_modulation.v * lfos[b] * (float)DELAY_SUBSAMPLE_RANGE);
          float tap_outL = 0.f;


### PR DESCRIPTION
Reverb1 and 2 use a simple one pole damper for low pass and
high pass, which requires the damping coefficient is in the
range [0.1]; modulation can push it outside this range explosively
causing unbounded feedback, which isn't desirable

CLoses #2034