### PR TITLE
Filters, Ranges in the Sin Oscillator

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -193,6 +193,7 @@ void Parameter::clear_flags()
    temposync = false;
    extend_range = false;
    absolute = false;
+   deactivated = true; // CHOICE: if you are a deactivatble parameter make it so you are by default
 }
 
 bool Parameter::can_temposync()
@@ -219,6 +220,7 @@ bool Parameter::can_extend_range()
    case ct_decibel_narrow_extendable:
    case ct_oscspread:
    case ct_osc_feedback:
+   case ct_osc_feedback_negative:
       return true;
    }
    return false;
@@ -230,6 +232,16 @@ bool Parameter::can_be_absolute()
    {
    case ct_oscspread:
    case ct_pitch_semi7bp_absolutable:
+      return true;
+   }
+   return false;
+}
+
+bool Parameter::can_deactivate()
+{
+   switch(ctrltype)
+   {
+   case ct_freq_audible_deactivatable:
       return true;
    }
    return false;
@@ -306,6 +318,7 @@ void Parameter::set_type(int ctrltype)
       val_default.f = 0;
       break;
    case ct_freq_audible:
+   case ct_freq_audible_deactivatable:
       valtype = vt_float;
       val_min.f = -60;
       val_max.f = 70;
@@ -684,6 +697,12 @@ void Parameter::set_type(int ctrltype)
       valtype = vt_float;
       val_default.f = 0;
       break;
+   case ct_osc_feedback_negative:
+      val_min.f = -1;
+      val_max.f = 1;
+      valtype = vt_float;
+      val_default.f = 0;
+      break;
    default:
    case ct_none:
       sprintf(dispname, "-");
@@ -731,6 +750,7 @@ void Parameter::bound_value(bool force_integer)
       case ct_percent:
       case ct_percent_bidirectional:
       case ct_osc_feedback:
+      case ct_osc_feedback_negative:
       case ct_detuning:
       {
          val.f = floor(val.f * 100) / 100.0;
@@ -977,7 +997,9 @@ float Parameter::get_extended(float f)
    case ct_oscspread:
       return 12.f * f;
    case ct_osc_feedback:
-      return 8.f * f - 4.f;
+      return 8.f * f - 4.f * f;
+   case ct_osc_feedback_negative:
+      return 4.f * f;
    default:
       return f;
    }
@@ -1101,6 +1123,7 @@ void Parameter::get_display_alt(char* txt, bool external, float ef)
    {
    case ct_freq_hpf:
    case ct_freq_audible:
+   case ct_freq_audible_deactivatable:
    case ct_freq_vocoder_low:
    case ct_freq_vocoder_high:
    {
@@ -1252,6 +1275,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
          break;
       case ct_freq_hpf:
       case ct_freq_audible:
+      case ct_freq_audible_deactivatable:
       case ct_freq_vocoder_low:
       case ct_freq_vocoder_high:
          sprintf(txt, "%.*f Hz", (detailedMode ? 6 : 3), 440.f * powf(2.0f, f / 12.f));
@@ -1280,6 +1304,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
          sprintf(txt, "%.*f", (detailedMode ? 6 : 2), f);
          break;
       case ct_osc_feedback:
+      case ct_osc_feedback_negative:
          sprintf(txt, "%.*f %c", (detailedMode ? 6 : 2), get_extended(f) * 100.f, '%');
          break;
       default:
@@ -1751,6 +1776,7 @@ bool Parameter::can_setvalue_from_string()
    case ct_decibel_fmdepth:
    case ct_decibel_extendable:
    case ct_freq_audible:
+   case ct_freq_audible_deactivatable:
    case ct_freq_shift:
    case ct_freq_hpf:
    case ct_freq_vocoder_low:
@@ -1769,6 +1795,7 @@ bool Parameter::can_setvalue_from_string()
    case ct_flangerpitch:
    case ct_flangervoices:
    case ct_osc_feedback:
+   case ct_osc_feedback_negative:
    case ct_chorusmodtime:
    case ct_pbdepth:
    case ct_polylimit:
@@ -1992,6 +2019,7 @@ bool Parameter::set_value_from_string( std::string s )
    }
    case ct_freq_hpf:
    case ct_freq_audible:
+   case ct_freq_audible_deactivatable:
    case ct_freq_vocoder_low:
    case ct_freq_vocoder_high:
    {  
@@ -2067,7 +2095,29 @@ bool Parameter::set_value_from_string( std::string s )
       else
       {
          if (nv < 0 || nv > 100) {
-            return false; }
+            return false;
+         }
+
+         val.f = nv / 100.f;
+      }
+
+      break;
+   }
+   case ct_osc_feedback_negative:
+   {
+      if (extend_range)
+      {
+         if (nv < -400 || nv > 400) {
+            return false;
+         }
+
+         val.f = (nv * 0.00125);
+      }
+      else
+      {
+         if (nv < -1000 || nv > 100) {
+            return false;
+         }
 
          val.f = nv / 100.f;
       }

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -44,6 +44,7 @@ enum ctrltypes
    ct_decibel_fmdepth,
    ct_decibel_extendable,
    ct_freq_audible,
+   ct_freq_audible_deactivatable,
    ct_freq_mod,
    ct_freq_hpf,
    ct_freq_shift,
@@ -103,6 +104,7 @@ enum ctrltypes
    ct_flangervoices,
    ct_flangerchord,
    ct_osc_feedback,
+   ct_osc_feedback_negative,
    ct_chorusmodtime,
    num_ctrltypes,
 };
@@ -244,6 +246,7 @@ public:
    bool can_temposync();
    bool can_extend_range();
    bool can_be_absolute();
+   bool can_deactivate();
    bool can_setvalue_from_string();
    void clear_flags();
    void set_type(int ctrltype);
@@ -298,7 +301,7 @@ public:
    bool affect_other_parameters;
    float moverate;
    bool per_voice_processing;
-   bool temposync, extend_range, absolute;
+   bool temposync, extend_range, absolute, deactivated;
    
    ParamUserData* user_data;              // I know this is a bit gross but we have a runtime type
    void set_user_data(ParamUserData* ud); // I take a shallow copy and don't assume ownership and assume i am referencable

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -51,7 +51,8 @@ const int gui_mid_topbar_y = 17;
 // 9 -> 10 added character parameter
 // 10 -> 11 (1.6.2 release) added DAW Extra State
 // 11 -> 12 (1.6.3 release) added new parameters to the Distortion effect
-const int ff_revision = 12;
+// 12 -> 13 (1.7.0 release) deactivation; sine LP/HP
+const int ff_revision = 13;
 
 SurgePatch::SurgePatch(SurgeStorage* storage)
 {
@@ -1204,6 +1205,18 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
             param_ptr[i]->temposync = true;
          else
             param_ptr[i]->temposync = false;
+         if ((p->QueryIntAttribute("deactivated", &j) == TIXML_SUCCESS))
+         {
+            if(j == 1)
+               param_ptr[i]->deactivated = true;
+            else
+               param_ptr[i]->deactivated = false;
+         }
+         else
+         {
+            if( param_ptr[i]->can_deactivate() )
+               param_ptr[i]->deactivated = true;
+         }
          if ((p->QueryIntAttribute("extend_range", &j) == TIXML_SUCCESS) && (j == 1))
             param_ptr[i]->extend_range = true;
          else
@@ -1754,6 +1767,8 @@ unsigned int SurgePatch::save_xml(void** data) // allocates mem, must be freed b
             p.SetAttribute("extend_range", "1");
          if (param_ptr[i]->absolute)
             p.SetAttribute("absolute", "1");
+         if (param_ptr[i]->can_deactivate())
+            p.SetAttribute("deactivated", param_ptr[i]->deactivated ? "1" : "0" );
 
          // param_ptr[i]->val.i;
          parameters.InsertEndChild(p);

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -77,6 +77,9 @@ public:
    int id_mode, id_fb, id_fmlegacy, id_detune;
    float lastvalue[MAX_UNISON];
 
+   BiquadFilter lp, hp;
+   void applyFilter();
+   
    inline float valueFromSinAndCos(float svalue, float cvalue ) {
       return valueFromSinAndCos(svalue, cvalue, localcopy[id_mode].i );
    }

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -42,6 +42,7 @@ CSurgeSlider::CSurgeSlider(const CPoint& loc,
 
    modmode = 0;
    disabled = false;
+   deactivated = false;
 
    label[0] = 0;
    leftlabel[0] = 0;
@@ -395,7 +396,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
    }
    
 
-   if (pHandle && (modmode != 2))
+   if (pHandle && (modmode != 2) && ! deactivated)
    {
       if (style & CSlider::kHorizontal)
       {
@@ -428,7 +429,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
             }
          }
       }
-      else
+      else if( ! deactivated )
       {
          pHandle->draw(dc, hrect, CPoint(0, 28 * typehy), modmode ? 0x7f : 0xff);
          if( is_temposync )
@@ -466,7 +467,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
    }
 
    // draw mod-fader
-   if (pHandle && modmode)
+   if (pHandle && modmode && ! deactivated)
    {
       CRect hrect(headrect);
       handle_rect = handle_rect_orig;

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -74,7 +74,8 @@ public:
    CLASS_METHODS(CSurgeSlider, CControl)
 
    bool is_mod;
-   bool disabled;
+   bool disabled; // means it can't be used unless something else changes
+   bool deactivated; // means it has been turned off by user action
    bool hasBeenDraggedDuringMouseGesture = false;
 
    SurgeStorage* storage = nullptr;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1118,6 +1118,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          case ct_freq_mod:
          case ct_percent_bidirectional:
          case ct_freq_shift:
+         case ct_osc_feedback_negative:
             style |= kBipolar;
             break;
          };
@@ -1140,6 +1141,11 @@ void SurgeGUIEditor::openOrRecreateEditor()
             hs->setModPresent(synth->isModDestUsed(p->id));
             hs->setDefaultValue(p->get_default_value_f01());
 
+            if( p->can_deactivate() )
+               hs->deactivated = p->deactivated;
+            else
+               hs->deactivated = false;
+            
             if (synth->isValidModulation(p->id, modsource))
             {
                hs->setModMode(mod_editor ? 1 : 0);
@@ -1286,6 +1292,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          case ct_decibel_extendable:
          case ct_freq_mod:
          case ct_percent_bidirectional:
+         case ct_osc_feedback_negative:
          case ct_freq_shift:
             style |= kBipolar;
             break;
@@ -1772,6 +1779,12 @@ void SurgeGUIEditor::openOrRecreateEditor()
                hs->setMoveRate(p->moverate);
                if( p->can_temposync() )
                   hs->setTempoSync(p->temposync);
+
+               if( p->can_deactivate() )
+                  hs->deactivated = p->deactivated;
+               else
+                  hs->deactivated = false;
+
                frame->addView(hs);
                param[i] = hs;
             }
@@ -1791,6 +1804,12 @@ void SurgeGUIEditor::openOrRecreateEditor()
                hs->setMoveRate(p->moverate);
                if( p->can_temposync() )
                   hs->setTempoSync(p->temposync);
+
+               if( p->can_deactivate() )
+                  hs->deactivated = p->deactivated;
+               else
+                  hs->deactivated = false;
+
                frame->addView(hs);
                param[i] = hs;
             }
@@ -2877,6 +2896,19 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             {
                addCallbackMenu(contextMenu, "Absolute", [this, p]() { p->absolute = !p->absolute; });
                contextMenu->checkEntry(eid, p->absolute);
+               eid++;
+            }
+            if (p->can_deactivate())
+            {
+               if( p->deactivated )
+               {
+                  addCallbackMenu(contextMenu, "Activate", [this, p]() { p->deactivated = false; this->synth->refresh_editor = true; } );
+               }
+               else
+               {
+                  addCallbackMenu(contextMenu, "Deactivate", [this, p]() { p->deactivated = true; this->synth->refresh_editor = true; } );
+
+               }
                eid++;
             }
 


### PR DESCRIPTION
1. The Sin Oscillator gets a high cut and low cut
2. The Sin Oscillator feedback range is -1,1 rather than 0,1
   This may impact saved DAW automations of this parameter.
3. Parameters can be activatable
4. High Cut and Low Cut are activatable
5. Modify streaming to store deactivation; up stremaing number to 13

Closes #2039
Closes #1661