### PR TITLE
Swapped the high/low cut filter parameter names

### DIFF
--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -625,10 +625,10 @@ void osc_sine::init_ctrltypes()
    oscdata->p[2].set_name("FM Behaviour");
    oscdata->p[2].set_type(ct_sinefmlegacy);
 
-   oscdata->p[3].set_name( "High Cut" );
+   oscdata->p[3].set_name("Low Cut");
    oscdata->p[3].set_type(ct_freq_audible_deactivatable);
 
-   oscdata->p[4].set_name( "Low Cut" );
+   oscdata->p[4].set_name("High Cut");
    oscdata->p[4].set_type(ct_freq_audible_deactivatable);
 
    oscdata->p[5].set_name("Unison Detune");


### PR DESCRIPTION
They were the other way around (plus if we look at, i.e. Chorus effect, you'll see low cut goes first then high cut).