### PR TITLE
Linux Transparency Workarounds; CSurgeSlider cleanup

### DIFF
--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -177,7 +177,15 @@ void CSurgeSlider::draw(CDrawContext* dc)
    if (has_modulation_current)
       typex = 2;
 
-   float slider_alpha = (disabled || deactivated) ? 0.35 : 1.0;
+   float slider_alpha = disabled ? 0.35 : 1.0;
+   float tray_alpha = slider_alpha;
+#if LINUX
+   if( controlstate == cs_drag )
+   {
+      // work around a VSTGUI bug w
+      slider_alpha = 1.0;
+   }
+#endif
 
    if (pTray)
    {
@@ -197,9 +205,9 @@ void CSurgeSlider::draw(CDrawContext* dc)
 
 
       if (style & CSlider::kHorizontal)
-         pTray->draw(dc, trect, CPoint(133 * typex, 14 * typey), slider_alpha);
+         pTray->draw(dc, trect, CPoint(133 * typex, 14 * typey), tray_alpha);
       else
-         pTray->draw(dc, trect, CPoint(16 * typex, 75 * typey), slider_alpha);
+         pTray->draw(dc, trect, CPoint(16 * typex, 75 * typey), tray_alpha);
    }
 
    CRect headrect;
@@ -257,7 +265,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
       CRect trect = hrect;
       CColor ColBar = skin->getColor("slider.modulation", CColor(173, 255, 107, 255));
 
-      ColBar.alpha = (int)(slider_alpha * 255.f);
+      ColBar.alpha = (int)(tray_alpha * 255.f);
 
       // float moddist = modval * range;
       // We want modval + value to be bould by -1 and 1. So
@@ -616,6 +624,11 @@ CMouseEventResult CSurgeSlider::onMouseUp(CPoint& where, const CButtonState& but
 
       attachCursor();
    }
+#if LINUX
+   // again handle the vstgui bug
+   invalid();
+#endif 
+
    return kMouseEventHandled;
 }
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1150,9 +1150,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
             hs->setDefaultValue(p->get_default_value_f01());
 
             if( p->can_deactivate() )
-               hs->deactivated = p->deactivated;
+               hs->disabled = p->deactivated;
             else
-               hs->deactivated = false;
+               hs->disabled = false;
 
             setDisabledForParameter(p, hs);
 
@@ -1792,9 +1792,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
                   hs->setTempoSync(p->temposync);
 
                if( p->can_deactivate() )
-                  hs->deactivated = p->deactivated;
+                  hs->disabled = p->deactivated;
                else
-                  hs->deactivated = false;
+                  hs->disabled = false;
 
                setDisabledForParameter(p, hs);
 
@@ -1819,9 +1819,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
                   hs->setTempoSync(p->temposync);
 
                if( p->can_deactivate() )
-                  hs->deactivated = p->deactivated;
+                  hs->disabled = p->deactivated;
                else
-                  hs->deactivated = false;
+                  hs->disabled = false;
 
                setDisabledForParameter(p, hs);
 


### PR DESCRIPTION
1. Opaque linux handle when dragging
2. disabled and deactivated are no longer different

Addresses #2053