### PR TITLE
A variety of cleanups and backdowns

### DIFF
--- a/src/common/dsp/effect/Reverb2Effect.cpp
+++ b/src/common/dsp/effect/Reverb2Effect.cpp
@@ -232,7 +232,7 @@ void Reverb2Effect::process(float* dataL, float* dataR)
       lfos[3] = -_lfo.i;
 
       auto hdc = limit_range( _hf_damp_coefficent.v, 0.01f, 0.99f );
-      auto ldc = limit_range( _hf_damp_coefficent.v, 0.01f, 0.99f );
+      auto ldc = limit_range( _lf_damp_coefficent.v, 0.01f, 0.99f );
       for (int b = 0; b < NUM_BLOCKS; b++)
       {
          x = x + in;

--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -380,9 +380,7 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
           context->setClipRect(clipR);
 
 #if LINUX
-         if( alpha > 1.0 ) alpha /= 255.0;
-         if( alpha > 1.0 ) alpha = 1.0;
-         if( alpha < 0.0 ) alpha = 0.0;
+          alpha = 1.0;
 #endif
           offscreenCache[offset]->draw(context, drect, CPoint(0, 0), alpha);
           context->setClipRect(origClip);

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -177,15 +177,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
    if (has_modulation_current)
       typex = 2;
 
-   float slider_alpha = disabled ? 0.35 : 1.0;
-   float tray_alpha = slider_alpha;
-#if LINUX
-   if( controlstate == cs_drag )
-   {
-      // work around a VSTGUI bug w
-      slider_alpha = 1.0;
-   }
-#endif
+   float slider_alpha = (disabled || deactivated) ? 0.35 : 1.0;
 
    if (pTray)
    {
@@ -205,9 +197,9 @@ void CSurgeSlider::draw(CDrawContext* dc)
 
 
       if (style & CSlider::kHorizontal)
-         pTray->draw(dc, trect, CPoint(133 * typex, 14 * typey), tray_alpha);
+         pTray->draw(dc, trect, CPoint(133 * typex, 14 * typey), slider_alpha);
       else
-         pTray->draw(dc, trect, CPoint(16 * typex, 75 * typey), tray_alpha);
+         pTray->draw(dc, trect, CPoint(16 * typex, 75 * typey), slider_alpha);
    }
 
    CRect headrect;
@@ -265,7 +257,7 @@ void CSurgeSlider::draw(CDrawContext* dc)
       CRect trect = hrect;
       CColor ColBar = skin->getColor("slider.modulation", CColor(173, 255, 107, 255));
 
-      ColBar.alpha = (int)(tray_alpha * 255.f);
+      ColBar.alpha = (int)(slider_alpha * 255.f);
 
       // float moddist = modval * range;
       // We want modval + value to be bould by -1 and 1. So
@@ -624,11 +616,6 @@ CMouseEventResult CSurgeSlider::onMouseUp(CPoint& where, const CButtonState& but
 
       attachCursor();
    }
-#if LINUX
-   // again handle the vstgui bug
-   invalid();
-#endif 
-
    return kMouseEventHandled;
 }
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1150,9 +1150,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
             hs->setDefaultValue(p->get_default_value_f01());
 
             if( p->can_deactivate() )
-               hs->disabled = p->deactivated;
+               hs->deactivated = p->deactivated;
             else
-               hs->disabled = false;
+               hs->deactivated = false;
 
             setDisabledForParameter(p, hs);
 
@@ -1792,9 +1792,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
                   hs->setTempoSync(p->temposync);
 
                if( p->can_deactivate() )
-                  hs->disabled = p->deactivated;
+                  hs->deactivated = p->deactivated;
                else
-                  hs->disabled = false;
+                  hs->deactivated = false;
 
                setDisabledForParameter(p, hs);
 
@@ -1819,9 +1819,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
                   hs->setTempoSync(p->temposync);
 
                if( p->can_deactivate() )
-                  hs->disabled = p->deactivated;
+                  hs->deactivated = p->deactivated;
                else
-                  hs->disabled = false;
+                  hs->deactivated = false;
 
                setDisabledForParameter(p, hs);
 


### PR DESCRIPTION
Revert "Linux Transparenty Fix 1-of-2 (#2057)"
This reverts commit 83b5a1bd38c192d3333d698fa923d0020743bcb0.

Revert "Linux Transparency Workarounds; CSurgeSlider cleanup (#2060)"
This reverts commit c88548ae218d1863ac688098fb46d06d7cbd24a1.

Fix a Reverb2 Typo when doing limit range for stability which
disabled the lfdamp

Closes #2061
Closes #2062
Closes #2063
Means we still have work for #2053