### PR TITLE
Midi Mapping ctd: LearnMacro corrected

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2531,9 +2531,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                cancellearn ? "Abort Macro MIDI Learn" : "MIDI Learn Macro...";
             addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu(learnTag), [this, cancellearn, ccid] {
                                                       if (cancellearn)
-                                                         synth->learn_param = -1;
+                                                         synth->learn_custom = -1;
                                                       else
-                                                         synth->learn_param = ccid;
+                                                         synth->learn_custom = ccid;
                                                    });
             eid++;
 


### PR DESCRIPTION
LearnMacro menu in SGE learned a param by mistake. This
meant if you midi learned controller 0 you actually
midi learned FX send (param 0) and so on.

Closes #2072