### PR TITLE
Materially finish User FX Presets

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -35,25 +35,6 @@ const int gui_modsec_x = 6, gui_modsec_y = 398 + gui_topbar;
 
 const int gui_mid_topbar_y = 17;
 
-// XML storage fileformat revision
-// 0 -> 1 new EG attack shapes (0>1, 1>2, 2>2)
-// 1 -> 2 new LFO EG stages (if (decay == max) sustain = max else sustain = min
-// 2 -> 3 filter subtypes added comb should default to 1 and moog to 3
-// 3 -> 4 comb+/- combined into 1 filtertype (subtype 0,0->0 0,1->1 1,0->2 1,1->3 )
-// 4 -> 5 stereo filterconf now have seperate pan controls
-// 5 -> 6 new filter sound in v1.2 (same parameters, but different sound & changed resonance
-// response).
-// 6 -> 7 custom controller state now stored (in seq. recall)
-// 7 -> 8 larger resonance
-// range (old filters are set to subtype 1), pan2 -> width
-// 8 -> 9 now 8 controls (offset ids larger
-// than ctrl7 by +1), custom controllers have names (guess for pre-rev9 patches)
-// 9 -> 10 added character parameter
-// 10 -> 11 (1.6.2 release) added DAW Extra State
-// 11 -> 12 (1.6.3 release) added new parameters to the Distortion effect
-// 12 -> 13 (1.7.0 release) deactivation; sine LP/HP
-const int ff_revision = 13;
-
 SurgePatch::SurgePatch(SurgeStorage* storage)
 {
    this->storage = storage;

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -349,6 +349,24 @@ bailOnPortable:
    {
        userDataPath = userSpecifiedDataPath;
    }
+
+   userFXPath = userDataPath +
+#if WINDOWS
+      "\\"
+#else
+      "/"
+#endif
+      + "FXSettings";
+
+   
+   userMidiMappingsPath = userDataPath +
+#if WINDOWS
+      "\\"
+#else
+      "/"
+#endif
+      + "MIDIMappings";
+   
    
 #if LINUX
    if (!snapshotloader.Parse((const char*)&configurationXmlStart, 0,

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -48,6 +48,25 @@ const int FIRoffset = FIRipol_N >> 1;
 const int FIRipolI16_N = 8;
 const int FIRoffsetI16 = FIRipolI16_N >> 1;
 
+// XML storage fileformat revision
+// 0 -> 1 new EG attack shapes (0>1, 1>2, 2>2)
+// 1 -> 2 new LFO EG stages (if (decay == max) sustain = max else sustain = min
+// 2 -> 3 filter subtypes added comb should default to 1 and moog to 3
+// 3 -> 4 comb+/- combined into 1 filtertype (subtype 0,0->0 0,1->1 1,0->2 1,1->3 )
+// 4 -> 5 stereo filterconf now have seperate pan controls
+// 5 -> 6 new filter sound in v1.2 (same parameters, but different sound & changed resonance
+// response).
+// 6 -> 7 custom controller state now stored (in seq. recall)
+// 7 -> 8 larger resonance
+// range (old filters are set to subtype 1), pan2 -> width
+// 8 -> 9 now 8 controls (offset ids larger
+// than ctrl7 by +1), custom controllers have names (guess for pre-rev9 patches)
+// 9 -> 10 added character parameter
+// 10 -> 11 (1.6.2 release) added DAW Extra State
+// 11 -> 12 (1.6.3 release) added new parameters to the Distortion effect
+// 12 -> 13 (1.7.0 release) deactivation; sine LP/HP
+const int ff_revision = 13;
+
 extern float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
 extern float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];
 extern short sinctableI16 alignas(16)[(FIRipol_M + 1) * FIRipolI16_N];
@@ -593,6 +612,8 @@ public:
    std::string datapath;
    std::string userDataPath;
    std::string userDefaultFilePath;
+   std::string userFXPath;
+   std::string userMidiMappingsPath;
 
    // float table_sin[512],table_sin_offset[512];
    Surge::CriticalSection CS_WaveTableData, CS_ModRouting;

--- a/src/common/gui/CSnapshotMenu.h
+++ b/src/common/gui/CSnapshotMenu.h
@@ -7,6 +7,8 @@
 #include "PopupEditorSpawner.h"
 #include "SurgeBitmaps.h"
 #include "SkinSupport.h"
+#include <unordered_map>
+#include <vector>
 
 class CSnapshotMenu : public VSTGUI::COptionMenu, public Surge::UI::SkinConsumingComponnt
 {
@@ -34,7 +36,8 @@ public:
    int selectedIdx = -1;
    std::string selectedName = "";
 protected:
-   void populateSubmenuFromTypeElement(TiXmlElement *typeElement, VSTGUI::COptionMenu *parent, int &main, int &sub, const long &max_sub, int &idx);
+   VSTGUI::COptionMenu *populateSubmenuFromTypeElement(TiXmlElement *typeElement, VSTGUI::COptionMenu *parent, int &main, int &sub, const long &max_sub, int &idx);
+   virtual void addToTopLevelTypeMenu(TiXmlElement *typeElement, VSTGUI::COptionMenu *subMenu) { }
    SurgeStorage* storage = nullptr;
    char mtype[16] = {0};
 
@@ -82,6 +85,7 @@ public:
    virtual void populate() override;
    
 protected:
+   virtual void addToTopLevelTypeMenu(TiXmlElement *typeElement, VSTGUI::COptionMenu *subMenu) override;
    FxStorage *fx = nullptr, *fxbuffer = nullptr;
    static std::vector<float> fxCopyPaste; // OK this is a crap data structure for now. See the code.
    int slot = 0;
@@ -106,7 +110,7 @@ protected:
       float p[n_fx_params];
       bool ts[n_fx_params], er[n_fx_params];
    };
-   static std::vector<UserPreset> userPresets;
+   static std::unordered_map<int,std::vector<UserPreset>> userPresets; // from type to presets
    static bool scanForUserPresets;
    
    void rescanUserPresets();

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1077,6 +1077,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
    fxPresetLabel->setTransparency(true);
    fxPresetLabel->setFont( displayFont );
    fxPresetLabel->setHoriAlign( kRightText );
+   fxPresetLabel->setTextTruncateMode( CTextLabel::TextTruncateMode::kTruncateTail );
    frame->addView(fxPresetLabel);
 
    CHSwitch2* b_store = new CHSwitch2(CRect(547 - 37, 41, 547, 41 + 12), this, tag_store, 1, 12, 1,


### PR DESCRIPTION
1. Preset files don't contain none; and do contain streaming
2: Preset menu intermixed with Factory Menu
3. Truncate preset name by jog
4. Move FXSettingsPath to storage
5. Better Data Structures

Closes #378
Closes #2001