### PR TITLE
Fix an AU load issue with factory presets

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -542,6 +542,9 @@ ComponentResult aulayer::RestoreState(CFPropertyListRef plist)
       plugin_instance->loadFromDawExtraState();
       if( editor_instance )
           editor_instance->loadFromDAWExtraState(plugin_instance);
+
+      // This stops any prior factory loads from clobbering me. #2102
+      plugin_instance->patchid_queue = -1;
    }
    return noErr;
 }


### PR DESCRIPTION
The NewFactoryPreset comes in and sets patchid_queue and then
calls processThreadUnsafe, then the RestoreState comes in,
but then the processing starts and that queue is sitting around,
so you get blammoed from RestoreState. Have RestoreState say we
don't have a patch queued and all good!

Closes #2102