### PR TITLE
LFORate used multiple places; split for deactivatable

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -211,6 +211,7 @@ bool Parameter::can_temposync()
    {
    case ct_portatime:
    case ct_lforate:
+   case ct_lforate_deactivatable:
    case ct_envtime:
    case ct_envtime_lfodecay:
       return true;
@@ -251,7 +252,7 @@ bool Parameter::can_deactivate()
    switch(ctrltype)
    {
    case ct_freq_audible_deactivatable:
-   case ct_lforate:
+   case ct_lforate_deactivatable:
    case ct_rotarydrive:
       return true;
    }
@@ -444,6 +445,7 @@ void Parameter::set_type(int ctrltype)
       val_default.f = -2;
       break;
    case ct_lforate:
+   case ct_lforate_deactivatable:
       valtype = vt_float;
       val_min.f = -7;
       val_max.f = 9;
@@ -876,6 +878,7 @@ void Parameter::bound_value(bool force_integer)
          }
          break;
       case ct_lforate:
+      case ct_lforate_deactivatable:
       {
          if (temposync)
          {
@@ -1249,6 +1252,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
          }
          break;
       case ct_lforate:
+      case ct_lforate_deactivatable:
          if (temposync)
          {
             std::string res = tempoSyncNotationValue(-f);
@@ -1803,6 +1807,7 @@ bool Parameter::can_setvalue_from_string()
    case ct_reverbpredelaytime:
    case ct_portatime:
    case ct_lforate:
+   case ct_lforate_deactivatable:
    case ct_detuning:
    case ct_oscspread:
    case ct_countedset_percent:
@@ -2073,6 +2078,7 @@ bool Parameter::set_value_from_string( std::string s )
    case ct_reverbpredelaytime:
    case ct_portatime:
    case ct_lforate:
+   case ct_lforate_deactivatable:
    case ct_chorusmodtime:
    {
       float oldval = val.f;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -60,6 +60,7 @@ enum ctrltypes
    ct_reverbpredelaytime,
    ct_portatime,
    ct_lforate,
+   ct_lforate_deactivatable,
    ct_lfoshape,
    ct_lfotrigmode,
    ct_detuning,

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -521,7 +521,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
          py = gui_modsec_y - 10;
 
          sprintf(label, "lfo%i_rate", l);
-         a->push_back(scene[sc].lfo[l].rate.assign(p_id.next(), id_s++, label, "Rate", ct_lforate,
+         a->push_back(scene[sc].lfo[l].rate.assign(p_id.next(), id_s++, label, "Rate", ct_lforate_deactivatable,
                                                    "lfo.rate", px, py, sc_id, cg_LFO, ms_lfo1 + l, true,
                                                    Surge::ParamConfig::kHorizontal | sceasy, false));
          py += gui_hfader_dist;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2805,7 +2805,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                   float tripoff = triplaboff;
                   float dotlaboff = log2(1.5);
                   float dotoff = dotlaboff;
-                  if( p->ctrltype == ct_lforate )
+                  if( p->ctrltype == ct_lforate || p->ctrltype == ct_lforate_deactivatable )
                   {
                      mul = -1.0;
                      triplaboff = log2(1.5);


### PR DESCRIPTION
ct_lforate becoming deactivatable broke delay, rotary, and other
spots, so split the param and use the deactivatable just for the LFO