### PR TITLE
Macro Automation in Render Mode

### DIFF
--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -354,6 +354,15 @@ void SurgeVst3Processor::processParameterChanges(int sampleOffset,
                }
                else
                {
+                  if( id >= metaparam_offset && id <= metaparam_offset + n_midi_controller_params )
+                  {
+                     paramQueue->getPoint(numPoints - 1, offsetSamples, value);
+                     
+                     // VST3 wants to send me these events a LOT
+                     if( surgeInstance->getParameter01(id) != value )
+                        surgeInstance->setParameter01(id, value, true);
+                  }
+
                   // std::cerr << "Unable to handle parameter " << id << " with npoints " << numPoints << std::endl;
                }
             }
@@ -870,7 +879,7 @@ ParamValue PLUGIN_API SurgeVst3Processor::getParamNormalized(ParamID tag)
 
 tresult PLUGIN_API SurgeVst3Processor::setParamNormalized(ParamID tag, ParamValue value)
 {
-   // std::cout << __LINE__ << " " << __func__ << " " << tag << std::endl;
+   // std::cout << __LINE__ << " " << __func__ << " " << tag << " " << value << std::endl;
    CHECK_INITIALIZED;
 
    if( tag >= metaparam_offset && tag <= metaparam_offset + num_metaparameters ) 
@@ -948,6 +957,7 @@ void SurgeVst3Processor::updateDisplay()
 
 void SurgeVst3Processor::setParameterAutomated(int inputParam, float value)
 {
+   // std::cout << "setParameterAutomated " << inputParam << " " << value << std::endl; 
    int externalparam;
    if( inputParam >= metaparam_offset && inputParam <= metaparam_offset + n_midi_controller_params )
    {


### PR DESCRIPTION
There's a few APIs to set a param in a VST3. setParamNormalized,
setParamAutomated, and processParameterChange(list). Funnily
Reaper calls setParamNormailzed in realtime playback mode and
processParameterChange(list) in render mode. But I had forgotten
to put in the special case for macros in processParameterChange
so they got dropped in reaper render. Fixed.

Closes #1999