### PR TITLE
Allow real-time phase scrubbing in a static LFO

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -265,7 +265,7 @@ void LfoModulationSource::release()
 
 void LfoModulationSource::process_block()
 {
-   if( ! phaseInitialized )
+   if( (! phaseInitialized) || (lfo->rate.deactivated) )
    {
       initPhaseFromStartPhase();
    }

--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -265,7 +265,7 @@ void LfoModulationSource::release()
 
 void LfoModulationSource::process_block()
 {
-   if( (! phaseInitialized) || (lfo->rate.deactivated) )
+   if( (! phaseInitialized) || lfo->rate.deactivated )
    {
       initPhaseFromStartPhase();
    }


### PR DESCRIPTION
This simple change allows real-time phase scrubbing in a LFO if its rate is deactivated (0 Hz).

What still needs to be done is to make it scrub through the Step-Sequencer steps.