### PR TITLE
Two Small but Important bug Fixes

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1625,16 +1625,18 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
 
             /*
             ** Clear modulation onto FX otherwise it hangs around from old ones, often with
-            ** disastrously bad meaning. #2036
+            ** disastrously bad meaning. #2036. But only do this if it is a one FX change
+            ** (not a patch load)
             */
-            for(int j=0; j<n_fx_params; j++)
-            {
-               auto p = &( storage.getPatch().fx[s].p[j] );
-               for( int ms=1; ms<n_modsources; ms++ )
+            if( ! force_reload_all ) 
+               for(int j=0; j<n_fx_params; j++)
                {
-                  clearModulation(p->id, (modsources)ms );
+                  auto p = &( storage.getPatch().fx[s].p[j] );
+                  for( int ms=1; ms<n_modsources; ms++ )
+                  {
+                     clearModulation(p->id, (modsources)ms );
+                  }
                }
-            }
             
          }
          something_changed = true;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4012,8 +4012,10 @@ void SurgeGUIEditor::draw_infowindow(int ptag, CControl* control, bool modulate,
    // A heuristic
    auto ml = ((CParameterTooltip*)infowindow)->getMaxLabelLen();
    auto iff = 148;
-   if( ml > 26 )
-      iff += ( ml - 26 ) * 6;
+   // This is just empirical. It would be lovely to use the actual string width but that needs a draw context
+   // of for these to be TextLabels so we can call sizeToFit
+   if( ml > 24 )
+      iff += ( ml - 24 ) * 5;
    
    CRect r(0, 0, iff, 18);
    if (modulate)


### PR DESCRIPTION
1. When we load a patch don't blow away FX modulations!
2. Size the infowindow. Closes #1885

OK maybe one important fix, two small ones :)