### PR TITLE
Add units to mod amounts, tweak order of certain FX ctrls, added ct_sendlevel

### DIFF
--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -109,6 +109,7 @@ enum ctrltypes
    ct_chorusmodtime,
    ct_percent200,
    ct_rotarydrive,
+   ct_sendlevel,
    num_ctrltypes,
 };
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -257,19 +257,16 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                           Surge::ParamConfig::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
       a->push_back(scene[sc].send_level[0].assign(p_id.next(), id_s++, "send_fx_1", "Send FX 1 Level",
-                                                  ct_amplitude,
+                                                  ct_sendlevel,
                                                   "global.send_fx_1", px, py,
                                                   sc_id, cg_GLOBAL, 0, true,
                                                   Surge::ParamConfig::kHorizontal | kWhite | sceasy));
       py += gui_hfader_dist;
       a->push_back(scene[sc].send_level[1].assign(p_id.next(), id_s++, "send_fx_2", "Send FX 2 Level",
-                                                  ct_amplitude,
+                                                  ct_sendlevel,
                                                   "global.send_fx_2", px, py,
                                                   sc_id, cg_GLOBAL, 0, true,
                                                   Surge::ParamConfig::kHorizontal | kWhite | sceasy));
-      scene[sc].send_level[0].val_max.f = 1.5874f;
-      scene[sc].send_level[1].val_max.f = 1.5874f;
-
       px = gui_oscmix_x;
       py = gui_oscmix_y;
       int mof = -36, sof = mof + 10, rof = mof + 20;

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -299,8 +299,8 @@ void DualDelayEffect::init_ctrltypes()
 
    fxdata->p[8].posy_offset = -15;
 
-   fxdata->p[10].posy_offset = 7;
-   fxdata->p[11].posy_offset = 7;
+   fxdata->p[10].posy_offset = 9;
+   fxdata->p[11].posy_offset = 5;
 }
 void DualDelayEffect::init_default_values()
 {

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -410,8 +410,8 @@ template <int v> void ChorusEffect<v>::init_ctrltypes()
    fxdata->p[3].posy_offset = 5;
    fxdata->p[4].posy_offset = 7;
    fxdata->p[5].posy_offset = 7;
-   fxdata->p[6].posy_offset = 9;
-   fxdata->p[7].posy_offset = 9;
+   fxdata->p[6].posy_offset = 11;
+   fxdata->p[7].posy_offset = 7;
 }
 template <int v> const char* ChorusEffect<v>::group_label(int id)
 {

--- a/src/common/dsp/effect/Reverb1Effect.cpp
+++ b/src/common/dsp/effect/Reverb1Effect.cpp
@@ -391,8 +391,8 @@ void Reverb1Effect::init_ctrltypes()
    fxdata->p[rp_gain1].posy_offset = 5;
    fxdata->p[rp_hicut].posy_offset = 5;
 
-   fxdata->p[rp_mix].posy_offset = 7;
-   fxdata->p[rp_width].posy_offset = 7;
+   fxdata->p[rp_mix].posy_offset = 9;
+   fxdata->p[rp_width].posy_offset = 5;
 
    // sections
    // pre-delay

--- a/src/common/dsp/effect/Reverb2Effect.cpp
+++ b/src/common/dsp/effect/Reverb2Effect.cpp
@@ -317,6 +317,9 @@ void Reverb2Effect::init_ctrltypes()
 
    fxdata->p[r2p_predelay].set_name("Pre-Delay");
    fxdata->p[r2p_predelay].set_type(ct_reverbpredelaytime);
+
+   fxdata->p[r2p_room_size].set_name("Room Size");
+   fxdata->p[r2p_room_size].set_type(ct_percent_bidirectional);
    fxdata->p[r2p_decay_time].set_name("Decay Time");
    fxdata->p[r2p_decay_time].set_type(ct_reverbtime);
    fxdata->p[r2p_diffusion].set_name("Diffusion");
@@ -325,16 +328,16 @@ void Reverb2Effect::init_ctrltypes()
    fxdata->p[r2p_buildup].set_type(ct_percent);
    fxdata->p[r2p_modulation].set_name("Modulation");
    fxdata->p[r2p_modulation].set_type(ct_percent);
+
    fxdata->p[r2p_hf_damping].set_name("HF Damping");
    fxdata->p[r2p_hf_damping].set_type(ct_percent);
    fxdata->p[r2p_lf_damping].set_name("LF Damping");
    fxdata->p[r2p_lf_damping].set_type(ct_percent);
+
+   fxdata->p[r2p_width].set_name("Width");
+   fxdata->p[r2p_width].set_type(ct_decibel_narrow);
    fxdata->p[r2p_mix].set_name("Mix");
    fxdata->p[r2p_mix].set_type(ct_percent);
-   fxdata->p[r2p_width].set_name("Width");
-   fxdata->p[r2p_width].set_type(ct_percent);
-   fxdata->p[r2p_room_size].set_name("Room Size");
-   fxdata->p[r2p_room_size].set_type(ct_percent_bidirectional);
 
    for( int i=r2p_predelay; i<r2p_num_params; ++i )
    {

--- a/src/common/dsp/effect/RingModulatorEffect.cpp
+++ b/src/common/dsp/effect/RingModulatorEffect.cpp
@@ -196,6 +196,8 @@ const char* RingModulatorEffect::group_label(int id)
    case 1:
       return "Diode";
    case 2:
+      return "EQ";
+   case 3:
       return "Output";
    }
    return 0;
@@ -211,6 +213,8 @@ int RingModulatorEffect::group_label_ypos(int id)
       return 11;
    case 2:
       return 17;
+   case 3:
+      return 23;
    }
    return 0;
 }
@@ -237,14 +241,16 @@ void RingModulatorEffect::init_ctrltypes()
    fxdata->p[rm_lowcut].set_type( ct_freq_audible );
    fxdata->p[rm_highcut].set_name( "High Cut" );
    fxdata->p[rm_highcut].set_type( ct_freq_audible );
+
    fxdata->p[rm_mix].set_name( "Mix" );
    fxdata->p[rm_mix].set_type( ct_percent );
 
-   for( int i=rm_carriershape; i<rm_num_params; ++i )
+   for( int i = rm_carriershape; i < rm_num_params; ++i )
    {
       auto a = 1;
       if( i >= rm_diode_vb ) a += 2;
       if( i >= rm_lowcut ) a += 2;
+      if( i >= rm_mix ) a += 2;
       fxdata->p[i].posy_offset = a;
    }
 


### PR DESCRIPTION
* ct_amplitude still creates some problems for mod amount units
* after fixing ct_amplitude, this PR closes #1991
* effects which had Width after Mix slider have the order reversed now
* Low/High Cut in ring modulator get their own section
* Width in Reverb 2 is now bipolar dB just like all other widths (but code needs tweaking so that it behaves like width in all other FX)