### PR TITLE
LFO Scrub controls

### DIFF
--- a/src/common/dsp/LfoModulationSource.h
+++ b/src/common/dsp/LfoModulationSource.h
@@ -62,7 +62,7 @@ private:
    bool phaseInitialized;
    void initPhaseFromStartPhase();
    
-   float phase, target, noise, noised1, env_phase;
+   float phase, target, noise, noised1, env_phase, priorPhase;
    float ratemult;
    float env_releasestart;
    float iout;


### PR DESCRIPTION
1. You can deactivate rate putting LFO in constant mode
2. In that mode, phase becomes a scrub through a single cycle (oscillators)
   or 16 steps (LFO)