### PR TITLE
Limit ranges in LFO

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -76,7 +76,7 @@ float LfoModulationSource::bend2(float x)
 
 float LfoModulationSource::bend3(float x)
 {
-   float a = 0.5f * localcopy[ideform].f;
+   float a = 0.5f * limit_range( localcopy[ideform].f, -3.f, 3.f );
 
    x = x - a * x * x + a;
    x = x - a * x * x + a; // do twice for extra pleasure
@@ -559,5 +559,6 @@ void LfoModulationSource::process_block()
       }
    }
 
-   output = env_val * localcopy[magn].f * io2;
+   auto magnf = limit_range( localcopy[magn].f, -3.f, 3.f );
+   output = env_val * magnf * io2;
 }


### PR DESCRIPTION
WIth feedback-modulating LFOs (like LFO 1 -> 2 and 2 -> 1 )
you could drive the deform and magnitude unstable. The instability
starts when bend3 goes crazy at high (>>1) deform rates for instance.
Clamp deform and magnitude to [-3,3] (that is full modulated double stacked)
to avoid these speaker destroying feedback loops

Closes #2040