### PR TITLE
Tiny bounds issue in LFO Scrub

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -499,8 +499,8 @@ void LfoModulationSource::process_block()
             /*
             ** Alright so in 0 rate mode we want to scrub through tne entire sequence. So
             */
-            float p16 = phase * ( n_stepseqsteps - 1 );
-            int pstep = (int)p16;
+            float p16 = phase * n_stepseqsteps;
+            int pstep = ( (int)p16 ) & ( n_stepseqsteps - 1 );
             float sphase = ( p16 - pstep );
 
             if( priorPhase != phase )


### PR DESCRIPTION
I had the -1 in the wrong spot so couldn't scrub into lst step