### PR TITLE
Initialize ratemult correctly

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -119,6 +119,7 @@ void LfoModulationSource::attack()
 
    env_val = 0.f;
    env_phase = 0;
+   ratemult = 1.f;
 
    if (localcopy[idelay].f == lfo->delay.val_min.f)
    {
@@ -278,7 +279,7 @@ void LfoModulationSource::process_block()
    int s = lfo->shape.val.i;
 
    float frate = envelope_rate_linear(-localcopy[rate].f);
-
+   
    if (lfo->rate.deactivated)
       frate = 0.0;
 


### PR DESCRIPTION
ratemult is how the SS implements shuffle. It is 1 everywhere
except the SS. BUT if you switch to SS, deform, and switch back,
it means ratemult was still set so you end up with a wierd timing
difference. So initialize ratemult to 1 in attack consistently.

Closes #2158