### PR TITLE
Fix a missing VSTGUI Coordinate Hover XForm

### DIFF
--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -133,32 +133,38 @@ CMouseEventResult CHSwitch2::onMouseMoved(CPoint& where, const CButtonState& but
 
    if( doingHover )
    {
-      auto mouseableArea = getMouseableArea();
-      double coefX, coefY;
-      coefX = (double)mouseableArea.getWidth() / (double)columns;
-      coefY = (double)mouseableArea.getHeight() / (double)rows;
-
-      int y = (int)((where.y - mouseableArea.top) / coefY);
-      int x = (int)((where.x - mouseableArea.left) / coefX);
-
-      x = limit_range(x, 0, columns - 1);
-      y = limit_range(y, 0, rows - 1);
-
-      if (columns * rows > 1)
-      {
-         float nhoverValue = (float)(x + y * columns) / (float)(columns * rows - 1);
-
-         nhoverValue = limit_range( nhoverValue, 0.f, 1.f );
-
-         if( nhoverValue != hoverValue )
-         {
-            hoverValue = nhoverValue;
-            invalid();
-         }
-      }
+      calculateHoverValue( where );
    }
    
    return kMouseEventNotHandled;
+}
+
+void CHSwitch2::calculateHoverValue(const CPoint &where )
+{
+   auto mouseableArea = getMouseableArea();
+   double coefX, coefY;
+   coefX = (double)mouseableArea.getWidth() / (double)columns;
+   coefY = (double)mouseableArea.getHeight() / (double)rows;
+   
+   int y = (int)((where.y - mouseableArea.top) / coefY);
+   int x = (int)((where.x - mouseableArea.left) / coefX);
+   
+   x = limit_range(x, 0, columns - 1);
+   y = limit_range(y, 0, rows - 1);
+   
+   if (columns * rows > 1)
+   {
+      float nhoverValue = (float)(x + y * columns) / (float)(columns * rows - 1);
+      
+      nhoverValue = limit_range( nhoverValue, 0.f, 1.f );
+
+      
+      if( nhoverValue != hoverValue )
+      {
+         hoverValue = nhoverValue;
+         invalid();
+      }
+   }
 }
 bool CHSwitch2::onWheel(const CPoint& where, const float& distance, const CButtonState& buttons)
 {

--- a/src/common/gui/CHSwitch2.h
+++ b/src/common/gui/CHSwitch2.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "vstcontrols.h"
 #include "SkinSupport.h"
+#include "DebugHelpers.h"
 
 class CHSwitch2 : public VSTGUI::CHorizontalSwitch, public Surge::UI::SkinConsumingComponnt
 {
@@ -58,8 +59,11 @@ public:
       // getFrame()->setCursor( VSTGUI::kCursorHand );
       doingHover = true;
       hoverValue = -1;
+      calculateHoverValue(where);
+      invalid();
       return VSTGUI::kMouseEventHandled;
    }
+   void calculateHoverValue( const VSTGUI::CPoint &where );
    virtual VSTGUI::CMouseEventResult onMouseExited (VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override {
       // getFrame()->setCursor( VSTGUI::kCursorDefault );
       doingHover = false;


### PR DESCRIPTION
VSTGUI missed one transform, so hovers-when-rebuilding gave
specious coordinates. Correct that, and at the same time,
clean up CHSwitch2 to be a bit better under hover.

Closes #2020
Closes #1922