### PR TITLE
RingModulator Phase Overflow

### DIFF
--- a/src/common/dsp/effect/RingModulatorEffect.cpp
+++ b/src/common/dsp/effect/RingModulatorEffect.cpp
@@ -137,7 +137,7 @@ void RingModulatorEffect::process(float* dataL, float* dataR)
          phase[u] += dphase[u];
          if( phase[u] > 1 )
          {
-            phase[u] -= 1;
+            phase[u] -= (int)phase[u];
          }
          for( int c=0; c<2; ++c )
          {


### PR DESCRIPTION
When pitch is modulated out of range the RM phase could overflow.
Simply reduce it by the integral part rather than 1.