### PR TITLE
Linux VST3 fix

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -308,6 +308,7 @@ private:
    void* _effect = nullptr;
    void* _userdata = nullptr;
    VSTGUI::SharedPointer<VSTGUI::CVSTGUITimer> _idleTimer;
+   bool isFirstIdle = false;
 
    /*
    ** Utility Function


### PR DESCRIPTION
Linux VST3 Juce hosts would sometimes stall a draw on open. This
is because the invalidation event was processed before the show
somewhere. Lots of ways I could debug and fix this I'm sure but
the way I chose was to just force a call to frame->invalid()
in the first run through the idle loop.

Also fixed some printf bounds for ubuntu 20.

Closes #2159