### PR TITLE
More work on FX Modulation Clear

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1634,7 +1634,7 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
                   auto p = &( storage.getPatch().fx[s].p[j] );
                   for( int ms=1; ms<n_modsources; ms++ )
                   {
-                     clearModulation(p->id, (modsources)ms );
+                     clearModulation(p->id, (modsources)ms, true );
                   }
                }
             
@@ -2008,10 +2008,11 @@ void SurgeSynthesizer::clear_osc_modulation(int scene, int entry)
    storage.CS_ModRouting.leave();
 }
 
-void SurgeSynthesizer::clearModulation(long ptag, modsources modsource)
+void SurgeSynthesizer::clearModulation(long ptag, modsources modsource, bool clearEvenIfInvalid)
 {
-   if (!isValidModulation(ptag, modsource))
+   if (!isValidModulation(ptag, modsource) && ! clearEvenIfInvalid )
       return;
+   
    int scene = storage.getPatch().param_ptr[ptag]->scene;
 
    vector<ModulationRouting>* modlist;

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -138,7 +138,7 @@ public:
    bool setModulation(long ptag, modsources modsource, float value);
    float getModulation(long ptag, modsources modsource);
    float getModDepth(long ptag, modsources modsource);
-   void clearModulation(long ptag, modsources modsource);
+   void clearModulation(long ptag, modsources modsource, bool clearEvenIfInvalid = false);
    void clear_osc_modulation(
        int scene, int entry); // clear the modulation routings on the algorithm-specific sliders
    int remapExternalApiToInternalId(unsigned int x);


### PR DESCRIPTION
If you had a modulation which transitioned from valid
to invalid under FX change it didn't clear. Make it so
it does by adding a `force` param to clearModulation which
is default false.

Closes #2177