### PR TITLE
More host idle startup nonsense for Linux

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -308,7 +308,7 @@ private:
    void* _effect = nullptr;
    void* _userdata = nullptr;
    VSTGUI::SharedPointer<VSTGUI::CVSTGUITimer> _idleTimer;
-   bool isFirstIdle = false;
+   int firstIdleCountdown = 0;
 
    /*
    ** Utility Function


### PR DESCRIPTION
Linux VST3 in Carla with JUCE misses the first runloop.
Instead of debugging, just invalidate twice at open, and
limit this behavior to linux VST3

Closes #2159