### PR TITLE
Have documentation per parmeter available

### DIFF
--- a/resources/data/paramdocumentation.xml
+++ b/resources/data/paramdocumentation.xml
@@ -1,0 +1,404 @@
+<param-doc>
+  <ctrl_group group="0" group_name="cg_GLOBAL" help_url=""/>
+  <ctrl_group group="2" group_name="cg_OSC" help_url="#oscillators"/>
+  <ctrl_group group="3" group_name="cg_MIX" help_url="#mixer"/>
+  <ctrl_group group="4" group_name="cg_FILTER" help_url=""/>
+  <ctrl_group group="5" group_name="cg_ENV" help_url=""/>
+  <ctrl_group group="6" group_name="cg_LFO" help_url=""/>
+  <ctrl_group group="7" group_name="cg_FX" help_url=""/>
+
+  <!-- Params for CG 0 -->
+  <param id="filter.balance" help_url=""/>
+  <param id="filter.config" help_url=""/>
+  <param id="filter.f2_link_resonance" help_url=""/>
+  <param id="filter.f2_offset_mode" help_url=""/>
+  <param id="filter.feedback" help_url=""/>
+  <param id="filter.highpass" help_url=""/>
+  <param id="filter.waveshaper_drive" help_url=""/>
+  <param id="filter.waveshaper_type" help_url=""/>
+  <param id="global.active_scene" help_url=""/>
+  <param id="global.character" help_url=""/>
+  <param id="global.drift" help_url=""/>
+  <param id="global.fmdepth" help_url=""/>
+  <param id="global.fmrouting" help_url=""/>
+  <param id="global.fx1_return" help_url="#fx-section"/>
+  <param id="global.fx2_return" help_url="#fx-section"/>
+  <param id="global.fx_bypass" help_url="#fx-section"/>
+  <param id="global.fx_disable" help_url="#fx-section"/>
+  <param id="global.gain" help_url=""/>
+  <param id="global.keytrack_root" help_url=""/>
+  <param id="global.master_volume" help_url=""/>
+  <param id="global.noise_color" help_url=""/>
+  <param id="global.pan" help_url=""/>
+  <param id="global.pbrange_dn" help_url=""/>
+  <param id="global.pbrange_up" help_url=""/>
+  <param id="global.playmode" help_url=""/>
+  <param id="global.polylimit" help_url=""/>
+  <param id="global.scene_mode" help_url=""/>
+  <param id="global.send_fx_1" help_url=""/>
+  <param id="global.send_fx_2" help_url=""/>
+  <param id="global.splitkey" help_url=""/>
+  <param id="global.velocity_sensitivity" help_url=""/>
+  <param id="global.volume" help_url=""/>
+  <param id="global.width" help_url=""/>
+  <param id="scene.octave" help_url=""/>
+  <param id="scene.pitch" help_url=""/>
+  <param id="scene.portatime" help_url=""/>
+
+  <!-- Params for CG 2 -->
+  <param id="osc.keytrack" help_url=""/>
+  <param id="osc.octave" help_url=""/>
+  <param id="osc.osctype" help_url=""/>
+  <param id="osc.param_1" help_url=""/>
+  <param id="osc.param_2" help_url=""/>
+  <param id="osc.param_3" help_url=""/>
+  <param id="osc.param_4" help_url=""/>
+  <param id="osc.param_5" help_url=""/>
+  <param id="osc.param_6" help_url=""/>
+  <param id="osc.param_7" help_url=""/>
+  <param id="osc.pitch" help_url=""/>
+  <param id="osc.retrigger" help_url=""/>
+
+  <!-- special case oscillator params for Classic (0) -->
+  <param id="osc.param_1" type="0" help_url=""/>
+  <param id="osc.param_2" type="0" help_url=""/>
+  <param id="osc.param_3" type="0" help_url=""/>
+  <param id="osc.param_4" type="0" help_url=""/>
+  <param id="osc.param_5" type="0" help_url=""/>
+  <param id="osc.param_6" type="0" help_url=""/>
+  <param id="osc.param_7" type="0" help_url=""/>
+
+  <!-- special case oscillator params for Sine (1) -->
+  <param id="osc.param_1" type="1" help_url=""/>
+  <param id="osc.param_2" type="1" help_url=""/>
+  <param id="osc.param_3" type="1" help_url=""/>
+  <param id="osc.param_4" type="1" help_url=""/>
+  <param id="osc.param_5" type="1" help_url=""/>
+  <param id="osc.param_6" type="1" help_url=""/>
+  <param id="osc.param_7" type="1" help_url=""/>
+
+  <!-- special case oscillator params for Wavetable (2) -->
+  <param id="osc.param_1" type="2" help_url="#wavetable"/>
+  <param id="osc.param_2" type="2" help_url="#wavetable"/>
+  <param id="osc.param_3" type="2" help_url="#wavetable"/>
+  <param id="osc.param_4" type="2" help_url="#wavetable"/>
+  <param id="osc.param_5" type="2" help_url="#wavetable"/>
+  <param id="osc.param_6" type="2" help_url="#wavetable"/>
+  <param id="osc.param_7" type="2" help_url="#wavetable"/>
+
+  <!-- special case oscillator params for SHNoise (3) -->
+  <param id="osc.param_1" type="3" help_url=""/>
+  <param id="osc.param_2" type="3" help_url=""/>
+  <param id="osc.param_3" type="3" help_url=""/>
+  <param id="osc.param_4" type="3" help_url=""/>
+  <param id="osc.param_5" type="3" help_url=""/>
+  <param id="osc.param_6" type="3" help_url=""/>
+  <param id="osc.param_7" type="3" help_url=""/>
+
+  <!-- special case oscillator params for Audio Input (4) -->
+  <param id="osc.param_1" type="4" help_url=""/>
+  <param id="osc.param_2" type="4" help_url=""/>
+  <param id="osc.param_3" type="4" help_url=""/>
+  <param id="osc.param_4" type="4" help_url=""/>
+  <param id="osc.param_5" type="4" help_url=""/>
+  <param id="osc.param_6" type="4" help_url=""/>
+  <param id="osc.param_7" type="4" help_url=""/>
+
+  <!-- special case oscillator params for FM3 (5) -->
+  <param id="osc.param_1" type="5" help_url=""/>
+  <param id="osc.param_2" type="5" help_url=""/>
+  <param id="osc.param_3" type="5" help_url=""/>
+  <param id="osc.param_4" type="5" help_url=""/>
+  <param id="osc.param_5" type="5" help_url=""/>
+  <param id="osc.param_6" type="5" help_url=""/>
+  <param id="osc.param_7" type="5" help_url=""/>
+
+  <!-- special case oscillator params for FM2 (6) -->
+  <param id="osc.param_1" type="6" help_url=""/>
+  <param id="osc.param_2" type="6" help_url=""/>
+  <param id="osc.param_3" type="6" help_url=""/>
+  <param id="osc.param_4" type="6" help_url=""/>
+  <param id="osc.param_5" type="6" help_url=""/>
+  <param id="osc.param_6" type="6" help_url=""/>
+  <param id="osc.param_7" type="6" help_url=""/>
+
+  <!-- special case oscillator params for WINDOW (7) -->
+  <param id="osc.param_1" type="7" help_url=""/>
+  <param id="osc.param_2" type="7" help_url=""/>
+  <param id="osc.param_3" type="7" help_url=""/>
+  <param id="osc.param_4" type="7" help_url=""/>
+  <param id="osc.param_5" type="7" help_url=""/>
+  <param id="osc.param_6" type="7" help_url=""/>
+  <param id="osc.param_7" type="7" help_url=""/>
+
+  <!-- Params for CG 3 -->
+  <param id="mix.level_noise" help_url=""/>
+  <param id="mix.level_o1" help_url=""/>
+  <param id="mix.level_o2" help_url=""/>
+  <param id="mix.level_o3" help_url=""/>
+  <param id="mix.level_prefiltergain" help_url=""/>
+  <param id="mix.level_ring12" help_url=""/>
+  <param id="mix.level_ring23" help_url=""/>
+  <param id="mix.mute_noise" help_url=""/>
+  <param id="mix.mute_o1" help_url=""/>
+  <param id="mix.mute_o2" help_url=""/>
+  <param id="mix.mute_o3" help_url=""/>
+  <param id="mix.mute_ring12" help_url=""/>
+  <param id="mix.mute_ring23" help_url=""/>
+  <param id="mix.route_noise" help_url=""/>
+  <param id="mix.route_o1" help_url=""/>
+  <param id="mix.route_o2" help_url=""/>
+  <param id="mix.route_o3" help_url=""/>
+  <param id="mix.route_ring12" help_url=""/>
+  <param id="mix.route_ring23" help_url=""/>
+  <param id="mix.solo_noise" help_url=""/>
+  <param id="mix.solo_o1" help_url=""/>
+  <param id="mix.solo_o2" help_url=""/>
+  <param id="mix.solo_o3" help_url=""/>
+  <param id="mix.solo_ring12" help_url=""/>
+  <param id="mix.solo_ring23" help_url=""/>
+
+  <!-- Params for CG 4 -->
+  <param id="filter.cutoff_1" help_url=""/>
+  <param id="filter.cutoff_2" help_url=""/>
+  <param id="filter.envmod_1" help_url=""/>
+  <param id="filter.envmod_2" help_url=""/>
+  <param id="filter.keytrack_1" help_url=""/>
+  <param id="filter.keytrack_2" help_url=""/>
+  <param id="filter.resonance_1" help_url=""/>
+  <param id="filter.resonance_2" help_url=""/>
+  <param id="filter.subtype_1" help_url=""/>
+  <param id="filter.subtype_2" help_url=""/>
+  <param id="filter.type_1" help_url=""/>
+  <param id="filter.type_2" help_url=""/>
+
+  <!-- Params for CG 5 -->
+  <param id="AEG.attack" help_url=""/>
+  <param id="AEG.attack_shape" help_url=""/>
+  <param id="AEG.decay" help_url=""/>
+  <param id="AEG.decay_shape" help_url=""/>
+  <param id="AEG.mode" help_url=""/>
+  <param id="AEG.release" help_url=""/>
+  <param id="AEG.release_shape" help_url=""/>
+  <param id="AEG.sustain" help_url=""/>
+  <param id="FEG.attack" help_url=""/>
+  <param id="FEG.attack_shape" help_url=""/>
+  <param id="FEG.decay" help_url=""/>
+  <param id="FEG.decay_shape" help_url=""/>
+  <param id="FEG.mode" help_url=""/>
+  <param id="FEG.release" help_url=""/>
+  <param id="FEG.release_shape" help_url=""/>
+  <param id="FEG.sustain" help_url=""/>
+
+  <!-- Params for CG 6 -->
+  <param id="lfo.amplitude" help_url=""/>
+  <param id="lfo.attack" help_url=""/>
+  <param id="lfo.decay" help_url=""/>
+  <param id="lfo.deform" help_url=""/>
+  <param id="lfo.delay" help_url=""/>
+  <param id="lfo.hold" help_url=""/>
+  <param id="lfo.phase" help_url=""/>
+  <param id="lfo.rate" help_url=""/>
+  <param id="lfo.release" help_url=""/>
+  <param id="lfo.shape" help_url=""/>
+  <param id="lfo.sustain" help_url=""/>
+  <param id="lfo.triggermode" help_url=""/>
+  <param id="lfo.unipolar" help_url=""/>
+
+  <!-- Params for CG 7 -->
+  <param id="FX.fxtype" help_url=""/>
+  <param id="FX.param_1" help_url="#fxsection"/>
+  <param id="FX.param_10" help_url=""/>
+  <param id="FX.param_11" help_url=""/>
+  <param id="FX.param_12" help_url=""/>
+  <param id="FX.param_2" help_url=""/>
+  <param id="FX.param_3" help_url=""/>
+  <param id="FX.param_4" help_url=""/>
+  <param id="FX.param_5" help_url=""/>
+  <param id="FX.param_6" help_url=""/>
+  <param id="FX.param_7" help_url=""/>
+  <param id="FX.param_8" help_url=""/>
+  <param id="FX.param_9" help_url=""/>
+
+  <!-- special case FX Param for fxt_delay(1) -->
+  <param id="FX.param_1" type="1" help_url=""/>
+  <param id="FX.param_10" type="1" help_url=""/>
+  <param id="FX.param_11" type="1" help_url=""/>
+  <param id="FX.param_12" type="1" help_url=""/>
+  <param id="FX.param_2" type="1" help_url=""/>
+  <param id="FX.param_3" type="1" help_url=""/>
+  <param id="FX.param_4" type="1" help_url=""/>
+  <param id="FX.param_5" type="1" help_url=""/>
+  <param id="FX.param_6" type="1" help_url=""/>
+  <param id="FX.param_7" type="1" help_url=""/>
+  <param id="FX.param_8" type="1" help_url=""/>
+  <param id="FX.param_9" type="1" help_url=""/>
+
+  <!-- special case FX Param for fxt_reverb(2) -->
+  <param id="FX.param_1" type="2" help_url=""/>
+  <param id="FX.param_10" type="2" help_url=""/>
+  <param id="FX.param_11" type="2" help_url=""/>
+  <param id="FX.param_12" type="2" help_url=""/>
+  <param id="FX.param_2" type="2" help_url=""/>
+  <param id="FX.param_3" type="2" help_url=""/>
+  <param id="FX.param_4" type="2" help_url=""/>
+  <param id="FX.param_5" type="2" help_url=""/>
+  <param id="FX.param_6" type="2" help_url=""/>
+  <param id="FX.param_7" type="2" help_url=""/>
+  <param id="FX.param_8" type="2" help_url=""/>
+  <param id="FX.param_9" type="2" help_url=""/>
+
+  <!-- special case FX Param for fxt_phaser(3) -->
+  <param id="FX.param_1" type="3" help_url=""/>
+  <param id="FX.param_10" type="3" help_url=""/>
+  <param id="FX.param_11" type="3" help_url=""/>
+  <param id="FX.param_12" type="3" help_url=""/>
+  <param id="FX.param_2" type="3" help_url=""/>
+  <param id="FX.param_3" type="3" help_url=""/>
+  <param id="FX.param_4" type="3" help_url=""/>
+  <param id="FX.param_5" type="3" help_url=""/>
+  <param id="FX.param_6" type="3" help_url=""/>
+  <param id="FX.param_7" type="3" help_url=""/>
+  <param id="FX.param_8" type="3" help_url=""/>
+  <param id="FX.param_9" type="3" help_url=""/>
+
+  <!-- special case FX Param for fxt_rotaryspeaker(4) -->
+  <param id="FX.param_1" type="4" help_url=""/>
+  <param id="FX.param_10" type="4" help_url=""/>
+  <param id="FX.param_11" type="4" help_url=""/>
+  <param id="FX.param_12" type="4" help_url=""/>
+  <param id="FX.param_2" type="4" help_url=""/>
+  <param id="FX.param_3" type="4" help_url=""/>
+  <param id="FX.param_4" type="4" help_url=""/>
+  <param id="FX.param_5" type="4" help_url=""/>
+  <param id="FX.param_6" type="4" help_url=""/>
+  <param id="FX.param_7" type="4" help_url=""/>
+  <param id="FX.param_8" type="4" help_url=""/>
+  <param id="FX.param_9" type="4" help_url=""/>
+
+  <!-- special case FX Param for fxt_distortion(5) -->
+  <param id="FX.param_1" type="5" help_url=""/>
+  <param id="FX.param_10" type="5" help_url=""/>
+  <param id="FX.param_11" type="5" help_url=""/>
+  <param id="FX.param_12" type="5" help_url=""/>
+  <param id="FX.param_2" type="5" help_url=""/>
+  <param id="FX.param_3" type="5" help_url=""/>
+  <param id="FX.param_4" type="5" help_url=""/>
+  <param id="FX.param_5" type="5" help_url=""/>
+  <param id="FX.param_6" type="5" help_url=""/>
+  <param id="FX.param_7" type="5" help_url=""/>
+  <param id="FX.param_8" type="5" help_url=""/>
+  <param id="FX.param_9" type="5" help_url=""/>
+
+  <!-- special case FX Param for fxt_eq(6) -->
+  <param id="FX.param_1" type="6" help_url=""/>
+  <param id="FX.param_10" type="6" help_url=""/>
+  <param id="FX.param_11" type="6" help_url=""/>
+  <param id="FX.param_12" type="6" help_url=""/>
+  <param id="FX.param_2" type="6" help_url=""/>
+  <param id="FX.param_3" type="6" help_url=""/>
+  <param id="FX.param_4" type="6" help_url=""/>
+  <param id="FX.param_5" type="6" help_url=""/>
+  <param id="FX.param_6" type="6" help_url=""/>
+  <param id="FX.param_7" type="6" help_url=""/>
+  <param id="FX.param_8" type="6" help_url=""/>
+  <param id="FX.param_9" type="6" help_url=""/>
+
+  <!-- special case FX Param for fxt_freqshift(7) -->
+  <param id="FX.param_1" type="7" help_url=""/>
+  <param id="FX.param_10" type="7" help_url=""/>
+  <param id="FX.param_11" type="7" help_url=""/>
+  <param id="FX.param_12" type="7" help_url=""/>
+  <param id="FX.param_2" type="7" help_url=""/>
+  <param id="FX.param_3" type="7" help_url=""/>
+  <param id="FX.param_4" type="7" help_url=""/>
+  <param id="FX.param_5" type="7" help_url=""/>
+  <param id="FX.param_6" type="7" help_url=""/>
+  <param id="FX.param_7" type="7" help_url=""/>
+  <param id="FX.param_8" type="7" help_url=""/>
+  <param id="FX.param_9" type="7" help_url=""/>
+
+  <!-- special case FX Param for fxt_conditioner(8) -->
+  <param id="FX.param_1" type="8" help_url=""/>
+  <param id="FX.param_10" type="8" help_url=""/>
+  <param id="FX.param_11" type="8" help_url=""/>
+  <param id="FX.param_12" type="8" help_url=""/>
+  <param id="FX.param_2" type="8" help_url=""/>
+  <param id="FX.param_3" type="8" help_url=""/>
+  <param id="FX.param_4" type="8" help_url=""/>
+  <param id="FX.param_5" type="8" help_url=""/>
+  <param id="FX.param_6" type="8" help_url=""/>
+  <param id="FX.param_7" type="8" help_url=""/>
+  <param id="FX.param_8" type="8" help_url=""/>
+  <param id="FX.param_9" type="8" help_url=""/>
+
+  <!-- special case FX Param for fxt_chorus4(9) -->
+  <param id="FX.param_1" type="9" help_url=""/>
+  <param id="FX.param_10" type="9" help_url=""/>
+  <param id="FX.param_11" type="9" help_url=""/>
+  <param id="FX.param_12" type="9" help_url=""/>
+  <param id="FX.param_2" type="9" help_url=""/>
+  <param id="FX.param_3" type="9" help_url=""/>
+  <param id="FX.param_4" type="9" help_url=""/>
+  <param id="FX.param_5" type="9" help_url=""/>
+  <param id="FX.param_6" type="9" help_url=""/>
+  <param id="FX.param_7" type="9" help_url=""/>
+  <param id="FX.param_8" type="9" help_url=""/>
+  <param id="FX.param_9" type="9" help_url=""/>
+
+  <!-- special case FX Param for fxt_vocoder(10) -->
+  <param id="FX.param_1" type="10" help_url=""/>
+  <param id="FX.param_10" type="10" help_url=""/>
+  <param id="FX.param_11" type="10" help_url=""/>
+  <param id="FX.param_12" type="10" help_url=""/>
+  <param id="FX.param_2" type="10" help_url=""/>
+  <param id="FX.param_3" type="10" help_url=""/>
+  <param id="FX.param_4" type="10" help_url=""/>
+  <param id="FX.param_5" type="10" help_url=""/>
+  <param id="FX.param_6" type="10" help_url=""/>
+  <param id="FX.param_7" type="10" help_url=""/>
+  <param id="FX.param_8" type="10" help_url=""/>
+  <param id="FX.param_9" type="10" help_url=""/>
+
+  <!-- special case FX Param for fxt_reverb2(11) -->
+  <param id="FX.param_1" type="11" help_url=""/>
+  <param id="FX.param_10" type="11" help_url=""/>
+  <param id="FX.param_11" type="11" help_url=""/>
+  <param id="FX.param_12" type="11" help_url=""/>
+  <param id="FX.param_2" type="11" help_url=""/>
+  <param id="FX.param_3" type="11" help_url=""/>
+  <param id="FX.param_4" type="11" help_url=""/>
+  <param id="FX.param_5" type="11" help_url=""/>
+  <param id="FX.param_6" type="11" help_url=""/>
+  <param id="FX.param_7" type="11" help_url=""/>
+  <param id="FX.param_8" type="11" help_url=""/>
+  <param id="FX.param_9" type="11" help_url=""/>
+
+  <!-- special case FX Param for fxt_flanger(12) -->
+  <param id="FX.param_1" type="12" help_url=""/>
+  <param id="FX.param_10" type="12" help_url=""/>
+  <param id="FX.param_11" type="12" help_url=""/>
+  <param id="FX.param_12" type="12" help_url=""/>
+  <param id="FX.param_2" type="12" help_url=""/>
+  <param id="FX.param_3" type="12" help_url=""/>
+  <param id="FX.param_4" type="12" help_url=""/>
+  <param id="FX.param_5" type="12" help_url=""/>
+  <param id="FX.param_6" type="12" help_url=""/>
+  <param id="FX.param_7" type="12" help_url=""/>
+  <param id="FX.param_8" type="12" help_url=""/>
+  <param id="FX.param_9" type="12" help_url=""/>
+
+  <!-- special case FX Param for fxt_ringmod(13) -->
+  <param id="FX.param_1" type="13" help_url=""/>
+  <param id="FX.param_10" type="13" help_url=""/>
+  <param id="FX.param_11" type="13" help_url=""/>
+  <param id="FX.param_12" type="13" help_url=""/>
+  <param id="FX.param_2" type="13" help_url=""/>
+  <param id="FX.param_3" type="13" help_url=""/>
+  <param id="FX.param_4" type="13" help_url=""/>
+  <param id="FX.param_5" type="13" help_url=""/>
+  <param id="FX.param_6" type="13" help_url=""/>
+  <param id="FX.param_7" type="13" help_url=""/>
+  <param id="FX.param_8" type="13" help_url=""/>
+  <param id="FX.param_9" type="13" help_url=""/>
+</param-doc>

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -127,6 +127,7 @@ enum ControlGroup
    cg_ENV = 5,
    cg_LFO = 6,
    cg_FX = 7,
+   endCG
 };
 
 struct ParamUserData

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -668,6 +668,11 @@ public:
 
    std::atomic<int> otherscene_clients;
 
+   std::unordered_map<int, std::string> helpURL_controlgroup;
+   std::unordered_map<std::string, std::string> helpURL_paramidentifier;
+   // Alterhately make this unordered and provide a hash
+   std::map<std::pair<std::string,int>, std::string> helpURL_paramidentifier_typespecialized;
+   
 private:
    TiXmlDocument snapshotloader;
    std::vector<Parameter> clipboard_p;

--- a/src/common/dsp/BiquadFilter.cpp
+++ b/src/common/dsp/BiquadFilter.cpp
@@ -186,6 +186,7 @@ void BiquadFilter::coeff_peakEQ(double omega, double BW, double gain)
 
 void BiquadFilter::coeff_orfanidisEQ(double omega, double BW, double G, double GB, double G0)
 {
+   // For the curious http://eceweb1.rutgers.edu/~orfanidi/ece521/hpeq.pdf appears to be the source of this
    double limit = 0.95;
    double w0 = omega; // min(M_PI-0.000001,omega);
    BW = max(minBW, BW);

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -102,6 +102,8 @@ CScalableBitmap* SurgeBitmaps::getBitmap(int id)
 
 CScalableBitmap* SurgeBitmaps::getBitmapByPath(std::string path)
 {
+   if( bitmap_file_registry.find(path) == bitmap_file_registry.end() )
+      return nullptr;
    return bitmap_file_registry.at(path);
 }
 

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -325,6 +325,8 @@ private:
    VSTGUI::COptionMenu* makeMidiMenu(VSTGUI::CRect &rect);
    bool scannedForMidiPresets = false;
 
+   std::string helpURLFor( Parameter *p );
+   
    void promptForUserValueEntry(Parameter *p, VSTGUI::CControl *c, int modulationSource = -1);
    
    /*


### PR DESCRIPTION
Allow documentation per parameter. Set up some initial cuts
at the data. the 'paramdocumentation.xml' shows the url relative
to the manual (or absolute if you really want) for each item and
evaluates in a heirarchy as identified in #1222. Launches documentation
on RMB for params.

Closes #1222