### PR TITLE
Fix a Reverb2 Pre-Delay out of bounds

### DIFF
--- a/src/common/dsp/effect/Reverb2Effect.cpp
+++ b/src/common/dsp/effect/Reverb2Effect.cpp
@@ -208,7 +208,7 @@ void Reverb2Effect::process(float* dataL, float* dataR)
 
    _lfo.set_rate(2.0 * M_PI * powf(2, -2.f) * dsamplerate_inv);
 
-   int pdt = (int)( samplerate * pow( 2.0, *f[r2p_predelay] ) );
+   int pdt = limit_range( (int)( samplerate * pow( 2.0, *f[r2p_predelay] ) ), 1, PREDELAY_BUFFER_SIZE_LIMIT - 1 );
 
    for (int k = 0; k < BLOCK_SIZE; k++)
    {

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -506,7 +506,8 @@ class Reverb2Effect : public Effect
       DELAY_LEN_MASK = MAX_DELAY_LEN - 1,
       DELAY_SUBSAMPLE_BITS = 8,
       DELAY_SUBSAMPLE_RANGE = (1 << DELAY_SUBSAMPLE_BITS),
-      PREDELAY_BUFFER_SIZE = 48000 * 4 * 2; // max sample rate is 48000 * 4 probably
+      PREDELAY_BUFFER_SIZE = 48000 * 4 * 4, // max sample rate is 48000 * 4 probably
+      PREDELAY_BUFFER_SIZE_LIMIT = 48000 * 4 * 3; // allow for one second of diffusion
 
    class allpass
    {
@@ -542,7 +543,7 @@ class Reverb2Effect : public Effect
       }
       float process( float in, int tap ) {
          k = ( k + 1 ); if( k == PREDELAY_BUFFER_SIZE ) k = 0;
-         auto p = k - tap; if( p < 0 ) p += PREDELAY_BUFFER_SIZE;
+         auto p = k - tap; while( p < 0 ) p += PREDELAY_BUFFER_SIZE;
          auto res = _data[p];
          _data[k] = in;
          return res;


### PR DESCRIPTION
Reverb2 if you modulated pre-delay out of bounds very very far could
explode. Fix it in two ways. (1) if->while in wrap code in the delay
in case I miss a spot; (2) clamp the predelay to far less than the delay
line (to allow the diffusion to spread across the delay)

Closes #2208