### PR TITLE
Rework the Param -> String architecture

### DIFF
--- a/resources/data/paramdocumentation.xml
+++ b/resources/data/paramdocumentation.xml
@@ -9,6 +9,7 @@
 
   <!-- Special controls - bit of a hack but here they are -->
   <special id="scene-select" help_url="#the-scene-concept"/>
+  <special id="osc-select" help_url="#oscillators"/>
   <special id="mpe-menu" help_url="#mpe"/>
   <special id="tun-menu" help_url="#tuning-options"/>
   <special id="zoom-menu" help_url="#zoom"/>

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -5,6 +5,8 @@
 #include "globals.h"
 #include <string>
 #include <memory>
+#include <cstdint>
+#include <functional>
 
 union pdata
 {
@@ -227,6 +229,12 @@ private:
 
 class SurgeStorage;
 
+/*
+** WARNING WARNING
+**
+** Parameter is copied with memcpy
+** Don't have complex types as members therefore
+*/
 class Parameter
 {
 public:
@@ -320,6 +328,39 @@ public:
    bool temposync, extend_range, absolute, deactivated;
    bool porta_constrate, porta_gliss, porta_retrigger;
    int porta_curve;
+
+   enum ParamDisplayType {
+      Custom,
+      LinearWithScale,
+      ATwoToTheBx,
+      Decibel
+   } displayType = Custom;
+
+   enum ParamDisplayFeatures {
+      kHasCustomMinString = 1 << 0,
+      kHasCustomMaxString = 1 << 1,
+      kHasCustomMinValue = 1 << 2,
+      kHasCustomMaxValue = 1 << 3,
+      kUnitsAreSemitonesOrKeys = 1 << 4
+   };
+   
+   struct DisplayInfo {
+      char unit[128], absoluteUnit[128];
+      float scale = 1;
+      float a = 1.0, b = 1.0;
+      int decimals = 2;
+      int64_t customFeatures = 0;
+
+      float tempoSyncNotationMultiplier = 1.f;
+      
+      char minLabel[128], maxLabel[128];
+      float minLabelValue = 0.f, maxLabelValue = 0.f;
+
+      float modulationCap = -1.f;
+      
+      float extendFactor = 1.0, absoluteFactor = 1.0; // set these to 1 in case we sneak by and divide by accident
+   } displayInfo;
+      
    
    ParamUserData* user_data;              // I know this is a bit gross but we have a runtime type
    void set_user_data(ParamUserData* ud); // I take a shallow copy and don't assume ownership and assume i am referencable

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -445,7 +445,6 @@ bailOnPortable:
    }
    else
    {
-      std::cout << "Loaded " << dsf << " without concern" << std::endl;
       TiXmlElement* pdoc = TINYXML_SAFE_TO_ELEMENT(doc.FirstChild("param-doc"));
       if( ! pdoc )
       {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2345,8 +2345,22 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          int eid = 0;
 
          char txt[256];
-         sprintf(txt, "Osc %i", a + 1);
-         contextMenu->addEntry(txt, eid++);
+         auto hu = helpURLForSpecial( "osc-select" );
+         if( hu != "" )
+         {
+            sprintf(txt, "[?] Osc %i", a + 1);
+            auto lurl = fullyResolvedHelpURL(hu);
+            addCallbackMenu(contextMenu, txt, [lurl]() {
+                                                 Surge::UserInteractions::openURL( lurl );
+                                              } );
+            eid++;
+         }
+         else
+         {
+            sprintf(txt, "Osc %i", a + 1);
+            contextMenu->addEntry(txt, eid++);
+         }
+
          contextMenu->addSeparator(eid++);
          addCallbackMenu(contextMenu, "Copy",
                          [this, a]() { synth->storage.clipboard_copy(cp_osc, current_scene, a); });
@@ -5924,7 +5938,7 @@ void SurgeGUIEditor::promptForUserValueEntry( Parameter *p, CControl *c, int ms 
    inner->addView(typeinLabel);
 
    char txt[256];
-   char ptext[512];
+   char ptext[1024];
    if( p )
    {
       if( ismod )


### PR DESCRIPTION
The Param -> String architecture was becoming unwieldy as we
implemented display modes and typeins for modulations and different
types with different contents. So instead of having lots of sprintfs
which differed only by a constant or a unit, add a DisplayInfo structure
to a param which tells it how to participate in stringification.
There's 4 types, Custom (which we don't really use for floats),
Linear, a 2^bx and decibel.

This lets us move tons of stuff from code to config and generally clean things up.

A big change, but one which adds uniformity to the codebase so should
reduce bugs.