### PR TITLE
Initialize DisplayInfo for every setType

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -766,6 +766,14 @@ void Parameter::set_type(int ctrltype)
    /*
    ** Setup display info here
    */
+   displayType = Custom;
+   DisplayInfo d; // reset everything to default
+   displayInfo = d;
+   displayInfo.unit[0] = 0;
+   displayInfo.absoluteUnit[0] = 0;
+   displayInfo.minLabel[0] = 0;
+   displayInfo.maxLabel[0] = 0;
+   
    switch( ctrltype )
    {
    case ct_percent:


### PR DESCRIPTION
when we setType we want to init DisplayInfo back
to original state. This particularly was important
for things like the control flags, where we had
lingering values.

Addresses #2229