### PR TITLE
Flanger Arp Mode is Stereo Wide

### DIFF
--- a/src/common/dsp/effect/FlangerEffect.cpp
+++ b/src/common/dsp/effect/FlangerEffect.cpp
@@ -43,7 +43,8 @@ void FlangerEffect::init()
          lfophase[c][i] =  1.f * ( i + 0.5 * c ) / COMBS_PER_CHANNEL;
          lfosandhtarget[c][i] = 0.0;
       }
-   longphase = 0;
+   longphase[0] = 0;
+   longphase[1] = 0.5;
    
    for( int i=0; i<LFO_TABLE_SIZE; ++i )
    {
@@ -78,8 +79,11 @@ void FlangerEffect::process(float* dataL, float* dataR)
 
    float rate = envelope_rate_linear(-limit_range( *f[flng_rate], -8.f, 10.f ) ) * (fxdata->p[flng_rate].temposync ? storage->temposyncratio : 1.f);
 
-   longphase += rate;
-   if( longphase >= COMBS_PER_CHANNEL ) longphase -= COMBS_PER_CHANNEL;
+   for( int c=0; c<2; ++c )
+   {
+      longphase[c] += rate;
+      if( longphase[c] >= COMBS_PER_CHANNEL ) longphase[c] -= COMBS_PER_CHANNEL;
+   }
    
    const float oneoverFreq0 = 1.0f / Tunings::MIDI_0_FREQ;
 
@@ -108,7 +112,7 @@ void FlangerEffect::process(float* dataL, float* dataR)
          if( mode == arp_mix || mode == arp_solo )
          {
             // arpeggio - everyone needs to use the same phase with the voice swap
-            thisphase = longphase - (int)longphase;
+            thisphase = longphase[c] - (int)longphase[c];
          }
          switch( mwave )
          {
@@ -236,8 +240,9 @@ void FlangerEffect::process(float* dataL, float* dataR)
       
       if( mode == arp_mix || mode == arp_solo )
       {
-         int ilp = (int)longphase;
-         float flp = longphase - ilp;
+         int ilp = (int)longphase[c];
+         float flp = longphase[c] - ilp;
+
          if( ilp == COMBS_PER_CHANNEL )
             ilp = 0;
          

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -671,7 +671,7 @@ private:
    int ringout_value = -1;
    InterpDelay idels[2];
 
-   float lfophase[2][COMBS_PER_CHANNEL], longphase;
+   float lfophase[2][COMBS_PER_CHANNEL], longphase[2];
    float lpaL = 0.f, lpaR = 0.f; // state for the onepole LP filter
    
    lipol<float,true> lfoval[2][COMBS_PER_CHANNEL], delaybase[2][COMBS_PER_CHANNEL];


### PR DESCRIPTION
The ARP mode was stereo unison so width didn't do much
on a mono signal etc... Fix that by having the longphase
L and R out of phase by 180deg

Closes #2221