### PR TITLE
Don't wrap LFO rate in extreme modulations

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1530,6 +1530,16 @@ float envelope_rate_linear(float x)
    return (1 - a) * table_envrate_linear[e & 0x1ff] + a * table_envrate_linear[(e + 1) & 0x1ff];
 }
 
+float envelope_rate_linear_nowrap(float x)
+{
+   x *= 16.f;
+   x += 256.f;
+   int e = limit_range( (int)x, 0, 0x1ff - 1 );;
+   float a = x - (float)e;
+
+   return (1 - a) * table_envrate_linear[e & 0x1ff] + a * table_envrate_linear[(e + 1) & 0x1ff];
+}
+
 // this function is only valid for x = {0, 1}
 float glide_exp(float x)
 {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -694,6 +694,7 @@ float lookup_waveshape(int, float);
 float lookup_waveshape_warp(int, float);
 float envelope_rate_lpf(float);
 float envelope_rate_linear(float);
+float envelope_rate_linear_nowrap(float);
 float glide_log(float);
 float glide_exp(float);
 

--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -278,7 +278,7 @@ void LfoModulationSource::process_block()
    retrigger_AEG = false;
    int s = lfo->shape.val.i;
 
-   float frate = envelope_rate_linear(-localcopy[rate].f);
+   float frate = envelope_rate_linear_nowrap(-localcopy[rate].f);
    
    if (lfo->rate.deactivated)
       frate = 0.0;


### PR DESCRIPTION
LFO rate uses envelope_rate_linear which wraps around
if you go too far negative or positive, meaning your
ever slowing LFO would suddenly perk up, undesirably.
Add an evenlope_linear_nowrap and call it.

Closes #2209