### PR TITLE
Don't rebuild on renaming a Macro

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3909,7 +3909,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                   strncpy(lbl, p->get_name(), 15);
                   synth->storage.getPatch().CustomControllerLabel[ccid][15] = 0;
                   ((CModulationSourceButton*)gui_modsrc[modsource])->setlabel(lbl);
-                  synth->updateDisplay();
+                  ((CModulationSourceButton*)gui_modsrc[modsource])->invalid();
                }
             }
          }


### PR DESCRIPTION
Macro would rename to mod target. This forced a needless
rebuild which stalled sliders. invalidate the widget instead.

Closes #2251