### PR TITLE
HideCursor invalidation turned off scaling in drags

### DIFF
--- a/src/common/gui/CCursorHidingControl.cpp
+++ b/src/common/gui/CCursorHidingControl.cpp
@@ -43,7 +43,7 @@ CMouseEventResult CCursorHidingControl::onMouseMoved(CPoint& where, const CButto
    double dy = where.y - _lastPos.y;
    _lastPos = where;
 
-   if (_isDetatched && !buttons.isTouch())
+   if (( scaleAnyway ||  _isDetatched ) && !buttons.isTouch())
    {
       double scaling = getMouseDeltaScaling(where, buttons);
 
@@ -83,6 +83,10 @@ void CCursorHidingControl::detachCursor(CPoint& where)
    {
       doDetach(where);
    }
+   if( ! hideCursor )
+   {
+      scaleAnyway = true;
+   }
 }
 
 void CCursorHidingControl::attachCursor()
@@ -90,6 +94,10 @@ void CCursorHidingControl::attachCursor()
    if (_isDetatched && hideCursor)
    {
       doAttach();
+   }
+   if( ! hideCursor )
+   {
+      scaleAnyway = false;
    }
 }
 

--- a/src/common/gui/CCursorHidingControl.h
+++ b/src/common/gui/CCursorHidingControl.h
@@ -25,6 +25,7 @@ protected:
    void attachCursor();
 
    bool hideCursor = true;
+   bool scaleAnyway = false;
 
 private:
    void doDetach(VSTGUI::CPoint& where);


### PR DESCRIPTION
HideCursor skipped the scaling part of drag gestures.
That's wrong. So make it so there's a state which is
not hidden but still scaling.

Closes #1957