### PR TITLE
Infowindow hangs out while mouse is down on Slider

### DIFF
--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -1,6 +1,7 @@
 //-------------------------------------------------------------------------------------------------------
 //	Copyright 2005 Claes Johanson & Vember Audio
 //-------------------------------------------------------------------------------------------------------
+#include "SurgeGUIEditor.h"
 #include "CSurgeSlider.h"
 #include "resource.h"
 #include "DspUtilities.h"
@@ -10,6 +11,7 @@
 #include "SurgeStorage.h"
 #include <UserDefaults.h>
 #include <iostream>
+
 
 using namespace VSTGUI;
 using namespace std;
@@ -651,6 +653,13 @@ bool CSurgeSlider::isInMouseInteraction()
 
 CMouseEventResult CSurgeSlider::onMouseDown(CPoint& where, const CButtonState& buttons)
 {
+   {
+      auto sge = dynamic_cast<SurgeGUIEditor*>(listener);
+      if( sge )
+      {
+         sge->clear_infoview_peridle = 0;
+      }
+   }
    if (storage)
       this->hideCursor = !Surge::Storage::getUserDefaultValue(storage, "showCursorWhileEditing", 0);
 
@@ -704,6 +713,14 @@ CMouseEventResult CSurgeSlider::onMouseDown(CPoint& where, const CButtonState& b
 
 CMouseEventResult CSurgeSlider::onMouseUp(CPoint& where, const CButtonState& buttons)
 {
+   {
+      auto sge = dynamic_cast<SurgeGUIEditor*>(listener);
+      if( sge )
+      {
+         sge->clear_infoview_peridle = -1;
+      }
+   }
+
    CCursorHidingControl::onMouseUp(where, buttons);
 
    if (controlstate)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -748,7 +748,7 @@ void SurgeGUIEditor::idle()
                ->get_target01());
          }
       }
-      clear_infoview_countdown--;
+      clear_infoview_countdown += clear_infoview_peridle;
       if (clear_infoview_countdown == 0)
       {
          ((CParameterTooltip*)infowindow)->Hide();
@@ -938,6 +938,8 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
    CPoint nopoint(0, 0);
 
+   clear_infoview_peridle = -1;
+   
    /*
    ** There are a collection of member states we need to reset
    */

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -309,6 +309,9 @@ private:
    HWND ToolTipWnd;
 #endif
    int clear_infoview_countdown = 0;
+public:
+   int clear_infoview_peridle = -1;
+private:
    float blinktimer = 0;
    bool blinkstate = false;
    bool useDevMenu = false;


### PR DESCRIPTION
The Infowindow shouldn't go just because you are deep
in thought about a value. If you keep your button down
keep the window on.

Closes #2268