### PR TITLE
Two Parameter Display Changes from the Beta

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -529,6 +529,7 @@ void Parameter::set_type(int ctrltype)
       val_default.i = 1;
       break;
    case ct_envshape:
+   case ct_envshape_attack:
       valtype = vt_int;
       val_min.i = 0;
       val_max.i = 2;
@@ -651,6 +652,7 @@ void Parameter::set_type(int ctrltype)
       val_default.f = 1;
       break;
    case ct_percent_bidirectional:
+   case ct_percent_bidirectional_stereo:
       val_min.f = -1;
       val_max.f = 1;
       valtype = vt_float;
@@ -783,6 +785,19 @@ void Parameter::set_type(int ctrltype)
    case ct_countedset_percent:
       displayType = LinearWithScale;
       sprintf(displayInfo.unit, "%%" );
+      displayInfo.scale = 100;
+      break;
+
+   case ct_percent_bidirectional_stereo:
+      displayType = LinearWithScale;
+      displayInfo.customFeatures = ParamDisplayFeatures::kHasCustomMinString |
+         ParamDisplayFeatures::kHasCustomMaxString |
+         ParamDisplayFeatures::kHasCustomDefaultString;
+      
+      sprintf(displayInfo.unit, "%%" );
+      sprintf( displayInfo.minLabel, "-100.00 %% (Left)" );
+      sprintf( displayInfo.defLabel, "0.00 %% (Stereo)" );
+      sprintf( displayInfo.maxLabel, "100.00 %% (Right)" );
       displayInfo.scale = 100;
       break;
 
@@ -948,6 +963,7 @@ void Parameter::bound_value(bool force_integer)
       case ct_percent:
       case ct_percent200:
       case ct_percent_bidirectional:
+      case ct_percent_bidirectional_stereo:
       case ct_rotarydrive:
       case ct_osc_feedback:
       case ct_osc_feedback_negative:
@@ -1739,6 +1755,19 @@ void Parameter::get_display(char* txt, bool external, float ef)
             u = displayInfo.absoluteUnit;
          }
          sprintf( txt, "%.*f %s", (detailedMode ? 6 : displayInfo.decimals ), displayInfo.scale * f, u.c_str() );
+
+         if( f >= val_max.f && ( displayInfo.customFeatures & ParamDisplayFeatures::kHasCustomMaxString ) )
+         {
+            strcpy( txt, displayInfo.maxLabel );
+         }
+         if( f <= val_min.f && ( displayInfo.customFeatures & ParamDisplayFeatures::kHasCustomMinString ) )
+         {
+            strcpy( txt, displayInfo.minLabel );
+         }
+         if( f == val_default.f && ( displayInfo.customFeatures & ParamDisplayFeatures::kHasCustomDefaultString ) )
+         {
+            strcpy( txt, displayInfo.defLabel );
+         }
          return;
          break;
       }
@@ -1890,6 +1919,40 @@ void Parameter::get_display(char* txt, bool external, float ef)
          break;
       case ct_fmratio_int:
          sprintf(txt, "C : %d", i);
+         break;
+      case ct_envshape:
+         switch(i)
+         {
+         case 0:
+            sprintf( txt, "Linear" );
+            break;
+         case 1:
+            sprintf( txt, "Quadratic" );
+            break;
+         case 2:
+            sprintf( txt, "Cubic" );
+            break;
+         default:
+            sprintf( txt, "%d", i );
+            break;
+         }
+         break;
+      case ct_envshape_attack:
+         switch(i)
+         {
+         case 0:
+            sprintf( txt, "Sqrt" );
+            break;
+         case 1:
+            sprintf( txt, "Linear" );
+            break;
+         case 2:
+            sprintf( txt, "Quadratic" );
+            break;
+         default:
+            sprintf( txt, "%d", i );
+            break;
+         }
          break;
       case ct_sineoscmode:
          switch (i)
@@ -2192,6 +2255,7 @@ bool Parameter::can_setvalue_from_string()
    case ct_percent:
    case ct_percent200:
    case ct_percent_bidirectional:
+   case ct_percent_bidirectional_stereo:
    case ct_pitch_semi7bp:
    case ct_pitch_semi7bp_absolutable:
    case ct_pitch:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -27,6 +27,7 @@ enum ctrltypes
    ct_none,
    ct_percent,
    ct_percent_bidirectional,
+   ct_percent_bidirectional_stereo, // a bidirectional with special string at -100% +100% and 0%
    ct_pitch_octave,
    ct_pitch_semi7bp,
    ct_pitch_semi7bp_absolutable,
@@ -56,6 +57,7 @@ enum ctrltypes
    ct_envtime,
    ct_envtime_lfodecay,
    ct_envshape,
+   ct_envshape_attack,
    ct_envmode,
    ct_delaymodtime,
    ct_reverbtime,
@@ -349,9 +351,10 @@ public:
    enum ParamDisplayFeatures {
       kHasCustomMinString = 1 << 0,
       kHasCustomMaxString = 1 << 1,
-      kHasCustomMinValue = 1 << 2,
-      kHasCustomMaxValue = 1 << 3,
-      kUnitsAreSemitonesOrKeys = 1 << 4
+      kHasCustomDefaultString = 1 << 2,
+      kHasCustomMinValue = 1 << 3,
+      kHasCustomMaxValue = 1 << 4,
+      kUnitsAreSemitonesOrKeys = 1 << 5
    };
    
    struct DisplayInfo {
@@ -363,7 +366,7 @@ public:
 
       float tempoSyncNotationMultiplier = 1.f;
       
-      char minLabel[128], maxLabel[128];
+      char minLabel[128], maxLabel[128], defLabel[128];
       float minLabelValue = 0.f, maxLabelValue = 0.f;
 
       float modulationCap = -1.f;

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -472,7 +472,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                                  envs + "attack", px, py, sc_id, cg_ENV, e, true,
                                                  Surge::ParamConfig::kVertical | kWhite | sceasy));
          a->push_back(scene[sc].adsr[e].a_s.assign(p_id.next(), id_s++, "attack_shape", "Attack Shape",
-                                                   ct_envshape,
+                                                   ct_envshape_attack,
                                                    envs + "attack_shape", px, py + so, sc_id, cg_ENV, e,
                                                    false, kNoPopup));
          px += gui_vfader_dist;

--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -749,14 +749,14 @@ osc_audioinput::~osc_audioinput()
 
 void osc_audioinput::init_ctrltypes(int scene, int osc)
 {
-   oscdata->p[0].set_name("Audio In Channel");
-   oscdata->p[0].set_type(ct_percent_bidirectional);
+   oscdata->p[0].set_name("Audio In L/R Channel");
+   oscdata->p[0].set_type(ct_percent_bidirectional_stereo);
    oscdata->p[1].set_name("Audio In Gain");
    oscdata->p[1].set_type(ct_decibel);
    if( scene == 1 )
    {
-      oscdata->p[2].set_name("Scene A Channel");
-      oscdata->p[2].set_type(ct_percent_bidirectional);
+      oscdata->p[2].set_name("Scene A L/R Channel");
+      oscdata->p[2].set_type(ct_percent_bidirectional_stereo);
       oscdata->p[3].set_name("Scene A Gain");
       oscdata->p[3].set_type(ct_decibel);
       oscdata->p[4].set_name("Audio In<>Scene A Mix");

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1218,6 +1218,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          case ct_decibel_extendable:
          case ct_freq_mod:
          case ct_percent_bidirectional:
+         case ct_percent_bidirectional_stereo:
          case ct_freq_shift:
          case ct_osc_feedback_negative:
             style |= kBipolar;
@@ -1416,6 +1417,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          case ct_decibel_extendable:
          case ct_freq_mod:
          case ct_percent_bidirectional:
+         case ct_percent_bidirectional_stereo:
          case ct_osc_feedback_negative:
          case ct_freq_shift:
             style |= kBipolar;
@@ -1510,6 +1512,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          }
          break;
          case ct_envshape:
+         case ct_envshape_attack:
          {
             bool hasShape = synth->storage.getPatch()
                .scene[current_scene]


### PR DESCRIPTION
1. The attack envelopes showed 0,1,2 in the RMB not the actual
   shape, so spearate into 2 params (alas) and make them
   stringify properly

2. The "Audio In Channel" was confusing - which channel? So
   we changed it to "Audio In L/R Channel" and made the extrema
   add "(Left)" "(Right)" and "(Stereo)"

Closes #2281
Closes #2282