### PR TITLE
LFO Phase Deactivation Freerun and Random

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -269,7 +269,7 @@ void LfoModulationSource::release()
 
 void LfoModulationSource::process_block()
 {
-   if( (! phaseInitialized) || lfo->rate.deactivated )
+   if( (! phaseInitialized) || ( lfo->trigmode.val.i == lm_keytrigger && lfo->rate.deactivated ) )
    {
       initPhaseFromStartPhase();
    }


### PR DESCRIPTION
In Freerun and Random mode only reset phase at attack not
in every cycle, meaning the randomness stays and we don't
end up using the phase slider

Closes #2289