### PR TITLE
Update Hover in MouseMove always

### DIFF
--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -121,6 +121,11 @@ CMouseEventResult CHSwitch2::onMouseUp(CPoint& where, const CButtonState& button
 }
 CMouseEventResult CHSwitch2::onMouseMoved(CPoint& where, const CButtonState& buttons)
 {
+   if( doingHover )
+   {
+      calculateHoverValue( where );
+   }
+
    if (dragable && ( buttons.getButtonState() ))
    {
       auto mouseableArea = getMouseableArea();
@@ -151,10 +156,6 @@ CMouseEventResult CHSwitch2::onMouseMoved(CPoint& where, const CButtonState& but
       return kMouseEventHandled;
    }
 
-   if( doingHover )
-   {
-      calculateHoverValue( where );
-   }
    
    return kMouseEventNotHandled;
 }


### PR DESCRIPTION
If moue was down the return killed the hover update so
a right-mouse-drag would keep the hover orphaned. Just
change an order

Closes #2292