### PR TITLE
Fix an Absolute OSCSPREAD formatting bug

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -919,7 +919,7 @@ void Parameter::set_type(int ctrltype)
       displayInfo.scale = 100.0;
       sprintf(displayInfo.unit, "cents");
       sprintf(displayInfo.absoluteUnit, "Hz");
-      displayInfo.absoluteFactor = 16;
+      displayInfo.absoluteFactor = 0.16; // absolute factor also takes scale into account hence the /100
       displayInfo.extendFactor = 12;
       break;
 


### PR DESCRIPTION
it was v * scale * absfac and scale was 100 for cents so
absfac needed to be 1/100th the size for consistency

Closes #2299