### PR TITLE
More final fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,7 +350,7 @@ if( APPLE )
     "-framework QuartzCore"
     )
 elseif( UNIX AND NOT APPLE )
-  file(GLOB PIGGY_INPUTS assets/original-vector/SVG/exported/*svg)
+  file(GLOB PIGGY_INPUTS ${CMAKE_SOURCE_DIR}/assets/original-vector/SVG/exported/*svg)
   add_custom_command( OUTPUT ${CMAKE_BINARY_DIR}/lintemp/ScalablePiggy.S
                       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                       DEPENDS ${PIGGY_INPUTS}

--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -1,4 +1,4 @@
-<surge-skin name="Surge Dark" author="Decoded Enterprises">
+<surge-skin name="Surge Dark" author="Decoded Enterprises" version="1">
   <globals>
     <!-- This means if there is a bmp00???.svg in this directory we use it over the built in for this skin -->
     <defaultimage directory="SVG/"/>

--- a/resources/data/skins/default.surge-skin/skin.xml
+++ b/resources/data/skins/default.surge-skin/skin.xml
@@ -1,4 +1,4 @@
-<surge-skin name="Surge Classic" author="Surge Synth Team" authorURL="https://surge-synth-team.org/">
+<surge-skin name="Surge Classic" author="Surge Synth Team" authorURL="https://surge-synth-team.org/" version="1">
   <!-- This skin exists to make sure we can fall back on defaults with no assets and an empty XML. The defaults are built into the DLL -->
   <globals>
     <defaultimage directory="SVG/"/>

--- a/resources/data/skins/tests/test-minimal-position.surge-skin/skin.xml
+++ b/resources/data/skins/tests/test-minimal-position.surge-skin/skin.xml
@@ -1,4 +1,4 @@
-<surge-skin name="Test: Minimal Position Change" author="Surge Synth Team" authorURL="https://surge-synth-team.org/">
+<surge-skin name="Test: Minimal Position Change" author="Surge Synth Team" authorURL="https://surge-synth-team.org/" version="1">
   <globals>
     <color id="white" value="#ffffff"/>
     <defaultimage directory="SVG/"/>
@@ -48,6 +48,13 @@
     <control ui_identifier="filter.cutoff_2" class="boompoop"/>
     <control ui_identifier="filter.resonance_2" class="boompoop"/>
     <control ui_identifier="lfo.rate" class="boompoop"/>
-    
+
+    <control ui_identifier="filter.f2_link_resonance" x="723" y="239" w="12" h="18" class="CSwitchControl" bg_id="121"/>
+
+    <!-- right now only the x and y are actually used from these -->
+    <control tag_value="51" tag_name="tag_mp_jogfx" x="852" y="207" w="37" h="12" class="CHSwitch2" bg_id="149" subpixmaps="2" rows="1" columns="2"/>
+    <control tag_value="9" tag_name="tag_mp_patch" x="234" y="37" w="37" h="12" class="CHSwitch2"   bg_id="149"  subpixmaps="2" rows="1" columns="2"/>
+    <control tag_value="8" tag_name="tag_mp_category" x="158" y="45" w="37" h="12" class="CHSwitch2"  bg_id="149"  subpixmaps="2" rows="1" columns="2"/>
+
   </controls>
 </surge-skin>

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -871,7 +871,7 @@ void Parameter::set_type(int ctrltype)
       displayType = ATwoToTheBx;
       displayInfo.decimals = 3;
       displayInfo.tempoSyncNotationMultiplier = -1.0f;
-      displayInfo.modulationCap = 48000;
+      displayInfo.modulationCap = 512 * 8;
       sprintf( displayInfo.unit, "Hz" );
       break;
 

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -315,6 +315,19 @@ bool Skin::reloadSkin(std::shared_ptr<SurgeBitmaps> bitmapStore)
    if ( ( a = surgeskin->Attribute("authorURL") ) )
       authorURL = a;
 
+   int version = -1;
+   if( ! ( surgeskin->QueryIntAttribute( "version", &version ) == TIXML_SUCCESS ) )
+   {
+      FIXMEERROR << "Skin file does not contain a 'version' attribute. You must contain a version at most " << Skin::current_format_version << std::endl;
+      return false;
+   }
+   if( version > Skin::current_format_version )
+   {
+      FIXMEERROR << "Skin version '" << version << "' is greater than the max version '"
+                 << Skin::current_format_version << "' supported by this binary" << std::endl;
+      return false;
+   }
+   
    auto globalsxml = TINYXML_SAFE_TO_ELEMENT(surgeskin->FirstChild("globals"));
    auto componentclassesxml = TINYXML_SAFE_TO_ELEMENT(surgeskin->FirstChild("component-classes"));
    auto controlsxml = TINYXML_SAFE_TO_ELEMENT(surgeskin->FirstChild("controls"));

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -70,6 +70,8 @@ class SkinDB;
 class Skin
 {
 public:
+   static constexpr int current_format_version = 1;
+   
    typedef std::shared_ptr<Skin> ptr_t;
    typedef std::unordered_map<std::string, std::string> props_t;
    
@@ -150,6 +152,19 @@ public:
    VSTGUI::CColor getColor( std::string id, const VSTGUI::CColor &def, std::unordered_set<std::string> noLoops = std::unordered_set<std::string>() );
    std::unordered_set<std::string> getQueriedColors() { return queried_colors; }
 
+   Skin::Control::ptr_t controlForEnumID( int enum_id ) {
+      // FIXME don't be stupid like this of course
+      for( auto ic : controls )
+      {
+         if( ic->type == Control::Type::ENUM && ic->enum_id == enum_id  )
+         {
+            return ic;
+         }
+      }
+      
+      return nullptr;
+   }
+   
    Skin::Control::ptr_t controlForUIID( std::string ui_id ) {
       // FIXME don't be stupid like this of course
       for( auto ic : controls )

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1154,21 +1154,43 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
    frame->addView(statuspanel);
 
+   int catx = 157, caty = 41;
+   auto catctrl = currentSkin->controlForEnumID( tag_mp_category );
+   if( catctrl )
+   {
+      catx = catctrl->x;
+      caty = catctrl->y;
+   }
+   
    CHSwitch2* mp_cat =
-      new CHSwitch2(CRect(157, 41, 157 + 37, 41 + 12), this, tag_mp_category, 2, 12, 1, 2,
+      new CHSwitch2(CRect(catx, caty, 157 + 37, 41 + 12), this, tag_mp_category, 2, 12, 1, 2,
                     bitmapStore->getBitmap(IDB_BUTTON_MINUSPLUS), nopoint, false);
    mp_cat->setUsesMouseWheel(false); // mousewheel on category and patch buttons is undesirable
    mp_cat->setSkin( currentSkin, bitmapStore );
    frame->addView(mp_cat);
 
+   int patchx = 242, patchy = 41;
+   auto patchctrl = currentSkin->controlForEnumID( tag_mp_patch );
+   if( patchctrl )
+   {
+      patchx = patchctrl->x;
+      patchy = patchctrl->y;
+   }
    CHSwitch2* mp_patch =
-      new CHSwitch2(CRect(242, 41, 242 + 37, 41 + 12), this, tag_mp_patch, 2, 12, 1, 2,
+      new CHSwitch2(CRect(patchx, patchy, 242 + 37, 41 + 12), this, tag_mp_patch, 2, 12, 1, 2,
                     bitmapStore->getBitmap(IDB_BUTTON_MINUSPLUS), nopoint, false);
    mp_patch->setUsesMouseWheel(false);// mousewheel on category and patch buttons is undesirable
    mp_patch->setSkin( currentSkin, bitmapStore );
    frame->addView(mp_patch);
 
    int jogx = 759 + 131 - 39, jogy = 182 + 15;
+   auto jogctrl = currentSkin->controlForEnumID( tag_mp_jogfx );
+   if( jogctrl )
+   {
+      jogx = jogctrl->x;
+      jogy = jogctrl->y;
+   }
+
    CHSwitch2* mp_jogfx =
       new CHSwitch2(CRect(jogx, jogy, jogx + 37, jogy + 12), this, tag_mp_jogfx, 2, 12, 1, 2,
                     bitmapStore->getBitmap(IDB_BUTTON_MINUSPLUS), nopoint, false);


### PR DESCRIPTION
1. CMakeLIsts has right glob for ScalablePiggies. Closes #2303
2. Add a skin streaming version. Closes #2278
3. Sets max LFO modulation to 4096, a far more reasonable amount. Closes #2271
4. Make the patch cat and fxjog buttons repositionable in skin