### PR TITLE
Fixes a rounding issue with host automation not updating the active/deactivated slider state in VST2

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -705,7 +705,7 @@ void SurgeGUIEditor::idle()
                auto sv = synth->getParameter01(j);
                auto cv = cc->getValue();
 
-               if ((sv == cv) && ((tag == fmconfig_tag || tag == filterblock_tag)))
+               if ((sv != cv) && ((tag == fmconfig_tag || tag == filterblock_tag)))
                {
                   std::unordered_map<int, bool> resetMap;
 


### PR DESCRIPTION
Glad to do my first PR.

Fixes a rounding issue with host automation not updating the active/deactivated slider state properly that still existed in VST2 after commit b8f60a51 was merged.

Automating with for example a square waveform or S&H would not update the slider. It is now fixed and I have double checked several times.

How it was
![175](https://user-images.githubusercontent.com/56724286/86875537-0c053b00-c0e3-11ea-97af-1f3e08d07b71.gif)

How it is now after this change.
![174](https://user-images.githubusercontent.com/56724286/86875558-16bfd000-c0e3-11ea-915d-8bfecaf45f77.gif)
