### PR TITLE
Rescan Skins; clean up StdOut

### DIFF
--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -34,7 +34,7 @@ SkinDB::SkinDB()
 #ifdef INSTRUMENT_UI
    Surge::Debug::record( "SkinDB::SkinDB" );
 #endif   
-   std::cout << "Constructing SkinDB" << std::endl;
+   // std::cout << "Constructing SkinDB" << std::endl;
 }
 
 SkinDB::~SkinDB()
@@ -44,7 +44,7 @@ SkinDB::~SkinDB()
 #endif   
    skins.clear(); // Not really necessary but means the skins are destroyed before the rest of the
                   // dtor runs
-   std::cout << "Destroying SkinDB" << std::endl;
+   // std::cout << "Destroying SkinDB" << std::endl;
 }
 
 std::shared_ptr<Skin> SkinDB::defaultSkin(SurgeStorage *storage)
@@ -260,7 +260,7 @@ Skin::Skin(std::string root, std::string name) : root(root), name(name)
    Surge::Debug::record( "Skin::Skin" );
 #endif   
    instances++;
-   std::cout << "Constructing a skin " << _D(root) << _D(name) << _D(instances) << std::endl;
+   // std::cout << "Constructing a skin " << _D(root) << _D(name) << _D(instances) << std::endl;
    imageIds = createIdNameMap();
 }
 
@@ -270,7 +270,7 @@ Skin::~Skin()
    Surge::Debug::record( "Skin::~Skin" );
 #endif   
    instances--;
-   std::cout << "Destroying a skin " << _D(instances) << std::endl;
+   // std::cout << "Destroying a skin " << _D(instances) << std::endl;
 }
 
 #if !defined(TINYXML_SAFE_TO_ELEMENT)
@@ -283,7 +283,7 @@ bool Skin::reloadSkin(std::shared_ptr<SurgeBitmaps> bitmapStore)
    Surge::Debug::record( "Skin::reloadSkin" );
    Surge::Debug::TimeThisBlock _trs_( "Skin::reloadSkin" );
 #endif   
-   std::cout << "Reloading skin " << _D(name) << std::endl;
+   // std::cout << "Reloading skin " << _D(name) << std::endl;
    TiXmlDocument doc;
    // Obviously fix this
    doc.SetTabSize(4);

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -294,6 +294,16 @@ public:
    
    void rescanForSkins(SurgeStorage *);
    std::vector<Entry> getAvailableSkins() { return availableSkins; }
+   Maybe<Entry> getEntryByRootAndName( const std::string &r, const std::string &n ) {
+      for( auto &a : availableSkins )
+         if( a.root == r && a.name == n )
+            return Maybe<Entry>(a);
+      return Maybe<Entry>();
+   }
+   const Entry &getDefaultSkinEntry() const {
+      return defaultSkinEntry;
+   }
+   
    Skin::ptr_t getSkin( const Entry &skinEntry );
    Skin::ptr_t defaultSkin(SurgeStorage *);
 

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -15,7 +15,7 @@ SurgeBitmaps::SurgeBitmaps()
    Surge::Debug::record( "SurgeBitmaps::SurgeBitmaps" );
 #endif   
 
-   std::cout << "Constructing a SurgeBitmaps; Instances is " << instances << std::endl;
+   // std::cout << "Constructing a SurgeBitmaps; Instances is " << instances << std::endl;
 }
 
 SurgeBitmaps::~SurgeBitmaps()
@@ -39,7 +39,7 @@ SurgeBitmaps::~SurgeBitmaps()
    bitmap_file_registry.clear();
    bitmap_stringid_registry.clear();
    instances --;
-   std::cout << "Destroying a SurgeBitmaps; Instances is " << instances << std::endl;
+   // std::cout << "Destroying a SurgeBitmaps; Instances is " << instances << std::endl;
 }
 
 void SurgeBitmaps::setupBitmapsForFrame(VSTGUI::CFrame* f)

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -359,6 +359,7 @@ private:
    ** Skin support
    */
    Surge::UI::Skin::ptr_t currentSkin;
+   void setupSkinFromEntry( const Surge::UI::SkinDB::Entry &entry );
    void reloadFromSkin();
 
    /*


### PR DESCRIPTION
1. Rescan skin option rescans skin and reloads current,
   correctly dealing with deleted skin
2. Rescan user data does a rescan skin too
3. Some specious couts killed also

Closes #2350