### PR TITLE
Fix broken help context links

### DIFF
--- a/resources/data/paramdocumentation.xml
+++ b/resources/data/paramdocumentation.xml
@@ -30,32 +30,32 @@
   <param id="filter.waveshaper_type" help_url="#other-parameters"/>
   <param id="global.active_scene" help_url="#scene-select-and-scene-mode"/>
   <param id="global.character" help_url="#fx-bypass-character-and-master-volume"/>
-  <param id="global.drift" help_url="#other-settings"/>
-  <param id="global.fmdepth" help_url="#other-parameters"/>
-  <param id="global.fmrouting" help_url="#other-parameters"/>
+  <param id="scene.drift" help_url="#other-sound-generation-parameters"/>
+  <param id="scene.fmdepth" help_url="#other-parameters"/>
+  <param id="scene.fmrouting" help_url="#other-parameters"/>
   <param id="global.fx1_return" help_url="#fx-section"/>
   <param id="global.fx2_return" help_url="#fx-section"/>
   <param id="global.fx_bypass" help_url="#fx-bypass-character-and-master-volume"/>
   <param id="global.fx_disable" help_url="#fx-section"/>
-  <param id="global.gain" help_url="#other-parameters"/>
-  <param id="global.keytrack_root" help_url="#other-parameters"/>
+  <param id="scene.gain" help_url="#other-parameters"/>
+  <param id="scene.keytrack_root" help_url="#other-parameters"/>
   <param id="global.master_volume" help_url="#fx-bypass-character-and-master-volume"/>
-  <param id="global.noise_color" help_url="#other-settings"/>
-  <param id="global.pan" help_url="#output-stage"/>
-  <param id="global.pbrange_dn" help_url="#other-settings"/>
-  <param id="global.pbrange_up" help_url="#other-settings"/>
-  <param id="global.playmode" help_url="#other-settings"/>
+  <param id="scene.noise_color" help_url="#other-sound-generation-parameters"/>
+  <param id="scene.pan" help_url="#output-stage"/>
+  <param id="scene.pbrange_dn" help_url="#other-sound-generation-parameters"/>
+  <param id="scene.pbrange_up" help_url="#other-sound-generation-parameters"/>
+  <param id="scene.playmode" help_url="#other-sound-generation-parameters"/>
   <param id="global.polylimit" help_url="#scene-select-and-scene-mode"/>
   <param id="global.scene_mode" help_url="#scene-select-and-scene-mode"/>
-  <param id="global.send_fx_1" help_url="#output-stage"/>
-  <param id="global.send_fx_2" help_url="#output-stage"/>
+  <param id="scene.send_fx_1" help_url="#output-stage"/>
+  <param id="scene.send_fx_2" help_url="#output-stage"/>
   <param id="global.splitkey" help_url="#scene-select-and-scene-mode"/>
-  <param id="global.velocity_sensitivity" help_url="#other-parameters"/>
-  <param id="global.volume" help_url="#output-stage"/>
-  <param id="global.width" help_url="#output-stage"/>
-  <param id="scene.octave" help_url="#other-settings"/>
-  <param id="scene.pitch" help_url="#other-settings"/>
-  <param id="scene.portatime" help_url="#other-settings"/>
+  <param id="scene.velocity_sensitivity" help_url="#other-parameters"/>
+  <param id="scene.volume" help_url="#output-stage"/>
+  <param id="scene.width" help_url="#output-stage"/>
+  <param id="scene.octave" help_url="#other-sound-generation-parameters"/>
+  <param id="scene.pitch" help_url="#other-sound-generation-parameters"/>
+  <param id="scene.portatime" help_url="#other-sound-generation-parameters"/>
 
   <!-- Params for CG 2 -->
   <param id="osc.keytrack" help_url=""/>

--- a/resources/data/patchbrowser/patchbrowser_init.sql
+++ b/resources/data/patchbrowser/patchbrowser_init.sql
@@ -1,0 +1,33 @@
+-- Initialize the SQLite DB for the Patch Browser
+
+CREATE TABLE surge_metadata (
+    schema_version integer
+)
+
+CREATE TABLE patches (
+    id integer primary key,
+    filename varchar(1024),
+    patchname varchar( 256 ),
+    author varchar(256),
+
+    comment varchar(4096),
+
+    factoryThirdPartyOrUser integer
+);
+
+CREATE TABLE patchtag (
+    id integer primary key,
+    patchid integer,
+    tag integer
+);
+
+CREATE TABLE tags (
+   id integer primary key,
+   tagcagetory integer,
+   tag varchar(256) 
+);
+
+CREATE TABLE tagcategory (
+   id integer primary key,
+   tagcategory varchar( 256 )
+);

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3059,10 +3059,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             std::string helpstr = "[?] ";
             auto lurl = fullyResolvedHelpURL(helpurl);
             auto fnmi = addCallbackMenu(contextMenu, std::string(helpstr + p->get_full_name()).c_str(),
-                                         [lurl]()
-                                            {
-                                               Surge::UserInteractions::openURL( lurl );
-                                            }
+                                        [lurl]()
+                                           {
+                                              Surge::UserInteractions::openURL( lurl );
+                                           }
                );
             eid++;
          }
@@ -6447,6 +6447,31 @@ Steinberg::Vst::IContextMenu* SurgeGUIEditor::addVst3MenuForParams(VSTGUI::COpti
 std::string SurgeGUIEditor::helpURLFor( Parameter *p )
 {
    auto storage = &(synth->storage);
+#if 0 // useful debug   
+   static bool once = false;
+   if( ! once )
+   {
+      once = true;
+      for( auto hp : storage->helpURL_paramidentifier )
+      {
+         auto k = hp.first;
+         bool found = false;
+         for (auto iter = synth->storage.getPatch().param_ptr.begin();
+              iter != synth->storage.getPatch().param_ptr.end(); iter++)
+         {
+            Parameter* q = *iter;
+            if( ! q ) break;
+            if( q->ui_identifier == k )
+            {
+               found = true;
+               break;
+            }
+         }
+         if( ! found )
+            std::cout << "UNFOUND : " << k << std::endl;
+      }
+   }
+#endif   
    std::string id = p->ui_identifier;
    int type = -1;
    if( p->ctrlgroup == cg_OSC )


### PR DESCRIPTION
When we renamed global -> scene we didn't update the xml.
Also keep the useful debugging code ifdefed out that I wrote
to find the stragglers