### PR TITLE
VST3 Signing; Fix Live for Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,6 +611,8 @@ if( BUILD_AU )
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND echo "Packaging up AU component"
     COMMAND ./scripts/macOS/package-au.sh  ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/libsurge-au-dll.dylib ${SURGE_PRODUCT_DIR}
+    COMMAND codesign --force --sign - --timestamp=none ${SURGE_PRODUCT_DIR}/Surge.component/
+    COMMAND codesign -v ${SURGE_PRODUCT_DIR}/Surge.component/
     )
 
 endif()
@@ -682,6 +684,8 @@ if( BUILD_VST3 )
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND echo "Packaging up VST3 component"
       COMMAND ./scripts/macOS/package-vst3.sh ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/libsurge-vst3-dll.dylib ${SURGE_PRODUCT_DIR}
+      COMMAND codesign --force --sign - --timestamp=none ${SURGE_PRODUCT_DIR}/Surge.vst3/
+      COMMAND codesign -v ${SURGE_PRODUCT_DIR}/Surge.vst3/
       )
    elseif( UNIX )
     add_custom_target( Surge-VST3-Packaged ALL )
@@ -771,6 +775,8 @@ if( BUILD_VST2 )
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND echo "Packaging up VST2 component"
       COMMAND ./scripts/macOS/package-vst.sh   ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/libsurge-vst2-dll.dylib ${SURGE_PRODUCT_DIR}
+      COMMAND codesign --force --sign - --timestamp=none ${SURGE_PRODUCT_DIR}/Surge.vst2/
+      COMMAND codesign -v ${SURGE_PRODUCT_DIR}/Surge.vst2/
       )
    endif()
   if( UNIX AND NOT APPLE )

--- a/resources/osx-vst2/Info.plist
+++ b/resources/osx-vst2/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>SURGE</string>
+	<string>Surge</string>
 	<key>CFBundleIconFile</key>
 	<string>surgeicon.icns</string>
 	<key>CFBundleIdentifier</key>

--- a/resources/osx-vst3/Info.plist
+++ b/resources/osx-vst3/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>SURGE</string>
+	<string>Surge</string>
 	<key>CFBundleIconFile</key>
 	<string>surgeicon.icns</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Live for Mac checks a signature of its sub-entries and cmake
ejected an invalid one for surge. Correct this by signing
all our products with an empty signature after assembly.

Closes #2374