### PR TITLE
Unison Absolute Sync on Classic and S&H oscillator fix

### DIFF
--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -186,7 +186,7 @@ void SampleAndHoldOscillator::convolute(int voice, bool FM, bool stereo)
    if (oscdata->p[5].absolute)
    {
       // see the comment in SurgeSuperOscillator in the absolute branch
-      t = storage->note_to_pitch_inv_ignoring_tuning( detune * storage->note_to_pitch_inv_ignoring_tuning( pitch ) * 16 / 0.9443 );
+      t = storage->note_to_pitch_inv_ignoring_tuning( (detune + l_sync.v) * storage->note_to_pitch_inv_ignoring_tuning( pitch ) * 16 / 0.9443 );
       if( t < 0.1 ) t = 0.1;
    }
    else

--- a/src/common/dsp/SurgeSuperOscillator.cpp
+++ b/src/common/dsp/SurgeSuperOscillator.cpp
@@ -367,7 +367,16 @@ template <bool FM> void SurgeSuperOscillator::convolute(int voice, bool stereo)
          ipos = (unsigned int)(p24 * (syncstate[voice] * pitchmult_inv));
       // double t = max(0.5,dsamplerate_os * (1/8.175798915) * storage->note_to_pitch_inv(pitch +
       // detune) * 2);
-      float t = storage->note_to_pitch_inv_tuningctr(detune) * 2;
+      float t;
+      // See the extensive comment below
+      
+      if (! oscdata->p[5].absolute)
+         t = storage->note_to_pitch_inv_tuningctr(detune) * 2;
+      else
+         // Copy the mysterious *2 and drop the +sync
+         t = storage->note_to_pitch_inv_ignoring_tuning( detune * storage->note_to_pitch_inv_ignoring_tuning( pitch ) * 16 / 0.9443 ) * 2;
+
+      
       state[voice] = 0;
       last_level[voice] += dc_uni[voice] * (oscstate[voice] - syncstate[voice]);
 


### PR DESCRIPTION
Resetting the sync state on Classic and S&H ignored absolute
on unison voices. Fix by resetting t appropriately.

Closes #2365