### PR TITLE
Fix a pointer-compare error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,7 @@ if( APPLE )
     -Werror=dynamic-class-memaccess
     -Werror=undefined-bool-conversion
     -Werror=bitwise-op-parentheses
+    -Werror=pointer-bool-conversion
     )
   set(OS_INCLUDE_DIRECTORIES
     src/mac

--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -799,7 +799,7 @@ void osc_audioinput::init_default_values()
 void osc_audioinput::process_block(float pitch, float drift, bool stereo, bool FM, float FMdepth)
 {
    bool useOtherScene = false;
-   if( isInSceneB && localcopy[oscdata->p[4].param_id_in_scene].f > 0.f && storage->audio_otherscene )
+   if( isInSceneB && localcopy[oscdata->p[4].param_id_in_scene].f > 0.f )
    {
       useOtherScene = true;
    }


### PR DESCRIPTION
We were checking the validity of a member variable, which
was true but generated a clang warning, which on FreeBSD
resulted in the compilation breaking. So activate that warning-as-error
on mac and fix it.

Closes #2384