### PR TITLE
More Clang Changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,7 +423,6 @@ elseif( UNIX AND NOT APPLE )
   else()
     set(ARCH_COMPILE_OPTIONS
       -msse2
-      -Wno-implicit-int-float-conversion
       -Werror 
       "-D_aligned_malloc(x,a)=malloc(x)"
       "-D_aligned_free(x)=free(x)"

--- a/src/common/dsp/DspUtilities.cpp
+++ b/src/common/dsp/DspUtilities.cpp
@@ -4,7 +4,7 @@ float correlated_noise(float lastval, float correlation)
 {
    float wf = correlation * 0.9;
    float wfabs = fabs(wf);
-   float rand11 = (((float)rand() / RAND_MAX) * 2.f - 1.f);
+   float rand11 = (((float)rand() / (float)RAND_MAX) * 2.f - 1.f);
    float randt = rand11 * (1 - wfabs) - wf * lastval;
    return randt;
 }
@@ -14,7 +14,7 @@ float correlated_noise_mk2(float& lastval, float correlation)
    float wf = correlation * 0.9;
    float wfabs = fabs(wf);
    float m = 1.f / sqrt(1.f - wfabs);
-   float rand11 = (((float)rand() / RAND_MAX) * 2.f - 1.f);
+   float rand11 = (((float)rand() / (float)RAND_MAX) * 2.f - 1.f);
    lastval = rand11 * (1 - wfabs) - wf * lastval;
    return lastval * m;
 }
@@ -26,7 +26,7 @@ float drift_noise(float& lastval)
    //__m128 mvec = _mm_rsqrt_ss(_mm_load_ss(&filter));
    //_mm_store_ss(&m,mvec);
 
-   float rand11 = (((float)rand() / RAND_MAX) * 2.f - 1.f);
+   float rand11 = (((float)rand() / (float)RAND_MAX) * 2.f - 1.f);
    lastval = lastval * (1.f - filter) + rand11 * filter;
    return lastval * m;
 }
@@ -35,7 +35,7 @@ float correlated_noise_o2(float lastval, float& lastval2, float correlation)
 {
    float wf = correlation * 0.9;
    float wfabs = fabs(wf);
-   float rand11 = (((float)rand() / RAND_MAX) * 2.f - 1.f);
+   float rand11 = (((float)rand() / (float)RAND_MAX) * 2.f - 1.f);
    float randt = rand11 * (1 - wfabs) - wf * lastval2;
    lastval2 = randt;
    randt = lastval2 * (1 - wfabs) - wf * lastval;
@@ -61,7 +61,7 @@ float correlated_noise_o2mk2(float& lastval, float& lastval2, float correlation)
    _mm_store_ss(&m, m1);
    // if (wf>0.f) m *= 1 + wf*8;
 #endif
-   float rand11 = (((float)rand() / RAND_MAX) * 2.f - 1.f);
+   float rand11 = (((float)rand() / (float)RAND_MAX) * 2.f - 1.f);
    lastval2 = rand11 * (1 - wfabs) - wf * lastval2;
    lastval = lastval2 * (1 - wfabs) - wf * lastval;
    return lastval * m;

--- a/src/common/dsp/FastMath.h
+++ b/src/common/dsp/FastMath.h
@@ -25,8 +25,8 @@ namespace DSP
 inline float fastsin( float x ) noexcept
 {
    auto x2 = x * x;
-   auto numerator = -x * (-11511339840 + x2 * (1640635920 + x2 * (-52785432 + x2 * 479249)));
-   auto denominator = 11511339840 + x2 * (277920720 + x2 * (3177720 + x2 * 18361));
+   auto numerator = -x * (-(float)11511339840 + x2 * ((float)1640635920 + x2 * (-(float)52785432 + x2 * (float)479249)));
+   auto denominator = (float)11511339840 + x2 * ((float)277920720 + x2 * ((float)3177720 + x2 * (float)18361));
    return numerator / denominator;
 }
 
@@ -34,8 +34,8 @@ inline float fastsin( float x ) noexcept
 inline float fastcos( float x ) noexcept
 {
    auto x2 = x * x;
-   auto numerator = -(-39251520 + x2 * (18471600 + x2 * (-1075032 + 14615 * x2)));
-   auto denominator = 39251520 + x2 * (1154160 + x2 * (16632 + x2 * 127));
+   auto numerator = -(-(float)39251520 + x2 * ((float)18471600 + x2 * (-1075032 + 14615 * x2)));
+   auto denominator = (float)39251520 + x2 * (1154160 + x2 * (16632 + x2 * 127));
    return numerator / denominator;
 }
 

--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -52,7 +52,7 @@ void LfoModulationSource::assign(SurgeStorage* storage,
    noised1 = 0.f;
    target = 0.f;
    for (int i = 0; i < 4; i++)
-      wf_history[i] = 0.f; //((float) rand()/RAND_MAX)*2.f - 1.f;
+      wf_history[i] = 0.f; //((float) rand()/(float)RAND_MAX)*2.f - 1.f;
 }
 
 float LfoModulationSource::bend1(float x)
@@ -162,7 +162,7 @@ void LfoModulationSource::attack()
          step = 0;
          break;
       case lm_random:
-         phase = (float)rand() / RAND_MAX;
+         phase = (float)rand() / (float)RAND_MAX;
          if( ss->loop_end == 0 )
             step = 0;
          else

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -197,7 +197,7 @@ void SampleAndHoldOscillator::convolute(int voice, bool FM, bool stereo)
    float wf = l_shape.v * 0.8 * invertcorrelation;
    float wfabs = fabs(wf);
    float smooth = l_smooth.v;
-   float rand11 = (((float)rand() * rcp(RAND_MAX)) * 2.f - 1.f);
+   float rand11 = (((float)rand() * rcp((float)RAND_MAX)) * 2.f - 1.f);
    float randt = rand11 * (1 - wfabs) - wf * last_level[voice];
 
    randt = randt * rcp(1.0f - wfabs);

--- a/src/common/dsp/WavetableOscillator.cpp
+++ b/src/common/dsp/WavetableOscillator.cpp
@@ -96,7 +96,7 @@ void WavetableOscillator::init(float pitch, bool is_display)
             s = 0.f; //(oscdata->startphase.val.f) * (float)oscdata->wt.size;
          else if (!is_display)
          {
-            float drand = (float)rand() / RAND_MAX;
+            float drand = (float)rand() / (float)RAND_MAX;
             oscstate[i] = drand; // * (float)oscdata->wt.size;
          }
 

--- a/src/common/dsp/effect/FlangerEffect.cpp
+++ b/src/common/dsp/effect/FlangerEffect.cpp
@@ -150,7 +150,7 @@ void FlangerEffect::process(float* dataL, float* dataR)
          {
             if( lforeset )
             {
-               lfosandhtarget[c][i] = 1.f * rand() / RAND_MAX  - 1.f;
+               lfosandhtarget[c][i] = 1.f * rand() / (float)RAND_MAX  - 1.f;
             }
             // FIXME - exponential creep up. We want to get there in a time related to our rate
             auto cv = lfoval[c][i].v;

--- a/src/headless/UnitTestsDSP.cpp
+++ b/src/headless/UnitTestsDSP.cpp
@@ -192,7 +192,7 @@ TEST_CASE( "Unison at Sample Rates", "[osc]" )
                             {
                                REQUIRE( surge->loadPatchByPath( pn, -1, "Test" ) );
                                int note = rand() % 70 + 22;
-                               float abss = rand() * 1.f / RAND_MAX * 0.8 + 0.15;
+                               float abss = rand() * 1.f / (float)RAND_MAX * 0.8 + 0.15;
                                auto ap = &(surge->storage.getPatch().scene[0].osc[0].p[n_osc_params - 2]);
                                ap->set_value_f01(abss);
                                char txt[256];

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -213,10 +213,10 @@ TEST_CASE( "ADSR Envelope Behaviour", "[mod]" )
                
                for( int rc=0;rc<10; ++rc )
                {
-                  auto a = rand() * 1.0 / RAND_MAX;
-                  auto d = rand() * 1.0 / RAND_MAX;
-                  auto s = 0.8 * rand() * 1.0 / RAND_MAX + 0.1; // we have tested the s=0 case above
-                  auto r = rand() * 1.0 / RAND_MAX;
+                  auto a = rand() * 1.0 / (float)RAND_MAX;
+                  auto d = rand() * 1.0 / (float)RAND_MAX;
+                  auto s = 0.8 * rand() * 1.0 / (float)RAND_MAX + 0.1; // we have tested the s=0 case above
+                  auto r = rand() * 1.0 / (float)RAND_MAX;
                   runCompare( a, d, s, r, as, ds, rs, false );
                }
             }
@@ -301,10 +301,10 @@ TEST_CASE( "ADSR Envelope Behaviour", "[mod]" )
       testAnalog( 0.1, 0.2, 0.0, 0.1 );
       for( int rc=0;rc<50; ++rc )
       {
-         auto a = rand() * 1.0 / RAND_MAX + 0.03;
-         auto d = rand() * 1.0 / RAND_MAX + 0.03;
-         auto s = 0.7 * rand() * 1.0 / RAND_MAX + 0.2; // we have tested the s=0 case above
-         auto r = rand() * 1.0 / RAND_MAX + 0.03;
+         auto a = rand() * 1.0 / (float)RAND_MAX + 0.03;
+         auto d = rand() * 1.0 / (float)RAND_MAX + 0.03;
+         auto s = 0.7 * rand() * 1.0 / (float)RAND_MAX + 0.2; // we have tested the s=0 case above
+         auto r = rand() * 1.0 / (float)RAND_MAX + 0.03;
          testAnalog( a, d, s, r);
       }
       
@@ -334,8 +334,8 @@ TEST_CASE( "ADSR Envelope Behaviour", "[mod]" )
 
       for( auto i=0; i<10; ++i )
       {
-         auto s1 = 0.95f * rand() / RAND_MAX + 0.02;
-         auto s2 = 0.95f * rand() / RAND_MAX + 0.02;
+         auto s1 = 0.95f * rand() / (float)RAND_MAX + 0.02;
+         auto s2 = 0.95f * rand() / (float)RAND_MAX + 0.02;
          testSusPush( s1, s2 );
       }
    }
@@ -450,10 +450,10 @@ TEST_CASE( "ADSR Envelope Behaviour", "[mod]" )
          
       for( int rc=0;rc<100; ++rc )
       {
-         float a = rand() * 1.0 / RAND_MAX + 0.03;
-         float d = rand() * 1.0 / RAND_MAX + 0.01;
-         float s = 0.7 * rand() * 1.0 / RAND_MAX + 0.1; // we have tested the s=0 case above
-         float r = rand() * 1.0 / RAND_MAX + 0.1; // smaller versions can get one bad point in the pipeline
+         float a = rand() * 1.0 / (float)RAND_MAX + 0.03;
+         float d = rand() * 1.0 / (float)RAND_MAX + 0.01;
+         float s = 0.7 * rand() * 1.0 / (float)RAND_MAX + 0.1; // we have tested the s=0 case above
+         float r = rand() * 1.0 / (float)RAND_MAX + 0.1; // smaller versions can get one bad point in the pipeline
          INFO(  "Testing " << rc << " with ADSR=" << a << " " << d << " " << s << " " << r );
          compareSrgRepl( a, d, s, r );
 
@@ -504,8 +504,8 @@ TEST_CASE( "ADSR Envelope Behaviour", "[mod]" )
       testSusPush( 0.3, 0.7 );
       for( auto i=0; i<10; ++i )
       {
-         auto s1 = 0.95f * rand() / RAND_MAX + 0.02;
-         auto s2 = 0.95f * rand() / RAND_MAX + 0.02;
+         auto s1 = 0.95f * rand() / (float)RAND_MAX + 0.02;
+         auto s2 = 0.95f * rand() / (float)RAND_MAX + 0.02;
          testSusPush( s1, s2 );
       }
    }

--- a/src/headless/UnitTestsTUN.cpp
+++ b/src/headless/UnitTestsTUN.cpp
@@ -229,7 +229,7 @@ TEST_CASE( "KBM File Remaps Center", "[tun]" )
 
       for( int i=0; i<50; ++i )
       {
-         auto fr = 1.0f * rand() / RAND_MAX;
+         auto fr = 1.0f * rand() / (float)RAND_MAX;
          if( fr > 0 )
          {
             surge->storage.remapToKeyboard(k440);
@@ -866,7 +866,7 @@ TEST_CASE( "Ignoring Tuning Tables are Correct", "[dsp][tun]" )
       auto surge = surgeOnSine();
       for( int i=0; i<1000; ++i )
       {
-         auto e = 512.f * rand() / RAND_MAX;
+         auto e = 512.f * rand() / (float)RAND_MAX;
          REQUIRE( surge->storage.note_to_pitch(e) == surge->storage.note_to_pitch_ignoring_tuning(e) );
          REQUIRE( surge->storage.note_to_pitch_inv(e) == surge->storage.note_to_pitch_inv_ignoring_tuning(e) );
 
@@ -887,7 +887,7 @@ TEST_CASE( "Ignoring Tuning Tables are Correct", "[dsp][tun]" )
 
       for( int i=0; i<1000; ++i )
       {
-         auto e = 512.f * rand() / RAND_MAX;
+         auto e = 512.f * rand() / (float)RAND_MAX;
          REQUIRE( surge->storage.note_to_pitch(e) == surgeTuned->storage.note_to_pitch_ignoring_tuning(e) );
          REQUIRE( surge->storage.note_to_pitch(e) != surgeTuned->storage.note_to_pitch(e) );
          


### PR DESCRIPTION
Clang complains about large ints auto-casting to float.
Moreover, clang changes the flag to supress that warning
from clang 9 -> clang 10.

So just put in explicit casts to float.

Addresses #2386