### PR TITLE
Attempt to fix StudioOne zoom failure problems

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4535,6 +4535,20 @@ bool SurgeGUIEditor::doesZoomFitToScreen(int zf, int &correctedZf)
 
 void SurgeGUIEditor::setZoomFactor(int zf)
 {
+   zoomFactorRecursionGuard ++;
+
+   if( zoomFactorRecursionGuard > 3 )
+   {
+      std::ostringstream oss;
+      oss << "Surge has recursed into setZoomFactor too many times. This indicates an error in the interaction "
+          << "Surge, your Host's Zoom implementation, and your screen size. Please report this error to the "
+          << "Surge Synth Team on GitHub, since we think it should never happen. But it seems it has!";
+      // Choose to not show this error.  It only ever happens in Studio one. See issue 2397.
+      // Surge::UserInteractions::promptError( oss.str(), "Surge Software Zoom Error" );
+      zoomFactorRecursionGuard--;
+      return;
+   }
+   
    if (!zoomEnabled)
       zf = 100.0;
 
@@ -4585,6 +4599,8 @@ void SurgeGUIEditor::setZoomFactor(int zf)
    int fullPhysicalZoomFactor = (int)(zf * dbs);
    if (bitmapStore != nullptr)
       bitmapStore->setPhysicalZoomFactor(fullPhysicalZoomFactor);
+
+   zoomFactorRecursionGuard--;
 }
 
 void SurgeGUIEditor::showSettingsMenu(CRect &menuRect)

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -213,6 +213,7 @@ public:
    }
    int  getZoomFactor() { return zoomFactor; }
    void setZoomFactor(int zf);
+   int zoomFactorRecursionGuard = 0;
    bool doesZoomFitToScreen(int zf, int &correctedZf); // returns true if it fits; false if not; sets correctedZF to right size in either case
    void disableZoom()
    {

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -1067,7 +1067,14 @@ void SurgeVst3Processor::handleZoom(SurgeGUIEditor *e)
             Steinberg::ViewRect vr( 0, 0, newW, newH );
             Steinberg::tresult res = ipf->resizeView(e, &vr);
             if (res != Steinberg::kResultTrue)
-               Surge::UserInteractions::promptError("Your host failed to zoom VST3", "Host Error");
+            {
+               std::ostringstream oss;
+               oss << "Your host failed to zoom your VST3 to scale " << e->getZoomFactor() << ". "
+                   << "Surge will now attempt to reset your zoom to 100%. You may see several "
+                   << "other error messages in the course of this being resolved.";
+               Surge::UserInteractions::promptError(oss.str(), "Host VST3 Zoom Error" );
+               e->setZoomFactor(100);
+            }
         }
             
         /*


### PR DESCRIPTION
StudioOne Zoom fails sometimes in the VST3 API and that sends
Surge into a bit of a death spiral. Try to exit that death spiral
by having that failure try to set zoom to 100%, but with a recursion
guard.

Addresses #2397