### PR TITLE
Some ARM tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ cmake-stamp
 build/
 build32/
 buildlin/
+buildlin-*/
 buildmac/
 buildwin/
 build-arm/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required(VERSION 3.10)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9 CACHE STRING "Build for 10.9")
 
 project(Surge VERSION 1.7.1.0 LANGUAGES CXX ASM)
+message( STATUS "CMake Version is ${CMAKE_VERSION}" )
 message( STATUS "Compiler Version is ${CMAKE_CXX_COMPILER_VERSION}" )
 
 add_custom_target(surge-shared)

--- a/README.md
+++ b/README.md
@@ -218,8 +218,9 @@ git submodule update --init --recursive
 
 `build-linux.sh` is a wrapper on the various cmake and make commands needed to build Surge. As with
 macOS, it is getting smaller every day as we move more things direclty into cmake. 
-As of this Surge 1.7.1, `build-linux.sh` only works on intel platforms. If you are building on 
-ARM please keep reading below for directions on the ARM compile mechanism.
+As of Surge 1.7.1, `build-linux.sh` only works on intel platforms. If you are building on 
+ARM, please use the ARM specific instructions below or use the head of the codebase, where
+we are continuing to improve the ARM experience and build-linux is ARM aware.
 
 You can build with the command:
 
@@ -261,6 +262,9 @@ make -j 2 Surge.vst3
 will build the VST3 and deposit it in surge/products.
 
 ## Building for ARM platforms
+
+As of August 4, build-linux supports ARM builds. If you are building the 1.7.0 or
+1.7.1 release, though, you need to follow these instructions.
 
 With 1.7.0 we have merged changes needed to build with ARM platforms and have done some 
 raspberry pi testing. Due to a variety of choices an ARM user needs to make, and due to

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -37,6 +37,21 @@ GREEN=`tput setaf 2`
 NC=`tput sgr0`
 DEF_BUILD_DIR="buildlin"
 
+UNAME_M=`uname -m`
+if [[ "$UNAME_M" =~ ^arm ]]; then
+   ARM=1
+fi
+if [[ "$UNAME_M" =~ ^aarch ]]; then
+   ARM=1
+fi
+
+if [[ ! -z $ARM ]]; then
+   CMAKE_EXTRA_ARGS="-DARM_NATIVE=native"
+   DEF_BUILD_DIR="buildlin-${UNAME_M}"
+   echo "ARM build activated. Using ARM_NATIVE=native settings; building in ${DEF_BUILD_DIR}"
+fi
+
+
 prerequisite_check()
 {
     if [ ! -f vst3sdk/LICENSE.txt ]; then
@@ -51,7 +66,7 @@ prerequisite_check()
 
 run_cmake()
 {
-    cmake . -B${DEF_BUILD_DIR}
+    cmake . -B${DEF_BUILD_DIR} ${CMAKE_EXTRA_ARGS}
 }
 
 run_cmake_if()

--- a/src/common/vt_dsp/lipol.cpp
+++ b/src/common/vt_dsp/lipol.cpp
@@ -15,11 +15,7 @@ lipol_ps::lipol_ps()
 
 void lipol_ps::set_blocksize(int bs)
 {
-#ifdef ARM_NEON
-   lipol_BLOCK_SIZE = vdupq_n_f32(bs);
-#else
    lipol_BLOCK_SIZE = _mm_cvt_si2ss(m128_zero, bs);
-#endif
    m128_bs4_inv = _mm_div_ss(m128_four, lipol_BLOCK_SIZE);
 }
 


### PR DESCRIPTION
1. build-linux now recognizes arm
2. lipol had old hand-crafted ARM which didn't work on some 32 bit
   ARM builds
3. Update README and so on accordingly

Closes #2417