### PR TITLE
Remove an unused dereference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,7 +369,6 @@ if( APPLE )
     "-D_aligned_malloc(x,a)=malloc(x)"
     "-D_aligned_free(x)=free(x)"
     -Wno-deprecated-declarations
-    -Wno-unused-value
     -Werror=inconsistent-missing-override
     -Werror=logical-op-parentheses
     -Werror=dynamic-class-memaccess
@@ -466,7 +465,6 @@ elseif( UNIX AND NOT APPLE )
   else()
     set(ARCH_COMPILE_OPTIONS
       -msse2
-      -Wno-unused-value   # requiref for airwindows
       -Werror 
       "-D_aligned_malloc(x,a)=malloc(x)"
       "-D_aligned_free(x)=free(x)"

--- a/libs/airwindows/src/ADClip7Proc.cpp
+++ b/libs/airwindows/src/ADClip7Proc.cpp
@@ -462,10 +462,10 @@ void ADClip7::processReplacing(float **inputs, float **outputs, VstInt32 sampleF
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -924,10 +924,10 @@ void ADClip7::processDoubleReplacing(double **inputs, double **outputs, VstInt32
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/ApicolypseProc.cpp
+++ b/libs/airwindows/src/ApicolypseProc.cpp
@@ -179,10 +179,10 @@ void Apicolypse::processReplacing(float **inputs, float **outputs, VstInt32 samp
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -355,10 +355,10 @@ void Apicolypse::processDoubleReplacing(double **inputs, double **outputs, VstIn
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/BassDriveProc.cpp
+++ b/libs/airwindows/src/BassDriveProc.cpp
@@ -327,10 +327,10 @@ void BassDrive::processReplacing(float **inputs, float **outputs, VstInt32 sampl
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -651,10 +651,10 @@ void BassDrive::processDoubleReplacing(double **inputs, double **outputs, VstInt
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/BitGlitterProc.cpp
+++ b/libs/airwindows/src/BitGlitterProc.cpp
@@ -217,10 +217,10 @@ void BitGlitter::processReplacing(float **inputs, float **outputs, VstInt32 samp
 		*out1 = outputSampleL;
 		*out2 = outputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -433,10 +433,10 @@ void BitGlitter::processDoubleReplacing(double **inputs, double **outputs, VstIn
 		*out1 = outputSampleL;
 		*out2 = outputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/BlockPartyProc.cpp
+++ b/libs/airwindows/src/BlockPartyProc.cpp
@@ -564,10 +564,10 @@ void BlockParty::processReplacing(float **inputs, float **outputs, VstInt32 samp
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -1125,10 +1125,10 @@ void BlockParty::processDoubleReplacing(double **inputs, double **outputs, VstIn
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/BrassRiderProc.cpp
+++ b/libs/airwindows/src/BrassRiderProc.cpp
@@ -145,10 +145,10 @@ void BrassRider::processReplacing(float **inputs, float **outputs, VstInt32 samp
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -287,10 +287,10 @@ void BrassRider::processDoubleReplacing(double **inputs, double **outputs, VstIn
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/BrightAmbience2Proc.cpp
+++ b/libs/airwindows/src/BrightAmbience2Proc.cpp
@@ -71,10 +71,10 @@ void BrightAmbience2::processReplacing(float **inputs, float **outputs, VstInt32
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -139,10 +139,10 @@ void BrightAmbience2::processDoubleReplacing(double **inputs, double **outputs, 
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/ButterComp2Proc.cpp
+++ b/libs/airwindows/src/ButterComp2Proc.cpp
@@ -238,10 +238,10 @@ void ButterComp2::processReplacing(float **inputs, float **outputs, VstInt32 sam
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -475,10 +475,10 @@ void ButterComp2::processDoubleReplacing(double **inputs, double **outputs, VstI
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/CojonesProc.cpp
+++ b/libs/airwindows/src/CojonesProc.cpp
@@ -173,10 +173,10 @@ void Cojones::processReplacing(float **inputs, float **outputs, VstInt32 sampleF
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -345,10 +345,10 @@ void Cojones::processDoubleReplacing(double **inputs, double **outputs, VstInt32
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/CompresaturatorProc.cpp
+++ b/libs/airwindows/src/CompresaturatorProc.cpp
@@ -218,10 +218,10 @@ void Compresaturator::processReplacing(float **inputs, float **outputs, VstInt32
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -433,10 +433,10 @@ void Compresaturator::processDoubleReplacing(double **inputs, double **outputs, 
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/CrunchyGrooveWearProc.cpp
+++ b/libs/airwindows/src/CrunchyGrooveWearProc.cpp
@@ -446,10 +446,10 @@ void CrunchyGrooveWear::processReplacing(float **inputs, float **outputs, VstInt
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -891,10 +891,10 @@ void CrunchyGrooveWear::processDoubleReplacing(double **inputs, double **outputs
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/DeBessProc.cpp
+++ b/libs/airwindows/src/DeBessProc.cpp
@@ -105,10 +105,10 @@ void DeBess::processReplacing(float **inputs, float **outputs, VstInt32 sampleFr
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -207,10 +207,10 @@ void DeBess::processDoubleReplacing(double **inputs, double **outputs, VstInt32 
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/DeEssProc.cpp
+++ b/libs/airwindows/src/DeEssProc.cpp
@@ -163,10 +163,10 @@ void DeEss::processReplacing(float **inputs, float **outputs, VstInt32 sampleFra
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -325,10 +325,10 @@ void DeEss::processDoubleReplacing(double **inputs, double **outputs, VstInt32 s
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/DeRez2Proc.cpp
+++ b/libs/airwindows/src/DeRez2Proc.cpp
@@ -181,10 +181,10 @@ void DeRez2::processReplacing(float **inputs, float **outputs, VstInt32 sampleFr
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -359,10 +359,10 @@ void DeRez2::processDoubleReplacing(double **inputs, double **outputs, VstInt32 
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/DeckWreckaProc.cpp
+++ b/libs/airwindows/src/DeckWreckaProc.cpp
@@ -188,10 +188,10 @@ void Deckwrecka::processReplacing(float **inputs, float **outputs, VstInt32 samp
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -373,10 +373,10 @@ void Deckwrecka::processDoubleReplacing(double **inputs, double **outputs, VstIn
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/DensityProc.cpp
+++ b/libs/airwindows/src/DensityProc.cpp
@@ -163,10 +163,10 @@ void Density::processReplacing(float **inputs, float **outputs, VstInt32 sampleF
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -325,10 +325,10 @@ void Density::processDoubleReplacing(double **inputs, double **outputs, VstInt32
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/DriveProc.cpp
+++ b/libs/airwindows/src/DriveProc.cpp
@@ -142,10 +142,10 @@ void Drive::processReplacing(float **inputs, float **outputs, VstInt32 sampleFra
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -283,10 +283,10 @@ void Drive::processDoubleReplacing(double **inputs, double **outputs, VstInt32 s
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/DustBunnyProc.cpp
+++ b/libs/airwindows/src/DustBunnyProc.cpp
@@ -130,10 +130,10 @@ void DustBunny::processReplacing(float **inputs, float **outputs, VstInt32 sampl
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -257,10 +257,10 @@ void DustBunny::processDoubleReplacing(double **inputs, double **outputs, VstInt
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/FocusProc.cpp
+++ b/libs/airwindows/src/FocusProc.cpp
@@ -141,10 +141,10 @@ void Focus::processReplacing(float **inputs, float **outputs, VstInt32 sampleFra
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -279,10 +279,10 @@ void Focus::processDoubleReplacing(double **inputs, double **outputs, VstInt32 s
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/FractureProc.cpp
+++ b/libs/airwindows/src/FractureProc.cpp
@@ -113,10 +113,10 @@ void Fracture::processReplacing(float **inputs, float **outputs, VstInt32 sample
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -228,10 +228,10 @@ void Fracture::processDoubleReplacing(double **inputs, double **outputs, VstInt3
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/GrooveWearProc.cpp
+++ b/libs/airwindows/src/GrooveWearProc.cpp
@@ -445,10 +445,10 @@ void GrooveWear::processReplacing(float **inputs, float **outputs, VstInt32 samp
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -889,10 +889,10 @@ void GrooveWear::processDoubleReplacing(double **inputs, double **outputs, VstIn
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/HardVacuumProc.cpp
+++ b/libs/airwindows/src/HardVacuumProc.cpp
@@ -188,10 +188,10 @@ void HardVacuum::processReplacing(float **inputs, float **outputs, VstInt32 samp
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -376,10 +376,10 @@ void HardVacuum::processDoubleReplacing(double **inputs, double **outputs, VstIn
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/HombreProc.cpp
+++ b/libs/airwindows/src/HombreProc.cpp
@@ -146,10 +146,10 @@ void Hombre::processReplacing(float **inputs, float **outputs, VstInt32 sampleFr
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -291,10 +291,10 @@ void Hombre::processDoubleReplacing(double **inputs, double **outputs, VstInt32 
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/IronOxide5Proc.cpp
+++ b/libs/airwindows/src/IronOxide5Proc.cpp
@@ -434,10 +434,10 @@ void IronOxide5::processReplacing(float **inputs, float **outputs, VstInt32 samp
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -867,10 +867,10 @@ void IronOxide5::processDoubleReplacing(double **inputs, double **outputs, VstIn
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/Logical4Proc.cpp
+++ b/libs/airwindows/src/Logical4Proc.cpp
@@ -886,10 +886,10 @@ void Logical4::processReplacing(float **inputs, float **outputs, VstInt32 sample
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -1769,10 +1769,10 @@ void Logical4::processDoubleReplacing(double **inputs, double **outputs, VstInt3
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/LoudProc.cpp
+++ b/libs/airwindows/src/LoudProc.cpp
@@ -155,10 +155,10 @@ void Loud::processReplacing(float **inputs, float **outputs, VstInt32 sampleFram
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -308,10 +308,10 @@ void Loud::processDoubleReplacing(double **inputs, double **outputs, VstInt32 sa
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/MeltProc.cpp
+++ b/libs/airwindows/src/MeltProc.cpp
@@ -283,10 +283,10 @@ void Melt::processReplacing(float **inputs, float **outputs, VstInt32 sampleFram
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -565,10 +565,10 @@ void Melt::processDoubleReplacing(double **inputs, double **outputs, VstInt32 sa
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/MojoProc.cpp
+++ b/libs/airwindows/src/MojoProc.cpp
@@ -50,10 +50,10 @@ void Mojo::processReplacing(float **inputs, float **outputs, VstInt32 sampleFram
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -97,10 +97,10 @@ void Mojo::processDoubleReplacing(double **inputs, double **outputs, VstInt32 sa
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/NCSeventeenProc.cpp
+++ b/libs/airwindows/src/NCSeventeenProc.cpp
@@ -359,10 +359,10 @@ void NCSeventeen::processReplacing(float **inputs, float **outputs, VstInt32 sam
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -716,10 +716,10 @@ void NCSeventeen::processDoubleReplacing(double **inputs, double **outputs, VstI
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/NoiseProc.cpp
+++ b/libs/airwindows/src/NoiseProc.cpp
@@ -311,10 +311,10 @@ void Noise::processReplacing(float **inputs, float **outputs, VstInt32 sampleFra
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -619,10 +619,10 @@ void Noise::processDoubleReplacing(double **inputs, double **outputs, VstInt32 s
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/OneCornerClipProc.cpp
+++ b/libs/airwindows/src/OneCornerClipProc.cpp
@@ -176,10 +176,10 @@ void OneCornerClip::processReplacing(float **inputs, float **outputs, VstInt32 s
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -352,10 +352,10 @@ void OneCornerClip::processDoubleReplacing(double **inputs, double **outputs, Vs
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/PocketVerbsProc.cpp
+++ b/libs/airwindows/src/PocketVerbsProc.cpp
@@ -9181,10 +9181,10 @@ void PocketVerbs::processReplacing(float **inputs, float **outputs, VstInt32 sam
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -18353,10 +18353,10 @@ void PocketVerbs::processDoubleReplacing(double **inputs, double **outputs, VstI
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/PointProc.cpp
+++ b/libs/airwindows/src/PointProc.cpp
@@ -142,10 +142,10 @@ void Point::processReplacing(float **inputs, float **outputs, VstInt32 sampleFra
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -283,10 +283,10 @@ void Point::processDoubleReplacing(double **inputs, double **outputs, VstInt32 s
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/PopProc.cpp
+++ b/libs/airwindows/src/PopProc.cpp
@@ -283,10 +283,10 @@ void Pop::processReplacing(float **inputs, float **outputs, VstInt32 sampleFrame
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -565,10 +565,10 @@ void Pop::processDoubleReplacing(double **inputs, double **outputs, VstInt32 sam
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/Pressure4Proc.cpp
+++ b/libs/airwindows/src/Pressure4Proc.cpp
@@ -207,10 +207,10 @@ void Pressure4::processReplacing(float **inputs, float **outputs, VstInt32 sampl
 		*outputL = inputSampleL;
 		*outputR = inputSampleR;
 		
-		*inputL++;
-		*inputR++;
-		*outputL++;
-		*outputR++;
+		inputL++;
+		inputR++;
+		outputL++;
+		outputR++;
     }
 }
 
@@ -414,10 +414,10 @@ void Pressure4::processDoubleReplacing(double **inputs, double **outputs, VstInt
 		*outputL = inputSampleL;
 		*outputR = inputSampleR;
 
-		*inputL++;
-		*inputR++;
-		*outputL++;
-		*outputR++;
+		inputL++;
+		inputR++;
+		outputL++;
+		outputR++;
     }
 }
 

--- a/libs/airwindows/src/PurestDriveProc.cpp
+++ b/libs/airwindows/src/PurestDriveProc.cpp
@@ -102,10 +102,10 @@ void PurestDrive::processReplacing(float **inputs, float **outputs, VstInt32 sam
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -204,10 +204,10 @@ void PurestDrive::processDoubleReplacing(double **inputs, double **outputs, VstI
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/PyeWacketProc.cpp
+++ b/libs/airwindows/src/PyeWacketProc.cpp
@@ -148,10 +148,10 @@ void Pyewacket::processReplacing(float **inputs, float **outputs, VstInt32 sampl
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -295,10 +295,10 @@ void Pyewacket::processDoubleReplacing(double **inputs, double **outputs, VstInt
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/SingleEndedTriodeProc.cpp
+++ b/libs/airwindows/src/SingleEndedTriodeProc.cpp
@@ -142,10 +142,10 @@ void SingleEndedTriode::processReplacing(float **inputs, float **outputs, VstInt
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -283,10 +283,10 @@ void SingleEndedTriode::processDoubleReplacing(double **inputs, double **outputs
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/Spiral2Proc.cpp
+++ b/libs/airwindows/src/Spiral2Proc.cpp
@@ -133,10 +133,10 @@ void Spiral2::processReplacing(float **inputs, float **outputs, VstInt32 sampleF
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -266,10 +266,10 @@ void Spiral2::processDoubleReplacing(double **inputs, double **outputs, VstInt32
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/SpiralProc.cpp
+++ b/libs/airwindows/src/SpiralProc.cpp
@@ -75,10 +75,10 @@ void Spiral::processReplacing(float **inputs, float **outputs, VstInt32 sampleFr
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -149,10 +149,10 @@ void Spiral::processDoubleReplacing(double **inputs, double **outputs, VstInt32 
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/StarChildProc.cpp
+++ b/libs/airwindows/src/StarChildProc.cpp
@@ -404,10 +404,10 @@ void StarChild::processReplacing(float **inputs, float **outputs, VstInt32 sampl
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -807,10 +807,10 @@ void StarChild::processDoubleReplacing(double **inputs, double **outputs, VstInt
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/SurgeProc.cpp
+++ b/libs/airwindows/src/SurgeProc.cpp
@@ -132,10 +132,10 @@ void Surge::processReplacing(float **inputs, float **outputs, VstInt32 sampleFra
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -262,10 +262,10 @@ void Surge::processDoubleReplacing(double **inputs, double **outputs, VstInt32 s
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 		
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/ToTape6Proc.cpp
+++ b/libs/airwindows/src/ToTape6Proc.cpp
@@ -337,10 +337,10 @@ void ToTape6::processReplacing(float **inputs, float **outputs, VstInt32 sampleF
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -671,10 +671,10 @@ void ToTape6::processDoubleReplacing(double **inputs, double **outputs, VstInt32
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/UnBoxProc.cpp
+++ b/libs/airwindows/src/UnBoxProc.cpp
@@ -233,10 +233,10 @@ void UnBox::processReplacing(float **inputs, float **outputs, VstInt32 sampleFra
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -465,10 +465,10 @@ void UnBox::processDoubleReplacing(double **inputs, double **outputs, VstInt32 s
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/VariMuProc.cpp
+++ b/libs/airwindows/src/VariMuProc.cpp
@@ -248,10 +248,10 @@ void VariMu::processReplacing(float **inputs, float **outputs, VstInt32 sampleFr
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -495,10 +495,10 @@ void VariMu::processDoubleReplacing(double **inputs, double **outputs, VstInt32 
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/libs/airwindows/src/VoiceOfTheStarshipProc.cpp
+++ b/libs/airwindows/src/VoiceOfTheStarshipProc.cpp
@@ -193,10 +193,10 @@ void VoiceOfTheStarship::processReplacing(float **inputs, float **outputs, VstIn
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 
@@ -384,10 +384,10 @@ void VoiceOfTheStarship::processDoubleReplacing(double **inputs, double **output
 		*out1 = inputSampleL;
 		*out2 = inputSampleR;
 
-		*in1++;
-		*in2++;
-		*out1++;
-		*out2++;
+		in1++;
+		in2++;
+		out1++;
+		out2++;
     }
 }
 

--- a/src/common/dsp/effect/airwindows/airwindows_adapter.cpp
+++ b/src/common/dsp/effect/airwindows/airwindows_adapter.cpp
@@ -96,7 +96,7 @@ void AirWindowsEffect::process( float *dataL, float *dataR )
    
    for( int i=0; i<airwin->paramCount && i < n_fx_params - 1; ++i )
    {
-      param_lags[i].newValue( *f[i+1] );
+      param_lags[i].newValue( limit_range( *f[i+1], 0.f, 1.f ) );
       airwin->setParameter( i, param_lags[i].v );
       param_lags[i].process();
    }


### PR DESCRIPTION
The AirWindows wrappers have an unused de-reference
as discussed in https://github.com/airwindows/airwindows/issues/18.
Remove it from our copy, and remove our compile flags which
elevate it to a warning on mac and linux