### PR TITLE
Patch Menu and Loading Cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -837,8 +837,8 @@ if( BUILD_VST2 )
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND echo "Packaging up VST2 component"
       COMMAND ./scripts/macOS/package-vst.sh   ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/libsurge-vst2-dll.dylib ${SURGE_PRODUCT_DIR}
-      COMMAND codesign --force --sign - --timestamp=none ${SURGE_PRODUCT_DIR}/Surge.vst2/
-      COMMAND codesign -v ${SURGE_PRODUCT_DIR}/Surge.vst2/
+      COMMAND codesign --force --sign - --timestamp=none ${SURGE_PRODUCT_DIR}/Surge.vst/
+      COMMAND codesign -v ${SURGE_PRODUCT_DIR}/Surge.vst/
       )
    endif()
   if( UNIX AND NOT APPLE )

--- a/libs/filesystem/filesystem.cpp
+++ b/libs/filesystem/filesystem.cpp
@@ -55,6 +55,16 @@ namespace std { namespace experimental { namespace filesystem {
         path res(p.substr(idx));
         return res;
     }
+
+    path path::stem() {
+        auto idx = this->p.find_last_of("/");
+        auto q = this->p.substr(idx+1);
+        idx = q.find_last_of(".");
+        if( idx != std::string::npos )
+           q = q.substr( 0, idx );
+
+        return path( q );;
+    }
     // emd path class
 
     // file class:

--- a/libs/filesystem/filesystem.h
+++ b/libs/filesystem/filesystem.h
@@ -43,7 +43,8 @@ namespace std { namespace experimental { namespace filesystem {
         std::string generic_string() const;
         
         path filename();
-        
+        path stem();
+       
         path extension();
     };
     

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -25,6 +25,7 @@ struct QuadFilterChainState;
 #include <list>
 #include <utility>
 #include <atomic>
+#include <cstdio>
 
 #if TARGET_AUDIOUNIT
 class aulayer;
@@ -190,6 +191,8 @@ public:
    float refresh_ctrl_queue_value[8];
    bool process_input;
    int patchid_queue;
+   bool has_patchid_file;
+   char patchid_file[FILENAME_MAX];
 
    float vu_peak[8];
 

--- a/src/common/gui/CMenuAsSlider.cpp
+++ b/src/common/gui/CMenuAsSlider.cpp
@@ -13,8 +13,8 @@
 ** open source in September 2018.
 */
 
-#include "CMenuAsSlider.h"
 #include "SurgeGUIEditor.h"
+#include "CMenuAsSlider.h"
 #include "CScalableBitmap.h"
 #include <iostream>
 #include "DebugHelpers.h"

--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -18,7 +18,7 @@
 #include "SurgeStorage.h"
 #include "SkinSupport.h"
 
-class CPatchBrowser : public VSTGUI::CControl, public Surge::UI::SkinConsumingComponnt
+class CPatchBrowser : public VSTGUI::CControl, public VSTGUI::IDropTarget, public Surge::UI::SkinConsumingComponnt
 {
 public:
 
@@ -66,6 +66,21 @@ public:
          author = "";
       setDirty(true);
    }
+
+   virtual VSTGUI::DragOperation onDragEnter(VSTGUI::DragEventData data) override {
+      return VSTGUI::DragOperation::Copy;
+   }
+   virtual VSTGUI::DragOperation onDragMove(VSTGUI::DragEventData data) override
+   {
+       return VSTGUI::DragOperation::Copy;
+   }
+   virtual void onDragLeave(VSTGUI::DragEventData data) override
+   {
+   }
+
+   virtual bool onDrop(VSTGUI::DragEventData data) override;
+
+   virtual VSTGUI::SharedPointer<VSTGUI::IDropTarget> getDropTarget () override { return this; }
 
    virtual void draw(VSTGUI::CDrawContext* dc) override;
    VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -253,6 +253,12 @@ public:
                           std::function<void()> onClose = [](){} );
 
    std::string getDisplayForTag( long tag );
+
+   void queuePatchFileLoad( std::string file )
+      {
+         strncpy( synth->patchid_file, file.c_str(), FILENAME_MAX );
+         synth->has_patchid_file = true;
+      }
    
 private:
    int wsx = BASE_WINDOW_SIZE_X;


### PR DESCRIPTION
Add "Show Folder" menus to the Patch Browser menu.
Closes #2514

Load a patch from a file or Drag n Drop it in.
Closes #2475

Support FX Presets in per-FX folder.
Closes #2510