### PR TITLE
Airwindows Uses built In Defaults

### DIFF
--- a/resources/data/configuration.xml
+++ b/resources/data/configuration.xml
@@ -139,7 +139,7 @@
     </type>
     <separator/>
     <type i="14" name="Airwindows">
-      <snapshot name="Init"/>
+      <snapshot name="Init"  p0="0" p1="0" p2="0.5" p3="0.5" p4="0"/>
     </type>
 </fx>
 <customctrl>

--- a/src/common/dsp/effect/airwindows/airwindows_adapter.h
+++ b/src/common/dsp/effect/airwindows/airwindows_adapter.h
@@ -19,7 +19,7 @@ public:
    virtual void init_ctrltypes() override;
    virtual void init_default_values() override;
 
-   void resetCtrlTypes();
+   void resetCtrlTypes( bool useStreamedValues );
    
    virtual void process( float *dataL, float *dataR ) override;
 
@@ -30,10 +30,10 @@ public:
 
    lag<float, true> param_lags[n_fx_params - 1];
    
-   void setupSubFX(int awfx);
+   void setupSubFX(int awfx, bool useStreamedValues );
    std::unique_ptr<AirWinBaseClass> airwin;
    int lastSelected = -1;
-
+   
    struct Registration {
       std::function<std::unique_ptr<AirWinBaseClass>()> generator;
       int id;


### PR DESCRIPTION
Airwindows, when you swap the type manually or automate it,
brings the new FX online with reasonable defaults.

Closes #2526