### PR TITLE
TypeInStrings and BiPolar Trays for Airwindows

### DIFF
--- a/libs/airwindows/src/BitGlitter.cpp
+++ b/libs/airwindows/src/BitGlitter.cpp
@@ -137,6 +137,27 @@ void BitGlitter::getParameterDisplay(VstInt32 index, char *text) {
 	} //this displays the values and handles 'popups' where it's discrete choices
 }
 
+bool BitGlitter::parseParameterValueFromString( VstInt32 index, const char* txt, float &tf)
+{
+   float f = std::atof( txt );
+   switch( index ) {
+   case kParamA:
+   case kParamC:
+      tf = (f + 18.0)/36.0;
+      break;
+   default:
+      tf = f;
+      break;
+   }
+   return true;
+}
+
+bool BitGlitter::isParameterBipolar( VstInt32 index )
+{
+   if( index == kParamA || index == kParamC ) return true;
+   return false;
+}
+   
 void BitGlitter::getParameterLabel(VstInt32 index, char *text) {
     switch (index) {
         case kParamA: vst_strncpy (text, "", kVstMaxParamStrLen); break;

--- a/libs/airwindows/src/BitGlitter.h
+++ b/libs/airwindows/src/BitGlitter.h
@@ -53,6 +53,11 @@ public:
     virtual void getParameterName(VstInt32 index, char *text);    // name of the parameter
     virtual void getParameterDisplay(VstInt32 index, char *text); // text description of the current value    
     virtual VstInt32 canDo(char *text);
+
+   // Surge Add
+   virtual bool parseParameterValueFromString( VstInt32 index, const char* txt, float &f);
+   virtual bool isParameterBipolar( VstInt32 index );
+   // End Surge Add
 private:
     char _programName[kVstMaxProgNameLen + 1];
     std::set< std::string > _canDo;

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -312,6 +312,7 @@ void Parameter::set_user_data(ParamUserData* ud)
       }
       break;
    case ct_airwindow_param:
+   case ct_airwindow_param_bipolar:
       if( dynamic_cast<ParameterExternalFormatter*>(ud))
       {
          user_data = ud;
@@ -809,6 +810,7 @@ void Parameter::set_type(int ctrltype)
       val_default.i = 0;
       break;
    case ct_airwindow_param:
+   case ct_airwindow_param_bipolar: // it's still 0,1; this is just a display thing
       val_min.f = 0;
       val_max.f = 1;
       valtype = vt_float;
@@ -995,6 +997,7 @@ void Parameter::set_type(int ctrltype)
       break;
 
    case ct_airwindow_param:
+   case ct_airwindow_param_bipolar:
       displayType = DelegatedToFormatter;
       displayInfo.scale = 1.0;
       displayInfo.unit[0] = 0;
@@ -2463,6 +2466,7 @@ bool Parameter::can_setvalue_from_string()
    case ct_sendlevel:
    case ct_freq_mod:
    case ct_airwindow_param:
+   case ct_airwindow_param_bipolar:
    {
       return true;
       break;
@@ -2597,6 +2601,19 @@ bool Parameter::set_value_from_string( std::string s )
       // handled below
       break;
    case DelegatedToFormatter:
+   {
+      auto ef = dynamic_cast<ParameterExternalFormatter *>( user_data );
+      if( ef )
+      {
+         float f;
+         if( ef->stringToValue( c, f ) )
+         {
+            val.f = limit_range( f, val_min.f, val_max.f );
+            return true;
+         }
+      }
+      // break; DO NOT break. Fall back
+   }
    case LinearWithScale:
    {
       float ext_mul = ( can_extend_range() && extend_range ) ? displayInfo.extendFactor : 1.0;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -132,6 +132,7 @@ enum ctrltypes
    ct_vocoder_modulator_mode,
    ct_airwindow_fx,
    ct_airwindow_param,
+   ct_airwindow_param_bipolar,
    num_ctrltypes,
 };
 
@@ -165,6 +166,7 @@ struct CountedSetUserData : public ParamUserData
 struct ParameterExternalFormatter : public ParamUserData
 {
    virtual void formatValue( float value, char *txt, int txtlen ) = 0;
+   virtual bool stringToValue( const char* txt, float &outVal ) = 0;
 };
 
 struct ParameterDiscreteIndexRemapper : public ParamUserData

--- a/src/common/dsp/effect/airwindows/airwindows_adapter.cpp
+++ b/src/common/dsp/effect/airwindows/airwindows_adapter.cpp
@@ -106,7 +106,14 @@ void AirWindowsEffect::resetCtrlTypes( bool useStreamedValues ) {
          airwin->getParameterName( i, txt );
          auto priorVal = fxdata->p[i+1].val.f;
          fxdata->p[i+1].set_name( txt );
-         fxdata->p[i+1].set_type( ct_airwindow_param );
+         if( airwin->isParameterBipolar( i ) )
+         {
+            fxdata->p[i+1].set_type( ct_airwindow_param_bipolar );
+         }
+         else
+         {
+            fxdata->p[i+1].set_type( ct_airwindow_param );
+         }
          fxdata->p[i+1].set_user_data( fxFormatters[i].get() );
          fxdata->p[i+1].posy_offset = 3;
 

--- a/src/common/dsp/effect/airwindows/airwindows_adapter.h
+++ b/src/common/dsp/effect/airwindows/airwindows_adapter.h
@@ -83,6 +83,19 @@ public:
             sprintf( txt, "AWA.ERROR %lf", value );
          }
       }
+
+      virtual bool stringToValue( const char* txt, float &outVal ) override {
+         if( fx && fx->airwin )
+         {
+            float v;
+            if( fx->airwin->parseParameterValueFromString( idx, txt, v ) )
+            {
+               outVal = v;
+               return true;
+            }
+         }
+         return false;
+      }
       AirWindowsEffect *fx;
       int idx;
    };

--- a/src/common/dsp/effect/airwindows/audioeffect_airwinstub.h
+++ b/src/common/dsp/effect/airwindows/audioeffect_airwinstub.h
@@ -31,6 +31,12 @@ struct AirWinBaseClass {
    
    virtual float getParameter( VstInt32 index ) = 0;
    virtual void setParameter( VstInt32 index, float value ) = 0;
+
+   virtual bool parseParameterValueFromString( VstInt32 index, const char* str, float &f ) {
+      return false;
+   }
+   virtual bool isParameterBipolar( VstInt32 index ) { return false; }
+   
    virtual void processReplacing( float **in, float **out, VstInt32 sampleFrames ) = 0;
 
    virtual void getParameterName(VstInt32 index, char *text) = 0;    // name of the parameter

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1261,6 +1261,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          case ct_percent_bidirectional_stereo:
          case ct_freq_shift:
          case ct_osc_feedback_negative:
+         case ct_airwindow_param_bipolar:
             style |= kBipolar;
             break;
          case ct_lfoamplitude:
@@ -1468,6 +1469,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          case ct_percent_bidirectional_stereo:
          case ct_freq_shift:
          case ct_osc_feedback_negative:
+         case ct_airwindow_param_bipolar:
             style |= kBipolar;
             break;
          case ct_lfoamplitude:


### PR DESCRIPTION
AW now has an API by which we can delegate back to the
plugin for typein strings and bipolarity, and implements that in BitGlitter

Addresses #2525