### PR TITLE
Make mousewheel click threshold more correct in windows

### DIFF
--- a/src/common/gui/CMenuAsSlider.cpp
+++ b/src/common/gui/CMenuAsSlider.cpp
@@ -130,14 +130,18 @@ void CMenuAsSlider::onSkinChanged()
 bool CMenuAsSlider::onWheel( const VSTGUI::CPoint &where, const float &distance, const VSTGUI::CButtonState &buttons ) {
    wheelDistance += distance;
    float dDistance = 1.f / std::max( ( iMax - iMin ), 1 );
-   if( wheelDistance > 1 ) {
-      wheelDistance -= 1;
+   float threshold = 1;
+#if WINDOWS
+   threshold = 0.33;
+#endif   
+   if( wheelDistance > threshold ) {
+      wheelDistance -= threshold;
       setValue( limit_range( getValue() - dDistance, 0.f, 1.f ) );
       if( listener )
          listener->valueChanged(this);
    }
-   if( wheelDistance < -1 ) {
-      wheelDistance += 1;
+   if( wheelDistance < -threshold ) {
+      wheelDistance += threshold;
       setValue( limit_range( getValue() + dDistance, 0.f, 1.f ) );
       if( listener )
          listener->valueChanged(this);


### PR DESCRIPTION
Instead of three clicks to change step in a menu, now only one click is required.