### PR TITLE
Split the unwrapped phase into an int and float part

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -106,12 +106,12 @@ float CubicInterpolate(float y0, float y1, float y2, float y3, float mu)
 void LfoModulationSource::initPhaseFromStartPhase()
 {
    phase = localcopy[startphase].f;
-   unwrappedphase = phase;
    phaseInitialized = true;
    while( phase < 0.f )
       phase += 1.f;
    while( phase > 1.f )
       phase -= 1.f;
+   unwrappedphase_intpart = 0;
 }
 
 void LfoModulationSource::attack()
@@ -249,7 +249,10 @@ void LfoModulationSource::attack()
       {
          phase += 0.25;
          if (phase > 1.f)
+         {
             phase -= 1.f;
+            unwrappedphase_intpart ++;
+         }
       }
    }
    break;
@@ -259,7 +262,10 @@ void LfoModulationSource::attack()
       {
          phase += 0.75;
          if (phase > 1.f)
+         {
             phase -= 1.f;
+            unwrappedphase_intpart ++;
+         }
       }
    }
    break;
@@ -295,7 +301,6 @@ void LfoModulationSource::process_block()
    if (lfo->rate.temposync)
       frate *= storage->temposyncratio;
    phase += frate * ratemult;
-   unwrappedphase += frate * ratemult;
 
    if( frate == 0 && phase == 0 && s == ls_stepseq )
    {
@@ -412,6 +417,7 @@ void LfoModulationSource::process_block()
       {
          float ipart;
          phase = modf( phase, &ipart );
+         unwrappedphase_intpart += ipart;
       }
       else if( phase < 0 )
       {
@@ -419,14 +425,17 @@ void LfoModulationSource::process_block()
          //
          int p = (int) phase - 1;
          float np = -p + phase;
-         if( np >= 0 && np < 1 )
+         if( np >= 0 && np < 1 ) {
             phase = np;
+            unwrappedphase_intpart += p;
+         }
          else
             phase = 0; // should never get here but something is already wierd with the mod stack
       }
       else
       {
          phase -= 1;
+         unwrappedphase_intpart ++;
       }
 
       switch (s)
@@ -574,7 +583,7 @@ void LfoModulationSource::process_block()
       }
       break;
    case ls_mseg:
-      iout = MSEGModulationHelper::valueAt( unwrappedphase, localcopy[ideform].f, ms );
+      iout = MSEGModulationHelper::valueAt( unwrappedphase_intpart, phase, localcopy[ideform].f, ms );
       break;
    };
 

--- a/src/common/dsp/LfoModulationSource.h
+++ b/src/common/dsp/LfoModulationSource.h
@@ -79,7 +79,8 @@ private:
    bool phaseInitialized;
    void initPhaseFromStartPhase();
 
-   float phase, unwrappedphase, target, noise, noised1, env_phase, priorPhase;
+   float phase, target, noise, noised1, env_phase, priorPhase;
+   int unwrappedphase_intpart;
    float ratemult;
    float env_releasestart;
    float iout;

--- a/src/common/dsp/MSEGModulationHelper.cpp
+++ b/src/common/dsp/MSEGModulationHelper.cpp
@@ -49,14 +49,20 @@ void MSEGModulationHelper::rebuildCache( MSEGStorage *ms )
       }
    }
    ms->totalDuration = totald;
-   
 }
 
-float MSEGModulationHelper::valueAt(float up, float df, MSEGStorage *ms)
+float MSEGModulationHelper::valueAt(int ip, float fup, float df, MSEGStorage *ms)
 {
    if( ms->n_activeSegments == 0 ) return df;
-   
-   while( up >= ms->totalDuration ) up -= ms->totalDuration;
+
+   // This still has some problems but lets try this for now
+   double up = (double)ip + fup;
+   if( up >= ms->totalDuration ) {
+      double nup = up / ms->totalDuration;
+      up -= (int)nup * ms->totalDuration;
+      if( up < 0 )
+         up += ms->totalDuration;
+   }
 
    df = limit_range( df, -1.f, 1.f );
    

--- a/src/common/dsp/MSEGModulationHelper.h
+++ b/src/common/dsp/MSEGModulationHelper.h
@@ -4,5 +4,5 @@
 
 struct MSEGModulationHelper {
    static void rebuildCache(MSEGStorage *s);
-   static float valueAt(float unwrappedPhase, float deform, MSEGStorage *s );
+   static float valueAt(int phaseIntPart, float phaseFracPart, float deform, MSEGStorage *s );
 };

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -497,7 +497,9 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent {
       for( int i=0; i<drawArea.getWidth(); ++i )
       {
          float up = pxt( i );
-         float v = MSEGModulationHelper::valueAt( up, lfodata->deform.val.f, ms );
+         float iup = (int)up;
+         float fup = up - iup;
+         float v = MSEGModulationHelper::valueAt( iup, fup, lfodata->deform.val.f, ms );
          v = valpx( v );
          if( up <= ms->totalDuration )
          {


### PR DESCRIPTION
Unwrapped phase was a float which woulc quickly accumulate
errors. Make it an int and a float part separately.