### PR TITLE
Fixing a slider bug in VST2

### DIFF
--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -370,19 +370,19 @@ void Vst2PluginInstance::getParameterLabel(VstInt32 index, char* label)
 
 bool Vst2PluginInstance::getEffectName(char* name)
 {
-   strcpy(name, stringProductName);
+   strcpy(name, "Surge");
    return true;
 }
 
 bool Vst2PluginInstance::getProductString(char* name)
 {
-   strcpy(name, stringProductName);
+   strcpy(name, "Surge");
    return true;
 }
 
 bool Vst2PluginInstance::getVendorString(char* text)
 {
-   strcpy(text, stringCompanyName);
+   strcpy(text, "Open Source Surge Synth Team");
    return true;
 }
 


### PR DESCRIPTION
Changes to name and string caused problems in VST2 on filter 1 resonance slider. This change fixes it.

closes #2584