### PR TITLE
Deactivated rate SS can still trigger envelopes

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -542,6 +542,26 @@ void LfoModulationSource::process_block()
             while( pstep > last_step && pstep >= 0 ) pstep -= loop_len;
             pstep = pstep & ( n_stepseqsteps - 1 );
 
+            if( pstep != priorStep )
+            {
+               priorStep = pstep;
+               
+               if (ss->trigmask & (UINT64_C(1) << pstep))
+               {
+                  retrigger_FEG = true;
+                  retrigger_AEG = true;
+               }
+               if (ss->trigmask & (UINT64_C(1) << (16+pstep)))
+               {
+                  retrigger_FEG = true;
+               }
+               if (ss->trigmask & (UINT64_C(1) << (32+pstep)))
+               {
+                  retrigger_AEG = true;
+               }
+
+            }
+            
             if( priorPhase != phase )
             {
                priorPhase = phase;

--- a/src/common/dsp/LfoModulationSource.h
+++ b/src/common/dsp/LfoModulationSource.h
@@ -81,6 +81,7 @@ private:
 
    float phase, target, noise, noised1, env_phase, priorPhase;
    int unwrappedphase_intpart;
+   int priorStep = -1;
    float ratemult;
    float env_releasestart;
    float iout;


### PR DESCRIPTION
The SS can still trigger an envelope, in this case
whenever it hits a new step first.

Closes #2575