### PR TITLE
Expand WT Format

### DIFF
--- a/resources/data/wavetables/wt fileformat.txt
+++ b/resources/data/wavetables/wt fileformat.txt
@@ -8,6 +8,7 @@ the rest of the data is in little-endian types
         0002: loop sample
         0004: if clear, wave data is in float32 format
               if set, wave data is in int16 format
+        0008: if set, int16 data is in range 2^16; if not set it is in range 2^15 (legacy)
 12-end	wave data
         float32 format: 4*wave_size*wave_count bytes
         int16 format: 2*wave_size*wave_count bytes

--- a/scripts/wt-tool/wt-info.py
+++ b/scripts/wt-tool/wt-info.py
@@ -5,7 +5,12 @@ for dirpath, dirnames, files in os.walk("resources/data"):
         if name.lower().endswith(".wt"):
             wt = os.path.join(dirpath, name)
             with open(wt, "rb") as f:
-                f.read(4)
-                wsize = int.from_bytes(f.read(4), 'little')
-                if(wsize == 128):
-                    print(wt)
+                header = {}
+                header["ident"] = f.read(4)
+                # FIXME: Check that this is actually vawt
+
+                header["wavsz"] = f.read(4)
+                header["wavct"] = f.read(2)
+                header["flags"] = f.read(2)
+
+                print( wt, " ", header["flags" ][0], header["flags"][1] );

--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -221,6 +221,12 @@ bool Wavetable::BuildWT(void* wdata, wt_header& wh, bool AppendSilence)
       {
          vt_copyblock_W_LE(&this->TableI16WeakPointers[0][j][FIRoffsetI16],
                            &((short*)wdata)[this->size * j], this->size);
+         if( this->flags & wtf_int16_is_16 )
+         {
+            i16toi15_block(&this->TableI16WeakPointers[0][j][FIRoffsetI16],
+                           &this->TableI16WeakPointers[0][j][FIRoffsetI16],
+                           this->size);
+         }
          i152float_block(&this->TableI16WeakPointers[0][j][FIRoffsetI16],
                          this->TableF32WeakPointers[0][j], this->size);
       }

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -51,5 +51,6 @@ enum wtflags
 {
    wtf_is_sample = 1,
    wtf_loop_sample = 2,
-   wtf_int16 = 4,
+   wtf_int16 = 4, // If this is set we have int16 in range 0-2^15
+   wtf_int16_is_16 = 8, // and in this case, range 0-2^16 if with above
 };

--- a/src/common/vt_dsp/basic_dsp.cpp
+++ b/src/common/vt_dsp/basic_dsp.cpp
@@ -172,6 +172,15 @@ void i152float_block(short* s, float* f, int n)
    }
 }
 
+
+void i16toi15_block(short* s, short* o, int n)
+{
+   for (int i = 0; i < n; i++)
+   {
+      o[i] = s[i] >> 1;
+   }
+}
+
 void hardclip_block(float* x, unsigned int nquads)
 {
    const __m128 x_min = _mm_set1_ps(-1.0f);

--- a/src/common/vt_dsp/basic_dsp.h
+++ b/src/common/vt_dsp/basic_dsp.h
@@ -38,6 +38,7 @@ float get_squaremax(float* d, unsigned int nquads);
 float get_absmax_2(float* d1, float* d2, unsigned int nquads);
 void float2i15_block(float*, short*, int);
 void i152float_block(short*, float*, int);
+void i16toi15_block(short*, short*, int);
 
 float sine_ss(unsigned int x);
 int sine(int x);


### PR DESCRIPTION
The WT Format with integers (flag & 4 == 1) assumes int16
has range 0-2^15. This requires all sorts of normalization
and stuff. That has to stay, but if we add another flag
(flag & 8 == 1) we can then do the 2^16 -> 2^15 in code rather
than at WT time (and in the future, perhaps even keep that extra
bit of precision).