### PR TITLE
Implemented sticky mod assign mode

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3867,10 +3867,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
             {
             case 0:
                modsource = newsource;
-
-               mod_editor = false;
-               // mod_editor = true;
-               queue_refresh = true;
+               mod_editor = true;
                refresh_mod();
                break;
             case 1:
@@ -3888,7 +3885,6 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                break;
             };
          }
-         //((gui_modsrcbutton*)control)->
 
          if (isLFO(newsource) && !(buttons & kShift))
          {


### PR DESCRIPTION
Closes #1152

Clicking on another modulator while in mod assign mode doesn't reset the mod assign mode, instead stays active. To disable mod assign mode gotta click the active modulator, or press Tab or middle mouse click as usual.
