### PR TITLE
Clamp FM Depth

### DIFF
--- a/src/headless/UnitTestsDSP.cpp
+++ b/src/headless/UnitTestsDSP.cpp
@@ -348,6 +348,17 @@ TEST_CASE( "lipol_ps class", "[dsp]" )
 
 TEST_CASE( "Check FastMath Functions", "[dsp]" )
 {
+   SECTION( "Clamp to -PI,PI" )
+   {
+      for( float f = -2132.7; f < 37424.3; f += 0.741 )
+      {
+         float q = Surge::DSP::clampToPiRange( f );
+         INFO( "Clamping " << f << " to " << q );
+         REQUIRE( q > -M_PI );
+         REQUIRE( q < M_PI );
+      }
+   }
+   
    SECTION( "fastSin and fastCos in range -PI, PI" )
    {
       float sds = 0, md = 0;


### PR DESCRIPTION
In extremis, FM Depth pushed phase beyond the floating
point accuracy needed to even clamp to -PI,PI, so
apply a clamp at the outset of the block.

CLoses #2619