### PR TITLE
Airwindows loading anew while suspended gives correct state

### DIFF
--- a/src/common/dsp/effect/airwindows/airwindows_adapter.cpp
+++ b/src/common/dsp/effect/airwindows/airwindows_adapter.cpp
@@ -81,7 +81,7 @@ void AirWindowsEffect::init_ctrltypes() {
 
    for( int i=0; i<n_fx_params - 1; ++i )
    {
-      fxdata->p[i+1].set_type( ct_airwindow_param );
+      fxdata->p[i+1].set_type( ct_none );
       std::string w = "Airwindow " + std::to_string(i);
       fxdata->p[i+1].set_name( w.c_str() );
 

--- a/src/common/dsp/effect/airwindows/airwindows_adapter.h
+++ b/src/common/dsp/effect/airwindows/airwindows_adapter.h
@@ -29,9 +29,15 @@ public:
    // TODO ringout and only control and suspend
    virtual void suspend() override
    {
-      if( fxdata )
-         fxdata->p[0].deactivated = true;
       hasInvalidated = true;
+
+      if( fxdata ) {
+         fxdata->p[0].deactivated = true;
+         if( fxdata->p[1].ctrltype == ct_none )
+         {
+            setupSubFX( fxdata->p[0].val.i, true );
+         }
+      }
    }
 
    lag<float, true> param_lags[n_fx_params - 1];
@@ -110,6 +116,6 @@ public:
 
    std::array<std::unique_ptr<AWFxParamFormatter>, n_fx_params - 1> fxFormatters;
    
-   
+
    std::unique_ptr<AWFxSelectorMapper> mapper;
 };


### PR DESCRIPTION
Airwindows when loading anwe while suspended didn't reset the
FX information so we got an unsatisfactory display. Remediate.

CLoses #2649