### PR TITLE
Parameter names change fix for VST2

### DIFF
--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -400,7 +400,7 @@ void Vst2PluginInstance::processT(float** inputs, float** outputs, VstInt32 samp
    s->process_input = (!plug_is_synth || input_connected);
 
 
-   if( checkNamesEvery++ == 20 )
+   if( checkNamesEvery++ == 350 )
    {
       checkNamesEvery = 0;
       if( std::atomic_exchange( &parameterNameUpdated, false ) )


### PR DESCRIPTION
Lower then 350 and the crashes start.