### PR TITLE
VST2 Header Order Problem

### DIFF
--- a/src/common/gui/vstcontrols.h
+++ b/src/common/gui/vstcontrols.h
@@ -1,4 +1,8 @@
 #pragma once
 
+#if TARGET_VST2
+#include "vstgui/plugin-bindings/aeffguieditor.h"
+#endif
+
 #include "vstgui/vstgui.h"
 #include "CCursorHidingControl.h"


### PR DESCRIPTION
VST2SDK and VSTGUI have a required-include-order bug.
So force the required include order if TARGET_VST2 is true.