### PR TITLE
Extend Phase Ringout at High Feedback

### DIFF
--- a/src/common/dsp/effect/PhaserEffect.cpp
+++ b/src/common/dsp/effect/PhaserEffect.cpp
@@ -282,3 +282,15 @@ void PhaserEffect::handleStreamingMismatches(int streamingRevision, int currentS
       fxdata->p[pp_width].val.f = 0.f;
    }
 }
+
+int PhaserEffect::get_ringout_decay()
+{
+   auto fb = fxdata->p[pp_feedback].val.f;
+   // The ringout is longer at high feedbacks. This is just a heuristic based on
+   // testing with the patch in #2663
+   if( fb > 0.9 || fb < -0.9 )
+      return 5000;
+   if( fb > 0.5 || fb < -0.5 )
+      return 3000;
+   return 1000;
+}

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -214,10 +214,7 @@ public:
    virtual void init() override;
    virtual void process_only_control() override;
    virtual void process(float* dataL, float* dataR) override;
-   virtual int get_ringout_decay() override
-   {
-      return 1000;
-   }
+   virtual int get_ringout_decay() override;
    virtual void suspend() override;
    void setvars();
    virtual void init_ctrltypes() override;


### PR DESCRIPTION
At High Feedback the short phaser ringout would truncate
feedback resonances. Add a heursitic which gives us more time.

Closes #2663