### PR TITLE
Random and Alternate are stateful-per-scene but Snapped-per-voice

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -153,6 +153,7 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    modsources[ms_releasevelocity] = &releaseVelocitySource;
    modsources[ms_keytrack] = &keytrackSource;
    modsources[ms_polyaftertouch] = &polyAftertouchSource;
+
    polyAftertouchSource.init(storage->poly_aftertouch[state.scene_id & 1][state.key & 127]);
 
    velocitySource.output = state.fvel;
@@ -185,10 +186,21 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    modsources[ms_slfo5] = oscene->modsources[ms_slfo5];
    modsources[ms_slfo6] = oscene->modsources[ms_slfo6];
 
-   modsources[ms_random_bipolar] = oscene->modsources[ms_random_bipolar];
-   modsources[ms_random_unipolar] = oscene->modsources[ms_random_unipolar];
-   modsources[ms_alternate_bipolar] = oscene->modsources[ms_alternate_bipolar];
-   modsources[ms_alternate_unipolar] = oscene->modsources[ms_alternate_unipolar];
+   /*
+   ** We want to snap the rnd and alt
+   */
+   rndUni.output = oscene->modsources[ms_random_unipolar]->output;
+   modsources[ms_random_unipolar] = &rndUni;
+
+   rndBi.output = oscene->modsources[ms_random_bipolar]->output;
+   modsources[ms_random_bipolar] = &rndBi;
+
+   altUni.output = oscene->modsources[ms_alternate_unipolar]->output;
+   modsources[ms_alternate_unipolar] = &altUni;
+
+   altBi.output = oscene->modsources[ms_alternate_bipolar]->output;
+   modsources[ms_alternate_bipolar] = &altBi;
+
    
    id_cfa = scene->filterunit[0].cutoff.param_id_in_scene;
    id_cfb = scene->filterunit[1].cutoff.param_id_in_scene;

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -186,6 +186,7 @@ private:
    ControllerModulationSource polyAftertouchSource;
    ModulationSource monoAftertouchSource;
    ModulationSource timbreSource;
+   ModulationSource rndUni, rndBi, altUni, altBi;
    AdsrEnvelope ampEGSource;
    AdsrEnvelope filterEGSource;
 


### PR DESCRIPTION
Make sure the voice holds the value of the random or alternate
modulator from voice inception until voice completion even
though the state in the scene marches forwards