### PR TITLE
Pop an error if a patch doesn't get a load attempt

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -196,6 +196,8 @@ private:
    int zoomFactor;
    bool zoomEnabled = true;
 
+   int patchCountdown = -1;
+   
 public:
 
    void populateDawExtraState(SurgeSynthesizer *synth) {


### PR DESCRIPTION
Patch loads happen in SurgeSynth::process so if you don't have audio
running in some daws on windows it just looks broken when you use
the menu. Detect this condition in the idle loop and pop an instructive
error.

Closes #2479