### PR TITLE
When closing miniEdit we didn't nullptr it

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4219,6 +4219,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
          editorOverlay = nullptr;
       }
    }
+   break;
    case tag_miniedit_ok:
    case tag_miniedit_cancel:
    {
@@ -4234,8 +4235,10 @@ void SurgeGUIEditor::valueChanged(CControl* control)
          }
          minieditOverlay->setVisible( false );
          removeFromFrame.push_back( minieditOverlay );
+         minieditOverlay = nullptr;
       }
    }
+   break;
    case tag_value_typein:
    {
       if( typeinDialog && typeinMode != Inactive )


### PR DESCRIPTION
Set the poitner to null to avoid future references after
deletion

Addresses #2698