### PR TITLE
macOS: Fix build with generators other than Xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,7 @@ if( APPLE )
     )
 
   set(OS_COMPILE_OPTIONS
+    -fasm-blocks
     -msse2
     "-D_aligned_malloc(x,a)=malloc(x)"
     "-D_aligned_free(x)=free(x)"
@@ -717,7 +718,7 @@ if( BUILD_AU )
     POST_BUILD
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND echo "Packaging up AU component"
-    COMMAND ./scripts/macOS/package-au.sh  ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/libsurge-au-dll.dylib ${SURGE_PRODUCT_DIR}
+    COMMAND ./scripts/macOS/package-au.sh  $<TARGET_FILE:surge-au-dll> ${SURGE_PRODUCT_DIR}
     COMMAND codesign --force --sign - --timestamp=none ${SURGE_PRODUCT_DIR}/Surge.component/
     COMMAND codesign -v ${SURGE_PRODUCT_DIR}/Surge.component/
     )

--- a/scripts/macOS/package-au.sh
+++ b/scripts/macOS/package-au.sh
@@ -1,5 +1,7 @@
 #!/bin/bash          
 
+set -euo pipefail
+
 # If no vectors are specified, use the original-vector by default
 # input config
 RES_SRC_LOCATION="resources"

--- a/scripts/macOS/package-vst.sh
+++ b/scripts/macOS/package-vst.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # If no vectors are specified, use the original-vector by default
 # input config
 RES_SRC_LOCATION="resources"

--- a/scripts/macOS/package-vst3.sh
+++ b/scripts/macOS/package-vst3.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # If no vectors are specified, use the original-vector by default
 echo "$1 is bin"
 # input config


### PR DESCRIPTION
Enables effective use of alternative IDEs such as [CLion](https://www.jetbrains.com/clion/).