### PR TITLE
Keep original value on screen for a bit after releasing the elastic gesture

### DIFF
--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -739,6 +739,7 @@ CMouseEventResult CSurgeSlider::onMouseUp(CPoint& where, const CButtonState& but
    // "elastic edit" - resets to the value before the drag started if Alt is held
    if (buttons & kAlt)
    {
+      hasBeenDraggedDuringMouseGesture = false;
       *edit_value = oldVal;
       setDirty();
       if (isDirty() && listener)


### PR DESCRIPTION
- Keep original value on screen for a bit after releasing the elastic gesture
