### PR TITLE
Implement MIDI smoothing options

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -114,6 +114,8 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
 
    SurgePatch& patch = storage.getPatch();
 
+   smoothingMode = (ControllerModulationSource::SmoothingMode)(int)Surge::Storage::getUserDefaultValue( &storage, "smoothingMode", (int)( ControllerModulationSource::SmoothingMode::LEGACY ));
+
    patch.polylimit.val.i = 16;
    for (int sc = 0; sc < 2; sc++)
    {
@@ -121,15 +123,15 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
       scene.modsources.resize(n_modsources);
       for (int i = 0; i < n_modsources; i++)
          scene.modsources[i] = 0;
-      scene.modsources[ms_modwheel] = new ControllerModulationSource();
-      scene.modsources[ms_breath] = new ControllerModulationSource();
-      scene.modsources[ms_expression] = new ControllerModulationSource();
-      scene.modsources[ms_sustain] = new ControllerModulationSource();
-      scene.modsources[ms_aftertouch] = new ControllerModulationSource();
-      scene.modsources[ms_pitchbend] = new ControllerModulationSource();
-      scene.modsources[ms_lowest_key] = new ControllerModulationSource();
-      scene.modsources[ms_highest_key] = new ControllerModulationSource();
-      scene.modsources[ms_latest_key] = new ControllerModulationSource();
+      scene.modsources[ms_modwheel] = new ControllerModulationSource(smoothingMode);
+      scene.modsources[ms_breath] = new ControllerModulationSource(smoothingMode);
+      scene.modsources[ms_expression] = new ControllerModulationSource(smoothingMode);
+      scene.modsources[ms_sustain] = new ControllerModulationSource(smoothingMode);
+      scene.modsources[ms_aftertouch] = new ControllerModulationSource(smoothingMode);
+      scene.modsources[ms_pitchbend] = new ControllerModulationSource(smoothingMode);
+      scene.modsources[ms_lowest_key] = new ControllerModulationSource(smoothingMode);
+      scene.modsources[ms_highest_key] = new ControllerModulationSource(smoothingMode);
+      scene.modsources[ms_latest_key] = new ControllerModulationSource(smoothingMode);
 
       scene.modsources[ms_random_bipolar] = new RandomModulationSource( true );
       scene.modsources[ms_random_unipolar] = new RandomModulationSource( false );
@@ -150,7 +152,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
    }
    for (int i = 0; i < n_customcontrollers; i++)
    {
-      patch.scene[0].modsources[ms_ctrl1 + i] = new ControllerModulationSource();
+      patch.scene[0].modsources[ms_ctrl1 + i] = new ControllerModulationSource(smoothingMode);
       patch.scene[1].modsources[ms_ctrl1 + i] =
          patch.scene[0].modsources[ms_ctrl1 + i];
    }
@@ -224,7 +226,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
       }
       pid++;
    }
-#endif   
+#endif
 }
 
 SurgeSynthesizer::~SurgeSynthesizer()
@@ -1459,6 +1461,8 @@ ControllerModulationSource* SurgeSynthesizer::AddControlInterpolator(int Id, boo
       // Add new
       mControlInterpolator[Index].id = Id;
       mControlInterpolatorUsed[Index] = true;
+
+      mControlInterpolator[Index].smoothingMode = smoothingMode; // IMPLEMENT THIS HERE
       return &mControlInterpolator[Index];
    }
 
@@ -3190,4 +3194,20 @@ void SurgeSynthesizer::swapMetaControllers( int c1, int c2 )
    storage.CS_ModRouting.leave();
 
    refresh_editor = true;
+}
+
+void SurgeSynthesizer::changeModulatorSmoothing( ControllerModulationSource::SmoothingMode m )
+{
+   smoothingMode = m;
+   for (int sc = 0; sc < n_scenes; ++sc)
+   {
+      for( int q = 0; q<n_modsources; ++q )
+      {
+         auto cms = dynamic_cast<ControllerModulationSource *>(storage.getPatch().scene[sc].modsources[q]) ;
+         if( cms )
+         {
+            cms->smoothingMode = m;
+         }
+      }
+   }
 }

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -240,7 +240,9 @@ public:
    std::string hostProgram = "Unknown Host";
    bool activateExtraOutputs = true;
    void setupActivateExtraOutputs();
-   
+
+   void changeModulatorSmoothing( ControllerModulationSource::SmoothingMode m );
+
    // these have to be thread-safe, so keep private
 private:
    
@@ -249,7 +251,7 @@ private:
    void switch_toggled();
 
    // midicontrol-interpolators
-   static const int num_controlinterpolators = 32;
+   static const int num_controlinterpolators = 128;
    ControllerModulationSource mControlInterpolator[num_controlinterpolators];
    bool mControlInterpolatorUsed[num_controlinterpolators];
 
@@ -258,4 +260,6 @@ private:
    void ReleaseControlInterpolator(int Idx);
    ControllerModulationSource* ControlInterpolator(int Idx);
    ControllerModulationSource* AddControlInterpolator(int Idx, bool& AlreadyExisted);
+
+   ControllerModulationSource::SmoothingMode smoothingMode;
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -5800,10 +5800,33 @@ VSTGUI::COptionMenu* SurgeGUIEditor::makeDataMenu(VSTGUI::CRect& menuRect)
 
 VSTGUI::COptionMenu* SurgeGUIEditor::makeMidiMenu(VSTGUI::CRect& menuRect)
 {
-   int did = 0;
    COptionMenu* midiSubMenu = new COptionMenu(menuRect, 0, 0, 0, 0,
                                               VSTGUI::COptionMenu::kNoDrawStyle |
-                                                  VSTGUI::COptionMenu::kMultipleCheckStyle);
+                                              VSTGUI::COptionMenu::kMultipleCheckStyle);
+
+
+   int did = 0;
+   COptionMenu *smoothMenu = new COptionMenu( menuRect, 0, 0, 0, 0,
+                                                VSTGUI::COptionMenu::kNoDrawStyle |
+                                                VSTGUI::COptionMenu::kMultipleCheckStyle );
+
+   int smoothing = Surge::Storage::getUserDefaultValue(&(synth->storage), "smoothingMode", (int)ControllerModulationSource::SmoothingMode::LEGACY );
+
+   auto asmt = [this, smoothMenu, smoothing]( const char* label, ControllerModulationSource::SmoothingMode md )
+   {
+     auto me = addCallbackMenu(smoothMenu, label,
+                        [this, md]() {this->resetSmoothing(md);});
+     me->setChecked( smoothing == md );
+   };
+   asmt( "Legacy", ControllerModulationSource::SmoothingMode::LEGACY );
+   asmt( "Slow Smooth", ControllerModulationSource::SmoothingMode::SLOW_EXP );
+   asmt( "Fast Smooth", ControllerModulationSource::SmoothingMode::FAST_EXP );
+   asmt( "Fast Line", ControllerModulationSource::SmoothingMode::FAST_LINE );
+   asmt( "Direct (unsmoothed)", ControllerModulationSource::SmoothingMode::DIRECT );
+   midiSubMenu->addEntry( smoothMenu, "Controller Smoothing" );
+   did++;
+   midiSubMenu->addSeparator();
+   did++;
 
    addCallbackMenu(
        midiSubMenu, Surge::UI::toOSCaseForMenu("Save MIDI Mapping As..."),
@@ -5822,8 +5845,8 @@ VSTGUI::COptionMenu* SurgeGUIEditor::makeMidiMenu(VSTGUI::CRect& menuRect)
    addCallbackMenu(
       midiSubMenu, Surge::UI::toOSCaseForMenu("Show Current MIDI Mapping..."),
       [this]() {
-         Surge::UserInteractions::showHTML( this->midiMappingToHtml() );
-      }
+            Surge::UserInteractions::showHTML( this->midiMappingToHtml() );
+         }
       );
 
    did++;
@@ -7103,4 +7126,11 @@ void SurgeGUIEditor::openModTypeinOnDrop( int modt, CControl *sl, int slidertag 
 
    if( synth->isValidModulation( p->id, (modsources)ms ) )
        promptForUserValueEntry( p, sl, ms );
+}
+
+void SurgeGUIEditor::resetSmoothing( ControllerModulationSource::SmoothingMode t )
+{
+   // Reset the default value and tell the synth it is updated
+   Surge::Storage::updateUserDefaultValue(&(synth->storage), "smoothingMode", (int)t );
+   synth->changeModulatorSmoothing( t );
 }

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -395,6 +395,8 @@ private:
    VSTGUI::COptionMenu* makeDevMenu(VSTGUI::CRect &rect);
    bool scannedForMidiPresets = false;
 
+   void resetSmoothing( ControllerModulationSource::SmoothingMode t );
+
 public:
    std::string helpURLFor( Parameter *p );
    std::string helpURLForSpecial( std::string special );

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -745,3 +745,105 @@ TEST_CASE( "LfoTempoSync Latch Drift", "[mod]" )
 
    }
 }
+
+TEST_CASE( "CModulationSources", "[mod]" )
+{
+   SECTION( "Legacy Mode")
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge );
+      ControllerModulationSource a(ControllerModulationSource::SmoothingMode::LEGACY);
+      a.init( 0.5f );
+      REQUIRE( a.output == 0.5f );
+      float t = 0.6;
+      a.set_target( t );
+      float priorO = a.output;
+      float dO = 100000;
+      for( int i=0; i<100; ++i )
+      {
+         a.process_block();
+         REQUIRE( t - a.output < t - priorO );
+         REQUIRE( a.output - priorO < dO );
+         dO = a.output - priorO;
+         priorO = a.output;
+      }
+   }
+
+   SECTION( "Fast Exp Mode gets there")
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge );
+
+      ControllerModulationSource a(ControllerModulationSource::SmoothingMode::FAST_EXP);
+      a.init( 0.5f );
+      REQUIRE( a.output == 0.5f );
+      float t = 0.6;
+      a.set_target( t );
+      float priorO = a.output;
+      float dO = 100000;
+      for( int i=0; i<200; ++i )
+      {
+         a.process_block();
+         REQUIRE( t - a.output <= t - priorO );
+         REQUIRE( ( ( a.output == t ) || ( a.output - priorO < dO ) ) );
+         dO = a.output - priorO;
+         priorO = a.output;
+      }
+      REQUIRE( a.output == t );
+   }
+
+   SECTION( "Slow Exp Mode gets there eventually")
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge );
+
+      ControllerModulationSource a(ControllerModulationSource::SmoothingMode::SLOW_EXP);
+      a.init( 0.5f );
+      REQUIRE( a.output == 0.5f );
+      float t = 0.6;
+      a.set_target( t );
+      int idx = 0;
+      while( a.output != t && idx < 10000 )
+      {
+         a.process_block();
+         idx++;
+      }
+      REQUIRE( a.output == t );
+      REQUIRE( idx < 1000 );
+   }
+
+   SECTION( "Go as a Line" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge );
+
+      ControllerModulationSource a(ControllerModulationSource::SmoothingMode::FAST_LINE);
+      a.init( 0.5f );
+      for( int i=0; i<10; ++i )
+      {
+         float r = rand() / ((float)RAND_MAX);
+         a.set_target(r);
+         for( int j=0; j<60; ++j )
+         {
+            a.process_block();
+         }
+         REQUIRE( a.output == r );
+      }
+   }
+
+   SECTION( "Direct is Direct" )
+   {
+      auto surge = Surge::Headless::createSurge(44100);
+      REQUIRE( surge );
+
+      ControllerModulationSource a(ControllerModulationSource::SmoothingMode::DIRECT);
+      a.init( 0.5f );
+      for( int i=0; i<100; ++i )
+      {
+         float r = rand() / ((float)RAND_MAX);
+         a.set_target(r);
+         a.process_block();
+         REQUIRE( a.output == r );
+      }
+   }
+}


### PR DESCRIPTION
Midi smoothing was a never-finishing exponential creep
towards the target. This had a variety of undesirable
effects, including making controllers seem not very
snappy and making DAWs show creeping values.

Replace that with a set of options to have different
MIDI input smoothing curves and speeds, which are
a synth-wide default.

Closes #1412