### PR TITLE
Windows: Switch to Unicode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,13 +378,10 @@ set(SURGE_GUI_INCLUDES
 
 ### OS SPECIFIC SECTION
 if( APPLE )
-  set(SURGE_OS_SOURCES
-    src/mac/UserInteractionsMac.mm
-    )
-
   set(SURGE_OS_GUI_SOURCES
     src/mac/DisplayInfoMac.mm
     src/mac/RuntimeFontMac.cpp
+    src/mac/UserInteractionsMac.mm
     src/mac/cocoa_utils.mm
     vstgui.surge/vstgui/vstgui_mac.mm
     vstgui.surge/vstgui/vstgui_uidescription_mac.mm
@@ -448,12 +445,6 @@ elseif( UNIX AND NOT APPLE )
     set( cxml src/linux/ConfigurationXml.S )
   endif()
 
-  set(SURGE_OS_SOURCES
-    src/linux/UserInteractionsLinux.cpp
-    ${cxml}
-    ${CMAKE_BINARY_DIR}/lintemp/ScalablePiggy.S
-    )
-
   file(GLOB LINUX_VSTGUI_GLOB vstgui.surge/vstgui/lib/platform/linux/*.cpp )
 
   # Our friends at steinberg have this maddening habig of using #warning DEPRECATED in linux code
@@ -462,13 +453,16 @@ elseif( UNIX AND NOT APPLE )
 
 
   set(SURGE_OS_GUI_SOURCES
+    ${CMAKE_BINARY_DIR}/lintemp/ScalablePiggy.S
+    ${LINUX_VSTGUI_GLOB}
+    ${cxml}
     src/linux/DisplayInfoLinux.cpp
     src/linux/RuntimeFontLinux.cpp
-    vstgui.surge/vstgui/vstgui.cpp
-    vstgui.surge/vstgui/vstgui_uidescription.cpp
+    src/linux/UserInteractionsLinux.cpp
     vstgui.surge/vstgui/lib/platform/common/genericoptionmenu.cpp
     vstgui.surge/vstgui/lib/platform/common/generictextedit.cpp
-    ${LINUX_VSTGUI_GLOB}
+    vstgui.surge/vstgui/vstgui.cpp
+    vstgui.surge/vstgui/vstgui_uidescription.cpp
     )
 
   find_package(PkgConfig REQUIRED)
@@ -563,12 +557,13 @@ elseif( UNIX AND NOT APPLE )
 elseif( WIN32 )
 
   set(SURGE_OS_SOURCES
-    src/windows/UserInteractionsWin.cpp
+    src/windows/surge_win_fopen_utf8.cpp
     )
 
   set(SURGE_OS_GUI_SOURCES
     src/windows/DisplayInfoWin.cpp
     src/windows/RuntimeFontWin.cpp
+    src/windows/UserInteractionsWin.cpp
     src/windows/surge.rc
     vstgui.surge/vstgui/vstgui_win32.cpp
     vstgui.surge/vstgui/vstgui_uidescription_win32.cpp
@@ -584,6 +579,8 @@ elseif( WIN32 )
     TIXML_USE_STL
     USE_LIBPNG
     _CRT_SECURE_NO_WARNINGS=1
+    UNICODE
+    _UNICODE
     ${SURGE_EXTRA_FILTERS_DEFINITIONS}
     )
 
@@ -981,6 +978,7 @@ endif()
 if( BUILD_HEADLESS )
   add_executable(surge-headless
     ${SURGE_COMMON_SOURCES}
+    ${SURGE_OS_SOURCES}
     ${SURGE_GENERATED_SOURCES}
     ${LIB_MIDIFILE_SOURCES}
     src/headless/main.cpp

--- a/libs/filesystem/filesystem.cpp
+++ b/libs/filesystem/filesystem.cpp
@@ -41,13 +41,13 @@ namespace std { namespace experimental { namespace filesystem {
         return p;
     }
     
-    path path::filename() {
+    path path::filename() const {
         auto idx = this->p.find_last_of("/");
         path p(this->p.substr(idx+1));
         return p;
     }
     
-    path path::extension() {
+    path path::extension() const {
         auto idx = this->p.find_last_of(".");
         if( idx == std::string::npos )
             return path( "" );
@@ -56,7 +56,7 @@ namespace std { namespace experimental { namespace filesystem {
         return res;
     }
 
-    path path::stem() {
+    path path::stem() const {
         auto idx = this->p.find_last_of("/");
         auto q = this->p.substr(idx+1);
         idx = q.find_last_of(".");

--- a/libs/filesystem/filesystem.h
+++ b/libs/filesystem/filesystem.h
@@ -37,15 +37,16 @@ namespace std { namespace experimental { namespace filesystem {
         operator std::string();
         
         void append(std::string s);
+        path& operator /=(const path& path) { append(path.p); return *this; }
         
         const char* c_str();
         
         std::string generic_string() const;
         
-        path filename();
-        path stem();
+        path filename() const;
+        path stem() const;
        
-        path extension();
+        path extension() const;
     };
     
     class file {

--- a/src/common/ImportFilesystem.h
+++ b/src/common/ImportFilesystem.h
@@ -23,3 +23,21 @@ namespace fs = std::experimental::filesystem;
 #else
 #error FILESYSTEM is not configured by build system
 #endif
+
+inline std::string path_to_string(const fs::path& path)
+{
+#if WINDOWS && !TARGET_RACK
+   return path.u8string();
+#else
+   return path.generic_string();
+#endif
+}
+
+inline fs::path string_to_path(const std::string& path)
+{
+#if WINDOWS && !TARGET_RACK
+   return fs::u8path(path);
+#else
+   return fs::path(path);
+#endif
+}

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -930,15 +930,6 @@ bool isValidUTF8( const std::string &testThis);
 std::string findReplaceSubstring(std::string &source, const std::string &from, const std::string &to);
 std::string makeStringVertical(std::string &source);
 
-#if WINDOWS
-/*
-** Windows filesystem names are properly wstrings which, if we want them to
-** display properly in vstgui, need to be converted to UTF8 using the
-** windows widechar API. Linux and Mac do not require this.
-*/
-std::string wstringToUTF8(const std::wstring &ws);
-#endif
-
 std::string appendDirectory( const std::string &root, const std::string &path1 );
 std::string appendDirectory( const std::string &root, const std::string &path1, const std::string &path2 );
 std::string appendDirectory( const std::string &root, const std::string &path1, const std::string &path2, const std::string &path3 );

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2502,8 +2502,8 @@ DWORD WINAPI loadPatchInBackgroundThread(LPVOID lpParam)
    }
    if( synth->has_patchid_file )
    {
-      fs::path p(synth->patchid_file);
-      auto s = p.stem().generic_string();
+      auto p(string_to_path(synth->patchid_file));
+      auto s = path_to_string(p.stem());
       synth->has_patchid_file = false;
       synth->allNotesOff();
       synth->loadPatchByPath( synth->patchid_file, -1, s.c_str() );

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -155,7 +155,7 @@ void SurgeSynthesizer::loadPatch(int id)
    patchid = id;
 
    Patch e = storage.patch_list[id];
-   loadPatchByPath( e.path.generic_string().c_str(), e.category, e.name.c_str() );
+   loadPatchByPath(path_to_string(e.path).c_str(), e.category, e.name.c_str());
 }
 
 bool SurgeSynthesizer::loadPatchByPath( const char* fxpPath, int categoryId, const char* patchName )
@@ -347,8 +347,8 @@ void SurgeSynthesizer::savePatch()
    if (storage.getPatch().category.empty())
       storage.getPatch().category = "Default";
 
-   fs::path savepath = getUserPatchDirectory();
-   savepath.append(storage.getPatch().category);
+   fs::path savepath = string_to_path(getUserPatchDirectory());
+   savepath /= (string_to_path(storage.getPatch().category));
 
    create_directories(savepath);
 
@@ -376,7 +376,7 @@ void SurgeSynthesizer::savePatch()
    }
 
    fs::path filename = savepath;
-   filename.append(legalname + ".fxp");
+   filename /= string_to_path(legalname + ".fxp");
 
    if (fs::exists(filename))
    {

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -44,6 +44,11 @@ static inline int _stricmp(const char *s1, const char *s2)
 }
 #endif
 
+#if WINDOWS && !TARGET_RACK
+FILE* surge_win_fopen_utf8(const char* pathname, const char* mode);
+#define fopen(pathname, mode) surge_win_fopen_utf8((pathname), (mode))
+#endif
+
 #define _SURGE_STR(x) #x
 #define SURGE_STR(x) _SURGE_STR(x)
 

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -396,12 +396,13 @@ bool COscillatorDisplay::onDrop(VSTGUI::DragEventData data )
          const void* fn;
          drag->getData(0, fn, t);
          const char* fName = static_cast<const char*>(fn);
-         fs::path fPath(fName);
-         if ((_stricmp(fPath.extension().generic_string().c_str(), ".wt") != 0) &&
-             (_stricmp(fPath.extension().generic_string().c_str(), ".wav") != 0))
+         fs::path fPath(string_to_path(fName));
+         auto extStr(path_to_string(fPath.extension()));
+         if ((_stricmp(extStr.c_str(), ".wt") != 0) &&
+             (_stricmp(extStr.c_str(), ".wav") != 0))
          {
             Surge::UserInteractions::promptError(
-                std::string("Surge only supports drag-and-drop of .wt or .wav wavetable files onto the oscillator! You have dropped a file with extension ") + fPath.extension().generic_string() + ".",
+                std::string("Surge only supports drag-and-drop of .wt or .wav wavetable files onto the oscillator! You have dropped a file with extension ") + extStr + ".",
                 "Wavetable Import Error");
          }
          else

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -335,11 +335,12 @@ bool CPatchBrowser::onDrop(VSTGUI::DragEventData data )
          const void* fn;
          drag->getData(0, fn, t);
          const char* fName = static_cast<const char*>(fn);
-         fs::path fPath(fName);
-         if ((_stricmp(fPath.extension().generic_string().c_str(), ".fxp") != 0) )
+         fs::path fPath(string_to_path(fName));
+         auto extStr(path_to_string(fPath.extension()));
+         if ((_stricmp(extStr.c_str(), ".fxp") != 0))
          {
             Surge::UserInteractions::promptError(
-               std::string( "Surge only supports drag-and-drop of .fxp files onto the patch browser! You have dropped a file with extension ") + fPath.extension().generic_string() + ".",
+               std::string( "Surge only supports drag-and-drop of .fxp files onto the patch browser! You have dropped a file with extension ") + extStr + ".",
                "Patch Import Error");
          }
          else

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -466,7 +466,7 @@ void CFxMenu::rescanUserPresets()
             {
                workStack.push_back(d);
             }
-            else if( d.path().extension().generic_string() == ".srgfx" )
+            else if (path_to_string(d.path().extension()) == ".srgfx")
             {
                sfxfiles.push_back( d.path() );
             }
@@ -476,7 +476,7 @@ void CFxMenu::rescanUserPresets()
 
    for( auto f : sfxfiles )
    {
-      auto fn = f.generic_string();
+      auto fn = path_to_string(f);
 
       {
          UserPreset preset;

--- a/src/common/gui/CStatusPanel.cpp
+++ b/src/common/gui/CStatusPanel.cpp
@@ -179,12 +179,13 @@ bool CStatusPanel::onDrop(VSTGUI::DragEventData data )
          drag->getData(0, fn, t);
          const char* fName = static_cast<const char*>(fn);
          fs::path fPath(fName);
-         if ((_stricmp(fPath.extension().generic_string().c_str(), ".scl") == 0))
+         std::string fExt(path_to_string(fPath.extension()));
+         if ((_stricmp(fExt.c_str(), ".scl") == 0))
          {
             if ( editor )
                editor->tuningFileDropped(fName);
          }
-         if ((_stricmp(fPath.extension().generic_string().c_str(), ".kbm") == 0))
+         if ((_stricmp(fExt.c_str(), ".kbm") == 0))
          {
             if ( editor )
                editor->mappingFileDropped(fName);

--- a/src/headless/UnitTestsIO.cpp
+++ b/src/headless/UnitTestsIO.cpp
@@ -66,7 +66,8 @@ TEST_CASE( "All .wt and .wav factory assets load", "[io]" )
       auto wt = &(surge->storage.getPatch().scene[0].osc[0].wt);
       wt->size = -1;
       wt->n_tables = -1;
-      surge->storage.load_wt(p.path.generic_string(), wt, &(surge->storage.getPatch().scene[0].osc[0]) );
+      surge->storage.load_wt(path_to_string(p.path), wt,
+                             &(surge->storage.getPatch().scene[0].osc[0]));
       REQUIRE( wt->size > 0 );
       REQUIRE( wt->n_tables > 0 );
    }

--- a/src/windows/surge_win_fopen_utf8.cpp
+++ b/src/windows/surge_win_fopen_utf8.cpp
@@ -1,0 +1,28 @@
+#include <cstdio>
+#include <vector>
+
+#include <windows.h>
+
+namespace
+{
+
+std::vector<wchar_t> utf8ToWide(const char* s)
+{
+   std::vector<wchar_t> wide;
+   if (auto size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s, -1, nullptr, 0))
+   {
+      wide.resize(size);
+      if (!MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s, -1, &wide[0], wide.size()))
+         wide[0] = L'\0'; // let _wfopen() fail with invalid parameter
+   }
+   return wide;
+}
+
+} // anonymous namespace
+
+FILE* surge_win_fopen_utf8(const char* pathname, const char* mode)
+{
+   const auto pathNameWide = utf8ToWide(pathname);
+   const auto modeWide = utf8ToWide(mode);
+   return _wfopen(pathNameWide.data(), modeWide.data());
+}


### PR DESCRIPTION
This makes Windows builds Unicode-aware, most notably unlocking the full
range of NTFS file system paths.

To avoid #ifdef, paths in std::strings are now UTF-8, like on other
platforms. They are converted to and from the native UTF-16 as needed.
This is mostly transparent, except when converting between fs::path and
std::string. There, the following should be observed:

- Use path_to_string() instead of .generic_path()
- Don't pass strings into fs::path API, convert them to paths first via
  string_to_path()

Otherwise, on Windows and if the path contains chars other than 7-bit
ASCII, either a system_error will be thrown, or (less likely) the path
could be mistranscoded.

This should become less and less of an issue as fs::path <-> std::string
conversions are refactored away.

Fixes #2579