### PR TITLE
Better MiniEdit Position

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -511,12 +511,13 @@ void COscillatorDisplay::populateMenu(COptionMenu* contextMenu, int selectedItem
                          auto *sge = dynamic_cast<SurgeGUIEditor*>(listener);
                          if( sge )
                          {
-                            sge->promptForMiniEdit(c, "Enter a custom wavetable display name:", "Wavetable Display Name",
-                                                   [this](const std::string &s) {
-                                                      strncpy( this->oscdata->wavetable_display_name, s.c_str(), 256 );
-                                                      this->invalid();
-                                                   }
-                               );
+                            sge->promptForMiniEdit(
+                                c,
+                                "Enter a custom wavetable display name:", "Wavetable Display Name",
+                                CPoint( -1, -1 ), [this](const std::string& s) {
+                                   strncpy(this->oscdata->wavetable_display_name, s.c_str(), 256);
+                                   this->invalid();
+                                });
                          }
                       };
    renameItem->setActions(rnaction, nullptr);

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -696,7 +696,7 @@ void CFxMenu::saveFX()
    if( sge )
    {
       sge->promptForMiniEdit("", "Enter a name for the FX preset:", "Save FX Preset",
-                             [this](const std::string &s) { this->saveFXIn( s ); } );
+                             CPoint(-1,-1), [this](const std::string& s) { this->saveFXIn(s); });
    }
 
 

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -341,7 +341,11 @@ private:
    VSTGUI::CTextEdit *minieditTypein = nullptr;
    std::function<void( const char* )> minieditOverlayDone = [](const char *){};
 public:
-   void promptForMiniEdit( const std::string &value, const std::string & prompt, const std::string & title, std::function<void( const std::string & )> onOK );
+   void promptForMiniEdit(const std::string& value,
+                          const std::string& prompt,
+                          const std::string& title,
+                          const VSTGUI::CPoint& where,
+                          std::function<void(const std::string&)> onOK);
 private:
    
    VSTGUI::CTextLabel* lfoNameLabel = nullptr;


### PR DESCRIPTION
Position miniedit near where the menu originated, not
where the menu item was clicked. Along the way change
rename "" to mean "-" and rename of "-" to show "".

Closes #2692
Closes #2718