### PR TITLE
Begin moving default colors to the SkinColor objects

### DIFF
--- a/src/common/gui/CAboutBox.cpp
+++ b/src/common/gui/CAboutBox.cpp
@@ -107,7 +107,7 @@ void CAboutBox::draw(CDrawContext* pContext)
          int yMargin = 6;
          int yPos = toDisplay.getHeight() - msgs.size() * (strHeight + yMargin); // one for the last; one for the margin
          int xPos = strHeight;
-         pContext->setFontColor(skin->getColor(Colors::AboutBox::Text, kWhiteCColor));
+         pContext->setFontColor(skin->getColor(Colors::AboutBox::Text));
          pContext->setFont(infoFont);
          for (auto s : msgs)
          {
@@ -116,7 +116,7 @@ void CAboutBox::draw(CDrawContext* pContext)
          }
 
          // link to Surge github repo in another color because VSTGUI -_-
-         pContext->setFontColor(skin->getColor(Colors::AboutBox::Link, CColor(46, 134, 255)));
+         pContext->setFontColor(skin->getColor(Colors::AboutBox::Link));
          pContext->drawString("https://github.com/surge-synthesizer/surge",
                               CPoint(253, skin->getWindowSizeY() - 36 - strHeight - yMargin));
       }

--- a/src/common/gui/SkinColors.cpp
+++ b/src/common/gui/SkinColors.cpp
@@ -4,8 +4,8 @@ namespace Colors
 {
    namespace AboutBox
    {
-      const Surge::UI::SkinColor Text("aboutbox.text"),
-                                 Link("aboutbox.link");
+      const Surge::UI::SkinColor Text("aboutbox.text", VSTGUI::kWhiteCColor),
+                                 Link("aboutbox.link", VSTGUI::CColor(46, 134, 255));
    }
 
    namespace Dialog

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -748,7 +748,12 @@ CScalableBitmap *Skin::hoverBitmapOverlayForBackgroundBitmap( Skin::Control::ptr
    return nullptr;
 }
 
-Surge::UI::SkinColor::SkinColor( const std::string &n ) : name( n ) {
+Surge::UI::SkinColor::SkinColor( const std::string &n ) : name( n ), defaultColor( VSTGUI::kRedCColor ) {
+   static int uidstart = 1;
+   uid = uidstart++;
+}
+
+Surge::UI::SkinColor::SkinColor( const std::string &n, const VSTGUI::CColor &c ) : name( n ), defaultColor(c) {
    static int uidstart = 1;
    uid = uidstart++;
 }

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -70,8 +70,10 @@ class SkinDB;
 
 struct SkinColor {
    SkinColor(const std::string &n);
+   SkinColor(const std::string &n, const VSTGUI::CColor &col);
    std::string name;
    int uid;
+   VSTGUI::CColor defaultColor = VSTGUI::kBlackCColor;
 };
 
 class Skin
@@ -164,11 +166,17 @@ public:
       bool hasColor(const std::string &id) const;
       VSTGUI::CColor getColor(const std::string &id, const VSTGUI::CColor &def, std::unordered_set<std::string> noLoops = std::unordered_set<std::string>()) const;
 
+   //private: make this private instead of public to see if you got em all
    public:
       VSTGUI::CColor getColor(const SkinColor &id, const VSTGUI::CColor &def, std::unordered_set<std::string> noLoops = std::unordered_set<std::string>()) const
       {
          // for now do this - later make it so we get them all by uncommenting the private: and public: above
          return getColor( id.name, def, noLoops );
+      }
+   public:
+      VSTGUI::CColor getColor( const SkinColor &id, std::unordered_set<std::string> noLoops = std::unordered_set<std::string>()) const
+      {
+         return getColor( id, id.defaultColor, noLoops );
       }
 
       bool hasColor(const SkinColor &col) const


### PR DESCRIPTION
The SkinColor objects were really just symbols acting as names.
If instead they act as default holders we consolidate the default
colors in one place.

This implements that strategy in the appropriate classes and usese
it in CAboutBox. It is the first step in issue #2748