### PR TITLE
macOS, Linux: Move _aligned_malloc/free defines to globals.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,8 +392,6 @@ if( APPLE )
   set(OS_COMPILE_OPTIONS
     -fasm-blocks
     -msse2
-    "-D_aligned_malloc(x,a)=malloc(x)"
-    "-D_aligned_free(x)=free(x)"
     -Wno-deprecated-declarations
     -Werror=inconsistent-missing-override
     -Werror=logical-op-parentheses
@@ -482,8 +480,6 @@ elseif( UNIX AND NOT APPLE )
   if( LINUX_ON_ARM )
     set(ARCH_COMPILE_OPTIONS
       ${LINUX_ON_ARM_COMPILE_OPTIONS}
-      "-D_aligned_malloc(x,a)=aligned_alloc(a,x)"
-      "-D_aligned_free(x)=free(x)"
       )
     set(ARCH_COMPILE_DEFINITIONS ARM_NEON=1)
     set(ARCH_INCLUDE_DIRECTORIES libs/simde)
@@ -491,8 +487,6 @@ elseif( UNIX AND NOT APPLE )
     set(ARCH_COMPILE_OPTIONS
       -msse2
       -Werror
-      "-D_aligned_malloc(x,a)=malloc(x)"
-      "-D_aligned_free(x)=free(x)"
       )
     set(ARCH_COMPILE_DEFINITIONS INTEL_SSE=1)
   endif()

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -49,6 +49,14 @@ FILE* surge_win_fopen_utf8(const char* pathname, const char* mode);
 #define fopen(pathname, mode) surge_win_fopen_utf8((pathname), (mode))
 #endif
 
+#if MAC
+#define _aligned_malloc(size, alignment) malloc(size)
+#define _aligned_free(memblock) free(memblock)
+#elif LINUX
+#define _aligned_malloc(size, alignment) aligned_alloc((alignment), (size))
+#define _aligned_free(memblock) free(memblock)
+#endif
+
 #define _SURGE_STR(x) #x
 #define SURGE_STR(x) _SURGE_STR(x)
 


### PR DESCRIPTION
OS-specific defines don't belong in compile options and CMake doesn't
support function-style defines in compile definitions.