### PR TITLE
filesystem: path: Disable implicit conversion from std::string

### DIFF
--- a/libs/filesystem/include/filesystem/filesystem.h
+++ b/libs/filesystem/include/filesystem/filesystem.h
@@ -19,7 +19,7 @@ namespace Surge { namespace filesystem {
         
         path();
 
-        path(std::string filePath);
+        explicit path(std::string filePath); // Hint: Did you mean to use string_to_path()?
         
         operator std::string();
         

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -213,7 +213,7 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
        {
            datapath = std::string(xdgDataPath) + "/surge/";
        }
-       else if ( fs::is_directory(localDataPath) )
+       else if (fs::is_directory(string_to_path(localDataPath)))
        {
            datapath = localDataPath;
        }
@@ -226,20 +226,20 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
        ** If local directory doesn't exists - we probably came here through an installer -
        ** check for /usr/share/surge and use /usr/share/Surge as our last guess
        */
-       if (! fs::is_directory(datapath))
+       if (!fs::is_directory(string_to_path(datapath)))
        {
-          if( fs::is_directory( std::string() + Surge::Build::CMAKE_INSTALL_PREFIX + "/share/surge" ) )
+          if (fs::is_directory(string_to_path(std::string(Surge::Build::CMAKE_INSTALL_PREFIX) + "/share/surge")))
           {
              datapath = std::string() + Surge::Build::CMAKE_INSTALL_PREFIX + "/share/surge";
           }
-          else if( fs::is_directory( std::string() + Surge::Build::CMAKE_INSTALL_PREFIX + "/share/Surge" ) )
+          else if (fs::is_directory(string_to_path(std::string(Surge::Build::CMAKE_INSTALL_PREFIX) + "/share/Surge")))
           {
              datapath = std::string() + Surge::Build::CMAKE_INSTALL_PREFIX + "/share/Surge";
           }
           else
           {
              std::string systemDataPath = "/usr/share/surge/";
-             if ( fs::is_directory(systemDataPath) )
+             if (fs::is_directory(string_to_path(systemDataPath)))
                 datapath = systemDataPath;
              else
                 datapath = "/usr/share/Surge/";
@@ -264,15 +264,15 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
    std::string dotSurge = std::string(homePath) + "/.Surge";
    std::string documents = std::string(homePath) + "/Documents/";
 
-   if( fs::is_directory(documentsSurge) )
+   if (fs::is_directory(string_to_path(documentsSurge)))
    { 
       userDataPath = documentsSurge;
    }
-   else if( fs::is_directory(dotSurge) )
+   else if (fs::is_directory(string_to_path(dotSurge)))
    {
       userDataPath = dotSurge;
    }
-   else if( fs::is_directory(documents) )
+   else if (fs::is_directory(string_to_path(documents)))
    {
       userDataPath = documentsSurge;
    }
@@ -1761,7 +1761,7 @@ void SurgeStorage::storeMidiMappingToName(std::string name)
 
    doc.InsertEndChild( sm );
 
-   fs::create_directories( userMidiMappingsPath );
+   fs::create_directories(string_to_path(userMidiMappingsPath));
    std::string fn = Surge::Storage::appendDirectory(userMidiMappingsPath, name + ".srgmid");
 
    if( ! doc.SaveFile( fn.c_str() ) )

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -91,7 +91,7 @@ bool storeUserDefaultValue(SurgeStorage *storage, const std::string &key, const 
     ** See SurgeSytnehsizer::savePatch for instance
     ** and so we have to do the same here
     */
-    fs::create_directories(storage->userDefaultFilePath);
+    fs::create_directories(string_to_path(storage->userDefaultFilePath));
 
     
     UserDefaultValue v;

--- a/src/common/WavSupport.cpp
+++ b/src/common/WavSupport.cpp
@@ -475,7 +475,7 @@ void SurgeStorage::export_wt_wav_portable(std::string fbase, Wavetable *wt)
 {
    std::string path;
    path = Surge::Storage::appendDirectory(userDataPath, "Exported Wavetables");
-   fs::create_directories(path);
+   fs::create_directories(string_to_path(path));
 
    auto fnamePre = fbase + ".wav";
    auto fname = Surge::Storage::appendDirectory(path, fbase + ".wav");

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -724,7 +724,7 @@ void CFxMenu::saveFXIn( const std::string &s )
    oss << storage->userFXPath << PATH_SEPARATOR << fx_type_names[ti] << PATH_SEPARATOR;
 
    auto pn = oss.str();
-   fs::create_directories( pn );
+   fs::create_directories(string_to_path(pn));
 
    auto fn = pn + fxName + ".srgfx";
    std::ofstream pfile( fn, std::ios::out );

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -5016,7 +5016,7 @@ VSTGUI::COptionMenu* SurgeGUIEditor::makeDataMenu(VSTGUI::CRect& menuRect)
 
    addCallbackMenu(dataSubMenu, Surge::UI::toOSCaseForMenu("Open User Data Folder..."), [this]() {
       // make it if it isn't there
-      fs::create_directories(this->synth->storage.userDataPath);
+      fs::create_directories(string_to_path(this->synth->storage.userDataPath));
       Surge::UserInteractions::openFolderInFileBrowser(this->synth->storage.userDataPath);
    });
    did++;


### PR DESCRIPTION
This conversion is unsafe on Windows because its native std::filesystem
expects ANSI strings and ours are UTF-8. It's easy to miss and there's
nothing we can do on Windows, so make it break the macOS build instead.