### PR TITLE
Add a Figma fix script

### DIFF
--- a/scripts/misc/fixFigmaSVG.pl
+++ b/scripts/misc/fixFigmaSVG.pl
@@ -1,0 +1,41 @@
+#!/usr/bin/perl
+
+open( IN, "< $ARGV[0]" ) || die "Can't open SVG file $ARGV[0]";
+@lines = <IN>;
+$defSection = "";
+$inDef = 0;
+foreach( @lines )
+{
+	if( m/<defs>/ )
+	{
+		$inDef = 1;
+	}
+	if( $inDef )
+	{
+		$defSection .= $_;
+	}
+	if( m:</defs>: )
+	{
+		$inDef = 0;
+	}
+}
+
+foreach( @lines )
+{
+	if( m/<defs>/ )
+	{
+		$inDef = 1;
+	}
+	if( ! $inDef )
+	{
+		print;
+	}
+	if( m:<svg: ) {
+		print $defSection;
+		$defSection = "";
+	}	
+	if( m:</defs>: )
+	{
+		$inDef = 0;
+	}
+}


### PR DESCRIPTION
Figma puts defs at the end. We should be reslient to that.
Until we are, here's a script to move em to the front.

A hack around #2813