### PR TITLE
Only allow a single editorOverlay

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -5814,6 +5814,12 @@ void SurgeGUIEditor::sliderHoverEnd( int tag )
 
 void SurgeGUIEditor::setEditorOverlay(VSTGUI::CView *c, std::string editorTitle, const VSTGUI::CPoint &topLeft, bool modalOverlay, std::function<void ()> onClose)
 {
+   if( editorOverlay != nullptr )
+   {
+      editorOverlayOnClose();
+      frame->removeView(editorOverlay);
+   }
+
    const int header = 18;
    const int buttonwidth = 40;
    


### PR DESCRIPTION
If an editorOverlay is shown, and a new one is requested,
close and remove the prior one. This solves the problem of
double-opening an MSEG resulting in a never closing MSEG.