### PR TITLE
Fix: do not produce CCs when parameter automation changes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,5 +34,6 @@ Paul Walker <paul@pwjw.com>
 Keith Zantow <kzantow@gmail.com>
 Vincent Zauhar <v.zauhar@bell.net>
 簡志瑋 <dppss92132@gmail.com>
+Marty Lake <matthieu@talbot.audio>
 
 

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1221,12 +1221,6 @@ void SurgeSynthesizer::channelController(char channel, int cc, int value)
       {
          ((ControllerModulationSource*)storage.getPatch().scene[0].modsources[ms_ctrl1 + i])
              ->set_target01(fval);
-#if !TARGET_LV2
-         sendParameterAutomation(i + metaparam_offset, fval);
-#else
-         // LV2 must not modify its own control input; just set the value.
-         setParameter01(i + metaparam_offset, fval);
-#endif
       }
    }
 


### PR DESCRIPTION
Fixes https://github.com/surge-synthesizer/surge/issues/2778

Hey baconpaul, apparently, it's this line that produces parameter change on CC mapped parameters. Is it really a feature at all ? Can we just remove it ? Or maybe add an option for the end user (like the ui size or something?)