### PR TITLE
Show WaveForm when LFO deactivated

### DIFF
--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -28,6 +28,7 @@
     <color id="lfo.waveform.centerline" value="$buttonbg"/>
     <color id="lfo.waveform.envelope" value="$surgebluetrans"/>
     <color id="lfo.waveform.wave" value="$modblue"/>
+    <color id="lfo.waveform.deactivatedwave" value="$surgebluetrans"/>
     <color id="lfo.waveform.majordivisions" value="$buttonbg"/>
 
     <color id="lfo.type.selected.background" value="$surgeblue"/>

--- a/src/common/gui/SkinColors.cpp
+++ b/src/common/gui/SkinColors.cpp
@@ -139,7 +139,8 @@ namespace Colors
                                     Envelope("lfo.waveform.envelope", CColor(176, 96, 0)),
                                     Fill("lfo.waveform.fill", CColor(255, 144, 0)),
                                     MajorDivisions("lfo.waveform.majordivisions", CColor(224, 128, 0)),
-                                    Wave("lfo.waveform.wave", kBlackCColor);
+                                    Wave("lfo.waveform.wave", kBlackCColor),
+                                    DeactivatedWave( "lfo.waveform.deactivatedwave", CColor( 176, 96, 0 ) );
 
          namespace Ruler
          {

--- a/src/common/gui/SkinColors.h
+++ b/src/common/gui/SkinColors.h
@@ -94,7 +94,7 @@ namespace Colors
       }
       namespace Waveform
       {
-         extern const Surge::UI::SkinColor Background, Bounds, CenterLine, Envelope, Fill, MajorDivisions, Wave;
+         extern const Surge::UI::SkinColor Background, Bounds, CenterLine, Envelope, Fill, MajorDivisions, Wave, DeactivatedWave;
 
          namespace Ruler
          {


### PR DESCRIPTION
When the LFO is deactivated, show the
waveform over which we are scrubbing.
Displays in a skin color
lfo.waveform.deactivatedwave

Closes #2761