### PR TITLE
Correct a serious bug with LFO Freerun

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -832,6 +832,23 @@ void SurgeGUIEditor::idle()
       // frame->update(&drawContext);
       // frame->idle();
   }
+
+#if BUILD_IS_DEBUG
+  if( debugLabel )
+  {
+     /*
+      * We can do debuggy stuff here to get an indea about internal state on the screen
+      */
+
+   /*
+     auto t = std::to_string( synth->storage.songpos );
+     debugLabel->setText(t.c_str());
+     debugLabel->invalid();
+     */
+
+
+  }
+#endif
 }
 
 void SurgeGUIEditor::toggle_mod_editing()
@@ -1480,8 +1497,10 @@ void SurgeGUIEditor::openOrRecreateEditor()
    /*
     * This code is here JUST because baconpaul keeps developing surge and then swapping
     * to make music and wondering why LPX is stuttering. Please don't remove it!
+    *
+    * UPDATE: Might as well keep a reference to the object though so we can touch it in idle
     */
-   auto lb = new CTextLabel( CRect( CPoint( 321, 39 ), CPoint( 100, 15 ) ), "DEBUG BUILD" );
+   auto lb = new CTextLabel( CRect( CPoint( 310, 39 ), CPoint( 195, 15 ) ), "DEBUG BUILD" );
    lb->setTransparency( false );
    lb->setBackColor( kRedCColor );
    lb->setFontColor( kWhiteCColor );
@@ -1489,6 +1508,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
    lb->setHoriAlign(VSTGUI::kCenterText);
    lb->setAntialias(true);
    frame->addView(lb);
+   debugLabel = lb;
 #endif
    if( editorOverlay )
    {

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -332,6 +332,9 @@ private:
    VSTGUI::CTextEdit* patchComment = nullptr;
    VSTGUI::CCheckBox* patchTuning = nullptr;
    VSTGUI::CTextLabel* patchTuningLabel = nullptr;
+#if BUILD_IS_DEBUG
+   VSTGUI::CTextLabel* debugLabel = nullptr;
+#endif
 
    VSTGUI::CViewContainer* typeinDialog = nullptr;
    VSTGUI::CTextEdit* typeinValue = nullptr;


### PR DESCRIPTION
LFO Freerun had a couple of serious bugs

- It used songpos (in beats) but didn't use the tempo to convert songpos to time
- In SS mode it used end-start, not end-start+1, as the step count

Fix both.

Closes #2826