### PR TITLE
Don't require $ for color values

### DIFF
--- a/resources/data/skins/Tutorial/02 Changing Images and Colors.surge-skin/skin.xml
+++ b/resources/data/skins/Tutorial/02 Changing Images and Colors.surge-skin/skin.xml
@@ -2,6 +2,9 @@
 [doc]-->
 <surge-skin name="02 Changing Images and Colors" category="Tutorial" author="Surge Synth Team" authorURL="https://surge-synth-team.org/" version="1">
   <globals>
+    <color id="hotpink" value="#FF69B4"/>
+
+    <color id="lfo.waveform.background" value="hotpink"/>
   </globals>
   <component-classes>
   </component-classes>

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -307,13 +307,15 @@ private:
 
       typedef enum {
          COLOR,
-         ALIAS
+         ALIAS,
+         UNRESOLVED_ALIAS
       } Type;
 
       Type type;
       ColorStore() : type( COLOR ), color( VSTGUI::kBlackCColor ) { }
       ColorStore( VSTGUI::CColor c ) : type( COLOR ), color( c ) { }
       ColorStore( std::string a ) : type( ALIAS ), alias( a ) { }
+      ColorStore( std::string a, Type t ) : type( t ), alias( a ) { }
    };
    std::unordered_map<std::string, ColorStore> colors;
    std::unordered_map<std::string, int> imageIds;


### PR DESCRIPTION
Color values required a $ so you would say
<color id="lfo.blah" value="$white"/>
even though eadlier you said
<color id="white" value="#ffffff"/>

Make it so you don't need that any more.

Still need a # for RGBs of course.

Closes #2736