### PR TITLE
Deactivated BiPolar Triangle Scrub Fix

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -107,6 +107,8 @@ void LfoModulationSource::initPhaseFromStartPhase()
 {
    phase = localcopy[startphase].f;
    phaseInitialized = true;
+   if( lfo->shape.val.i == ls_tri && lfo->rate.deactivated && ! lfo->unipolar.val.b )
+      phase += 0.25;
    while( phase < 0.f )
       phase += 1.f;
    while( phase > 1.f )


### PR DESCRIPTION
when the triangle mode was in scrub mode it missed the
hack where phase gets pushed forward 1/4 in bipolar mode to
start at 0. Correct that so scrub mode mathces the display