### PR TITLE
Add missing skin colors for text edit fields in MSEG editor

### DIFF
--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -8,6 +8,8 @@
     <color id="lightgray" value="#B4B4B4"/>
     <color id="gray" value="#808080"/>
     <color id="almostblack" value="#050505"/>
+    <color id="bggray" value="#242424"/>
+    <color id="bordergray" value="#0F0F0F"/>
     <color id="darkestgray" value="#131313"/>
     <color id="moregray" value="#4f4f4f"/>
     <color id="darkgray" value="#3c3c3c"/>
@@ -18,110 +20,107 @@
     <color id="buttonbg" value="#151515"/>
     <color id="modblue" value="#2E86FE"/>
 
-    <color id="lfo.title.font" value="#B4B4B490"/>
+    <color id="lfo.title.text" value="#B4B4B490"/>
 
-    <color id="lfo.waveform.background" value="#242424"/>
-    <color id="lfo.waveform.ruler.font" value="$lightgray"/>
-    <color id="lfo.waveform.ruler.ticks" value="$buttonbg"/>
-    <color id="lfo.waveform.ruler.ticks.small" value="$surgebluetrans"/>
-    <color id="lfo.waveform.bounds" value="$buttonbg"/>
-    <color id="lfo.waveform.centerline" value="$buttonbg"/>
-    <color id="lfo.waveform.envelope" value="$surgebluetrans"/>
-    <color id="lfo.waveform.wave" value="$modblue"/>
-    <color id="lfo.waveform.deactivatedwave" value="$surgebluetrans"/>
-    <color id="lfo.waveform.majordivisions" value="$buttonbg"/>
+    <color id="lfo.waveform.background" value="bggray"/>
+    <color id="lfo.waveform.ruler.text" value="lightgray"/>
+    <color id="lfo.waveform.ruler.ticks" value="buttonbg"/>
+    <color id="lfo.waveform.ruler.ticks.small" value="surgebluetrans"/>
+    <color id="lfo.waveform.ruler.ticks.extended" value="buttonbg"/>
+    <color id="lfo.waveform.bounds" value="buttonbg"/>
+    <color id="lfo.waveform.center" value="buttonbg"/>
+    <color id="lfo.waveform.envelope" value="surgebluetrans"/>
+    <color id="lfo.waveform.wave" value="modblue"/>
+    <color id="lfo.waveform.wave.deactivated" value="#2E86FE90"/>
 
-    <color id="lfo.type.selected.background" value="$surgeblue"/>
-    <color id="lfo.type.selected.font" value="#E5E5E5"/>
-    <color id="lfo.type.unselected.font" value="$lightgray"/>
+    <color id="lfo.type.selected.background" value="surgeblue"/>
+    <color id="lfo.type.selected.text" value="#E5E5E5"/>
+    <color id="lfo.type.unselected.text" value="lightgray"/>
 
-    <color id="lfo.stepseq.background" value="$darkergray"/>
-    <color id="lfo.stepseq.column.shadow" value="$almostblack"/>
-    <color id="lfo.stepseq.step.fill" value="$surgeblue"/>
-    <color id="lfo.stepseq.step.fill.disabled" value="$moregray"/>
-    <color id="lfo.stepseq.loop.outside.majorstep" value="$darkergray"/>
-    <color id="lfo.stepseq.loop.outside.minorstep" value="#303030"/>
-    <color id="lfo.stepseq.loop.majorstep" value="$buttonbg"/>
-    <color id="lfo.stepseq.loop.minorstep" value="$black"/>
-    <color id="lfo.stepseq.loop.markers" value="$modblue"/>
-    <color id="lfo.stepseq.trigger.click" value="$lightgray"/>
-    <color id="lfo.stepseq.drag.line" value="$lightgray"/>
-    <color id="lfo.stepseq.envelope" value="$surgebluetrans"/>
-    <color id="lfo.stepseq.wave" value="$modblue"/>
+    <color id="lfo.stepseq.background" value="darkergray"/>
+    <color id="lfo.stepseq.column.shadow" value="almostblack"/>
+    <color id="lfo.stepseq.step.fill" value="surgeblue"/>
+    <color id="lfo.stepseq.step.fill.disabled" value="moregray"/>
+    <color id="lfo.stepseq.step.fill.outside" value="moregray"/>
+    <color id="lfo.stepseq.loop.outside.step.primary" value="darkergray"/>
+    <color id="lfo.stepseq.loop.outside.step.secondary" value="#303030"/>
+    <color id="lfo.stepseq.loop.step.primary" value="buttonbg"/>
+    <color id="lfo.stepseq.loop.step.secondary" value="black"/>
+    <color id="lfo.stepseq.loop.markers" value="modblue"/>
+    <color id="lfo.stepseq.trigger.click" value="lightgray"/>
+    <color id="lfo.stepseq.drag.line" value="lightgray"/>
+    <color id="lfo.stepseq.envelope" value="surgebluetrans"/>
+    <color id="lfo.stepseq.wave" value="modblue"/>
 
-    <color id="lfo.stepseq.button.border" value="$buttonbg"/>
-    <color id="lfo.stepseq.button.fill" value="$darkergray"/>
-    <color id="lfo.stepseq.button.hover" value="$darkgray"/>
-    <color id="lfo.stepseq.button.arrow.fill" value="$lightgray"/>
+    <color id="lfo.stepseq.button.background" value="darkergray"/>
+    <color id="lfo.stepseq.button.border" value="buttonbg"/>
+    <color id="lfo.stepseq.button.hover" value="darkgray"/>
+    <color id="lfo.stepseq.button.arrow" value="lightgray"/>
 
-    <color id="lfo.stepseq.popup.border" value="$darkestgray"/>
-    <color id="lfo.stepseq.popup.background" value="$white"/>
-    <color id="lfo.stepseq.popup.font" value="$darkestgray"/>
+    <color id="lfo.stepseq.popup.background" value="white"/>
+    <color id="lfo.stepseq.popup.border" value="darkestgray"/>
+    <color id="lfo.stepseq.popup.text" value="darkestgray"/>
 
     <color id="overlay.background" value="#000000C0"/>
 
     <color id="msegeditor.background" value="#202020"/>
-    <color id="msegeditor.curve" value="$modblue"/>
+    <color id="msegeditor.curve" value="modblue"/>
     <color id="msegeditor.panel" value="#2D2D2D"/>
-    <color id="msegeditor.panel.font" value="$lightgray"/>
-    <color id="msegeditor.axis.font" value="$lightgray"/>
+    <color id="msegeditor.panel.text" value="lightgray"/>
+    <color id="msegeditor.axis.text" value="lightgray"/>
     <color id="msegeditor.fill.gradient.start" value="#2E86FE80"/>
     <color id="msegeditor.fill.gradient.end" value="#2E86FE0F"/>
+    <color id="msegeditor.numberfield.background" value="bggray"/>
+    <color id="msegeditor.numberfield.border" value="bordergray"/>
+    <color id="msegeditor.numberfield.text" value="lightgray"/>
 
-    <color id="dialog.background" value="#242424"/>
-    <color id="dialog.border" value="#0F0F0F"/>
+    <color id="dialog.background" value="bggray"/>
+    <color id="dialog.border" value="bordergray"/>
 
-    <color id="dialog.titlebar.background" value="#0F0F0F"/>
-    <color id="dialog.titlebar.text" value="$white"/>
+    <color id="dialog.titlebar.background" value="bordergray"/>
+    <color id="dialog.titlebar.text" value="white"/>
     <color id="dialog.button.background" value="#404040"/>
-    <color id="dialog.button.border" value="#0F0F0F"/>
-    <color id="dialog.button.font" value="$lightgray"/>
+    <color id="dialog.button.border" value="bordergray"/>
+    <color id="dialog.button.text" value="lightgray"/>
 
-    <color id="dialog.textfield.focuscolor" value="#2E2E5E"/>
-    <color id="dialog.textfield.border" value="#0F0F0F"/>
+    <color id="dialog.textfield.focus" value="red"/>
+    <color id="dialog.textfield.border" value="bordergray"/>
     <color id="dialog.textfield.background" value="#2E2E2E"/>
-    <color id="dialog.textfield.font" value="$lightgray"/>
-    <color id="dialog.label.font" value="$lightgray"/>
+    <color id="dialog.textfield.text" value="lightgray"/>
+    <color id="dialog.label.text" value="lightgray"/>
 
-    <color id="dialog.checkbox.border" value="$lightgray"/>
-    <color id="dialog.checkbox.fill" value="$white"/>
-    <color id="dialog.checkbox.tick" value="$darkergray"/>
+    <color id="dialog.checkbox.background" value="white"/>
+    <color id="dialog.checkbox.border" value="lightgray"/>
+    <color id="dialog.checkbox.tick" value="darkergray"/>
 
-    <color id="effect.label.hrule" value="#5E5E5E"/>
-    <color id="effect.label.font" value="$lightgray"/>
-    <color id="effect.label.presetname" value="$lightgray"/>
+    <color id="effect.label.separator" value="#5E5E5E"/>
+    <color id="effect.label.text" value="lightgray"/>
+    <color id="effect.label.presetname" value="lightgray"/>
 
-    <color id="menu.name" value="$lightgray"/>
-    <color id="menu.name.hover" value="$white"/>
-    <color id="menu.name.deactivated" value="$gray"/>
-    <color id="menu.value" value="$lightgray"/>
-    <color id="menu.value.hover" value="$white"/>
-    <color id="menu.value.deactivated" value="$gray"/>
+    <color id="menu.name" value="lightgray"/>
+    <color id="menu.name.hover" value="white"/>
+    <color id="menu.name.deactivated" value="gray"/>
+    <color id="menu.value" value="lightgray"/>
+    <color id="menu.value.hover" value="white"/>
+    <color id="menu.value.deactivated" value="gray"/>
 
-    <color id="filtermenu.value" value="$white"/>
-    <color id="filtermenu.value.hover" value="$white"/>
+    <color id="filtermenu.value" value="white"/>
+    <color id="filtermenu.value.hover" value="white"/>
 
-    <color id="patchbrowser.background" value="$lightgray"/>
-    <color id="patchbrowser.font" value="$lightgray"/>
+    <color id="patchbrowser.background" value="lightgray"/>
+    <color id="patchbrowser.text" value="lightgray"/>
 
-    <color id="control.numberfield.background" value="$lightgray"/>
-    <color id="control.numberfield.font" value="$lightgray"/>
-    <color id="control.numberfield.env" value="$lightgray"/>
-    <color id="control.numberfield.rule" value="$lightgray"/>
-
-    <color id="slider.light.label" value="$lightgray"/>
-    <color id="slider.dark.label" value="$lightgray"/>
-    <color id="slider.modulation" value="#82BF50"/>
-    <color id="slider.negative.modulation" value="$gray"/>
+    <color id="slider.light.label" value="lightgray"/>
+    <color id="slider.dark.label" value="lightgray"/>
+    <color id="slider.modulation.positive" value="#82BF50"/>
+    <color id="slider.modulation.negative" value="gray"/>
 
     <color id="vumeter.level" value="#0055B0"/>
-    <color id="vumeter.highlevel" value="$red"/>
-    <color id="vumeter.background" value="$darkergray"/>
-    <color id="vumeter.border" value="#0F0F0F"/>
+    <color id="vumeter.highlevel" value="red"/>
+    <color id="vumeter.background" value="darkergray"/>
+    <color id="vumeter.border" value="bordergray"/>
 
-    <color id="osc.label" value="$lightgray"/>
-
-    <color id="fxmenu.font" value="$lightgray"/>
+    <color id="fxmenu.text" value="lightgray"/>
 
     <image id="TEMPOSYNC_HORIZONTAL_OVERLAY" resource="SVG/bmpTS00153.svg"/>
     <image id="TEMPOSYNC_VERTICAL_OVERLAY" resource="SVG/bmpTS00157.svg"/>

--- a/src/common/gui/CEffectLabel.h
+++ b/src/common/gui/CEffectLabel.h
@@ -32,7 +32,7 @@ public:
       VSTGUI::CRect bl(size);
       bl.top = bl.bottom - 2;
 
-      dc->setFillColor(skin->getColor(Colors::Effect::Label::Line));
+      dc->setFillColor(skin->getColor(Colors::Effect::Label::Separator));
       dc->drawRect(bl, VSTGUI::kDrawFilled);
 
       dc->setFontColor(skin->getColor(Colors::Effect::Label::Text));

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -296,7 +296,7 @@ void CLFOGui::draw(CDrawContext* dc)
 
       dc->setLineWidth(1.0);
       // LFO bg center line
-      dc->setFrameColor(skin->getColor(Colors::LFO::Waveform::CenterLine));
+      dc->setFrameColor(skin->getColor(Colors::LFO::Waveform::Center));
       dc->drawLine(mid0, mid1);
 
       dc->setLineWidth(1.0);
@@ -350,8 +350,7 @@ void CLFOGui::draw(CDrawContext* dc)
                tf.transform(vruleS);
                tf.transform(vruleE);
                // major beat divisions on the LFO waveform bg
-               dc->setFrameColor(
-                   skin->getColor(Colors::LFO::Waveform::MajorDivisions));
+               dc->setFrameColor(skin->getColor(Colors::LFO::Waveform::Ruler::ExtendedTicks));
                // dc->drawLine(mps,mp); // this draws the hat on the bar which I decided to skip
                dc->drawLine(vruleS, vruleE);
             }
@@ -600,11 +599,11 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp, VST
 
    auto shadowcol = skin->getColor(Colors::LFO::StepSeq::ColumnShadow);
    auto stepMarker = skin->getColor(Colors::LFO::StepSeq::Step::Fill);
-   auto disStepMarker = skin->getColor(Colors::LFO::StepSeq::Step::OutsideFill);
-   auto noLoopHi = skin->getColor(Colors::LFO::StepSeq::Loop::OutsideMajorStep);
-   auto noLoopLo = skin->getColor(Colors::LFO::StepSeq::Loop::OutsideMinorStep);
-   auto loopRegionHi = skin->getColor(Colors::LFO::StepSeq::Loop::MajorStep);
-   auto loopRegionLo = skin->getColor(Colors::LFO::StepSeq::Loop::MinorStep);
+   auto disStepMarker = skin->getColor(Colors::LFO::StepSeq::Step::FillOutside);
+   auto noLoopHi = skin->getColor(Colors::LFO::StepSeq::Loop::OutsidePrimaryStep);
+   auto noLoopLo = skin->getColor(Colors::LFO::StepSeq::Loop::OutsideSecondaryStep);
+   auto loopRegionHi = skin->getColor(Colors::LFO::StepSeq::Loop::PrimaryStep);
+   auto loopRegionLo = skin->getColor(Colors::LFO::StepSeq::Loop::SecondaryStep);
    auto grabMarker = skin->getColor(Colors::LFO::StepSeq::Loop::Marker);
    auto grabMarkerHi = skin->getColor(Colors::LFO::StepSeq::TriggerClick);
 

--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -69,9 +69,7 @@ public:
 
    void resetColorTable()
    {
-      auto c = skin->getColor(Colors::LFO::Waveform::Fill);
       auto d = skin->getColor(Colors::LFO::Waveform::Wave);
-      
    }
    // virtual void mouse (CDrawContext *pContext, VSTGUI::CPoint &where, long buttons = -1);
    virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override;

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -256,7 +256,7 @@ void COscillatorDisplay::draw(CDrawContext* dc)
          dc->setDrawMode(VSTGUI::kAntiAliasing);
 
          dc->setLineWidth(1.0);
-         dc->setFrameColor(skin->getColor(Colors::Osc::Display::CenterLine));
+         dc->setFrameColor(skin->getColor(Colors::Osc::Display::Center));
          dc->drawLine(mid0, mid1);
 
          dc->setLineWidth(1.0);

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -919,9 +919,10 @@ void MSEGControlRegion::rebuild()
       htxt->setTextInset(CPoint(3, 1));
 #endif
       htxt->setFont(editFont);
-      htxt->setFontColor(kBlackCColor);
-      htxt->setFrameColor(kBlackCColor);
-      htxt->setBackColor(kWhiteCColor);
+      htxt->setFontColor(skin->getColor(Colors::MSEGEditor::NumberField::Text));
+      htxt->setFrameColor(skin->getColor(Colors::MSEGEditor::NumberField::Border));
+      htxt->setBackColor(skin->getColor(Colors::MSEGEditor::NumberField::Background));
+      htxt->setRoundRectRadius(CCoord(3.f));
       addView(htxt);
 
       xpos += segWidth;
@@ -937,9 +938,10 @@ void MSEGControlRegion::rebuild()
       vtxt->setTextInset(CPoint(3, 1));
 #endif
       vtxt->setFont(editFont);
-      vtxt->setFontColor(kBlackCColor);
-      vtxt->setFrameColor(kBlackCColor);
-      vtxt->setBackColor(kWhiteCColor);
+      vtxt->setFontColor(skin->getColor(Colors::MSEGEditor::NumberField::Text));
+      vtxt->setFrameColor(skin->getColor(Colors::MSEGEditor::NumberField::Border));
+      vtxt->setBackColor(skin->getColor(Colors::MSEGEditor::NumberField::Background));
+      vtxt->setRoundRectRadius(CCoord(3.f));
       addView(vtxt);
    }
 }

--- a/src/common/gui/SkinColors.cpp
+++ b/src/common/gui/SkinColors.cpp
@@ -18,20 +18,20 @@ namespace Colors
       namespace Titlebar
       {
          const Surge::UI::SkinColor Background("dialog.titlebar.background", CColor(160, 164, 183)),
-                                    Text("dialog.titlebar.font", kWhiteCColor);
+                                    Text("dialog.titlebar.text", kWhiteCColor);
       }
       namespace Button
       {
          const Surge::UI::SkinColor Background("dialog.button.background", CColor(227, 227, 227)),
                                     Border("dialog.button.border", CColor(160, 160, 160)),
-                                    Text("dialog.button.font", kBlackCColor),
+                                    Text("dialog.button.text", kBlackCColor),
                                     BackgroundHover("dialog.button.hover.background", CColor(255, 144, 0)),
                                     BorderHover("dialog.button.hover.border", CColor(160, 160, 160)),
-                                    TextHover("dialog.button.hover.font", kWhiteCColor);
+                                    TextHover("dialog.button.hover.text", kWhiteCColor);
       }
       namespace Checkbox
       {
-         const Surge::UI::SkinColor Background("dialog.checkbox.fill", kWhiteCColor),
+         const Surge::UI::SkinColor Background("dialog.checkbox.background", kWhiteCColor),
                                     Border("dialog.checkbox.border", kBlackCColor),
                                     Tick("dialog.checkbox.tick", kBlackCColor);
       }
@@ -39,13 +39,13 @@ namespace Colors
       {
          const Surge::UI::SkinColor Background("dialog.textfield.background", kWhiteCColor),
                                     Border("dialog.textfield.border", CColor(160, 160, 160)),
-                                    Focus("dialog.textfield.focuscolor", CColor(170, 170, 230)),
-                                    Text("dialog.textfield.font", kBlackCColor);
+                                    Focus("dialog.textfield.focus", CColor(170, 170, 230)),
+                                    Text("dialog.textfield.text", kBlackCColor);
       }
       namespace Label
       {
-         const Surge::UI::SkinColor Error("dialog.label.error.font", kRedCColor),
-                                    Text("dialog.label.font", kBlackCColor);
+         const Surge::UI::SkinColor Error("dialog.label.text.error", kRedCColor),
+                                    Text("dialog.label.text", kBlackCColor);
       }
    }
 
@@ -53,8 +53,8 @@ namespace Colors
    {
       namespace Label
       {
-         const Surge::UI::SkinColor Text("effect.label.font", CColor(76, 76, 76)),
-                                    Line("effect.label.hrule", CColor(106, 106, 106));
+         const Surge::UI::SkinColor Text("effect.label.text", CColor(76, 76, 76)),
+                                    Separator("effect.label.separator", CColor(106, 106, 106));
       }
       namespace Preset
       {
@@ -62,7 +62,7 @@ namespace Colors
       }
       namespace Menu
       {
-         const Surge::UI::SkinColor Text("fxmenu.font", kBlackCColor);
+         const Surge::UI::SkinColor Text("fxmenu.text", kBlackCColor);
       }
       namespace SelectorPanel
       {
@@ -78,10 +78,10 @@ namespace Colors
 
       namespace Modulation
       {
-         const Surge::UI::SkinColor Negative("infowindow.font.modulationnegative", kBlackCColor),
-                                    Positive("infowindow.font.modulationpositive", kBlackCColor),
-                                    ValueNegative("infowindow.font.modulationvaluenegative", kBlackCColor),
-                                    ValuePositive("infowindow.font.modulationvaluepositive", kBlackCColor);
+         const Surge::UI::SkinColor Negative("infowindow.text.modulation.negative", kBlackCColor),
+                                    Positive("infowindow.text.modulation.positive", kBlackCColor),
+                                    ValueNegative("infowindow.text.modulation.value.negative", kBlackCColor),
+                                    ValuePositive("infowindow.text.modulation.value.positive", kBlackCColor);
       }
    }
 
@@ -89,13 +89,13 @@ namespace Colors
    {
       namespace Title
       {
-          const Surge::UI::SkinColor Text("lfo.title.font", CColor(0, 0, 0, 192));
+          const Surge::UI::SkinColor Text("lfo.title.text", CColor(0, 0, 0, 192));
       }
 
       namespace Type
       {
-         const Surge::UI::SkinColor Text("lfo.type.unselected.font", kBlackCColor),
-                                    SelectedText("lfo.type.selected.font", kBlackCColor),
+         const Surge::UI::SkinColor Text("lfo.type.unselected.text", kBlackCColor),
+                                    SelectedText("lfo.type.selected.text", kBlackCColor),
                                     SelectedBackground("lfo.type.selected.background", CColor(255, 152, 21));
       }
       namespace StepSeq
@@ -109,47 +109,46 @@ namespace Colors
 
          namespace Button
          {
-            const Surge::UI::SkinColor Background("lfo.stepseq.button.fill", CColor(151, 152, 154)),
+            const Surge::UI::SkinColor Background("lfo.stepseq.button.background", CColor(151, 152, 154)),
                                        Border("lfo.stepseq.button.border", CColor(93, 93, 93)),
                                        Hover("lfo.stepseq.button.hover", CColor(174, 175, 190)),
-                                       Arrow("lfo.stepseq.button.arrow.fill", kWhiteCColor);
+                                       Arrow("lfo.stepseq.button.arrow", kWhiteCColor);
          }
          namespace InfoWindow
          {
             const Surge::UI::SkinColor Background("lfo.stepseq.popup.background", kWhiteCColor),
                                        Border("lfo.stepseq.popup.border", kBlackCColor),
-                                       Text("lfo.stepseq.popup.font", kBlackCColor);
+                                       Text("lfo.stepseq.popup.text", kBlackCColor);
          }
          namespace Loop
          {
             const Surge::UI::SkinColor Marker("lfo.stepseq.loop.markers", CColor(18, 52, 99)),
-                                       MajorStep("lfo.stepseq.loop.majorstep", CColor(169, 208, 239)),
-                                       MinorStep("lfo.stepseq.loop.minorstep", CColor(154, 191, 224)),
-                                       OutsideMajorStep("lfo.stepseq.loop.outside.majorstep", CColor(222, 222, 222)),
-                                       OutsideMinorStep("lfo.stepseq.loop.outside.minorstep", CColor(208, 208, 208));
+                                       PrimaryStep("lfo.stepseq.loop.step.primary", CColor(169, 208, 239)),
+                                       SecondaryStep("lfo.stepseq.loop.step.secondary", CColor(154, 191, 224)),
+                                       OutsidePrimaryStep("lfo.stepseq.loop.outside.step.primary", CColor(222, 222, 222)),
+                                       OutsideSecondaryStep("lfo.stepseq.loop.outside.step.secondary", CColor(208, 208, 208));
          }
          namespace Step
          {
             const Surge::UI::SkinColor Fill("lfo.stepseq.step.fill", CColor(18, 52, 99)),
                                        FillDeactivated("lfo.stepseq.step.fill.deactivated", CColor(46, 134, 255)),
-                                       OutsideFill("lfo.stepseq.step.fill.disabled", kWhiteCColor);
+                                       FillOutside("lfo.stepseq.step.fill.outside", kGreyCColor);
          }
       }
       namespace Waveform
       {
          const Surge::UI::SkinColor Background("lfo.waveform.background", CColor(255, 144, 0)),
                                     Bounds("lfo.waveform.bounds", CColor(224, 128, 0)),
-                                    CenterLine("lfo.waveform.centerline", CColor(224, 128, 0)),
+                                    Center("lfo.waveform.center", CColor(224, 128, 0)),
                                     Envelope("lfo.waveform.envelope", CColor(176, 96, 0)),
-                                    Fill("lfo.waveform.fill", CColor(255, 144, 0)),
-                                    MajorDivisions("lfo.waveform.majordivisions", CColor(224, 128, 0)),
                                     Wave("lfo.waveform.wave", kBlackCColor),
-                                    DeactivatedWave( "lfo.waveform.deactivatedwave", CColor( 176, 96, 0 ) );
+                                    DeactivatedWave("lfo.waveform.wave.deactivated", CColor(0, 0, 0, 144));
 
          namespace Ruler
          {
-            const Surge::UI::SkinColor Text("lfo.waveform.ruler.font", kBlackCColor),
+            const Surge::UI::SkinColor Text("lfo.waveform.ruler.text", kBlackCColor),
                                        Ticks("lfo.waveform.ruler.ticks", kBlackCColor),
+                                       ExtendedTicks("lfo.waveform.ruler.ticks.extended", CColor(224, 128, 0)),
                                        SmallTicks("lfo.waveform.ruler.ticks.small", CColor(176, 96, 0));
          }
       }
@@ -175,34 +174,34 @@ namespace Colors
          const Surge::UI::SkinColor Background("modbutton.unused.fill", CColor(18, 52, 99)),
                                     Border("modbutton.unused.frame", CColor(32, 93, 176)),
                                     BorderHover("modbutton.unused.frame.hover", CColor(144, 216, 255)),
-                                    Text("modbutton.unused.font", CColor(46, 134, 254)),
-                                    TextHover("modbutton.unused.font.hover", CColor(144, 216, 255));
+                                    Text("modbutton.unused.text", CColor(46, 134, 254)),
+                                    TextHover("modbutton.unused.text.hover", CColor(144, 216, 255));
       }
       namespace Used
       {
          const Surge::UI::SkinColor Background("modbutton.used.fill", CColor(18, 52, 99)),
                                     Border("modbutton.used.frame", CColor(64, 173, 255)),
                                     BorderHover("modbutton.used.frame.hover", CColor(192, 235, 255)),
-                                    Text("modbutton.used.font", CColor(64, 173, 255)),
-                                    TextHover("modbutton.used.font.hover", CColor(192, 235, 255)),
-                                    UsedModHover("modbutton.used.font.usedmod.hover", CColor(154, 225, 95));
+                                    Text("modbutton.used.text", CColor(64, 173, 255)),
+                                    TextHover("modbutton.used.text.hover", CColor(192, 235, 255)),
+                                    UsedModHover("modbutton.used.text.usedmod.hover", CColor(154, 225, 95));
       }
       namespace Selected
       {
          const Surge::UI::SkinColor Background("modbutton.selected.fill", CColor(35, 100, 192)),
                                     Border("modbutton.selected.frame", CColor(46, 134, 254)),
                                     BorderHover("modbutton.selected.frame.hover", CColor(192, 235, 255)),
-                                    Text("modbutton.selected.font", CColor(18, 52, 99)),
-                                    TextHover("modbutton.selected.font.hover", CColor(192, 235, 255)),
-                                    UsedModHover("modbutton.selected.font.usedmod.hover", CColor(154, 225, 95));
+                                    Text("modbutton.selected.text", CColor(18, 52, 99)),
+                                    TextHover("modbutton.selected.text.hover", CColor(192, 235, 255)),
+                                    UsedModHover("modbutton.selected.text.usedmod.hover", CColor(154, 225, 95));
          namespace Used
          {
             const Surge::UI::SkinColor Background("modbutton.selected.used.fill", CColor(35, 100, 192)),
                                        Border("modbutton.selected.used.frame", CColor(144, 216, 255)),
                                        BorderHover("modbutton.selected.used.frame.hover", CColor(185, 255, 255)),
-                                       Text("modbutton.selected.used.font", CColor(144, 216, 255)),
-                                       TextHover("modbutton.selected.used.font.hover", CColor(185, 255, 255)),
-                                       UsedModHover("modbutton.selected.used.font.usedmod.hover", CColor(154, 225, 95));
+                                       Text("modbutton.selected.used.text", CColor(144, 216, 255)),
+                                       TextHover("modbutton.selected.used.text.hover", CColor(185, 255, 255)),
+                                       UsedModHover("modbutton.selected.used.text.usedmod.hover", CColor(154, 225, 95));
          }
       }
       namespace Armed
@@ -210,9 +209,9 @@ namespace Colors
          const Surge::UI::SkinColor Background("modbutton.armed.fill", CColor(116, 172, 72)),
                                     Border("modbutton.armed.frame", CColor(173, 255, 107)),
                                     BorderHover("modbutton.armed.frame.hover", CColor(208, 255, 255)),
-                                    Text("modbutton.armed.font", CColor(173, 255, 107)),
-                                    TextHover("modbutton.armed.font.hover", CColor(208, 255, 255)),
-                                    UsedModHover("modbutton.armed.font.usedmod.hover", CColor(46, 134, 254));
+                                    Text("modbutton.armed.text", CColor(173, 255, 107)),
+                                    TextHover("modbutton.armed.text.hover", CColor(208, 255, 255)),
+                                    UsedModHover("modbutton.armed.text.usedmod.hover", CColor(46, 134, 254));
       }
    }
 
@@ -221,12 +220,12 @@ namespace Colors
       const Surge::UI::SkinColor Background("msegeditor.background", CColor(17, 17, 17)),
                                  Curve("msegeditor.curve", kWhiteCColor),
                                  Panel("msegeditor.panel", CColor(205, 206, 212)),
-                                 Text("msegeditor.panel.font", kBlackCColor);
+                                 Text("msegeditor.panel.text", kBlackCColor);
 
       namespace Axis
       {
          const Surge::UI::SkinColor Line("msegeditor.axis.line", CColor(220, 220, 240)),
-                                    Text("msegeditor.axis.font", kWhiteCColor);
+                                    Text("msegeditor.axis.text", kWhiteCColor);
       }
       namespace GradientFill
       {
@@ -242,29 +241,35 @@ namespace Colors
       {
          const Surge::UI::SkinColor Line("msegeditor.loop.line", CColor(255, 144, 0));
       }
+      namespace NumberField
+      {
+         const Surge::UI::SkinColor Background("msegeditor.numberfield.background", CColor(216, 216, 216)),
+                                    Text("msegeditor.numberfield.text", kBlackCColor),
+                                    Border("msegeditor.numberfield.border", CColor(151, 151, 151));
+      }
    }
 
    namespace NumberField
    {
-      const Surge::UI::SkinColor Background("control.numberfield.background", kWhiteCColor),
-                                 Text("control.numberfield.font", CColor(42, 42, 42)),
-                                 Border("control.numberfield.rule", CColor(42, 42, 42)),
-                                 Env("control.numberfield.env", CColor(214, 209, 198));
+      const Surge::UI::SkinColor Background("numberfield.background", kWhiteCColor),
+                                 Text("numberfield.text", CColor(42, 42, 42)),
+                                 Border("numberfield.border", CColor(42, 42, 42)),
+                                 Env("numberfield.env", CColor(214, 209, 198));
    }
 
    namespace Osc
    {
       namespace Display
       {
-         const Surge::UI::SkinColor Bounds("osc.topline", CColor(70, 70, 70)),
-                                    CenterLine("osc.midline", CColor(90, 90, 90)),
-                                    AnimatedWave("osc.label", kWhiteCColor),
-                                    Wave("osc.wave", CColor(255, 144, 0));
+         const Surge::UI::SkinColor Bounds("osc.line.bounds", CColor(70, 70, 70)),
+                                    Center("osc.line.center", CColor(90, 90, 90)),
+                                    AnimatedWave("osc.waveform.animated", kWhiteCColor),
+                                    Wave("osc.waveform", CColor(255, 144, 0));
       }
       namespace Filename
       {
          const Surge::UI::SkinColor Background("osc.wavename.background", CColor(255, 160, 16)),
-                                    Text("osc.wavename.font", kBlackCColor);
+                                    Text("osc.wavename.text", kBlackCColor);
       }
    }
 
@@ -276,7 +281,7 @@ namespace Colors
    namespace PatchBrowser
    {
       const Surge::UI::SkinColor Background("patchbrowser.background", kWhiteCColor),
-                                 Text("patchbrowser.font", kBlackCColor);
+                                 Text("patchbrowser.text", kBlackCColor);
    }
 
    namespace Slider
@@ -288,18 +293,18 @@ namespace Colors
       }
       namespace Modulation
       {
-         const Surge::UI::SkinColor Positive("slider.modulation", CColor(173, 255, 107)),
-                                    Negative("slider.negative.modulation", CColor(173, 255, 107));
+         const Surge::UI::SkinColor Positive("slider.modulation.positive", CColor(173, 255, 107)),
+                                    Negative("slider.modulation.negative", CColor(173, 255, 107));
       }
    }
 
    namespace StatusButton
    {
       const Surge::UI::SkinColor Background("status.button.background", CColor(227, 227, 227)),
-                                 Border("status.button.outline", CColor(151, 151, 151)),
-                                 Text("status.button.unselected.font", kBlackCColor),
                                  SelectedBackground("status.button.highlight", CColor(255, 154, 16)),
-                                 SelectedText("status.button.selected.font", kBlackCColor);
+                                 Border("status.button.border", CColor(151, 151, 151)),
+                                 Text("status.button.text.unselected", kBlackCColor),
+                                 SelectedText("status.button.text.selected", kBlackCColor);
    }
 
    namespace VuMeter

--- a/src/common/gui/SkinColors.h
+++ b/src/common/gui/SkinColors.h
@@ -39,7 +39,7 @@ namespace Colors
    {
       namespace Label
       {
-         extern const Surge::UI::SkinColor Text, Line;
+         extern const Surge::UI::SkinColor Text, Separator;
       }
       namespace Preset
       {
@@ -88,20 +88,20 @@ namespace Colors
          }
          namespace Loop
          {
-            extern const Surge::UI::SkinColor Marker, MinorStep, MajorStep, OutsideMinorStep, OutsideMajorStep;
+            extern const Surge::UI::SkinColor Marker, PrimaryStep, SecondaryStep, OutsidePrimaryStep, OutsideSecondaryStep;
          }
          namespace Step
          {
-            extern const Surge::UI::SkinColor Fill, OutsideFill, FillDeactivated;
+            extern const Surge::UI::SkinColor Fill, FillDeactivated, FillOutside;
          }
       }
       namespace Waveform
       {
-         extern const Surge::UI::SkinColor Background, Bounds, CenterLine, Envelope, Fill, MajorDivisions, Wave, DeactivatedWave;
+         extern const Surge::UI::SkinColor Background, Bounds, Center, Envelope, Wave, DeactivatedWave;
 
          namespace Ruler
          {
-            extern const Surge::UI::SkinColor Text, Ticks, SmallTicks;
+            extern const Surge::UI::SkinColor Text, Ticks, ExtendedTicks, SmallTicks;
          }
       }
    }
@@ -157,6 +157,10 @@ namespace Colors
       {
           extern const Surge::UI::SkinColor Line;
       }
+      namespace NumberField
+      {
+         extern const Surge::UI::SkinColor Background, Text, Border;
+      }
    }
 
    namespace NumberField
@@ -168,7 +172,7 @@ namespace Colors
    {
       namespace Display
       {
-         extern const Surge::UI::SkinColor Bounds, CenterLine, AnimatedWave, Wave;
+         extern const Surge::UI::SkinColor Bounds, Center, AnimatedWave, Wave;
       }
       namespace Filename
       {


### PR DESCRIPTION
Skin color naming scheme is now more consistent
Update dark skin with new skin color names (and no $ used for tagged colors)