### PR TITLE
Make sure time_data and Storage are consistent

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -428,6 +428,8 @@ ComponentResult aulayer::Render(AudioUnitRenderActionFlags& ioActionFlags,
       // See github issue #146
       if (isPlaying)
          plugin_instance->time_data.ppqPos = CurrentBeat;
+
+      plugin_instance->resetStateFromTimeData();
    }
    else
    {

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2530,6 +2530,20 @@ void SurgeSynthesizer::processThreadunsafeOperations()
    }
 }
 
+void SurgeSynthesizer::resetStateFromTimeData()
+{
+   storage.songpos = time_data.ppqPos;
+   if( time_data.tempo > 0 )
+   {
+      storage.temposyncratio = time_data.tempo / 120.f;
+      storage.temposyncratio_inv = 1.f / storage.temposyncratio;
+   }
+   else
+   {
+      storage.temposyncratio = 1.f;
+      storage.temposyncratio_inv = 1.f;
+   }
+}
 void SurgeSynthesizer::processControl()
 {
    storage.perform_queued_wtloads();

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -117,6 +117,7 @@ public:
    void onRPN(int channel, int lsbRPN, int msbRPN, int lsbValue, int msbValue);
    void onNRPN(int channel, int lsbNRPN, int msbNRPN, int lsbValue, int msbValue);
 
+   void resetStateFromTimeData();
    void processControl();
    void processThreadunsafeOperations();
    bool loadFx(bool initp, bool force_reload_all);

--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -122,7 +122,6 @@ void LfoModulationSource::attack()
    {
       initPhaseFromStartPhase();
    }
-
    env_state = lenv_delay;
 
    env_val = 0.f;

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -27,7 +27,6 @@
 #if MAC
 #include <fenv.h>
 #include <AvailabilityMacros.h>
-#pragma STDC FENV_ACCESS on
 #elif WINDOWS
 #include <windows.h>
 #endif
@@ -417,24 +416,29 @@ void Vst2PluginInstance::processT(float** inputs, float** outputs, VstInt32 samp
    }
 
    // do each buffer
-   VstTimeInfo* timeinfo = getTimeInfo(kVstPpqPosValid | kVstTempoValid | kVstTransportPlaying);
+   VstTimeInfo* timeinfo = getTimeInfo(kVstTransportChanged | kVstTempoValid | kVstTransportPlaying | kVstPpqPosValid );
    if (timeinfo)
    {
       if (timeinfo->flags & kVstTempoValid)
          _instance->time_data.tempo = timeinfo->tempo;
-      if (timeinfo->flags & kVstTransportPlaying)
+      if (timeinfo->flags & kVstTransportPlaying || timeinfo->flags & kVstTransportChanged )
       {
          if (timeinfo->flags & kVstPpqPosValid)
+         {
             _instance->time_data.ppqPos = timeinfo->ppqPos;
+         }
       }
+
       if (timeinfo->flags & kVstTimeSigValid )
       {
          _instance->time_data.timeSigNumerator = timeinfo->timeSigNumerator;
          _instance->time_data.timeSigDenominator = timeinfo->timeSigDenominator;
       }
+      _instance->resetStateFromTimeData();
    }
    else
    {
+      std::cout << "TIMEPOS IS UNKNOWABLE" << std::endl;
       _instance->time_data.tempo = 120;
    }
 

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -459,6 +459,26 @@ tresult PLUGIN_API SurgeVst3Processor::process(ProcessData& data)
    {
       surgeInstance->time_data.ppqPos = data.processContext->projectTimeMusic;
    }
+   if (data.processContext && data.processContext->state & ProcessContext::kTimeSigValid)
+   {
+      surgeInstance->time_data.timeSigNumerator = data.processContext->timeSigNumerator;
+      surgeInstance->time_data.timeSigDenominator = data.processContext->timeSigDenominator;
+   }
+   else
+   {
+      surgeInstance->time_data.timeSigNumerator = 4;
+      surgeInstance->time_data.timeSigDenominator = 4;
+   }
+
+   double tempo = 120;
+   if (data.processContext && data.processContext->state & ProcessContext::kTempoValid)
+   {
+      tempo = data.processContext->tempo;
+   }
+
+   // move clock
+   surgeInstance->time_data.tempo = tempo;
+   surgeInstance->resetStateFromTimeData();
 
    if( checkNamesEvery++ == 20 )
    {
@@ -479,28 +499,8 @@ tresult PLUGIN_API SurgeVst3Processor::process(ProcessData& data)
       {
          if (data.processContext)
          {
-            double tempo = 120;
-
-            if (data.processContext->state & ProcessContext::kTempoValid)
-            {
-               tempo = data.processContext->tempo;
-            }
-
-            // move clock
-            surgeInstance->time_data.tempo = tempo;
             surgeInstance->time_data.ppqPos +=
                 (double)BLOCK_SIZE * tempo / (60. * data.processContext->sampleRate);
-
-            if (data.processContext->state & ProcessContext::kTimeSigValid)
-            {
-               surgeInstance->time_data.timeSigNumerator = data.processContext->timeSigNumerator;
-               surgeInstance->time_data.timeSigDenominator = data.processContext->timeSigDenominator;
-            }
-            else
-            {
-               surgeInstance->time_data.timeSigNumerator = 4;
-               surgeInstance->time_data.timeSigDenominator = 4;
-            }
          }
 
          processEvents(i, data.inputEvents, noteEventIndex);


### PR DESCRIPTION
time_data.ppqPos gets set by the plugins; and then
SurgeSynthesizer::processControl would copy it to songpos
but in some cases, especially when transport started simultaneoulsy
with a note in a vst2, the LfoModulationSource::attack would trigger
before the ::processControl meaning the random ppqpos value was
snapped for freerun LFO phase. Fix this by having an explicit
snap function wihch we call from the plugins

Closes #2836