### PR TITLE
BSD support fix.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,5 +35,5 @@ Keith Zantow <kzantow@gmail.com>
 Vincent Zauhar <v.zauhar@bell.net>
 簡志瑋 <dppss92132@gmail.com>
 Marty Lake <matthieu@talbot.audio>
-
+David Carlier <devnexen@gmail.com>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,10 @@ elseif( UNIX AND NOT APPLE )
     ${XKBX11COMMON_LDFLAGS}
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "BSD")
+      set(OS_LINK_LIBRARIES ${OS_LINK_LIBRARIES} execinfo)
+    endif()
+
 elseif( WIN32 )
 
   set(SURGE_OS_SOURCES
@@ -1025,6 +1029,10 @@ if( BUILD_HEADLESS )
       stdc++fs
       Threads::Threads
       )
+
+    if (CMAKE_SYSTEM_NAME MATCHES "BSD")
+      target_link_libraries(surge-headless PRIVATE execinfo)
+    endif()
   endif()
 endif()
 

--- a/libs/catch2/include/catch2/catch2.hpp
+++ b/libs/catch2/include/catch2/catch2.hpp
@@ -73,7 +73,7 @@
 #  define CATCH_PLATFORM_IPHONE
 # endif
 
-#elif defined(linux) || defined(__linux) || defined(__linux__)
+#elif defined(linux) || defined(__linux) || defined(__linux__) || defined(__FreeBSD__)
 #  define CATCH_PLATFORM_LINUX
 
 #elif defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) || defined(__MINGW32__)


### PR DESCRIPTION
backtrace API is in a separated (execinfo) library in these platforms.