### PR TITLE
Unstick LFO type hover

### DIFF
--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -99,6 +99,14 @@ public:
          
    virtual void onMouseMoveDelta(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons, double dx, double dy) override {}
 
+
+   virtual VSTGUI::CMouseEventResult onMouseExited(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override {
+      ss_shift_hover = 0;
+      lfo_type_hover = -1;
+      invalid();
+      return VSTGUI::kMouseEventHandled;
+   }
+
 protected:
    LFOStorage* lfodata;
    StepSequencerStorage* ss;


### PR DESCRIPTION
LFO type hover would stick with fast mouse move because we
didn't clear hover state in mouseExit

Closes #2844