### PR TITLE
Handle ownership of VST Drop Adapter correctly

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -169,10 +169,11 @@ struct SGEDropAdapter : public VSTGUI::IDropTarget, public VSTGUI::ReferenceCoun
    SurgeGUIEditor *buddy = nullptr;
    SGEDropAdapter( SurgeGUIEditor *buddy ) {
       this->buddy = buddy;
+      //std::cout << "Adapter created" << std::endl;
    }
    ~SGEDropAdapter()
    {
-
+      //std::cout << "Adapter Destroyed" << std::endl;
    }
 
    std::string singleFileFName(VSTGUI::DragEventData data)
@@ -246,8 +247,6 @@ SurgeGUIEditor::SurgeGUIEditor(void* effect, SurgeSynthesizer* synth, void* user
    blinkstate = false;
    aboutbox = 0;
    patchCountdown = -1;
-   dropAdapter = new SGEDropAdapter(this);
-   dropAdapter->remember();
 
    for (int i = 0; i < n_scenes; i++)
    {
@@ -384,17 +383,18 @@ SurgeGUIEditor::SurgeGUIEditor(void* effect, SurgeSynthesizer* synth, void* user
 
 SurgeGUIEditor::~SurgeGUIEditor()
 {
-   if( dropAdapter )
-   {
-      dropAdapter->buddy = nullptr;
-      dropAdapter->forget();
-   }
-
    if (frame)
    {
       getFrame()->unregisterKeyboardHook(this);
       frame->close();
    }
+   if( dropAdapter )
+   {
+      dropAdapter->buddy = nullptr;
+      dropAdapter->forget();
+      dropAdapter = nullptr;
+   }
+
 }
 
 void SurgeGUIEditor::idle()
@@ -1599,6 +1599,10 @@ bool PLUGIN_API SurgeGUIEditor::open(void* parent, const PlatformType& platformT
     * and add a comment
     * and think - sigh. VSTGUI.
     */
+
+   dropAdapter = new SGEDropAdapter(this);
+   dropAdapter->remember();
+
    VSTGUI::IDropTarget *dt = nullptr;
    nframe->getAttribute( 'vcdt', dt );
    if( dt ) dt->forget();
@@ -1653,14 +1657,22 @@ bool PLUGIN_API SurgeGUIEditor::open(void* parent, const PlatformType& platformT
 
 void SurgeGUIEditor::close()
 {
-#if TARGET_VST2 && WINDOWS
+#if TARGET_VST2 // && WINDOWS
    // We may need this in other hosts also; but for now
-   if (frame);
+   if (frame)
    {
       getFrame()->unregisterKeyboardHook(this);
       frame->close();
       frame = nullptr;
    }
+
+   if( dropAdapter )
+   {
+      dropAdapter->buddy = nullptr;
+      dropAdapter->forget();
+      dropAdapter = nullptr;
+   }
+
 #endif
 
 #if !TARGET_VST3


### PR DESCRIPTION
Lifecycle is same as frame, not editor

Closes #2839