### PR TITLE
Fix to make windows also copy the closing parentheses on about screen

### DIFF
--- a/src/common/gui/CAboutBox.cpp
+++ b/src/common/gui/CAboutBox.cpp
@@ -194,9 +194,11 @@ CAboutBox::onMouseDown(CPoint& where,
              where.y <= (skin->getWindowSizeY() - 50))
       Surge::UserInteractions::openURL("https://github.com/surge-synthesizer/surge");
    else if( copyBox.pointInside(where) ){
-
-      auto a = CDropSource::create(identifierLine.c_str(), identifierLine.size(), IDataPackage::kText );
-      getFrame()->setClipboard(a);
+     #if WINDOWS
+         identifierLine = identifierLine + " ";
+     #endif
+         auto a = CDropSource::create(identifierLine.c_str(), identifierLine.size(), IDataPackage::kText );
+         getFrame()->setClipboard(a);
    }
    else
       boxHide();


### PR DESCRIPTION
For some reason this didn't work on windows fully, but it did on mac. So when copying the hash line in about box the clipboard copied all the line except the last closing parentheses, this fixes it. 