### PR TITLE
MSEG Endpoint Locks, Deform Skip, Tests, and More

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -979,6 +979,7 @@ if( BUILD_HEADLESS )
     src/headless/UnitTestsIO.cpp
     src/headless/UnitTestsMIDI.cpp
     src/headless/UnitTestsMOD.cpp
+    src/headless/UnitTestsMSEG.cpp
     src/headless/UnitTestsPARAM.cpp
     src/headless/UnitTestsTUN.cpp
     )

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1569,6 +1569,25 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
       auto *ms = &( msegs[sc][mi] );
       ms->n_activeSegments = 0;
       if( p->QueryIntAttribute( "activeSegments", &v ) == TIXML_SUCCESS ) ms->n_activeSegments = v;
+      if( p->QueryIntAttribute("endpointMode", &v) == TIXML_SUCCESS )
+         ms->endpointMode = (MSEGStorage::EndpointMode)v;
+      else
+         ms->endpointMode = MSEGStorage::EndpointMode::FREE;
+      if( p->QueryIntAttribute( "loopMode", &v ) == TIXML_SUCCESS )
+         ms->loopMode = (MSEGStorage::LoopMode)v;
+      else
+         ms->loopMode = MSEGStorage::LoopMode::LOOP;
+      if( p->QueryIntAttribute( "loopStart", &v ) == TIXML_SUCCESS )
+         ms->loop_start = v;
+      else
+         ms->loop_start = -1;
+
+      if( p->QueryIntAttribute( "loopEnd", &v ) == TIXML_SUCCESS )
+         ms->loop_end = v;
+      else
+         ms->loop_end = -1;
+
+
       auto segs = TINYXML_SAFE_TO_ELEMENT(p->FirstChild( "segments" ));
       if( segs )
       {
@@ -1582,11 +1601,17 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
             MSGF( v0 );
             MSGF( cpduration );
             MSGF( cpv );
+            MSGF( nv1 );
             
             int t = 0;
             if( seg->QueryIntAttribute( "type", &v ) == TIXML_SUCCESS ) t = v;
             ms->segments[idx].type = (MSEGStorage::segment::Type)t;
-            
+
+            if( seg->QueryIntAttribute( "useDeform", &v) == TIXML_SUCCESS )
+               ms->segments[idx].useDeform = v;
+            else
+               ms->segments[idx].useDeform = true;
+
             seg = TINYXML_SAFE_TO_ELEMENT( seg->NextSibling( "segment" ) );
             
             idx++;
@@ -1964,6 +1989,10 @@ unsigned int SurgePatch::save_xml(void** data) // allocates mem, must be freed b
 
             auto *ms = &(msegs[sc][l]);
             p.SetAttribute( "activeSegments", ms->n_activeSegments );
+            p.SetAttribute( "endpointMode", ms->endpointMode );
+            p.SetAttribute( "loopMode", ms->loopMode );
+            p.SetAttribute( "loopStart", ms->loop_start);
+            p.SetAttribute( "loopEnd", ms->loop_end );
 
             TiXmlElement segs( "segments" );
             for( int s=0; s<ms->n_activeSegments; ++s )
@@ -1971,9 +2000,11 @@ unsigned int SurgePatch::save_xml(void** data) // allocates mem, must be freed b
                TiXmlElement seg( "segment" );
                seg.SetDoubleAttribute( "duration", ms->segments[s].duration );
                seg.SetDoubleAttribute( "v0", ms->segments[s].v0 );
+               seg.SetDoubleAttribute( "nv1", ms->segments[s].nv1 );
                seg.SetDoubleAttribute( "cpduration", ms->segments[s].cpduration );
                seg.SetDoubleAttribute( "cpv", ms->segments[s].cpv );
                seg.SetAttribute( "type", (int)( ms->segments[s].type ));
+               seg.SetAttribute( "useDeform", (int)(ms->segments[s].useDeform));
                segs.InsertEndChild( seg );
             }
             p.InsertEndChild(segs);

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -534,6 +534,7 @@ bailOnPortable:
          ms->segments[3].duration = 0.5;
          ms->segments[3].type = MSEGStorage::segment::SCURVE;
          ms->segments[3].v0 = -0.7;
+         ms->segments[3].nv1 = 0; // Have to set this now due to endpoint mode
          ms->segments[3].cpduration = 0.4;
          ms->segments[3].cpv = -0.3;
          Surge::MSEG::rebuildCache( ms );

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -614,7 +614,9 @@ struct MSEGStorage {
       float v0;
       float dragv0; // in snap mode, this is the location we are dragged to. It is just convenience storage.
       float nv1; // this is the v0 of the neighbor and is here just for convenience. MSEGModulationHelper::rebuildCache will set it
+      float dragv1; // only used in the endpoint
       float cpduration, cpv, dragcpv;
+      bool  useDeform = true;
       enum Type {
          LINEAR = 1,
          QUAD_BEZIER,
@@ -625,6 +627,22 @@ struct MSEGStorage {
          SQUARE,
       } type;
    };
+
+   // These values are streamed so please don't change the integer values
+   enum EndpointMode {
+      LOCKED = 1,
+      FREE = 2
+   } endpointMode = FREE;
+
+   // These values are streamed so please don't change the integer values
+   enum LoopMode {
+      ONESHOT = 1, // Play the MSEG front to back and then output the final value
+      LOOP = 2, // Play the mseg Front to Loop End and then return to Loop Start
+      GATED_LOOP = 3 // Play the mseg front to loop end, then return to loo pstart; but if at any time
+          // a release is generated, jump to loop end at current value and progress to end once
+   } loopMode = LOOP;
+
+   int loop_start = -1, loop_end = -1; // -1 signifies the entire mseg in this context
 
    int n_activeSegments = 0;
    std::array<segment, max_msegs> segments;

--- a/src/headless/UnitTestsMSEG.cpp
+++ b/src/headless/UnitTestsMSEG.cpp
@@ -1,0 +1,273 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <algorithm>
+
+#include "HeadlessUtils.h"
+#include "catch2/catch2.hpp"
+#include "FastMath.h"
+#include "MSEGModulationHelper.h"
+
+struct msegObservation {
+   msegObservation(int ip, float fp, float va ) {
+      iPhase = ip; fPhase = fp; phase = ip + fp; v = va;
+   }
+   int iPhase;
+   float fPhase;
+   float v;
+   float phase;
+};
+
+std::vector<msegObservation> runMSEG( MSEGStorage *ms, float dPhase, float phaseMax, float deform = 0 )
+{
+   auto res = std::vector<msegObservation>();
+   double phase = 0.0;
+   int iphase = 0;
+   int lastSeg;
+   float state[6];
+   while( phase + iphase < phaseMax )
+   {
+      auto r = Surge::MSEG::valueAt(iphase, phase, deform, ms, lastSeg, state );
+      res.push_back( msegObservation( iphase, phase, r ));
+      phase += dPhase;
+      if( phase > 1 ) { phase -= 1; iphase += 1; }
+   }
+   return res;
+}
+
+/*
+ * These tests test the relationship between configuration of MSEG Storage and the phase evaluator
+ */
+TEST_CASE( "Basic MSEG Evaluation", "[mseg]" )
+{
+   SECTION( "Simple Square" )
+   {
+      MSEGStorage ms;
+      ms.n_activeSegments = 4;
+      ms.endpointMode = MSEGStorage::EndpointMode::LOCKED;
+      ms.segments[0].duration = 0.5 - MSEGStorage::minimumDuration;
+      ms.segments[0].type = MSEGStorage::segment::LINEAR;
+      ms.segments[0].v0 = 1.0;
+
+      ms.segments[1].duration = MSEGStorage::minimumDuration;
+      ms.segments[1].type = MSEGStorage::segment::LINEAR;
+      ms.segments[1].v0 = 1.0;
+
+      ms.segments[2].duration = 0.5 - MSEGStorage::minimumDuration;
+      ms.segments[2].type = MSEGStorage::segment::LINEAR;
+      ms.segments[2].v0 = -1.0;
+
+      ms.segments[3].duration = MSEGStorage::minimumDuration;
+      ms.segments[3].type = MSEGStorage::segment::LINEAR;
+      ms.segments[3].v0 = -1.0;
+
+      Surge::MSEG::rebuildCache(&ms);
+
+      // OK so lets go ahead and run it at a variety of forward phases
+      auto runIt = runMSEG(&ms, 0.0321, 5 );
+      for( auto c : runIt )
+      {
+         if( c.fPhase < 0.5 - MSEGStorage::minimumDuration )
+            REQUIRE( c.v == 1 );
+         if( c.fPhase > 0.5 &&  c.fPhase < 1 - MSEGStorage::minimumDuration )
+            REQUIRE( c.v == -1 );
+      }
+   }
+
+   SECTION( "Longer Square" )
+   {
+      MSEGStorage ms;
+      ms.n_activeSegments = 4;
+      ms.endpointMode = MSEGStorage::EndpointMode::LOCKED;
+      ms.segments[0].duration = 0.5 - MSEGStorage::minimumDuration;
+      ms.segments[0].type = MSEGStorage::segment::LINEAR;
+      ms.segments[0].v0 = 1.0;
+
+      ms.segments[1].duration = MSEGStorage::minimumDuration;
+      ms.segments[1].type = MSEGStorage::segment::LINEAR;
+      ms.segments[1].v0 = 1.0;
+
+      ms.segments[2].duration = 1.0 - MSEGStorage::minimumDuration;
+      ms.segments[2].type = MSEGStorage::segment::LINEAR;
+      ms.segments[2].v0 = -1.0;
+
+      ms.segments[3].duration = MSEGStorage::minimumDuration;
+      ms.segments[3].type = MSEGStorage::segment::LINEAR;
+      ms.segments[3].v0 = -1.0;
+
+      Surge::MSEG::rebuildCache(&ms);
+
+      // OK so lets go ahead and run it at a variety of forward phases
+      auto runIt = runMSEG(&ms, 0.0321, 14 );
+      for( auto c : runIt )
+      {
+         auto dbphase = (int)( 2 * c.phase ) % 3;
+         INFO( "phase is " << c.phase << " " << dbphase )
+         if( dbphase == 0 )
+            REQUIRE( c.v == 1 );
+         if( dbphase == 1 || dbphase == 2  )
+            REQUIRE( c.v == -1 );
+      }
+   }
+}
+
+TEST_CASE( "Unlocked Endpoitns", "[mseg]" )
+{
+   SECTION( "Simple Square Default Locks" )
+   {
+      MSEGStorage ms;
+      ms.n_activeSegments = 3;
+      ms.endpointMode = MSEGStorage::EndpointMode::LOCKED;
+      ms.segments[0].duration = 0.5 - MSEGStorage::minimumDuration;
+      ms.segments[0].type = MSEGStorage::segment::LINEAR;
+      ms.segments[0].v0 = 1.0;
+
+      ms.segments[1].duration = MSEGStorage::minimumDuration;
+      ms.segments[1].type = MSEGStorage::segment::LINEAR;
+      ms.segments[1].v0 = 1.0;
+
+      ms.segments[2].duration = 0.5;
+      ms.segments[2].type = MSEGStorage::segment::LINEAR;
+      ms.segments[2].v0 = -1.0;
+
+      Surge::MSEG::rebuildCache(&ms);
+
+      // OK so lets go ahead and run it at a variety of forward phases
+      auto runIt = runMSEG(&ms, 0.0321, 5 );
+      for( auto c : runIt )
+      {
+         if( c.fPhase < 0.5 - MSEGStorage::minimumDuration )
+            REQUIRE( c.v == 1 );
+         if( c.fPhase > 0.5 &&  c.fPhase < 1 - MSEGStorage::minimumDuration )
+            REQUIRE( c.v > -1 );
+      }
+   }
+
+   SECTION( "Free Endpoint is a Square" )
+   {
+      MSEGStorage ms;
+      ms.n_activeSegments = 3;
+      ms.endpointMode = MSEGStorage::EndpointMode::FREE;
+      ms.segments[0].duration = 0.5 - MSEGStorage::minimumDuration;
+      ms.segments[0].type = MSEGStorage::segment::LINEAR;
+      ms.segments[0].v0 = 1.0;
+
+      ms.segments[1].duration = MSEGStorage::minimumDuration;
+      ms.segments[1].type = MSEGStorage::segment::LINEAR;
+      ms.segments[1].v0 = 1.0;
+
+      ms.segments[2].duration = 0.5;
+      ms.segments[2].type = MSEGStorage::segment::LINEAR;
+      ms.segments[2].v0 = -1.0;
+      ms.segments[2].nv1 = -1.0; // The free mode will preserve this
+
+      Surge::MSEG::rebuildCache(&ms);
+
+      // OK so lets go ahead and run it at a variety of forward phases
+      auto runIt = runMSEG(&ms, 0.0321, 5 );
+      for( auto c : runIt )
+      {
+         if( c.fPhase < 0.5 - MSEGStorage::minimumDuration )
+            REQUIRE( c.v == 1 );
+         if( c.fPhase > 0.5 &&  c.fPhase < 1 - MSEGStorage::minimumDuration )
+            REQUIRE( c.v == -1 );
+      }
+   }
+}
+
+TEST_CASE( "Deform per Segment", "[mseg]" )
+{
+   SECTION( "Triangle with Deform" )
+   {
+      MSEGStorage ms;
+      ms.n_activeSegments = 2;
+      ms.endpointMode = MSEGStorage::EndpointMode::LOCKED;
+      ms.segments[0].duration = 0.5;
+      ms.segments[0].type = MSEGStorage::segment::LINEAR;
+      ms.segments[0].v0 = -1.0;
+
+      ms.segments[1].duration = 0.5;
+      ms.segments[1].type = MSEGStorage::segment::LINEAR;
+      ms.segments[1].v0 = 1.0;
+
+      Surge::MSEG::rebuildCache(&ms);
+
+      // OK so lets go ahead and run it at a variety of forward phases
+      auto runIt = runMSEG(&ms, 0.0321, 3 );
+      for( auto c : runIt )
+      {
+         if( c.fPhase < 0.5  )
+            REQUIRE( c.v == Approx( 2 * c.fPhase / 0.5 - 1 ) );
+         if( c.fPhase > 0.5 )
+            REQUIRE( c.v == Approx( 1 - 2 * (c.fPhase - 0.5 ) / 0.5 ) );
+      }
+
+      auto runDef = runMSEG(&ms, 0.0321, 3, 0.9 );
+      for( auto c : runDef )
+      {
+         if( c.fPhase < 0.5 && c.v != -1 )
+            REQUIRE( c.v < 2 * c.fPhase / 0.5 - 1 );
+         if( c.fPhase > 0.5 && c.v != 1 )
+            REQUIRE( c.v > 1 - 2 * (c.fPhase - 0.5 ) / 0.5 );
+      }
+
+      ms.segments[0].useDeform = false;
+      auto runDefPartial = runMSEG(&ms, 0.0321, 3, 0.9 );
+      for( auto c : runDefPartial )
+      {
+         if( c.fPhase < 0.5 && c.v != -1 )
+            REQUIRE( c.v == Approx( 2 * c.fPhase / 0.5 - 1 ) );
+         if( c.fPhase > 0.5 && c.v != 1 )
+            REQUIRE( c.v > 1 - 2 * (c.fPhase - 0.5 ) / 0.5 );
+      }
+   }
+}
+
+TEST_CASE("OneShot vs Loop", "[mseg]" )
+{
+   SECTION( "Triangle Loop" )
+   {
+      MSEGStorage ms;
+      ms.n_activeSegments = 2;
+      ms.endpointMode = MSEGStorage::EndpointMode::LOCKED;
+      ms.segments[0].duration = 0.5;
+      ms.segments[0].type = MSEGStorage::segment::LINEAR;
+      ms.segments[0].v0 = -1.0;
+
+      ms.segments[1].duration = 0.5;
+      ms.segments[1].type = MSEGStorage::segment::LINEAR;
+      ms.segments[1].v0 = 1.0;
+
+      Surge::MSEG::rebuildCache(&ms);
+
+      // OK so lets go ahead and run it at a variety of forward phases
+      auto runIt = runMSEG(&ms, 0.0321, 3 );
+      for( auto c : runIt )
+      {
+         if( c.fPhase < 0.5  )
+            REQUIRE( c.v == Approx( 2 * c.fPhase / 0.5 - 1 ) );
+         if( c.fPhase > 0.5 )
+            REQUIRE( c.v == Approx( 1 - 2 * (c.fPhase - 0.5 ) / 0.5 ) );
+      }
+
+      ms.loopMode = MSEGStorage::LoopMode::ONESHOT;
+      auto runOne = runMSEG(&ms, 0.0321, 3 );
+      for( auto c : runOne )
+      {
+         if( c.phase < 1 )
+         {
+            if (c.fPhase < 0.5)
+               REQUIRE(c.v == Approx(2 * c.fPhase / 0.5 - 1));
+            if (c.fPhase > 0.5)
+               REQUIRE(c.v == Approx(1 - 2 * (c.fPhase - 0.5) / 0.5));
+         }
+         else
+         {
+            REQUIRE( c.v == -1 );
+         }
+      }
+
+
+   }
+
+}


### PR DESCRIPTION
- RegTest for basic MSEGs
- Endpoint Locking Mode
- Deform de-activation per segment
- Add loop modes but don't expose them
- Implement ONESHOT mode
- Implement above in MSEG Editor
- Store above in the SurgePatch