### PR TITLE
Don't update UI from Audio Thread in VST2

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -945,9 +945,8 @@ void SurgeSynthesizer::programChange(char channel, int value)
 
 void SurgeSynthesizer::updateDisplay()
 {
-#if ! TARGET_AUDIOUNIT
-   getParent()->updateDisplay();
-#endif
+   // This used to (in VSt2) call udpateDisplay but that did an Audio -> UI thread cross. Just mark
+   // the flag as true.
    refresh_editor = true;
 }
 


### PR DESCRIPTION
The VST2 would call udpateDisplay but call it in a way
that the audio thread would call it. That's obviously wrong
so remove that call and just have all the hosts force the update
through the refresh flag.