### PR TITLE
More MSEG Quality Changes

### DIFF
--- a/src/common/dsp/MSEGModulationHelper.cpp
+++ b/src/common/dsp/MSEGModulationHelper.cpp
@@ -486,7 +486,7 @@ void insertBefore( MSEGStorage *ms, float t ) {
 
 void extendTo( MSEGStorage *ms, float t, float nv ) {
    if( t < ms->totalDuration ) return;
-   
+   nv = limit_range( nv, -1.f, 1.f );
    insertAtIndex( ms, ms->n_activeSegments );
 
    auto sn = ms->n_activeSegments - 1;
@@ -524,6 +524,7 @@ void extendTo( MSEGStorage *ms, float t, float nv ) {
 
 void splitSegment( MSEGStorage *ms, float t, float nv ) {
    int idx = timeToSegment( ms, t );
+   nv = limit_range( nv, -1.f, 1.f );
    if( idx >= 0 )
    {
       while( t > ms->totalDuration ) t -= ms->totalDuration;

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -1382,10 +1382,7 @@ CMouseEventResult CLFOGui::onMouseMoved(CPoint& where, const CButtonState& butto
                }
 
                // this is less of a hack.
-               if( prior == ls_mseg || i == ls_mseg )
-               {
-                  sge->queueRebuildUI();
-               }
+               sge->lfoShapeChanged( prior, i );
 
             }
          }

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -280,6 +280,7 @@ public:
                           const VSTGUI::CPoint &topleft = VSTGUI::CPoint( 0, 0 ),
                           bool modalOverlay = true,
                           std::function<void()> onClose = [](){} );
+   void dismissEditorOverlay();
 
 
    std::string getDisplayForTag( long tag );
@@ -289,7 +290,8 @@ public:
          strncpy( synth->patchid_file, file.c_str(), FILENAME_MAX );
          synth->has_patchid_file = true;
       }
-   
+
+   void lfoShapeChanged(int prior, int curr);
 private:
    SGEDropAdapter *dropAdapter = nullptr;
    friend class SGEDropAdapter;
@@ -345,6 +347,7 @@ private:
    VSTGUI::CTextEdit* patchComment = nullptr;
    VSTGUI::CCheckBox* patchTuning = nullptr;
    VSTGUI::CTextLabel* patchTuningLabel = nullptr;
+   VSTGUI::CControl *msegEditSwitch = nullptr;
 #if BUILD_IS_DEBUG
    VSTGUI::CTextLabel* debugLabel = nullptr;
 #endif


### PR DESCRIPTION
- Split and Extend are bounded by grid
- MSEG Edit Button is hide/show rather than rebuild
- MSEG Edit Button state can close the MSEG window too and is preserved