### PR TITLE
filesystem: Rewrite

### DIFF
--- a/libs/filesystem/CMakeLists.txt
+++ b/libs/filesystem/CMakeLists.txt
@@ -1,8 +1,19 @@
 project(filesystem VERSION 0.0.0 LANGUAGES CXX)
 
 add_library(${PROJECT_NAME}
+  src/directory_iterator.cpp
   src/filesystem.cpp
+  src/path.cpp
+  src/recursive_directory_iterator.cpp
+  src/util.h
+  include/${PROJECT_NAME}/directory_entry.h
+  include/${PROJECT_NAME}/directory_iterator.h
   include/${PROJECT_NAME}/filesystem.h
+  include/${PROJECT_NAME}/filesystem_error.h
+  include/${PROJECT_NAME}/path.h
+  include/${PROJECT_NAME}/recursive_directory_iterator.h
 )
 add_library(surge::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(${PROJECT_NAME} PUBLIC include)
+
+target_sources(surge-tests INTERFACE src/tests.cpp)

--- a/libs/filesystem/include/filesystem/directory_entry.h
+++ b/libs/filesystem/include/filesystem/directory_entry.h
@@ -15,24 +15,26 @@
 
 #pragma once
 
-#include "filesystem/filesystem_error.h"
 #include "filesystem/path.h"
-#include "filesystem/directory_iterator.h"
-#include "filesystem/recursive_directory_iterator.h"
-
-#include <cstdint>
 
 namespace Surge { namespace filesystem {
 
-// filesystem operations                                                               [fs.op.funcs]
-bool create_directories(const path& p);
-bool create_directory(const path& p);
-bool exists(const path& p);
-std::uintmax_t file_size(const path& p);
-bool is_directory(const path& p);
-bool is_regular_file(const path& p);
-bool remove(const path& p);
-std::uintmax_t remove_all(const path& p);
+class directory_entry //                                                  [fs.class.directory_entry]
+{
+public:
+   // constructors and destructor                                                [fs.dir.entry.cons]
+   directory_entry() noexcept = default;
+   explicit directory_entry(const path& p) : pth(p) {}
+
+   // modifiers                                                                  [fs.dir.entry.mods]
+   const class path& path() const noexcept { return pth; }
+   operator const class path& () const noexcept { return pth; }
+
+private:
+   class path pth;
+
+   friend class directory_iterator;
+};
 
 } // namespace filesystem
 

--- a/libs/filesystem/include/filesystem/directory_iterator.h
+++ b/libs/filesystem/include/filesystem/directory_iterator.h
@@ -1,0 +1,65 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#pragma once
+
+#include "filesystem/path.h"
+#include "filesystem/directory_entry.h"
+
+#include <iterator>
+#include <memory>
+#include <system_error>
+
+namespace Surge { namespace filesystem {
+
+class directory_iterator //                                            [fs.class.directory_iterator]
+{
+public:
+   using iterator_category = std::input_iterator_tag;
+   using value_type = directory_entry;
+   using difference_type = ptrdiff_t;
+   using pointer = const value_type*;
+   using reference = const value_type&;
+
+   // member functions                                                          [fs.dir.itr.members]
+   directory_iterator() noexcept = default;
+   explicit directory_iterator(const path& p);
+   directory_iterator(const path& p, std::error_code& ec) noexcept;
+
+   const value_type& operator*() const noexcept;
+   const value_type* operator->() const noexcept { return &**this; }
+
+   directory_iterator& operator++();
+
+private:
+   struct Impl;
+   std::shared_ptr<Impl> d;
+
+   explicit directory_iterator(const path::string_type& p);
+
+   friend bool operator==(const directory_iterator& lhs, const directory_iterator& rhs) noexcept
+   { return lhs.d == rhs.d; }
+
+   friend bool operator!=(const directory_iterator& lhs, const directory_iterator& rhs) noexcept
+   { return !(lhs == rhs); }
+};
+
+// non-member functions                                                      [fs.dir.itr.nonmembers]
+inline directory_iterator begin(directory_iterator it) noexcept { return it; }
+inline directory_iterator end(const directory_iterator&) noexcept { return directory_iterator(); }
+
+} // namespace filesystem
+
+} // namespace Surge

--- a/libs/filesystem/include/filesystem/filesystem_error.h
+++ b/libs/filesystem/include/filesystem/filesystem_error.h
@@ -15,24 +15,20 @@
 
 #pragma once
 
-#include "filesystem/filesystem_error.h"
-#include "filesystem/path.h"
-#include "filesystem/directory_iterator.h"
-#include "filesystem/recursive_directory_iterator.h"
-
-#include <cstdint>
+#include <system_error>
 
 namespace Surge { namespace filesystem {
 
-// filesystem operations                                                               [fs.op.funcs]
-bool create_directories(const path& p);
-bool create_directory(const path& p);
-bool exists(const path& p);
-std::uintmax_t file_size(const path& p);
-bool is_directory(const path& p);
-bool is_regular_file(const path& p);
-bool remove(const path& p);
-std::uintmax_t remove_all(const path& p);
+class filesystem_error : public std::system_error //                     [fs.class.filesystem_error]
+{
+public:
+   filesystem_error(const std::string& what_arg, std::error_code ec)
+   : system_error(ec, std::string{"filesystem error: "} + what_arg) {}
+
+   filesystem_error(int errnum, const std::string& what_arg) // non-standard convenience overload
+   : filesystem_error(what_arg, std::error_code(errnum, std::generic_category()))
+   {}
+};
 
 } // namespace filesystem
 

--- a/libs/filesystem/include/filesystem/path.h
+++ b/libs/filesystem/include/filesystem/path.h
@@ -1,0 +1,83 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#pragma once
+
+#include <iosfwd>
+#include <string>
+#include <utility>
+
+namespace Surge { namespace filesystem {
+
+class path //                                                                        [fs.class.path]
+{
+public:
+   using value_type = char;
+   using string_type = std::basic_string<value_type>;
+
+   static constexpr value_type preferred_separator = '/';
+
+   // constructors and destructor                                                [fs.path.construct]
+   path() = default;
+   explicit path(string_type p) noexcept // Hint: Did you mean to use string_to_path()?
+   : pth(std::move(p)) {}
+
+   // appends                                                                       [fs.path.append]
+   path& operator/=(const path& rhs);
+
+   // modifiers                                                                  [fs.path.modifiers]
+   void clear() noexcept { pth.clear(); }
+   path& make_preferred() noexcept { return *this; }
+   path& remove_filename();
+
+   // native format observers                                                   [fs.path.native.obs]
+   const string_type& native() const noexcept { return pth; }
+   const value_type* c_str() const noexcept { return pth.c_str(); }
+#if __cplusplus < 201703L
+   // Pre-C++17 fstream compatibility. Otherwise disabled because this is unsafe on Windows.
+   operator string_type() const { return pth; }
+#endif
+   const std::string& string() const noexcept { return pth; }
+   const std::string& u8string() const noexcept { return pth; }
+
+   // generic format observers                                                 [fs.path.generic.obs]
+   const std::string& generic_string() const noexcept { return pth; }
+   const std::string& generic_u8string() const noexcept { return pth; }
+
+   // decomposition                                                              [fs.path.decompose]
+   path filename() const;
+   path stem() const;
+   path extension() const;
+
+   // query                                                                          [fs.path.query]
+   bool empty() const noexcept { return pth.empty(); }
+   bool has_filename() const noexcept { return !pth.empty() && pth.back() != preferred_separator; }
+   bool has_stem() const noexcept;
+   bool has_extension() const noexcept;
+   bool is_absolute() const noexcept { return !pth.empty() && pth.front() == preferred_separator; }
+   bool is_relative() const noexcept { return !is_absolute(); }
+
+   friend path operator/(const path& lhs, const path& rhs) { return path(lhs) /= rhs; }
+   friend std::ostream& operator<<(std::ostream& os, const path& p);
+
+private:
+   string_type pth;
+
+   friend class directory_iterator;
+};
+
+} // namespace filesystem
+
+} // namespace Surge

--- a/libs/filesystem/include/filesystem/recursive_directory_iterator.h
+++ b/libs/filesystem/include/filesystem/recursive_directory_iterator.h
@@ -1,0 +1,68 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#pragma once
+
+#include "filesystem/directory_entry.h"
+
+#include <memory>
+#include <system_error>
+
+namespace Surge { namespace filesystem {
+
+class recursive_directory_iterator //                                         [fs.class.rec.dir.itr]
+{
+public:
+   using iterator_category = std::input_iterator_tag;
+   using value_type = directory_entry;
+   using difference_type = ptrdiff_t;
+   using pointer = const value_type*;
+   using reference = const value_type&;
+
+   // constructors and destructor                                           [fs.rec.dir.itr.members]
+   recursive_directory_iterator() noexcept = default;
+   explicit recursive_directory_iterator(const path& p);
+   recursive_directory_iterator(const path& p, std::error_code& ec) noexcept;
+
+   // observers
+   const value_type& operator*() const noexcept;
+   const value_type* operator->() const noexcept { return &**this; }
+
+   // modifiers
+   recursive_directory_iterator& operator++();
+
+private:
+   struct Impl;
+   std::shared_ptr<Impl> d;
+
+   friend bool operator==(const recursive_directory_iterator& lhs,
+                          const recursive_directory_iterator& rhs) noexcept
+   { return lhs.d == rhs.d; }
+
+   friend bool operator!=(const recursive_directory_iterator& lhs,
+                          const recursive_directory_iterator& rhs) noexcept
+   { return !(lhs == rhs); }
+};
+
+// non-member functions                                                  [fs.rec.dir.itr.nonmembers]
+inline recursive_directory_iterator begin(recursive_directory_iterator it) noexcept
+{ return it; }
+
+inline recursive_directory_iterator end(const recursive_directory_iterator&) noexcept
+{ return recursive_directory_iterator(); }
+
+} // namespace filesystem
+
+} // namespace Surge

--- a/libs/filesystem/src/directory_iterator.cpp
+++ b/libs/filesystem/src/directory_iterator.cpp
@@ -1,0 +1,116 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "filesystem/directory_iterator.h"
+#include "filesystem/filesystem.h"
+
+#include <cerrno>
+#include <climits>
+
+#include <sys/types.h>
+#include <dirent.h>
+
+#include "util.h"
+
+namespace Surge { namespace filesystem {
+
+namespace {
+struct DirDeleter
+{
+   void operator()(DIR* dirp)
+   {
+      if (dirp)
+         ::closedir(dirp);
+   }
+};
+} // anonymous namespace
+
+using dir_unique_ptr = std::unique_ptr<DIR, DirDeleter>;
+
+struct directory_iterator::Impl
+{
+   value_type entry;
+   dir_unique_ptr dirp;
+   const path::string_type::size_type pathlen_with_slash;
+   const path::string_type::size_type pathlen_user;
+
+   Impl(dir_unique_ptr&& dirp, const path::string_type& p)
+   : dirp{std::move(dirp)}
+   , pathlen_with_slash{p.size() + (p.back() != path::preferred_separator)}
+   , pathlen_user{p.size()}
+   {
+      entry.pth.pth.reserve(pathlen_with_slash + NAME_MAX + 1);
+      entry.pth.pth.append(p);
+      if (pathlen_user != pathlen_with_slash)
+         entry.pth.pth.push_back(path::preferred_separator);
+   }
+};
+
+directory_iterator::directory_iterator(const path::string_type& p)
+{
+   if (dir_unique_ptr dirp{::opendir(p.c_str())})
+      d = std::make_shared<Impl>(std::move(dirp), p);
+}
+
+directory_iterator::directory_iterator(const path& p)
+: directory_iterator{p.native()}
+{
+   if (!d)
+      throw filesystem_error{errno,
+                             "directory iterator cannot open directory \"" + p.native() + '\"'};
+   ++*this;
+}
+
+directory_iterator::directory_iterator(const path& p, std::error_code& ec) noexcept
+: directory_iterator{p.native()}
+{
+   if (d)
+      ++*this;
+   else
+      ec = std::error_code(errno, std::system_category());
+}
+
+const directory_iterator::value_type& directory_iterator::operator*() const noexcept
+{
+   return d->entry;
+}
+
+directory_iterator& directory_iterator::operator++()
+{
+   errno = 0;
+   while (auto* const dirent = ::readdir(d->dirp.get()))
+   {
+      if (is_dot_or_dotdot(dirent->d_name))
+         continue;
+      d->entry.pth.pth.resize(d->pathlen_with_slash);
+      d->entry.pth.pth.append(dirent->d_name);
+      return *this;
+   }
+
+   if (const auto errno_copy{errno})
+   {
+      d->entry.pth.pth.resize(d->pathlen_user);
+      const auto impl{std::move(d)};
+      throw filesystem_error{errno_copy,
+                             "directory iterator cannot read directory \"" + impl->entry.pth.pth + '\"'};
+   }
+
+   d.reset();
+   return *this;
+}
+
+} // namespace filesystem
+
+} // namespace Surge

--- a/libs/filesystem/src/path.cpp
+++ b/libs/filesystem/src/path.cpp
@@ -1,0 +1,149 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "filesystem/path.h"
+
+#include "util.h"
+
+#include <iomanip>
+#include <iostream>
+
+namespace Surge { namespace filesystem {
+
+namespace {
+// No string_view in C++14 :(
+struct slice
+{
+   const path::value_type* const p;
+   const path::string_type::size_type len;
+
+   bool empty() const noexcept { return !p || !*p; }
+
+   path::string_type as_string() const
+   {
+      if (!p)
+         return path::string_type{};
+      if (!len)
+         return path::string_type{p};
+      return path::string_type{p, len};
+   }
+
+   path as_path() const { return path{as_string()}; }
+};
+
+const path::value_type* filename_internal(const path& p) noexcept
+{
+   const auto& s = p.native();
+   const auto slash = s.find_last_of(path::preferred_separator);
+   if (slash == path::string_type::npos)
+      return s.c_str();
+   return s.c_str() + slash + 1;
+}
+
+slice stem_internal(const path& p) noexcept
+{
+   const auto* filename = filename_internal(p);
+   const auto& pth = p.native();
+   if (!is_dot_or_dotdot(filename))
+   {
+      for (const auto* x = &*pth.end(); x > filename; --x)
+         if (*x == '.')
+            return slice{filename, path::string_type::size_type(x - filename)};
+   }
+   return slice{filename};
+}
+
+const path::value_type* extension_internal(const path& p) noexcept
+{
+   const auto* filename = filename_internal(p);
+   const auto& pth = p.native();
+   auto period_idx = pth.find_last_of('.');
+   if (period_idx == path::string_type::npos)
+      return nullptr;
+   const auto* period = pth.c_str() + period_idx;
+   if (period <= filename)
+      return nullptr;
+   if (is_dot_or_dotdot(filename))
+      return nullptr;
+   while (period[1] && period[1] == '.')
+      ++period;
+   return period;
+}
+} // anonymous namespace
+
+path& path::operator/=(const path& rhs)
+{
+   if (rhs.is_absolute())
+      pth = rhs.pth;
+   else
+   {
+      if (pth.back() != preferred_separator)
+         pth.push_back(preferred_separator);
+      pth.append(rhs.pth);
+   }
+   return *this;
+}
+
+path& path::remove_filename()
+{
+   pth.resize(filename_internal(*this) - pth.c_str());
+   return *this;
+}
+
+path path::filename() const
+{
+   return path{filename_internal(*this)};
+}
+
+path path::stem() const
+{
+   return stem_internal(*this).as_path();
+}
+
+path path::extension() const
+{
+   const auto* filename = filename_internal(*this);
+   auto period_idx = pth.find_last_of('.');
+   if (period_idx == string_type::npos)
+      return path{};
+   const auto* period = pth.c_str() + period_idx;
+   if (period <= filename)
+      return path{};
+   if (is_dot_or_dotdot(filename))
+      return path{};
+   while (period[1] && period[1] == '.')
+      ++period;
+   return path{period};
+}
+
+bool path::has_stem() const noexcept
+{
+   return !stem_internal(*this).empty();
+}
+
+bool path::has_extension() const noexcept
+{
+   return !!extension_internal(*this);
+}
+
+std::ostream& operator<<(std::ostream& os, const path& p)
+{
+   os << std::quoted(p.pth);
+   return os;
+}
+
+} // namespace filesystem
+
+} // namespace Surge

--- a/libs/filesystem/src/recursive_directory_iterator.cpp
+++ b/libs/filesystem/src/recursive_directory_iterator.cpp
@@ -1,0 +1,93 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "filesystem/recursive_directory_iterator.h"
+#include "filesystem/filesystem.h"
+#include "filesystem/directory_iterator.h"
+
+#include <stack>
+
+namespace Surge { namespace filesystem {
+
+struct recursive_directory_iterator::Impl
+{
+   std::stack<directory_iterator> stack;
+
+   // If p refers to a non-empty directory, put it on the stack and return true.
+   bool descend(const path& p)
+   {
+      std::error_code ec;
+      directory_iterator it{p, ec};
+      if (it != directory_iterator{})
+      {
+         stack.emplace(std::move(it));
+         return true;
+      }
+      if (!ec || ec == std::errc::not_a_directory)
+         return false;
+      throw filesystem_error{"recursive directory iterator cannot open directory \"" + p.native() + '\"', ec};
+   }
+
+   explicit Impl(directory_iterator&& it)
+   {
+      stack.push(std::move(it));
+   }
+};
+
+recursive_directory_iterator::recursive_directory_iterator(const path& p)
+{
+   std::error_code ec;
+   directory_iterator it{p, ec};
+   if (ec)
+      throw filesystem_error{"recursive directory iterator cannot open directory \"" + p.native() + '\"', ec};
+   if (it != directory_iterator{})
+      d = std::make_shared<Impl>(std::move(it));
+}
+
+recursive_directory_iterator::recursive_directory_iterator(const path& p, std::error_code& ec) noexcept
+{
+   directory_iterator it{p, ec};
+   if (!ec && it != directory_iterator{})
+      d = std::make_shared<Impl>(std::move(it));
+}
+
+const recursive_directory_iterator::value_type& recursive_directory_iterator::operator*() const noexcept
+{
+   return *d->stack.top();
+}
+
+recursive_directory_iterator& recursive_directory_iterator::operator++()
+{
+   auto& stack = d->stack;
+
+   if (stack.top() != directory_iterator())
+   {
+      if (d->descend(stack.top()->path()))
+         return *this;
+      do
+      {
+         if (++stack.top() != directory_iterator{})
+            return *this;
+         stack.pop();
+      } while (!stack.empty());
+   }
+
+   d.reset();
+   return *this;
+}
+
+} // namespace filesystem
+
+} // namespace Surge

--- a/libs/filesystem/src/tests.cpp
+++ b/libs/filesystem/src/tests.cpp
@@ -1,0 +1,428 @@
+#if 0
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include "filesystem/filesystem.h"
+namespace fs = Surge::filesystem;
+#endif
+
+#include "catch2/catch2.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+namespace {
+std::string temp_name()
+{
+   char temp_late[] = "/tmp/surge-tests-filesystem-XXXXXX";
+   REQUIRE(mktemp(temp_late)[0]);
+   return temp_late;
+}
+
+std::string temp_mkdir(mode_t mode)
+{
+   std::string name{temp_name()};
+   REQUIRE(mkdir(name.c_str(), mode) == 0);
+   return name;
+}
+} // anonymous namespace
+
+// Less noise than with an exception matcher
+#define REQUIRE_THROWS_FS_ERROR(expr, errcode) do { \
+    try { expr; FAIL("Did not throw: " #expr); } \
+    catch (fs::filesystem_error & e) { REQUIRE(e.code() == std::errc::errcode); } \
+} while (0)
+
+TEST_CASE("Filesystem", "[filesystem]")
+{
+   SECTION("Directory Iterators")
+   {
+      SECTION("Reports errors at construction")
+      {
+         std::error_code ec;
+         const fs::path p{"/dev/null"};
+         SECTION("directory_iterator")
+         {
+            REQUIRE_THROWS_FS_ERROR(fs::directory_iterator{p}, not_a_directory);
+            fs::directory_iterator it{p, ec};
+            REQUIRE(ec == std::errc::not_a_directory);
+         }
+         SECTION("recursive_directory_iterator")
+         {
+            REQUIRE_THROWS_FS_ERROR(fs::recursive_directory_iterator{p}, not_a_directory);
+            fs::recursive_directory_iterator it{p, ec};
+            REQUIRE(ec == std::errc::not_a_directory);
+         }
+      }
+
+      SECTION("Reports errors during recursion")
+      {
+         fs::path p{temp_mkdir(0777)};
+         fs::path denied{p / fs::path("denied")};
+         fs::create_directories(denied);
+         REQUIRE(chmod(denied.c_str(), 0) == 0);
+         fs::recursive_directory_iterator it{p};
+         REQUIRE_THROWS_FS_ERROR(++it, permission_denied);
+         REQUIRE_THROWS_FS_ERROR(fs::remove_all(p), permission_denied);
+         REQUIRE(fs::remove(denied));
+         REQUIRE(fs::remove(p));
+      }
+
+      SECTION("Skips . and ..")
+      {
+         std::error_code ec;
+         fs::path p{temp_mkdir(0777)};
+         SECTION("directory_iterator")
+         {
+            REQUIRE(fs::directory_iterator{p} == fs::directory_iterator{});
+            REQUIRE(fs::directory_iterator{p, ec} == fs::directory_iterator{});
+            REQUIRE_FALSE(ec);
+         }
+         SECTION("directory_iterator")
+         {
+            REQUIRE(fs::recursive_directory_iterator{p} == fs::recursive_directory_iterator{});
+            REQUIRE(fs::recursive_directory_iterator{p, ec} == fs::recursive_directory_iterator{});
+            REQUIRE_FALSE(ec);
+         }
+         REQUIRE(fs::remove(p));
+         REQUIRE_FALSE(fs::remove(p));
+      }
+
+      SECTION("Visits each directory entry exactly once")
+      {
+         std::vector<std::string> paths = {
+             "dir/1_entry/1a.file",
+             "dir/2_entries/2a.dir",
+             "dir/2_entries/2b.file",
+             "dir/3_entries/3a.dir",
+             "dir/3_entries/3b.dir",
+             "dir/3_entries/3c.file",
+             "file.file",
+         };
+
+         std::set<std::string> filenames;
+         std::transform(paths.begin(), paths.end(), std::inserter(filenames, filenames.begin()),
+                        [](const auto& p) {
+                           auto fn(fs::path(p).filename());
+                           REQUIRE_FALSE(fn.empty());
+                           return fn.native();
+                        });
+         REQUIRE(filenames.size() == paths.size());
+
+         fs::path rootdir{temp_mkdir(0777)};
+         for (auto& pp : paths)
+         {
+            fs::path p{rootdir / fs::path{pp}};
+            if (p.extension().native() == ".file")
+            {
+               fs::path f{p};
+               f.remove_filename();
+               fs::create_directories(f);
+               const std::ofstream of{p};
+               REQUIRE(of.good());
+            }
+            else
+            {
+               REQUIRE(fs::create_directories(p) > 0);
+               REQUIRE(fs::is_directory(p));
+            }
+         }
+
+         const auto iterate = [&](auto& it) {
+            REQUIRE(it->path().native() != "");
+            for (const fs::path& p : it)
+            {
+               auto fit{filenames.find(p.filename().native())};
+               if (fit != end(filenames))
+                  filenames.erase(fit);
+               if (p.extension().native() == ".file")
+               {
+                  REQUIRE(fs::is_regular_file(p));
+                  REQUIRE_FALSE(fs::is_directory(p));
+               }
+               else
+               {
+                  REQUIRE_FALSE(fs::is_regular_file(p));
+                  REQUIRE(fs::is_directory(p));
+               }
+            }
+         };
+
+         SECTION("directory_iterator")
+         {
+            for (auto& pp : paths)
+            {
+               fs::path dir{(rootdir / fs::path{pp}).remove_filename()};
+               fs::directory_iterator it{dir};
+               iterate(it);
+            }
+         }
+
+         SECTION("recursive_directory_iterator")
+         {
+            fs::recursive_directory_iterator it{rootdir};
+            iterate(it);
+         }
+
+         REQUIRE(fs::remove_all(rootdir) == 12);
+         REQUIRE(filenames.empty());
+      }
+   }
+
+   SECTION("Operations")
+   {
+      SECTION("create_directories")
+      {
+         REQUIRE_THROWS_FS_ERROR(fs::create_directories(fs::path{"/dev/null"}), file_exists);
+         REQUIRE_THROWS_FS_ERROR(fs::create_directories(fs::path{"/dev/null/dir"}), not_a_directory);
+
+         const fs::path basep{temp_name()};
+         REQUIRE_FALSE(fs::exists(basep));
+         const fs::path p{basep / fs::path("this/is/a/test")};
+         REQUIRE(fs::create_directories(p));
+         REQUIRE(fs::is_directory(p));
+         REQUIRE(fs::create_directories(p) == 0);
+         REQUIRE(fs::remove_all(basep) == 5);
+         REQUIRE_FALSE(fs::exists(basep));
+         REQUIRE(fs::remove_all(basep) == 0);
+         REQUIRE_FALSE(fs::is_directory(p));
+      }
+
+      SECTION("create_directory")
+      {
+         REQUIRE_FALSE(fs::create_directory(fs::path{"/dev/null"}));
+         REQUIRE_THROWS_FS_ERROR(fs::create_directory(fs::path{"/dev/null/dir"}), not_a_directory);
+
+         const fs::path p{temp_name()};
+         REQUIRE_FALSE(fs::exists(p));
+         REQUIRE(fs::create_directory(p));
+         REQUIRE_FALSE(fs::create_directory(p));
+         REQUIRE(fs::remove(p));
+         REQUIRE_FALSE(fs::exists(p));
+         REQUIRE_FALSE(fs::remove(p));
+         REQUIRE_FALSE(fs::is_directory(p));
+      }
+
+      SECTION("exists")
+      {
+         REQUIRE(fs::exists(fs::path{"."}));
+         const fs::path p{temp_mkdir(0)};
+         REQUIRE_THROWS_FS_ERROR(fs::exists(p / fs::path{"file"}), permission_denied);
+         REQUIRE(fs::remove(p));
+         REQUIRE_FALSE(fs::remove(p));
+      }
+
+      SECTION("file_size")
+      {
+         REQUIRE_THROWS_FS_ERROR(fs::file_size(fs::path{"."}), is_a_directory);
+         REQUIRE_THROWS_FS_ERROR(fs::file_size(fs::path{"/dev/null"}), not_supported);
+
+         const fs::path p{temp_name()};
+         const char testdata[] = "testdata";
+         std::ofstream of{p};
+         REQUIRE(of.good());
+         REQUIRE(fs::file_size(p) == 0);
+         of << testdata;
+         of.close();
+         REQUIRE(fs::file_size(p) == sizeof(testdata) - 1);
+         REQUIRE(fs::remove(p));
+         REQUIRE_FALSE(fs::remove(p));
+      }
+
+      SECTION("is_directory")
+      {
+         REQUIRE(fs::is_directory(fs::path{"."}));
+         REQUIRE(fs::is_directory(fs::path{"/"}));
+         REQUIRE_FALSE(fs::is_directory(fs::path{"/dev/null"}));
+         REQUIRE_FALSE(fs::is_directory(fs::path{"/dev/null/dir"}));
+      }
+
+      SECTION("is_regular_file")
+      {
+         const fs::path p{temp_name()};
+         const std::ofstream of{p};
+         REQUIRE(of.good());
+         REQUIRE(fs::is_regular_file(p));
+         REQUIRE(fs::remove(p));
+         REQUIRE_FALSE(fs::remove(p));
+
+         REQUIRE_FALSE(fs::is_regular_file(fs::path{"."}));
+         REQUIRE_FALSE(fs::is_regular_file(fs::path{"/"}));
+         REQUIRE_FALSE(fs::is_regular_file(fs::path{"/dev/null"}));
+         REQUIRE_FALSE(fs::is_regular_file(fs::path{"/dev/null/file"}));
+      }
+
+      SECTION("remove")
+      {
+         {
+            const fs::path p{temp_name()};
+            const std::ofstream of{p};
+            REQUIRE(of.good());
+            REQUIRE(fs::remove(p));
+            REQUIRE_FALSE(fs::remove(p));
+         }
+         {
+            const fs::path p{temp_mkdir(0777)};
+            REQUIRE(fs::remove(p / fs::path("")));
+            REQUIRE_FALSE(fs::remove(p / fs::path("")));
+         }
+         {
+            const fs::path p{temp_mkdir(0777)};
+            REQUIRE(fs::create_directories(p / fs::path{"dir"}));
+            REQUIRE_THROWS_FS_ERROR(fs::remove(p), directory_not_empty);
+            REQUIRE(fs::remove_all(p) == 2);
+         }
+      }
+
+      SECTION("remove_all")
+      {
+         const fs::path p{temp_name()};
+         const std::ofstream of{p};
+         REQUIRE(of.good());
+         REQUIRE(fs::remove_all(p) == 1);
+         REQUIRE(fs::remove_all(p) == 0);
+      }
+   }
+
+   SECTION("Path")
+   {
+      SECTION("operator /=, /")
+      {
+         REQUIRE((fs::path("foo") / fs::path("/bar")).native() == "/bar");
+         REQUIRE((fs::path("foo") /= fs::path("/bar")).native() == "/bar");
+         REQUIRE((fs::path("foo") / fs::path()).native() == "foo/");
+         REQUIRE((fs::path("foo") /= fs::path()).native() == "foo/");
+         REQUIRE((fs::path("foo") / fs::path("bar")).native() == "foo/bar");
+         REQUIRE((fs::path("foo") /= fs::path("bar")).native() == "foo/bar");
+         REQUIRE((fs::path("foo/") / fs::path("bar")).native() == "foo/bar");
+         REQUIRE((fs::path("foo/") /= fs::path("bar")).native() == "foo/bar");
+      }
+
+      SECTION("remove_filename")
+      {
+         // https://en.cppreference.com/w/cpp/filesystem/path/remove_filename
+         REQUIRE(fs::path{"foo/bar"}.remove_filename().native() == "foo/");
+         REQUIRE(fs::path{"foo/"}.remove_filename().native() == "foo/");
+         REQUIRE(fs::path{"/foo"}.remove_filename().native() == "/");
+         REQUIRE(fs::path{"/"}.remove_filename().native() == "/");
+         REQUIRE(fs::path{}.remove_filename().native() == "");
+      }
+
+      SECTION("filename, has_filename")
+      {
+         REQUIRE(fs::path().filename().native() == "");
+         REQUIRE_FALSE(fs::path().has_filename());
+
+         // https://en.cppreference.com/w/cpp/filesystem/path/filename
+         REQUIRE(fs::path("/foo/bar.txt").filename().native() == "bar.txt");
+         REQUIRE(fs::path("/foo/bar.txt").has_filename());
+
+         REQUIRE(fs::path("/foo/.bar").filename().native() == ".bar");
+         REQUIRE(fs::path("/foo/.bar").has_filename());
+
+         REQUIRE(fs::path("/foo/bar/").filename().native() == "");
+         REQUIRE_FALSE(fs::path("/foo/bar/").has_filename());
+
+         REQUIRE(fs::path("/foo/.").filename().native() == ".");
+         REQUIRE(fs::path("/foo/.").has_filename());
+
+         REQUIRE(fs::path("/foo/..").filename().native() == "..");
+         REQUIRE(fs::path("/foo/..").has_filename());
+
+         REQUIRE(fs::path(".").filename().native() == ".");
+         REQUIRE(fs::path(".").has_filename());
+
+         REQUIRE(fs::path("..").filename().native() == "..");
+         REQUIRE(fs::path("..").has_filename());
+
+         REQUIRE(fs::path("/").filename().native() == "");
+         REQUIRE_FALSE(fs::path("/").has_filename());
+
+         REQUIRE(fs::path("//host").filename().native() == "host");
+         REQUIRE(fs::path("//host").has_filename());
+      }
+
+      SECTION("stem, has_stem")
+      {
+         REQUIRE(fs::path().stem().native() == "");
+         REQUIRE_FALSE(fs::path().has_stem());
+
+         REQUIRE(fs::path(".").stem().native() == ".");
+         REQUIRE(fs::path(".").has_stem());
+
+         REQUIRE(fs::path("..").stem().native() == "..");
+         REQUIRE(fs::path("..").has_stem());
+
+         REQUIRE(fs::path("...").stem().native() == "..");
+         REQUIRE(fs::path("...").has_stem());
+
+         // https://en.cppreference.com/w/cpp/filesystem/path/stem
+         REQUIRE(fs::path("/foo/bar.txt").stem().native() == "bar");
+         REQUIRE(fs::path("/foo/bar.txt").has_stem());
+
+         REQUIRE(fs::path("/foo/.bar").stem().native() == ".bar");
+         REQUIRE(fs::path("/foo/.bar").has_stem());
+
+         REQUIRE(fs::path("foo.bar.baz.tar").stem().native() == "foo.bar.baz");
+         REQUIRE(fs::path("foo.bar.baz.tar").has_stem());
+      }
+
+      SECTION("extension, has_extension")
+      {
+         REQUIRE(fs::path().extension().native() == "");
+         REQUIRE_FALSE(fs::path().has_extension());
+
+         // https://en.cppreference.com/w/cpp/filesystem/path/extension
+         REQUIRE(fs::path("/foo/bar.txt").extension().native() == ".txt");
+         REQUIRE(fs::path("/foo/bar.txt").has_extension());
+
+         REQUIRE(fs::path("/foo/bar.").extension().native() == ".");
+         REQUIRE(fs::path("/foo/bar.").has_extension());
+
+         REQUIRE(fs::path("/foo/bar").extension().native() == "");
+         REQUIRE_FALSE(fs::path("/foo/bar").has_extension());
+
+         REQUIRE(fs::path("/foo/bar.txt/bar.cc").extension().native() == ".cc");
+         REQUIRE(fs::path("/foo/bar.txt/bar.cc").has_extension());
+
+         REQUIRE(fs::path("/foo/bar.txt/bar.").extension().native() == ".");
+         REQUIRE(fs::path("/foo/bar.txt/bar.").has_extension());
+
+         REQUIRE(fs::path("/foo/bar.txt/bar").extension().native() == "");
+         REQUIRE_FALSE(fs::path("/foo/bar.txt/bar").has_extension());
+
+         REQUIRE(fs::path("/foo/.").extension().native() == "");
+         REQUIRE_FALSE(fs::path("/foo/.").has_extension());
+
+         REQUIRE(fs::path("/foo/..").extension().native() == "");
+         REQUIRE_FALSE(fs::path("/foo/..").has_extension());
+
+         REQUIRE(fs::path("/foo/.hidden").extension().native() == "");
+         REQUIRE_FALSE(fs::path("/foo/.hidden").has_extension());
+
+         REQUIRE(fs::path("/foo/..bar").extension().native() == ".bar");
+         REQUIRE(fs::path("/foo/..bar").has_extension());
+      }
+
+      SECTION("is_absolute, is_relative")
+      {
+         REQUIRE_FALSE(fs::path("").is_absolute());
+         REQUIRE(fs::path("").is_relative());
+         REQUIRE(fs::path("/").is_absolute());
+         REQUIRE_FALSE(fs::path("/").is_relative());
+         REQUIRE(fs::path("/dir/").is_absolute());
+         REQUIRE_FALSE(fs::path("/dir/").is_relative());
+         REQUIRE(fs::path("/file").is_absolute());
+         REQUIRE_FALSE(fs::path("/file").is_relative());
+         REQUIRE_FALSE(fs::path("file").is_absolute());
+         REQUIRE(fs::path("file").is_relative());
+      }
+   }
+}

--- a/libs/filesystem/src/util.h
+++ b/libs/filesystem/src/util.h
@@ -1,0 +1,25 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#pragma once
+
+inline bool is_dot_or_dotdot(const char* s) noexcept
+{
+   if (*s++ != '.')
+      return false;
+   if (*s && *s++ != '.')
+      return false;
+   return !*s;
+}


### PR DESCRIPTION
Replaces the "make it compile on macOS"-quality fallback filesystem with
a more robust implementation. It still only provides the bare minimum we
can get away with. The tests also pass against libc++ on both macOS and
Linux.