### PR TITLE
filesystem: Manage filesystem selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,13 @@ endif()
 set(SURGE_PRODUCT_DIR ${CMAKE_BINARY_DIR}/surge_products)
 file(MAKE_DIRECTORY ${SURGE_PRODUCT_DIR})
 
-add_subdirectory(libs/catch2)
-
 add_library(surge-shared INTERFACE)
 add_library(surge-tests INTERFACE)
+
+add_subdirectory(libs/catch2)
+add_subdirectory(libs/filesystem)
+
+target_link_libraries(surge-shared INTERFACE surge::filesystem)
 
 # We want to run this once alas, since JUCE needs it even though it is a byproduct of a phase to build the
 # JUCE Cmake file list.
@@ -154,57 +157,6 @@ elseif( APPLE )
   set( BUILD_LV2 false )  # Status as of Apr 26. This CMake will build 'something' in products/Surge.lv2 but :shrug:
 else()
   set( BUILD_LV2 false )
-endif()
-
-function(use_fallback_fs)
-  add_subdirectory(libs/filesystem)
-  target_link_libraries(surge-shared INTERFACE surge::filesystem)
-  target_compile_definitions(surge-shared INTERFACE USE_FALLBACK_FILESYSTEM=1)
-  message(STATUS "Using fallback filesystem")
-endfunction()
-
-set(SURGE_DEVEL_FORCE_FALLBACK_FS OFF CACHE BOOL "Force fallback std::filesystem impl (development only)")
-mark_as_advanced(FORCE SURGE_DEVEL_FORCE_FALLBACK_FS)
-if (${SURGE_DEVEL_FORCE_FALLBACK_FS})
-  use_fallback_fs()
-else()
-  include(CheckCXXSymbolExists)
-  CHECK_CXX_SYMBOL_EXISTS(std::filesystem::path::preferred_separator "filesystem" CXX_STD_FS)
-  if( CXX_STD_FS )
-    # This is not strictly necessary but since we build with 17 on unix lets check with 17 here
-    if( UNIX AND NOT APPLE )
-      set (CMAKE_REQUIRED_FLAGS "-std=c++17")
-    endif()
-    target_compile_definitions(surge-shared INTERFACE USE_STD_FILESYSTEM=1)
-    if( UNIX AND NOT APPLE )
-      set (CMAKE_REQUIRED_FLAGS "")
-    endif()
-    message( STATUS "Using std::filesystem" )
-  else()
-    # if that check failed we are on one of the wonky gccs in te 7 and 5 family which need to check this with 11 and link stdc++fs
-    if( UNIX AND NOT APPLE )
-      set (CMAKE_REQUIRED_FLAGS "-std=c++11")
-      set (CMAKE_REQUIRED_LIBRARIES "stdc++fs")
-    endif()
-    CHECK_CXX_SYMBOL_EXISTS(std::experimental::filesystem::path::preferred_separator "experimental/filesystem" CXX_EXP_STD_FS)
-    if( UNIX AND NOT APPLE )
-      set (CMAKE_REQUIRED_FLAGS "")
-      set (CMAKE_REQUIRED_LIBRARIES "")
-    endif()
-
-    if( CXX_EXP_STD_FS )
-      target_compile_definitions(surge-shared INTERFACE USE_STD_EXPERIMENTAL_FILESYSTEM=1)
-      message( STATUS "Using std::experimental::filesystem" )
-    else()
-      CHECK_CXX_SYMBOL_EXISTS(std::experimental::filesystem::path::preferred_separator "filesystem" CXX_EXP_STD_FS_FS_HDR)
-      if( CXX_EXP_STD_FS_FS_HDR )
-        target_compile_definitions(surge-shared INTERFACE USE_STD_EXPERIMENTAL_FILESYSTEM_FROM_FILESYSTEM=1)
-        message( STATUS "Using std::experimental::filesystem but from <filesystem> header" )
-      else()
-        use_fallback_fs()
-      endif()
-    endif()
-  endif()
 endif()
 
 # Surge features at compile time
@@ -565,9 +517,6 @@ elseif( UNIX AND NOT APPLE )
 
   set(OS_LINK_LIBRARIES_NOGUI
     pthread
-    stdc++fs
-    gcc_s
-    gcc
     dl
     -Wl,--no-undefined
     )
@@ -1030,7 +979,6 @@ if( BUILD_HEADLESS )
     endif()
     target_link_libraries(surge-headless
       PRIVATE
-      stdc++fs
       Threads::Threads
       )
 

--- a/libs/filesystem/CMakeLists.txt
+++ b/libs/filesystem/CMakeLists.txt
@@ -1,19 +1,68 @@
 project(filesystem VERSION 0.0.0 LANGUAGES CXX)
 
-add_library(${PROJECT_NAME}
-  src/directory_iterator.cpp
-  src/filesystem.cpp
-  src/path.cpp
-  src/recursive_directory_iterator.cpp
-  src/util.h
-  include/${PROJECT_NAME}/directory_entry.h
-  include/${PROJECT_NAME}/directory_iterator.h
-  include/${PROJECT_NAME}/filesystem.h
-  include/${PROJECT_NAME}/filesystem_error.h
-  include/${PROJECT_NAME}/path.h
-  include/${PROJECT_NAME}/recursive_directory_iterator.h
-)
-add_library(surge::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-target_include_directories(${PROJECT_NAME} PUBLIC include)
+function(generate_header FS_HEADER FS_NAMESPACE)
+  message(STATUS "${PROJECT_NAME}: Using ${FS_NAMESPACE} from ${FS_HEADER}")
+  set(INC_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
+  set(HEADER_DIR "${INC_DIR}/${PROJECT_NAME}")
+  set(HEADER_FILE "${HEADER_DIR}/import.h")
+  configure_file(src/import.h.in "${HEADER_FILE}" @ONLY)
+  target_sources(${PROJECT_NAME} INTERFACE "${HEADER_FILE}")
+  target_include_directories(${PROJECT_NAME} INTERFACE "${INC_DIR}")
+endfunction()
 
-target_sources(surge-tests INTERFACE src/tests.cpp)
+function(use_fallback_fs)
+  add_library(${PROJECT_NAME}
+    src/directory_iterator.cpp
+    src/filesystem.cpp
+    src/path.cpp
+    src/recursive_directory_iterator.cpp
+    src/util.h
+    include/${PROJECT_NAME}/directory_entry.h
+    include/${PROJECT_NAME}/directory_iterator.h
+    include/${PROJECT_NAME}/filesystem.h
+    include/${PROJECT_NAME}/filesystem_error.h
+    include/${PROJECT_NAME}/path.h
+    include/${PROJECT_NAME}/recursive_directory_iterator.h
+  )
+  target_include_directories(${PROJECT_NAME} PUBLIC include)
+
+  target_sources(surge-tests INTERFACE src/tests.cpp)
+  generate_header("\"filesystem/filesystem.h\"" "Surge::filesystem")
+endfunction()
+
+function(use_platform_fs FS_HEADER FS_NAMESPACE)
+  add_library(${PROJECT_NAME} INTERFACE)
+  generate_header("${FS_HEADER}" "${FS_NAMESPACE}")
+endfunction()
+
+set(SURGE_DEVEL_FORCE_FALLBACK_FS OFF CACHE BOOL "Force fallback std::filesystem impl (development only)")
+mark_as_advanced(FORCE SURGE_DEVEL_FORCE_FALLBACK_FS)
+if (${SURGE_DEVEL_FORCE_FALLBACK_FS})
+  use_fallback_fs()
+else()
+  include(CheckCXXSymbolExists)
+  CHECK_CXX_SYMBOL_EXISTS(std::filesystem::path::preferred_separator "filesystem" FS_FOUND)
+  if (FS_FOUND)
+    use_platform_fs("<filesystem>" "std::filesystem")
+  else()
+    # if that check failed we are on one of the wonky gccs in the 7 and 5 family which need to check this with 11 and link stdc++fs
+    if (UNIX AND NOT APPLE)
+      set (CMAKE_REQUIRED_LIBRARIES "stdc++fs")
+    endif()
+    CHECK_CXX_SYMBOL_EXISTS(std::experimental::filesystem::path::preferred_separator "experimental/filesystem" FS_FOUND)
+    if (FS_FOUND)
+      use_platform_fs("<experimental/filesystem>" "std::experimental::filesystem")
+      target_link_libraries(${PROJECT_NAME} INTERFACE stdc++fs)
+    else()
+      set (CMAKE_REQUIRED_LIBRARIES "")
+      CHECK_CXX_SYMBOL_EXISTS(std::experimental::filesystem::path::preferred_separator "filesystem" FS_FOUND)
+      if (FS_FOUND)
+        use_platform_fs("<filesystem>" "std::experimental::filesystem")
+      else()
+        use_fallback_fs()
+      endif()
+    endif()
+  endif()
+endif()
+
+add_library(surge::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/libs/filesystem/src/import.h.in
+++ b/libs/filesystem/src/import.h.in
@@ -7,26 +7,12 @@
 ** supporting VS2017 and macos 10.12 and stuff we need it.
 */
 
-
-#if USE_STD_FILESYSTEM
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif USE_STD_EXPERIMENTAL_FILESYSTEM
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#elif USE_STD_EXPERIMENTAL_FILESYSTEM_FROM_FILESYSTEM
-#include <filesystem>
-namespace fs = std::experimental::filesystem;
-#elif USE_FALLBACK_FILESYSTEM || TARGET_RACK
-#include "filesystem/filesystem.h"
-namespace fs = Surge::filesystem;
-#else
-#error FILESYSTEM is not configured by build system
-#endif
+#include @FS_HEADER@
+namespace fs = @FS_NAMESPACE@;
 
 inline std::string path_to_string(const fs::path& path)
 {
-#if WINDOWS && !TARGET_RACK
+#ifdef _WIN32
    return path.u8string();
 #else
    return path.generic_string();
@@ -35,9 +21,10 @@ inline std::string path_to_string(const fs::path& path)
 
 inline fs::path string_to_path(const std::string& path)
 {
-#if WINDOWS && !TARGET_RACK
+#ifdef _WIN32
    return fs::u8path(path);
 #else
    return fs::path(path);
 #endif
 }
+

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -29,7 +29,7 @@
 #endif
 #include <tinyxml.h>
 
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 
 #include <fstream>
 #include <iterator>

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -51,7 +51,7 @@
 #include "SurgeParamConfig.h"
 
 #include "UserDefaults.h"
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 
 using namespace std;
 

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -18,7 +18,7 @@
 #include <time.h>
 #include <vt_dsp/vt_dsp_endian.h>
 
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 
 #include <fstream>
 #include <iterator>

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -9,7 +9,7 @@
 #include <sstream>
 #include <fstream>
 
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 
 namespace Surge
 {

--- a/src/common/WavSupport.cpp
+++ b/src/common/WavSupport.cpp
@@ -26,7 +26,7 @@
 #include <cerrno>
 #include <cstring>
 
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 
 
 // Sigh - lets write a portable ntol by hand

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -22,7 +22,7 @@
 #include "guihelpers.h"
 #include "SkinColors.h"
 
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 
 using namespace VSTGUI;
 

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -6,7 +6,7 @@
 #include "CScalableBitmap.h"
 #include "SurgeBitmaps.h"
 #include "SurgeStorage.h" // for TINYXML macro
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 #include "SkinColors.h"
 #include "guihelpers.h"
 

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -10,7 +10,7 @@
 #include "UIInstrumentation.h"
 #include "CScalableBitmap.h"
 
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 
 #include <array>
 #include <iostream>

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -96,7 +96,7 @@ struct RememberForgetGuard {
 #include "aulayer.h"
 #endif
 
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 
 #if LINUX
 #include "vstgui/lib/platform/platform_x11.h"

--- a/utils/svgshow/src/main.cpp
+++ b/utils/svgshow/src/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <iomanip>
 
-#include "ImportFilesystem.h"
+#include "filesystem/import.h"
 
 #if MAC
 #include "cocoa_minimal_main.h"


### PR DESCRIPTION
Moves the selection of the filesystem implementation into the filesystem
library so it is visible to other libraries.