### PR TITLE
Proper state management of MSEG editor

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -656,9 +656,6 @@ struct MSEGStorage {
    float durationToLoopEnd;
    float durationLoopStartToLoopEnd;
 
-   // These are values used by the editor which are per mseg but not persisted
-   float vSnap = 0, hSnap = 0, vSnapDefault = 0.25, hSnapDefault = 0.1;
-
    static constexpr float minimumDuration = 0.0;
 };
 

--- a/src/common/gui/MSEGEditor.h
+++ b/src/common/gui/MSEGEditor.h
@@ -19,6 +19,10 @@
 #include "SkinSupport.h"
 
 struct MSEGEditor : public VSTGUI::CViewContainer, public Surge::UI::SkinConsumingComponent {
-   MSEGEditor(LFOStorage *lfodata, MSEGStorage *ms, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b);
+   struct State {
+      float vSnap = 0, hSnap = 0, vSnapDefault = 0.25, hSnapDefault = 0.1;
+      int timeEditMode = 1;
+   };
+   MSEGEditor(LFOStorage *lfodata, MSEGStorage *ms, State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b);
    ~MSEGEditor();
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -6771,7 +6771,7 @@ void SurgeGUIEditor::showMSEGEditor()
    auto lfo_id = modsource_editor[current_scene] - ms_lfo1;
    auto lfodata = &synth->storage.getPatch().scene[current_scene].lfo[lfo_id];
    auto ms = &synth->storage.getPatch().msegs[current_scene][lfo_id];
-   auto mse = new MSEGEditor(lfodata, ms, currentSkin, bitmapStore);
+   auto mse = new MSEGEditor(lfodata, ms, &msegEditState[lfo_id], currentSkin, bitmapStore);
    auto vs = mse->getViewSize().getWidth();
    float xp = (currentSkin->getWindowSizeX() - (vs + 8)) * 0.5;
 

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -48,6 +48,7 @@ typedef VSTGUI::PluginGUIEditor EditorType;
 #include "SkinColors.h"
 
 #include <vector>
+#include "MSEGEditor.h"
  
 class CSurgeSlider;
 class CModulationSourceButton;
@@ -295,6 +296,7 @@ public:
    void showMSEGEditor();
    void closeMSEGEditor();
    void toggleMSEGEditor();
+   MSEGEditor::State msegEditState[n_lfos];
 
 private:
    SGEDropAdapter *dropAdapter = nullptr;


### PR DESCRIPTION
1. New class "MSEGEditor::State" takes the UI things (hSnap, etc...)
   from MSEGStorage
2. SurgeGUIEditor contains array of states for editing
3. Respond properly to hSnapDefault, loopmode, etc...