### PR TITLE
Make SurgeVoice-level modulators obey the Controller Smoothing setting

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -914,6 +914,8 @@ public:
    bool isStandardMapping = true;
    float tuningPitch = 32.0f, tuningPitchInv = 0.03125f;
 
+   ControllerModulationSource::SmoothingMode smoothingMode = ControllerModulationSource::SmoothingMode::LEGACY;
+
    std::atomic<int> otherscene_clients;
 
    std::unordered_map<int, std::string> helpURL_controlgroup;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -114,7 +114,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
 
    SurgePatch& patch = storage.getPatch();
 
-   smoothingMode = (ControllerModulationSource::SmoothingMode)(int)Surge::Storage::getUserDefaultValue( &storage, "smoothingMode", (int)( ControllerModulationSource::SmoothingMode::LEGACY ));
+   storage.smoothingMode = (ControllerModulationSource::SmoothingMode)(int)Surge::Storage::getUserDefaultValue( &storage, "smoothingMode", (int)( ControllerModulationSource::SmoothingMode::LEGACY ));
 
    patch.polylimit.val.i = 16;
    for (int sc = 0; sc < 2; sc++)
@@ -123,15 +123,15 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
       scene.modsources.resize(n_modsources);
       for (int i = 0; i < n_modsources; i++)
          scene.modsources[i] = 0;
-      scene.modsources[ms_modwheel] = new ControllerModulationSource(smoothingMode);
-      scene.modsources[ms_breath] = new ControllerModulationSource(smoothingMode);
-      scene.modsources[ms_expression] = new ControllerModulationSource(smoothingMode);
-      scene.modsources[ms_sustain] = new ControllerModulationSource(smoothingMode);
-      scene.modsources[ms_aftertouch] = new ControllerModulationSource(smoothingMode);
-      scene.modsources[ms_pitchbend] = new ControllerModulationSource(smoothingMode);
-      scene.modsources[ms_lowest_key] = new ControllerModulationSource(smoothingMode);
-      scene.modsources[ms_highest_key] = new ControllerModulationSource(smoothingMode);
-      scene.modsources[ms_latest_key] = new ControllerModulationSource(smoothingMode);
+      scene.modsources[ms_modwheel] = new ControllerModulationSource(storage.smoothingMode);
+      scene.modsources[ms_breath] = new ControllerModulationSource(storage.smoothingMode);
+      scene.modsources[ms_expression] = new ControllerModulationSource(storage.smoothingMode);
+      scene.modsources[ms_sustain] = new ControllerModulationSource(storage.smoothingMode);
+      scene.modsources[ms_aftertouch] = new ControllerModulationSource(storage.smoothingMode);
+      scene.modsources[ms_pitchbend] = new ControllerModulationSource(storage.smoothingMode);
+      scene.modsources[ms_lowest_key] = new ControllerModulationSource(storage.smoothingMode);
+      scene.modsources[ms_highest_key] = new ControllerModulationSource(storage.smoothingMode);
+      scene.modsources[ms_latest_key] = new ControllerModulationSource(storage.smoothingMode);
 
       scene.modsources[ms_random_bipolar] = new RandomModulationSource( true );
       scene.modsources[ms_random_unipolar] = new RandomModulationSource( false );
@@ -152,7 +152,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
    }
    for (int i = 0; i < n_customcontrollers; i++)
    {
-      patch.scene[0].modsources[ms_ctrl1 + i] = new ControllerModulationSource(smoothingMode);
+      patch.scene[0].modsources[ms_ctrl1 + i] = new ControllerModulationSource(storage.smoothingMode);
       patch.scene[1].modsources[ms_ctrl1 + i] =
          patch.scene[0].modsources[ms_ctrl1 + i];
    }
@@ -1455,7 +1455,7 @@ ControllerModulationSource* SurgeSynthesizer::AddControlInterpolator(int Id, boo
       mControlInterpolator[Index].id = Id;
       mControlInterpolatorUsed[Index] = true;
 
-      mControlInterpolator[Index].smoothingMode = smoothingMode; // IMPLEMENT THIS HERE
+      mControlInterpolator[Index].smoothingMode = storage.smoothingMode; // IMPLEMENT THIS HERE
       return &mControlInterpolator[Index];
    }
 
@@ -3203,7 +3203,7 @@ void SurgeSynthesizer::swapMetaControllers( int c1, int c2 )
 
 void SurgeSynthesizer::changeModulatorSmoothing( ControllerModulationSource::SmoothingMode m )
 {
-   smoothingMode = m;
+   storage.smoothingMode = m;
    for (int sc = 0; sc < n_scenes; ++sc)
    {
       for( int q = 0; q<n_modsources; ++q )

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -273,6 +273,4 @@ private:
    void ReleaseControlInterpolator(int Idx);
    ControllerModulationSource* ControlInterpolator(int Idx);
    ControllerModulationSource* AddControlInterpolator(int Idx, bool& AlreadyExisted);
-
-   ControllerModulationSource::SmoothingMode smoothingMode;
 };

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -126,6 +126,14 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    }
    memset(&FBP, 0, sizeof(FBP));
 
+   polyAftertouchSource = ControllerModulationSource(storage->smoothingMode);
+   monoAftertouchSource = ControllerModulationSource(storage->smoothingMode);
+   timbreSource         = ControllerModulationSource(storage->smoothingMode);
+
+   polyAftertouchSource.init(storage->poly_aftertouch[state.scene_id & 1][state.key & 127]);
+   timbreSource.init(state.voiceChannelState->timbre);
+   monoAftertouchSource.init(state.voiceChannelState->pressure);
+
    lag_id[le_osc1] = scene->level_o1.param_id_in_scene;
    lag_id[le_osc2] = scene->level_o2.param_id_in_scene;
    lag_id[le_osc3] = scene->level_o3.param_id_in_scene;
@@ -154,8 +162,6 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    modsources[ms_keytrack] = &keytrackSource;
    modsources[ms_polyaftertouch] = &polyAftertouchSource;
 
-   polyAftertouchSource.init(storage->poly_aftertouch[state.scene_id & 1][state.key & 127]);
-
    velocitySource.output = state.fvel;
    releaseVelocitySource.output = state.freleasevel;
    keytrackSource.output = 0;
@@ -173,9 +179,7 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    modsources[ms_lowest_key] = oscene->modsources[ms_lowest_key];
    modsources[ms_highest_key] = oscene->modsources[ms_highest_key];
    modsources[ms_latest_key] = oscene->modsources[ms_latest_key];
-   monoAftertouchSource.init(state.voiceChannelState->pressure);
    modsources[ms_timbre] = &timbreSource;
-   timbreSource.init(state.voiceChannelState->timbre);
    modsources[ms_pitchbend] = oscene->modsources[ms_pitchbend];
    for (int i = 0; i < n_customcontrollers; i++)
       modsources[ms_ctrl1 + i] = oscene->modsources[ms_ctrl1 + i];


### PR DESCRIPTION
Moves SurgeSynthesizer::smoothingMode into SurgeStorage so SurgeVoice can access it.