### PR TITLE
Add smoothing to pitchbend

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -915,6 +915,7 @@ public:
    float tuningPitch = 32.0f, tuningPitchInv = 0.03125f;
 
    ControllerModulationSource::SmoothingMode smoothingMode = ControllerModulationSource::SmoothingMode::LEGACY;
+   float mpePitchBendRange = -1.0f;
 
    std::atomic<int> otherscene_clients;
 

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -885,17 +885,16 @@ void SurgeSynthesizer::pitchBend(char channel, int value)
 {
    if (mpeEnabled)
    {
-      float bendNormalized = value / 8192.f;
       channelState[channel].pitchBend = value;
 
-      if (channel == 0)
-      {
-         channelState[channel].pitchBendInSemitones = bendNormalized * mpeGlobalPitchBendRange;
-      }
-      else
-      {
-         channelState[channel].pitchBendInSemitones = bendNormalized * mpePitchBendRange;
-      }
+      /*
+      ** todo: handling of channel 0 and mpeGlobalPitchBendRange were broken with the addition
+      ** of smoothing. we should probably add that back in if it turns out someone actually uses it
+      *:)
+      ** currently channelState[].pitchBendInSemitones is now unused, but it hasn't been removed
+      *from
+      ** the code yet for this reason.
+      */
    }
 
    /*

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -206,7 +206,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer* parent, std::string suppliedData
 
    mpeEnabled = false;
    mpeVoices = 0;
-   mpePitchBendRange = Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
+   storage.mpePitchBendRange = (float)Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
    mpeGlobalPitchBendRange = 0;
 
 #if TARGET_VST3 || TARGET_VST2 || TARGET_AUDIOUNIT 
@@ -1010,7 +1010,7 @@ void SurgeSynthesizer::onRPN(int channel, int lsbRPN, int msbRPN, int lsbValue, 
    {
       if (channel == 1)
       {
-         mpePitchBendRange = msbValue;
+         storage.mpePitchBendRange = msbValue;
       }
       else if (channel == 0)
       {
@@ -1021,8 +1021,8 @@ void SurgeSynthesizer::onRPN(int channel, int lsbRPN, int msbRPN, int lsbValue, 
    {
       mpeEnabled = msbValue > 0;
       mpeVoices = msbValue & 0xF;
-      if( mpePitchBendRange < 0 )
-         mpePitchBendRange = Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
+      if( storage.mpePitchBendRange < 0.0f )
+         storage.mpePitchBendRange = Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
       mpeGlobalPitchBendRange = 0;
       return;
    }
@@ -3032,7 +3032,7 @@ PluginLayer* SurgeSynthesizer::getParent()
 void SurgeSynthesizer::populateDawExtraState() {
    storage.getPatch().dawExtraState.isPopulated = true;
    storage.getPatch().dawExtraState.mpeEnabled = mpeEnabled;
-   storage.getPatch().dawExtraState.mpePitchBendRange = mpePitchBendRange;
+   storage.getPatch().dawExtraState.mpePitchBendRange = storage.mpePitchBendRange;
    
    storage.getPatch().dawExtraState.hasTuning = !storage.isStandardTuning;
    if( ! storage.isStandardTuning )
@@ -3068,7 +3068,7 @@ void SurgeSynthesizer::loadFromDawExtraState() {
       return;
    mpeEnabled = storage.getPatch().dawExtraState.mpeEnabled;
    if( storage.getPatch().dawExtraState.mpePitchBendRange > 0 )
-      mpePitchBendRange = storage.getPatch().dawExtraState.mpePitchBendRange;
+      storage.mpePitchBendRange = storage.getPatch().dawExtraState.mpePitchBendRange;
    
    if( storage.getPatch().dawExtraState.hasTuning )
    {

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -883,7 +883,7 @@ void SurgeSynthesizer::updateHighLowKeys(int scene)
 
 void SurgeSynthesizer::pitchBend(char channel, int value)
 {
-   if (mpeEnabled)
+   if (mpeEnabled && channel != 0)
    {
       channelState[channel].pitchBend = value;
 
@@ -894,6 +894,8 @@ void SurgeSynthesizer::pitchBend(char channel, int value)
       ** currently channelState[].pitchBendInSemitones is now unused, but it hasn't been removed
       *from
       ** the code yet for this reason.
+      ** For now, we ignore channel zero here so it functions like the old code did in practice when
+      ** mpeGlobalPitchBendRange remained at zero.
       */
    }
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -226,7 +226,6 @@ public:
    MidiChannelState channelState[16];
    bool mpeEnabled = false;
    int mpeVoices = 0;
-   int mpePitchBendRange = 0;
    int mpeGlobalPitchBendRange = 0;
 
    int current_category_id = 0;

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -103,7 +103,7 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    state.voiceChannelState = voiceChannelState;
 
    state.mpePitchBendRange = storage->mpePitchBendRange;
-   state.mpePitchBend = ControllerModulationSource(storage->smoothingMode);
+   state.mpePitchBend = ControllerModulationSource(ControllerModulationSource::SmoothingMode::FAST_LINE);
    state.mpePitchBend.init(voiceChannelState->pitchBend / 8192.f);
 
    if ((scene->polymode.val.i == pm_mono_st_fp) ||

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -102,7 +102,7 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    state.mainChannelState = mainChannelState;
    state.voiceChannelState = voiceChannelState;
 
-   state.mpePitchBendRange = storage->getPatch().dawExtraState.mpePitchBendRange;
+   state.mpePitchBendRange = storage->mpePitchBendRange;
    state.mpePitchBend = ControllerModulationSource(storage->smoothingMode);
    state.mpePitchBend.init(voiceChannelState->pitchBend / 8192.f);
 

--- a/src/common/dsp/SurgeVoiceState.h
+++ b/src/common/dsp/SurgeVoiceState.h
@@ -27,5 +27,10 @@ struct SurgeVoiceState
    float portasrc_key, portaphase;
    bool porta_doretrigger;
 
+   // note that this does not replace the regular pitch bend modulator, only used to smooth MPE
+   // pitch
+   ControllerModulationSource mpePitchBend;
+   float mpePitchBendRange;
+
    float getPitch();
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4544,15 +4544,15 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMpeMenu(VSTGUI::CRect &menuRect, bool s
                     [this]() { this->synth->mpeEnabled = !this->synth->mpeEnabled; });
 
     std::ostringstream oss;
-    oss << "Change MPE Pitch Bend Range (Current: " << synth->mpePitchBendRange << " Semitones)";
+    oss << "Change MPE Pitch Bend Range (Current: " << synth->storage.mpePitchBendRange << " Semitones)";
     addCallbackMenu(mpeSubMenu, Surge::UI::toOSCaseForMenu(oss.str().c_str()), [this,menuRect]() {
        // FIXME! This won't work on linux
        char c[256];
-       snprintf(c, 256, "%d", synth->mpePitchBendRange);
+       snprintf(c, 256, "%d", synth->storage.mpePitchBendRange);
        promptForMiniEdit(c, "Enter new MPE pitch bend range:", "MPE Pitch Bend Range",
                          menuRect.getTopLeft(), [this](const std::string& c) {
                             int newVal = ::atoi(c.c_str());
-                            this->synth->mpePitchBendRange = newVal;
+                            this->synth->storage.mpePitchBendRange = newVal;
                          });
     });
 
@@ -4562,13 +4562,13 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMpeMenu(VSTGUI::CRect &menuRect, bool s
     addCallbackMenu(mpeSubMenu, Surge::UI::toOSCaseForMenu(oss2.str().c_str()), [this, menuRect]() {
        // FIXME! This won't work on linux
        char c[256];
-       snprintf(c, 256, "%d", synth->mpePitchBendRange);
+       snprintf(c, 256, "%d", synth->storage.mpePitchBendRange);
        promptForMiniEdit(c, "Enter default MPE pitch bend range:", "Default MPE Pitch Bend Range",
                          menuRect.getTopLeft(), [this](const std::string& s) {
                             int newVal = ::atoi(s.c_str());
                             Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
                                                                    "mpePitchBendRange", newVal);
-                            this->synth->mpePitchBendRange = newVal;
+                            this->synth->storage.mpePitchBendRange = newVal;
                          });
     });
 

--- a/src/headless/UnitTestsIO.cpp
+++ b/src/headless/UnitTestsIO.cpp
@@ -145,22 +145,22 @@ TEST_CASE( "DAW Streaming and Unstreaming", "[io][mpe][tun]" )
       auto v2 = 13;
 
       // Test from defaulted dest
-      surgeSrc->mpePitchBendRange = v2;
+      surgeSrc->storage.mpePitchBendRange = v2;
       fromto( surgeSrc, surgeDest );
-      REQUIRE( surgeDest->mpePitchBendRange == v2 );
+      REQUIRE( surgeDest->storage.mpePitchBendRange == v2 );
 
       // Test from set dest
-      surgeSrc->mpePitchBendRange = v1;
-      surgeDest->mpePitchBendRange = v1;
-      REQUIRE( surgeSrc->mpePitchBendRange == v1 );
-      REQUIRE( surgeDest->mpePitchBendRange == v1 );
+      surgeSrc->storage.mpePitchBendRange = v1;
+      surgeDest->storage.mpePitchBendRange = v1;
+      REQUIRE( surgeSrc->storage.mpePitchBendRange == v1 );
+      REQUIRE( surgeDest->storage.mpePitchBendRange == v1 );
       
-      surgeSrc->mpePitchBendRange = v2;
-      REQUIRE( surgeSrc->mpePitchBendRange == v2 );
-      REQUIRE( surgeDest->mpePitchBendRange == v1 );
+      surgeSrc->storage.mpePitchBendRange = v2;
+      REQUIRE( surgeSrc->storage.mpePitchBendRange == v2 );
+      REQUIRE( surgeDest->storage.mpePitchBendRange == v1 );
 
       fromto( surgeSrc, surgeDest );
-      REQUIRE( surgeDest->mpePitchBendRange == v2 );
+      REQUIRE( surgeDest->storage.mpePitchBendRange == v2 );
    }
    
    SECTION( "Everything Standard Stays Standard" )

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -625,10 +625,14 @@ TEST_CASE( "Pitch Bend and Tuning", "[mod][tun]" )
 TEST_CASE( "MPE pitch bend", "[mod]" )
 {
    SECTION( "Channel 0 bends should be a correct global bend" )
-   {
+   { // note that this test actually checks if channel 0 bends behave like non-MPE bends
       auto surge = surgeOnSine();
       surge->mpeEnabled = true;
       surge->mpePitchBendRange = 48;
+
+      // hack around multiple copies of mpePitchBendRange, we should fix this properly!
+      surge->populateDawExtraState();
+
       surge->storage.getPatch().scene[0].pbrange_up.val.i = 2;
       surge->storage.getPatch().scene[0].pbrange_dn.val.i = 2;
       
@@ -654,6 +658,10 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
       auto sbs = 8192 * 1.f / pbr;
       
       surge->mpePitchBendRange = pbr;
+
+      // hack around multiple copies of mpePitchBendRange, we should fix this properly!
+      surge->populateDawExtraState();
+
       surge->storage.getPatch().scene[0].pbrange_up.val.i = 2;
       surge->storage.getPatch().scene[0].pbrange_dn.val.i = 2;
 
@@ -673,8 +681,8 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
                                  on.data1 = n;
                                  on.data2 = 100;
                                  on.atSample = 100;
-                                 
-                                 off.type = Surge::Headless::Event::NOTE_ON;
+
+                                 off.type = Surge::Headless::Event::NOTE_OFF;
                                  off.channel = 1;
                                  off.data1 = n;
                                  off.data2 = 100;
@@ -690,8 +698,8 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
                                  events.push_back( bend );
                                  events.push_back( off );
 
-                                 return frequencyForEvents( surge, events, 0,
-                                                            2000, 44100 * 2 - 8000 );
+                                 return frequencyForEvents(surge, events, 0, 4000,
+                                                           44100 * 2 - 8000);
                               };
 
 

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -658,6 +658,7 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
       auto sbs = 8192 * 1.f / pbr;
       
       surge->mpePitchBendRange = pbr;
+      surge->changeModulatorSmoothing(ControllerModulationSource::SmoothingMode::FAST_LINE);
 
       // hack around multiple copies of mpePitchBendRange, we should fix this properly!
       surge->populateDawExtraState();

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -655,8 +655,7 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
       auto sbs = 8192 * 1.f / pbr;
       
       surge->storage.mpePitchBendRange = pbr;
-      surge->changeModulatorSmoothing(ControllerModulationSource::SmoothingMode::DIRECT);
-
+      
       surge->storage.getPatch().scene[0].pbrange_up.val.i = 2;
       surge->storage.getPatch().scene[0].pbrange_dn.val.i = 2;
 

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -628,10 +628,7 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
    { // note that this test actually checks if channel 0 bends behave like non-MPE bends
       auto surge = surgeOnSine();
       surge->mpeEnabled = true;
-      surge->mpePitchBendRange = 48;
-
-      // hack around multiple copies of mpePitchBendRange, we should fix this properly!
-      surge->populateDawExtraState();
+      surge->storage.mpePitchBendRange = 48;
 
       surge->storage.getPatch().scene[0].pbrange_up.val.i = 2;
       surge->storage.getPatch().scene[0].pbrange_dn.val.i = 2;
@@ -657,11 +654,8 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
       auto pbr = 48;
       auto sbs = 8192 * 1.f / pbr;
       
-      surge->mpePitchBendRange = pbr;
+      surge->storage.mpePitchBendRange = pbr;
       surge->changeModulatorSmoothing(ControllerModulationSource::SmoothingMode::DIRECT);
-
-      // hack around multiple copies of mpePitchBendRange, we should fix this properly!
-      surge->populateDawExtraState();
 
       surge->storage.getPatch().scene[0].pbrange_up.val.i = 2;
       surge->storage.getPatch().scene[0].pbrange_dn.val.i = 2;

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -658,7 +658,7 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
       auto sbs = 8192 * 1.f / pbr;
       
       surge->mpePitchBendRange = pbr;
-      surge->changeModulatorSmoothing(ControllerModulationSource::SmoothingMode::FAST_LINE);
+      surge->changeModulatorSmoothing(ControllerModulationSource::SmoothingMode::DIRECT);
 
       // hack around multiple copies of mpePitchBendRange, we should fix this properly!
       surge->populateDawExtraState();
@@ -699,7 +699,7 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
                                  events.push_back( bend );
                                  events.push_back( off );
 
-                                 return frequencyForEvents(surge, events, 0, 4000,
+                                 return frequencyForEvents(surge, events, 0, 2000,
                                                            44100 * 2 - 8000);
                               };
 

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -692,7 +692,7 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
                                  events.push_back( bend );
                                  events.push_back( off );
 
-                                 return frequencyForEvents(surge, events, 0, 2000,
+                                 return frequencyForEvents(surge, events, 0, 4000,
                                                            44100 * 2 - 8000);
                               };
 


### PR DESCRIPTION
This is a bit of a hack and kind of breaks channel 0 pitch bends.

I‘ve kept #2921 separate / still open if you'd rather keep this patch out of main.