### PR TITLE
Fix a couple of crash-on-close scenarios

### DIFF
--- a/src/au/aulayer_cocoaui.mm
+++ b/src/au/aulayer_cocoaui.mm
@@ -195,12 +195,15 @@ void timerCallback( CFRunLoopTimerRef timer, void *info )
 
 - (void) doIdle
 {
-    editController->idle();
+   if( editController )
+      editController->idle();
 }
 
 - (void) dealloc
 {
-    editController->close();
+   // You would think we want to editor->close() here, but we don't; by this point there's a good chance
+   // the AU host has killed our underlying editor object anyway.
+    editController = nullptr;
     if( idleTimer )
     {
         CFRunLoopTimerInvalidate( idleTimer );

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1690,6 +1690,13 @@ bool PLUGIN_API SurgeGUIEditor::open(void* parent, const PlatformType& platformT
 
 void SurgeGUIEditor::close()
 {
+   if( editorOverlay )
+   {
+      frame->removeView( editorOverlay );
+      editorOverlayOnClose();
+      editorOverlayTag = "";
+      editorOverlay = nullptr;
+   }
 #if TARGET_VST2 // && WINDOWS
    // We may need this in other hosts also; but for now
    if (frame)


### PR DESCRIPTION
1. The AU could get the editor cleaned up underneath it
2. The MSEG being on led to a double delete on close/reopen/close

Closes #2925