### PR TITLE
Hardclip bypass

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -459,6 +459,7 @@ void Parameter::set_type(int ctrltype)
       val_default.f = 0;
       break;
    case ct_decibel_attenuation:
+   case ct_decibel_attenuation_clipper:
       valtype = vt_float;
       val_min.f = -48;
       val_max.f = 0;
@@ -979,6 +980,7 @@ void Parameter::set_type(int ctrltype)
 
    case ct_decibel:
    case ct_decibel_attenuation:
+   case ct_decibel_attenuation_clipper:
    case ct_decibel_attenuation_large:
    case ct_decibel_fmdepth:
    case ct_decibel_narrow:
@@ -1150,6 +1152,7 @@ void Parameter::bound_value(bool force_integer)
       case ct_decibel_narrow_short_extendable:
       case ct_decibel_extra_narrow:
       case ct_decibel_attenuation:
+      case ct_decibel_attenuation_clipper:
       case ct_decibel_attenuation_large:
       case ct_decibel_fmdepth:
       case ct_decibel_extendable:
@@ -2585,6 +2588,7 @@ bool Parameter::can_setvalue_from_string()
    case ct_decibel_narrow_short_extendable:
    case ct_decibel_extra_narrow:
    case ct_decibel_attenuation:
+   case ct_decibel_attenuation_clipper:
    case ct_decibel_attenuation_large:
    case ct_decibel_fmdepth:
    case ct_decibel_extendable:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -58,6 +58,7 @@ enum ctrltypes
    ct_decibel_narrow_short_extendable, // shorter extend range
    ct_decibel_extra_narrow,
    ct_decibel_attenuation,
+   ct_decibel_attenuation_clipper,
    ct_decibel_attenuation_large,
    ct_decibel_fmdepth,
    ct_decibel_extendable,

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -44,7 +44,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                                     Surge::ParamConfig::kHorizontal));
       // TODO don't store in the patch ?
       param_ptr.push_back(volume.assign(
-          p_id.next(), 0, "volume", "Master Volume", ct_decibel_attenuation_clipper,
+          p_id.next(), 0, "volume", "Main Volume", ct_decibel_attenuation_clipper,
           Surge::Skin::Global::master_volume,
           0, cg_GLOBAL, 0, true, Surge::ParamConfig::kHorizontal | kEasy));
    }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -44,7 +44,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                                     Surge::ParamConfig::kHorizontal));
       // TODO don't store in the patch ?
       param_ptr.push_back(volume.assign(
-          p_id.next(), 0, "volume", "Master Volume", ct_decibel_attenuation,
+          p_id.next(), 0, "volume", "Master Volume", ct_decibel_attenuation_clipper,
           Surge::Skin::Global::master_volume,
           0, cg_GLOBAL, 0, true, Surge::ParamConfig::kHorizontal | kEasy));
    }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -44,7 +44,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
                                                     Surge::ParamConfig::kHorizontal));
       // TODO don't store in the patch ?
       param_ptr.push_back(volume.assign(
-          p_id.next(), 0, "volume", "Main Volume", ct_decibel_attenuation_clipper,
+          p_id.next(), 0, "volume", "Global Volume", ct_decibel_attenuation_clipper,
           Surge::Skin::Global::master_volume,
           0, cg_GLOBAL, 0, true, Surge::ParamConfig::kHorizontal | kEasy));
    }
@@ -198,7 +198,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       // ct_midikey
       // drift,keytrack_root
 
-      a->push_back(scene[sc].volume.assign(p_id.next(), id_s++, "volume", "Volume", ct_amplitude,
+      a->push_back(scene[sc].volume.assign(p_id.next(), id_s++, "volume", "Scene Volume", ct_amplitude,
                                            Surge::Skin::Scene::volume,
                                            sc_id, cg_GLOBAL, 0, true,
                                             sceasy));

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2913,15 +2913,19 @@ void SurgeSynthesizer::process()
 
    if (play_scene[0])
    {
-      hardclip_block8(sceneout[0][0], BLOCK_SIZE_OS_QUAD);
-      hardclip_block8(sceneout[0][1], BLOCK_SIZE_OS_QUAD);
+      if (hardclipEnabled){ 
+         hardclip_block8(sceneout[0][0], BLOCK_SIZE_OS_QUAD);
+         hardclip_block8(sceneout[0][1], BLOCK_SIZE_OS_QUAD);
+      }
       halfbandA.process_block_D2(sceneout[0][0], sceneout[0][1]);
    }
 
    if (play_scene[1])
    {
-      hardclip_block8(sceneout[1][0], BLOCK_SIZE_OS_QUAD);
-      hardclip_block8(sceneout[1][1], BLOCK_SIZE_OS_QUAD);
+      if (hardclipEnabled){
+         hardclip_block8(sceneout[1][0], BLOCK_SIZE_OS_QUAD);
+         hardclip_block8(sceneout[1][1], BLOCK_SIZE_OS_QUAD);
+      }
       halfbandB.process_block_D2(sceneout[1][0], sceneout[1][1]);
    }
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -228,6 +228,8 @@ public:
    int mpeVoices = 0;
    int mpeGlobalPitchBendRange = 0;
 
+   bool hardclipEnabled = true;
+
    int current_category_id = 0;
    bool modsourceused[n_modsources];
    bool midiprogramshavechanged = false;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3090,7 +3090,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             }
          } // end vt_float if statement
 
-         if (p->ctrltype = ct_decibel_attenuation && !strcmp(p->name, "volume")){
+         if (p->ctrltype == ct_decibel_attenuation_clipper){
              const char* tmptxt = synth->hardclipEnabled ? "Disable Hardclip" : "Enable Hardclip";
              addCallbackMenu(contextMenu, tmptxt, [this]() {
                      synth->hardclipEnabled = !synth->hardclipEnabled;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3059,7 +3059,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                   if (synth->isActiveModulation(ptag, ms))
                   {
                      char tmptxt[256];
-                     sprintf(tmptxt, "Clear %s -> %s", (char*)modulatorName(ms, true).c_str(),
+                     snprintf(tmptxt, 256, "Clear %s -> %s", (char*)modulatorName(ms, true).c_str(),
                              p->get_name() );
                      // clear_ms[ms] = eid;
                      // contextMenu->addEntry(tmptxt, eid++);
@@ -3089,6 +3089,14 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                }
             }
          } // end vt_float if statement
+
+         if (p->ctrltype = ct_decibel_attenuation && !strcmp(p->name, "volume")){
+             char tmptxt[256];
+             snprintf(tmptxt, 256, "%sable hardclipping", synth->hardclipEnabled ? "Dis" : "En");
+             addCallbackMenu(contextMenu, tmptxt, [this]() {
+                     synth->hardclipEnabled = !synth->hardclipEnabled;
+                     });
+         }
 
 #if TARGET_VST3
             auto hostMenu = addVst3MenuForParams(contextMenu, ptag, eid );
@@ -4555,7 +4563,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMpeMenu(VSTGUI::CRect &menuRect, bool s
     addCallbackMenu(mpeSubMenu, Surge::UI::toOSCaseForMenu(oss.str().c_str()), [this,menuRect]() {
        // FIXME! This won't work on linux
        char c[256];
-       snprintf(c, 256, "%d", synth->storage.mpePitchBendRange);
+       snprintf(c, 256, "%.0f", synth->storage.mpePitchBendRange);
        promptForMiniEdit(c, "Enter new MPE pitch bend range:", "MPE Pitch Bend Range",
                          menuRect.getTopLeft(), [this](const std::string& c) {
                             int newVal = ::atoi(c.c_str());
@@ -4569,7 +4577,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMpeMenu(VSTGUI::CRect &menuRect, bool s
     addCallbackMenu(mpeSubMenu, Surge::UI::toOSCaseForMenu(oss2.str().c_str()), [this, menuRect]() {
        // FIXME! This won't work on linux
        char c[256];
-       snprintf(c, 256, "%d", synth->storage.mpePitchBendRange);
+       snprintf(c, 256, "%.0f", synth->storage.mpePitchBendRange);
        promptForMiniEdit(c, "Enter default MPE pitch bend range:", "Default MPE Pitch Bend Range",
                          menuRect.getTopLeft(), [this](const std::string& s) {
                             int newVal = ::atoi(s.c_str());

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3091,11 +3091,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          } // end vt_float if statement
 
          if (p->ctrltype = ct_decibel_attenuation && !strcmp(p->name, "volume")){
-             char tmptxt[256];
-             snprintf(tmptxt, 256, "%sable hardclipping", synth->hardclipEnabled ? "Dis" : "En");
+             const char* tmptxt = synth->hardclipEnabled ? "Disable Hardclip" : "Enable Hardclip";
              addCallbackMenu(contextMenu, tmptxt, [this]() {
                      synth->hardclipEnabled = !synth->hardclipEnabled;
                      });
+             eid++;
          }
 
 #if TARGET_VST3


### PR DESCRIPTION
This patch allows the hardclipping before the main volume slider to be disabled by right clicking this slider.

Hard clipping is enabled by default to retain Surge's current behaviour.

Hard clipping state is not saved, the intention is more like giving the user the ability to hear whether their patch was clipping so it can be adjusted.

It also renames this slider to "Main Volume" in line with the renaming of the main branch.