### PR TITLE
Clip LFO path to the axis box

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -371,9 +371,13 @@ void CLFOGui::draw(CDrawContext* dc)
       }
 
       // LFO waveform itself
+      CRect cr;
+      dc->getClipRect(cr);
+      auto axesbox = CRect( top0.x, top0.y, bot1.x, bot1.y );
+      dc->setClipRect(axesbox);
       dc->setFrameColor(skin->getColor(Colors::LFO::Waveform::Wave));
       dc->drawGraphicsPath(path, VSTGUI::CDrawContext::PathDrawMode::kPathStroked, &tfpath );
-
+      dc->setClipRect(cr);
       // top ruler
       if (drawBeats)
       {


### PR DESCRIPTION
This stops the over-draw artefacts from quickly changing lines
at high frequencies