### PR TITLE
Add Spike waveform to MSEG

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -630,6 +630,7 @@ struct MSEGStorage {
          TRIANGLE,
          HOLD,
          SAWTOOTH,
+         SPIKE,
       } type;
    };
 

--- a/src/common/dsp/MSEGModulationHelper.cpp
+++ b/src/common/dsp/MSEGModulationHelper.cpp
@@ -167,16 +167,16 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
          cpratio = ( r.cpv - r.v0 ) / ( r.nv1 - r.v0 );
       lcpv = cpratio * ( r.nv1 - lv0 ) + lv0;
    }
+
    switch( r.type )
    {
    case MSEGStorage::segment::HOLD:
    {
-      es->lastOutput = lv0;
-      return lv0;
+      res = lv0;
       break;
    }
-   case MSEGStorage::segment::SCURVE: // Wuh? S-Curve and Linear are the same? Well kinda
    case MSEGStorage::segment::LINEAR:
+   case MSEGStorage::segment::SCURVE: // Wuh? S-Curve and Linear are the same? Well kinda
    {
       if( lv0 == lv1 ) return lv0;
       float frac = timeAlongSegment / r.duration;
@@ -278,79 +278,6 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
       res = cpline * ( lv1 - lv0 ) + lv0;
       break;
    }
-   case MSEGStorage::segment::BROWNIAN:
-   {
-      static constexpr int validx = 0, lasttime = 1, outidx = 2;
-      if( segInit )
-      {
-         es->msegState[validx] = lv0;
-         es->msegState[outidx] = lv0;
-         es->msegState[lasttime] = 0;
-      }
-      float targetTime = timeAlongSegment /r.duration;
-      if( targetTime >= 1 )
-      {
-         res = lv1;
-      }
-      else if( targetTime <= 0 )
-      {
-         res = lv0;
-      }
-      else if( targetTime <= es->msegState[lasttime] )
-      {
-         res = es->msegState[outidx];
-      }
-      else
-      {
-         while( es->msegState[lasttime] < targetTime && es->msegState[lasttime] < 1 )
-         {
-            auto ncd = r.cpduration; // 0-1
-            // OK so the closer this is to 1 the more spiky we should be, which is basically
-            // increasing the dt.
-
-            // The slowest is 5 steps (max dt is 0.2)
-            float sdt = 0.2f * ( 1 - ncd ) * ( 1 - ncd );
-            float dt = std::min( std::max( sdt, 0.0001f ), 1 - es->msegState[lasttime] );
-
-            if( es->msegState[lasttime] < 1 )
-            {
-               float lincoef  = ( lv1 - es->msegState[validx] ) / ( 1 - es->msegState[lasttime] );
-               float randcoef = 0.1 * lcpv; // CPV is on -1,1
-               /*
-               * Modification to standard bridge. We want to move away from 1,-1 so lets
-               * explicitly bounce away from them if random will push us over
-               */
-               auto uniformRand = ( ( 2.f * rand() ) / (float)(RAND_MAX) - 1 );
-               auto linstp = es->msegState[validx] + lincoef * dt;
-               float randup = randcoef;
-               float randdn = randcoef;
-               if( linstp + randup > 1 ) randup = 1 - linstp;
-               else if( linstp - randdn < -1 ) randdn = linstp + 1;
-               auto randadj = ( uniformRand > 0 ? randup * uniformRand : randdn * uniformRand );
-
-               es->msegState[validx] += limit_range( lincoef * dt + randadj, -1.f, 1.f );
-               es->msegState[lasttime] += dt;
-            }
-            else
-               es->msegState[validx] = lv1;
-         }
-         if( lcpv < 0 )
-         {
-            // Snap to between 1 and 24 values.
-            int a = floor( - lcpv * 24 ) + 1;
-            es->msegState[outidx] = floor( es->msegState[validx] * a ) * 1.f / a;
-         }
-         else
-         {
-            es->msegState[outidx] = es->msegState[validx];
-         }
-         es->msegState[outidx] = limit_range(es->msegState[outidx],-1.f, 1.f );
-         // so basically softclip it
-         res  = es->msegState[outidx];
-      }
-      
-      break;
-   }
    case MSEGStorage::segment::QUAD_BEZIER:
    {
       /*
@@ -425,7 +352,29 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
 
       break;
    }
+   case MSEGStorage::segment::SPIKE: 
+   {
+      auto t = timeAlongSegment / r.duration;
 
+      // this part is if we want 2D adjustment of control point
+      //auto cpd = r.cpduration;
+      //auto a = 50.f - ((1.f - (cpd * cpd)) * 44.f);
+
+      // but decided to do it via deform
+      auto deform = df < 0 ? -df * 40.f : -df * 6.f;
+      auto a = 10.f + deform;
+      auto g = exp(-a * t);
+      auto c = r.cpv;
+
+      auto q = c * g;
+
+      auto pos = q * (1 - r.nv1) + r.nv1;
+      auto neg = ((1 + r.nv1) * q) + r.nv1;
+
+      res = c > 0 ? pos : neg;
+
+      break;
+   }
    case MSEGStorage::segment::SINE: 
    case MSEGStorage::segment::SAWTOOTH: 
    case MSEGStorage::segment::TRIANGLE: 
@@ -434,14 +383,7 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
       float as = 5.0;
       float scaledpct = ( exp( as * pct ) - 1 ) / (exp(as)-1);
       int steps = (int)( scaledpct * 100 );
-      auto f = timeAlongSegment /r.duration;
-
-      float a = 1;
-      
-      if( df < 0 )
-         a = 1 + df * 0.5;
-      if( df > 0 )
-         a = 1 + df * 1.5;
+      auto frac = timeAlongSegment /r.duration;
 
       float kernel = 0;
 
@@ -458,19 +400,19 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
           * so we get one and a half waveforms
           */
          float mul = ( 1 + 2 * steps ) * M_PI;
-         kernel = cos( mul * f );
+         kernel = cos( mul * frac );
       }
       if( r.type == MSEGStorage::segment::SAWTOOTH )
       {
          double mul = steps + 1;
-         double phase = mul * f;
+         double phase = mul * frac;
          double dphase = phase - (int)phase;
          kernel = 1 - 2 * dphase;
       }
       if( r.type == MSEGStorage::segment::TRIANGLE )
       {
          double mul = ( 0.5 + steps );
-         double phase = mul * f;
+         double phase = mul * frac;
          double dphase = phase - (int)phase;
          if( dphase < 0.5 )
          {
@@ -486,17 +428,22 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
       }
       if( r.type == MSEGStorage::segment::SQUARE )
       {
-         /*
-          * Deform does PWM here
-          */
+         // dDeform does PWM here
          float mul = steps + 1;
-         float tphase = mul * f;
+         float tphase = mul * frac;
          float phase = tphase - (int)tphase;
          float pw = ( df + 1 ) / 2.0; // so now 0 -> 1
          kernel = ( phase < pw ? 1 : -1 );
       }
+
+      // This is the equivalent of LFOModulationSource.cpp::bend3
+      float a = -0.5f * limit_range(df, -3.f, 3.f);
+
+      kernel = kernel - a * kernel * kernel + a;
+      kernel = kernel - a * kernel * kernel + a; // do twice because bend3 does it twice
       
-      res = (lv0 - lv1) * pow((kernel + 1) * 0.5, a) + lv1;
+      res = (lv0 - lv1) * ((kernel + 1) * 0.5) + lv1;
+
       break;
    }
 
@@ -514,9 +461,81 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
       res = frac * lv1 + ( 1 - frac ) * lv0;
       break;
    }
+   case MSEGStorage::segment::BROWNIAN:
+   {
+      static constexpr int validx = 0, lasttime = 1, outidx = 2;
+      if( segInit )
+      {
+         es->msegState[validx] = lv0;
+         es->msegState[outidx] = lv0;
+         es->msegState[lasttime] = 0;
+      }
+      float targetTime = timeAlongSegment /r.duration;
+      if( targetTime >= 1 )
+      {
+         res = lv1;
+      }
+      else if( targetTime <= 0 )
+      {
+         res = lv0;
+      }
+      else if( targetTime <= es->msegState[lasttime] )
+      {
+         res = es->msegState[outidx];
+      }
+      else
+      {
+         while( es->msegState[lasttime] < targetTime && es->msegState[lasttime] < 1 )
+         {
+            auto ncd = r.cpduration; // 0-1
+            // OK so the closer this is to 1 the more spiky we should be, which is basically
+            // increasing the dt.
 
-   
+            // The slowest is 5 steps (max dt is 0.2)
+            float sdt = 0.2f * ( 1 - ncd ) * ( 1 - ncd );
+            float dt = std::min( std::max( sdt, 0.0001f ), 1 - es->msegState[lasttime] );
+
+            if( es->msegState[lasttime] < 1 )
+            {
+               float lincoef  = ( lv1 - es->msegState[validx] ) / ( 1 - es->msegState[lasttime] );
+               float randcoef = 0.1 * lcpv; // CPV is on -1,1
+               /*
+               * Modification to standard bridge. We want to move away from 1,-1 so lets
+               * explicitly bounce away from them if random will push us over
+               */
+               auto uniformRand = ( ( 2.f * rand() ) / (float)(RAND_MAX) - 1 );
+               auto linstp = es->msegState[validx] + lincoef * dt;
+               float randup = randcoef;
+               float randdn = randcoef;
+               if( linstp + randup > 1 ) randup = 1 - linstp;
+               else if( linstp - randdn < -1 ) randdn = linstp + 1;
+               auto randadj = ( uniformRand > 0 ? randup * uniformRand : randdn * uniformRand );
+
+               es->msegState[validx] += limit_range( lincoef * dt + randadj, -1.f, 1.f );
+               es->msegState[lasttime] += dt;
+            }
+            else
+               es->msegState[validx] = lv1;
+         }
+         if( lcpv < 0 )
+         {
+            // Snap to between 1 and 24 values.
+            int a = floor( - lcpv * 24 ) + 1;
+            es->msegState[outidx] = floor( es->msegState[validx] * a ) * 1.f / a;
+         }
+         else
+         {
+            es->msegState[outidx] = es->msegState[validx];
+         }
+         es->msegState[outidx] = limit_range(es->msegState[outidx],-1.f, 1.f );
+         // so basically softclip it
+         res  = es->msegState[outidx];
+      }
+      
+      break;
    }
+   }
+
    //std::cout << _D(timeAlongSegment) << _D(r.type) << _D(r.duration) << _D(lv0) << std::endl;
    res = limit_range(res, -1.f, 1.f);
    es->lastOutput = res;

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -359,11 +359,13 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
             }
          };
 
+         auto unipolarFactor = 1 + lfodata->unipolar.val.b;
+
          // We get a mousable point at the start of the line
          rectForPoint(
              t0, s.v0, hotzone::SEGMENT_ENDPOINT,
-             [i, this, vscale, tscale, timeConstraint](float dx, float dy, const CPoint& where) {
-                adjustValue(i, false, -2 * dy / vscale, eds->vSnap);
+             [i, this, vscale, tscale, timeConstraint, unipolarFactor](float dx, float dy, const CPoint& where) {
+                adjustValue(i, false, -2 * dy / vscale, eds->vSnap * unipolarFactor);
 
                 if (i != 0)
                 {
@@ -372,9 +374,7 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
              });
 
          // Control point editor
-         if (ms->segments[i].duration > 0.01 &&
-             fabs(ms->segments[i].nv1 - ms->segments[i].v0) > 0.01 &&
-             ms->segments[i].type != MSEGStorage::segment::HOLD )
+         if (ms->segments[i].duration > 0.01 && ms->segments[i].type != MSEGStorage::segment::HOLD )
          {
             /*
              * Drop in a control point. But where and moving how?
@@ -389,8 +389,6 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
             {
             // Ones where we scan the entire square
             case MSEGStorage::segment::QUAD_BEZIER:
-               horizontalMotion = true;
-               break;
             case MSEGStorage::segment::BROWNIAN:
                horizontalMotion = true;
                break;
@@ -508,11 +506,11 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
          {
             rectForPoint( tpx(ms->totalDuration), ms->segments[ms->n_activeSegments-1].nv1, /* which is [0].v0 in lock mode only */
                          hotzone::SEGMENT_ENDPOINT,
-                          [this,vscale,tscale](float dx, float dy, const CPoint &where) {
+                          [this, vscale, tscale, unipolarFactor](float dx, float dy, const CPoint &where) {
                              if( ms->endpointMode == MSEGStorage::EndpointMode::FREE )
                              {
                                 float d = -2 * dy / vscale;
-                                float snapResolution = eds->vSnap;
+                                float snapResolution = eds->vSnap * unipolarFactor;
                                 int idx = ms->n_activeSegments - 1;
                                 offsetValue( ms->segments[idx].dragv1, d );
                                 if( snapResolution <= 0 )
@@ -1293,6 +1291,7 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
          typeTo( "Linear", MSEGStorage::segment::Type::LINEAR );
          typeTo( "Bezier", MSEGStorage::segment::Type::QUAD_BEZIER );
          typeTo(Surge::UI::toOSCaseForMenu("S-Curve"), MSEGStorage::segment::Type::SCURVE);
+         typeTo( "Spike", MSEGStorage::segment::Type::SPIKE);
          typeTo( "Sine", MSEGStorage::segment::Type::SINE );
          typeTo( "Sawtooth", MSEGStorage::segment::Type::SAWTOOTH );
          typeTo( "Triangle", MSEGStorage::segment::Type::TRIANGLE );


### PR DESCRIPTION
Sine/Saw/Triangle waves are now using bend3 deform, just like Linear/S-curve
Order of cases for MSEG curve types matches the order of dropdown menu
Control point is always visible even on dead flat lines now
Correct vertical snapping in MSEG when in unipolar LFO mode