### PR TITLE
Add K35 filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ set(SURGE_COMMON_SOURCES
   src/common/dsp/effect/VocoderEffect.cpp
   src/common/dsp/filters/VintageLadders.cpp
   src/common/dsp/filters/Obxd.cpp
+  src/common/dsp/filters/K35.cpp
   src/common/dsp/AdsrEnvelope.cpp
   src/common/dsp/AudioInputOscillator.cpp
   src/common/dsp/BiquadFilter.cpp

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2164,6 +2164,10 @@ void Parameter::get_display(char* txt, bool external, float ef)
                   case fut_obxd_4pole:
                      sprintf( txt, "%s", fut_obxd_4p_subtypes[i]);
                      break;
+                  case fut_k35_lp:
+                  case fut_k35_hp:
+                     sprintf( txt, "%s", fut_k35_subtypes[i]);
+                     break;
 #if SURGE_EXTRA_FILTERS
 #endif                     
                   default:

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -367,6 +367,8 @@ enum fu_type
    fut_vintageladder,
    fut_obxd_2pole,
    fut_obxd_4pole,
+   fut_k35_lp,
+   fut_k35_hp,
    n_fu_type,
 };
 const char fut_names[n_fu_type][32] =
@@ -384,6 +386,8 @@ const char fut_names[n_fu_type][32] =
    "Vintage Ladder",
    "OB-Xd 12 dB/oct",
    "OB-Xd 24 dB/oct",
+   "K35 Lowpass",
+   "K35 Highpass",
 };
 
 const char fut_bp_subtypes[6][32] =
@@ -436,6 +440,8 @@ const char fut_vintageladder_subtypes[6][32] =
 };
 const char fut_obxd_2p_subtypes[1][32] = {"12 dB/oct"};
 const char fut_obxd_4p_subtypes[1][32] = {"24 dB/oct"};
+
+const char fut_k35_subtypes[1][32] = {"12 dB/oct"};
 
 const int fut_subcount[n_fu_type] = {0, 3, 3, 4, 3, 3, 6, 4, 4, 0, 4, 0, 0 };
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -441,9 +441,21 @@ const char fut_vintageladder_subtypes[6][32] =
 const char fut_obxd_2p_subtypes[1][32] = {"12 dB/oct"};
 const char fut_obxd_4p_subtypes[1][32] = {"24 dB/oct"};
 
-const char fut_k35_subtypes[1][32] = {"12 dB/oct"};
+const char fut_k35_subtypes[4][32] = {
+   "No Saturation",
+   "1 Saturation",
+   "2 Saturation",
+   "3 Saturation"
+};
 
-const int fut_subcount[n_fu_type] = {0, 3, 3, 4, 3, 3, 6, 4, 4, 0, 4, 0, 0 };
+const float fut_k35_saturations[4] = {
+   0.0f,
+   1.0f,
+   2.0f,
+   3.0f
+};
+
+const int fut_subcount[n_fu_type] = {0, 3, 3, 4, 3, 3, 6, 4, 4, 0, 4, 0, 0, 4, 4 };
 
 enum fu_subtype
 {

--- a/src/common/dsp/FastMath.h
+++ b/src/common/dsp/FastMath.h
@@ -68,6 +68,16 @@ inline float fasttanh (float x) noexcept
    return numerator / denominator;
 }
 
+// Valid in range (-PI/2, PI/2)
+inline float fasttan(float x) noexcept
+{
+   auto x2 = x * x;
+   auto numerator = x * (-135135 + x2 * (17325 + x2 * (-378 + x2)));
+   auto denominator = -135135 + x2 * (62370 + x2 * (-3150 + 28 * x2));
+   return numerator / denominator;
+}
+
+
 inline __m128 fasttanhSSE( __m128 x )
 {
    static const __m128

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -4,6 +4,7 @@
 
 #include "filters/VintageLadders.h"
 #include "filters/Obxd.h"
+#include "filters/K35.h"
 
 using namespace std;
 
@@ -87,6 +88,12 @@ void FilterCoefficientMaker::MakeCoeffs(
       break;
    case fut_obxd_4pole:
       ObxdFilter::makeCoefficients(this, ObxdFilter::FOUR_POLE, Freq, Reso, SubType, storageI);
+      break;
+   case fut_k35_lp:
+      K35Filter::makeCoefficients(this, Freq, Reso, true, storageI);
+      break;
+   case fut_k35_hp:
+      K35Filter::makeCoefficients(this, Freq, Reso, false, storageI);
       break;
 #if SURGE_EXTRA_FILTERS
 #endif      

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -15,8 +15,6 @@ FilterCoefficientMaker::FilterCoefficientMaker()
    Reset();
 }
 
-
-
 void FilterCoefficientMaker::MakeCoeffs(
     float Freq, float Reso, int Type, int SubType, SurgeStorage* storageI)
 {

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -90,10 +90,10 @@ void FilterCoefficientMaker::MakeCoeffs(
       ObxdFilter::makeCoefficients(this, ObxdFilter::FOUR_POLE, Freq, Reso, SubType, storageI);
       break;
    case fut_k35_lp:
-      K35Filter::makeCoefficients(this, Freq, Reso, true, storageI);
+      K35Filter::makeCoefficients(this, Freq, Reso, true, fut_k35_saturations[SubType], storageI);
       break;
    case fut_k35_hp:
-      K35Filter::makeCoefficients(this, Freq, Reso, false, storageI);
+      K35Filter::makeCoefficients(this, Freq, Reso, false, fut_k35_saturations[SubType], storageI);
       break;
 #if SURGE_EXTRA_FILTERS
 #endif      

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -5,6 +5,7 @@
 
 #include "filters/VintageLadders.h"
 #include "filters/Obxd.h"
+#include "filters/K35.h"
 
 __m128 SVFLP12Aquad(QuadFilterUnitState* __restrict f, __m128 in)
 {
@@ -799,6 +800,12 @@ FilterUnitQFPtr GetQFPtrFilterUnit(int type, int subtype)
       break;
    case fut_obxd_4pole:
       return ObxdFilter::process_4_pole;
+      break;
+   case fut_k35_lp:
+      return K35Filter::process_lp;
+      break;
+   case fut_k35_hp:
+      return K35Filter::process_hp;
       break;
    default:
       // SOFTWARE ERROR

--- a/src/common/dsp/filters/K35.cpp
+++ b/src/common/dsp/filters/K35.cpp
@@ -1,0 +1,146 @@
+#include "globals.h"
+#include "K35.h"
+#include "QuadFilterUnit.h"
+#include "FilterCoefficientMaker.h"
+#include "DebugHelpers.h"
+#include "SurgeStorage.h"
+#include "vt_dsp/basic_dsp.h"
+#include "FastMath.h"
+
+/*
+** This contains various adaptations of the models found at
+** https://github.com/TheWaveWarden/odin2/blob/master/Source/audio/Filters/Korg35Filter.cpp
+*/
+
+static float clampedFrequency( float pitch, SurgeStorage *storage )
+{
+   auto freq = storage->note_to_pitch_ignoring_tuning( pitch + 69 ) * Tunings::MIDI_0_FREQ;
+   freq = limit_range( (float)freq, 5.f, (float)( dsamplerate_os * 0.3f ) );
+   return freq;
+}
+
+// like in FastMath.h this is from
+// https://github.com/juce-framework/JUCE/blob/master/modules/juce_dsp/maths/juce_FastMathApproximations.h
+// but it's kept here because we only need the double version here
+static inline double fastdtan(double x) noexcept
+{
+   auto x2 = x * x;
+   auto numerator = x * (-135135 + x2 * (17325 + x2 * (-378 + x2)));
+   auto denominator = -135135 + x2 * (62370 + x2 * (-3150 + 28 * x2));
+   return numerator / denominator;
+}
+
+#define F(a) _mm_set_ps1( a )         
+#define M(a,b) _mm_mul_ps( a, b )
+#define D(a,b) _mm_div_ps( a, b )
+#define A(a,b) _mm_add_ps( a, b )
+#define S(a,b) _mm_sub_ps( a, b )
+
+// note that things that were NOPs in the Odin code have been removed.
+// m_gamma remains 1.0 so xn * m_gamma == xn; that's a NOP
+// m_feedback remains 0, that's a NOP
+// m_epsilon remains 0, that's a NOP
+// m_a_0 remains 1 so that's also a NOP
+// so we only need to compute:
+// (xn - z) * alpha + za
+static inline __m128 doLpf(const __m128 &G, const __m128 &input, __m128 &z) noexcept {
+   const __m128 v = M(S(input, z), G);
+   const __m128 result = A(v, z);
+   z = A(v, result);
+   return result;
+}
+static inline __m128 doHpf(const __m128 &G, const __m128 &input, __m128 &z) noexcept {
+   return S(input, doLpf(G, input, z));
+}
+
+namespace K35Filter
+{
+   enum k35_coeffs { 
+      k35_G = 0, // aka alpha
+      k35_lb,    // LPF beta
+      k35_hb,    // HPF beta
+      k35_k,     // k (m_k_modded)
+      k35_alpha, // aka m_alpha
+      k35_isLP   // is lowpass?
+   };
+
+   enum k35_state {
+      k35_l1z, // LPF1 z-1 storage
+      k35_l2z, // LPF2 z-1 storage
+      k35_h1z, // HPF1 z-1 storage
+      k35_h2z, // HPF2 z-1 storage
+   };
+
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, bool is_lowpass, SurgeStorage *storage )
+   {
+      const double wd = clampedFrequency( freq, storage ) * 2.0 * M_PI;
+      const double wa = (2.0 * dsamplerate_os) * fastdtan(wd * dsamplerate_os_inv * 0.5);
+      const double g  = wa * dsamplerate_os_inv * 0.5;
+      const double gp1= (1.0 + g); // g plus 1
+      const double G  = g / gp1;
+
+      const double k = reso * 2.0;
+      // clamp to [0.01..1.96]
+      const double mk = (k > 1.96) ? 1.96 : ((k < 0.01) ? 0.01 : k);
+
+      cm->C[k35_G] = G;
+
+      if(is_lowpass) {
+         cm->C[k35_lb] = (mk - mk * G) / gp1;
+         cm->C[k35_hb] = -1.0 / gp1;
+         cm->C[k35_isLP] = 1.0;
+      }
+      else {
+         cm->C[k35_lb] =  1.0 / gp1;
+         cm->C[k35_hb] = -G / gp1;
+         cm->C[k35_isLP] = 0.0;
+      }
+
+      cm->C[k35_k] = mk;
+
+      cm->C[k35_alpha] = 1.0 / (1.0 - mk * G + mk * G * G);
+   }
+
+   __m128 process_lp( QuadFilterUnitState * __restrict f, __m128 input )
+   {
+      const __m128 y1 = doLpf(f->C[k35_G], input, f->R[k35_l1z]);
+      // (lpf beta * lpf2 feedback) + (hpf beta * hpf1 feedback)
+      const __m128 s35 = A(M(f->C[k35_lb], f->R[k35_l2z]), M(f->C[k35_hb], f->R[k35_h1z]));
+      // alpha * (y1 + s35)
+      const __m128 u = M(f->C[k35_alpha], A(y1, s35));
+
+      // mk * lpf2(u)
+      const __m128 y = M(f->C[k35_k], doLpf(f->C[k35_G], u, f->R[k35_l2z]));
+      doHpf(f->C[k35_G], y, f->R[k35_h1z]);
+
+      const __m128 result = D(y, f->C[k35_k]);
+
+      // todo: apply overdrive? we don't have a way to supply the saturation level
+
+      return result;
+   }
+
+   __m128 process_hp( QuadFilterUnitState * __restrict f, __m128 input )
+   {
+      const __m128 y1 = doHpf(f->C[k35_G], input, f->R[k35_h1z]);
+      // (lpf beta * lpf2 feedback) + (hpf beta * hpf1 feedback)
+      const __m128 s35 = A(M(f->C[k35_hb], f->R[k35_h2z]), M(f->C[k35_lb], f->R[k35_l1z]));
+      // alpha * (y1 + s35)
+      const __m128 u = M(f->C[k35_alpha], A(y1, s35));
+
+      // mk * lpf2(u)
+      const __m128 y = M(f->C[k35_k], u);
+      doLpf(f->C[k35_G], doHpf(f->C[k35_G], y, f->R[k35_h2z]), f->R[k35_l1z]);
+
+      const __m128 result = D(y, f->C[k35_k]);
+
+      // todo: apply overdrive? we don't have a way to supply the saturation level
+
+      return result;
+   }
+#undef F
+#undef M
+#undef D
+#undef A
+#undef S
+}

--- a/src/common/dsp/filters/K35.cpp
+++ b/src/common/dsp/filters/K35.cpp
@@ -61,7 +61,6 @@ namespace K35Filter
       k35_hb,    // HPF beta
       k35_k,     // k (m_k_modded)
       k35_alpha, // aka m_alpha
-      k35_isLP   // is lowpass?
    };
 
    enum k35_state {
@@ -88,12 +87,10 @@ namespace K35Filter
       if(is_lowpass) {
          cm->C[k35_lb] = (mk - mk * G) / gp1;
          cm->C[k35_hb] = -1.0 / gp1;
-         cm->C[k35_isLP] = 1.0;
       }
       else {
          cm->C[k35_lb] =  1.0 / gp1;
          cm->C[k35_hb] = -G / gp1;
-         cm->C[k35_isLP] = 0.0;
       }
 
       cm->C[k35_k] = mk;

--- a/src/common/dsp/filters/K35.h
+++ b/src/common/dsp/filters/K35.h
@@ -1,0 +1,12 @@
+#pragma once
+
+struct QuadFilterUnitState;
+class FilterCoefficientMaker;
+class SurgeStorage;
+
+namespace K35Filter
+{
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, bool is_lowpass, SurgeStorage *storage );
+   __m128 process_lp( QuadFilterUnitState * __restrict f, __m128 in );
+   __m128 process_hp( QuadFilterUnitState * __restrict f, __m128 in );
+}

--- a/src/common/dsp/filters/K35.h
+++ b/src/common/dsp/filters/K35.h
@@ -6,7 +6,7 @@ class SurgeStorage;
 
 namespace K35Filter
 {
-   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, bool is_lowpass, SurgeStorage *storage );
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, bool is_lowpass, float saturation, SurgeStorage *storage );
    __m128 process_lp( QuadFilterUnitState * __restrict f, __m128 in );
    __m128 process_hp( QuadFilterUnitState * __restrict f, __m128 in );
 }

--- a/src/headless/UnitTestsDSP.cpp
+++ b/src/headless/UnitTestsDSP.cpp
@@ -459,6 +459,19 @@ TEST_CASE( "Check FastMath Functions", "[dsp]" )
       }
    }
 
+   SECTION( "fastTan" )
+   {
+      // need to bump start point slightly, fasttan is only valid just after -PI/2
+      for( float x=-M_PI/2.0 + 0.001; x < M_PI/2.0; x += 0.02 )
+      {
+         INFO( "Testing fasttan at " << x );
+         auto rn = tanf( x );
+         auto rd = Surge::DSP::fasttan( x );
+         REQUIRE( rd == Approx( rn ).epsilon( 1e-4 ) );
+      }
+   }
+
+
    SECTION( "fastexp and fastexpSSE" )
    {
       for( float x=-3.9; x < 2.9; x += 0.02 )


### PR DESCRIPTION
Some issues/uncertainties:
* I used the `clampedFrequency` stuff from `VintageLadder` to stop it from exploding when the frequency goes too high. It's possible that it can be set higher than `VintageLadder`'s limit, but be cautious for now.
* Coefficient calculation probably doesn't need to use `double` but I've kept it like the original. **FIXED**
* `applyOverdrive` is implemented differently than in Odin2 - might need more oversampling to avoid artifacts.
* ... just noticed I didn't use the `SURGE_EXTRA_FILTERS` ifdef. Oh.