### PR TITLE
Fix an MSEG crash from DAW ID

### DIFF
--- a/src/common/SurgeSynthesizerIDManagement.cpp
+++ b/src/common/SurgeSynthesizerIDManagement.cpp
@@ -175,7 +175,7 @@ bool SurgeSynthesizer::fromSynthSideIdWithGuiOffset(int i,
                                                     ID& q)
 {
    bool res = false;
-   if( i >= start_paramtags )
+   if( i >= start_paramtags  && i <= start_paramtags + n_total_params )
       res = fromSynthSideId(i-start_paramtags, q ); // wrong for macros and stuff
    else if( i >= start_metacontrol_tag && i <= start_metacontrol_tag + num_metaparameters )
       res = fromSynthSideId(i-start_metacontrol_tag+metaparam_offset, q );

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -56,7 +56,7 @@ struct MSEGControlRegion : public CViewContainer, public Surge::UI::SkinConsumin
    };
 
    enum {
-      tag_segment_nodeedit_mode = 300000,
+      tag_segment_nodeedit_mode = metaparam_offset + 1000, // Just to push outside any ID range
       tag_segment_movement_mode,
       tag_vertical_snap,
       tag_vertical_value,


### PR DESCRIPTION
I had missed an out-of-bounds check on a beginEdit supress
implicitly when refactoring the ID stuff. Also set the base
ID so we are sure that it is above the metaparam offset.