### PR TITLE
Even more MSEG tweaks

### DIFF
--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -70,6 +70,7 @@
     <color id="msegeditor.panel" value="#2D2D2D"/>
     <color id="msegeditor.panel.text" value="lightgray"/>
     <color id="msegeditor.axis.text" value="lightgray"/>
+    <color id="msegeditor.axis.text.secondary" value="#B4B4B4C0"/>
     <color id="msegeditor.fill.gradient.start" value="#2E86FE80"/>
     <color id="msegeditor.fill.gradient.end" value="#2E86FE0F"/>
     <color id="msegeditor.numberfield.text" value="lightgray"/>

--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -227,7 +227,8 @@ namespace Colors
       namespace Axis
       {
          const Surge::Skin::Color Line("msegeditor.axis.line", 220, 220, 240),
-                                  Text("msegeditor.axis.text", 255, 255, 255);
+                                  Text("msegeditor.axis.text", 255, 255, 255),
+                                  SecondaryText("msegeditor.axis.text.secondary", 255, 255, 255, 128);
       }
       namespace GradientFill
       {
@@ -237,8 +238,8 @@ namespace Colors
       namespace Grid
       {
          const Surge::Skin::Color Primary("msegeditor.grid.primary", 255, 255, 255, 192),
-                                  SecondaryHorizontal("msegeditor.grid.secondary.horizontal", 255, 255, 255, 48),
-                                  SecondaryVertical("msegeditor.grid.secondary.vertical", 255, 255, 255, 96);
+                                  SecondaryHorizontal("msegeditor.grid.secondary.horizontal", 255, 255, 255, 64),
+                                  SecondaryVertical("msegeditor.grid.secondary.vertical", 255, 255, 255, 128);
       }
       namespace Loop
       {

--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -168,7 +168,7 @@ namespace Colors
 
       namespace Axis
       {
-          extern const Surge::Skin::Color Line, Text;
+          extern const Surge::Skin::Color Line, Text, SecondaryText;
       }
       namespace GradientFill
       {

--- a/src/common/SurgeSynthesizerIDManagement.cpp
+++ b/src/common/SurgeSynthesizerIDManagement.cpp
@@ -15,7 +15,7 @@
 */
 
 /*
-** This file also includes the 2020 non fiction work, "A Short Essay on Indices in
+** This file also includes the 2020 non-fiction work, "A Short Essay on Indices in
 ** Surge".
 **
 ** A Short Essay on Indices in Surge
@@ -27,51 +27,51 @@
 ** 2. The SurgeStorage object indicates a layout of types and subtypes, but the
 **    code is full of implicit and explicit assumptions that the parameter indices
 **    of those parameters are adjacent. That is, the parameters in OSCStorage
-**    are a contiguious non-overlapping bunch of parameter ids. Moreover, SurgeStorage
-**    assumes everywhere that given a parameter with id, that param_ptr[p->id] is that
-**    param, so the internal IDs are also the array indices.
+**    are a contiguious non-overlapping bunch of parameter IDs. Moreover, SurgeStorage
+**    assumes everywhere that given a parameter with ID, that param_ptr[p->id] is that
+**    parameter, so the internal IDs are also the array indices.
 ** 3. The DAWs expose a variety of phantom IDs. For instance, the Macros are
 **    the first 8 DAW parameters, but they are not actually parameters at all
-**    in surge
-** 4. SurgeGUIEditor uses the VSTGUI concept of 'tag' on a control but some controls
-**    also don't bind to parameters (like the menu button) so it has a collection
+**    in Surge.
+** 4. SurgeGUIEditor uses the VSTGUI concept of 'tag' on a control, but some controls
+**    also don't bind to parameters (like the Menu button) so it has a collection
 **    of control tags which are 'up front' in tag space. That means a SurgeGUIEditor
-**    tag from control->getTag() will either be internal (if c->gT() < start_paramtags)
+**    tag from control->getTag() will either be internal (if c->getTag() < start_paramtags)
 **    or refer to an internal parameter index (control->getTag() - start_paramtags is an index
 **    into the synth->param_ptr array).
-** 5. The VST3 makes it worse since, as VST3 doesn't support midi control inputs, we
-**    have had to create midi control port virtual parameters above the end of surge
+** 5. The VST3 makes it worse since, as VST3 doesn't support MIDI control inputs, we
+**    have had to create MIDI control port virtual parameters after the end of Surge
 **    params, so the VST3 is full of ifs which work but are not very well documented.
 **
 ** Luckily, patch streaming is immune to all of this since patches (and LV2 control ports)
 ** use the streaming name. So this problem only really rears its hed if those DAW phantom
-** IDs align with the Parameter IDs as 1:1 offsets. If that was the case, then adding
-** a param would change VST IDs. And that is the case in surge 1.7.1 and earlier.
+** IDs align with the parameter IDs as 1:1 offsets. If that was the case, then adding
+** a parameter would change VST IDs. And that is the case in Surge 1.7.1 and earlier.
 **
-** So what does it mean to add a parameter? Well lets consider adding a parameter to
+** So what does it mean to add a parameter? Well let's consider adding a parameter to
 ** OSCStorage so oscillators had 8, not 7, slots each. If you just did that willy nilly
-** today here's what would happen.
+** today here's what would happen:
 **
-** 1. You would change n_osc_params from 7 to 8 and recomile. Great. Everything would work
+** 1. You would change n_osc_params from 7 to 8 and recompile. Great. Everything would work
 **    in headless and the synth would come up no problem and load patches and run. If we had
-**    some place put in a '7' rather than an 'n_osc_params' you woudl have to find and fix that.
+**    some place put in a '7' rather than an 'n_osc_params' you would have to find and fix that.
 ** 2. The VST2/3/AU ID of every item after scene 1 / osc 1 would increase by 3 (in scene A)
 **    and 6 (in scene B)
 ** 3. So almost all your old automation would map to the wrong spot in your DAW.
 **
-** So this file exists to "not have that happen" (or more accurately "make it so that can not
+** So this file exists to "not have that happen" (or more accurately "make it so that cannot
  * happen when we expand"). How does it work?
  *
- * Well first SurgeSynthesizer has had all of its internal APIs to do things like get and set
+ * Well first, SurgeSynthesizer has had all of its internal APIs to do things like get and set
  * parameters converted from int as index to an ID object as index. This solves one of the biggest
- * confusing points, which is "is the int I am taking about the param index, the gui index, the daw
- * index, or the daw id". Once that's done you get obvious constructors for those, which are the
+ * confusing points, which is "is the int I am taking about the param index, the GUI index, the DAW
+ * index, or the DAW ID". Once that's done you get obvious constructors for those, which are the
  * from methods. (Note the fromGUITag is a static on SurgeGUIEditor since that requires GUI information
- * but also is only called from GUI aware clients).
+ * but also is only called from GUI-aware clients).
  *
  * And then you have two strategies.
  *
- * For hosts which match the DAW index and DAW id (! PLUGIN_ID_AND_INDEX_ARE_DISTINCT, which in
+ * For hosts which match the DAW index and DAW ID (! PLUGIN_ID_AND_INDEX_ARE_DISTINCT, which in
  * this implementation are the VST2, LV2 and AU) you build everything on the DAWSideIndex and
  * the SynthID and basically convert back and forth using get methods at control points.
  *
@@ -85,9 +85,9 @@
  *    DAW params 0->7 map to the custom controls, which have SynthID metaparam_offset_i
  *    DAW params 8->n_params map to the params, which have identical SynthID values
  *    DAW params n_params -> n_params + 7 map to the first 8 params, displaces by the controls, which have
- *         synthid 0-7.
+ *         SynthID 0-7.
  *
- *  The ID version basically keeps the DAWID and the SYnthID the same for now. In a future version
+ *  The ID version basically keeps the DAW ID and the SynthID the same for now. In a future version
  *  where we expand SynthIDs (which remember will need to be continugous) that constraint will break
  *  to preserve streaming.
 */

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -568,6 +568,10 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
    const int gridMaxHSteps = 20, gridMaxVSteps = 10;
 
    inline void drawAxis( CDrawContext *dc ) {
+
+      auto primaryFont = new VSTGUI::CFontDesc("Lato", 9, kBoldFace);
+      auto secondaryFont = new VSTGUI::CFontDesc("Lato", 7);
+
       auto uni = lfodata->unipolar.val.b;
       auto haxisArea = getHAxisArea();
       float maxt = drawDuration();
@@ -579,25 +583,48 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
 
       skips = std::max( 1, skips );
 
-      dc->setFont( displayFont );
-      dc->setFontColor(skin->getColor(Colors::MSEGEditor::Axis::Text));
       dc->setLineWidth( 1 );
-      dc->setFrameColor(skin->getColor(Colors::MSEGEditor::Axis::Line));
       dc->drawLine( haxisArea.getTopLeft(), haxisArea.getTopRight() );
+
       for( int gi = 0; gi < maxt * skips + 1; ++gi )
       {
          float t = 1.0f * gi / skips;
-         float px = tpx( t );
+         float px = tpx(t);
          float off = haxisArea.getHeight() / 2;
+         int xoff = 0;
+
          if( gi % skips == 0 )
+         {
             off = 0;
-         dc->drawLine( CPoint( px, haxisArea.top ), CPoint( px, haxisArea.bottom - off ) );
+            dc->setFrameColor(skin->getColor(Colors::MSEGEditor::Axis::Line));
+         }
+         else
+            dc->setFrameColor(skin->getColor(Colors::MSEGEditor::Grid::SecondaryVertical));
+
+         dc->drawLine( CPoint( px, haxisArea.top), CPoint( px, haxisArea.bottom - off ) );
+
          char txt[16];
-         snprintf( txt, 16, "%5.2f", t );
-         int xoff =0;
-         if( maxt < 1.1 && t > 0.99 )
-            xoff = -25;
-         dc->drawString( txt, CRect( CPoint( px + 4 + xoff, haxisArea.top + 2), CPoint( 15, 10 )));
+
+         if (floor(t) == t)
+         {
+            dc->setFontColor(skin->getColor(Colors::MSEGEditor::Axis::Text));
+            dc->setFont(primaryFont);
+            snprintf( txt, 16, "%d", (int)t );
+
+            if (gi != 0)
+               xoff = 0;
+
+            if( maxt < 1.1 && t > 0.99 )
+               xoff = -13;
+         }
+         else
+         {
+            dc->setFontColor(skin->getColor(Colors::MSEGEditor::Axis::SecondaryText));
+            dc->setFont(secondaryFont);
+            snprintf( txt, 16, "%5.2f", t );
+            xoff = -7;
+         }
+         dc->drawString( txt, CRect( CPoint( px + xoff, haxisArea.top + 5), CPoint( 15, 10 )));
       }
 
       // draw loop markers
@@ -605,20 +632,22 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
       int le = ( ms->loop_end >= 0 ? ms->loop_end : ms->n_activeSegments - 1 );
       float pxs = tpx( ms->segmentStart[ls] );
       float pxe = tpx(ms->segmentEnd[le]);
-      auto r = VSTGUI::CRect( CPoint( pxs-10, haxisArea.top), CPoint( 10, 10 ));
-      dc->setFillColor( kGreenCColor );
+      
+      auto r = VSTGUI::CRect( CPoint( pxs, haxisArea.top + 1), CPoint( 10, 10 ));
+      dc->setFillColor(CColor(0, 255, 0, 128));
       dc->drawRect( r, kDrawFilled );
 
-      r = VSTGUI::CRect( CPoint( pxe, haxisArea.top), CPoint( 10, 10 ));
-      dc->setFillColor( kRedCColor );
+      r = VSTGUI::CRect( CPoint( pxe - 8, haxisArea.top + 1), CPoint( 10, 10 ));
+      dc->setFillColor(CColor(255, 0, 0, 128));
       dc->drawRect( r, kDrawFilled );
 
       // vertical axis
       auto vaxisArea = getVAxisArea();
-      dc->setLineWidth( 1 );
-      dc->setFrameColor(skin->getColor(Colors::MSEGEditor::Axis::Line));
-      dc->drawLine( vaxisArea.getTopRight(), vaxisArea.getBottomRight() );
       auto valpx = valToPx();
+
+      dc->setFont(primaryFont);
+      dc->setFontColor(skin->getColor(Colors::MSEGEditor::Axis::Text));
+      dc->setLineWidth( 1 );
 
       skips = round(1.f / eds->vSnapDefault);
 
@@ -640,6 +669,11 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
 
          if (i == -1 || fabs(i - 1) < 1e-3 || (fabs(i) < 1e-3 && !uni))
             off = 0;
+
+         if( off == 0 )
+            dc->setFrameColor(skin->getColor(Colors::MSEGEditor::Axis::Line));
+         else
+            dc->setFrameColor(skin->getColor(Colors::MSEGEditor::Grid::SecondaryHorizontal));
 
          dc->drawLine( CPoint( vaxisArea.left + off, p ), CPoint( vaxisArea.right, p ) );
 
@@ -985,13 +1019,13 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
                 * onMouseMove so if you change shift/ctrl here or what not change it
                 * there too.
                 */
-               bool c = buttons & kShift;
-               bool s = buttons & kControl;
+               bool s = buttons & kShift;
+               bool c = buttons & kControl;
                if( s || c  )
                {
                   snapGuard = std::make_shared<SnapGuard>(eds, this);
-                  if( c ) eds->hSnap = eds->hSnapDefault;
-                  if( s ) eds->vSnap = eds->vSnapDefault;
+                  if( s ) eds->hSnap = eds->hSnapDefault;
+                  if( c ) eds->vSnap = eds->vSnapDefault;
                }
                break;
             }
@@ -1137,16 +1171,16 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
             invalid();
          }
          /*
-          * Activate temporary snap. NOte this is also checked in onMoueDown
+          * Activate temporary snap. Note this is also checked in onMouseDown
           * so if you change shift/ctrl whatever here change it there too
           */
-         bool c = buttons & kShift;
-         bool s = buttons & kControl;
+         bool s = buttons & kShift;
+         bool c = buttons & kControl;
          if( ( s || c ) && ! snapGuard )
          {
             snapGuard = std::make_shared<SnapGuard>(eds, this);
-            if( c ) eds->hSnap = eds->hSnapDefault;
-            if( s ) eds->vSnap = eds->vSnapDefault;
+            if( s ) eds->hSnap = eds->hSnapDefault;
+            if( c ) eds->vSnap = eds->vSnapDefault;
          }
          else if( ! ( s || c ) && snapGuard )
          {
@@ -1412,6 +1446,37 @@ void MSEGControlRegion::rebuild()
    int controlHeight = 12;
    int xpos = 10;
 
+   // movement modes
+   {
+      int segWidth = 110;
+      int marginPos = xpos + margin;
+      int btnWidth = 94;
+      int ypos = 1;
+
+      // label
+      auto mml = new CTextLabel(CRect(CPoint(marginPos, ypos), CPoint(btnWidth, labelHeight)), "Movement Mode");
+      mml->setTransparency(true);
+      mml->setFont(labelFont);
+      mml->setFontColor(skin->getColor(Colors::MSEGEditor::Text));
+      mml->setHoriAlign(kLeftText);
+      addView(mml);
+
+      ypos += margin + labelHeight;
+
+      // button
+      auto btnrect = CRect(CPoint(marginPos, ypos), CPoint(btnWidth, controlHeight));
+      auto mw =
+          new CHSwitch2(btnrect, this, tag_segment_movement_mode, 3, controlHeight, 1, 3,
+                        associatedBitmapStore->getBitmap(IDB_MSEG_MOVEMENT), CPoint(0, 0), true);
+      mw->setSkin(skin, associatedBitmapStore);
+      addView(mw);
+      mw->setValue(canvas->timeEditMode / 2.f);
+
+      // this value centers the loop mode and snap sections against the MSEG editor width
+      // if more controls are to be added to that center section, reduce this value
+      xpos += 225;
+   }
+
    // loop mode
    {
       int segWidth = 110;
@@ -1438,34 +1503,6 @@ void MSEGControlRegion::rebuild()
       xpos += segWidth;
    }
    
-   // movement modes
-   {
-      int segWidth = 110;
-      int marginPos = xpos + margin;
-      int btnWidth = 94;
-      int ypos = 1;
-
-      // label
-      auto mml = new CTextLabel(CRect(CPoint(marginPos, ypos), CPoint(btnWidth, labelHeight)), "Movement Mode");
-      mml->setTransparency(true);
-      mml->setFont(labelFont);
-      mml->setFontColor(skin->getColor(Colors::MSEGEditor::Text));
-      mml->setHoriAlign(kLeftText);
-      addView(mml);
-      
-      ypos += margin + labelHeight;
-
-      // button
-      auto btnrect = CRect(CPoint(marginPos, ypos), CPoint(btnWidth, controlHeight));
-      auto mw = new CHSwitch2(btnrect, this, tag_segment_movement_mode, 3, controlHeight, 1, 3,
-                        associatedBitmapStore->getBitmap(IDB_MSEG_MOVEMENT), CPoint(0, 0), true);
-      mw->setSkin(skin,associatedBitmapStore);
-      addView(mw);
-      mw->setValue(canvas->timeEditMode / 2.f);
-
-      xpos += segWidth;
-   }
-
    // Snap Section
    {
       int btnWidth = 49, editWidth = 32;

--- a/src/common/gui/MSEGEditor.h
+++ b/src/common/gui/MSEGEditor.h
@@ -20,8 +20,8 @@
 
 struct MSEGEditor : public VSTGUI::CViewContainer, public Surge::UI::SkinConsumingComponent {
    struct State {
-      float vSnap = 0, hSnap = 0, vSnapDefault = 0.25, hSnapDefault = 0.1;
-      int timeEditMode = 1;
+      float vSnap = 0, hSnap = 0, vSnapDefault = 0.25, hSnapDefault = 0.125;
+      int timeEditMode = 0;
    };
    MSEGEditor(LFOStorage *lfodata, MSEGStorage *ms, State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b);
    ~MSEGEditor();


### PR DESCRIPTION
Default horizontal snap is 8, default movement mode is Single
Different for secondary gridlines in horizontal axis (including secondary text color for the skin)
Integer only primary horizontal labels
Secondary horizontal labels centered on notch (roughly, with large phase counts it will be off - to fix when we have horizontal scrolling implemented!)
Temporary loop markers are semitransparent now
Movement mode switch is now all the way to the left (to be made global), per MSEG controls are centered