### PR TITLE
Fix an AU crash on exit

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -20,15 +20,16 @@ aulayer::aulayer(AudioUnit au) : AUInstrumentBase(au, 1, 1)
 
 aulayer::~aulayer()
 {
+   // Editor refers to synth so delete it first
+   if (editor_instance)
+   {
+      delete editor_instance;
+   }
+
    if (plugin_instance)
    {
       plugin_instance->~plugin();
       _aligned_free(plugin_instance);
-   }
-
-   if (editor_instance)
-   {
-      delete editor_instance;
    }
 }
 


### PR DESCRIPTION
AU deleted the synth before the editor. Now that the
editor refers to the synth to preserve state when
deleting we needed to flip that order.