### PR TITLE
SurgeStorage: Make modRoutingMutex a std::recursive_mutex for now

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -922,7 +922,8 @@ public:
    void storeMidiMappingToName( std::string name );
 
    // float table_sin[512],table_sin_offset[512];
-   std::mutex waveTableDataMutex, modRoutingMutex;
+   std::mutex waveTableDataMutex;
+   std::recursive_mutex modRoutingMutex;
    Wavetable WindowWT;
 
    float note_to_pitch(float x);


### PR DESCRIPTION
Turns out `SurgeStorage::modRoutingMutex` is used recursively after all:

> SurgeSynthesizer::clearModulation(long ptag, modsources modsource, bool clearEvenIfInvalid) 行 2140 C++
  SurgeSynthesizer::loadFx(bool initp, bool force_reload_all) 行 1752 C++
  SurgeSynthesizer::processControl() 行 2692 C++
> SurgeSynthesizer::process() 行 2803 C++
  SurgeVst3Processor::process(Steinberg::Vst::ProcessData & data) 行 503 C++

Broken by cd2c84c15768f31c98a306142e03765ef48827bb

Fixes #2948