### PR TITLE
Hiding of components in the Skin engine

### DIFF
--- a/resources/data/skins/Tutorial/08 Hiding Controls.surge-skin/skin.xml
+++ b/resources/data/skins/Tutorial/08 Hiding Controls.surge-skin/skin.xml
@@ -1,5 +1,12 @@
 <!--[doc]
-Make sure you can't hide menu
+Hiding a control is remarkably easy. Just find a control and give it class "none". This works
+for sliders, switches, and also for special types and panels. If for a panel you set a class
+'none' it pushes to the children of the panel, effectively hiding the entire group.
+
+This example simply ides the LFO deform and amplitude sliders, the Oscillator display, and the
+entire mixer section. That's not a very useful skin practically, but combined with the move
+and resize examples shown in other tutorials, it gives an idea of how to generate 'compact' or
+'player' skins.
 [doc]-->
 <surge-skin name="08 Hiding Controls" category="Tutorial" author="Surge Synth Team" authorURL="https://surge-synth-team.org/" version="1">
   <globals>
@@ -7,5 +14,21 @@ Make sure you can't hide menu
   <component-classes>
   </component-classes>
   <controls>
+    <!--[doc]
+    Here we hide a couple of sliders. We could do the same with switches and so on of course.
+    [doc]-->
+    <control ui_identifier="lfo.deform" class="none"/>
+    <control ui_identifier="lfo.amplitude" class="none"/>
+
+    <!--[doc]
+    But you can also hide more special non-slider controls. Here's the osc.display being hidden.
+    [doc]-->
+    <control ui_identifier="osc.display" class="none"/>
+
+    <!--[doc]
+    Finally, the skin model places items into groups, and so assigning a group a class of 'none'
+    hides all the components inside the panel.
+    [doc]-->
+    <control ui_identifier="mix.panel" class="none"/>
   </controls>
 </surge-skin>

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -21,6 +21,8 @@ namespace Surge
 namespace UI
 {
 
+
+const std::string NoneClassName = "none";
 const std::string Skin::defaultImageIDPrefix = "DEFAULT/";
 std::ostringstream SkinDB::errorStream;
    
@@ -992,6 +994,15 @@ void Surge::UI::Skin::resolveBaseParentOffsets(Skin::Control::ptr_t c)
       auto pc = controlForUIID(bp);
       while( pc )
       {
+         /*
+          * A special case: If a group has control type 'none' then my control adopts it
+          * This is the case only for none.
+          */
+         if( pc->classname == NoneClassName )
+         {
+            c->classname = NoneClassName;
+            c->ultimateparentclassname = NoneClassName;
+         }
          c->x += pc->x;
          c->y += pc->y;
          if( pc->allprops.find( "base_parent" ) != pc->allprops.end() )

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -71,6 +71,7 @@ private:
 namespace UI
 {
 
+extern const std::string NoneClassName;
 class SkinDB;
 
 class Skin

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1233,6 +1233,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
          std::cout << "Unable to find SkinCtrl" << std::endl;
          continue;
       }
+      if( skinCtrl->classname == Surge::UI::NoneClassName )
+         continue;
+
       /*
        * Many of the controls are special and so require non-generalizable constructors
        * handled here. Some are standard and so once we know the tag we can use layoutComponentForSkin
@@ -6758,7 +6761,8 @@ VSTGUI::CControl *SurgeGUIEditor::layoutComponentForSkin( std::shared_ptr<Surge:
       nonmod_param[paramIndex] = hsw;
       return hsw;
    }
-   std::cout << "Unable to make control with upc " << skinCtrl->ultimateparentclassname << std::endl;
+   if( skinCtrl->ultimateparentclassname != Surge::UI::NoneClassName )
+      std::cout << "Unable to make control with upc " << skinCtrl->ultimateparentclassname << std::endl;
    return nullptr;
 }
 


### PR DESCRIPTION
Any component in the skin engine which has 'class="none"' will
not be creted or displayed. Update tutorial 08 to show this.

Closes #2976