### PR TITLE
Handle the case that automation overflows our refresh slots

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1650,14 +1650,18 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
    }
    if (external && !need_refresh)
    {
+      bool got = false;
       for (int i = 0; i < 8; i++)
       {
          if (refresh_parameter_queue[i] < 0)
          {
             refresh_parameter_queue[i] = index;
+            got = true;
             break;
          }
       }
+      if( ! got )
+         refresh_overflow = true;
    }
    return need_refresh;
 }

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -334,6 +334,7 @@ public:
    int learn_param, learn_custom;
    int refresh_ctrl_queue[8];
    int refresh_parameter_queue[8];
+   bool refresh_overflow = false;
    float refresh_ctrl_queue_value[8];
    bool process_input;
    int patchid_queue;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -697,7 +697,35 @@ void SurgeGUIEditor::idle()
          }
       }
 
-      for (int i = 0; i < 8; i++)
+      if( synth->refresh_overflow )
+      {
+         // Basicall yreset everything and repaint.
+         synth->refresh_overflow = false;
+         for( int i=0; i<8; ++i )
+            synth->refresh_parameter_queue[i] = -1;
+         for( int i=0; i<n_total_params; ++i )
+         {
+            auto p = param[i];
+            if( ! p ) p = nonmod_param[i];
+            if( p )
+            {
+               SurgeSynthesizer::ID jid;
+               if( synth->fromSynthSideId(i, jid ))
+                  if( synth->getParameter01(jid) != p->getValue() )
+                     p->setValue(synth->getParameter01(jid));
+            }
+
+         }
+         for( int i=0; i<n_customcontrollers; ++i )
+         {
+            gui_modsrc[ms_ctrl1 + i]->setValue(
+                ((ControllerModulationSource*)synth->storage.getPatch()
+                    .scene[current_scene].modsources[ms_ctrl1 + i])->get_target01());
+
+         }
+         frame->invalid();
+      }
+      else for (int i = 0; i < 8; i++)
       {
          if (synth->refresh_parameter_queue[i] >= 0)
          {


### PR DESCRIPTION
In a given idle, if more than 8 on screen automations gtrigger
we would drop some. Adjust so that in that overflow case we
reset and repaint the UI en masse.

Closes #2972