### PR TITLE
airwindows: Remove references to audioeffectx.h

### DIFF
--- a/libs/airwindows/CMakeLists.txt
+++ b/libs/airwindows/CMakeLists.txt
@@ -149,9 +149,12 @@ add_library(${PROJECT_NAME}
   src/VoiceOfTheStarship.h
   src/VoiceOfTheStarshipProc.cpp
   src/AirWinBaseClass_pluginRegistry.cpp
-  src/audioeffectx.h
   include/${PROJECT_NAME}/AirWinBaseClass.h
 )
-target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+  AudioEffectX=AirWinBaseClass
+  VstPlugCategory=long
+  _USE_MATH_DEFINES
+)
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 add_library(surge::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/libs/airwindows/grab.pl
+++ b/libs/airwindows/grab.pl
@@ -10,7 +10,7 @@ open( OUT, "> src/$pl.h" );
 $openNS = 0;
 while( <IN> )
 {
-    s/audioeffectx.h/audioeffect_airwinstub.h/;
+    s/audioeffectx.h/airwindows\/AirWinBaseClass.h/;
     if( m/enum/ && !$openNS )
     {
         $openNS = 1;

--- a/libs/airwindows/include/airwindows/AirWinBaseClass.h
+++ b/libs/airwindows/include/airwindows/AirWinBaseClass.h
@@ -1,4 +1,5 @@
-// -*-c++-*-
+#pragma once
+
 /*
 ** We copy the AirWindows VST2s but we don't need the VST2 API; we just need the process and
 ** param methods. So this is a minimal header that lets us compile

--- a/libs/airwindows/src/ADClip7.h
+++ b/libs/airwindows/src/ADClip7.h
@@ -8,7 +8,7 @@
 #define __ADClip7_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Air.h
+++ b/libs/airwindows/src/Air.h
@@ -8,7 +8,7 @@
 #define __Air_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Apicolypse.h
+++ b/libs/airwindows/src/Apicolypse.h
@@ -8,7 +8,7 @@
 #define __Apicolypse_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/BassDrive.h
+++ b/libs/airwindows/src/BassDrive.h
@@ -8,7 +8,7 @@
 #define __BassDrive_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/BitGlitter.h
+++ b/libs/airwindows/src/BitGlitter.h
@@ -8,7 +8,7 @@
 #define __BitGlitter_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/BlockParty.h
+++ b/libs/airwindows/src/BlockParty.h
@@ -8,7 +8,7 @@
 #define __BlockParty_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/BrightAmbience2.h
+++ b/libs/airwindows/src/BrightAmbience2.h
@@ -8,7 +8,7 @@
 #define __BrightAmbience2_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/BussColors4.h
+++ b/libs/airwindows/src/BussColors4.h
@@ -8,7 +8,7 @@
 #define __BussColors4_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/ButterComp2.h
+++ b/libs/airwindows/src/ButterComp2.h
@@ -8,7 +8,7 @@
 #define __ButterComp2_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Capacitor.h
+++ b/libs/airwindows/src/Capacitor.h
@@ -8,7 +8,7 @@
 #define __Capacitor_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Cojones.h
+++ b/libs/airwindows/src/Cojones.h
@@ -8,7 +8,7 @@
 #define __Cojones_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Compresaturator.h
+++ b/libs/airwindows/src/Compresaturator.h
@@ -8,7 +8,7 @@
 #define __Compresaturator_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/CrunchyGrooveWear.h
+++ b/libs/airwindows/src/CrunchyGrooveWear.h
@@ -8,7 +8,7 @@
 #define __CrunchyGrooveWear_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/DeBess.h
+++ b/libs/airwindows/src/DeBess.h
@@ -8,7 +8,7 @@
 #define __DeBess_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/DeEss.h
+++ b/libs/airwindows/src/DeEss.h
@@ -8,7 +8,7 @@
 #define __DeEss_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/DeRez2.h
+++ b/libs/airwindows/src/DeRez2.h
@@ -8,7 +8,7 @@
 #define __DeRez2_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/DeckWrecka.h
+++ b/libs/airwindows/src/DeckWrecka.h
@@ -8,7 +8,7 @@
 #define __Deckwrecka_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Density.h
+++ b/libs/airwindows/src/Density.h
@@ -8,7 +8,7 @@
 #define __Density_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Drive.h
+++ b/libs/airwindows/src/Drive.h
@@ -8,7 +8,7 @@
 #define __Drive_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/DrumSlam.h
+++ b/libs/airwindows/src/DrumSlam.h
@@ -8,7 +8,7 @@
 #define __DrumSlam_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/DustBunny.h
+++ b/libs/airwindows/src/DustBunny.h
@@ -8,7 +8,7 @@
 #define __DustBunny_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Focus.h
+++ b/libs/airwindows/src/Focus.h
@@ -8,7 +8,7 @@
 #define __Focus_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Fracture.h
+++ b/libs/airwindows/src/Fracture.h
@@ -8,7 +8,7 @@
 #define __Fracture_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/GrooveWear.h
+++ b/libs/airwindows/src/GrooveWear.h
@@ -8,7 +8,7 @@
 #define __GrooveWear_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/HardVacuum.h
+++ b/libs/airwindows/src/HardVacuum.h
@@ -8,7 +8,7 @@
 #define __HardVacuum_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Hombre.h
+++ b/libs/airwindows/src/Hombre.h
@@ -8,7 +8,7 @@
 #define __Hombre_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/IronOxide5.h
+++ b/libs/airwindows/src/IronOxide5.h
@@ -8,7 +8,7 @@
 #define __IronOxide5_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Logical4.h
+++ b/libs/airwindows/src/Logical4.h
@@ -8,7 +8,7 @@
 #define __Logical4_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Loud.h
+++ b/libs/airwindows/src/Loud.h
@@ -8,7 +8,7 @@
 #define __Loud_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Melt.h
+++ b/libs/airwindows/src/Melt.h
@@ -8,7 +8,7 @@
 #define __Melt_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Mojo.h
+++ b/libs/airwindows/src/Mojo.h
@@ -8,7 +8,7 @@
 #define __Mojo_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/NCSeventeen.h
+++ b/libs/airwindows/src/NCSeventeen.h
@@ -8,7 +8,7 @@
 #define __NCSeventeen_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Noise.h
+++ b/libs/airwindows/src/Noise.h
@@ -8,7 +8,7 @@
 #define __Noise_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/OneCornerClip.h
+++ b/libs/airwindows/src/OneCornerClip.h
@@ -8,7 +8,7 @@
 #define __OneCornerClip_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/PocketVerbs.h
+++ b/libs/airwindows/src/PocketVerbs.h
@@ -8,7 +8,7 @@
 #define __PocketVerbs_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Point.h
+++ b/libs/airwindows/src/Point.h
@@ -8,7 +8,7 @@
 #define __Point_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Pop.h
+++ b/libs/airwindows/src/Pop.h
@@ -8,7 +8,7 @@
 #define __Pop_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Pressure4.h
+++ b/libs/airwindows/src/Pressure4.h
@@ -8,7 +8,7 @@
 #define __Pressure4_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/PyeWacket.h
+++ b/libs/airwindows/src/PyeWacket.h
@@ -8,7 +8,7 @@
 #define __Pyewacket_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/SingleEndedTriode.h
+++ b/libs/airwindows/src/SingleEndedTriode.h
@@ -8,7 +8,7 @@
 #define __SingleEndedTriode_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Slew.h
+++ b/libs/airwindows/src/Slew.h
@@ -8,7 +8,7 @@
 #define __Slew_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Slew2.h
+++ b/libs/airwindows/src/Slew2.h
@@ -8,7 +8,7 @@
 #define __Slew2_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Spiral2.h
+++ b/libs/airwindows/src/Spiral2.h
@@ -8,7 +8,7 @@
 #define __Spiral2_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/StarChild.h
+++ b/libs/airwindows/src/StarChild.h
@@ -8,7 +8,7 @@
 #define __StarChild_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/Surge.h
+++ b/libs/airwindows/src/Surge.h
@@ -8,7 +8,7 @@
 #define __Surge_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/ToTape6.h
+++ b/libs/airwindows/src/ToTape6.h
@@ -8,7 +8,7 @@
 #define __ToTape6_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/UnBox.h
+++ b/libs/airwindows/src/UnBox.h
@@ -8,7 +8,7 @@
 #define __UnBox_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/VariMu.h
+++ b/libs/airwindows/src/VariMu.h
@@ -8,7 +8,7 @@
 #define __VariMu_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/VoiceOfTheStarship.h
+++ b/libs/airwindows/src/VoiceOfTheStarship.h
@@ -8,7 +8,7 @@
 #define __VoiceOfTheStarship_H
 
 #ifndef __audioeffect__
-#include "audioeffectx.h"
+#include "airwindows/AirWinBaseClass.h"
 #endif
 
 #include <set>

--- a/libs/airwindows/src/audioeffectx.h
+++ b/libs/airwindows/src/audioeffectx.h
@@ -1,6 +1,0 @@
-#pragma once
-
-#include "airwindows/AirWinBaseClass.h"
-
-using AudioEffectX = AirWinBaseClass;
-using VstPlugCategory = long;


### PR DESCRIPTION
An earlier change introduced a header of this name to avoid changing
include directives in the imported sources. But the original is part of
the VST2 SDK, which might get the repo flagged by filename sweeps.