### PR TITLE
Make MPE timbre correctly display in the UI as a bipolar modulator

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1941,7 +1941,7 @@ bool SurgeSynthesizer::isBipolarModulation(modsources tms)
       else
          return false;
    }
-   if (tms == ms_keytrack || tms == ms_lowest_key || tms == ms_highest_key || tms == ms_latest_key || tms == ms_pitchbend || tms == ms_random_bipolar || tms == ms_alternate_bipolar )
+   if (tms == ms_keytrack || tms == ms_lowest_key || tms == ms_highest_key || tms == ms_latest_key || tms == ms_pitchbend || tms == ms_random_bipolar || tms == ms_alternate_bipolar || tms == ms_timbre )
       return true;
    else
       return false;


### PR DESCRIPTION
Timbre behaves as a bipolar modulator ([https://github.com/surge-synthesizer/surge/blob/main/src/common/SurgeSynthesizer.cpp#L1168](src/common/SurgeSynthesizer.cpp:1168)) but displayed in the UI like a unipolar modulator. This makes the UI display it as a bipolar modulator.