### PR TITLE
MSEG horiz flip, fix vertical flip, remove Spike (RIP)

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -647,7 +647,7 @@ struct MSEGStorage {
          TRIANGLE,
          HOLD,
          SAWTOOTH,
-         SPIKE,
+         RESERVED,  // used to be Spike curve, but it broke some MSEG model constraints, so we ditched it - can add a different curve type later on!
          BUMP,
          SMOOTH_STAIRS,
       } type;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -647,7 +647,7 @@ struct MSEGStorage {
          TRIANGLE,
          HOLD,
          SAWTOOTH,
-         RESERVED,  // used to be Spike curve, but it broke some MSEG model constraints, so we ditched it - can add a different curve type later on!
+         RESERVED,  // used to be Spike, but it broke some MSEG model constraints, so we ditched it - can add a different curve type later on!
          BUMP,
          SMOOTH_STAIRS,
       } type;

--- a/src/common/dsp/MSEGModulationHelper.h
+++ b/src/common/dsp/MSEGModulationHelper.h
@@ -58,5 +58,6 @@ namespace Surge
       void scaleDurations(MSEGStorage* s, float factor);
       void scaleValues(MSEGStorage* s, float factor);
       void setAllDurationsTo(MSEGStorage* s, float value);
+      void mirrorMSEG(MSEGStorage* s);
    }
 }


### PR DESCRIPTION
Vertical flip didn't work correctly for last node in unlinked endpoints mode
Rebuild cache in free functions called to execute MSEG actions
"Link start and end nodes" option is always shown in context menu now