### PR TITLE
Call restartComponent on the UI thread

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -57,6 +57,8 @@
 
 #include "vstgui/lib/cvstguitimer.h"
 
+#include "SurgeVst3Processor.h"
+
 
 template< typename T >
 struct RememberForgetGuard {
@@ -236,7 +238,7 @@ bool SurgeGUIEditor::fromSynthGUITag(SurgeSynthesizer *synth, int tag, SurgeSynt
    return synth->fromSynthSideIdWithGuiOffset(tag, start_paramtags, tag_mod_source0 + ms_ctrl1, q );
 }
 
-SurgeGUIEditor::SurgeGUIEditor(void* effect, SurgeSynthesizer* synth, void* userdata) : super(effect)
+SurgeGUIEditor::SurgeGUIEditor(PARENT_PLUGIN_TYPE* effect, SurgeSynthesizer* synth, void* userdata) : super(effect)
 {
 #ifdef INSTRUMENT_UI
    Surge::Debug::record( "SurgeGUIEditor::SurgeGUIEditor" );
@@ -417,6 +419,10 @@ void SurgeGUIEditor::idle()
 #endif
 #if TARGET_VST3 && LINUX
    LinuxVST3Idle();
+#endif
+#if TARGET_VST3
+   if( _effect )
+      _effect->uithreadIdleActivity();
 #endif
 
    if (!synth)

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -24,6 +24,7 @@ typedef VSTGUI::PluginGUIEditor EditorType;
 #elif TARGET_VST3
 #include "public.sdk/source/vst/vstguieditor.h"
 typedef Steinberg::Vst::VSTGUIEditor EditorType;
+#define PARENT_PLUGIN_TYPE SurgeVst3Processor
 #elif TARGET_VST2
 #if LINUX
 #include "../linux/linux-aeffguieditor.h"
@@ -35,6 +36,10 @@ typedef VSTGUI::AEffGUIEditor EditorType;
 #else
 #include "vstgui/plugin-bindings/plugguieditor.h"
 typedef VSTGUI::PluginGUIEditor EditorType;
+#endif
+
+#ifndef PARENT_PLUGIN_TYPE
+#define PARENT_PLUGIN_TYPE void
 #endif
 
 #include "SurgeStorage.h"
@@ -72,7 +77,7 @@ private:
    using super = EditorType;
 
 public:
-   SurgeGUIEditor(void* effect, SurgeSynthesizer* synth, void* userdata = nullptr);
+   SurgeGUIEditor(PARENT_PLUGIN_TYPE* effect, SurgeSynthesizer* synth, void* userdata = nullptr);
    virtual ~SurgeGUIEditor();
 
    static int start_paramtag_value;
@@ -440,7 +445,7 @@ private:
    float blinktimer = 0;
    bool blinkstate = false;
    bool useDevMenu = false;
-   void* _effect = nullptr;
+   PARENT_PLUGIN_TYPE* _effect = nullptr;
    void* _userdata = nullptr;
    VSTGUI::SharedPointer<VSTGUI::CVSTGUITimer> _idleTimer;
    int firstIdleCountdown = 0;

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -471,19 +471,6 @@ tresult PLUGIN_API SurgeVst3Processor::process(ProcessData& data)
    surgeInstance->time_data.tempo = tempo;
    surgeInstance->resetStateFromTimeData();
 
-   if( checkNamesEvery++ == 20 )
-   {
-      checkNamesEvery = 0;
-      if( std::atomic_exchange( &parameterNameUpdated, false ) )
-      {
-         auto comph = getComponentHandler();
-         if( comph )
-         {
-            comph->restartComponent( kParamTitlesChanged );
-         }
-      }
-   }
-   
    for (i = 0; i < numSamples; i++)
    {
       if (blockpos == 0)
@@ -1049,4 +1036,20 @@ void SurgeVst3Processor::handleZoom(SurgeGUIEditor *e)
         haveZoomed = true;
         lastZoom = e->getZoomFactor();
     }
+}
+
+void SurgeVst3Processor::uithreadIdleActivity()
+{
+   if (checkNamesEvery++ == 2)
+   {
+      checkNamesEvery = 0;
+      if (std::atomic_exchange(&parameterNameUpdated, false))
+      {
+         auto comph = getComponentHandler();
+         if (comph)
+         {
+            comph->restartComponent(kParamTitlesChanged | kParamValuesChanged);
+         }
+      }
+   }
 }

--- a/src/vst3/SurgeVst3Processor.h
+++ b/src/vst3/SurgeVst3Processor.h
@@ -113,6 +113,8 @@ public:
                        Steinberg::Vst::ParamValue valueNormalized) override;
    tresult endEdit(Steinberg::Vst::ParamID id) override;
 
+   void uithreadIdleActivity();
+
 protected:
    void createSurge();
    void destroySurge();


### PR DESCRIPTION
which is where it has to be called, it seems. (One wonders
what happens if there is no UI thread when you change a component
name but :shrug: vst3 gonna vst3)

Closes #2965