### PR TITLE
Add Diode Ladder Filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ set(SURGE_COMMON_SOURCES
   src/common/dsp/filters/VintageLadders.cpp
   src/common/dsp/filters/Obxd.cpp
   src/common/dsp/filters/K35.cpp
+  src/common/dsp/filters/DiodeLadder.cpp
   src/common/dsp/AdsrEnvelope.cpp
   src/common/dsp/AudioInputOscillator.cpp
   src/common/dsp/BiquadFilter.cpp

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2169,7 +2169,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
                      sprintf( txt, "%s", fut_k35_subtypes[i]);
                      break;
                   case fut_diode:
-                     sprintf( txt, "%s", fut_obxd_4p_subtypes[i]);
+                     sprintf( txt, "%s", fut_diode_subtypes[i]);
                      break;
 #if SURGE_EXTRA_FILTERS
 #endif                     

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2168,6 +2168,9 @@ void Parameter::get_display(char* txt, bool external, float ef)
                   case fut_k35_hp:
                      sprintf( txt, "%s", fut_k35_subtypes[i]);
                      break;
+                  case fut_diode:
+                     sprintf( txt, "%s", fut_obxd_4p_subtypes[i]);
+                     break;
 #if SURGE_EXTRA_FILTERS
 #endif                     
                   default:

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -366,6 +366,7 @@ enum fu_type
    fut_obxd_4pole,
    fut_k35_lp,
    fut_k35_hp,
+   fut_diode,
    n_fu_type,
 };
 const char fut_names[n_fu_type][32] =
@@ -385,6 +386,7 @@ const char fut_names[n_fu_type][32] =
    "OB-Xd 24 dB/oct",
    "Sallen-Key Lowpass",
    "Sallen-Key Highpass",
+   "Diode Ladder",
 };
 
 const char fut_bp_subtypes[6][32] =
@@ -454,7 +456,9 @@ const float fut_k35_saturations[5] = {
    4.0f
 };
 
-const int fut_subcount[n_fu_type] = {0, 3, 3, 4, 3, 3, 6, 4, 4, 0, 4, 0, 0, 5, 5 };
+const char fut_diode_subtypes[1][32] = {"24 dB/oct"};
+
+const int fut_subcount[n_fu_type] = {0, 3, 3, 4, 3, 3, 6, 4, 4, 0, 4, 0, 0, 5, 5, 0 };
 
 enum fu_subtype
 {

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -5,6 +5,7 @@
 #include "filters/VintageLadders.h"
 #include "filters/Obxd.h"
 #include "filters/K35.h"
+#include "filters/DiodeLadder.h"
 
 using namespace std;
 
@@ -92,6 +93,9 @@ void FilterCoefficientMaker::MakeCoeffs(
       break;
    case fut_k35_hp:
       K35Filter::makeCoefficients(this, Freq, Reso, false, fut_k35_saturations[SubType], storageI);
+      break;
+   case fut_diode:
+      DiodeLadderFilter::makeCoefficients(this, Freq, Reso, storageI);
       break;
 #if SURGE_EXTRA_FILTERS
 #endif      

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -6,6 +6,7 @@
 #include "filters/VintageLadders.h"
 #include "filters/Obxd.h"
 #include "filters/K35.h"
+#include "filters/DiodeLadder.h"
 
 __m128 SVFLP12Aquad(QuadFilterUnitState* __restrict f, __m128 in)
 {
@@ -806,6 +807,9 @@ FilterUnitQFPtr GetQFPtrFilterUnit(int type, int subtype)
       break;
    case fut_k35_hp:
       return K35Filter::process_hp;
+      break;
+   case fut_diode:
+      return DiodeLadderFilter::process;
       break;
    default:
       // SOFTWARE ERROR

--- a/src/common/dsp/filters/DiodeLadder.cpp
+++ b/src/common/dsp/filters/DiodeLadder.cpp
@@ -94,12 +94,9 @@ namespace DiodeLadderFilter
 
       const float G = g / (1.0 + g);
 
-      // Odin multiplies its resonance by 16, but when we do that the filter explodes.
-      // Experimentally, a limit of 3 worked okay... but it's a bit concerning that there's
-      // a difference to Odin.
-      const float k = reso * 3.0f;
+      const float k = reso * 16.0f;
       // clamp to [0..16]
-      const float km = (k > 3.f) ? 3.f : ((k < 0.f) ? 0.f : k);
+      const float km = (k > 16.f) ? 16.f : ((k < 0.f) ? 0.f : k);
 
       C[dlf_alpha] = G;
       C[dlf_gamma] = m_gamma;
@@ -163,7 +160,7 @@ namespace DiodeLadderFilter
       // feedback4 is always zero, inline it
       const __m128 feedback3 = getFO(beta4, zero, zero, f->R[dlf_z4]);
       const __m128 feedback2 = getFO(beta3, hg, f->R[dlf_feedback3], f->R[dlf_z3]);
-      const __m128 feedback1 = getFO(beta2, hg, f->R[dlf_feedback2], f->R[dlf_z1]);
+      const __m128 feedback1 = getFO(beta2, hg, f->R[dlf_feedback2], f->R[dlf_z2]);
 
       const __m128 sigma =
          A(A(A(

--- a/src/common/dsp/filters/DiodeLadder.cpp
+++ b/src/common/dsp/filters/DiodeLadder.cpp
@@ -179,13 +179,13 @@ namespace DiodeLadderFilter
       // (comp - km * sigma) / (km * gamma + 1.0)
       const __m128 u = D(S(comp, M(f->C[dlf_km], sigma)), A(M(f->C[dlf_km], f->C[dlf_gamma]), one));
 
-      const __m128 result1 = doLpf(      u, f->C[dlf_alpha], beta1, gamma1, g, f->C[dlf_G2], one, feedback1,
+      const __m128 result1 = doLpf(      u, f->C[dlf_alpha], beta1, gamma1,    g, f->C[dlf_G2],  one, feedback1,
             getFO(beta1,    g, feedback1, f->R[dlf_z1]), f->R[dlf_z1]);
       const __m128 result2 = doLpf(result1, f->C[dlf_alpha], beta2, gamma2,   hg, f->C[dlf_G3], half, feedback2,
             getFO(beta2,   hg, feedback2, f->R[dlf_z2]), f->R[dlf_z2]);
-      const __m128 result3 = doLpf(result2, f->C[dlf_alpha], beta1, gamma3,   hg, f->C[dlf_G4], half, feedback3,
+      const __m128 result3 = doLpf(result2, f->C[dlf_alpha], beta3, gamma3,   hg, f->C[dlf_G4], half, feedback3,
             getFO(beta3,   hg, feedback3, f->R[dlf_z3]), f->R[dlf_z3]);
-      const __m128 result  = doLpf(result1, f->C[dlf_alpha], beta1,    one, zero,         zero, half, zero,
+      const __m128 result  = doLpf(result3, f->C[dlf_alpha], beta4,    one, zero,         zero, half, zero,
             getFO(beta4, zero,      zero, f->R[dlf_z4]), f->R[dlf_z4]);
 
       return result;

--- a/src/common/dsp/filters/DiodeLadder.cpp
+++ b/src/common/dsp/filters/DiodeLadder.cpp
@@ -126,8 +126,8 @@ namespace DiodeLadderFilter
       const __m128 half = F(0.5f);
 
       const __m128 sg3 = f->C[dlf_G4];
-      const __m128 sg2 = sg3 * f->C[dlf_G3];
-      const __m128 sg1 = sg2 * f->C[dlf_G2];
+      const __m128 sg2 = M(sg3, f->C[dlf_G3]);
+      const __m128 sg1 = M(sg2, f->C[dlf_G2]);
       // sg4 is 1.0, just inline it
       
       const __m128 g = f->C[dlf_g];

--- a/src/common/dsp/filters/DiodeLadder.cpp
+++ b/src/common/dsp/filters/DiodeLadder.cpp
@@ -94,9 +94,12 @@ namespace DiodeLadderFilter
 
       const float G = g / (1.0 + g);
 
-      const float k = reso * 16.0f;
+      // Odin multiplies its resonance by 16, but when we do that the filter explodes.
+      // Experimentally, a limit of 3 worked okay... but it's a bit concerning that there's
+      // a difference to Odin.
+      const float k = reso * 3.0f;
       // clamp to [0..16]
-      const float km = (k > 16.f) ? 16.f : ((k < 0.f) ? 0.f : k);
+      const float km = (k > 3.f) ? 3.f : ((k < 0.f) ? 0.f : k);
 
       C[dlf_alpha] = G;
       C[dlf_gamma] = m_gamma;

--- a/src/common/dsp/filters/DiodeLadder.cpp
+++ b/src/common/dsp/filters/DiodeLadder.cpp
@@ -1,0 +1,200 @@
+#include "globals.h"
+#include "K35.h"
+#include "QuadFilterUnit.h"
+#include "FilterCoefficientMaker.h"
+#include "DebugHelpers.h"
+#include "SurgeStorage.h"
+#include "vt_dsp/basic_dsp.h"
+#include "FastMath.h"
+
+/*
+** This contains various adaptations of the models found at
+** https://github.com/TheWaveWarden/odin2/blob/master/Source/audio/Filters/DiodeFilter.cpp
+*/
+
+static float clampedFrequency( float pitch, SurgeStorage *storage )
+{
+   auto freq = storage->note_to_pitch_ignoring_tuning( pitch + 69 ) * Tunings::MIDI_0_FREQ;
+   freq = limit_range( (float)freq, 5.f, (float)( dsamplerate_os * 0.25f ) );
+   return freq;
+}
+
+#define F(a) _mm_set_ps1( a )         
+#define M(a,b) _mm_mul_ps( a, b )
+#define D(a,b) _mm_div_ps( a, b )
+#define A(a,b) _mm_add_ps( a, b )
+#define S(a,b) _mm_sub_ps( a, b )
+// reciprocal
+#define reci(a) _mm_rcp_ps( a )
+
+static inline __m128 getFO(const __m128 beta, const __m128 delta, const __m128 feedback, const __m128 z) noexcept {
+   // (feedback * delta + z) * beta
+   return M(A(M(feedback, delta), z), beta);
+}
+
+static inline __m128 doLpf(
+      const __m128 input,
+      const __m128 alpha,
+      const __m128 beta,
+      const __m128 gamma,
+      const __m128 delta,
+      const __m128 epsilon,
+      const __m128 ma0,
+      const __m128 feedback,
+      const __m128 feedback_output,
+      __m128 &z)
+   noexcept
+{
+   // input * gamma + feedback + epsilon * feedback_output
+   const __m128 i = A(A(M(input, gamma), feedback), M(epsilon, feedback_output));
+   const __m128 v = M(S(M(ma0, i), z), alpha);
+   const __m128 result = A(v, z);
+   z = A(v, result);
+   return result;
+}
+
+namespace DiodeLadderFilter
+{
+   // can't fit all the coefficients in the 8-coefficient limit, so we have to compute a lot of
+   // stuff per sample q_q
+   enum dlf_coeffs { 
+      dlf_alpha = 0, // aka
+      dlf_gamma,
+      dlf_g,
+      dlf_G4,
+      dlf_G3,
+      dlf_G2,
+      dlf_G1,
+      dlf_km, // k_modded
+   };
+
+   enum dlf_state {
+      dlf_z1, // z-1 state for LPF 1
+      dlf_z2, // LPF2
+      dlf_z3, // ...
+      dlf_z4,
+      dlf_feedback3, // feedback for LPF3 (feedback for LPF4 is 0)
+      dlf_feedback2,
+      dlf_feedback1,
+   };
+
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, SurgeStorage *storage )
+   {
+      float C[n_cm_coeffs];
+
+      const float wd = clampedFrequency( freq, storage ) * 2.0f * M_PI;
+      const float wa = (2.0f * dsamplerate_os) * Surge::DSP::fasttan(wd * dsamplerate_os_inv * 0.5);
+      const float g  = wa * dsamplerate_os_inv * 0.5f;
+      
+      const float G4 = 0.5 * g / (1.0 + g);
+      const float G3 = 0.5 * g / (1.0 + g - 0.5 * g * G4);
+      const float G2 = 0.5 * g / (1.0 + g - 0.5 * g * G3);
+      const float G1 = g / (1.0 + g - g * G2);
+      const float m_gamma = G4 * G3 * G2 * G1;
+
+      const float G = g / (1.0 + g);
+
+      const float k = reso * 16.0f;
+      // clamp to [0..16]
+      const float km = (k > 16.f) ? 16.f : ((k < 0.f) ? 0.f : k);
+
+      C[dlf_alpha] = G;
+      C[dlf_gamma] = m_gamma;
+      C[dlf_g]     = g;
+      C[dlf_G4]    = G4;
+      C[dlf_G3]    = G3;
+      C[dlf_G2]    = G2;
+      C[dlf_G1]    = G1;
+      C[dlf_km]    = km;
+
+      cm->FromDirect(C);
+   }
+
+#define process_coeffs() \
+   for(int i=0; i < n_cm_coeffs; ++i){ \
+      f->C[i] = A(f->C[i], f->dC[i]); \
+   }
+
+   __m128 process( QuadFilterUnitState * __restrict f, __m128 input )
+   {
+      process_coeffs();
+
+      // hopefully the optimiser will take care of the duplicatey bits
+      
+      const __m128 zero = F(0.0f);
+      const __m128 one  = F(1.0f);
+      const __m128 half = F(0.5f);
+
+      const __m128 sg3 = f->C[dlf_G4];
+      const __m128 sg2 = sg3 * f->C[dlf_G3];
+      const __m128 sg1 = sg2 * f->C[dlf_G2];
+      // sg4 is 1.0, just inline it
+      
+      const __m128 g = f->C[dlf_g];
+      // g plus one, common so do it only once
+      const __m128 gp1 = A(g, one);
+      // half of g
+      const __m128 hg = M(f->C[dlf_g], half);
+      
+      // 1.0 / (gp1 - g * G2)
+      const __m128 beta1 = reci(S(gp1, M(g, f->C[dlf_G2])));
+      // 1.0 / (gp1 - g * 0.5 * G3
+      const __m128 beta2 = reci(S(gp1, M(hg, f->C[dlf_G3])));
+      // 1.0 / (gp1 - g * 0.5 * G4
+      const __m128 beta3 = reci(S(gp1, M(hg, f->C[dlf_G4])));
+      // 1.0 / gp1
+      const __m128 beta4 = reci(gp1);
+
+      // nothing to compute for deltas, inline them
+
+      // G1 * G2 + 1.0
+      const __m128 gamma1 = A(M(f->C[dlf_G1], f->C[dlf_G2]), one);
+      // G2 * G3 + 1.0
+      const __m128 gamma2 = A(M(f->C[dlf_G2], f->C[dlf_G3]), one);
+      // G3 * G4 + 1.0
+      const __m128 gamma3 = A(M(f->C[dlf_G3], f->C[dlf_G4]), one);
+      // gamma4 is always 1.0, just inline it
+      
+      // nothing to compute for epsilons or ma0, inline them
+      
+      // feedback4 is always zero, inline it
+      const __m128 feedback3 = getFO(beta4, zero, zero, f->R[dlf_z4]);
+      const __m128 feedback2 = getFO(beta3, hg, f->R[dlf_feedback3], f->R[dlf_z3]);
+      const __m128 feedback1 = getFO(beta2, hg, f->R[dlf_feedback2], f->R[dlf_z1]);
+
+      const __m128 sigma =
+         A(A(A(
+            M(sg1, getFO(beta1,    g, feedback1, f->R[dlf_z1])),
+            M(sg2, getFO(beta2,   hg, feedback2, f->R[dlf_z2]))),
+            M(sg3, getFO(beta3,   hg, feedback3, f->R[dlf_z3]))),
+            M(one, getFO(beta4, zero,      zero, f->R[dlf_z4])));
+
+      f->R[dlf_feedback3] = feedback3;
+      f->R[dlf_feedback2] = feedback2;
+      f->R[dlf_feedback1] = feedback1;
+
+      // gain compensation
+      const __m128 comp = M(A(M(F(0.3), f->C[dlf_km]), one), input);
+
+      // (comp - km * sigma) / (km * gamma + 1.0)
+      const __m128 u = D(S(comp, M(f->C[dlf_km], sigma)), A(M(f->C[dlf_km], f->C[dlf_gamma]), one));
+
+      const __m128 result1 = doLpf(      u, f->C[dlf_alpha], beta1, gamma1, g, f->C[dlf_G2], one, feedback1,
+            getFO(beta1,    g, feedback1, f->R[dlf_z1]), f->R[dlf_z1]);
+      const __m128 result2 = doLpf(result1, f->C[dlf_alpha], beta2, gamma2,   hg, f->C[dlf_G3], half, feedback2,
+            getFO(beta2,   hg, feedback2, f->R[dlf_z2]), f->R[dlf_z2]);
+      const __m128 result3 = doLpf(result2, f->C[dlf_alpha], beta1, gamma3,   hg, f->C[dlf_G4], half, feedback3,
+            getFO(beta3,   hg, feedback3, f->R[dlf_z3]), f->R[dlf_z3]);
+      const __m128 result  = doLpf(result1, f->C[dlf_alpha], beta1,    one, zero,         zero, half, zero,
+            getFO(beta4, zero,      zero, f->R[dlf_z4]), f->R[dlf_z4]);
+
+      return result;
+   }
+
+#undef overdrive
+#undef F
+#undef M
+#undef D
+#undef A
+#undef S
+}

--- a/src/common/dsp/filters/DiodeLadder.h
+++ b/src/common/dsp/filters/DiodeLadder.h
@@ -1,0 +1,11 @@
+#pragma once
+
+struct QuadFilterUnitState;
+class FilterCoefficientMaker;
+class SurgeStorage;
+
+namespace DiodeLadderFilter 
+{
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, SurgeStorage *storage );
+   __m128 process( QuadFilterUnitState * __restrict f, __m128 in );
+}

--- a/src/common/dsp/filters/K35.cpp
+++ b/src/common/dsp/filters/K35.cpp
@@ -71,7 +71,7 @@ namespace K35Filter
       const float gp1= (1.0f + g); // g plus 1
       const float G  = g / gp1;
 
-      const float k = reso * 2.0f;
+      const float k = reso * 1.96f;
       // clamp to [0.01..1.96]
       const float mk = (k > 1.96f) ? 1.96f : ((k < 0.01f) ? 0.01f : k);
 


### PR DESCRIPTION
Add the diode ladder filter from Odin2.

May still be buggy so watch out for DSP glitches.

Note this PR also fixes the range of the Sallen Key filter resonance so that the upper range doesn't just clamp to the same value. As a consequence, patches with less than maximum resonance will have slightly lower resonance than they did before. It's a minor difference though.