### PR TITLE
Resetting value via param queue had a bad type in compare

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -788,7 +788,7 @@ void SurgeGUIEditor::idle()
                auto tag = cc->getTag();
                SurgeSynthesizer::ID jid;
 
-               auto sv = 0;
+               auto sv = 0.f;
                if( synth->fromSynthSideId(j, jid ))
                   sv = synth->getParameter01(jid);
                auto cv = cc->getValue();


### PR DESCRIPTION
Fixes "Control not activated properly in live" bug

Closes #2991