### PR TITLE
Warn if stored version > runtie version

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -22,6 +22,8 @@
 #include "MSEGModulationHelper.h"
 #include "DebugHelpers.h"
 #include "SkinModel.h"
+#include "UserInteractions.h"
+#include "version.h"
 
 using namespace std;
 
@@ -1082,6 +1084,17 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
    patch->QueryIntAttribute("revision", &revision);
    streamingRevision = revision;
    currentSynthStreamingRevision = ff_revision;
+
+   if( revision > ff_revision )
+   {
+      std::ostringstream oss;
+      oss << "The version of Surge you are running is older than the version with which this patch "
+          << "was created. Your version of surge (" << Surge::Build::FullVersionStr << ") has a "
+          << "streaming revision of " << ff_revision << ", whereas the patch you are loading was "
+          << "created with " << revision << ". Features of the patch will not be available in your "
+          << "session. You can always find the latest Surge at https://surge-synthesizer.github.io/";
+      Surge::UserInteractions::promptError( oss.str(), "Surge Version is Older than Patch" );
+   }
    
    TiXmlElement* meta =  TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("meta"));
    if (meta)


### PR DESCRIPTION
If you have a patch with streaming version 27 and are running
a surge which thinks the largest version is 24, warn. This means
after 1.8 patches with the 1.9 nightly will warn in the 1.8 master
if we up streaming again

Closes #2887