### PR TITLE
Filter SubType automation changes

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2140,8 +2140,11 @@ void Parameter::get_display(char* txt, bool external, float ef)
                if (id == patch.scene[scene].filterunit[unit].subtype.id)
                {
                   int type = patch.scene[scene].filterunit[unit].type.val.i;
-
-                  switch (type)
+                  if (i >= fut_subcount[type])
+                  {
+                     sprintf( txt, "None" );
+                  }
+                  else switch (type)
                   {
                   case fut_lpmoog:
                      sprintf(txt, "%s", fut_ldr_subtypes[i]);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -550,7 +550,7 @@ struct OscillatorStorage : public CountedSetUserData // The counted set is the w
 struct FilterStorage
 {
    Parameter type;
-   Parameter subtype;
+   Parameter subtype; // NOTE: In SurgeSynthesizer we assume that type and subtype are adjacent in param space. See comment there.
    Parameter cutoff;
    Parameter resonance;
    Parameter envmod;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1543,6 +1543,8 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
       case ct_filtertype:
          switch_toggled_queued = true;
          {
+            // Oh my goodness this is deeply sketchy code to not document! It assumes that subtype
+            // is right after type in ID space without documenting it. So now documented!
             switch (storage.getPatch().param_ptr[index]->val.i)
             {
             case fut_lpmoog:
@@ -1583,8 +1585,17 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
       case ct_bool_fm:
       case ct_fbconfig:
       case ct_filtersubtype:
-         switch_toggled_queued = true;
-         break;
+         // See above: We know the filter type for this subtype is at index - 1. Cap max to be the fut-subtype
+         {
+            auto filterType = storage.getPatch().param_ptr[index-1]->val.i;
+            auto maxIVal = fut_subcount[filterType];
+            if( maxIVal == 0 )
+               storage.getPatch().param_ptr[index]->val.i = 0;
+            else
+               storage.getPatch().param_ptr[index]->val.i = std::min( maxIVal-1,
+                                                                     storage.getPatch().param_ptr[index]->val.i );
+            break;
+         }
       case ct_fxtype:
          switch_toggled_queued = true;
          load_fx_needed = true;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -844,6 +844,17 @@ void SurgeGUIEditor::idle()
 #else
                cc->setValue(synth->getParameter01(jid));
 #endif
+
+               // Integer switches also work differently
+               auto assw = dynamic_cast<CSwitchControl *>(cc);
+               if( assw )
+               {
+                  if( assw->is_itype )
+                  {
+                     assw->ivalue = synth->storage.getPatch().param_ptr[j]->val.i + 1;
+                  }
+               }
+
                cc->setDirty();
                cc->invalid();
             }
@@ -1647,7 +1658,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
       v->onMouseEntered(tr, 0);
    }
 
-   frame->setDirty();
    frame->invalid();
 
 }


### PR DESCRIPTION
1. The UI updates when you automate subtype
2. You cannot automate a subtype beyond the range of the filters sybtules
3. The name of the subtype for no filters is correct
4. Fix a memory bound problem when setting subtype values over fut_subcount

Closes #2414