### PR TITLE
Apply "Last chance" widget elsewhere on GUI

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -223,6 +223,19 @@ inline bool uses_wavetabledata(int i)
    return false;
 }
 
+const char fxslot_names[8][NAMECHARS] =
+{
+   "A Insert FX 1",
+   "A Insert FX 2",
+   "B Insert FX 1",
+   "B Insert FX 2",
+   "Send FX 1",
+   "Send FX 2",
+   "Master FX 1",
+   "Master FX 2",
+};
+
+
 enum fx_types
 {
    fxt_off = 0,

--- a/src/common/gui/CEffectSettings.cpp
+++ b/src/common/gui/CEffectSettings.cpp
@@ -85,6 +85,12 @@ void CEffectSettings::draw(CDrawContext* dc)
 
 CMouseEventResult CEffectSettings::onMouseDown(CPoint& where, const CButtonState& buttons)
 {
+   if (listener && (buttons & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, buttons);
+      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
+
    mouseActionMode = click;
    dragStart = where;
    for (int i = 0; i < 8; i++)

--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -61,12 +61,19 @@ CMouseEventResult CHSwitch2::onMouseDown(CPoint& where, const CButtonState& butt
    /*
    ** If we have two mousedowns without an up, skip stuff. This means pressing left/right on
    ** win doesn't confuse us. BUT if we return kMouseDownEventHandledButDontNeedMovedOrUpEvents
-   ** we won't ever get the up so this counter will be in trouble. This the --s scattered
+   ** we won't ever get the up so this counter will be in trouble. That's why we have --s scattered
    ** throughout this code
    */
    mouseDowns++;
    if (mouseDowns > 1)
       return kMouseEventHandled;
+
+   if (listener && (buttons & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, buttons);
+      mouseDowns--;
+      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
 
    if (listener && buttons & (kAlt | kShift | kRButton | kControl | kApple))
    {

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -1092,6 +1092,12 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp, VST
 
 CMouseEventResult CLFOGui::onMouseDown(CPoint& where, const CButtonState& buttons)
 {
+   if (listener && (buttons & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, buttons);
+      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
+
    if( ( buttons & kDoubleClick ) && lfodata->shape.val.i == ls_mseg )
    {
       auto sge = dynamic_cast<SurgeGUIEditor *>(listener);

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -380,8 +380,11 @@ void COscillatorDisplay::draw(CDrawContext* dc)
 
 CMouseEventResult COscillatorDisplay::onMouseDown(CPoint& where, const CButtonState& button)
 {
-   if (!((button & kLButton) || (button & kRButton)))
+   if (listener && (button & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, button);
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
 
    assert(oscdata);
 

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -61,8 +61,11 @@ void CPatchBrowser::draw(CDrawContext* dc)
 
 CMouseEventResult CPatchBrowser::onMouseDown(CPoint& where, const CButtonState& button)
 {
-   if (!(button & kLButton || button & kRButton))
+   if (listener && (button & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, button);
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
 
    CRect menurect(0, 0, 0, 0);
    menurect.offset(where.x, where.y);

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -36,6 +36,7 @@ CMouseEventResult CSnapshotMenu::onMouseDown(CPoint& where, const CButtonState& 
 {
    if (listener && (button & (kMButton | kButton4 | kButton5)))
    {
+      printf("I'm a snapshot menu and I was clicked!\n");
       listener->controlModifierClicked(this, button);
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
    }

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -32,6 +32,15 @@ CSnapshotMenu::CSnapshotMenu(const CRect& size,
 CSnapshotMenu::~CSnapshotMenu()
 {}
 
+CMouseEventResult CSnapshotMenu::onMouseDown(CPoint& where, const CButtonState& button)
+{
+   if (listener && (button & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, button);
+      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
+}
+
 void CSnapshotMenu::draw(CDrawContext* dc)
 {
    setDirty(false);
@@ -247,6 +256,15 @@ COscMenu::COscMenu(const CRect& size,
       currentIdx = firstSnapshotByType[osc->type.val.i];
 }
 
+CMouseEventResult COscMenu::onMouseDown(CPoint& where, const CButtonState& button)
+{
+   if (listener && (button & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, button);
+      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
+}
+
 void COscMenu::draw(CDrawContext* dc)
 {
    if( ! attemptedHoverLoad )
@@ -346,6 +364,15 @@ CFxMenu::CFxMenu(const CRect& size,
    this->slot = slot;
    selectedName = "";
    populate();
+}
+
+CMouseEventResult CFxMenu::onMouseDown(CPoint& where, const CButtonState& button)
+{
+   if (listener && (button & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, button);
+      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
 }
 
 void CFxMenu::draw(CDrawContext* dc)

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -39,6 +39,7 @@ CMouseEventResult CSnapshotMenu::onMouseDown(CPoint& where, const CButtonState& 
       listener->controlModifierClicked(this, button);
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
    }
+   return CControl::onMouseDown(where, button);
 }
 
 void CSnapshotMenu::draw(CDrawContext* dc)
@@ -256,15 +257,6 @@ COscMenu::COscMenu(const CRect& size,
       currentIdx = firstSnapshotByType[osc->type.val.i];
 }
 
-CMouseEventResult COscMenu::onMouseDown(CPoint& where, const CButtonState& button)
-{
-   if (listener && (button & (kMButton | kButton4 | kButton5)))
-   {
-      listener->controlModifierClicked(this, button);
-      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
-   }
-}
-
 void COscMenu::draw(CDrawContext* dc)
 {
    if( ! attemptedHoverLoad )
@@ -344,9 +336,6 @@ j;
 
 // CFxMenu
 
-const char fxslot_names[8][NAMECHARS] = {"A Insert FX 1", "A Insert FX 2", "B Insert FX 1", "B Insert FX 2",
-                                         "Send FX 1",  "Send FX 2",  "Master FX 1",   "Master FX 2"};
-
 std::vector<float> CFxMenu::fxCopyPaste;
 
 CFxMenu::CFxMenu(const CRect& size,
@@ -366,14 +355,6 @@ CFxMenu::CFxMenu(const CRect& size,
    populate();
 }
 
-CMouseEventResult CFxMenu::onMouseDown(CPoint& where, const CButtonState& button)
-{
-   if (listener && (button & (kMButton | kButton4 | kButton5)))
-   {
-      listener->controlModifierClicked(this, button);
-      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
-   }
-}
 
 void CFxMenu::draw(CDrawContext* dc)
 {

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -34,13 +34,12 @@ CSnapshotMenu::~CSnapshotMenu()
 
 CMouseEventResult CSnapshotMenu::onMouseDown(CPoint& where, const CButtonState& button)
 {
-   if (listener && (button & (kMButton | kButton4 | kButton5)))
+   if (listenerNotForParent && (button & (kMButton | kButton4 | kButton5)))
    {
-      printf("I'm a snapshot menu and I was clicked!\n");
-      listener->controlModifierClicked(this, button);
+      listenerNotForParent->controlModifierClicked(this, button);
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
    }
-   return CControl::onMouseDown(where, button);
+   return COptionMenu::onMouseDown(where, button);
 }
 
 void CSnapshotMenu::draw(CDrawContext* dc)

--- a/src/common/gui/CSnapshotMenu.h
+++ b/src/common/gui/CSnapshotMenu.h
@@ -28,13 +28,14 @@ public:
    CSnapshotMenu(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener, long tag, SurgeStorage* storage);
    virtual ~CSnapshotMenu();
    virtual void draw(VSTGUI::CDrawContext* dc) override;
-   // virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons);
    virtual void populate();
    virtual void loadSnapshot(int type, TiXmlElement* e, int idx){};
    virtual bool loadSnapshotByIndex(int idx);
 
    virtual void saveSnapshot(TiXmlElement* e, const char* name){};
    virtual bool canSave();
+   
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
 
    virtual VSTGUI::CMouseEventResult onMouseEntered (VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons) override {
       // getFrame()->setCursor( VSTGUI::kCursorHand );
@@ -48,8 +49,6 @@ public:
       invalid();
       return VSTGUI::kMouseEventHandled;
    }
-
-   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
 
    bool onWheel(const VSTGUI::CPoint& where, const float& distance, const VSTGUI::CButtonState& buttons) override
    {
@@ -86,7 +85,6 @@ public:
    virtual void draw(VSTGUI::CDrawContext* dc) override;
    virtual void loadSnapshot(int type, TiXmlElement* e, int idx) override;
 
-   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
    virtual bool onWheel(const VSTGUI::CPoint& where, const float& distance, const VSTGUI::CButtonState& buttons) override;
 
 protected:
@@ -117,7 +115,6 @@ public:
    virtual void loadSnapshot(int type, TiXmlElement* e, int idx) override;
    virtual void saveSnapshot(TiXmlElement* e, const char* name) override;
    virtual void populate() override;
-   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
    
 protected:
    virtual void addToTopLevelTypeMenu(TiXmlElement *typeElement, VSTGUI::COptionMenu *subMenu, int &idx) override;

--- a/src/common/gui/CSnapshotMenu.h
+++ b/src/common/gui/CSnapshotMenu.h
@@ -49,6 +49,8 @@ public:
       return VSTGUI::kMouseEventHandled;
    }
 
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
+
    bool onWheel(const VSTGUI::CPoint& where, const float& distance, const VSTGUI::CButtonState& buttons) override
    {
       // TODO - mousehweel support when these things can jog and maintain state
@@ -84,6 +86,7 @@ public:
    virtual void draw(VSTGUI::CDrawContext* dc) override;
    virtual void loadSnapshot(int type, TiXmlElement* e, int idx) override;
 
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
    virtual bool onWheel(const VSTGUI::CPoint& where, const float& distance, const VSTGUI::CButtonState& buttons) override;
 
 protected:
@@ -114,6 +117,7 @@ public:
    virtual void loadSnapshot(int type, TiXmlElement* e, int idx) override;
    virtual void saveSnapshot(TiXmlElement* e, const char* name) override;
    virtual void populate() override;
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
    
 protected:
    virtual void addToTopLevelTypeMenu(TiXmlElement *typeElement, VSTGUI::COptionMenu *subMenu, int &idx) override;

--- a/src/common/gui/CSurgeVuMeter.cpp
+++ b/src/common/gui/CSurgeVuMeter.cpp
@@ -17,6 +17,15 @@ float scale(float x)
    return powf(x, 0.3333333333f);
 }
 
+//CMouseEventResult CVuMeter::onMouseDown(CPoint& where, const CButtonState& button)
+//{
+//   if (listener && (button & (kMButton | kButton4 | kButton5)))
+//   {
+//      listener->controlModifierClicked(this, button);
+//      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+//   }
+//}
+
 void CSurgeVuMeter::setType(int vutype)
 {
    type = vutype;

--- a/src/common/gui/CSurgeVuMeter.cpp
+++ b/src/common/gui/CSurgeVuMeter.cpp
@@ -17,14 +17,15 @@ float scale(float x)
    return powf(x, 0.3333333333f);
 }
 
-//CMouseEventResult CVuMeter::onMouseDown(CPoint& where, const CButtonState& button)
-//{
-//   if (listener && (button & (kMButton | kButton4 | kButton5)))
-//   {
-//      listener->controlModifierClicked(this, button);
-//      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
-//   }
-//}
+CMouseEventResult CSurgeVuMeter::onMouseDown(CPoint& where, const CButtonState& button)
+{
+   if (listener && (button & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, button);
+      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
+   return CControl::onMouseDown(where, button);
+}
 
 void CSurgeVuMeter::setType(int vutype)
 {

--- a/src/common/gui/CSurgeVuMeter.cpp
+++ b/src/common/gui/CSurgeVuMeter.cpp
@@ -21,6 +21,7 @@ CMouseEventResult CSurgeVuMeter::onMouseDown(CPoint& where, const CButtonState& 
 {
    if (listener && (button & (kMButton | kButton4 | kButton5)))
    {
+      printf("I'm a VU meter and I was clicked!\n");
       listener->controlModifierClicked(this, button);
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
    }

--- a/src/common/gui/CSurgeVuMeter.cpp
+++ b/src/common/gui/CSurgeVuMeter.cpp
@@ -4,7 +4,7 @@
 
 using namespace VSTGUI;
 
-CSurgeVuMeter::CSurgeVuMeter(const CRect& size) : CControl(size, 0, 0, 0)
+CSurgeVuMeter::CSurgeVuMeter(const CRect& size, VSTGUI::IControlListener *listener) : CControl(size, listener, 0, 0)
 {
    stereo = true;
    valueR = 0.0;
@@ -21,7 +21,6 @@ CMouseEventResult CSurgeVuMeter::onMouseDown(CPoint& where, const CButtonState& 
 {
    if (listener && (button & (kMButton | kButton4 | kButton5)))
    {
-      printf("I'm a VU meter and I was clicked!\n");
       listener->controlModifierClicked(this, button);
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
    }

--- a/src/common/gui/CSurgeVuMeter.h
+++ b/src/common/gui/CSurgeVuMeter.h
@@ -32,7 +32,7 @@ public:
    }
    bool stereo;
 
-   //virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
+   virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
 
 private:
    float valueR;

--- a/src/common/gui/CSurgeVuMeter.h
+++ b/src/common/gui/CSurgeVuMeter.h
@@ -21,7 +21,7 @@
 class CSurgeVuMeter : public VSTGUI::CControl, public Surge::UI::SkinConsumingComponent
 {
 public:
-   CSurgeVuMeter(const VSTGUI::CRect& size);
+   CSurgeVuMeter(const VSTGUI::CRect& size, VSTGUI::IControlListener* listener);
    virtual void draw(VSTGUI::CDrawContext* dc) override;
    void setType(int vutype);
    // void setSecondaryValue(float v);

--- a/src/common/gui/CSurgeVuMeter.h
+++ b/src/common/gui/CSurgeVuMeter.h
@@ -32,6 +32,8 @@ public:
    }
    bool stereo;
 
+   //virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint& where, const VSTGUI::CButtonState& button) override;
+
 private:
    float valueR;
    int type;

--- a/src/common/gui/CSwitchControl.cpp
+++ b/src/common/gui/CSwitchControl.cpp
@@ -63,6 +63,12 @@ void CSwitchControl::setValue(float f)
 
 CMouseEventResult CSwitchControl::onMouseDown(CPoint& where, const CButtonState& buttons)
 {
+   if (listener && (buttons & (kMButton | kButton4 | kButton5)))
+   {
+      listener->controlModifierClicked(this, buttons);
+      return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+   }
+
    if (listener && ( buttons & (kAlt | kShift | kControl | kApple) || unValueClickable ))
    {
       if (listener->controlModifierClicked(this, buttons) != 0)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1250,7 +1250,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             CRect vr(fxRect); // FIXME (vurect);
             vr.offset(6, yofs * synth->fx[current_fx]->vu_ypos(i));
             vr.offset(0, -14);
-            vu[i + 1] = new CSurgeVuMeter(vr);
+            vu[i + 1] = new CSurgeVuMeter(vr, this);
             ((CSurgeVuMeter*)vu[i + 1])->setSkin(currentSkin,bitmapStore);
             ((CSurgeVuMeter*)vu[i + 1])->setType(t);
             frame->addView(vu[i + 1]);
@@ -1428,7 +1428,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          break;
       }
       case Surge::Skin::Connector::NonParameterConnection::MAIN_VU_METER: { // main vu-meter
-         vu[0] = new CSurgeVuMeter(skinCtrl->getRect());
+         vu[0] = new CSurgeVuMeter(skinCtrl->getRect(), this);
          ((CSurgeVuMeter*)vu[0])->setSkin(currentSkin,bitmapStore);
          ((CSurgeVuMeter*)vu[0])->setType(vut_vu_stereo);
          frame->addView(vu[0]);


### PR DESCRIPTION
Now modbutton arming can be done when middle clicking over: oscillator display, VU meter, patch browser, LFO display, FX grid, any switches, and snapshot menus