### PR TITLE
Correct a Property Query bug

### DIFF
--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -257,7 +257,7 @@ public:
          }
          else
             return Maybe<std::string>();
-      } while( true );
+      } while( cl );
 
       return Maybe<std::string>();
    }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -6664,14 +6664,11 @@ VSTGUI::CControl *SurgeGUIEditor::layoutComponentForSkin( std::shared_ptr<Surge:
       else
          hs->deactivated = false;
 
-      // we had crashes on Win/Lin because of this, so until mvf does font loading on those two platforms, compile-time if this bugger!
-#if MAC
       auto ff = currentSkin->propertyValue(skinCtrl, "font-family", "" );
       if( ff.size() > 0 )
       {
          hs->setFont(new CFontDesc(ff.c_str(), 9 ));
       }
-#endif
 
       if (p->valtype == vt_int || p->valtype == vt_bool)
       {


### PR DESCRIPTION
Property Queries for properties which were not in any
class nor the base class could nullptr meaning
the change to queriy font families crashed skins
with custom control classes, like the dark skin