### PR TITLE
Independent RNGs for S&H/LFO

### DIFF
--- a/src/common/dsp/DspUtilities.cpp
+++ b/src/common/dsp/DspUtilities.cpp
@@ -66,3 +66,30 @@ float correlated_noise_o2mk2(float& lastval, float& lastval2, float correlation)
    lastval = lastval2 * (1 - wfabs) - wf * lastval;
    return lastval * m;
 }
+
+float correlated_noise_o2mk2_suppliedrng(float& lastval, float& lastval2, float correlation,
+                                         std::function<float()> &urng
+    )
+{
+   float wf = correlation;
+   float wfabs = fabs(wf) * 0.8f;
+   // wfabs = 1.f - (1.f-wfabs)*(1.f-wfabs);
+   wfabs = (2.f * wfabs - wfabs * wfabs);
+   if (wf > 0.f)
+      wf = wfabs;
+   else
+      wf = -wfabs;
+#if MAC
+   float m = 1.f / sqrt(1.f - wfabs);
+#else
+   float m = 1.f - wfabs;
+   // float m = 1.f/sqrt(1.f-wfabs);
+   __m128 m1 = _mm_rsqrt_ss(_mm_load_ss(&m));
+   _mm_store_ss(&m, m1);
+   // if (wf>0.f) m *= 1 + wf*8;
+#endif
+   float rand11 = urng();
+   lastval2 = rand11 * (1 - wfabs) - wf * lastval2;
+   lastval = lastval2 * (1 - wfabs) - wf * lastval;
+   return lastval * m;
+}

--- a/src/common/dsp/DspUtilities.h
+++ b/src/common/dsp/DspUtilities.h
@@ -21,6 +21,7 @@
 #include "unitconversion.h"
 #include <vt_dsp/basic_dsp.h>
 #include <vt_dsp/halfratefilter.h>
+#include <functional>
 
 #define setzero(x) memset(x, 0, sizeof(*x))
 
@@ -347,6 +348,8 @@ float correlated_noise_mk2(float& lastval, float correlation);
 float drift_noise(float& lastval);
 float correlated_noise_o2(float lastval, float& lastval2, float correlation);
 float correlated_noise_o2mk2(float& lastval, float& lastval2, float correlation);
+// An alternate version where you supply a uniform RNG on -1,1 externally
+float correlated_noise_o2mk2_suppliedrng(float& lastval, float& lastval2, float correlation, std::function<float()> &urng);
 
 inline double hanning(int i, int n)
 {

--- a/src/common/dsp/LfoModulationSource.h
+++ b/src/common/dsp/LfoModulationSource.h
@@ -20,6 +20,7 @@
 #include "SurgeVoiceState.h"
 #include "ModulationSource.h"
 #include "MSEGModulationHelper.h" // We need this for the MSEGEvalatorState member
+#include <functional>
 
 enum lfoenv_state
 {
@@ -92,5 +93,6 @@ private:
    bool is_display;
    int step, shuffle_id;
    int magn, rate, iattack, idecay, idelay, ihold, isustain, irelease, startphase, ideform;
+   std::function<float()> urng;
    quadr_osc sinus;
 };

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -67,7 +67,17 @@ void SampleAndHoldOscillator::init(float pitch, bool is_display)
    if (is_display)
    {
       n_unison = 1;
-      srand(2);
+
+      auto gen = std::minstd_rand(2);
+      std::uniform_real_distribution<float> distro(-1.f,1.f);
+      urng = std::bind(distro, gen);
+   }
+   else
+   {
+      std::random_device rd;
+      auto gen = std::minstd_rand(rd());
+      std::uniform_real_distribution<float> distro(-1.f,1.f);
+      urng = std::bind(distro, gen);
    }
    prepare_unison(n_unison);
 
@@ -198,7 +208,7 @@ void SampleAndHoldOscillator::convolute(int voice, bool FM, bool stereo)
    float wf = l_shape.v * 0.8 * invertcorrelation;
    float wfabs = fabs(wf);
    float smooth = l_smooth.v;
-   float rand11 = (((float)rand() * rcp((float)RAND_MAX)) * 2.f - 1.f);
+   float rand11 = urng();
    float randt = rand11 * (1 - wfabs) - wf * last_level[voice];
 
    randt = randt * rcp(1.0f - wfabs);

--- a/src/common/dsp/SampleAndHoldOscillator.h
+++ b/src/common/dsp/SampleAndHoldOscillator.h
@@ -51,4 +51,5 @@ private:
    int id_pw, id_shape, id_smooth, id_sub, id_sync, id_detune;
    int FMdelay;
    float FMmul_inv;
+   std::function<float()> urng; // A uniform -1,1 RNG
 };


### PR DESCRIPTION
The S&H and LFO used the global RNG from back when C++
didn't have independent RNGs. That meant things like
displaying an LFO could change the audio stream etc...
so use proper objects from c++ random

Closes #2958
Closes #233