### PR TITLE
Mac ARM build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,7 @@ if( APPLE )
 
   set(OS_INCLUDE_DIRECTORIES
     src/mac
+    libs/simde
     )
   set(OS_COMPILE_DEFINITIONS
     MAC=1
@@ -430,6 +431,7 @@ if( APPLE )
     "-framework OpenGL"
     "-framework QuartzCore"
     )
+
 elseif( UNIX AND NOT APPLE )
   file(GLOB PIGGY_INPUTS ${CMAKE_SOURCE_DIR}/assets/SurgeClassic/exported/*svg)
   add_custom_command( OUTPUT ${CMAKE_BINARY_DIR}/lintemp/ScalablePiggy.S
@@ -940,7 +942,8 @@ if( BUILD_HEADLESS )
     src/headless
     )
 
-  find_package(LibSndFile ${PACKAGE_OPTION})
+  # Temporarily disable libsndfile which we don't use anyway, but we don't have a link for on arm
+  # find_package(LibSndFile ${PACKAGE_OPTION})
   if(NOT LIBSNDFILE_FOUND)
     message("-- LibSndFile not installed; building without wav support")
     message("-- You can 'brew install libsndfile' or 'apt-get install libsndfile1-dev'")

--- a/doc/build-mac-arm.md
+++ b/doc/build-mac-arm.md
@@ -1,0 +1,23 @@
+Install XCode 12.2 beta or later
+
+xcode-select it
+
+```
+sudo xcode-select -s /Applications/Xcode-beta.app/
+```
+
+Run CMAKE with both architectures and then xcodebuild
+
+```
+cmake -GXcode -Bbuild_fat -D"CMAKE_OSX_ARCHITECTURES=arm64;x86_64"
+xcodebuild -target surge-headless build -project build_fat/Surge.xcodeproj/ -arch x86_64 -arch arm64 ONLY_ACTIVE_ARCH=NO
+```
+
+And then:
+
+```
+paul:~/dev/music/surge$ lipo -archs build_fat/Debug/surge-headless 
+x86_64 arm64
+```
+
+Right now full AU doesn't build because of the objc compat layer in vstgui.

--- a/libs/catch2/include/catch2/catch2.hpp
+++ b/libs/catch2/include/catch2/catch2.hpp
@@ -7625,8 +7625,11 @@ namespace Catch {
 }
 
 #ifdef CATCH_PLATFORM_MAC
-
+#if defined(__x86_64__ )
     #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+#else
+#define CATCH_TRAP()
+#endif
 
 #elif defined(CATCH_PLATFORM_LINUX)
     // If we can use inline assembler, do it because this allows us to break

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -132,7 +132,7 @@ inline unsigned int BigMULr16(unsigned int a, unsigned int b)
 #if _M_X64 && ! TARGET_RACK
    unsigned __int64 c = __emulu(a, b);
    return c >> 16;
-#elif LINUX || TARGET_RACK
+#elif LINUX || TARGET_RACK  || MAC_ARM
    uint64_t c = (uint64_t)a * (uint64_t)b;
    return c >> 16;
 #else

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -23,7 +23,15 @@
 
 #if MAC
 #include "vt_dsp/macspecific.h"
+
+#if defined(__x86_64__)
+#else
+#define ARM_NEON 1
+#define MAC_ARM 1
 #endif
+
+#endif
+
 #if ARM_NEON
 #define SIMDE_ENABLE_NATIVE_ALIASES
 #include "simde/x86/sse2.h"

--- a/src/common/precompiled.h
+++ b/src/common/precompiled.h
@@ -1,7 +1,8 @@
+
+#include "globals.h"
+
 #ifndef ARM_NEON
 #include <emmintrin.h>
 #endif
-
-#include "globals.h"
 
 //#include <vt_util/vt_string.h>

--- a/src/common/util/FpuState.cpp
+++ b/src/common/util/FpuState.cpp
@@ -1,3 +1,4 @@
+#include "globals.h"
 #include "FpuState.h"
 #ifndef ARM_NEON
 #include <emmintrin.h>


### PR DESCRIPTION
With xcode 12.2 this will build a fat binary of surge-headless
if you follow the prescription in the doc.