### PR TITLE
Some mod preset tweaks

### DIFF
--- a/src/common/ModulatorPresetManager.cpp
+++ b/src/common/ModulatorPresetManager.cpp
@@ -36,11 +36,11 @@ void savePresetToUser( const fs::path & location, SurgeStorage *s, int scene, in
    auto containingPath = fs::path{ string_to_path( s->userDataPath ) / fs::path{ PresetDir }};
 
    if( shapev == ls_mseg )
-      containingPath = containingPath / fs::path{ "MSEGs" };
+      containingPath = containingPath / fs::path{ "MSEG" };
    else if( shapev == ls_stepseq )
-      containingPath = containingPath / fs::path{ "StepSequences" };
+      containingPath = containingPath / fs::path{ "Step Seq" };
    else
-      containingPath = containingPath / fs::path{ "Lfos" };
+      containingPath = containingPath / fs::path{ "LFO" };
 
    fs::create_directories(containingPath);
    auto fullLocation = fs::path( { containingPath / location }).replace_extension( fs::path{ PresetXtn } );

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4728,11 +4728,11 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeLfoMenu(VSTGUI::CRect &menuRect)
    int currentLfoId = modsource_editor[current_scene] - ms_lfo1;
 
    int shapev = synth->storage.getPatch().scene[current_scene].lfo[currentLfoId].shape.val.i;
-   std::string what = "Lfo";
+   std::string what = "LFO";
    if( ls_mseg == shapev )
       what = "MSEG";
    if( ls_stepseq == shapev)
-      what = "StepSeq";
+      what = "Step Seq";
 
    COptionMenu* lfoSubMenu =
        new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
@@ -4753,9 +4753,12 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeLfoMenu(VSTGUI::CRect &menuRect)
                       // and save
                    }
                    );
-
-   lfoSubMenu->addSeparator();
+   
    auto presetCategories = Surge::ModulatorPreset::getPresets(&(synth->storage));
+
+   if (!presetCategories.empty())
+      lfoSubMenu->addSeparator();
+
    for( auto const &cat : presetCategories )
    {
       COptionMenu *catSubMenu = new COptionMenu( menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);


### PR DESCRIPTION
Capitalization (Lfo -> LFO) and spaces (StepSeq -> Step Seq)
Subfolder name changes
Separator after "Save xyz as..." only shows if we have any mod presets saved