### PR TITLE
A variety of MSEG fixes

### DIFF
--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -243,7 +243,9 @@ namespace Colors
       }
       namespace Loop
       {
-         const Surge::Skin::Color Line("msegeditor.loop.line", 255, 144, 0);
+         const Surge::Skin::Color Line("msegeditor.loop.line", 255, 144, 0),
+          Marker( "msegeditor.loop.marker", 255, 144, 0 ),
+          MarkerHover( "msegeditor.loop.marker.hover", 255, 255, 255 );
       }
       namespace NumberField
       {

--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -180,7 +180,7 @@ namespace Colors
       }
       namespace Loop
       {
-          extern const Surge::Skin::Color Line;
+          extern const Surge::Skin::Color Line, Marker, MarkerHover;
       }
       namespace NumberField
       {

--- a/src/common/dsp/MSEGModulationHelper.cpp
+++ b/src/common/dsp/MSEGModulationHelper.cpp
@@ -772,11 +772,13 @@ void splitSegment( MSEGStorage *ms, float t, float nv ) {
 }
 
 
-void unsplitSegment( MSEGStorage *ms, float t ) {
+void unsplitSegment( MSEGStorage *ms, float t, bool wrapTime ) {
    // Can't unsplit a single segment
    if( ms->n_activeSegments - 1 == 0 ) return;
 
    int idx = timeToSegment( ms, t );
+   if( ! wrapTime && t >= ms->totalDuration )
+      idx = ms->n_activeSegments - 1;
    if( idx < 0 ) idx = 0;
    if( idx >= ms->n_activeSegments - 1 ) idx = ms->n_activeSegments - 1;
    int prior = idx;;
@@ -785,7 +787,7 @@ void unsplitSegment( MSEGStorage *ms, float t ) {
       if( idx == ms->n_activeSegments - 1 )
       {
          // We are just deleting the last segment
-         deleteSegment( ms, t );
+         deleteSegment( ms, idx );
          return;
       }
       idx++;
@@ -811,7 +813,6 @@ void unsplitSegment( MSEGStorage *ms, float t ) {
    ms->segments[prior].cpduration = cpdratio * ms->segments[prior].duration;
    ms->segments[prior].cpv = (ms->segments[prior].nv1 - ms->segments[prior].v0 ) * cpvratio + ms->segments[prior].v0;
 
-   
    for( int i=idx; i<ms->n_activeSegments - 1; ++i )
    {
       ms->segments[i] = ms->segments[i+1];
@@ -827,7 +828,11 @@ void deleteSegment( MSEGStorage *ms, float t ) {
    if( ms->n_activeSegments <= 1 ) return;
 
    auto idx = timeToSegment( ms, t );
-   
+   deleteSegment( ms, idx );
+}
+
+void deleteSegment( MSEGStorage *ms, int idx )
+{
    for( int i=idx; i<ms->n_activeSegments - 1; ++i )
    {
       ms->segments[i] = ms->segments[i+1];

--- a/src/common/dsp/MSEGModulationHelper.h
+++ b/src/common/dsp/MSEGModulationHelper.h
@@ -48,8 +48,9 @@ namespace Surge
 
       void extendTo( MSEGStorage *s, float t, float mv );
       void splitSegment( MSEGStorage *s, float t, float nv );
-      void unsplitSegment( MSEGStorage *s, float t );
+      void unsplitSegment( MSEGStorage *s, float t, bool wrapTime = false ); // for unsplit we often want past-end-is-last
       void deleteSegment( MSEGStorage *s, float t );
+      void deleteSegment( MSEGStorage *s, int idx );
 
       void resetControlPoint( MSEGStorage *s, float t );
       void resetControlPoint( MSEGStorage *s, int idx );


### PR DESCRIPTION
- Always draw line points to avoid clip with tight beziers and stuff
- Fix a problem with doubleclick deleting the wrong segment near the end
- Ctrl-LeftClick == DoubleClick for add and remove
- Make loop markers hotzones (but still not draggable)