### PR TITLE
Include Path Opacity in Gradients

### DIFF
--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -531,7 +531,7 @@ void CScalableBitmap::drawSVG(CDrawContext* dc,
             for (int i = 0; i < ngrad->nstops; ++i)
             {
                auto stop = ngrad->stops[i];
-               cg->addColorStop(stop.offset, svgColorToCColor(stop.color));
+               cg->addColorStop(stop.offset, svgColorToCColor(stop.color, shape->opacity));
             }
             VSTGUI::CPoint s0(0, 0), s1(0, 1);
             VSTGUI::CPoint p0 = gradXform.inverse().transform(s0);
@@ -554,7 +554,7 @@ void CScalableBitmap::drawSVG(CDrawContext* dc,
             for( int i=0; i<ngrad->nstops; ++i )
             {
                auto stop = ngrad->stops[i];
-               cg->addColorStop(stop.offset, svgColorToCColor(stop.color));
+               cg->addColorStop(stop.offset, svgColorToCColor(stop.color, shape->opacity));
             }
 
             VSTGUI::CPoint s0(0, 0), s1(0.5,0); // the box has size -0.5, 0.5 so the radius is 0.5

--- a/utils/svgshow/src/main.cpp
+++ b/utils/svgshow/src/main.cpp
@@ -25,7 +25,10 @@ struct SvgBrowser : public VSTGUI::IKeyboardHook
       SurgeSVGRenderComponent(const VSTGUI::CRect &size, VSTGUI::CFrame *f, VSTGUI::CTextLabel *ll ) : VSTGUI::CControl(size), frame(f)
          {
             l = ll;
-            csb = nullptr;
+
+            std::string defload =  "/Users/paul/Desktop/SVG3031/single_transp.svg";
+
+            csb = new CScalableBitmap( defload, f );
             /* if( l )
                l->remeber(); */
          }


### PR DESCRIPTION
If an object had both a gradient *and* a path opacity the
path opacity was ignored constructing gradient stops.

Closes #3031