### PR TITLE
VST2 Delete on Exit Cleanup

### DIFF
--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -110,6 +110,11 @@ void Vst2PluginInstance::inputConnected(VstInt32 index, bool state)
 
 Vst2PluginInstance::~Vst2PluginInstance()
 {
+   if( editor )
+   {
+      delete editor;
+      editor = nullptr;
+   }
    delete _instance;
 }
 


### PR DESCRIPTION
When deleting the instance, make sure the editor is deleted
first so editor cleanup can run with a valid synth reference.