### PR TITLE
Gropu Opacity reaches Paths as well as Fills

### DIFF
--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -579,7 +579,7 @@ void CScalableBitmap::drawSVG(CDrawContext* dc,
       {
          if (shape->stroke.type == NSVG_PAINT_COLOR)
          {
-            dc->setFrameColor(svgColorToCColor(shape->stroke.color));
+            dc->setFrameColor(svgColorToCColor(shape->stroke.color, shape->opacity));
          }
          else
          {


### PR DESCRIPTION
More SVG transparency adjustments as we re-build skins in figma