### PR TITLE
FX Drag n Drop; and Int Error (FX Lifecycle 1)

### DIFF
--- a/doc/FXLifecycle.md
+++ b/doc/FXLifecycle.md
@@ -1,0 +1,116 @@
+# FX Lifecycle
+
+This documents how FX are created, swapped, initialized, etc... as of
+8e03ba0b54b09 or so. 
+
+There's lots of cases. Lets enumerate all of them
+
+## Core data structures and Functions
+
+* `spawn_effect` creates an instance of an Effect with the appropriate type bound to a storage and data
+* `loadFx` compares the synth state with the runtime state and optionally reloads effects
+    * the first argument `initp` if true means the new effect calls `init_default_values` and if false
+      just forces all params within their default ranges
+    * the second `force_reload_all` makes all fx reload
+    * loadFX begins in all cases where a type switches setting all params to type 'none'.
+    * `loadFx` is called from three places
+        * synth::processThreadunsafeOperations if `load_fx_needed` is true with false/false
+        * synth::processControl if `load_fx_needed` with false/false
+        * synth::loadRaw in all cases with false/true (namely, force a full reload on patch load)
+* `load_fx_needed` is a bool on SurgeSynth
+    * triggers a call to loadFx in processControlEV
+    * set to true in the constructor of synth
+    * set to true on a setParameter01 of ct_fxtype (so automation path)
+    * set to false in loadFx
+    * set to true in SGE when you have a tag_fx_menu
+* The patch has the `fx[n_fx]` array which holds the FXStorage pointers
+* The synth has an `FXStorage *fxsync` which is malloced to `n_fx_slots * sizeof(FXStorage)`. This
+  object acts as an edit buffer for external editors who want to bulk update the type of objects.
+  * In the synth constructor it is set to the value of `patch.fx[i]` for each i
+  * In SurgeGUIEditor the fxsync is used as the storage which is edited by the CSnapshotMenu, not
+    the patch buffer
+  * In `loadFX`
+     * if reloading an FX, copy from the sync to the patch. This defacto means "take the sync values as
+        they have been set by a UI"
+     * Similarly if fx_reload[s] is true, copy from the sync and syspend and init the FX
+* The slot `fx_reload[n_fx_slots]`
+  * This is set by SurgeGUIEditor primarily to force a reload of an FX in the event that the type has not changed
+
+## Empty FX to Loaded FX, FX On
+
+Spawn Effect is called twice
+
+```
+Spawn Effect  id=6
+-------- StackTrace (7 frames of 40 depth showing) --------
+  [  1]: 1   Surge                               0x000000015000dc72 _Z12spawn_effectiP12SurgeStorageP9FxStorageP5pdata + 130
+  [  2]: 2   Surge                               0x0000000150214423 _ZN7CFxMenu12loadSnapshotEiP12TiXmlElementi + 227
+  [  3]: 3   Surge                               0x000000015022bc4e _ZZN13CSnapshotMenu30populateSubmenuFromTypeElementEP12TiXmlElementPN6VSTGUI11COptionMenuERiS5_RKlS5_ENK3$_0clEPNS2_16CCommandMenuItemE + 62
+  [  4]: 4   Surge                               0x000000015022bbf2 _ZNSt3__1L8__invokeIRZN13CSnapshotMenu30populateSubmenuFromTypeElementEP12TiXmlElementPN6VSTGUI11COptionMenuERiS7_RKlS7_E3$_0JPNS4_16CCommandMenuItemEEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOSE_DpOSF_ + 50
+  [  5]: 5   Surge                               0x000000015022bb92 _ZNSt3__128__invoke_void_return_wrapperIvE6__callIJRZN13CSnapshotMenu30populateSubmenuFromTypeElementEP12TiXmlElementPN6VSTGUI11COptionMenuERiS9_RKlS9_E3$_0PNS6_16CCommandMenuItemEEEEvDpOT_ + 50
+  [  6]: 6   Surge                               0x000000015022bb42 _ZNSt3__110__function12__alloc_funcIZN13CSnapshotMenu30populateSubmenuFromTypeElementEP12TiXmlElementPN6VSTGUI11COptionMenuERiS8_RKlS8_E3$_0NS_9allocatorISB_EEFvPNS5_16CCommandMenuItemEEEclEOSF_ + 50
+Spawn Effect  id=6
+-------- StackTrace (7 frames of 38 depth showing) --------
+  [  1]: 1   Surge                               0x000000015000dc72 _Z12spawn_effectiP12SurgeStorageP9FxStorageP5pdata + 130
+  [  2]: 2   Surge                               0x0000000150107b73 _ZN16SurgeSynthesizer6loadFxEbb + 1155
+  [  3]: 3   Surge                               0x000000015010c5f3 _ZN16SurgeSynthesizer14processControlEv + 3667
+  [  4]: 4   Surge                               0x000000015010ccb2 _ZN16SurgeSynthesizer7processEv + 1234
+  [  5]: 5   Surge                               0x000000015063eb2d _ZN7aulayer6RenderERjRK14AudioTimeStampj + 1277
+  [  6]: 6   Surge                               0x0000000150640620 _ZN6AUBase9RenderBusERjRK14AudioTimeStampjj + 96
+```
+
+* CSnapshotMenu::loadSnapshot
+    * Load an FX and call `init_ctryltypes` and `init_default_values`. This sets up the params on the control to defaults
+      in the storage bound to the FX
+    * delete the FX
+    * Parse the XML and set the fxbuffer parameter values as described in the FX. This leaves the storage configured with
+       values and types but does not leave the synth with the FX setup
+    * raise a valueChanged so SurgeGuiEditor sets load_fx_needed to true. 
+    * If audio_processing_active is false it also sets up the FX from the UI thread via the
+      call to synth->processThreadunsafeOperations() but we will ignroe that case in this document
+      from hereon out
+* SurgeSynthesizer
+    * In the next `process()` and call to `processControl` `load_fx_needed` will be true
+    * so call `loadFx(false,false)` which will force FX where the type in the FX to be noticed as
+      changed and will spawn an fx
+    * but since `initp` is false, dont call `init_default_values` and instead continue to use the values
+      left lingering in the FX from the invocation in CSnapshotMenu.
+    
+## Loaded FX to Off, FX On
+
+* CSnapshotMenu calls loadSnapshot with type 0 and null XML (fine).
+* This sets the valtype to 0 and then SGE gets the message
+* Question: What sets the types to none everywhere?
+
+## Empty FX to Loaded FX, FX Bypassed
+
+## Active FX to New preset of Same Type, FX On
+
+* CSnapshotMenu 
+
+## Active FX to New FX of Different Type, FX On
+
+## Active FX to New FX, FX Bypassed
+
+Question: is bypass from CEG different than global bypass?
+
+## Load a patch with FX Off
+
+## Load a patch with active FX
+
+## Load a User FX setting
+
+* CFXMenu::loadUserPreset looks like loadSnapshot in that it creates a new FX on the sync buffer, applies the value
+  from the preset, and raises the event
+* After that it's just like a same-type load
+
+## Swap an FX
+
+## An Airwondow is activated and changes type
+
+## An Airwindow is de-activated and changes type
+
+## A non-airwindow becomes an airwindow in activated state
+
+## A non-airwindow becomes an airwindow in deactivated state
+

--- a/src/common/DebugHelpers.cpp
+++ b/src/common/DebugHelpers.cpp
@@ -61,14 +61,15 @@ bool Surge::Debug::toggleConsole()
 #endif
 }
 
-void Surge::Debug::stackTraceToStdout()
+void Surge::Debug::stackTraceToStdout( int depth )
 {
 #if MAC || LINUX
     void* callstack[128];
     int i, frames = backtrace(callstack, 128);
     char** strs = backtrace_symbols(callstack, frames);
-    printf( "-------- StackTrace (%d frames deep) --------\n", frames );
-    for (i = 1; i < frames; ++i) {
+   if( depth < 0 ) depth = frames;
+   printf( "-------- StackTrace (%d frames of %d depth showing) --------\n", depth, frames );
+    for (i = 1; i < frames && i < depth; ++i) {
         printf( "  [%3d]: %s\n", i, strs[i] );
     }
     free(strs);

--- a/src/common/DebugHelpers.h
+++ b/src/common/DebugHelpers.h
@@ -22,7 +22,7 @@ namespace Debug {
 bool openConsole(); // no-op on Linux and macOS; force console open on Windows
 bool toggleConsole(); // no-op on Linux and macOS; shows or closes console on Windows
 
-void stackTraceToStdout(); // no-op on Windows; shows stack trace on macOS and Linunx
+void stackTraceToStdout(int depth = -1); // no-op on Windows; shows stack trace on macOS and Linunx
 
 struct LifeCycleToConsole { // simple class which printfs in ctor and dtor
    LifeCycleToConsole( std::string s );

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -126,14 +126,7 @@ public:
 
    // We have to push this onto the audio thread so have an enqueue and so on
    enum FXReorderMode { NONE, SWAP, COPY, MOVE };
-   struct { int s; int t; FXReorderMode m; } reorderFxQueue;
-   void enqueuReorderFx( int source, int target, FXReorderMode m )
-   {
-      reorderFxQueue.s = source;
-      reorderFxQueue.t = target;
-      reorderFxQueue.m = m;
-   }
-   void reorderFx();
+   void reorderFx( int source, int target, FXReorderMode m  ); // This is safe to call from the UI thread since it just edits the sync
 
    void playVoice(int scene, char channel, char key, char velocity, char detune);
    void releaseScene(int s);

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -12,11 +12,14 @@
 #include "FlangerEffect.h"
 #include "RingModulatorEffect.h"
 #include "airwindows/AirWindowsEffect.h"
+#include "DebugHelpers.h"
 
 using namespace std;
 
 Effect* spawn_effect(int id, SurgeStorage* storage, FxStorage* fxdata, pdata* pd)
 {
+   // std::cout << "Spawn Effect " << _D(id) << std::endl;
+   // Surge::Debug::stackTraceToStdout(7);
    switch (id)
    {
    case fxt_delay:

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.cpp
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.cpp
@@ -1,5 +1,6 @@
 #include "AirWindowsEffect.h"
 #include "UserDefaults.h"
+#include "DebugHelpers.h"
 
 AirWindowsEffect::AirWindowsEffect( SurgeStorage *storage, FxStorage *fxdata, pdata *pd ) :
    Effect( storage, fxdata, pd )
@@ -18,7 +19,14 @@ AirWindowsEffect::~AirWindowsEffect()
 {
 }
 
-void AirWindowsEffect::init() {
+void AirWindowsEffect::init()
+{
+
+   //std::cout << "AirWindows init " << std::endl;
+   //for( int i=1;i<n_fx_params;++i)
+   //   if( fxdata->p[i].ctrltype != ct_none )
+   //      std::cout << _D(i) << _D(fxdata->p[i].val.f) << std::endl;
+
 }
 
 const char* AirWindowsEffect::group_label(int id)

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -416,6 +416,7 @@ void CFxMenu::loadSnapshot(int type, TiXmlElement* e, int idx)
 {
    if (!type)
       fxbuffer->type.val.i = type;
+
    if (e)
    {
       fxbuffer->type.val.i = type;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -7018,9 +7018,7 @@ bool SurgeGUIEditor::onDrop( const std::string& fname)
 
 void SurgeGUIEditor::swapFX(int source, int target, SurgeSynthesizer::FXReorderMode m)
 {
-   std::cout << "Swapping " << source << " and " << target << " mode=" << m << std::endl;
-   // synth->enqueuReorderFx(source, target, m );
-   Surge::UserInteractions::promptError( "Drag and Drop FX coming in Surge 1.8", "Not quite done yet" );
+   synth->reorderFx(source, target, m );
 }
 
 void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)


### PR DESCRIPTION
First commit in the FX lifecycle series

- Add documentation on the data structures
- Fix load-over path for integer params leaving garbled values
  (closes #3054)
- Correctly implement Drag-n-Drop function both threadwise and
  value wise. Closes #2787