### PR TITLE
FX Type Automation; DnD Fixes

### DIFF
--- a/doc/FXLifecycle.md
+++ b/doc/FXLifecycle.md
@@ -114,3 +114,7 @@ Question: is bypass from CEG different than global bypass?
 
 ## A non-airwindow becomes an airwindow in deactivated state
 
+## The DAW AUtomation Path
+
+The DAW Automation Path comes in through `synth::setParameter01` and handles the `ct_fxtype` to do the spawn-and-replace.
+See the comments there for more.

--- a/src/common/gui/CEffectSettings.cpp
+++ b/src/common/gui/CEffectSettings.cpp
@@ -73,7 +73,20 @@ void CEffectSettings::draw(CDrawContext* dc)
 
    if( mouseActionMode == drag )
    {
+      auto vs = getViewSize();
+      vs = vs.inset(1,1);
       auto r = CRect( dragCurrent - dragCornerOff, CPoint( 17, 9 ) );
+      // r = vs.bound(r); this just pushes it inside; we need to keep constant size so
+      float dx = 0, dy=0;
+      if( r.top < vs.top ) { dy = vs.top - r.top; }
+      if( r.bottom > vs.bottom ) { dy = vs.bottom - r.bottom; }
+      if( r.left < vs.left ) { dx = vs.left - r.left; }
+      if( r.right > vs.right ) { dx = vs.right - r.right; }
+      r.top += dy;
+      r.bottom += dy;
+      r.right += dx;
+      r.left += dx;
+
       auto q = r;
       q = q.extend(1,1);
       dc->setFillColor(skin->getColor( Colors::Effect::Grid::Border));

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -7018,6 +7018,13 @@ bool SurgeGUIEditor::onDrop( const std::string& fname)
 
 void SurgeGUIEditor::swapFX(int source, int target, SurgeSynthesizer::FXReorderMode m)
 {
+   auto t = fxPresetName[target];
+   fxPresetName[target] = fxPresetName[source];
+   if( m == SurgeSynthesizer::SWAP )
+      fxPresetName[source] = t;
+   if( m == SurgeSynthesizer::MOVE )
+      fxPresetName[source] = "";
+
    synth->reorderFx(source, target, m );
 }
 


### PR DESCRIPTION
1. FXType Automation works correctly with the right
   lifecycle hooks. Closes #2402
2. FX Drag and Drop copies patch name
3. FX Drag and Drop maintains the widget inside the window.
   Closes #3058