### PR TITLE
Minor bug with FilterUnit unstreaming

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1463,9 +1463,9 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
    {
       for (int u = 0; u < n_filterunits_per_scene; u++)
       {
-         sc.filterunit[0].subtype.val.i =
-             limit_range(sc.filterunit[0].subtype.val.i, 0,
-                         max(0, fut_subcount[sc.filterunit[0].type.val.i] - 1));
+         sc.filterunit[u].subtype.val.i =
+             limit_range(sc.filterunit[u].subtype.val.i, 0,
+                         max(0, fut_subcount[sc.filterunit[u].type.val.i] - 1));
       }
    }
 


### PR DESCRIPTION
Apparently since 2018 we ahve not limited filterunit2 subtype
properly on unstream. So now we do.

Closes #3059