### PR TITLE
Initial implementation of decimal pitch bend range adjustment

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -402,10 +402,10 @@ void Parameter::set_type(int ctrltype)
       val_default.i = 1;
       break;
    case ct_pbdepth:
-      valtype = vt_int;
-      val_min.i = 0;
-      val_max.i = 24;
-      val_default.i = 2;
+      valtype = vt_float;
+      val_min.f = 0.f;
+      val_max.f = 24.f;
+      val_default.f = 2.f;
       break;
    case ct_pitch_semi7bp:
    case ct_pitch_semi7bp_absolutable:
@@ -895,6 +895,10 @@ void Parameter::set_type(int ctrltype)
 
    switch( ctrltype )
    {
+   case ct_pbdepth:
+      displayType = LinearWithScale;
+      displayInfo.customFeatures = ParamDisplayFeatures::kUnitsAreSemitonesOrKeys;
+      break;
    case ct_percent:
    case ct_percent200:
    case ct_percent_bidirectional:

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -646,8 +646,8 @@ void SurgePatch::init_default_values()
       scene[sc].route_ring_12.val.i = 1;
       scene[sc].route_ring_23.val.i = 1;
       scene[sc].route_noise.val.i = 1;
-      scene[sc].pbrange_up.val.i = 2.f;
-      scene[sc].pbrange_dn.val.i = 2.f;
+      scene[sc].pbrange_up.val.f = 2.f;
+      scene[sc].pbrange_dn.val.f = 2.f;
       scene[sc].lowcut.val.f = scene[sc].lowcut.val_min.f;
       scene[sc].lowcut.deactivated = false;
       scene[sc].lowcut.per_voice_processing = false;
@@ -1319,7 +1319,7 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
 
    if (scene[0].pbrange_up.val.i & 0xffffff00) // is outside range, it must have been save
    {
-      for (int sc; sc < n_scenes; sc++)
+      for (int sc = 0; sc < n_scenes; sc++)
       {
          scene[sc].pbrange_up.val.i = (int)scene[sc].pbrange_up.val.f;
          scene[sc].pbrange_dn.val.i = (int)scene[sc].pbrange_dn.val.f;
@@ -1328,7 +1328,7 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
 
    if (revision < 1)
    {
-      for (int sc; sc < n_scenes; sc++)
+      for (int sc = 0; sc < n_scenes; sc++)
       {
          scene[sc].adsr[0].a_s.val.i = limit_range(scene[sc].adsr[0].a_s.val.i + 1, 0, 2);
          scene[sc].adsr[1].a_s.val.i = limit_range(scene[sc].adsr[1].a_s.val.i + 1, 0, 2);

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -303,10 +303,11 @@ void SurgeVoice::switch_toggled()
 {
    update_portamento();
    float pb = modsources[ms_pitchbend]->output;
+   printf("%.3f\n", scene->pbrange_up.val.f);
    if (pb > 0)
-      pb *= (float)scene->pbrange_up.val.i;
+      pb *= scene->pbrange_up.val.f;
    else
-      pb *= (float)scene->pbrange_dn.val.i;
+      pb *= scene->pbrange_dn.val.f;
 
    // scenepbpitch is pitch state but without state.pkey, so that it can be used to add
    // scene pitch/octave, pitch bend and associated modulations to non-keytracked oscillators
@@ -611,10 +612,11 @@ template <bool first> void SurgeVoice::calc_ctrldata(QuadFilterChainState* Q, in
    }
 
    float pb = modsources[ms_pitchbend]->output;
+   printf("%.3f\n", scene->pbrange_up.val.f);
    if (pb > 0)
-      pb *= (float)scene->pbrange_up.val.i;
+      pb *= scene->pbrange_up.val.f;
    else
-      pb *= (float)scene->pbrange_dn.val.i;
+      pb *= scene->pbrange_dn.val.f;
 
    octaveSize = 12.0f;
    if( ! storage->isStandardTuning )

--- a/src/common/gui/CNumberField.cpp
+++ b/src/common/gui/CNumberField.cpp
@@ -213,9 +213,9 @@ void CNumberField::setControlMode(int mode)
       setDefaultValue(8);
       break;
    case cm_pbdepth:
-      setIntMin(0);
-      setIntMax(24);
-      setDefaultValue(2);
+      setFloatMin(0);
+      setFloatMax(24);
+      setDefaultValue(1);
       break;
    case cm_envshape:
       setFloatMin(-10.f);
@@ -311,7 +311,7 @@ void CNumberField::draw(CDrawContext* pContext)
       sprintf(the_text, "%i", max(1, min(16, (int)value)));
       break;
    case cm_pbdepth:
-      sprintf(the_text, "%i", i_value);
+      sprintf(the_text, "%.2f", value * 24);
       break;
    case cm_count4:
       sprintf(the_text, "%i", max(1, min(4, (int)value)));

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -517,8 +517,8 @@ TEST_CASE( "Non-MPE pitch bend", "[mod]" )
    {
       auto surge = surgeOnSine();
       surge->mpeEnabled = false;
-      surge->storage.getPatch().scene[0].pbrange_up.val.i = 2;
-      surge->storage.getPatch().scene[0].pbrange_dn.val.i = 2;
+      surge->storage.getPatch().scene[0].pbrange_up.val.f = 2.f;
+      surge->storage.getPatch().scene[0].pbrange_dn.val.f = 2.f;
 
       auto f60 = frequencyForNote( surge, 60 );
       auto f62 = frequencyForNote( surge, 62 );
@@ -543,8 +543,8 @@ TEST_CASE( "Non-MPE pitch bend", "[mod]" )
          int bUp = rand() % 24 + 1;
          int bDn = rand() % 24 + 1;
 
-         surge->storage.getPatch().scene[0].pbrange_up.val.i = bUp;
-         surge->storage.getPatch().scene[0].pbrange_dn.val.i = bDn;
+         surge->storage.getPatch().scene[0].pbrange_up.val.f = (float)bUp;
+         surge->storage.getPatch().scene[0].pbrange_dn.val.f = (float)bDn;
          auto fUpD = frequencyForNote( surge, 60 + bUp );
          auto fDnD = frequencyForNote( surge, 60 - bDn );
 
@@ -589,8 +589,8 @@ TEST_CASE( "Pitch Bend and Tuning", "[mod][tun]" )
             int bUp = rand() % 24 + 1;
             int bDn = rand() % 24 + 1;
             
-            surge->storage.getPatch().scene[0].pbrange_up.val.i = bUp;
-            surge->storage.getPatch().scene[0].pbrange_dn.val.i = bDn;
+            surge->storage.getPatch().scene[0].pbrange_up.val.f = (float)bUp;
+            surge->storage.getPatch().scene[0].pbrange_dn.val.f = (float)bDn;
             auto fUpD = frequencyForNote( surge, 60 + bUp );
             auto fDnD = frequencyForNote( surge, 60 - bDn );
             
@@ -630,8 +630,8 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
       surge->mpeEnabled = true;
       surge->storage.mpePitchBendRange = 48;
 
-      surge->storage.getPatch().scene[0].pbrange_up.val.i = 2;
-      surge->storage.getPatch().scene[0].pbrange_dn.val.i = 2;
+      surge->storage.getPatch().scene[0].pbrange_up.val.f = 2.f;
+      surge->storage.getPatch().scene[0].pbrange_dn.val.f = 2.f;
       
       auto f60 = frequencyForNote( surge, 60 );
       auto f62 = frequencyForNote( surge, 62 );
@@ -656,8 +656,8 @@ TEST_CASE( "MPE pitch bend", "[mod]" )
       
       surge->storage.mpePitchBendRange = pbr;
       
-      surge->storage.getPatch().scene[0].pbrange_up.val.i = 2;
-      surge->storage.getPatch().scene[0].pbrange_dn.val.i = 2;
+      surge->storage.getPatch().scene[0].pbrange_up.val.f = 2.f;
+      surge->storage.getPatch().scene[0].pbrange_dn.val.f = 2.f;
 
       // Play on channel 1 which is now an MPE bend channel and send bends on that chan
       auto f60 = frequencyForNote( surge, 60, 2, 0, 1 );


### PR DESCRIPTION
Breaks old patches (they load with PB ranges set to 0), needs work
When implemented correctly, closes #2192