### PR TITLE
Updated S&H LFO display pattern

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -55,7 +55,7 @@ void LfoModulationSource::assign(SurgeStorage* storage,
 
    if (is_display)
    {
-      auto gen = std::minstd_rand(17);
+      auto gen = std::minstd_rand(46);
       std::uniform_real_distribution<float> distro(-1.f,1.f);
       urng = std::bind(distro, gen);
 


### PR DESCRIPTION
Updated the S&H display seed for it to look nicer after #3030. This makes it more random and S&H-y looking like it was before. Here's the new vs old comparison:

![image](https://user-images.githubusercontent.com/50145178/98418150-4dd1ce00-2050-11eb-9326-2f762bdff7ed.png)
![image](https://user-images.githubusercontent.com/50145178/98418214-6e9a2380-2050-11eb-80f0-773f5ff82aec.png)
