### PR TITLE
Enable all OB-Xd filter subtypes!

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2181,20 +2181,20 @@ void Parameter::get_display(char* txt, bool external, float ef)
                      sprintf(txt, "%s", fut_comb_subtypes[i]);
                      break;
                   case fut_vintageladder:
-                     sprintf( txt, "%s", fut_vintageladder_subtypes[i]);
+                     sprintf(txt, "%s", fut_vintageladder_subtypes[i]);
                      break;
                   case fut_obxd_2pole:
-                     sprintf( txt, "%s", fut_obxd_2p_subtypes[i]);
+                     sprintf(txt, "%s", fut_obxd_2p_subtypes[i]);
                      break;
                   case fut_obxd_4pole:
-                     sprintf( txt, "%s", fut_obxd_4p_subtypes[i]);
+                     sprintf(txt, "%s", fut_obxd_4p_subtypes[i]);
                      break;
                   case fut_k35_lp:
                   case fut_k35_hp:
-                     sprintf( txt, "%s", fut_k35_subtypes[i]);
+                     sprintf(txt, "%s", fut_k35_subtypes[i]);
                      break;
                   case fut_diode:
-                     sprintf( txt, "%s", fut_diode_subtypes[i]);
+                     sprintf(txt, "%s", fut_diode_subtypes[i]);
                      break;
 #if SURGE_EXTRA_FILTERS
 #endif

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -459,11 +459,28 @@ const char fut_vintageladder_subtypes[6][32] =
    "Dampened Compensated",
 };
 
-const char fut_obxd_2p_subtypes[1][32] = {"12 dB/oct"};
+const char fut_obxd_2p_subtypes[8][32] =
+{
+   "Lowpass",
+   "Bandpass",
+   "Highpass",
+   "Notch",
+   "Lowpass Pushed",
+   "Bandpass Pushed",
+   "Highpass Pushed",
+   "Notch Pushed",
+};
 
-const char fut_obxd_4p_subtypes[1][32] = {"24 dB/oct"};
+const char fut_obxd_4p_subtypes[4][32] =
+{
+   "6 dB/oct",
+   "12 dB/oct",
+   "18 dB/oct",
+   "24 dB/oct",
+};
 
-const char fut_k35_subtypes[5][32] = {
+const char fut_k35_subtypes[5][32] =
+{
    "No Saturation",
    "Mild Saturation",
    "Moderate Saturation",
@@ -471,7 +488,8 @@ const char fut_k35_subtypes[5][32] = {
    "Extreme Saturation"
 };
 
-const float fut_k35_saturations[5] = {
+const float fut_k35_saturations[5] =
+{
    0.0f,
    1.0f,
    2.0f,
@@ -479,7 +497,10 @@ const float fut_k35_saturations[5] = {
    4.0f
 };
 
-const char fut_diode_subtypes[1][32] = {"24 dB/oct"};
+const char fut_diode_subtypes[1][32] =
+{
+   "24 dB/oct"
+};
 
 const int fut_subcount[n_fu_type] = {
    0, // fut_none
@@ -493,8 +514,8 @@ const int fut_subcount[n_fu_type] = {
    4, // fut_comb
    0, // fut_SNH
    4, // fut_vintageladder
-   0, // fut_obxd_2pole
-   0, // fut_obxd_4pole
+   8, // fut_obxd_2pole
+   4, // fut_obxd_4pole
    5, // fut_k35_lp
    5, // fut_k35_hp
    0  // fut_diode

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1558,6 +1558,7 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
             switch (storage.getPatch().param_ptr[index]->val.i)
             {
             case fut_lpmoog:
+            case fut_obxd_4pole:
                storage.getPatch().param_ptr[index + 1]->val.i = 3;
                break;
             case fut_comb:

--- a/src/common/dsp/filters/Obxd.cpp
+++ b/src/common/dsp/filters/Obxd.cpp
@@ -1,5 +1,3 @@
-
-
 #include "Obxd.h"
   
 /*
@@ -63,11 +61,11 @@ namespace ObxdFilter {
    const __m128 two = _mm_set1_ps(2.0f);
    const __m128 three = _mm_set1_ps(3.0f);
 
-   const __m128 mm = _mm_set1_ps(0.0);
-   const __m128 mmch = _mm_set1_ps(0.0);
-   const __m128 mmt = _mm_sub_ps(_mm_mul_ps(mm, _mm_set1_ps(3.0f)), mmch);
-   const __m128 selfOscPush = _mm_set1_ps(0.0);
-   const __m128 bandPass = _mm_set1_ps(0.0);
+   __m128 mm = _mm_set1_ps(0.0);
+   __m128 mmch = _mm_set1_ps(0.0);
+   __m128 mmt = _mm_sub_ps(_mm_mul_ps(mm, _mm_set1_ps(3.0f)), mmch);
+   __m128 selfOscPush = _mm_set1_ps(0.0);
+   __m128 bandPass = _mm_set1_ps(0.0);
 
    const __m128 gainAdjustment2Pole = _mm_set1_ps(0.74);
    const __m128 gainAdjustment4Pole = _mm_set1_ps(0.6);
@@ -75,27 +73,24 @@ namespace ObxdFilter {
 
 inline __m128 diodePairResistanceApprox(__m128 x)
    {
-      //return (((((0.0103592f)*x + 0.00920833f)*x + 0.185f)*x + 0.05f )*x + 1.0f);
+      // return (((((0.0103592f)*x + 0.00920833f)*x + 0.185f)*x + 0.05f )*x + 1.0f);
       return _mm_add_ps(_mm_mul_ps(_mm_add_ps(_mm_mul_ps(_mm_add_ps(_mm_mul_ps(_mm_add_ps(_mm_mul_ps(one_zero_three, x), nine_two_zero), x), one_eight_five), x), zero_zero_five), x), one);
-      //Taylor approx of slightly mismatched diode pair
+      // Taylor approximation of a slightly mismatched diode pair
    }
    
-   //resolve 0-delay feedback
+   // resolve 0-delay feedback
    inline __m128 NR(__m128 sample, QuadFilterUnitState * __restrict f)
    {
-      //calculating feedback non-linear transconducance and compensated for R (-1)
-      //Boosting non-linearity
+      // calculating feedback non-linear transconducance and compensated for R (-1)
+      // boosting non-linearity
       __m128 tCfb;
-
-      // Self osc currently always on - commented out lines are so we can bring back the switch later
-      //__m128 selfOscEnabledMask = _mm_cmpeq_ps(selfOscPush, zero);
+      __m128 selfOscEnabledMask = _mm_cmpeq_ps(selfOscPush, one);
       __m128 selfOscOffVal =  _mm_sub_ps(diodePairResistanceApprox(_mm_mul_ps(f->R[s1], eight_seven_six)), one);
-      //__m128 selfOscOnVal = _mm_sub_ps(diodePairResistanceApprox(_mm_mul_ps(f->R[s1], eight_seven_six)), one_three_five);
-      //tCfb = _mm_add_ps(_mm_and_ps(selfOscEnabledMask, selfOscOnVal), _mm_andnot_ps(selfOscEnabledMask, selfOscOffVal));
-      tCfb = selfOscOffVal;
+      __m128 selfOscOnVal = _mm_sub_ps(diodePairResistanceApprox(_mm_mul_ps(f->R[s1], eight_seven_six)), one_three_five);
+      tCfb = _mm_add_ps(_mm_and_ps(selfOscEnabledMask, selfOscOnVal), _mm_andnot_ps(selfOscEnabledMask, selfOscOffVal));
 
-      //resolve linear feedback
-      //float y = ((sample - 2*(s1*(R+tCfb)) - g*s1  - s2)/(1+ g*(2*(R+tCfb)+ g)));
+      // resolve linear feedback
+      // float y = ((sample - 2*(s1*(R+tCfb)) - g*s1  - s2)/(1+ g*(2*(R+tCfb)+ g)));
       __m128 y = _mm_div_ps(_mm_sub_ps(_mm_sub_ps(_mm_sub_ps(sample, _mm_mul_ps(two, _mm_mul_ps(f->R[s1], _mm_add_ps(f->C[R], tCfb)))), _mm_mul_ps(f->C[g], f->R[s1])), f->R[s2]), _mm_add_ps(one, _mm_mul_ps(f->C[g], _mm_add_ps(_mm_mul_ps(two, _mm_add_ps(f->C[R], tCfb)), f->C[g]))));
 
       return y;
@@ -106,28 +101,26 @@ inline __m128 diodePairResistanceApprox(__m128 x)
       for( int i=0; i<n_obxd_coeff; ++i )
          f->C[i] = _mm_add_ps( f->C[i], f->dC[i] );
 
-      //float v = ((sample- R * s1*2 - g2*s1 - s2)/(1+ R*g1*2 + g1*g2));
+      // float v = ((sample- R * s1*2 - g2*s1 - s2)/(1+ R*g1*2 + g1*g2));
       __m128 v = NR(sample, f);
-      //float y1 = v * g + s1;
+      // float y1 = v * g + s1;
       __m128 y1 = _mm_add_ps(_mm_mul_ps(v, f->C[g]), f->R[s1]);
-      //s1 = v * g + y1;
+      // s1 = v * g + y1;
       f->R[s1] = _mm_add_ps(_mm_mul_ps(v, f->C[g]), y1);
-      //float y2 = y1 * g + s2;
+      // float y2 = y1 * g + s2;
       __m128 y2 = _mm_add_ps(_mm_mul_ps(y1, f->C[g]), f->R[s2]);
-      //s2 = y1 * g + y2;
+      // s2 = y1 * g + y2;
       f->R[s2] = _mm_add_ps(_mm_mul_ps(y1, f->C[g]), y2);
 
       __m128 mc;
-      // bandpass is always off right now..
-      //__m128 mask_bp = _mm_cmpeq_ps(bandPass, zero);
+      __m128 mask_bp = _mm_cmpeq_ps(bandPass, zero);
       __m128 bp_false = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, mm), y2), _mm_mul_ps(mm, v));
-      //__m128 mask = _mm_cmplt_ps(mm, zero_five);
-      //__m128 val1 = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(zero_five, mm), y2), _mm_mul_ps(mm, y1));
-      //__m128 val2 = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, mm), y1), _mm_mul_ps(_mž_sub_ps(mm, zero_five), v));
-      //__m128 bp_true = _mm_add_ps(_mm_and_ps( mask, val1 ), _mm_andnot_ps( mask, val2));
-      //mc =_mm_add_ps(_mm_and_ps(mask_bp, bp_false), _mm_andnot_ps(mask_bp, bp_true));
-      mc = bp_false;
-      return _mm_mul_ps( mc, gainAdjustment2Pole );
+      __m128 mask = _mm_cmplt_ps(mm, zero_five);
+      __m128 val1 = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(zero_five, mm), y2), _mm_mul_ps(mm, y1));
+      __m128 val2 = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, mm), y1), _mm_mul_ps(_mm_sub_ps(mm, zero_five), v));
+      __m128 bp_true = _mm_add_ps(_mm_and_ps(mask, val1), _mm_andnot_ps(mask, val2));
+      mc =_mm_add_ps(_mm_and_ps(mask_bp, bp_false), _mm_andnot_ps(mask_bp, bp_true));
+      return _mm_mul_ps(mc, gainAdjustment2Pole);
    }
 
    void makeCoefficients(FilterCoefficientMaker *cm, Poles p, float freq, float reso, int sub, SurgeStorage *storage)
@@ -142,18 +135,51 @@ inline __m128 diodePairResistanceApprox(__m128 x)
       lC[R] = 1.0 - reso;
       lC[R24] = 3.5 * reso;
       cm->FromDirect(lC);
+
+      if (p == TWO_POLE)
+      {
+         switch (sub)
+         {
+         case 0:    // lowpass
+         case 4:    // lowpass self-oscillation push
+            mm = _mm_set1_ps(0.f);
+            break;
+         case 1:    // bandpass
+         case 5:    // bandpass self-oscillation push
+            mm = _mm_set1_ps(0.5);
+            bandPass = _mm_set1_ps(1.f);
+            break;
+         case 2:    // highpass
+         case 6:    // highpass self-oscillation push
+            mm = _mm_set1_ps(1.0);
+            break;
+         case 3:    // notch
+         case 7:    // notch self-oscillation push
+            mm = _mm_set1_ps(0.5);
+            bandPass = _mm_set1_ps(0.f);
+            break;
+         }
+
+         selfOscPush = _mm_set1_ps(sub > 3);
+      }
+      else
+      {
+         mm = _mm_set1_ps(1.f - (sub / 3.f));
+         mmch = _mm_set1_ps(3.f - sub);
+         mmt = _mm_sub_ps(_mm_mul_ps(mm, _mm_set1_ps(3.0f)), mmch);
+      }
    }
    
    inline __m128 NR24(__m128 sample, __m128 lpc, QuadFilterUnitState * __restrict f)
    {
-      //float ml = 1 / (1+g);
+      // float ml = 1 / (1+g);
      __m128 ml = _mm_div_ps(one, _mm_add_ps(one, f->C[g]));
-      //float S = (lpc * (lpc * (lpc * f->R[s1] + f->R[s2]) + f->R[s3]) + f->R[s4]) * ml;
+      // float S = (lpc * (lpc * (lpc * f->R[s1] + f->R[s2]) + f->R[s3]) + f->R[s4]) * ml;
      __m128 S = _mm_mul_ps(_mm_add_ps(_mm_mul_ps(lpc, _mm_add_ps(_mm_mul_ps(lpc, _mm_add_ps(_mm_mul_ps(lpc, f->R[s1]), f->R[s2])), f->R[s3])), f->R[s4]), ml);
       
       // float G = lpc * lpc * lpc * lpc;
      __m128 G = _mm_mul_ps(_mm_mul_ps(_mm_mul_ps(lpc, lpc), lpc), lpc);
-      //float y = (sample - f->C[R24] * S) / (1 + f->C[R24] * G);
+      // float y = (sample - f->C[R24] * S) / (1 + f->C[R24] * G);
      __m128 y = _mm_div_ps(_mm_sub_ps(sample, _mm_mul_ps(f->C[R24], S)), _mm_add_ps(one, _mm_mul_ps(f->C[R24], G)));
       return y;
    }
@@ -171,24 +197,24 @@ inline __m128 diodePairResistanceApprox(__m128 x)
       for( int i=0; i<n_obxd_coeff; ++i )
          f->C[i] = _mm_add_ps( f->C[i], f->dC[i] );
 
-      //float lpc = f->C[g] / (1 + f->C[g]);
+      // float lpc = f->C[g] / (1 + f->C[g]);
      __m128 lpc = _mm_div_ps(f->C[g], _mm_add_ps(one, f->C[g]));
       
-      //float y0 = NR24(sample,f->C[g],lpc);
+      // float y0 = NR24(sample,f->C[g],lpc);
      __m128 y0 = NR24(sample, lpc, f);
       
-      //first low pass in cascade
-      //double v = (y0 - f->R[s1]) * lpc;
+      // first lowpass in cascade
+      // double v = (y0 - f->R[s1]) * lpc;
      __m128 v = _mm_mul_ps(_mm_sub_ps(y0, f->R[s1]), lpc);
       
-      //double res = v + f->R[s1];
+      // double res = v + f->R[s1];
      __m128 res = _mm_add_ps(v, f->R[s1]);
       
-      //f->R[s1] = res + v;
+      // f->R[s1] = res + v;
       f->R[s1] = _mm_add_ps(res, v);
       
-      //damping
-      //f->R[s1] =atan(s1*rcor24)*rcor24Inv;
+      // damping
+      // f->R[s1] =atan(s1*rcor24)*rcor24Inv;
       __m128 s1_rcor24 = _mm_mul_ps(f->R[s1], f->C[rcor24]);
       
       float s1_rcor24_arr[ssew];
@@ -202,37 +228,33 @@ inline __m128 diodePairResistanceApprox(__m128 x)
       s1_rcor24 = _mm_load_ps(s1_rcor24_arr);
       f->R[s1] = _mm_mul_ps(s1_rcor24, f->C[rcor24Inv]);
 
-      //float y1 = res;
+      // float y1 = res;
      __m128 y1 = res;
       
-      //float y2 = tptpc(f->R[s2],y1,f->C[g]);
+      // float y2 = tptpc(f->R[s2],y1,f->C[g]);
      __m128 y2 = tptpc(f->R[s2], y1, f->C[g]);
       
-      //float y3 = tptpc(f->R[s3],y2,f->C[g]);
+      // float y3 = tptpc(f->R[s3],y2,f->C[g]);
      __m128 y3 = tptpc(f->R[s3], y2, f->C[g]);
       
-      //float y4 = tptpc(f->R[s4],y3,f->C[g]);
+      // float y4 = tptpc(f->R[s4],y3,f->C[g]);
      __m128 y4 = tptpc(f->R[s4], y3, f->C[g]);
       
      __m128 mc;
       
-      //mmch will always be zero for now.. commented out lines are here so we can bring back the goodness later
-      //__m128 zero_mask = _mm_cmpeq_ps(mmch, zero);
       __m128 zero_val = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, mmt), y4), _mm_add_ps(mmt, y3));
+      __m128 zero_mask = _mm_cmpeq_ps(mmch, zero);
+      __m128 one_mask = _mm_cmpeq_ps(mmch, one);
+      __m128 one_val = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, mmt), y3), _mm_mul_ps(mmt, y2));
+      __m128 two_mask = _mm_cmpeq_ps(mmch, two);
+      __m128 two_val =_mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, mmt), y2), _mm_mul_ps(mmt, y1));
+      __m128 three_mask = _mm_cmpeq_ps(mmch, three);
+      __m128 three_val = y1;
+      mc =_mm_add_ps(_mm_and_ps(zero_mask, zero_val), _mm_and_ps(one_mask, one_val));
+      mc =_mm_add_ps(mc, _mm_add_ps(_mm_and_ps(two_mask, two_val), _mm_and_ps(three_mask, three_val)));
       
-      //__m128 one_mask = _mm_cmpeq_ps(mmch, one);
-      //__m128 one_val = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, mmt), y3), _mm_mul_ps(mmt, y2));
-      //__m128 two_mask = _mm_cmpeq_ps(mmch, two);
-      //__m128 two_val =_mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, mmt), y2), _mm_mul_ps(mmt, y1));
-      //__m128 three_mask = _mm_cmpeq_ps(mmch, three);
-      //__m128 three_val = y1;
-      //mc =_mm_add_ps(_mm_and_ps(zero_mask, zero_val), _mm_and_ps(one_mask, one_val));
-      //mc =_mm_add_ps(mc, _mm_add_ps(_mm_and_ps(two_mask, two_val), _mm_and_ps(three_mask, three_val)));
-      
-      mc = zero_val;
-      //half volume comp
+      // half volume compensation
       auto out = _mm_mul_ps(mc, _mm_add_ps(one, _mm_mul_ps(f->C[R24], zero_four_five)));
       return _mm_mul_ps( out, gainAdjustment4Pole );
    }
-
 }


### PR DESCRIPTION
Closes #2613

PSA: All existing patches utilizing the 24 dB/oct OB-Xd filter will now sound as 1-pole rather than 4-pole, due to matching the subtype order with legacy ladder filter! Simply change to subtype 4 on those. Nightlies gonna nightly!