### PR TITLE
Minor tweaks to skin engine

### DIFF
--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -118,8 +118,8 @@
     <color id="scene.keytrackroot.text" value="lightgray"/>
     <color id="scene.keytrackroot.text.hover" value="white"/>
 
-    <color id="global.split_poly.text" value="lightgray"/>
-    <color id="global.split_poly.text.hover" value="white"/>
+    <color id="scene.split_poly.text" value="lightgray"/>
+    <color id="scene.split_poly.text.hover" value="white"/>
 
     <color id="vumeter.level" value="#0055B0"/>
     <color id="vumeter.highlevel" value="red"/>
@@ -151,8 +151,19 @@
   <controls>
     <control ui_identifier="global.master_volume" class="def-hslider"/>
 
+ 	<control ui_identifier="scene.splitpoint" x="100" y="11" w="44"/>
+ 	<control ui_identifier="scene.polylimit" x="100" y="32" w="44"/>
+
+    <control ui_identifier="scene.pbrange_dn" x="162" w="26" h="12"/>
+    <control ui_identifier="scene.pbrange_up" x="186" w="25" h="12"/>
+
+    <control ui_identifier="scene.keytrack_root" x="308"/>
+
     <control ui_identifier="scene.drift" class="def-hslider"/>
     <control ui_identifier="scene.noise_color" class="def-hslider"/>
+
+    <control ui_identifier="scene.portatime" class="def-hslider"/>
+    <control ui_identifier="scene.pitch" class="def-hslider"/>
 
     <control ui_identifier="scene.fmdepth" class="def-hslider"/>
 
@@ -161,9 +172,6 @@
     <control ui_identifier="scene.width" class="def-hslider"/>
     <control ui_identifier="scene.send_fx_1" class="def-hslider"/>
     <control ui_identifier="scene.send_fx_2" class="def-hslider"/>
-
-    <control ui_identifier="scene.portatime" class="def-hslider"/>
-    <control ui_identifier="scene.pitch" class="def-hslider"/>
 
     <control ui_identifier="filter.cutoff_1" class="def-hslider"/>
     <control ui_identifier="filter.resonance_1" class="def-hslider"/>
@@ -198,12 +206,5 @@
     <control ui_identifier="fx.type" y="194"/>
     <control ui_identifier="fx.preset.prevnext" x="855" y="213"/>
     <control ui_identifier="fx.preset.name" x="762" y="213"/>
-
- 	<control ui_identifier="global.polylimit" x="100" y="32" w="44"/>
- 	<control ui_identifier="global.splitpoint" x="100" y="11" w="44"/>
-    <control ui_identifier="scene.pbrange_dn" x="162" w="26" h="12"/>
-    <control ui_identifier="scene.pbrange_up" x="186" w="25" h="12"/>
-    <control ui_identifier="scene.keytrack_root" x="308"/>
-
   </controls>
 </surge-skin>

--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -250,8 +250,8 @@ namespace Colors
       namespace Loop
       {
          const Surge::Skin::Color Line("msegeditor.loop.line", 255, 144, 0),
-          Marker( "msegeditor.loop.marker", 255, 144, 0 ),
-          MarkerHover( "msegeditor.loop.marker.hover", 255, 255, 255 );
+                                  Marker("msegeditor.loop.marker", 255, 144, 0),
+                                  MarkerHover("msegeditor.loop.marker.hover", 255, 255, 255);
       }
       namespace NumberField
       {
@@ -263,7 +263,7 @@ namespace Colors
    namespace NumberField
    {
       const Surge::Skin::Color Text("numberfield.text", 15, 15, 15),
-                               TextHover( "numberfield.text.hover", 90, 60, 30 );
+                               TextHover("numberfield.text.hover", 90, 60, 30);
    }
 
    namespace Osc
@@ -284,7 +284,7 @@ namespace Colors
 
    namespace Overlay
    {
-      const Surge::Skin::Color Background("overlay.background", 0, 0, 0, 204);
+      const Surge::Skin::Color Background("editor.overlay.background", 0, 0, 0, 204);
    }
 
    namespace PatchBrowser
@@ -302,8 +302,8 @@ namespace Colors
       }
       namespace SplitPoint
       {
-         const Surge::Skin::Color Text("global.split_poly.text", 0, 0, 0),
-                                  TextHover("global.split_poly.text.hover", 0, 0, 0);
+         const Surge::Skin::Color Text("scene.split_poly.text", 0, 0, 0),
+                                  TextHover("scene.split_poly.text.hover", 0, 0, 0);
       }
       namespace KeytrackRoot
       {

--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -139,18 +139,8 @@ namespace Surge
              .withHSwitch2Properties( IDB_FXBYPASS, 4, 1, 4 );
          Connector fx_disable = Connector( "global.fx_disable", 0, 0 );
          Connector master_volume = Connector( "global.master_volume", 756, 29 ); //check
-         Connector polylimit = Connector( "global.polylimit", 99, 32, 42, 14, Connector::NUMBERFIELD )
-             .withProperty( Connector::NUMBERFIELD_CONTROLMODE, cm_polyphony )
-             .withBackground(IDB_POLYSPLIT_NUM_BG)
-             .withProperty(Connector::TEXT_COLOR, "global.split_poly.text")
-             .withProperty(Connector::TEXT_HOVER_COLOR, "global.split_poly.text.hover");
          Connector scene_mode = Connector( "global.scene_mode", 62, 12, 36, 33, Connector::HSWITCH2 )
              .withHSwitch2Properties(IDB_SCENEMODE, 4, 4, 1 );
-         Connector splitpoint = Connector( "global.splitpoint", 99, 11, 43, 14, Connector::NUMBERFIELD )
-             .withBackground(IDB_POLYSPLIT_NUM_BG)
-             .withProperty(Connector::TEXT_COLOR, "global.split_poly.text")
-             .withProperty(Connector::TEXT_HOVER_COLOR, "global.split_poly.text.hover");
-            // this doesn't have a cm since it is special
       }
 
       namespace LFO { // DONE
@@ -243,6 +233,16 @@ namespace Surge
       }
 
       namespace Scene {
+         Connector polylimit = Connector( "scene.polylimit", 99, 32, 42, 14, Connector::NUMBERFIELD )
+             .withProperty( Connector::NUMBERFIELD_CONTROLMODE, cm_polyphony )
+             .withBackground(IDB_POLYSPLIT_NUM_BG)
+             .withProperty(Connector::TEXT_COLOR, "scene.split_poly.text")
+             .withProperty(Connector::TEXT_HOVER_COLOR, "scene.split_poly.text.hover");
+         Connector splitpoint = Connector( "scene.splitpoint", 99, 11, 43, 14, Connector::NUMBERFIELD )
+             .withBackground(IDB_POLYSPLIT_NUM_BG)
+             .withProperty(Connector::TEXT_COLOR, "scene.split_poly.text")
+             .withProperty(Connector::TEXT_HOVER_COLOR, "scene.split_poly.text.hover");
+            // this doesn't have a cm since it is special
          Connector drift = Connector( "scene.drift", 156, 141 ).asHorizontal().asWhite();
          Connector fmdepth = Connector( "scene.fmdepth", 306, 162 ).asHorizontal().asWhite();
          Connector fmrouting = Connector( "scene.fmrouting", 309, 89, 134, 52, Connector::HSWITCH2 )

--- a/src/common/SkinModel.h
+++ b/src/common/SkinModel.h
@@ -255,7 +255,7 @@ namespace Surge
           keytrack_1, keytrack_2, resonance_1, resonance_2, subtype_1, subtype_2, type_1, type_2, waveshaper_drive, waveshaper_type;
       }
       namespace Global {
-         extern Surge::Skin::Connector active_scene, character, fx1_return, fx2_return, fx_bypass, fx_disable, master_volume, polylimit, scene_mode, splitpoint;
+         extern Surge::Skin::Connector active_scene, character, fx1_return, fx2_return, fx_bypass, fx_disable, master_volume, scene_mode;
       }
       namespace LFO {
          extern Surge::Skin::Connector amplitude, attack, decay, deform, delay, hold, phase, rate, release, shape, sustain, triggermode, unipolar;
@@ -273,8 +273,8 @@ namespace Surge
          extern Surge::Skin::Connector keytrack, octave, osctype, param_1, param_2, param_3, param_4, param_5, param_6, param_7, pitch, retrigger;
       }
       namespace Scene {
-         extern Surge::Skin::Connector drift, fmdepth, fmrouting, gain, keytrack_root, noise_color, octave, pan, pbrange_dn, pbrange_up, pitch, playmode,
-          portatime, send_fx_1, send_fx_2, velocity_sensitivity, volume, width;
+         extern Surge::Skin::Connector polylimit, splitpoint, drift, fmdepth, fmrouting, gain, keytrack_root, noise_color, octave, pan, pbrange_dn, pbrange_up,
+          pitch, playmode, portatime, send_fx_1, send_fx_2, velocity_sensitivity, volume, width;
       }
 
       namespace ModSources {

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -61,7 +61,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
    //param_ptr.push_back(scenemorph.assign(p_id.next(),0,"scenemorph","scenemorph",ct_percent,hmargin+gui_sec_width,gui_mid_topbar_y,0,0,0,false,Surge::ParamConfig::kHorizontal));
 
    param_ptr.push_back(splitpoint.assign(p_id.next(), 0, "splitkey", "Split Point", ct_midikey_or_channel,
-                                       Surge::Skin::Global::splitpoint,
+                                       Surge::Skin::Scene::splitpoint,
                                         0, cg_GLOBAL, 0, false,
                                        Surge::ParamConfig::kHorizontal | kNoPopup));
    
@@ -71,7 +71,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
 
    // shouldnt't be stored in the patch
    param_ptr.push_back(polylimit.assign(p_id.next(), 0, "polylimit", "Polyphony Limit", ct_polylimit,
-                                        Surge::Skin::Global::polylimit,
+                                        Surge::Skin::Scene::polylimit,
                                         0, cg_GLOBAL, 0, false,
                                         Surge::ParamConfig::kHorizontal | kNoPopup));
    param_ptr.push_back(fx_bypass.assign(p_id.next(), 0, "fx_bypass", "FX Bypass", ct_fxbypass,

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -5422,15 +5422,19 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeSkinMenu(VSTGUI::CRect &menuRect)
 
     addCallbackMenu(skinSubMenu, Surge::UI::toOSCaseForMenu("Open Current Skin Folder..."),
                     [this]() {
-                       Surge::UserInteractions::openFolderInFileBrowser(this->currentSkin->root + this->currentSkin->name);
+                       Surge::UserInteractions::openFolderInFileBrowser(this->currentSkin->root +
+                                                                        this->currentSkin->name);
                     });
     tid++;
+
+    skinSubMenu->addSeparator();
+
     addCallbackMenu(skinSubMenu, Surge::UI::toOSCaseForMenu("Skin Development Guide..."),
                     []() {
                        Surge::UserInteractions::openURL( "https://surge-synthesizer.github.io/skin-manual.html" );
                     });
 
-    addCallbackMenu(skinSubMenu, Surge::UI::toOSCaseForMenu("Skin Inspector..."),
+    addCallbackMenu(skinSubMenu, Surge::UI::toOSCaseForMenu("Show Skin Inspector..."),
                    [this]()
                    {
                      Surge::UserInteractions::showHTML( skinInspectorHtml() );
@@ -5680,11 +5684,6 @@ void SurgeGUIEditor::reloadFromSkin()
    }
 }
 
-/*
-** The DEV menu is almost always off. @baconpaul just activates it above when he wants
-** to do stuff in the gui. We keep this code kicking around though in case we need it
-** even though it isn't callable in the production UI
-*/
 VSTGUI::COptionMenu *SurgeGUIEditor::makeDevMenu(VSTGUI::CRect &menuRect)
 {
     int tid = 0;
@@ -5698,7 +5697,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeDevMenu(VSTGUI::CRect &menuRect)
 
     static bool consoleState;
 
-    conItem = addCallbackMenu(devSubMenu, Surge::UI::toOSCaseForMenu("Debug Console"),
+    conItem = addCallbackMenu(devSubMenu, Surge::UI::toOSCaseForMenu("Show Debug Console..."),
         []() {
                 consoleState = Surge::Debug::toggleConsole();
              });
@@ -5707,21 +5706,13 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeDevMenu(VSTGUI::CRect &menuRect)
 #endif
 
 #ifdef INSTRUMENT_UI
-    addCallbackMenu(devSubMenu, Surge::UI::toOSCaseForMenu("Show UI Instrumentation"),
+    addCallbackMenu(devSubMenu, Surge::UI::toOSCaseForMenu("Show UI Instrumentation..."),
                     []() {
                        Surge::Debug::report();
                     }
        );
     tid++;
 #endif
-
-    addCallbackMenu(devSubMenu, Surge::UI::toOSCaseForMenu("Show Skin Inspector"),
-                    [this]()
-                       {
-                          Surge::UserInteractions::showHTML( skinInspectorHtml() );
-                       }
-       );
-    tid++;
 
     return devSubMenu;
 }


### PR DESCRIPTION
Rename global.split_poly.text/hover to scene
Rename global.splitpoint/polylimit to scene
Remove skin inspector from developer options
Slightly tweak the skin options menu