### PR TITLE
AirWindows FX Lifecycle Changes

### DIFF
--- a/doc/FXLifecycle.md
+++ b/doc/FXLifecycle.md
@@ -17,6 +17,7 @@ There's lots of cases. Lets enumerate all of them
         * synth::processThreadunsafeOperations if `load_fx_needed` is true with false/false
         * synth::processControl if `load_fx_needed` with false/false
         * synth::loadRaw in all cases with false/true (namely, force a full reload on patch load)
+    * If a reload of either form has changed, the `updateAfterReload()` virtual method is called on the FX
 * `load_fx_needed` is a bool on SurgeSynth
     * triggers a call to loadFx in processControlEV
     * set to true in the constructor of synth

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1727,9 +1727,9 @@ void SurgeSynthesizer::switch_toggled()
 bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
 {
    load_fx_needed = false;
-   bool something_changed = false;
    for (int s = 0; s < n_fx_slots; s++)
    {
+      bool something_changed = false;
       if ((fxsync[s].type.val.i != storage.getPatch().fx[s].type.val.i) || force_reload_all)
       {
          fx_reload[s] = false;
@@ -1845,6 +1845,12 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
          }
          fx_reload[s] = false;
          refresh_editor = true;
+         something_changed = true;
+      }
+
+      if( fx[s] && something_changed )
+      {
+         fx[s]->updateAfterReload();
       }
    }
 

--- a/src/common/dsp/effect/Effect.h
+++ b/src/common/dsp/effect/Effect.h
@@ -43,6 +43,10 @@ public:
    virtual void init(){};
    virtual void init_ctrltypes();
    virtual void init_default_values(){};
+
+   // No matter what path is used to reload (whether created anew or what not) this is called after
+   // the loading state of an item has changed
+   virtual void updateAfterReload(){};
    virtual int vu_type(int id)
    {
       return 0;

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.cpp
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.cpp
@@ -89,7 +89,7 @@ void AirWindowsEffect::init_ctrltypes() {
 
    for( int i=0; i<n_fx_params - 1; ++i )
    {
-      fxdata->p[i+1].set_type( ct_none );
+      fxdata->p[i+1].set_type( ct_percent ); // setting to ct_none means we don't stream onto this
       std::string w = "Airwindow " + std::to_string(i);
       fxdata->p[i+1].set_name( w.c_str() );
 
@@ -107,7 +107,6 @@ void AirWindowsEffect::resetCtrlTypes( bool useStreamedValues ) {
    fxdata->p[0].val_max.i = fxreg.size() - 1;
 
    fxdata->p[0].set_user_data( mapper.get() );
-   
    if( airwin )
    {
       for( int i=0; i<airwin->paramCount && i < n_fx_params - 1; ++i )
@@ -138,7 +137,9 @@ void AirWindowsEffect::resetCtrlTypes( bool useStreamedValues ) {
          fxdata->p[i+1].posy_offset = 3;
 
          if( useStreamedValues )
-            fxdata->p[i+1].val.f = priorVal;
+         {
+            fxdata->p[i + 1].val.f = priorVal;
+         }
          else
             fxdata->p[i+1].val.f = airwin->getParameter( i );
       }
@@ -228,4 +229,10 @@ void AirWindowsEffect::setupSubFX( int sfx, bool useStreamedValues )
    airwin->getEffectName(fxname);
    lastSelected = sfx;
    resetCtrlTypes( useStreamedValues );
+}
+
+void AirWindowsEffect::updateAfterReload()
+{
+   fxdata->p[0].deactivated = true; // assume I'm suspended unless I run
+   setupSubFX(fxdata->p[0].val.i, true );
 }

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.h
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.h
@@ -19,6 +19,8 @@ public:
    virtual void init_ctrltypes() override;
    virtual void init_default_values() override;
 
+   virtual void updateAfterReload() override;
+
    void resetCtrlTypes( bool useStreamedValues );
    
    virtual void process( float *dataL, float *dataR ) override;


### PR DESCRIPTION
These changes make sure that the FX lifecycle allows
Airwindows to appropriately initialie itself in various
load, copy, drag, etc... paths. Basically it gives us a
post-update-via-load-event hook which resets us appropriatley
and assumes we are disabled, which will immediately be
changed if we are not. Avoids the various uninitialized
states which occured due to mis-interaction with streaming.

Closes #2661
Closes #2652 