### PR TITLE
Fix AirWindows "Loud" FX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -947,6 +947,7 @@ if( BUILD_HEADLESS )
     src/headless/UnitTests.cpp
     src/headless/UnitTestUtilities.cpp
     src/headless/UnitTestsDSP.cpp
+    src/headless/UnitTestsFX.cpp
     src/headless/UnitTestsIO.cpp
     src/headless/UnitTestsMIDI.cpp
     src/headless/UnitTestsMOD.cpp

--- a/libs/airwindows/src/Loud.h
+++ b/libs/airwindows/src/Loud.h
@@ -56,10 +56,10 @@ private:
     char _programName[kVstMaxProgNameLen + 1];
     std::set< std::string > _canDo;
     
-	double lastSampleL;
-	double lastSampleR;
-	long double fpNShapeL;
-	long double fpNShapeR;
+	double lastSampleL = 0.0;
+	double lastSampleR = 0.0;
+	long double fpNShapeL = 0.0;
+	long double fpNShapeR = 0.0;
 	//default stuff
 
     float A;

--- a/src/headless/UnitTestsFX.cpp
+++ b/src/headless/UnitTestsFX.cpp
@@ -22,6 +22,45 @@ TEST_CASE( "Airwindows Loud", "[fx]" )
       REQUIRE( surge );
 
       for( int i=0; i<100; ++i ) surge->process();
-      
+
+      auto *pt = &(surge->storage.getPatch().fx[0].type);
+      auto awv = fxt_airwindows / ( pt->val_max.i - pt->val_min.i );
+
+
+      auto did = surge->idForParameter(pt);
+      surge->setParameter01(did, awv, false );
+
+      auto *pawt = &( surge->storage.getPatch().fx[0].p[0]);
+
+
+      for( int i=0; i<500; ++i )
+      {
+         pawt->val.i = 34;
+         surge->process();
+
+         float soo = 0.f;
+
+         INFO( "Swapping aiwrindow attempt " << i );
+         for (int s = 0; s < 100; ++s)
+         {
+            surge->process();
+            for (int p = 0; p < BLOCK_SIZE; ++p)
+            {
+               soo += surge->output[0][p] + surge->output[1][p];
+               REQUIRE( fabs( surge->output[0][p] ) < 1e-5 );
+               REQUIRE( fabs( surge->output[1][p] ) < 1e-5 );
+            }
+         }
+
+         REQUIRE( fabs(soo) < 1e-5 );
+
+         // Toggle to something which isn't 'loud'
+         pawt->val.i = rand() % 30 + 2;
+         for (int s = 0; s < 100; ++s)
+         {
+            surge->process();
+         }
+       }
+
    }
 }


### PR DESCRIPTION
The "Loud" FX required previous sample, but used uninitialized
memory to get there. Add a regtest which swaps onto-and-off-of it
and using that to catch the problem, add initializers to Loud.h.

Closes #2620