### PR TITLE
Prevent double savePatch executions by detecting state of Store Patch dialog

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -167,7 +167,7 @@ public:
 
 private:
    void openOrRecreateEditor();
-   void setupSaveDialog();
+   void makeStorePatchDialog();
    void close_editor();
    bool isControlVisible(ControlGroup controlGroup, int controlGroupEntry);
    void repushAutomationFor( Parameter *p );


### PR DESCRIPTION
Addresses #3106
Needs a better fix by @baconpaul