### PR TITLE
Allow controls to use direct hex colors

### DIFF
--- a/resources/data/skins/Tutorial/05 Labels And Modulators.surge-skin/skin.xml
+++ b/resources/data/skins/Tutorial/05 Labels And Modulators.surge-skin/skin.xml
@@ -6,5 +6,6 @@
   <component-classes>
   </component-classes>
   <controls>
+    <label x="10" y="30" w="150" h="30" font-size="24" font-style="bold" color="#004400" bg-color="#AAFFAA488" frame-color="#FFFFFF" text="I Am Green"/>
   </controls>
 </surge-skin>

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -540,26 +540,7 @@ bool Skin::reloadSkin(std::shared_ptr<SurgeBitmaps> bitmapStore)
          auto r = VSTGUI::CColor();
          if (val[0] == '#')
          {
-            uint32_t rgb;
-            sscanf(val.c_str() + 1, "%x", &rgb);
-
-            auto l = strlen( val.c_str() + 1 );
-            int a = 255;
-            if( l > 6 )
-            {
-               a = rgb % 256;
-               rgb = rgb >> 8;
-            }
-            
-            int b = rgb % 256;
-            rgb = rgb >> 8;
-
-            int g = rgb % 256;
-            rgb = rgb >> 8;
-
-            int r = rgb % 256;
-            
-            colors[id] = ColorStore( VSTGUI::CColor(r, g, b, a) );
+            colors[id] = ColorStore( colorFromHexString(val));
          }
          else if( val[0] == '$' )
          {
@@ -784,6 +765,30 @@ bool Skin::recursiveGroupParse( ControlGroup::ptr_t parent, TiXmlElement *contro
    return true;
 }
 
+VSTGUI::CColor Skin::colorFromHexString(const std::string& val) const
+{
+   uint32_t rgb;
+   sscanf(val.c_str() + 1, "%x", &rgb);
+
+   auto l = strlen( val.c_str() + 1 );
+   int a = 255;
+   if( l > 6 )
+   {
+      a = rgb % 256;
+      rgb = rgb >> 8;
+   }
+
+   int b = rgb % 256;
+   rgb = rgb >> 8;
+
+   int g = rgb % 256;
+   rgb = rgb >> 8;
+
+   int r = rgb % 256;
+
+   return VSTGUI::CColor(r, g, b, a);
+}
+
 bool Skin::hasColor(const std::string &iid) const
 {
    auto id = iid;
@@ -821,6 +826,11 @@ VSTGUI::CColor Skin::getColor(const std::string &iid, const VSTGUI::CColor& def,
       case ColorStore::UNRESOLVED_ALIAS: // This should never occur
          return VSTGUI::kRedCColor;
       }
+   }
+
+   if( id[0] == '#' )
+   {
+      return colorFromHexString(id);
    }
    return def;
 }

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -181,6 +181,9 @@ public:
    {
       return getColor( id, Surge::Skin::Color::colorByName(id));
    }
+
+   VSTGUI::CColor colorFromHexString( const std::string &hex ) const;
+
    private:
       VSTGUI::CColor getColor(const Surge::Skin::Color &id, const VSTGUI::CColor &def, std::unordered_set<std::string> noLoops = std::unordered_set<std::string>()) const
       {


### PR DESCRIPTION
Controls can use inline hex colors but it's not recommended.
Also show a label using this in tut 05
Closes #3108