### PR TITLE
Deactivate bands on EQ3

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -297,6 +297,7 @@ bool Parameter::can_deactivate()
    case ct_lforate_deactivatable:
    case ct_rotarydrive:
    case ct_airwindow_fx:
+   case ct_decibel_deactivatable:
       return true;
    }
    return false;
@@ -462,6 +463,7 @@ void Parameter::set_type(int ctrltype)
       break;
    case ct_decibel:
    case ct_decibel_extendable:
+   case ct_decibel_deactivatable:
       valtype = vt_float;
       val_min.f = -48;
       val_max.f = 48;
@@ -1005,6 +1007,7 @@ void Parameter::set_type(int ctrltype)
    case ct_decibel_fmdepth:
    case ct_decibel_narrow:
    case ct_decibel_extra_narrow:
+   case ct_decibel_deactivatable:
       displayType = LinearWithScale;
       sprintf(displayInfo.unit, "dB");
       break;
@@ -1180,6 +1183,7 @@ void Parameter::bound_value(bool force_integer)
       case ct_decibel_attenuation_large:
       case ct_decibel_fmdepth:
       case ct_decibel_extendable:
+      case ct_decibel_deactivatable:
       {
          val.f = floor(val.f);
          break;
@@ -2637,6 +2641,7 @@ bool Parameter::can_setvalue_from_string()
    case ct_decibel_attenuation_large:
    case ct_decibel_fmdepth:
    case ct_decibel_extendable:
+   case ct_decibel_deactivatable:
    case ct_freq_audible:
    case ct_freq_audible_deactivatable:
    case ct_freq_shift:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -61,6 +61,7 @@ enum ctrltypes
    ct_decibel_attenuation_large,
    ct_decibel_fmdepth,
    ct_decibel_extendable,
+   ct_decibel_deactivatable,
    ct_freq_audible,
    ct_freq_audible_deactivatable,
    ct_freq_mod,

--- a/src/common/dsp/effect/Eq3BandEffect.cpp
+++ b/src/common/dsp/effect/Eq3BandEffect.cpp
@@ -76,9 +76,12 @@ void Eq3BandEffect::process(float* dataL, float* dataR)
    copy_block(dataL, L, BLOCK_SIZE_QUAD);
    copy_block(dataR, R, BLOCK_SIZE_QUAD);
 
-   band1.process_block(L, R);
-   band2.process_block(L, R);
-   band3.process_block(L, R);
+   if( ! fxdata->p[eq3_gain1].deactivated )
+      band1.process_block(L, R);
+   if( ! fxdata->p[eq3_gain2].deactivated )
+      band2.process_block(L, R);
+   if( ! fxdata->p[eq3_gain3].deactivated )
+      band3.process_block(L, R);
 
    gain.set_target_smoothed(db_to_linear(*f[eq3_gain]));
    gain.multiply_2_blocks(L, R, BLOCK_SIZE_QUAD);
@@ -128,21 +131,24 @@ void Eq3BandEffect::init_ctrltypes()
    Effect::init_ctrltypes();
 
    fxdata->p[eq3_gain1].set_name("Gain 1");
-   fxdata->p[eq3_gain1].set_type(ct_decibel);
+   fxdata->p[eq3_gain1].set_type(ct_decibel_deactivatable);
+   fxdata->p[eq3_gain1].deactivated = false;
    fxdata->p[eq3_freq1].set_name("Frequency 1");
    fxdata->p[eq3_freq1].set_type(ct_freq_audible);
    fxdata->p[eq3_bw1].set_name("Bandwidth 1");
    fxdata->p[eq3_bw1].set_type(ct_bandwidth);
 
    fxdata->p[eq3_gain2].set_name("Gain 2");
-   fxdata->p[eq3_gain2].set_type(ct_decibel);
+   fxdata->p[eq3_gain2].set_type(ct_decibel_deactivatable);
+   fxdata->p[eq3_gain2].deactivated = false;
    fxdata->p[eq3_freq2].set_name("Frequency 2");
    fxdata->p[eq3_freq2].set_type(ct_freq_audible);
    fxdata->p[eq3_bw2].set_name("Bandwidth 2");
    fxdata->p[eq3_bw2].set_type(ct_bandwidth);
 
    fxdata->p[eq3_gain3].set_name("Gain 3");
-   fxdata->p[eq3_gain3].set_type(ct_decibel);
+   fxdata->p[eq3_gain3].set_type(ct_decibel_deactivatable);
+   fxdata->p[eq3_gain3].deactivated = false;
    fxdata->p[eq3_freq3].set_name("Frequency 3");
    fxdata->p[eq3_freq3].set_type(ct_freq_audible);
    fxdata->p[eq3_bw3].set_name("Bandwidth 3");


### PR DESCRIPTION
EQ3 can deactivate gain to turn off a band altogether.
Closes #302