### PR TITLE
Fix some smaller initialized memory problems

### DIFF
--- a/src/common/dsp/QuadFilterChain.cpp
+++ b/src/common/dsp/QuadFilterChain.cpp
@@ -41,12 +41,13 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
       {
          __m128 input = d.DL[k];
          __m128 x = input, y = d.DR[k];
+         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
 
          if (A)
             x = g.FU1ptr(&d.FU[0], x);
          if (WS)
          {
-            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, x));
+            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, _mm_and_ps(mask,x)));
             d.Drive = _mm_add_ps(d.Drive, d.dDrive);
             x = g.WSptr(d.wsLPF, d.Drive);
          }
@@ -65,7 +66,6 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          d.Mix2 = _mm_add_ps(d.Mix2, d.dMix2);
          x = _mm_add_ps(_mm_mul_ps(x, _mm_sub_ps(one, d.Mix2)), _mm_mul_ps(y, d.Mix2));
          d.Gain = _mm_add_ps(d.Gain, d.dGain);
-         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
          __m128 out = _mm_and_ps(mask, _mm_mul_ps(x, d.Gain));
 
          // output stage
@@ -78,13 +78,14 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          d.FB = _mm_add_ps(d.FB, d.dFB);
          __m128 input = vMul(d.FB, d.FBlineL);
          input = vAdd(d.DL[k], softclip_ps(input));
+         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
          __m128 x = input, y = d.DR[k];
 
          if (A)
             x = g.FU1ptr(&d.FU[0], x);
          if (WS)
          {
-            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, x));
+            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, _mm_and_ps(mask,x)));
             d.Drive = _mm_add_ps(d.Drive, d.dDrive);
             x = g.WSptr(d.wsLPF, d.Drive);
          }
@@ -103,7 +104,6 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          d.Mix2 = _mm_add_ps(d.Mix2, d.dMix2);
          x = _mm_add_ps(_mm_mul_ps(x, _mm_sub_ps(one, d.Mix2)), _mm_mul_ps(y, d.Mix2));
          d.Gain = _mm_add_ps(d.Gain, d.dGain);
-         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
          __m128 out = _mm_and_ps(mask, _mm_mul_ps(x, d.Gain));
          d.FBlineL = out;
 
@@ -119,12 +119,13 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          __m128 input = vMul(d.FB, d.FBlineL);
          input = vAdd(d.DL[k], softclip_ps(input));
          __m128 x = input, y = d.DR[k];
+         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
 
          if (A)
             x = g.FU1ptr(&d.FU[0], x);
          if (WS)
          {
-            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, x));
+            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, _mm_and_ps( mask,x)));
             d.Drive = _mm_add_ps(d.Drive, d.dDrive);
             x = g.WSptr(d.wsLPF, d.Drive);
          }
@@ -137,7 +138,6 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
 
          // output stage
          d.Gain = _mm_add_ps(d.Gain, d.dGain);
-         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
          x = _mm_and_ps(mask, _mm_mul_ps(x, d.Gain));
 
          MWriteOutputs(x)
@@ -161,6 +161,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          fb = softclip_ps(fb);
          __m128 x = _mm_add_ps(d.DL[k], fb);
          __m128 y = _mm_add_ps(d.DR[k], fb);
+         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
 
          if (A)
             x = g.FU1ptr(&d.FU[0], x);
@@ -173,13 +174,12 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
 
          if (WS)
          {
-            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, x));
+            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, _mm_and_ps(mask,x)));
             d.Drive = _mm_add_ps(d.Drive, d.dDrive);
             x = g.WSptr(d.wsLPF, d.Drive);
          }
 
          d.Gain = _mm_add_ps(d.Gain, d.dGain);
-         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
          __m128 out = _mm_and_ps(mask, _mm_mul_ps(x, d.Gain));
          d.FBlineL = out;
          // output stage
@@ -194,12 +194,13 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          fb = softclip_ps(fb);
          __m128 x = _mm_add_ps(d.DL[k], fb);
          __m128 y = _mm_add_ps(d.DR[k], fb);
+         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
 
          if (A)
             x = g.FU1ptr(&d.FU[0], x);
          if (WS)
          {
-            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, x));
+            d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, _mm_and_ps(mask,x)));
             d.Drive = _mm_add_ps(d.Drive, d.dDrive);
             x = g.WSptr(d.wsLPF, d.Drive);
          }
@@ -212,7 +213,6 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          x = _mm_add_ps(_mm_mul_ps(x, d.Mix1), _mm_mul_ps(y, d.Mix2));
 
          d.Gain = _mm_add_ps(d.Gain, d.dGain);
-         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
          __m128 out = _mm_and_ps(mask, _mm_mul_ps(x, d.Gain));
          d.FBlineL = out;
          // output stage
@@ -227,6 +227,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          fb = softclip_ps(fb);
          __m128 x = _mm_add_ps(d.DL[k], fb);
          __m128 y = _mm_add_ps(d.DR[k], fb);
+         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
 
          if (A)
             x = g.FU1ptr(&d.FU[0], x);
@@ -243,11 +244,10 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          {
             d.wsLPF = _mm_mul_ps(hb_c, _mm_add_ps(d.wsLPF, x));
             d.Drive = _mm_add_ps(d.Drive, d.dDrive);
-            x = g.WSptr(d.wsLPF, d.Drive);
+            x = g.WSptr(_mm_and_ps(mask,d.wsLPF), d.Drive);
          }
 
          d.Gain = _mm_add_ps(d.Gain, d.dGain);
-         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
          __m128 out = _mm_and_ps(mask, _mm_mul_ps(x, d.Gain));
          d.FBlineL = out;
          // output stage
@@ -262,6 +262,7 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          fb = softclip_ps(fb);
          __m128 x = _mm_add_ps(d.DL[k], fb);
          __m128 y = _mm_add_ps(d.DR[k], fb);
+         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
 
          if (A)
             x = g.FU1ptr(&d.FU[0], x);
@@ -271,8 +272,8 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          if (WS)
          {
             d.Drive = _mm_add_ps(d.Drive, d.dDrive);
-            x = g.WSptr(x, d.Drive);
-            y = g.WSptr(y, d.Drive);
+            x = g.WSptr(_mm_and_ps(mask,x), d.Drive);
+            y = g.WSptr(_mm_and_ps(mask,y), d.Drive);
          }
 
          d.Mix1 = _mm_add_ps(d.Mix1, d.dMix1);
@@ -281,7 +282,6 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          y = _mm_mul_ps(y, d.Mix2);
 
          d.Gain = _mm_add_ps(d.Gain, d.dGain);
-         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
          x = _mm_and_ps(mask, _mm_mul_ps(x, d.Gain));
          y = _mm_and_ps(mask, _mm_mul_ps(y, d.Gain));
          d.FBlineL = _mm_add_ps(x, y);
@@ -302,6 +302,8 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          __m128 x = xin;
          __m128 y = yin;
 
+         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
+
          if (A)
          {
             x = g.FU1ptr(&d.FU[0], x);
@@ -311,8 +313,8 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          if (WS)
          {
             d.Drive = _mm_add_ps(d.Drive, d.dDrive);
-            x = g.WSptr(x, d.Drive);
-            y = g.WSptr(y, d.Drive);
+            x = g.WSptr(_mm_and_ps(mask, x), d.Drive);
+            y = g.WSptr(_mm_and_ps(mask, y), d.Drive);
          }
 
          if (A || WS)
@@ -335,7 +337,6 @@ void ProcessFBQuad(QuadFilterChainState& d, fbq_global& g, float* OutL, float* O
          }
 
          d.Gain = _mm_add_ps(d.Gain, d.dGain);
-         __m128 mask = _mm_load_ps((float*)&d.FU[0].active);
          x = _mm_and_ps(mask, _mm_mul_ps(x, d.Gain));
          y = _mm_and_ps(mask, _mm_mul_ps(y, d.Gain));
          d.FBlineL = x;

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -1,6 +1,7 @@
 #include "QuadFilterUnit.h"
 #include "SurgeStorage.h"
 #include <vt_dsp/basic_dsp.h>
+#include <iostream>
 #include "DebugHelpers.h"
 
 #include "filters/VintageLadders.h"

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -28,13 +28,10 @@ void DualDelayEffect::init()
    LFOdirection = true;
    lp.suspend();
    hp.suspend();
-   setvars(true);
-   inithadtempo = true;
    // See issue #1444 and the fix for this stuff
-   if( storage->temposyncratio_inv == 0 )
-   {
-      inithadtempo = false;
-   }
+   inithadtempo = (storage->temposyncratio_inv != 0);
+   setvars(true);
+   inithadtempo = (storage->temposyncratio_inv != 0);
 }
 
 void DualDelayEffect::setvars(bool init)

--- a/src/common/dsp/effect/FreqshiftEffect.cpp
+++ b/src/common/dsp/effect/FreqshiftEffect.cpp
@@ -34,15 +34,11 @@ void FreqshiftEffect::init()
    fr.reset();
    fi.reset();
    ringout = 10000000;
-   setvars(true);
 
-   inithadtempo = true;
    // See issue #1444 and the fix for this stuff
-   if( storage->temposyncratio_inv == 0 )
-   {
-      inithadtempo = false;
-   }
-
+   inithadtempo = (storage->temposyncratio_inv != 0);
+   setvars(true);
+   inithadtempo = (storage->temposyncratio_inv != 0);
 }
 
 void FreqshiftEffect::setvars(bool init)

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -96,13 +96,15 @@ void playSomeBach()
 */
 int main(int argc, char** argv)
 {
+#define RUN_REGTEST 1
+#if RUN_REGTEST
    std::cout << "\n\n"
              << "surge-headless is our regtest engine for the synth engine excluding the UI\n"
              << "Run 'surge-headless --help' for options.\n\n";
    extern int runAllTests(int, char**);
    return runAllTests(argc, argv);
 
-#if 0
+#else
    std::cout << "Hi! HEADLESS is a development tool the SurgeDevs use to run parts of the synth\n"
               << "without a UI or a DAW. It explicitly is NOT a standalone version of surge or a\n"
               << "user targeted application. If you are running it and are not a dev you will\n"
@@ -110,11 +112,10 @@ int main(int argc, char** argv)
    try 
    {
       // simpleOscillatorToStdOut();
-      //statsFromPlayingEveryPatch();
+      statsFromPlayingEveryPatch();
       //playSomeBach();
       //Surge::Headless::createAndDestroyWithScaleAndRandomPatch(20000);
       // Surge::Headless::pullInitSamplesWithNoNotes(1000);
-      testTuning();
       //portableWt();
    }
    catch( Surge::Error &e )


### PR DESCRIPTION
Chasing a bug-that-wasn't I ran valgrnd and found that several
issues were still present. This fixes them by

1. Masking inputs I pass to the WaveShaper, which is required to
   avoid bad table lookups, and
2. Initializing memory in order in delay and frequency shifters.

Closes #3122