### PR TITLE
Symmetric Mod- and Non-Mod Double Click

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3333,7 +3333,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             ((CSurgeSlider*)control)->setModCurrent(synth->isActiveModulation(p->id, thisms), synth->isBipolarModulation(thisms));
             // control->setGhostValue(p->get_value_f01());
             oscdisplay->invalid();
-            return 1;
+            return 0;
          }
          else
          {


### PR DESCRIPTION
MOd- double click acted differently than Non-Mod in one
key way which meant the infowindow never dismissed.
Make them the same.

Closes #3128