### PR TITLE
String IDs for images are case insensitive

### DIFF
--- a/src/common/gui/SurgeBitmaps.h
+++ b/src/common/gui/SurgeBitmaps.h
@@ -4,6 +4,7 @@
 #include "vstgui/vstgui.h"
 #include <map>
 #include <atomic>
+#include <algorithm>
 
 class CScalableBitmap;
 
@@ -30,6 +31,14 @@ protected:
    void addEntry(int id, VSTGUI::CFrame* f);
    std::map<int, CScalableBitmap*> bitmap_registry;
    std::map<std::string, CScalableBitmap*> bitmap_file_registry;
-   std::map<std::string, CScalableBitmap*> bitmap_stringid_registry;
+
+   struct cicomp {
+      bool operator() (const std::string& a, const std::string& b) const {
+         std::string al = a; std::transform(al.begin(), al.end(), al.begin(), [](unsigned char c ) { return std::tolower(c); } );
+         std::string bl = b; std::transform(bl.begin(), bl.end(), bl.begin(), [](unsigned char c ) { return std::tolower(c); } );
+         return al < bl;
+      }
+   };
+   std::map<std::string, CScalableBitmap*, cicomp> bitmap_stringid_registry;
    VSTGUI::CFrame *frame;
 };


### PR DESCRIPTION
If you have a string ID (which means say you are an unnamed
asset whose name is implied in the skin engine) you are case
insensitive. Defacto means you can have HOVER00153.svg and it works.

This means you can't differ images in the default load image
directory just by case. But windows already means you can't
do that so its fine.

Closes #3109