### PR TITLE
Rename LFO shape to LFO type

### DIFF
--- a/src/common/ModulatorPresetManager.cpp
+++ b/src/common/ModulatorPresetManager.cpp
@@ -31,13 +31,13 @@ const static std::string PresetXtn = ".modpreset";
 void savePresetToUser( const fs::path & location, SurgeStorage *s, int scene, int lfoid )
 {
    auto lfo = &(s->getPatch().scene[scene].lfo[lfoid]);
-   int shapev = lfo->shape.val.i;
+   int lfotype = lfo->shape.val.i;
 
    auto containingPath = fs::path{ string_to_path( s->userDataPath ) / fs::path{ PresetDir }};
 
-   if( shapev == ls_mseg )
+   if( lfotype == lt_mseg )
       containingPath = containingPath / fs::path{ "MSEG" };
-   else if( shapev == ls_stepseq )
+   else if( lfotype == lt_stepseq )
       containingPath = containingPath / fs::path{ "Step Seq" };
    else
       containingPath = containingPath / fs::path{ "LFO" };
@@ -51,7 +51,7 @@ void savePresetToUser( const fs::path & location, SurgeStorage *s, int scene, in
    doc.InsertEndChild(decl);
 
    TiXmlElement lfox( "lfo" );
-   lfox.SetAttribute("shape", shapev );
+   lfox.SetAttribute("shape", lfotype );
 
    TiXmlElement params( "params" );
    for( auto curr = &(lfo->rate); curr <= &(lfo->release); ++curr )
@@ -82,13 +82,13 @@ void savePresetToUser( const fs::path & location, SurgeStorage *s, int scene, in
    }
    lfox.InsertEndChild(params);
 
-   if( shapev == ls_mseg )
+   if( lfotype == lt_mseg )
    {
       TiXmlElement ms( "mseg" );
       s->getPatch().msegToXMLElement(&(s->getPatch().msegs[scene][lfoid]), ms );
       lfox.InsertEndChild( ms );
    }
-   if( shapev == ls_stepseq )
+   if( lfotype == lt_stepseq )
    {
       TiXmlElement ss( "sequence" );
       s->getPatch().stepSeqToXmlElement(&(s->getPatch().stepsequences[scene][lfoid]), ss, true );
@@ -120,13 +120,13 @@ void loadPresetFrom( const fs::path &location, SurgeStorage *s, int scene, int l
       return;
    }
 
-   int shapev = 0;
-   if( lfox->QueryIntAttribute("shape", &shapev) != TIXML_SUCCESS )
+   int lfotype = 0;
+   if( lfox->QueryIntAttribute("shape", &lfotype) != TIXML_SUCCESS )
    {
       std::cout << "Bad shape" << std::endl;
       return;
    }
-   lfo->shape.val.i = shapev;
+   lfo->shape.val.i = lfotype;
 
    auto params = TINYXML_SAFE_TO_ELEMENT(lfox->FirstChildElement("params"));
    if (!params)
@@ -184,14 +184,14 @@ void loadPresetFrom( const fs::path &location, SurgeStorage *s, int scene, int l
       }
    }
 
-   if (shapev == ls_mseg)
+   if (lfotype == lt_mseg)
    {
       auto msn = lfox->FirstChildElement("mseg");
       if( msn )
          s->getPatch().msegFromXMLElement(&(s->getPatch().msegs[scene][lfoid]), msn);
    }
 
-   if( shapev == ls_stepseq )
+   if( lfotype == lt_stepseq )
    {
       auto msn = lfox->FirstChildElement("sequence");
       if( msn )

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -619,10 +619,10 @@ void Parameter::set_type(int ctrltype)
       val_max.f = 120;
       val_default.f = 90;
       break;
-   case ct_lfoshape:
+   case ct_lfotype:
       valtype = vt_int;
       val_min.i = 0;
-      val_max.i = n_lfoshapes - 1;
+      val_max.i = n_lfotypes - 1;
       val_default.i = 0;
       break;
    case ct_fbconfig:
@@ -2223,8 +2223,8 @@ void Parameter::get_display(char* txt, bool external, float ef)
       case ct_fmconfig:
          sprintf(txt, "%s", fmc_names[limit_range(i, 0, (int)n_fm_configuration - 1)]);
          break;
-      case ct_lfoshape:
-         sprintf(txt, "%s", ls_names[limit_range(i, 0, (int)n_lfoshapes - 1)]);
+      case ct_lfotype:
+         sprintf(txt, "%s", lt_names[limit_range(i, 0, (int)n_lfotypes - 1)]);
          break;
       case ct_scenemode:
          sprintf(txt, "%s", scene_mode_names[limit_range(i, 0, (int)n_scenemodes - 1)]);

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -82,7 +82,7 @@ enum ctrltypes
    ct_lforate,
    ct_lforate_deactivatable,
    ct_lfodeform,
-   ct_lfoshape,
+   ct_lfotype,
    ct_lfotrigmode,
    ct_detuning,
    ct_osctype,

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -454,7 +454,7 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       {
          char label[32];
 
-         sprintf(label, "lfo%i_type", l);
+         sprintf(label, "lfo%i_shape", l);
          a->push_back(scene[sc].lfo[l].shape.assign(p_id.next(), id_s++, label, "Type", ct_lfotype,
                                                     Surge::Skin::LFO::shape, sc_id, cg_LFO, ms_lfo1 + l));
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -454,8 +454,8 @@ SurgePatch::SurgePatch(SurgeStorage* storage)
       {
          char label[32];
 
-         sprintf(label, "lfo%i_shape", l);
-         a->push_back(scene[sc].lfo[l].shape.assign(p_id.next(), id_s++, label, "Shape", ct_lfoshape,
+         sprintf(label, "lfo%i_type", l);
+         a->push_back(scene[sc].lfo[l].shape.assign(p_id.next(), id_s++, label, "Type", ct_lfotype,
                                                     Surge::Skin::LFO::shape, sc_id, cg_LFO, ms_lfo1 + l));
 
          sprintf(label, "lfo%i_rate", l);
@@ -1912,7 +1912,7 @@ unsigned int SurgePatch::save_xml(void** data) // allocates mem, must be freed b
    {
       for (int l = 0; l < n_lfos; l++)
       {
-         if (scene[sc].lfo[l].shape.val.i == ls_stepseq)
+         if (scene[sc].lfo[l].shape.val.i == lt_stepseq)
          {
             char txt[256], txt2[256];
             TiXmlElement p("sequence");
@@ -1932,7 +1932,7 @@ unsigned int SurgePatch::save_xml(void** data) // allocates mem, must be freed b
    {
       for (int l = 0; l < n_lfos; l++)
       {
-         if (scene[sc].lfo[l].shape.val.i == ls_mseg)
+         if (scene[sc].lfo[l].shape.val.i == lt_mseg)
          {
             TiXmlElement p("mseg");
             p.SetAttribute("scene", sc);

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1060,10 +1060,10 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry)
       cgroup = 6;
       cgroup_e = entry + ms_lfo1;
       id = getPatch().scene[scene].lfo[entry].shape.id;
-      if (getPatch().scene[scene].lfo[entry].shape.val.i == ls_stepseq)
+      if (getPatch().scene[scene].lfo[entry].shape.val.i == lt_stepseq)
          memcpy(&clipboard_stepsequences[0], &getPatch().stepsequences[scene][entry],
                 sizeof(StepSequencerStorage));
-      if (getPatch().scene[scene].lfo[entry].shape.val.i == ls_mseg)
+      if (getPatch().scene[scene].lfo[entry].shape.val.i == lt_mseg)
          clipboard_msegs[0] = getPatch().msegs[scene][entry];
       break;
    case cp_scene:
@@ -1239,10 +1239,10 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry)
       }
       break;
       case cp_lfo:
-         if (getPatch().scene[scene].lfo[entry].shape.val.i == ls_stepseq)
+         if (getPatch().scene[scene].lfo[entry].shape.val.i == lt_stepseq)
             memcpy(&getPatch().stepsequences[scene][entry], &clipboard_stepsequences[0],
                    sizeof(StepSequencerStorage));
-         if (getPatch().scene[scene].lfo[entry].shape.val.i == ls_mseg)
+         if (getPatch().scene[scene].lfo[entry].shape.val.i == lt_mseg)
             getPatch().msegs[scene][entry] = clipboard_msegs[0];
 
          break;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -341,22 +341,22 @@ const char fmc_names[n_fm_configuration][16] =
    "2 > 1 < 3",
 };
 
-enum lfoshapes
+enum lfotypes
 {
-   ls_sine = 0,
-   ls_tri,
-   ls_square,
-   ls_ramp,
-   ls_noise,
-   ls_snh,
-   ls_envelope,
-   ls_stepseq,
-   ls_mseg,
-   ls_function,
-   n_lfoshapes
+   lt_sine = 0,
+   lt_tri,
+   lt_square,
+   lt_ramp,
+   lt_noise,
+   lt_snh,
+   lt_envelope,
+   lt_stepseq,
+   lt_mseg,
+   lt_function,
+   n_lfotypes
 };
 
-const char ls_names[n_lfoshapes][32] =
+const char lt_names[n_lfotypes][32] =
 {
    "Sine",
    "Triangle",

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2012,7 +2012,7 @@ bool SurgeSynthesizer::isBipolarModulation(modsources tms)
    if (tms >= ms_lfo1 && tms <= ms_slfo6)
    {
       bool isup = storage.getPatch().scene[scene_ms].lfo[tms-ms_lfo1].unipolar.val.i ||
-         storage.getPatch().scene[scene_ms].lfo[tms-ms_lfo1].shape.val.i == ls_envelope;
+         storage.getPatch().scene[scene_ms].lfo[tms-ms_lfo1].shape.val.i == lt_envelope;
       
       // For now
       return !isup;

--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -126,7 +126,7 @@ void LfoModulationSource::initPhaseFromStartPhase()
 {
    phase = localcopy[startphase].f;
    phaseInitialized = true;
-   if( lfo->shape.val.i == ls_tri && lfo->rate.deactivated && ! lfo->unipolar.val.b )
+   if( lfo->shape.val.i == lt_tri && lfo->rate.deactivated && ! lfo->unipolar.val.b )
       phase += 0.25;
    while( phase < 0.f )
       phase += 1.f;
@@ -161,14 +161,14 @@ void LfoModulationSource::attack()
    if (is_display)
    {
       phase = lfo->start_phase.val.f;
-      if (lfo->shape.val.i == ls_stepseq )
+      if (lfo->shape.val.i == lt_stepseq )
          phase = 0.f;
       step = 0;
    }
    else
    {
       float phaseslider;
-      if (lfo->shape.val.i == ls_stepseq)
+      if (lfo->shape.val.i == lt_stepseq)
          phaseslider = 0.f; // Use Phase as shuffle-parameter instead
       // else if(state) phaseslider = lfo->start_phase.val.f;
       else
@@ -229,13 +229,13 @@ void LfoModulationSource::attack()
 
    switch (lfo->shape.val.i)
    {
-   case ls_snh:
+   case lt_snh:
       noise = 0.f;
       noised1 = 0.f;
       target = 0.f;
       iout = correlated_noise_o2mk2_suppliedrng(target, noised1, limit_range(localcopy[ideform].f,-1.f,1.f), urng);
       break;
-   case ls_stepseq:
+   case lt_stepseq:
    {
       // fire up the engines
       wf_history[1] = ss->steps[step & (n_stepseqsteps - 1)];
@@ -263,7 +263,7 @@ void LfoModulationSource::attack()
       wf_history[0] = ss->steps[step & (n_stepseqsteps - 1)];
    }
    break;
-   case ls_noise:
+   case lt_noise:
    {
       noise = 0.f;
       noised1 = 0.f;
@@ -280,7 +280,7 @@ void LfoModulationSource::attack()
       phase = 0.f;
    }
    break;
-   case ls_tri:
+   case lt_tri:
    {
       if (!lfo->unipolar.val.b)
       {
@@ -293,7 +293,7 @@ void LfoModulationSource::attack()
       }
    }
    break;
-   case ls_sine:
+   case lt_sine:
    {
       if (lfo->unipolar.val.b)
       {
@@ -317,7 +317,7 @@ void LfoModulationSource::release()
       env_releasestart = env_val;
       env_phase = 0;
    }
-   else if( lfo->shape.val.i == ls_mseg )
+   else if( lfo->shape.val.i == lt_mseg )
    {
       env_state = lenv_msegrelease;
    }
@@ -364,7 +364,7 @@ void LfoModulationSource::process_block()
    phase += frate * ratemult;
    //if( lfo->rate.temposync )
    //std::cout << _D(phase) << _D(frate) << _D(ratemult) << _D(storage->temposyncratio) << std::endl;
-   if( frate == 0 && phase == 0 && s == ls_stepseq )
+   if( frate == 0 && phase == 0 && s == lt_stepseq )
    {
       phase = 0.001; // step forward a smidge
    }
@@ -414,8 +414,8 @@ void LfoModulationSource::process_block()
       // sustainlevel = sustainlevel*(1.f + localcopy[ideform].f) -
       // sustainlevel*sustainlevel*localcopy[ideform].f; sustainlevel = sustainlevel /
       // (sustainlevel*localcopy[ideform].f + 1 - localcopy[ideform].f); float dd =
-      // (localcopy[ideform].f - 1); if (s == ls_envelope) sustainlevel = 0.5f *
-      // (sqrt(4.f*sustainlevel + dd*dd) + dd); if (s == ls_envelope) sustainlevel = 1.f / (1.f +
+      // (localcopy[ideform].f - 1); if (s == lt_envelope) sustainlevel = 0.5f *
+      // (sqrt(4.f*sustainlevel + dd*dd) + dd); if (s == lt_envelope) sustainlevel = 1.f / (1.f +
       // localcopy[ideform].f); a = (1.f-localcopy[ideform].f) + localcopy[ideform].f*env_val;
       // u = e*a;
 
@@ -502,12 +502,12 @@ void LfoModulationSource::process_block()
 
       switch (s)
       {
-      case ls_snh:
+      case lt_snh:
       {
          iout = correlated_noise_o2mk2_suppliedrng(target, noised1, limit_range(localcopy[ideform].f,-1.f,1.f), urng);
       }
       break;
-      case ls_noise:
+      case lt_noise:
       {
          wf_history[3] = wf_history[2];
          wf_history[2] = wf_history[1];
@@ -517,7 +517,7 @@ void LfoModulationSource::process_block()
          // target = ((float) rand()/RAND_MAX)*2.f - 1.f;
       }
       break;
-      case ls_stepseq:
+      case lt_stepseq:
          /*
          ** You might thing we don't need this and technically we don't
          ** but I wanted to keep it here to retain compatability with 
@@ -563,8 +563,8 @@ void LfoModulationSource::process_block()
 
    switch (s)
    {
-   case ls_envelope:
-   case ls_function:
+   case lt_envelope:
+   case lt_function:
       switch (lfo->deform.deform_type)
       {
       case type_1:
@@ -577,7 +577,7 @@ void LfoModulationSource::process_block()
       }
       break;
 
-   case ls_sine:
+   case lt_sine:
       switch (lfo->deform.deform_type)
       {
       case type_1:
@@ -597,7 +597,7 @@ void LfoModulationSource::process_block()
       }               
    break;
    
-   case ls_tri:
+   case lt_tri:
       switch (lfo->deform.deform_type)
       {
       case type_1:
@@ -617,7 +617,7 @@ void LfoModulationSource::process_block()
       }
    break;
    
-   case ls_ramp:
+   case lt_ramp:
       switch (lfo->deform.deform_type)
       {
       case type_1:
@@ -639,19 +639,19 @@ void LfoModulationSource::process_block()
        
       break;
    
-   case ls_square:
+   case lt_square:
 
       iout = (phase > (0.5f + 0.5f * localcopy[ideform].f)) ? -1.f : 1.f;
       break;
    
-   case ls_noise:
+   case lt_noise:
    {
       // iout = noise*(1-phase) + phase*target;
       iout = CubicInterpolate(wf_history[3], wf_history[2], wf_history[1], wf_history[0], phase);
    }
    break;
    
-   case ls_stepseq:
+   case lt_stepseq:
       // iout = wf_history[0];
       {
          // Support 0 rate scrubbing across all 16 steps
@@ -732,7 +732,7 @@ void LfoModulationSource::process_block()
       }
       break;
    
-   case ls_mseg:
+   case lt_mseg:
       msegstate.released =  ( env_state == lenv_release || env_state == lenv_msegrelease );
       iout = Surge::MSEG::valueAt( unwrappedphase_intpart, phase, localcopy[ideform].f, ms, &msegstate );
       break;
@@ -742,7 +742,7 @@ void LfoModulationSource::process_block()
 
    if (lfo->unipolar.val.b)
    {
-      if (s != ls_stepseq)
+      if (s != lt_stepseq)
       {
          io2 = 0.5f + 0.5f * io2;
       }

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -70,7 +70,7 @@ void CLFOGui::draw(CDrawContext* dc)
    maindisp.top += 1;
    maindisp.bottom -= 1;
 
-   if (ss && lfodata->shape.val.i == ls_stepseq)
+   if (ss && lfodata->shape.val.i == lt_stepseq)
    {
       drawStepSeq(dc, maindisp, leftpanel);
    }
@@ -503,7 +503,7 @@ void CLFOGui::draw(CDrawContext* dc)
       auto off = lfodata->shape.val.i * 76;
       typeImg->draw( dc, CRect( CPoint( leftpanel.left, leftpanel.top + 2), CPoint( 51, 76 ) ), CPoint( 0, off ), 0xff );
 
-      for( int i=0; i<n_lfoshapes; ++i )
+      for( int i=0; i<n_lfotypes; ++i )
       {
          int xp = ( i % 2 ) * 25 + leftpanel.left;
          int yp = ( i / 2 ) * 15 + leftpanel.top;
@@ -528,7 +528,7 @@ void CLFOGui::draw(CDrawContext* dc)
    }
    else
    {
-      for (int i = 0; i < n_lfoshapes; i++)
+      for (int i = 0; i < n_lfotypes; i++)
       {
          CRect tb(leftpanel);
          tb.top = leftpanel.top + 10 * i;
@@ -555,7 +555,7 @@ void CLFOGui::draw(CDrawContext* dc)
          shaperect[i] = tb;
          // tb.offset(0,-1);
          tb.top += 1.6; // now the font is smaller and the box is square, smidge down the text
-         dc->drawString(ls_names[i], tb);
+         dc->drawString(lt_names[i], tb);
       }
    }
 
@@ -1156,7 +1156,7 @@ CMouseEventResult CLFOGui::onMouseDown(CPoint &where, const CButtonState &button
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
    }
 
-   if (lfodata->shape.val.i == ls_mseg)
+   if (lfodata->shape.val.i == lt_mseg)
    {
       // only the LFO waveform area
       auto displayrect = getViewSize();
@@ -1180,7 +1180,7 @@ CMouseEventResult CLFOGui::onMouseDown(CPoint &where, const CButtonState &button
    }
 
    // handle step sequencer mouse events
-   if (ss && lfodata->shape.val.i == ls_stepseq)
+   if (ss && lfodata->shape.val.i == lt_stepseq)
    {
        if (rect_steps.pointInside(where))
        {
@@ -1409,7 +1409,7 @@ CMouseEventResult CLFOGui::onMouseUp(CPoint& where, const CButtonState& buttons)
    {
       // onMouseMoved(where,buttons);
       controlstate = cs_null;
-      if( lfodata->shape.val.i == ls_stepseq )
+      if( lfodata->shape.val.i == lt_stepseq )
          invalid();
    }
    return kMouseEventHandled;
@@ -1417,7 +1417,7 @@ CMouseEventResult CLFOGui::onMouseUp(CPoint& where, const CButtonState& buttons)
 
 CMouseEventResult CLFOGui::onMouseExited(VSTGUI::CPoint& where, const VSTGUI::CButtonState& buttons)
 {
-   if (lfodata->shape.val.i == ls_mseg)
+   if (lfodata->shape.val.i == lt_mseg)
       getFrame()->setCursor(VSTGUI::kCursorDefault);
 
    ss_shift_hover = 0;
@@ -1429,7 +1429,7 @@ CMouseEventResult CLFOGui::onMouseExited(VSTGUI::CPoint& where, const VSTGUI::CB
 
 CMouseEventResult CLFOGui::onMouseMoved(CPoint& where, const CButtonState& buttons)
 {
-   if (lfodata->shape.val.i == ls_mseg)
+   if (lfodata->shape.val.i == lt_mseg)
    {
       auto displayrect = getViewSize();
       displayrect.left += lpsize + 19;
@@ -1442,7 +1442,7 @@ CMouseEventResult CLFOGui::onMouseMoved(CPoint& where, const CButtonState& butto
 
    int plt = lfo_type_hover;
    lfo_type_hover = -1;
-   for( int i=0; i<n_lfoshapes; ++i )
+   for( int i=0; i<n_lfotypes; ++i )
    {
       if( shaperect[i].pointInside(where) )
          lfo_type_hover = i;
@@ -1458,7 +1458,7 @@ CMouseEventResult CLFOGui::onMouseMoved(CPoint& where, const CButtonState& butto
    {
       // getFrame()->setCursor( VSTGUI::kCursorHand );
    }
-   else if (ss && lfodata->shape.val.i == ls_stepseq && (
+   else if (ss && lfodata->shape.val.i == lt_stepseq && (
                ss_shift_left.pointInside(where) ||
                ss_shift_right.pointInside(where)
                ))
@@ -1476,7 +1476,7 @@ CMouseEventResult CLFOGui::onMouseMoved(CPoint& where, const CButtonState& butto
 
    if (controlstate == cs_shape)
    {
-      for (int i = 0; i < n_lfoshapes; i++)
+      for (int i = 0; i < n_lfotypes; i++)
       {
          auto prior = lfodata->shape.val.i;
          if (shaperect[i].pointInside(where))
@@ -1676,7 +1676,7 @@ void CLFOGui::invalidateIfAnythingIsTemposynced()
 
 bool CLFOGui::onWheel( const VSTGUI::CPoint &where, const float &distance, const CButtonState &buttons )
 {
-   if (ss && lfodata->shape.val.i == ls_stepseq && rect_steps.pointInside(where) ) {
+   if (ss && lfodata->shape.val.i == lt_stepseq && rect_steps.pointInside(where) ) {
       for (int i = 0; i < n_stepseqsteps; i++)
       {
          if ((where.x > steprect[i].left) && (where.x < steprect[i].right))
@@ -1704,8 +1704,8 @@ bool CLFOGui::onWheel( const VSTGUI::CPoint &where, const float &distance, const
                     auto ns = ps + d;
                     if( ns < 0 )
                        ns = 0;
-                    if( ns >= n_lfoshapes )
-                       ns = n_lfoshapes - 1;
+                    if( ns >= n_lfotypes )
+                       ns = n_lfotypes - 1;
 
                     if( ns != this->lfodata->shape.val.i )
                     {

--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -113,7 +113,7 @@ protected:
    int tsNum = 4, tsDen = 4;
    
    
-   VSTGUI::CRect shaperect[n_lfoshapes];
+   VSTGUI::CRect shaperect[n_lfotypes];
    VSTGUI::CRect steprect[n_stepseqsteps];
    VSTGUI::CRect gaterect[n_stepseqsteps];
    VSTGUI::CRect rect_ls, rect_le, rect_shapes, rect_steps, rect_steps_retrig;

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -81,7 +81,7 @@ void COscillatorDisplay::draw(CDrawContext* dc)
              auto freq = powf(2.0f, frate );
 
              smt = sin(M_PI * freq * mod_time);
-             if( lfo->shape.val.i == ls_square )
+             if( lfo->shape.val.i == lt_square )
                  smt = ( smt > 0 ? 1 : -1 );
 
              if( lfo->unipolar.val.i )

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1382,7 +1382,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
          if( ( q >= ms_lfo1 && q <= ms_lfo6  ) || ( q >= ms_slfo1 && q <= ms_slfo6 ) )
          {
             auto *lfodata = &( synth->storage.getPatch().scene[current_scene].lfo[ q - ms_lfo1 ] );
-            if( lfodata->shape.val.i == ls_mseg )
+            if( lfodata->shape.val.i == lt_mseg )
                msegEditSwitch->setVisible( true );
          }
          break;
@@ -2625,7 +2625,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          return 1;
 
       bool blockForLFO = false;
-      if( p->ctrltype == ct_lfoshape )
+      if( p->ctrltype == ct_lfotype )
       {
          blockForLFO = true;
          auto *clfo = dynamic_cast<CLFOGui*>(control);
@@ -3007,9 +3007,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                auto* lfodata = &(synth->storage.getPatch().scene[current_scene].lfo[q - ms_lfo1]);
 
                switch (lfodata->shape.val.i) {
-               case ls_sine:
-               case ls_tri:
-               case ls_ramp:
+               case lt_sine:
+               case lt_tri:
+               case lt_ramp:
                    contextMenu->addSeparator(eid++);
 
                    addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Deform Type 1"), [this, p]() {
@@ -3343,7 +3343,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             ** control click on step sequencer, say, you go back to sin and lose your
             ** edits. So supress
             */
-            if (p->ctrltype != ct_lfoshape)
+            if (p->ctrltype != ct_lfotype)
             {
                p->set_value_f01(p->get_default_value_f01());
                control->setValue(p->get_value_f01());
@@ -3534,7 +3534,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                if(editorOverlay && editorOverlayTag == "msegEditor" )
                {
                   auto ld = &(synth->storage.getPatch().scene[current_scene].lfo[newsource-ms_lfo1]);
-                  if( ld->shape.val.i == ls_mseg )
+                  if( ld->shape.val.i == lt_mseg )
                   {
                      showMSEGEditor();
                   }
@@ -3583,7 +3583,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
       if (editorOverlay && editorOverlayTag == "msegEditor")
       {
          auto ld = &(synth->storage.getPatch().scene[current_scene].lfo[modsource_editor[current_scene] - ms_lfo1]);
-         if (ld->shape.val.i == ls_mseg)
+         if (ld->shape.val.i == lt_mseg)
          {
             showMSEGEditor();
          }
@@ -3991,7 +3991,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
          bool modulate = false;
 
          // This allows us to turn on and off the editor. FIXME mseg check it
-         if( p->ctrltype == ct_lfoshape )
+         if( p->ctrltype == ct_lfotype )
             synth->refresh_editor = true;
 
          if (modsource && mod_editor && synth->isValidModulation(p->id, modsource) &&
@@ -4118,7 +4118,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                   modulate = true;
             }
 
-            if( p->ctrltype == ct_bool_unipolar || p->ctrltype == ct_lfoshape )
+            if( p->ctrltype == ct_bool_unipolar || p->ctrltype == ct_lfotype )
             {
                // The green line might change so...
                refresh_mod();
@@ -4782,13 +4782,13 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeLfoMenu(VSTGUI::CRect &menuRect)
 
    int shapev = synth->storage.getPatch().scene[current_scene].lfo[currentLfoId].shape.val.i;
    std::string what = "LFO";
-   if( ls_mseg == shapev )
+   if( lt_mseg == shapev )
       what = "MSEG";
-   if( ls_stepseq == shapev)
+   if( lt_stepseq == shapev)
       what = "Step Seq";
-   if (ls_envelope == shapev)
+   if (lt_envelope == shapev)
       what = "Env";
-   if (ls_function == shapev) 
+   if (lt_function == shapev) 
       what = "Env"; //Change this later
 
    COptionMenu* lfoSubMenu =
@@ -4829,7 +4829,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeLfoMenu(VSTGUI::CRect &menuRect)
                             if( editorOverlay && editorOverlayTag == "msegEditor" )
                             {
                                closeMSEGEditor();
-                               if( newshape == ls_mseg )
+                               if( newshape == lt_mseg )
                                   showMSEGEditor();
                             }
 
@@ -6032,7 +6032,7 @@ std::string SurgeGUIEditor::modulatorName( int i, bool button )
       int fnum = idx % 6;
       auto *lfodata = &( synth->storage.getPatch().scene[current_scene].lfo[ i - ms_lfo1 ] );
 
-      if( lfodata->shape.val.i == ls_envelope )
+      if( lfodata->shape.val.i == lt_envelope )
       {
          char txt[64];
          if( button )
@@ -6041,7 +6041,7 @@ std::string SurgeGUIEditor::modulatorName( int i, bool button )
             sprintf( txt, "%s Envelope %d", (isS ? "Scene" : "Voice" ), fnum + 1 );
          return std::string( txt );
       }
-      else if( lfodata->shape.val.i == ls_stepseq )
+      else if( lfodata->shape.val.i == lt_stepseq )
       {
          char txt[64];
          if( button )
@@ -6050,7 +6050,7 @@ std::string SurgeGUIEditor::modulatorName( int i, bool button )
             sprintf( txt, "%s Step Sequencer %d", (isS ? "Scene" : "Voice" ), fnum + 1 );
          return std::string( txt );
       }
-      else if( lfodata->shape.val.i == ls_mseg )
+      else if( lfodata->shape.val.i == lt_mseg )
       {
          char txt[64];
          if( button )
@@ -6059,7 +6059,7 @@ std::string SurgeGUIEditor::modulatorName( int i, bool button )
             sprintf( txt, "%s MSEG %d", (isS ? "Scene" : "Voice" ), fnum + 1 );
          return std::string( txt );
       }
-      else if( lfodata->shape.val.i == ls_function)
+      else if( lfodata->shape.val.i == lt_function)
       {
          char txt[64];
          if( button )
@@ -7015,7 +7015,7 @@ VSTGUI::CControl *SurgeGUIEditor::layoutComponentForSkin( std::shared_ptr<Surge:
    {
       if( ! p )
          return nullptr;
-      if (p->ctrltype != ct_lfoshape)
+      if (p->ctrltype != ct_lfotype)
       {
          // FIXME - warning?
       }
@@ -7215,20 +7215,20 @@ void SurgeGUIEditor::swapFX(int source, int target, SurgeSynthesizer::FXReorderM
 
 void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)
 {
-   if( prior != curr || prior == ls_mseg || curr == ls_mseg )
+   if( prior != curr || prior == lt_mseg || curr == lt_mseg )
    {
       if( msegEditSwitch )
       {
-         msegEditSwitch->setVisible( curr == ls_mseg );
+         msegEditSwitch->setVisible( curr == lt_mseg );
       }
    }
 
-   if( curr == ls_mseg && editorOverlay && editorOverlayTag == "msegEditor" )
+   if( curr == lt_mseg && editorOverlay && editorOverlayTag == "msegEditor" )
    {
       // We have the MSEGEditor open and have swapped to the MSEG here
       showMSEGEditor();
    }
-   else if( prior == ls_mseg && curr != ls_mseg && editorOverlay && editorOverlayTag == "msegEditor" )
+   else if( prior == lt_mseg && curr != lt_mseg && editorOverlay && editorOverlayTag == "msegEditor" )
    {
       // We can choose to not do this too; if we do we are editing an MSEG which isn't used though
       closeMSEGEditor();

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -724,7 +724,7 @@ TEST_CASE( "LfoTempoSync Latch Drift", "[mod]" )
       SurgeSynthesizer::ID rid;
       surge->fromSynthSideId(lfostorage->rate.id, rid );
       surge->setParameter01( rid, 0.455068, false, false );
-      lfostorage->shape.val.i = ls_square;
+      lfostorage->shape.val.i = lt_square;
 
       surge->storage.getPatch().copy_scenedata(surge->storage.getPatch().scenedata[0], 0 );
       


### PR DESCRIPTION
...since we have more than shapes but entirely different modulator types (envelope, stepseq, MSEG, later function...)
Streaming name is retained (shape), for compatibility