### PR TITLE
TempoSync hover handles

### DIFF
--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -522,7 +522,11 @@ void CSurgeSlider::draw(CDrawContext* dc)
 
          if( is_temposync )
          {
-            if( pTempoSyncHandle )
+            if( in_hover && pTempoSyncHoverHandle )
+            {
+               pTempoSyncHoverHandle->draw( dc, hrect, CPoint( 0, 0 ), slider_alpha );
+            }
+            else if( pTempoSyncHandle )
             {
                pTempoSyncHandle->draw(dc, hrect, CPoint(0, 0), slider_alpha);
             }
@@ -556,7 +560,11 @@ void CSurgeSlider::draw(CDrawContext* dc)
 
          if( is_temposync )
          {
-            if( pTempoSyncHandle )
+            if( in_hover && pTempoSyncHoverHandle )
+            {
+               pTempoSyncHoverHandle->draw( dc, hrect, CPoint( 0, 0 ), slider_alpha );
+            }
+            else if( pTempoSyncHandle )
             {
                pTempoSyncHandle->draw(dc, hrect, CPoint(0, 0), slider_alpha);
             }
@@ -1006,12 +1014,14 @@ void CSurgeSlider::onSkinChanged()
       pTray = associatedBitmapStore->getBitmap(IDB_FADERH_BG);
       pHandle = associatedBitmapStore->getBitmap(IDB_FADERH_HANDLE);
       pTempoSyncHandle = associatedBitmapStore->getBitmapByStringID( "TEMPOSYNC_HORIZONTAL_OVERLAY" );
+      pTempoSyncHoverHandle = associatedBitmapStore->getBitmapByStringID( "TEMPOSYNC_HORIZONTAL_HOVER_OVERLAY" );
    }
    else
    {
       pTray = associatedBitmapStore->getBitmap(IDB_FADERV_BG);
       pHandle = associatedBitmapStore->getBitmap(IDB_FADERV_HANDLE);
       pTempoSyncHandle = associatedBitmapStore->getBitmapByStringID( "TEMPOSYNC_VERTICAL_OVERLAY" );
+      pTempoSyncHoverHandle = associatedBitmapStore->getBitmapByStringID( "TEMPOSYNC_VERTICAL_HOVER_OVERLAY" );
    }
 
    if( skinControl.get() )
@@ -1030,6 +1040,12 @@ void CSurgeSlider::onSkinChanged()
       if( ht.isJust() )
       {
          pTempoSyncHandle = associatedBitmapStore->getBitmapByStringID(ht.fromJust());
+      }
+
+      auto hth = skin->propertyValue( skinControl, "handle_temposync_hover_image" );
+      if( hth.isJust() )
+      {
+         pTempoSyncHoverHandle = associatedBitmapStore->getBitmapByStringID(hth.fromJust());
       }
    }
    

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -127,7 +127,7 @@ public:
 
 private:
    VSTGUI::CBitmap *pHandle = nullptr, *pTray = nullptr,
-      *pModHandle = nullptr, *pTempoSyncHandle = nullptr, *pHandleHover = nullptr;
+      *pModHandle = nullptr, *pTempoSyncHandle = nullptr, *pHandleHover = nullptr, *pTempoSyncHoverHandle = nullptr;
    VSTGUI::CRect handle_rect, handle_rect_orig;
    VSTGUI::CPoint offsetHandle;
    int range;


### PR DESCRIPTION
Just like we have a TS overlay, we have a TS Hover overlay.
It can be set globally with TEMPOSYNC_HORIZONTAL_HOVER_OVERLAY
or TEMPOSYNC_VERTICAL_HOVER_OVERLAY or can be set on a per-class
basis with `handle_temposync_hover_image`

Closes #3145