### PR TITLE
A few skin model renames

### DIFF
--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -208,9 +208,9 @@ namespace Surge
             Connector attack_shape = Connector("feg.attack_shape", 3, 1, 20, 16, Connector::HSWITCH2)
                       .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).inParent("feg.panel");
             Connector decay_shape = Connector("feg.decay_shape", 23, 1, 20, 16, Connector::HSWITCH2)
-                      .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).withProperty(Connector::IMGOFFSET, 3).inParent("feg.panel");
+                      .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).withProperty(Connector::FRAME_OFFSET, 3).inParent("feg.panel");
             Connector release_shape = Connector("feg.release_shape", 63, 1, 20, 16, Connector::HSWITCH2)
-                      .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).withProperty(Connector::IMGOFFSET, 6).inParent("feg.panel");
+                      .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).withProperty(Connector::FRAME_OFFSET, 6).inParent("feg.panel");
    
             Connector attack  = Connector("feg.attack", 0, 33).asVertical().asWhite().inParent("feg.panel");
             Connector decay   = Connector("feg.decay", 20, 33).asVertical().asWhite().inParent("feg.panel");
@@ -227,9 +227,9 @@ namespace Surge
             Connector attack_shape = Connector("aeg.attack_shape", 3, 1, 20, 16, Connector::HSWITCH2)
                       .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).inParent("aeg.panel");;
             Connector decay_shape = Connector("aeg.decay_shape", 23, 1, 20, 16, Connector::HSWITCH2)
-                      .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).withProperty(Connector::IMGOFFSET, 3).inParent("aeg.panel");;
+                      .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).withProperty(Connector::FRAME_OFFSET, 3).inParent("aeg.panel");;
             Connector release_shape = Connector("aeg.release_shape", 63, 1, 20, 16, Connector::HSWITCH2)
-                      .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).withProperty(Connector::IMGOFFSET, 6).inParent("aeg.panel");;
+                      .withHSwitch2Properties(IDB_ENVSHAPE, 3, 1, 3).withProperty(Connector::FRAME_OFFSET, 6).inParent("aeg.panel");;
    
             Connector attack  = Connector("aeg.attack", 0, 33).asVertical().asWhite().inParent("aeg.panel");;
             Connector decay   = Connector("aeg.decay", 20, 33).asVertical().asWhite().inParent("aeg.panel");;
@@ -303,14 +303,14 @@ namespace Surge
       {
          Connector surge_menu = Connector("controls.surge_menu", 844, 550, 50, 15, Connector::HSWITCH2, Connector::SURGE_MENU)
                    .withProperty(Connector::BACKGROUND, IDB_BUTTON_MENU)
-                   .withProperty(Connector::DRAGABLE_HSWITCH, false);
+                   .withProperty(Connector::DRAGGABLE_HSWITCH, false);
 
          Connector patch_browser = Connector("controls.patch_browser", 156, 11, 547-156, 28, Connector::CUSTOM, Connector::PATCH_BROWSER);
          Connector patch_category_jog = Connector("controls.category.prevnext", 157, 42, Connector::JOG_PATCHCATEGORY).asJogPlusMinus();
          Connector patch_jog = Connector("controls.patch.prevnext", 246, 42, Connector::JOG_PATCH).asJogPlusMinus();
          Connector patch_store = Connector("controls.patch.store", 510, 42, 37, 12, Connector::HSWITCH2, Connector::STORE_PATCH)
                    .withHSwitch2Properties(IDB_BUTTON_STORE, 1, 1, 1)
-                   .withProperty(Connector::DRAGABLE_HSWITCH, false);
+                   .withProperty(Connector::DRAGGABLE_HSWITCH, false);
 
          Connector status_panel = Connector("controls.status.panel", 562, 12, Connector::GROUP);
          Connector status_mpe = Connector("controls.status.mpe", 0, 0, 31, 12, Connector::SWITCH, Connector::STATUS_MPE)

--- a/src/common/SkinModel.h
+++ b/src/common/SkinModel.h
@@ -110,10 +110,10 @@ namespace Surge
             BACKGROUND=1001,
             ROWS,
             COLUMNS,
-            SUBPIXMAPS,
-            IMGOFFSET,
+            FRAMES,
+            FRAME_OFFSET,
             NUMBERFIELD_CONTROLMODE,
-            DRAGABLE_HSWITCH,
+            DRAGGABLE_HSWITCH,
             TEXT_COLOR,
             TEXT_HOVER_COLOR
          };
@@ -201,10 +201,10 @@ namespace Surge
             return withProperty(p, std::to_string(v));
          }
 
-         Connector & withHSwitch2Properties( int bgid, int subpix, int rows, int cols )
+         Connector & withHSwitch2Properties( int bgid, int frames, int rows, int cols )
          {
             return withProperty( Connector::BACKGROUND, bgid )
-                     .withProperty( Connector::SUBPIXMAPS, subpix )
+                     .withProperty( Connector::FRAMES, frames )
                      .withProperty( Connector::ROWS, rows )
                      .withProperty( Connector::COLUMNS, cols );
          }

--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -26,7 +26,7 @@ void CHSwitch2::draw(CDrawContext* dc)
    {
       // source position in bitmap
       CPoint where(0, heightOfOneImage *
-                          (long)(imgoffset + ((value * (float)(rows * columns - 1) + 0.5f))));
+                          (long)(frameOffset + ((value * (float)(rows * columns - 1) + 0.5f))));
       getBackground()->draw(dc, getViewSize(), where, 0xff);
 
       if( ! lookedForHover && skin.get() )
@@ -36,19 +36,19 @@ void CHSwitch2::draw(CDrawContext* dc)
          hoverOnBmp = skin->hoverBitmapOverlayForBackgroundBitmap( skinControl, dynamic_cast<CScalableBitmap*>( getBackground() ), associatedBitmapStore, Surge::UI::Skin::HoverType::HOVER_OVER_ON );
       }
 
-      long vv = (long)(imgoffset + ((value * (float)(rows * columns - 1) + 0.5f)));
-      long hv = (long)(imgoffset + ((hoverValue * (float)(rows * columns - 1) + 0.5f)));
+      long vv = (long)(frameOffset + ((value * (float)(rows * columns - 1) + 0.5f)));
+      long hv = (long)(frameOffset + ((hoverValue * (float)(rows * columns - 1) + 0.5f)));
       if( doingHover && hoverOnBmp && vv == hv )
       {
          CPoint hwhere(0, heightOfOneImage *
-                       (long)(imgoffset + ((hoverValue * (float)(rows * columns - 1) + 0.5f))));
+                       (long)(frameOffset + ((hoverValue * (float)(rows * columns - 1) + 0.5f))));
          
          hoverOnBmp->draw(dc, getViewSize(), hwhere, 0xff);
       }
       else if( hoverBmp && doingHover )
       {
          CPoint hwhere(0, heightOfOneImage *
-                      (long)(imgoffset + ((hoverValue * (float)(rows * columns - 1) + 0.5f))));
+                      (long)(frameOffset + ((hoverValue * (float)(rows * columns - 1) + 0.5f))));
          
          hoverBmp->draw(dc, getViewSize(), hwhere, 0xff);
       }
@@ -87,7 +87,7 @@ CMouseEventResult CHSwitch2::onMouseDown(CPoint& where, const CButtonState& butt
    if (!(buttons & kLButton))
       return kMouseEventNotHandled;
 
-   if (!dragable)
+   if (!draggable)
    {
       auto mouseableArea = getMouseableArea();
       beginEdit();
@@ -129,7 +129,7 @@ CMouseEventResult CHSwitch2::onMouseUp(CPoint& where, const CButtonState& button
 {
    mouseDowns--;
 
-   if (dragable)
+   if (draggable)
    {
       endEdit();
       return kMouseEventHandled;
@@ -143,7 +143,7 @@ CMouseEventResult CHSwitch2::onMouseMoved(CPoint& where, const CButtonState& but
       calculateHoverValue( where );
    }
 
-   if (dragable && ( buttons.getButtonState() ))
+   if (draggable && ( buttons.getButtonState() ))
    {
       auto mouseableArea = getMouseableArea();
       double coefX, coefY;

--- a/src/common/gui/CHSwitch2.h
+++ b/src/common/gui/CHSwitch2.h
@@ -24,22 +24,21 @@ public:
    CHSwitch2(const VSTGUI::CRect& size,
              VSTGUI::IControlListener* listener,
              long tag,
-             long subPixmaps,       // number of subPixmaps
-             long heightOfOneImage, // pixel
+             long frames,
+             long heightOfOneImage, // in pixels
              long rows,
              long columns,
              VSTGUI::CBitmap* background,
              const VSTGUI::CPoint& offset,
-             bool dragable = false)
-       : CHorizontalSwitch(
-             size, listener, tag, subPixmaps, heightOfOneImage, subPixmaps, background, offset)
+             bool draggable = false)
+       : CHorizontalSwitch(size, listener, tag, frames, heightOfOneImage, frames, background, offset)
    {
       this->rows = rows;
       this->columns = columns;
-      this->dragable = dragable;
+      this->draggable = draggable;
 
       mouseDowns = 0;
-      imgoffset = 0;
+      frameOffset = 0;
       usesMouseWheel = true; // use mousewheel by default
    }
 
@@ -48,8 +47,8 @@ public:
    virtual int getIValue() { return (int)(value * (float)(rows * columns - 1) + 0.5f); }
    
    int mouseDowns;
-   int imgoffset;
-   bool dragable;
+   int frameOffset;
+   bool draggable;
    bool usesMouseWheel;
 
    bool lookedForHover = false;

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -951,9 +951,9 @@ void Surge::UI::Skin::Control::copyFromConnector(const Surge::Skin::Connector& c
       transferPropertyIf(Surge::Skin::Connector::BACKGROUND, "bg_id" );
       transferPropertyIf(Surge::Skin::Connector::ROWS, "rows" );
       transferPropertyIf( Surge::Skin::Connector::COLUMNS, "columns" );
-      transferPropertyIf( Surge::Skin::Connector::SUBPIXMAPS, "subpixmaps" );
-      transferPropertyIf( Surge::Skin::Connector::IMGOFFSET, "imgoffset" );
-      transferPropertyIf( Surge::Skin::Connector::DRAGABLE_HSWITCH, "dragable" );
+      transferPropertyIf( Surge::Skin::Connector::FRAMES, "frames" );
+      transferPropertyIf( Surge::Skin::Connector::FRAME_OFFSET, "frame_offset" );
+      transferPropertyIf( Surge::Skin::Connector::DRAGGABLE_HSWITCH, "draggable" );
       break;
    }
    case Surge::Skin::Connector::SWITCH: {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1578,11 +1578,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
    // Mouse behavior
    if (CSurgeSlider::sliderMoveRateState == CSurgeSlider::kUnInitialized)
-      CSurgeSlider::sliderMoveRateState =
-          (CSurgeSlider::MoveRateState)Surge::Storage::getUserDefaultValue(
-              &(synth->storage), "sliderMoveRateState", (int)CSurgeSlider::kClassic);
-
-
+      CSurgeSlider::sliderMoveRateState = (CSurgeSlider::MoveRateState)Surge::Storage::getUserDefaultValue(&(synth->storage), "sliderMoveRateState", (int)CSurgeSlider::kClassic);
 
    /*
    ** Skin Labels
@@ -1595,7 +1591,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
       if (mtext.isJust())
       {
-         auto ta = currentSkin->propertyValue(l, "text-align", "left");
+         auto ta = currentSkin->propertyValue(l, "text_align", "left");
          // make text align value not case sensitive
          std::transform(ta.begin(), ta.end(), ta.begin(),[](unsigned char c) { return std::tolower(c); });
 
@@ -1608,10 +1604,10 @@ void SurgeGUIEditor::openOrRecreateEditor()
          else if (ta == "right")
             txtalign = kRightText;
 
-         auto fs = currentSkin->propertyValue(l, "font-size", "12");
+         auto fs = currentSkin->propertyValue(l, "font_size", "12");
          auto fsize = std::atof(fs.c_str());
 
-         auto fst = currentSkin->propertyValue(l, "font-style", "normal");
+         auto fst = currentSkin->propertyValue(l, "font_style", "normal");
          // make font style value not case sensitive
          std::transform(fst.begin(), fst.end(), fst.begin(),[](unsigned char c) { return std::tolower(c); });
          
@@ -1631,10 +1627,10 @@ void SurgeGUIEditor::openOrRecreateEditor()
          auto coln = currentSkin->propertyValue(l, "color", "#FF0000");
          auto col = currentSkin->getColor(coln, kRedCColor);
 
-         auto bgcoln = currentSkin->propertyValue(l, "bg-color", "#FFFFFF00");
+         auto bgcoln = currentSkin->propertyValue(l, "bg_color", "#FFFFFF00");
          auto bgcol = currentSkin->getColor(bgcoln, kTransparentCColor);
 
-         auto frcoln = currentSkin->propertyValue(l, "frame-color", "#FFFFFF00");
+         auto frcoln = currentSkin->propertyValue(l, "frame_color", "#FFFFFF00");
          auto frcol = currentSkin->getColor(frcoln, kTransparentCColor);
 
          VSTGUI::SharedPointer<VSTGUI::CFontDesc> fnt = new VSTGUI::CFontDesc("Lato", fsize, fstyle);
@@ -5500,19 +5496,19 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeSkinMenu(VSTGUI::CRect &menuRect)
 
     skinSubMenu->addSeparator();
 
-    addCallbackMenu(skinSubMenu, Surge::UI::toOSCaseForMenu("Skin Development Guide..."),
-                    []() {
-                       Surge::UserInteractions::openURL( "https://surge-synthesizer.github.io/skin-manual.html" );
-                    });
-
     addCallbackMenu(skinSubMenu, Surge::UI::toOSCaseForMenu("Show Skin Inspector..."),
                    [this]()
                    {
                      Surge::UserInteractions::showHTML( skinInspectorHtml() );
-                   }
-   );
+                   });
 
-   tid++;
+    tid++;
+    addCallbackMenu(skinSubMenu, Surge::UI::toOSCaseForMenu("Skin Development Guide..."),
+                   []() {
+                      Surge::UserInteractions::openURL( "https://surge-synthesizer.github.io/skin-manual.html" );
+                   });
+
+    tid++;
 
     return skinSubMenu;
 }
@@ -6949,12 +6945,12 @@ VSTGUI::CControl *SurgeGUIEditor::layoutComponentForSkin( std::shared_ptr<Surge:
          if( p && p->ctrltype == ct_scenesel )
             tag = tag_scene_select;
 
-         auto subpixmaps = currentSkin->propertyValue(skinCtrl, "subpixmaps", "1");
+         auto frames = currentSkin->propertyValue(skinCtrl, "frames", "1");
          auto rows = currentSkin->propertyValue(skinCtrl, "rows", "1");
          auto cols = currentSkin->propertyValue(skinCtrl, "columns", "1");
-         auto imgoff = currentSkin->propertyValue(skinCtrl, "imgoffset", "0" );
-         auto drgb = currentSkin->propertyValue( skinCtrl, "dragable", "1" );
-         auto hsw = new CHSwitch2(rect, this, tag, std::atoi(subpixmaps.c_str()), skinCtrl->h,
+         auto frameoffset = currentSkin->propertyValue(skinCtrl, "frame_offset", "0" );
+         auto drgb = currentSkin->propertyValue( skinCtrl, "draggable", "1" );
+         auto hsw = new CHSwitch2(rect, this, tag, std::atoi(frames.c_str()), skinCtrl->h,
                                   std::atoi(rows.c_str()), std::atoi(cols.c_str()), bmp, CPoint(0,0),
                                   std::atoi( drgb.c_str() ) );
          if( p )
@@ -6981,7 +6977,7 @@ VSTGUI::CControl *SurgeGUIEditor::layoutComponentForSkin( std::shared_ptr<Surge:
          }
          hsw->setSkin(currentSkin, bitmapStore, skinCtrl);
          hsw->setMouseableArea(rect);
-         hsw->imgoffset = std::atoi(imgoff.c_str());
+         hsw->frameOffset = std::atoi(frameoffset.c_str());
 
          frame->addView(hsw);
          if( paramIndex >= 0 ) nonmod_param[paramIndex] = hsw;


### PR DESCRIPTION
* subpixmaps -> frames
* imgoffset -> frame_offset
* dragable -> draggable
* skin label arguments for text/frame/font now have underlines instead of dashes, to match other XML arguments