### PR TITLE
Enumerate usages of waveshapers array, add deform modes for envelope LFO type

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2313,29 +2313,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
          sprintf(txt, "%d bands", i);
          break;
       case ct_distortion_waveshape:
-         // FIXME - do better than this of course
-         switch( i + 1 )
-         {
-         case wst_tanh:
-            sprintf(txt,"Soft");
-            break;
-         case wst_hard:
-            sprintf(txt,"Hard");
-            break;
-         case wst_asym:
-            sprintf(txt,"Asymmetric");
-            break;
-         case wst_sinus:
-            sprintf(txt,"Sine");
-            break;
-         case wst_digi:
-            sprintf(txt,"Digital");
-            break;
-         default:
-         case wst_none:
-            sprintf(txt,"None");
-            break;
-         }
+         sprintf(txt, wst_names[wst_soft + i]);
          break;
       case ct_oscroute:
          switch (i)

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -64,7 +64,7 @@ float table_dB alignas(16)[512],
       table_envrate_linear alignas(16)[512],
       table_glide_exp alignas(16)[512],
       table_glide_log alignas(16)[512];
-float waveshapers alignas(16)[8][1024];
+float waveshapers alignas(16)[n_ws_type][1024];
 float samplerate = 0, samplerate_inv;
 double dsamplerate, dsamplerate_inv;
 double dsamplerate_os, dsamplerate_os_inv;
@@ -1402,29 +1402,22 @@ void SurgeStorage::init_tables()
    for (int i = 0; i < 1024; i++)
    {
       double x = ((double)i - 512.0) * mult;
-      waveshapers[0][i] = (float)tanh(x);                            // wst_tanh,
-      waveshapers[1][i] = (float)pow(tanh(pow(::abs(x), 5.0)), 0.2); // wst_hard
+
+      waveshapers[wst_soft][i] = (float)tanh(x);
+      waveshapers[wst_hard][i] = (float)pow(tanh(pow(::abs(x), 5.0)), 0.2);
       if (x < 0)
-         waveshapers[1][i] = -waveshapers[1][i];
-      waveshapers[2][i] = (float)shafted_tanh(x + 0.5) - shafted_tanh(0.5);       // wst_assym
-      waveshapers[3][i] = (float)sin((double)((double)i - 512.0) * M_PI / 512.0); // wst_sinus
-      waveshapers[4][i] = (float)tanh((double)((double)i - 512.0) * mult);        // wst_digi
+         waveshapers[wst_hard][i] = -waveshapers[1][i];
+      waveshapers[wst_asym][i] = (float)shafted_tanh(x + 0.5) - shafted_tanh(0.5);
+      waveshapers[wst_sine][i] = (float)sin((double)((double)i - 512.0) * M_PI / 512.0);
+      waveshapers[wst_digital][i] = (float)tanh(x);
    }
-   /*for(int i=0; i<512; i++)
-   {
-           double x = 2.0*M_PI*((double)i)/512.0;
-           table_sin[i] = sin(x);
-           table_sin_offset[i] = sin(x+(2.0*M_PI/512.0))-sin(x);
-   }*/
+
    // from 1.2.2
-   // nyquist_pitch = (float)12.f*log((0.49999*M_PI) / (dsamplerate_os_inv *
-   // 2*M_PI*440.0))/log(2.0);	// include some margin for error (and to avoid denormals in IIR
+   // nyquist_pitch = (float)12.f*log((0.49999*M_PI) / (dsamplerate_os_inv */ 2*M_PI*440.0))/log(2.0);	// include some margin for error (and to avoid denormals in IIR
    // filter clamping)
    // 1.3
-   nyquist_pitch =
-       (float)12.f * log((0.75 * M_PI) / (dsamplerate_os_inv * 2 * M_PI * 440.0)) /
-       log(2.0); // include some margin for error (and to avoid denormals in IIR filter clamping)
-   vu_falloff = 0.997f; // TODO should be samplerate-dependent (this is per 32-sample block at 44.1)
+   nyquist_pitch = (float)12.f * log((0.75 * M_PI) / (dsamplerate_os_inv * 2 * M_PI * 440.0)) / log(2.0); // include some margin for error (and to avoid denormals in IIR filter clamping)
+   vu_falloff = 0.997f; // TODO should be sample rate-dependent (this is per 32-sample block at 44.1k)
 }
 
 float SurgeStorage::note_to_pitch(float x)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -89,7 +89,6 @@ extern float table_envrate_lpf alignas(16)[512],
              table_glide_exp alignas(16)[512],
              table_glide_log alignas(16)[512];
 extern float table_note_omega alignas(16)[2][512];
-extern float waveshapers alignas(16)[8][1024];
 extern float samplerate, samplerate_inv;
 extern double dsamplerate, dsamplerate_inv;
 extern double dsamplerate_os, dsamplerate_os_inv;
@@ -370,6 +369,20 @@ const char lt_names[n_lfotypes][32] =
    "Function (coming in 1.9!)",
 };
 
+const int lt_num_deforms[n_lfotypes] =
+{
+   3,   // lt_sine
+   3,   // lt_tri
+   0,   // lt_square
+   3,   // lt_ramp
+   0,   // lt_noise
+   0,   // lt_snh
+   3,   // lt_envelope
+   0,   // lt_stepseq
+   0,   // lt_mseg
+   3,   // lt_function
+};
+
 enum fu_type
 {
    fut_none = 0,
@@ -502,7 +515,8 @@ const char fut_diode_subtypes[1][32] =
    "24 dB/oct"
 };
 
-const int fut_subcount[n_fu_type] = {
+const int fut_subcount[n_fu_type] =
+{
    0, // fut_none
    3, // fut_lp12
    3, // fut_lp24
@@ -539,11 +553,11 @@ enum fu_subtype
 enum ws_type
 {
    wst_none = 0,
-   wst_tanh,
+   wst_soft,
    wst_hard,
    wst_asym,
-   wst_sinus,
-   wst_digi,
+   wst_sine,
+   wst_digital,
    n_ws_type,
 };
 
@@ -556,6 +570,8 @@ const char wst_names[n_ws_type][16] =
    "Sine",
    "Digital",
 };
+
+extern float waveshapers alignas(16)[n_ws_type][1024];
 
 enum env_mode_type
 {

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -649,22 +649,21 @@ __m128 SINUS_SSE2(__m128 in, __m128 drive)
    _mm_store_si128((__m128i*)&e4, e);
 #endif
 
-   __m128 ws1 = _mm_load_ss(&waveshapers[3][e4[0] & 0x3ff]);
-   __m128 ws2 = _mm_load_ss(&waveshapers[3][e4[1] & 0x3ff]);
-   __m128 ws3 = _mm_load_ss(&waveshapers[3][e4[2] & 0x3ff]);
-   __m128 ws4 = _mm_load_ss(&waveshapers[3][e4[3] & 0x3ff]);
+   __m128 ws1 = _mm_load_ss(&waveshapers[wst_sine][e4[0] & 0x3ff]);
+   __m128 ws2 = _mm_load_ss(&waveshapers[wst_sine][e4[1] & 0x3ff]);
+   __m128 ws3 = _mm_load_ss(&waveshapers[wst_sine][e4[2] & 0x3ff]);
+   __m128 ws4 = _mm_load_ss(&waveshapers[wst_sine][e4[3] & 0x3ff]);
    __m128 ws = _mm_movelh_ps(_mm_unpacklo_ps(ws1, ws2), _mm_unpacklo_ps(ws3, ws4));
-   ws1 = _mm_load_ss(&waveshapers[3][(e4[0] + 1) & 0x3ff]);
-   ws2 = _mm_load_ss(&waveshapers[3][(e4[1] + 1) & 0x3ff]);
-   ws3 = _mm_load_ss(&waveshapers[3][(e4[2] + 1) & 0x3ff]);
-   ws4 = _mm_load_ss(&waveshapers[3][(e4[3] + 1) & 0x3ff]);
+   ws1 = _mm_load_ss(&waveshapers[wst_sine][(e4[0] + 1) & 0x3ff]);
+   ws2 = _mm_load_ss(&waveshapers[wst_sine][(e4[1] + 1) & 0x3ff]);
+   ws3 = _mm_load_ss(&waveshapers[wst_sine][(e4[2] + 1) & 0x3ff]);
+   ws4 = _mm_load_ss(&waveshapers[wst_sine][(e4[3] + 1) & 0x3ff]);
    __m128 wsn = _mm_movelh_ps(_mm_unpacklo_ps(ws1, ws2), _mm_unpacklo_ps(ws3, ws4));
 
    x = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, a), ws), _mm_mul_ps(a, wsn));
 
    return x;
 }
-
 
 __m128 ASYM_SSE2(__m128 in, __m128 drive)
 {
@@ -695,15 +694,15 @@ __m128 ASYM_SSE2(__m128 in, __m128 drive)
    _mm_store_si128((__m128i*)&e4, e);
 #endif
 
-   __m128 ws1 = _mm_load_ss(&waveshapers[2][e4[0] & 0x3ff]);
-   __m128 ws2 = _mm_load_ss(&waveshapers[2][e4[1] & 0x3ff]);
-   __m128 ws3 = _mm_load_ss(&waveshapers[2][e4[2] & 0x3ff]);
-   __m128 ws4 = _mm_load_ss(&waveshapers[2][e4[3] & 0x3ff]);
+   __m128 ws1 = _mm_load_ss(&waveshapers[wst_asym][e4[0] & 0x3ff]);
+   __m128 ws2 = _mm_load_ss(&waveshapers[wst_asym][e4[1] & 0x3ff]);
+   __m128 ws3 = _mm_load_ss(&waveshapers[wst_asym][e4[2] & 0x3ff]);
+   __m128 ws4 = _mm_load_ss(&waveshapers[wst_asym][e4[3] & 0x3ff]);
    __m128 ws = _mm_movelh_ps(_mm_unpacklo_ps(ws1, ws2), _mm_unpacklo_ps(ws3, ws4));
-   ws1 = _mm_load_ss(&waveshapers[2][(e4[0] + 1) & 0x3ff]);
-   ws2 = _mm_load_ss(&waveshapers[2][(e4[1] + 1) & 0x3ff]);
-   ws3 = _mm_load_ss(&waveshapers[2][(e4[2] + 1) & 0x3ff]);
-   ws4 = _mm_load_ss(&waveshapers[2][(e4[3] + 1) & 0x3ff]);
+   ws1 = _mm_load_ss(&waveshapers[wst_asym][(e4[0] + 1) & 0x3ff]);
+   ws2 = _mm_load_ss(&waveshapers[wst_asym][(e4[1] + 1) & 0x3ff]);
+   ws3 = _mm_load_ss(&waveshapers[wst_asym][(e4[2] + 1) & 0x3ff]);
+   ws4 = _mm_load_ss(&waveshapers[wst_asym][(e4[3] + 1) & 0x3ff]);
    __m128 wsn = _mm_movelh_ps(_mm_unpacklo_ps(ws1, ws2), _mm_unpacklo_ps(ws3, ws4));
 
    x = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, a), ws), _mm_mul_ps(a, wsn));
@@ -826,16 +825,16 @@ WaveshaperQFPtr GetQFPtrWaveshaper(int type)
 {
    switch (type)
    {
-   case wst_digi:
-      return DIGI_SSE2;
+   case wst_soft:
+      return TANH;
    case wst_hard:
       return CLIP;
-   case wst_sinus:
-      return SINUS_SSE2;
    case wst_asym:
       return ASYM_SSE2;
-   case wst_tanh:
-      return TANH;
+   case wst_sine:
+      return SINUS_SSE2;
+   case wst_digital:
+      return DIGI_SSE2;
    }
    return 0;
 }

--- a/src/common/dsp/effect/DistortionEffect.cpp
+++ b/src/common/dsp/effect/DistortionEffect.cpp
@@ -91,8 +91,8 @@ void DistortionEffect::process(float* dataL, float* dataR)
          L = Lin + fb * L;
          R = Rin + fb * R;
          lp1.process_sample_nolag(L, R);
-         L = lookup_waveshape(ws, L);
-         R = lookup_waveshape(ws, R);
+         L = lookup_waveshape(wst_soft + ws, L);
+         R = lookup_waveshape(wst_soft + ws, R);
          L += a;
          R += a; // denormal
          lp2.process_sample_nolag(L, R);

--- a/src/common/dsp/effect/FreqshiftEffect.cpp
+++ b/src/common/dsp/effect/FreqshiftEffect.cpp
@@ -184,8 +184,8 @@ void FreqshiftEffect::process(float* dataL, float* dataR)
 
       feedback.process();
 
-      buffer[0][wp] = dataL[k] + (float)lookup_waveshape(0, (L[k] * feedback.v));
-      buffer[1][wp] = dataR[k] + (float)lookup_waveshape(0, (R[k] * feedback.v));
+      buffer[0][wp] = dataL[k] + (float)lookup_waveshape(wst_soft, (L[k] * feedback.v));
+      buffer[1][wp] = dataR[k] + (float)lookup_waveshape(wst_soft, (R[k] * feedback.v));
    }
 
    mix.fade_2_blocks_to(dataL, L, dataR, R, dataL, dataR, BLOCK_SIZE_QUAD);

--- a/src/common/dsp/effect/RotarySpeakerEffect.cpp
+++ b/src/common/dsp/effect/RotarySpeakerEffect.cpp
@@ -226,7 +226,7 @@ void RotarySpeakerEffect::process(float* dataL, float* dataR)
       compensateStartsAt = 0.05;
       break;
    }
-   case wst_sinus:
+   case wst_sine:
    {
       gain_tweak = 4.4;
       compensate = 10.f;
@@ -234,7 +234,7 @@ void RotarySpeakerEffect::process(float* dataL, float* dataR)
       square_drive_comp = true;
       break;
    }
-   case wst_digi:
+   case wst_digital:
    {
       gain_tweak = 1.f;
       compensate = 4.f;
@@ -266,7 +266,7 @@ void RotarySpeakerEffect::process(float* dataL, float* dataR)
 
       if (!fxdata->p[rsp_drive].deactivated)
       {
-          input = lookup_waveshape(ws, 0.5f * (dataL[k] + dataR[k]) * drive_factor) * gain_tweak;
+          input = lookup_waveshape(wst_soft + ws, 0.5f * (dataL[k] + dataR[k]) * drive_factor) * gain_tweak;   // ws + 1 to start on wst_soft
           input /= gain_comp_factor;
 
           drive.process();

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -223,7 +223,8 @@ void CLFOGui::draw(CDrawContext* dc)
          {
              path->beginSubpath(xc, val );
              eupath->beginSubpath(xc, euval);
-             if( ! lfodata->unipolar.val.b )
+             if ((lfodata->unipolar.val.b == false) && (lfodata->shape.val.i != lt_envelope) &&
+                 (lfodata->shape.val.i != lt_function)) // TODO FIXME: When function LFO type is added, remove it from this condition!
                 edpath->beginSubpath(xc, edval);
              if( tFullWave ) deactPath->beginSubpath(xc, wval );
              priorval = val;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3004,43 +3004,25 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                auto q = modsource_editor[current_scene];
                auto* lfodata = &(synth->storage.getPatch().scene[current_scene].lfo[q - ms_lfo1]);
 
-               switch (lfodata->shape.val.i) {
-               case lt_sine:
-               case lt_tri:
-               case lt_ramp:
-                   contextMenu->addSeparator(eid++);
+               if (lt_num_deforms[lfodata->shape.val.i] > 1)
+               {
+                  contextMenu->addSeparator(eid++);
 
-                   addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Deform Type 1"), [this, p]() {
-                       p->deform_type = 0;
-                       if (frame)
-                           frame->invalid();
-                   });
-                   contextMenu->checkEntry(eid, (p->deform_type == 0));
-                   eid++;
-               
+                  for (int i; i < lt_num_deforms[lfodata->shape.val.i]; i++)
+                  {
+                     char title[32];
+                     sprintf(title, "Deform Type %d", (i + 1));
 
-
-                   addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Deform Type 2"), [this, p]() {
-                    
-                       p->deform_type = 1;
-                       if (frame)
-                           frame->invalid();
-                   });
-                   contextMenu->checkEntry(eid, (p->deform_type == 1));
-                   eid++;
-
-
-                   addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Deform Type 3"), [this, p]() { 
-                       p->deform_type = 2; 
-                       if (frame)
-                           frame->invalid();
-                       });
-
-                   contextMenu->checkEntry(eid, (p->deform_type == 2));
-                   eid++;
+                     addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu(title), [this, p, i]() {
+                         p->deform_type = i;
+                         if (frame)
+                            frame->invalid();
+                     });
+                     contextMenu->checkEntry(eid, (p->deform_type == i));
+                     eid++;
+                  }
                }
             }
-
 
             if (p->can_extend_range())
             {
@@ -4797,7 +4779,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeLfoMenu(VSTGUI::CRect &menuRect)
    if (lt_envelope == shapev)
       what = "Env";
    if (lt_function == shapev) 
-      what = "Env"; //Change this later
+      what = "Env";     // TODO FIXME: When function LFO type is added, remove it from this condition!
 
    COptionMenu* lfoSubMenu =
        new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
@@ -6043,7 +6025,7 @@ std::string SurgeGUIEditor::modulatorName( int i, bool button )
       if( lfodata->shape.val.i == lt_envelope )
       {
          char txt[64];
-         if( button )
+         if (button)
             sprintf( txt, "%sENV %d", (isS ? "S-" : "" ), fnum + 1 );
          else
             sprintf( txt, "%s Envelope %d", (isS ? "Scene" : "Voice" ), fnum + 1 );
@@ -6052,7 +6034,7 @@ std::string SurgeGUIEditor::modulatorName( int i, bool button )
       else if( lfodata->shape.val.i == lt_stepseq )
       {
          char txt[64];
-         if( button )
+         if (button)
             sprintf( txt, "%sSEQ %d", (isS ? "S-" : "" ), fnum + 1 );
          else
             sprintf( txt, "%s Step Sequencer %d", (isS ? "Scene" : "Voice" ), fnum + 1 );
@@ -6061,7 +6043,7 @@ std::string SurgeGUIEditor::modulatorName( int i, bool button )
       else if( lfodata->shape.val.i == lt_mseg )
       {
          char txt[64];
-         if( button )
+         if (button)
             sprintf( txt, "%sMSEG %d", (isS ? "S-" : "" ), fnum + 1 );
          else
             sprintf( txt, "%s MSEG %d", (isS ? "Scene" : "Voice" ), fnum + 1 );
@@ -6070,7 +6052,9 @@ std::string SurgeGUIEditor::modulatorName( int i, bool button )
       else if( lfodata->shape.val.i == lt_function)
       {
          char txt[64];
-         if( button )
+
+         // TODO FIXME: When function LFO type is added, uncomment the second sprintf and remove the first one!
+         if (button)
             sprintf( txt, "%sENV %d", (isS ? "S-" : "" ), fnum + 1 );
             //sprintf( txt, "%sFUN %d", (isS ? "S-" : "" ), fnum + 1 );
          else


### PR DESCRIPTION
Envelope outline curve is not drawn on bottom for envelope LFO type (since envelope is unipolar)
Cleaner menu creation for deform types in SurgeGUIEditor