### PR TITLE
Default Skin Resolution Name Clash Fix

### DIFF
--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -57,9 +57,11 @@ std::shared_ptr<Skin> SkinDB::defaultSkin(SurgeStorage *storage)
       return getSkin(defaultSkinEntry);
    else
    {
+      auto st = (Entry::RootType)(Surge::Storage::getUserDefaultValue(storage, "defaultSkinRootType", Entry::UNKNOWN ));
+
       for( auto e : availableSkins )
       {
-         if( e.name == uds )
+         if( e.name == uds && ( e.rootType == st || st == Entry::UNKNOWN ))
             return getSkin(e);
       }
       return getSkin(defaultSkinEntry);
@@ -87,6 +89,10 @@ void SkinDB::rescanForSkins(SurgeStorage* storage)
 
    for (auto& source : paths)
    {
+      Entry::RootType rt = Entry::UNKNOWN;
+      if( path_to_string(source) == path_to_string(paths[0]) ) rt = Entry::FACTORY;
+      if( path_to_string(source) == path_to_string(paths[1]) ) rt = Entry::USER;
+
       std::vector<fs::path> alldirs;
       std::deque<fs::path> workStack;
       workStack.push_back(source);
@@ -130,9 +136,11 @@ void SkinDB::rescanForSkins(SurgeStorage* storage)
                auto path = name.substr(0, sp + 1);
                auto lo = name.substr(sp + 1);
                Entry e;
+               e.rootType = rt;
                e.root = path;
                e.name = lo + sep;
                if (e.name.find("default.surge-skin") != std::string::npos &&
+                   rt == Entry::FACTORY &&
                    defaultSkinEntry.name == "")
                {
                   defaultSkinEntry = e;

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -348,6 +348,13 @@ public:
    static SkinDB& get();
 
    struct Entry {
+
+      enum RootType {
+         UNKNOWN,
+         FACTORY,
+         USER
+      } rootType = UNKNOWN;
+
       std::string root;
       std::string name;
       std::string displayName;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -5442,6 +5442,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeSkinMenu(VSTGUI::CRect &menuRect)
              this->synth->refresh_editor = true;
              Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "defaultSkin",
                                                     entry.name);
+             Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "defaultSkinRootType", entry.rootType );
           });
           cb->setChecked(entry.matchesSkin(currentSkin));
           tid++;


### PR DESCRIPTION
Store the root type (factor/user/unk) on a given skin and use
it at resolution to make sure if I have a skin called "foo.surge-skin" in both
factory and user, that I store the one I mean.

Closes #2437