### PR TITLE
Fix a set of Automation problems

### DIFF
--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -419,6 +419,13 @@ public:
    ** if( storage && storage->isStandardTuning ) { }
    */
    SurgeStorage *storage = nullptr;
+
+   static inline float intScaledToFloat( int v, int vmax, int vmin = 0 ) {
+      return 0.005 + 0.99 * ((float)(v - vmin)) / ((float)(vmax - vmin));
+   }
+   static inline int intUnscaledFromFloat( float f, int vmax, int vmin = 0 ) {
+      return (int)((1 / 0.99) * (f - 0.005) * (float)(vmax - vmin) + 0.5) + vmin;
+   }
 };
 
 // I don't make this a member since param needs to be copyable with memcpy.

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1698,7 +1698,7 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
       bool got = false;
       for (int i = 0; i < 8; i++)
       {
-         if (refresh_parameter_queue[i] < 0)
+         if (refresh_parameter_queue[i] < 0 || refresh_parameter_queue[i] == index )
          {
             refresh_parameter_queue[i] = index;
             got = true;

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -22,7 +22,7 @@ void DualDelayEffect::init()
    lfophase = 0.0;
    ringout_time = 100000;
    envf = 0.f;
-   LFOval = 0,f;
+   LFOval = 0.f;
    LFOdirection = true;
    lp.suspend();
    hp.suspend();


### PR DESCRIPTION
1. Automation would fill the refresh_parameter if many messages
   came between idle, which previously would drop messages, but
   now would over-refresh. Two updates on a param between idles is
   the same as one
2. Rounding and integer handling in the idle loop was incorrect for
   fm and filterblock activation
3. In the event of overflow, the wrong codepath ran mis-reactivating
   some sliders. So consolidate the all-changed codepath and the
   some-changed codepath in idle.

Closes #3096