### PR TITLE
Move IntFloat Param conversion to a single spot

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2154,13 +2154,13 @@ void Parameter::get_display(char* txt, bool external, float ef)
    case vt_int:
    {
       if (external)
-         i = (int)((1 / 0.99) * (ef - 0.005) * (float)(val_max.i - val_min.i) + 0.5) + val_min.i;
+         i = Parameter::intUnscaledFromFloat(ef, val_max.i, val_min.i );
       else
          i = val.i;
 
       if( displayType == DelegatedToFormatter )
       {
-         float fv = 0.005 + 0.99 * ((float)(i - val_min.i)) / ((float)(val_max.i - val_min.i));
+         float fv = Parameter::intScaledToFloat(i, val_max.i, val_min.i );
 
          char vt[64];
 
@@ -2492,7 +2492,7 @@ float Parameter::get_value_f01()
       return (val.f - val_min.f) / (val_max.f - val_min.f);
       break;
    case vt_int:
-      return 0.005 + 0.99 * ((float)(val.i - val_min.i)) / ((float)(val_max.i - val_min.i));
+      return Parameter::intScaledToFloat(val.i, val_max.i, val_min.i );
       break;
    case vt_bool:
       return val.b ? 1.f : 0.f;
@@ -2550,8 +2550,7 @@ float Parameter::get_default_value_f01()
       return (val_default.f - val_min.f) / (val_max.f - val_min.f);
       break;
    case vt_int:
-      return 0.005 + 0.99 * ((float)(val_default.i - val_min.i)) / ((float)(val_max.i - val_min.i));
-      // return ((float)(val_default.i-val_min.i))/((float)(val_max.i - val_min.i));
+      return Parameter::intScaledToFloat(val_default.i, val_max.i, val_min.i );
       break;
    case vt_bool:
       return val_default.b ? 1.f : 0.f;
@@ -2568,7 +2567,7 @@ void Parameter::set_value_f01(float v, bool force_integer)
       val.f = v * (val_max.f - val_min.f) + val_min.f;
       break;
    case vt_int:
-      val.i = (int)((1 / 0.99) * (v - 0.005) * (float)(val_max.i - val_min.i) + 0.5) + val_min.i;
+      val.i = Parameter::intUnscaledFromFloat(v, val_max.i, val_min.i );
       break;
    case vt_bool:
       val.b = (v > 0.5f);

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -420,6 +420,12 @@ public:
    */
    SurgeStorage *storage = nullptr;
 
+   /*
+    * These are definitions which surge has used since time immemorial. If you
+    * change them you will break saved automation states in projects, so we stuck
+    * with the somewhat odd 99 and 005 but put them all in one place and used the
+    * consistently.
+    */
    static inline float intScaledToFloat( int v, int vmax, int vmin = 0 ) {
       return 0.005 + 0.99 * ((float)(v - vmin)) / ((float)(vmax - vmin));
    }

--- a/src/common/gui/CMenuAsSlider.cpp
+++ b/src/common/gui/CMenuAsSlider.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include "SkinColors.h"
 #include "DebugHelpers.h"
+#include "Parameter.h"
 
 using namespace VSTGUI;
 
@@ -236,8 +237,7 @@ CMouseEventResult CMenuAsSlider::onMouseMoved( CPoint &w, const CButtonState &bu
          iv = iv + inc;
          if( iv < 0 ) iv = iMax;
          if( iv > iMax ) iv = 0;
-         // This is the get_value_f01 code
-         float r = 0.005 + 0.99 * ( iv - iMin ) / ( float) ( iMax - iMin );
+         float r = Parameter::intScaledToFloat(iv, iMax, iMin );
          setValue( r );
          if( listener )
             listener->valueChanged(this);
@@ -293,7 +293,7 @@ bool CMenuAsSlider::onWheel( const VSTGUI::CPoint &where, const float &distance,
                    if( iv < 0 ) iv = iMax;
                    if( iv > iMax ) iv = 0;
                    // This is the get_value_f01 code
-                   float r = 0.005 + 0.99 * ( iv - iMin ) / ( float) ( iMax - iMin );
+                   float r = Parameter::intScaledToFloat(iv, iMax, iMin );
                    return r;
                 };
 

--- a/src/common/gui/CNumberField.cpp
+++ b/src/common/gui/CNumberField.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include "SkinColors.h"
 #include "CScalableBitmap.h"
+#include "Parameter.h"
 
 using namespace VSTGUI;
 
@@ -260,7 +261,7 @@ void CNumberField::setControlMode(int mode)
 void CNumberField::setValue(float val)
 {
    CControl::setValue(val);
-   i_value = (int)((1 / 0.99) * (val - 0.005) * (float)(i_max - i_min) + 0.5) + i_min;
+   i_value = Parameter::intUnscaledFromFloat(val, i_max, i_min );
    setDirty();
 }
 
@@ -648,10 +649,8 @@ CMouseEventResult CNumberField::onMouseMoved(CPoint& where, const CButtonState& 
       }
       
       value += delta * 0.01;
-      // i_value = i_min + (int)(value*((float)(i_max - i_min)));
-      i_value = (int)((1.f / 0.99f) * (value - 0.005f) * (float)(i_max - i_min) + 0.5) + i_min;
+      i_value = Parameter::intUnscaledFromFloat(value, i_max, i_min );
 
-      
       bounceValue();
       invalid();
       if (listener)
@@ -674,7 +673,7 @@ bool CNumberField::onWheel(const CPoint& where, const float& distance, const CBu
       value += distance / (i_max - i_min) * mouseFactor;
    
 
-   i_value = (int)((1.f / 0.99f) * (value - 0.005f) * (float)(i_max - i_min) + 0.5) + i_min;
+   i_value = Parameter::intUnscaledFromFloat(value, i_max, i_min );
    bounceValue();
    invalid();
    setDirty();

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4074,7 +4074,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
                   im = cs2->getIValue();
                   if( im == 3 ) im = 2;
                   else if( im == 2 ) im = 3;
-                  val = 0.005 + 0.99 * ( (float)( im ) / (n_scenemodes-1) );
+                  val = Parameter::intScaledToFloat(im, n_scenemodes-1);
                }
 
                /*
@@ -6981,7 +6981,7 @@ VSTGUI::CControl *SurgeGUIEditor::layoutComponentForSkin( std::shared_ptr<Surge:
                   guiscenemode = 2;
                else if (guiscenemode == 2)
                   guiscenemode = 3;
-               fval = 0.005 + 0.99 * ((float)(guiscenemode) / (n_scenemodes - 1));
+               fval = Parameter::intScaledToFloat(guiscenemode, n_scenemodes-1);
             }
             hsw->setValue( fval );
          }


### PR DESCRIPTION
That 0.005 + 0.99* blah code was all over the place and caused automation and other errors if mis-used.
Make it a function. Apply the function everywhere.
Closes #3189