### PR TITLE
MSEG LFO Mode and Other Fixes

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -765,6 +765,7 @@ struct MSEGStorage {
    std::array<float, max_msegs> segmentStart, segmentEnd;
    float durationToLoopEnd;
    float durationLoopStartToLoopEnd;
+   float envelopeModeDuration = -1;
 
    static constexpr float minimumDuration = 0.0;
 };

--- a/src/common/dsp/MSEGModulationHelper.h
+++ b/src/common/dsp/MSEGModulationHelper.h
@@ -52,6 +52,9 @@ namespace Surge
       void deleteSegment( MSEGStorage *s, float t );
       void deleteSegment( MSEGStorage *s, int idx );
 
+      void adjustDurationShiftingSubsequent( MSEGStorage *s, int idx, float dx, float snap = 0);
+      void adjustDurationConstantTotalDuration( MSEGStorage *s, int idx, float dx, float snap = 0);
+
       void resetControlPoint( MSEGStorage *s, float t );
       void resetControlPoint( MSEGStorage *s, int idx );
       void constrainControlPointAt( MSEGStorage *s, int idx );
@@ -60,5 +63,7 @@ namespace Surge
       void scaleValues(MSEGStorage* s, float factor);
       void setAllDurationsTo(MSEGStorage* s, float value);
       void mirrorMSEG(MSEGStorage* s);
+
+      void modifyEditMode( MSEGStorage *s, MSEGStorage::EditMode mode );
    }
 }


### PR DESCRIPTION
Addresses #2966

1. Draw endpoints together at the end give you points
2. LFO Mode: Swapping compresses and decompresses
3. Move the duration offset functions into the MSEGModHelper
   so we can adapt them
4. Constraints preserved on draw mode moves