### PR TITLE
Linux Fixes to MSEG and Copy

### DIFF
--- a/installer_linux/make_deb.sh
+++ b/installer_linux/make_deb.sh
@@ -60,7 +60,7 @@ Package: ${PACKAGE_NAME}
 Version: $DEB_VERSION
 Architecture: amd64
 Maintainer: surgeteam <noreply@github.com>
-Depends: libcairo2, libfontconfig1, libfreetype6, libx11-6, libxcb-cursor0, libxcb-util1, libxcb-xkb1, libxcb1, libxkbcommon-x11-0, libxkbcommon0, fonts-lato, xdg-utils, zenity
+Depends: libcairo2, libfontconfig1, libfreetype6, libx11-6, libxcb-cursor0, libxcb-util1, libxcb-xkb1, libxcb1, libxkbcommon-x11-0, libxkbcommon0, fonts-lato, xdg-utils, zenity, xclip
 Provides: vst-plugin
 Section: sound
 Priority: optional

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -1264,6 +1264,7 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
                   dragY *= 0.05;
                }
                h.onDrag( dragX, dragY, where );
+#if ! LINUX
                float dx = where.x - cursorHideOrigin.x;
                float dy = where.y - cursorHideOrigin.y;
                if( dx * dx + dy * dy > 100 )
@@ -1275,6 +1276,9 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
                {
                   mouseDownOrigin = where;
                }
+#else
+               mouseDownOrigin = where;
+#endif
                modelChanged(); // HACK FIXME
                break;
             }


### PR DESCRIPTION
1. Since Linux doesn't mouse hide, don't reposition the hidden
   cursor, fail to do so, but adjust internal state anyway.
2. put xclip in the deb

Closes #3211