### PR TITLE
Help URL in MSEG; Temp Cubase-only Zoom Fix

### DIFF
--- a/resources/data/paramdocumentation.xml
+++ b/resources/data/paramdocumentation.xml
@@ -15,6 +15,7 @@
   <special id="zoom-menu" help_url="#zoom"/>
   <special id="patch-browser" help_url="#patch-browser"/>
   <special id="wavetables" help_url="#wavetable"/>
+  <special id="mseg-editor" help_url="#mseg-editor"/>
 
   <special id="macro-modbutton" help_url="#assignable-controllers"/>
   <special id="lfo-modbutton" help_url="#lfos"/>

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -46,12 +46,13 @@ struct MSEGCanvas;
 
 // This is 720 x 120
 struct MSEGControlRegion : public CViewContainer, public Surge::UI::SkinConsumingComponent, public VSTGUI::IControlListener {
-   MSEGControlRegion(const CRect &size, MSEGCanvas *c, LFOStorage *lfos, MSEGStorage *ms, MSEGEditor::State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b ): CViewContainer( size ) {
+   MSEGControlRegion(const CRect &size, MSEGCanvas *c, SurgeStorage *storage, LFOStorage *lfos, MSEGStorage *ms, MSEGEditor::State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b ): CViewContainer( size ) {
       setSkin( skin, b );
       this->ms = ms;
       this->eds = eds;
       this->lfodata = lfos;
       this->canvas = c;
+      this->storage = storage;
       setBackgroundColor(skin->getColor(Colors::MSEGEditor::Panel));
       rebuild();
    };
@@ -81,6 +82,7 @@ struct MSEGControlRegion : public CViewContainer, public Surge::UI::SkinConsumin
    MSEGEditor::State *eds = nullptr;
    MSEGCanvas *canvas = nullptr;
    LFOStorage *lfodata = nullptr;
+   SurgeStorage *storage = nullptr;
 };
 
 
@@ -1773,7 +1775,13 @@ int32_t MSEGControlRegion::controlModifierClicked(CControl* pControl, CButtonSta
          com->addEntry(menu);
          return menu;
       };
-      addcb( "[?] " + menuName, [](){} );
+      auto msurl = SurgeGUIEditor::helpURLForSpecial(storage, "mseg-editor" );
+      auto hurl = SurgeGUIEditor::fullyResolvedHelpURL( msurl );
+
+      addcb( "[?] " + menuName, [hurl](){
+         std::cout << "OPENING " << hurl << std::endl;
+         Surge::UserInteractions::openURL(hurl);
+      } );
       com->addSeparator();
       if( isOnOff )
       {
@@ -1980,7 +1988,7 @@ void MSEGControlRegion::rebuild()
 
 struct MSEGMainEd : public CViewContainer {
 
-   MSEGMainEd(const CRect &size, LFOStorage *lfodata, MSEGStorage *ms, MSEGEditor::State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> bmp) : CViewContainer(size) {
+   MSEGMainEd(const CRect &size, SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, MSEGEditor::State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> bmp) : CViewContainer(size) {
       this->ms = ms;
       this->skin = skin;
 
@@ -1989,7 +1997,7 @@ struct MSEGMainEd : public CViewContainer {
       auto msegCanv = new MSEGCanvas( CRect( CPoint( 0, 0 ), CPoint( size.getWidth(), size.getHeight() - controlHeight ) ), lfodata, ms, eds, skin, bmp );
             
       auto msegControl = new MSEGControlRegion(CRect( CPoint( 0, size.getHeight() - controlHeight ), CPoint(  size.getWidth(), controlHeight ) ), msegCanv,
-                                               lfodata, ms, eds, skin, bmp );
+                                               storage, lfodata, ms, eds, skin, bmp );
 
 
       msegCanv->controlregion = msegControl;
@@ -2004,12 +2012,12 @@ struct MSEGMainEd : public CViewContainer {
 
 };
 
-MSEGEditor::MSEGEditor(LFOStorage *lfodata, MSEGStorage *ms, State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b) : CViewContainer( CRect( 0, 0, 750, 365) )
+MSEGEditor::MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b) : CViewContainer( CRect( 0, 0, 750, 365) )
 {
    // Leave these in for now
    setSkin( skin, b );
    setBackgroundColor( kRedCColor );
-   addView( new MSEGMainEd( getViewSize(), lfodata, ms, eds, skin, b ) );
+   addView( new MSEGMainEd( getViewSize(), storage, lfodata, ms, eds, skin, b ) );
 }
 
 MSEGEditor::~MSEGEditor() {

--- a/src/common/gui/MSEGEditor.h
+++ b/src/common/gui/MSEGEditor.h
@@ -23,6 +23,6 @@ struct MSEGEditor : public VSTGUI::CViewContainer, public Surge::UI::SkinConsumi
       float vSnap = 0, hSnap = 0, vSnapDefault = 0.25, hSnapDefault = 0.125;
       int timeEditMode = 0;
    };
-   MSEGEditor(LFOStorage *lfodata, MSEGStorage *ms, State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b);
+   MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b);
    ~MSEGEditor();
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -6315,6 +6315,11 @@ std::string SurgeGUIEditor::helpURLFor( Parameter *p )
 std::string SurgeGUIEditor::helpURLForSpecial( std::string key )
 {
    auto storage = &(synth->storage);
+   return helpURLForSpecial( storage, key );
+}
+
+std::string SurgeGUIEditor::helpURLForSpecial( SurgeStorage *storage, std::string key )
+{
    if( storage->helpURL_specials.find(key) != storage->helpURL_specials.end() )
    {
       auto r = storage->helpURL_specials[key];
@@ -6323,7 +6328,6 @@ std::string SurgeGUIEditor::helpURLForSpecial( std::string key )
    }
    return "";
 }
-
 std::string SurgeGUIEditor::fullyResolvedHelpURL( std::string helpurl )
 {
    std::string lurl = helpurl;
@@ -7331,7 +7335,7 @@ void SurgeGUIEditor::showMSEGEditor()
    auto lfo_id = modsource_editor[current_scene] - ms_lfo1;
    auto lfodata = &synth->storage.getPatch().scene[current_scene].lfo[lfo_id];
    auto ms = &synth->storage.getPatch().msegs[current_scene][lfo_id];
-   auto mse = new MSEGEditor(lfodata, ms, &msegEditState[lfo_id], currentSkin, bitmapStore);
+   auto mse = new MSEGEditor(&(synth->storage), lfodata, ms, &msegEditState[lfo_id], currentSkin, bitmapStore);
    auto vs = mse->getViewSize().getWidth();
    float xp = (currentSkin->getWindowSizeX() - (vs + 8)) * 0.5;
 

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -499,9 +499,11 @@ private:
    void resetPitchSmoothing(ControllerModulationSource::SmoothingMode t);
 
 public:
-   std::string helpURLFor( Parameter *p );
-   std::string helpURLForSpecial( std::string special );
-   std::string fullyResolvedHelpURL( std::string helpurl );
+   std::string helpURLFor( Parameter *p ); // this requires internal state so doesn't have statics
+   std::string helpURLForSpecial( std::string special ); // these can be either this way or static
+
+   static std::string helpURLForSpecial( SurgeStorage *, std::string special );
+   static std::string fullyResolvedHelpURL( std::string helpurl );
 
 private:
 


### PR DESCRIPTION
1. MSEG help menu goes to manual. We need the docs still tho. Closes #3221
2. Limit zoom fix to cubase for now. Closes #3225 but need a better fix