### PR TITLE
instanceZoomFactor should also work when when user chooses 100%

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -797,7 +797,7 @@ struct DAWExtraStateStorage
     */
    struct EditorState
    {
-      int instanceZoomFactor = 100;
+      int instanceZoomFactor = -1;
       int current_scene = 0;
       int current_fx = 0;
       int current_osc[n_scenes] = {0};

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -276,8 +276,8 @@ SurgeGUIEditor::SurgeGUIEditor(PARENT_PLUGIN_TYPE* effect, SurgeSynthesizer* syn
 
    // init the size of the plugin
    initialZoomFactor = Surge::Storage::getUserDefaultValue(&(synth->storage), "defaultZoom", 100);
-   auto instanceZoomFactor = synth->storage.getPatch().dawExtraState.editor.instanceZoomFactor;
-   if(instanceZoomFactor != 100)
+   int instanceZoomFactor = synth->storage.getPatch().dawExtraState.editor.instanceZoomFactor;
+   if(instanceZoomFactor > 0)
    {
 	   // dawExtraState zoomFactor wins defaultZoom
 	   initialZoomFactor = instanceZoomFactor;


### PR DESCRIPTION
Corner case bugfix.

If user has set their default zoom to anything else than 100% and then resize back to 100% - save the DAW project - instanceZoomFactor still needs to work on reopening the project.