### PR TITLE
Add pole tapping to Diode Ladder filter

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2231,6 +2231,7 @@ void Parameter::get_display(char* txt, bool external, float ef)
                   else switch (type)
                   {
                   case fut_lpmoog:
+                  case fut_diode:
                      sprintf(txt, "%s", fut_ldr_subtypes[i]);
                      break;
                   case fut_bp12:
@@ -2254,9 +2255,6 @@ void Parameter::get_display(char* txt, bool external, float ef)
                   case fut_k35_lp:
                   case fut_k35_hp:
                      sprintf(txt, "%s", fut_k35_subtypes[i]);
-                     break;
-                  case fut_diode:
-                     sprintf(txt, "%s", fut_diode_subtypes[i]);
                      break;
 #if SURGE_EXTRA_FILTERS
 #endif

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -522,11 +522,6 @@ const float fut_k35_saturations[5] =
    4.0f
 };
 
-const char fut_diode_subtypes[1][32] =
-{
-   "24 dB/oct"
-};
-
 const int fut_subcount[n_fu_types] =
 {
    0, // fut_none
@@ -544,7 +539,7 @@ const int fut_subcount[n_fu_types] =
    4, // fut_obxd_4pole
    5, // fut_k35_lp
    5, // fut_k35_hp
-   0  // fut_diode
+   4  // fut_diode
 };
 
 enum fu_subtype

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1564,7 +1564,6 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
             case fut_comb:
             default:
                storage.getPatch().param_ptr[index + 1]->val.i = 0;
-               storage.getPatch().param_ptr[index + 1]->val.i = 0;
                break;
             }
          }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1559,6 +1559,7 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
             {
             case fut_lpmoog:
             case fut_obxd_4pole:
+            case fut_diode:
                storage.getPatch().param_ptr[index + 1]->val.i = 3;
                break;
             case fut_comb:

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1028,10 +1028,12 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
 
             Q->FU[u].DB[e] = FBP.Delay[u];
             Q->FU[u].WP[e] = FBP.FU[u].WP;
-            if (scene->filterunit[u].type.val.i == fut_lpmoog)
+            if (scene->filterunit[u].type.val.i == fut_lpmoog || scene->filterunit[u].type.val.i == fut_diode)
+            {
                Q->FU[u].WP[0] =
                    scene->filterunit[u].subtype.val.i; // LPMoog's output stage index is stored in
                                                        // WP[0] for the entire quad
+            }
 
             if (scene->filterblock_configuration.val.i == fc_wide)
             {
@@ -1048,8 +1050,10 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
 
                Q->FU[u + 2].DB[e] = FBP.Delay[u + 2];
                Q->FU[u + 2].WP[e] = FBP.FU[u].WP;
-               if (scene->filterunit[u].type.val.i == fut_lpmoog)
+               if (scene->filterunit[u].type.val.i == fut_lpmoog || scene->filterunit[u].type.val.i == fut_diode)
+               {
                   Q->FU[u + 2].WP[0] = scene->filterunit[u].subtype.val.i;
+               }
             }
          }
       }

--- a/src/common/dsp/filters/DiodeLadder.cpp
+++ b/src/common/dsp/filters/DiodeLadder.cpp
@@ -185,9 +185,20 @@ namespace DiodeLadderFilter
             getFO(beta2,   hg, feedback2, f->R[dlf_z2]), f->R[dlf_z2]);
       const __m128 result3 = doLpf(result2, f->C[dlf_alpha], beta3, gamma3,   hg, f->C[dlf_G4], half, feedback3,
             getFO(beta3,   hg, feedback3, f->R[dlf_z3]), f->R[dlf_z3]);
-      const __m128 result  = doLpf(result3, f->C[dlf_alpha], beta4,    one, zero,         zero, half, zero,
+      const __m128 result4 = doLpf(result3, f->C[dlf_alpha], beta4,    one, zero,         zero, half, zero,
             getFO(beta4, zero,      zero, f->R[dlf_z4]), f->R[dlf_z4]);
 
-      return result;
+      // copying the QuadFilterUnit.cpp/LPMOOGquad implementation here.
+      // Means that the whole quad will return the same subtype... but apparently This Is Fine.
+      switch(f->WP[0] & 3){
+         case 0:
+            return result1; // 6dB/oct
+         case 1:
+            return result2; // 12dB/oct
+         case 2:
+            return result3; // 18dB/oct
+         default:
+            return result4;  // 24dB/oct
+      }
    }
 }


### PR DESCRIPTION
Add pole tapping to the Diode Ladder filter, same as Legacy Ladder.

Note that the whole quad will return the same tapped pole, also same as in Legacy Ladder.

Which... seems to be fine. It's a little freaky to see in SIMD code though.