### PR TITLE
Add a correct comb tuning option

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1768,6 +1768,21 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
          }
       }
    }
+
+   TiXmlElement *compat = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("compatability"));
+   correctlyTuneCombFilter = streamingRevision >= 14; // Tune correctly for all releases 18 and later
+   if( compat )
+   {
+      auto comb = TINYXML_SAFE_TO_ELEMENT(compat->FirstChild("correctlyTuneCombFilter"));
+      if (comb)
+      {
+         int i;
+         if( comb->QueryIntAttribute( "v", &i ) == TIXML_SUCCESS )
+         {
+            correctlyTuneCombFilter = i != 0;
+         }
+      }
+   }
 }
 
 struct srge_header
@@ -1970,6 +1985,16 @@ unsigned int SurgePatch::save_xml(void** data) // allocates mem, must be freed b
          mw.SetAttribute(str, float_to_str(((ControllerModulationSource*)scene[sc].modsources[ms_modwheel])->target, txt));
       }
       patch.InsertEndChild(mw);
+   }
+
+   {
+      TiXmlElement compat("compatability");
+
+      TiXmlElement comb( "correctlyTunedCombFilter" );
+      comb.SetAttribute( "v", correctlyTuneCombFilter ? 1 : 0 );
+      compat.InsertEndChild( comb );
+
+      patch.InsertEndChild(compat);
    }
 
    if( patchTuning.tuningStoredInPatch )

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -76,8 +76,9 @@ const int n_fx_slots=8;
 // 10 -> 11 (1.6.2 release) added DAW Extra State
 // 11 -> 12 (1.6.3 release) added new parameters to the Distortion effect
 // 12 -> 13 (1.7.0 release) deactivation; sine LP/HP, sine/FM2/3 feedback extension/bipolar
-// 13 -> 14 add phaser number of stages parameter
-// 13 -> 14 add ability to configure vocoder modulator mono/sterao/L/R
+// 13 -> 14 (1.8.0 release) add phaser number of stages parameter
+//                          add ability to configure vocoder modulator mono/sterao/L/R
+//                          add comb filter tuning and compat block
 
 const int ff_revision = 14;
 
@@ -899,6 +900,17 @@ public:
 
    int streamingRevision;
    int currentSynthStreamingRevision;
+
+   /*
+   * This parameter exists for the very special reason of maintaing compatability with
+   * comb filter tuning for streaming versions which are older than the 1.8 vingate surge.
+   * Prior to that the comb filter had a calculation error in the time and was out of tume
+   * but that lead toa unique sound in some classic patches. So we introduce this parameter
+   * which allows us to leave old patchs mis-tuned in FilterCoefficientMaker and is handled
+   * properly at stream time and so on.
+   */
+   bool correctlyTuneCombFilter = true;
+
 };
 
 struct Patch

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -434,9 +434,13 @@ void FilterCoefficientMaker::Coeff_LP4L(float freq, float reso, int subtype)
 
 void FilterCoefficientMaker::Coeff_COMB(float freq, float reso, int subtype)
 {
-   float dtime = (1.f / 440.f) * storage->note_to_pitch_ignoring_tuning(-freq);
-   dtime = dtime * dsamplerate_os -
-           FIRoffset; // 1 sample for feedback, 1 sample for the IIR-filter without resonance
+   float dtime = (1.f / 440.f) * storage->note_to_pitch_inv_ignoring_tuning(freq);
+   dtime = dtime * dsamplerate_os;
+
+   // See comment in SurgeStorage and issue #3248
+   if( ! storage->_patch->correctlyTuneCombFilter)
+      dtime -= FIRoffset;
+
    dtime = limit_range(dtime, (float)FIRipol_N, (float)MAX_FB_COMB - FIRipol_N);
    reso = ((subtype & 2) ? -1.0f : 1.0f) * limit_range(reso, 0.f, 1.f);
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2781,8 +2781,16 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
 
                // currently we only have this case with filter subtypes - different filter types have a different number of them
                // so let's do this!
+               bool isCombOnSubtype = false;
                if (p->ctrltype == ct_filtersubtype)
-                  max = fut_subcount[synth->storage.getPatch().scene[current_scene].filterunit[p->ctrlgroup_entry].type.val.i] - 1;
+               {
+                  if( synth->storage.getPatch().scene[current_scene].filterunit[p->ctrlgroup_entry].type.val.i == fut_comb )
+                     isCombOnSubtype = true;
+                  max = fut_subcount[synth->storage.getPatch()
+                                         .scene[current_scene]
+                                         .filterunit[p->ctrlgroup_entry]
+                                         .type.val.i] - 1;
+               }
 
                auto dm = dynamic_cast<ParameterDiscreteIndexRemapper*>( p->user_data );
 
@@ -2860,6 +2868,15 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                      eid++;
                      if( i == p->val.i )
                         b->setChecked(true);
+                  }
+                  if( isCombOnSubtype )
+                  {
+                     contextMenu->addSeparator();
+                     auto m = addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Correctly Tune Comb Filter" ),
+                                              [this]() {
+                                                 synth->storage.getPatch().correctlyTuneCombFilter = ! synth->storage.getPatch().correctlyTuneCombFilter;
+                                              });
+                     m->setChecked( synth->storage.getPatch().correctlyTuneCombFilter);
                   }
                }
             }


### PR DESCRIPTION
The comb filter is tuned incorrectly. Rather than correct it
globally, add a flag which is false for stremaing versions < 14
and user togglable and saved in the patch and defaults true.
Use this to fix the comb tuning.

Closes #3248.