### PR TITLE
Add Nonlinear Feedback Lowpass Filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ set(SURGE_SHARED_SOURCES
   src/common/dsp/filters/Obxd.cpp
   src/common/dsp/filters/K35.cpp
   src/common/dsp/filters/DiodeLadder.cpp
+  src/common/dsp/filters/NonlinearFeedback.cpp
   src/common/dsp/AudioInputOscillator.cpp
   src/common/dsp/BiquadFilter.cpp
   src/common/dsp/BiquadFilterSSE2.cpp

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2255,6 +2255,9 @@ void Parameter::get_display(char* txt, bool external, float ef)
                   case fut_k35_hp:
                      sprintf(txt, "%s", fut_k35_subtypes[i]);
                      break;
+                  case fut_nonlinearfb:
+                     sprintf(txt, "%s", fut_nlf_subtypes[i]);
+                     break;
 #if SURGE_EXTRA_FILTERS
 #endif
                   default:

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -525,10 +525,12 @@ const float fut_k35_saturations[5] =
    4.0f
 };
 
-const char fut_nlf_subtypes[2][32] =
+const char fut_nlf_subtypes[4][32] =
 {
-   "12 dB/oct",
-   "24 dB/oct",
+   "1 stage (12dB/oct)",
+   "2 stages",
+   "3 stages",
+   "4 stages",
 };
 
 const int fut_subcount[n_fu_types] =
@@ -549,7 +551,7 @@ const int fut_subcount[n_fu_types] =
    5, // fut_k35_lp
    5, // fut_k35_hp
    4, // fut_diode
-   2  // fut_nonlinearfb
+   4  // fut_nonlinearfb
 };
 
 enum fu_subtype

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -413,6 +413,7 @@ enum fu_type
    fut_k35_lp,
    fut_k35_hp,
    fut_diode,
+   fut_nonlinearfb,
 
    n_fu_types,
 };
@@ -434,6 +435,7 @@ const char fut_names[n_fu_types][32] =
    "K35 Lowpass",
    "K35 Highpass",
    "Diode Ladder",
+   "Nonlinear Feedback"
 };
 
 const char fut_bp_subtypes[6][32] =
@@ -523,6 +525,12 @@ const float fut_k35_saturations[5] =
    4.0f
 };
 
+const char fut_nlf_subtypes[2][32] =
+{
+   "12 dB/oct",
+   "24 dB/oct",
+};
+
 const int fut_subcount[n_fu_types] =
 {
    0, // fut_none
@@ -540,7 +548,8 @@ const int fut_subcount[n_fu_types] =
    4, // fut_obxd_4pole
    5, // fut_k35_lp
    5, // fut_k35_hp
-   4  // fut_diode
+   4, // fut_diode
+   2  // fut_nonlinearfb
 };
 
 enum fu_subtype

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -6,6 +6,7 @@
 #include "filters/Obxd.h"
 #include "filters/K35.h"
 #include "filters/DiodeLadder.h"
+#include "filters/NonlinearFeedback.h"
 
 using namespace std;
 
@@ -96,6 +97,9 @@ void FilterCoefficientMaker::MakeCoeffs(
       break;
    case fut_diode:
       DiodeLadderFilter::makeCoefficients(this, Freq, Reso, storageI);
+      break;
+   case fut_nonlinearfb:
+      NonlinearFeedbackFilter::makeCoefficients(this, Freq, Reso, storageI);
       break;
 #if SURGE_EXTRA_FILTERS
 #endif      

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -8,6 +8,7 @@
 #include "filters/Obxd.h"
 #include "filters/K35.h"
 #include "filters/DiodeLadder.h"
+#include "filters/NonlinearFeedback.h"
 
 __m128 SVFLP12Aquad(QuadFilterUnitState* __restrict f, __m128 in)
 {
@@ -811,6 +812,8 @@ FilterUnitQFPtr GetQFPtrFilterUnit(int type, int subtype)
    case fut_diode:
       return DiodeLadderFilter::process;
       break;
+   case fut_nonlinearfb:
+      return NonlinearFeedbackFilter::process;
    default:
       // SOFTWARE ERROR
       break;

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1028,7 +1028,9 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
 
             Q->FU[u].DB[e] = FBP.Delay[u];
             Q->FU[u].WP[e] = FBP.FU[u].WP;
-            if (scene->filterunit[u].type.val.i == fut_lpmoog || scene->filterunit[u].type.val.i == fut_diode)
+            if (scene->filterunit[u].type.val.i == fut_lpmoog ||
+                scene->filterunit[u].type.val.i == fut_diode  ||
+                scene->filterunit[u].type.val.i == fut_nonlinearfb)
             {
                Q->FU[u].WP[0] =
                    scene->filterunit[u].subtype.val.i; // LPMoog's output stage index is stored in
@@ -1050,7 +1052,9 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
 
                Q->FU[u + 2].DB[e] = FBP.Delay[u + 2];
                Q->FU[u + 2].WP[e] = FBP.FU[u].WP;
-               if (scene->filterunit[u].type.val.i == fut_lpmoog || scene->filterunit[u].type.val.i == fut_diode)
+               if (scene->filterunit[u].type.val.i == fut_lpmoog ||
+                   scene->filterunit[u].type.val.i == fut_diode  ||
+                   scene->filterunit[u].type.val.i == fut_nonlinearfb)
                {
                   Q->FU[u + 2].WP[0] = scene->filterunit[u].subtype.val.i;
                }

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -41,7 +41,7 @@ static inline __m128 doLpf(
    noexcept
 {
    // out = z1 + b0 * input
-   const __m128 out = z1 + M(b0, input);
+   const __m128 out = A(z1, M(b0, input));
    // nonlinear feedback = tanh(out)
    const __m128 nf  = Surge::DSP::fasttanhSSEclamped(out);
    // z1 = z2 + b1 * input - a1 * nf

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -1,0 +1,124 @@
+#include "globals.h"
+#include "K35.h"
+#include "QuadFilterUnit.h"
+#include "FilterCoefficientMaker.h"
+#include "DebugHelpers.h"
+#include "SurgeStorage.h"
+#include "vt_dsp/basic_dsp.h"
+#include "FastMath.h"
+
+/*
+** This contains an adaptation of the filter found at
+** https://ccrma.stanford.edu/~jatin/ComplexNonlinearities/NLFeedback.html
+** with coefficient calculation at
+** https://github.com/jatinchowdhury18/audio_dspy/blob/master/audio_dspy/eq_design.py
+*/
+
+static float clampedFrequency( float pitch, SurgeStorage *storage )
+{
+   auto freq = storage->note_to_pitch_ignoring_tuning( pitch + 69 ) * Tunings::MIDI_0_FREQ;
+   freq = limit_range( (float)freq, 5.f, (float)( dsamplerate_os * 0.3f ) );
+   return freq;
+}
+
+#define F(a) _mm_set_ps1( a )         
+#define M(a,b) _mm_mul_ps( a, b )
+#define D(a,b) _mm_div_ps( a, b )
+#define A(a,b) _mm_add_ps( a, b )
+#define S(a,b) _mm_sub_ps( a, b )
+// reciprocal
+#define reci(a) _mm_rcp_ps( a )
+
+// n.b. b2 was always equal to b0, so it has been optimised out
+static inline __m128 doLpf(
+      const __m128 input,
+      const __m128 a1,
+      const __m128 a2,
+      const __m128 b0,
+      const __m128 b1,
+      __m128 &z1,
+      __m128 &z2)
+   noexcept
+{
+   // out = z1 + b0 * input
+   const __m128 out = z1 + M(b0, input);
+   // nonlinear feedback = tanh(out)
+   const __m128 nf  = Surge::DSP::fasttanhSSEclamped(out);
+   // z1 = z2 + b1 * input - a1 * nf
+   z1 = A(z2, S(M(b1, input), M(a1, nf)));
+   // z2 = b2 * input - a2 * nf
+   z2 = S(M(b0, input), M(a2, nf));
+   return out;
+}
+
+namespace NonlinearFeedbackFilter
+{
+   enum nlf_coeffs { 
+      nlf_a1 = 0,
+      nlf_a2,
+      nlf_b0,
+      nlf_b1
+   };
+
+   enum dlf_state {
+      nlf_z1, // 1st z-1 state for first stage
+      nlf_z2, // 2nd z-1 state for first stage
+      nlf_z3, // 1st z-1 state for second stage
+      nlf_z4  // 2nd z-1 state for second stage
+   };
+
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, SurgeStorage *storage )
+   {
+      float C[n_cm_coeffs];
+
+      const float  wc = M_PI * clampedFrequency(freq, storage) / dsamplerate_os;
+      const float   c = 1.0 / Surge::DSP::fasttan(wc);
+      const float phi = c * c;
+      const float   K = c / (reso * 10.0 + 0.1);
+
+      const float  a0 = phi + K + 1.0;
+      
+      C[nlf_a1] = 2.0 * (1.0 - phi) / a0;
+      C[nlf_a2] = (phi - K + 1.0) / a0;
+      C[nlf_b0] = 1.0 / a0;
+      C[nlf_b1] = 2.0 / a0;
+
+      cm->FromDirect(C);
+   }
+
+#define process_coeffs() \
+   for(int i=0; i < n_cm_coeffs; ++i){ \
+      f->C[i] = A(f->C[i], f->dC[i]); \
+   }
+
+   __m128 process( QuadFilterUnitState * __restrict f, __m128 input )
+   {
+      process_coeffs();
+
+      const __m128 result1 =
+         doLpf(input,
+               f->C[nlf_a1],
+               f->C[nlf_a2],
+               f->C[nlf_b0],
+               f->C[nlf_b1],
+               f->R[nlf_z1],
+               f->R[nlf_z2]);
+
+      if(f->WP[0] == 0){ // if 12dB/oct
+         // then we're done, return result1
+         return result1;
+      }
+
+      // otherwise we calculate and return the second stage
+      const __m128 result2 =
+         doLpf(result1,
+               f->C[nlf_a1],
+               f->C[nlf_a2],
+               f->C[nlf_b0],
+               f->C[nlf_b1],
+               f->R[nlf_z3],
+               f->R[nlf_z4]);
+
+      return result2;
+   }
+}

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -61,10 +61,14 @@ namespace NonlinearFeedbackFilter
    };
 
    enum dlf_state {
-      nlf_z1, // 1st z-1 state for first stage
-      nlf_z2, // 2nd z-1 state for first stage
+      nlf_z1, // 1st z-1 state for first  stage
+      nlf_z2, // 2nd z-1 state for first  stage
       nlf_z3, // 1st z-1 state for second stage
-      nlf_z4  // 2nd z-1 state for second stage
+      nlf_z4, // 2nd z-1 state for second stage
+      nlf_z5, // 1st z-1 state for third  stage
+      nlf_z6, // 2nd z-1 state for third  stage
+      nlf_z7, // 1st z-1 state for fourth stage
+      nlf_z8  // 2nd z-1 state for fourth stage
    };
 
    void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, SurgeStorage *storage )
@@ -104,7 +108,7 @@ namespace NonlinearFeedbackFilter
                f->R[nlf_z1],
                f->R[nlf_z2]);
 
-      if(f->WP[0] == 0){ // if 12dB/oct
+      if(f->WP[0] == 0){ // if 1-stage
          // then we're done, return result1
          return result1;
       }
@@ -118,7 +122,34 @@ namespace NonlinearFeedbackFilter
                f->C[nlf_b1],
                f->R[nlf_z3],
                f->R[nlf_z4]);
+      // and so on
 
-      return result2;
+      if(f->WP[0] == 1){
+         return result2;
+      }
+
+      const __m128 result3 =
+         doLpf(result2,
+               f->C[nlf_a1],
+               f->C[nlf_a2],
+               f->C[nlf_b0],
+               f->C[nlf_b1],
+               f->R[nlf_z5],
+               f->R[nlf_z6]);
+
+      if(f->WP[0] == 2){
+         return result3;
+      }
+
+      const __m128 result4 =
+         doLpf(result3,
+               f->C[nlf_a1],
+               f->C[nlf_a2],
+               f->C[nlf_b0],
+               f->C[nlf_b1],
+               f->R[nlf_z7],
+               f->R[nlf_z8]);
+
+      return result4;
    }
 }

--- a/src/common/dsp/filters/NonlinearFeedback.h
+++ b/src/common/dsp/filters/NonlinearFeedback.h
@@ -1,0 +1,11 @@
+#pragma once
+
+struct QuadFilterUnitState;
+class FilterCoefficientMaker;
+class SurgeStorage;
+
+namespace NonlinearFeedbackFilter 
+{
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, SurgeStorage *storage );
+   __m128 process( QuadFilterUnitState * __restrict f, __m128 in );
+}


### PR DESCRIPTION
Adds a lowpass filter based on https://jatinchowdhury18.medium.com/complex-nonlinearities-episode-5-nonlinear-feedback-filters-115e65fc0402

Subtypes are the number of chained biquad stages in the filter. Unfortunately it won't self-resonate even if you crank the Q factor, but with four stages it's pretty resonant.

Could maybe use some tweaking, but let's maybe get some beta testers on this and see what happens?