### PR TITLE
Correctly initialize MSEG on load

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1536,10 +1536,11 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
    }
 
    // restore msegs
-   for (auto& ms : msegs )
-      for (auto& l : ms )
+   for (int s=0;s<n_scenes;++s)
+      for (int m=0; m<n_lfos; ++m )
       {
-         ms->n_activeSegments = 0;
+         auto *ms = &( msegs[s][m] );
+         Surge::MSEG::createInitMSEG(ms);
          Surge::MSEG::rebuildCache(ms);
       }
 

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -516,25 +516,7 @@ bailOnPortable:
       for( int i = 0; i < n_lfos; ++i )
       {
          auto ms = &(_patch->msegs[s][i]);
-         ms->n_activeSegments = 4;
-         ms->segments[0].duration = 0.25;
-         ms->segments[0].type = MSEGStorage::segment::LINEAR;
-         ms->segments[0].v0 = 0.0;
-
-         ms->segments[1].duration = 0.25;
-         ms->segments[1].type = MSEGStorage::segment::LINEAR;
-         ms->segments[1].v0 = 1.0;
-
-         ms->segments[2].duration = MSEGStorage::minimumDuration;
-         ms->segments[2].type = MSEGStorage::segment::LINEAR;
-         ms->segments[2].v0 = 0.7;
-
-         ms->segments[3].duration = 0.5;
-         ms->segments[3].type = MSEGStorage::segment::SCURVE;
-         ms->segments[3].v0 = -0.7;
-         ms->segments[3].nv1 = 0; // Have to set this now due to endpoint mode
-         ms->segments[3].cpduration = 0.4;
-         ms->segments[3].cpv = -0.3;
+         Surge::MSEG::createInitMSEG(ms);
          Surge::MSEG::rebuildCache( ms );
       }
    }

--- a/src/common/dsp/MSEGModulationHelper.cpp
+++ b/src/common/dsp/MSEGModulationHelper.cpp
@@ -966,7 +966,7 @@ void createInitMSEG(MSEGStorage* ms)
    ms->segments[0].cpv = 0.f;
    ms->segments[0].cpduration = 0.5;
    ms->segments[0].v0 = 1.f;
-   ms->segments[0].nv1 = 0.f;
+   ms->segments[0].nv1 = -1.f;
    ms->endpointMode = MSEGStorage::EndpointMode::FREE;
 
    Surge::MSEG::rebuildCache(ms);


### PR DESCRIPTION
Make sure that both the empty patch and a load of a
patch with no MSEG data sets the msegs to the
initMSEG as specified by Surge::MSEG:createInitMSEG

Closes #3262