### PR TITLE
Push Bitwig Resizes onto the Idle thread

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -128,6 +128,8 @@ public:
       return Steinberg::kResultTrue;
    }
 
+   void resizeFromIdleSentinel();
+
    bool initialZoom();
    virtual Steinberg::tresult PLUGIN_API onSize(Steinberg::ViewRect* newSize) override;
    virtual Steinberg::tresult PLUGIN_API checkSizeConstraint(Steinberg::ViewRect* newSize) override;
@@ -346,6 +348,9 @@ public:
 
    int oscilatorMenuIndex[n_scenes][n_oscs] = {0};
 
+   bool hasIdleRun = false;
+   VSTGUI::CPoint resizeToOnIdle = VSTGUI::CPoint(-1,-1);
+
 private:
    SGEDropAdapter *dropAdapter = nullptr;
    friend class SGEDropAdapter;
@@ -356,6 +361,7 @@ private:
 
    int wsx = BASE_WINDOW_SIZE_X;
    int wsy = BASE_WINDOW_SIZE_Y;
+
 
    /**
     * findLargestFittingZoomBetween

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -1007,14 +1007,21 @@ void SurgeVst3Processor::redraw(SurgeGUIEditor *e, bool resizeWindow)
     {
 		float fzf = e->getZoomFactor() / 100.0;
 		int width = e->getWindowSizeX() * fzf;
-		int heigth = e->getWindowSizeY() * fzf;
+		int height = e->getWindowSizeY() * fzf;
 
         frame->setZoom(fzf);
-        frame->setSize(width, heigth);
+        frame->setSize(width, height);
 
 		if (resizeWindow)
 		{
-			resize(e, width, heigth);
+                   if( ! e->hasIdleRun )
+                   {
+                      e->resizeToOnIdle = VSTGUI::CPoint( width, height );
+                   }
+                   else
+                   {
+                      resize(e, width, height);
+                   }
 		}
 
 		setExtraScaleFactor(frame->getBackground(), e->getZoomFactor());


### PR DESCRIPTION
Bitwig 3.1.2 hangs when you start it with current. I think it
is because the first resize is before the iPlugFrame is fully
initialized. So push the resize to the idle loop instead.

Should we do this for all VST3?

Addresses #3270