### PR TITLE
Hide Cursor only on Move

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -1224,7 +1224,6 @@ CMouseEventResult CLFOGui::onMouseDown(CPoint &where, const CButtonState &button
        if (storage)
            this->hideCursor = !Surge::Storage::getUserDefaultValue(storage, "showCursorWhileEditing", 0);
 
-       startCursorHide(where);
        if( buttons.isRightButton() )
        {
            rmStepStart = where;
@@ -1235,6 +1234,7 @@ CMouseEventResult CLFOGui::onMouseDown(CPoint &where, const CButtonState &button
            controlstate = cs_steps;
        }
        onMouseMoved(where, buttons);
+       enqueueCursorHide = true;
        return kMouseEventHandled;
        }
        else if (rect_steps_retrig.pointInside(where))
@@ -1315,6 +1315,7 @@ CMouseEventResult CLFOGui::onMouseDown(CPoint &where, const CButtonState &button
 }
 CMouseEventResult CLFOGui::onMouseUp(CPoint& where, const CButtonState& buttons)
 {
+   enqueueCursorHide = false;
    lfo_type_hover = -1;
    if (controlstate == cs_trigtray_toggle)
    {
@@ -1487,6 +1488,11 @@ CMouseEventResult CLFOGui::onMouseMoved(CPoint& where, const CButtonState& butto
       }
    }
 
+   if( enqueueCursorHide )
+   {
+      startCursorHide(where);
+      enqueueCursorHide = false;
+   }
    int plt = lfo_type_hover;
    lfo_type_hover = -1;
    for( int i=0; i<n_lfo_types; ++i )

--- a/src/common/gui/CLFOGui.h
+++ b/src/common/gui/CLFOGui.h
@@ -133,6 +133,8 @@ protected:
    VSTGUI::CPoint rmStepStart, rmStepCurr;
    VSTGUI::CPoint barDragTop;
 
+   bool enqueueCursorHide = false;
+
    int ss_shift_hover = 0;
    int lfo_type_hover = -1;
    CScalableBitmap *typeImg, *typeImgHover, *typeImgHoverOn;

--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -337,7 +337,7 @@ CMouseEventResult CModulationSourceButton::onMouseDown(CPoint& where, const CBut
       beginEdit();
       controlstate = cs_drag;
 
-      startCursorHide(where);
+      enqueueCursorHideIfMoved(where);
 
       return kMouseEventHandled;
    }
@@ -362,6 +362,8 @@ CMouseEventResult CModulationSourceButton::onMouseDown(CPoint& where, const CBut
 
 CMouseEventResult CModulationSourceButton::onMouseUp(CPoint& where, const CButtonState& buttons)
 {
+   unenqueueCursorHideIfMoved();
+
    if( controlstate == cs_swap && dragLabel )
    {
       dragLabel->setVisible( false );

--- a/src/common/gui/CNumberField.cpp
+++ b/src/common/gui/CNumberField.cpp
@@ -588,7 +588,7 @@ CMouseEventResult CNumberField::onMouseDown(CPoint& where, const CButtonState& b
 
    if ((buttons & kLButton) && (drawsize.pointInside(where)))
    {
-      startCursorHide(where);
+      enqueueCursorHide = true;
       controlstate = cs_drag;
       lastmousepos = where;
       startmousepos = where;
@@ -603,6 +603,7 @@ CMouseEventResult CNumberField::onMouseDown(CPoint& where, const CButtonState& b
 }
 CMouseEventResult CNumberField::onMouseUp(CPoint& where, const CButtonState& buttons)
 {
+   enqueueCursorHide = false;
    if (controlstate)
    {
       endEdit();
@@ -615,6 +616,11 @@ CMouseEventResult CNumberField::onMouseMoved(CPoint& where, const CButtonState& 
 {
    if ((controlstate == cs_drag) && (buttons & kLButton))
    {
+      if( enqueueCursorHide )
+      {
+         startCursorHide(where);
+         enqueueCursorHide = false;
+      }
       float dx = where.x - lastmousepos.x;
       float dy = where.y - lastmousepos.y;
       

--- a/src/common/gui/CNumberField.h
+++ b/src/common/gui/CNumberField.h
@@ -189,6 +189,7 @@ private:
    int i_default;
    int i_poly;
    int labelplacement;
+   bool enqueueCursorHide = false;
    VSTGUI::CRect drawsize;
    VSTGUI::CPoint lastmousepos, startmousepos;
 

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -704,8 +704,12 @@ CMouseEventResult CSurgeSlider::onMouseDown(CPoint& where, const CButtonState& b
    if (listener &&
        buttons & (kAlt | kRButton | kMButton | kButton4 | kButton5 | kShift | kControl | kApple | kDoubleClick))
    {
+      unenqueueCursorHideIfMoved();
+
       if (listener->controlModifierClicked(this, buttons) != 0)
+      {
          return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
+      }
    }
 
    onMouseDownCursorHelper(where);
@@ -733,7 +737,7 @@ CMouseEventResult CSurgeSlider::onMouseDown(CPoint& where, const CButtonState& b
          listener->valueChanged( this );
       
       // detachCursor(where);
-      startCursorHide(where);
+      enqueueCursorHideIfMoved(where);
       return kMouseEventHandled;
    }
    return kMouseEventHandled;
@@ -741,7 +745,7 @@ CMouseEventResult CSurgeSlider::onMouseDown(CPoint& where, const CButtonState& b
 
 CMouseEventResult CSurgeSlider::onMouseUp(CPoint& where, const CButtonState& buttons)
 {
-
+   unenqueueCursorHideIfMoved();
    {
       auto sge = dynamic_cast<SurgeGUIEditor*>(listener);
       if( sge )

--- a/src/common/gui/CursorControlGuard.h
+++ b/src/common/gui/CursorControlGuard.h
@@ -131,13 +131,31 @@ struct CursorControlAdapterWithMouseDelta : public CursorControlAdapter<T>
 {
    CursorControlAdapterWithMouseDelta(SurgeStorage *s) : CursorControlAdapter<T>(s) {}
 
+   bool hideIsEnqueued = false;
+   VSTGUI::CPoint enqueuedLocation;
    void onMouseDownCursorHelper( const VSTGUI::CPoint &where )
    {
+      hideIsEnqueued = false;
       deltapoint = where;
       origdeltapoint = where;
    }
+
+   void enqueueCursorHideIfMoved( const VSTGUI::CPoint &where )
+   {
+      hideIsEnqueued = true;
+      enqueuedLocation = where;
+   }
+   void unenqueueCursorHideIfMoved()
+   {
+      hideIsEnqueued = false;
+   }
    VSTGUI::CMouseEventResult onMouseMovedCursorHelper( const VSTGUI::CPoint &where, const VSTGUI::CButtonState &buttons )
    {
+      if( hideIsEnqueued )
+      {
+         CursorControlAdapter<T>::startCursorHide(enqueuedLocation);
+         hideIsEnqueued = false;
+      }
       auto scale = CursorControlAdapter<T>::asT()->getMouseDeltaScaling(where, buttons);
       float dx = (where.x -deltapoint.x);
       float dy = (where.y - deltapoint.y);

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -1065,6 +1065,7 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
    CPoint mouseDownOrigin, cursorHideOrigin, lastPanZoomMousePos;
    bool inDrag = false;
    bool inDrawDrag = false;
+   bool cursorHideEnqueued = false;
    virtual CMouseEventResult onMouseDown(CPoint &where, const CButtonState &buttons ) override {
       if (buttons & kRButton)
       {
@@ -1156,7 +1157,7 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
             if( h.rect.pointInside(where) && h.type == hotzone::MOUSABLE_NODE )
             {
                foundHZ = true;
-               startCursorHide(where);
+               cursorHideEnqueued = true;
                cursorHideOrigin = where;
                h.active = true;
                h.dragging = true;
@@ -1210,6 +1211,7 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
       }
       snapGuard = nullptr;
       endCursorHide();
+      cursorHideEnqueued = false;
 
       return kMouseEventHandled;
    }
@@ -1330,6 +1332,11 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
          {
             if( h.dragging )
             {
+               if( cursorHideEnqueued )
+               {
+                  startCursorHide(cursorHideOrigin);
+                  cursorHideEnqueued = false;
+               }
                gotOne = true;
                float dragX = where.x - mouseDownOrigin.x;
                float dragY = where.y - mouseDownOrigin.y;


### PR DESCRIPTION
Hide cursor on move not down. This avoids a variety of doubleclick
problems and other issues.

- Implement for CSurgeSlider
- MSEG Editor in place
- Everywhere else

This fixes the doubleclick problems iwth MSEG so Addresses #2474