### PR TITLE
Linux MSEG Drawing Improvements

### DIFF
--- a/src/linux/DisplayInfoLinux.cpp
+++ b/src/linux/DisplayInfoLinux.cpp
@@ -14,7 +14,7 @@ using namespace VSTGUI;
     
 float getDisplayBackingScaleFactor(CFrame *)
 {
-    return 1.0;
+    return 2.0;
 }
 
 


### PR DESCRIPTION
1. Get the transform bugs in VSTGUI compensated for
2. Set NonIntegral mode on everywhere not just mac and win
3. Set backing store to 2

Closes #3215