### PR TITLE
Different saturators, oversampling, and optimisation for NL Feedback Filter

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2260,10 +2260,15 @@ void Parameter::get_display(char* txt, bool external, float ef)
                   case fut_nonlinearfb_hp:
                   case fut_nonlinearfb_n:
                   case fut_nonlinearfb_bp:
-                     // why "i & 3"? because briefly in nightly builds there were more than 4 subtypes.
-                     // this is defensive coding so we don't crash loading patches from then.
-                     // (this bitmask is equivalent to i % 4, i.e. limits the range to 0..3)
-                     snprintf(txt, 32, "%s", fut_nlf_subtypes[i & 3]);
+                  case fut_nonlinearfb_lp_os:
+                  case fut_nonlinearfb_hp_os:
+                  case fut_nonlinearfb_n_os:
+                  case fut_nonlinearfb_bp_os:
+                     // "i & 3" selects the lower two bits that represent the stage count.
+                     // "(i >> 2) & 3" selects the next two bits that represent the saturator.
+                     snprintf(txt, 32, "%s %s",
+                        fut_nlf_subtypes[i & 3],
+                        fut_nlf_saturators[(i >> 2) & 3]);
                      break;
 #if SURGE_EXTRA_FILTERS
 #endif

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -418,7 +418,10 @@ enum fu_type
    fut_nonlinearfb_hp,
    fut_nonlinearfb_n,
    fut_nonlinearfb_bp,
-
+   fut_nonlinearfb_lp_os,
+   fut_nonlinearfb_hp_os,
+   fut_nonlinearfb_n_os,
+   fut_nonlinearfb_bp_os,
    n_fu_types,
 };
 const char fut_names[n_fu_types][32] =
@@ -439,10 +442,14 @@ const char fut_names[n_fu_types][32] =
    "K35 Lowpass",
    "K35 Highpass",
    "Diode Ladder",
-   "Nonlinear Feedback Lowpass",
-   "Nonlinear Feedback Highpass",
-   "Nonlinear Feedback Notch",
-   "Nonlinear Feedback Bandpass",
+   "Lowpass NL Feedback",
+   "Highpass NL Feedback",
+   "Notch NL Feedback",
+   "Bandpass NL Feedback",
+   "Lowpass OS NL Feedback",
+   "Highpass OS NL Feedback",
+   "Notch OS NL Feedback",
+   "Bandpass OS NL Feedback",
    /* this is a ruler to ensure names do not exceed 31 characters
     0123456789012345678901234567890
    */
@@ -537,10 +544,18 @@ const float fut_k35_saturations[5] =
 
 const char fut_nlf_subtypes[4][32] =
 {
-   "1 stage (12dB/oct)",
+   "1 stage ",
    "2 stages",
    "3 stages",
    "4 stages",
+};
+
+const char fut_nlf_saturators[4][6] =
+{
+   "tanh",
+   "soft",
+   "hard",
+   "asinh",
 };
 
 const int fut_subcount[n_fu_types] =
@@ -561,10 +576,14 @@ const int fut_subcount[n_fu_types] =
    5, // fut_k35_lp
    5, // fut_k35_hp
    4, // fut_diode
-   4, // fut_nonlinearfb_lp
-   4, // fut_nonlinearfb_hp
-   4, // fut_nonlinearfb_n
-   4, // fut_nonlinearfb_bp
+   16, // fut_nonlinearfb_lp
+   16, // fut_nonlinearfb_hp
+   16, // fut_nonlinearfb_n
+   16, // fut_nonlinearfb_bp
+   16, // fut_nonlinearfb_lp_os
+   16, // fut_nonlinearfb_hp_os
+   16, // fut_nonlinearfb_n_os
+   16, // fut_nonlinearfb_bp_os
 };
 
 enum fu_subtype

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -100,11 +100,18 @@ void FilterCoefficientMaker::MakeCoeffs(
       break;
    case fut_nonlinearfb_lp:
    case fut_nonlinearfb_hp:
-      NonlinearFeedbackFilter::makeCoefficientsLPHP(this, Freq, Reso, Type, storageI);
    case fut_nonlinearfb_n:
    case fut_nonlinearfb_bp:
-      NonlinearFeedbackFilter::makeCoefficientsNBP(this, Freq, Reso, Type, storageI);
+      // false for no oversampling
+      NonlinearFeedbackFilter::makeCoefficients(this, Freq, Reso, Type, false, storageI);
       break;
+   case fut_nonlinearfb_lp_os:
+   case fut_nonlinearfb_hp_os:
+   case fut_nonlinearfb_n_os:
+   case fut_nonlinearfb_bp_os:
+      NonlinearFeedbackFilter::makeCoefficients(this, Freq, Reso, Type, true, storageI);
+      break;
+
 #if SURGE_EXTRA_FILTERS
 #endif      
    };

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -817,6 +817,13 @@ FilterUnitQFPtr GetQFPtrFilterUnit(int type, int subtype)
    case fut_nonlinearfb_n:
    case fut_nonlinearfb_bp:
       return NonlinearFeedbackFilter::process;
+      break;
+   case fut_nonlinearfb_lp_os:
+   case fut_nonlinearfb_hp_os:
+   case fut_nonlinearfb_n_os:
+   case fut_nonlinearfb_bp_os:
+      return NonlinearFeedbackFilter::process_oversampled;
+      break;
    default:
       // SOFTWARE ERROR
       break;

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1031,7 +1031,7 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
             if (scene->filterunit[u].type.val.i == fut_lpmoog ||
                 scene->filterunit[u].type.val.i == fut_diode  ||
                 (scene->filterunit[u].type.val.i >= fut_nonlinearfb_lp &&
-                 scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp))
+                 scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp_os))
             {
                Q->FU[u].WP[0] =
                    scene->filterunit[u].subtype.val.i; // LPMoog's output stage index is stored in
@@ -1056,7 +1056,7 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
                if (scene->filterunit[u].type.val.i == fut_lpmoog ||
                    scene->filterunit[u].type.val.i == fut_diode  ||
                    (scene->filterunit[u].type.val.i >= fut_nonlinearfb_lp &&
-                    scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp))
+                    scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp_os))
                {
                   Q->FU[u + 2].WP[0] = scene->filterunit[u].subtype.val.i;
                }

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -8,8 +8,8 @@
 /*
 ** This contains an adaptation of the filter found at
 ** https://ccrma.stanford.edu/~jatin/ComplexNonlinearities/NLFeedback.html
-** with coefficient calculation at
-** https://github.com/jatinchowdhury18/audio_dspy/blob/master/audio_dspy/eq_design.py
+** with coefficient calculation from
+** https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html
 */
 
 static float clampedFrequency( float pitch, SurgeStorage *storage )
@@ -19,9 +19,21 @@ static float clampedFrequency( float pitch, SurgeStorage *storage )
    return freq;
 }
 
+#define F(a) _mm_set_ps1( a )
 #define M(a,b) _mm_mul_ps( a, b )
 #define A(a,b) _mm_add_ps( a, b )
 #define S(a,b) _mm_sub_ps( a, b )
+
+enum Saturator {
+    SAT_TANH = 0,
+    SAT_SOFT,
+    SAT_HARD,
+    SAT_ASINH
+};
+
+// do not change this without also recalculating windowFactors!
+static constexpr int extraOversample = 4;
+static constexpr float extraOversampleInv = 1.0f / (float)extraOversample;
 
 static inline __m128 doFilter(
       const __m128 input,
@@ -30,14 +42,34 @@ static inline __m128 doFilter(
       const __m128 b0,
       const __m128 b1,
       const __m128 b2,
+      const int sat,
       __m128 &z1,
       __m128 &z2)
    noexcept
 {
    // out = z1 + b0 * input
    const __m128 out = A(z1, M(b0, input));
-   // nonlinear feedback = tanh(out)
-   const __m128 nf  = Surge::DSP::fasttanhSSEclamped(out);
+
+   // nonlinear feedback = saturator(out)
+   __m128 nf;
+   switch(sat){
+      case SAT_TANH:
+         nf = Surge::DSP::fasttanhSSEclamped(out);
+         break;
+      case SAT_SOFT:
+         nf = softclip_ps(out); // note, this is a bit different to Jatin's softclipper
+         break;
+      case SAT_HARD:
+         nf = hardclip_ps(out);
+         break;
+      default: // SAT_ASINH
+         // for some reason the necessary SSE intrinsic is missing.
+         // until we sort this out, just pass `out` through without saturation.
+         // nf = _mm_asinh_ps(out);
+         nf = out;
+         break;
+   }
+
    // z1 = z2 + b1 * input - a1 * nf
    z1 = A(z2, S(M(b1, input), M(a1, nf)));
    // z2 = b2 * input - a2 * nf
@@ -47,12 +79,13 @@ static inline __m128 doFilter(
 
 namespace NonlinearFeedbackFilter
 {
-   enum nlf_coeffs { 
+   enum nlf_coeffs {
       nlf_a1 = 0,
       nlf_a2,
       nlf_b0,
       nlf_b1,
-      nlf_b2
+      nlf_b2,
+      n_nlf_coeff
    };
 
    enum dlf_state {
@@ -66,46 +99,15 @@ namespace NonlinearFeedbackFilter
       nlf_z8  // 2nd z-1 state for fourth stage
    };
 
-   void makeCoefficientsLPHP( FilterCoefficientMaker *cm, float freq, float reso, int type, SurgeStorage *storage )
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, int type, bool oversample, SurgeStorage *storage )
    {
       float C[n_cm_coeffs];
 
-      const float q = ((reso * reso * reso) * 10.0f + 0.1f);
+      const float q = ((reso * reso * reso) * 18.0f + 0.1f);
 
-      const float  wc = M_PI * clampedFrequency(freq, storage) / dsamplerate_os;
-      const float   c = 1.0f / Surge::DSP::fasttan(wc);
-      const float phi = c * c;
-      const float   K = c / q;
-      
-      // note we actually calculate the reciprocal of a0 because we only use a0 to normalize the
-      // other coefficients, and multiplication by reciprocal is cheaper than dividing.
-      const float a0r = 1.0f / (phi + K + 1.0f);
+      const float oversampling = oversample ? extraOversample : 1.0f;
 
-      if(type == fut_nonlinearfb_lp){ // lowpass
-         C[nlf_a1] = 2.0f * (1.0f - phi) * a0r;
-         C[nlf_a2] = (phi - K + 1.0f)    * a0r;
-         C[nlf_b0] = a0r;
-         C[nlf_b1] = 2.0f * C[nlf_b0];
-         C[nlf_b2] = C[nlf_b0];
-      }
-      else{ // highpass
-         C[nlf_a1] = 2.0f * (1.0f - phi) * a0r;
-         C[nlf_a2] = (phi - K + 1.0f)    * a0r;
-         C[nlf_b0] = phi                 * a0r;
-         C[nlf_b1] = -2.0f * C[nlf_b0];
-         C[nlf_b2] = C[nlf_b0];
-      }
-
-      cm->FromDirect(C);
-   }
-
-   void makeCoefficientsNBP( FilterCoefficientMaker *cm, float freq, float reso, int type, SurgeStorage *storage )
-   {
-      float C[n_cm_coeffs];
-
-      const float q = ((reso * reso * reso) * 10.0f + 0.1f);
-
-      const float wc = M_PI * clampedFrequency(freq, storage) / dsamplerate_os;
+      const float wc = 2.0f * M_PI * clampedFrequency(freq, storage) / (dsamplerate_os * oversampling);
 
       const float wsin  = Surge::DSP::fastsin(wc);
       const float wcos  = Surge::DSP::fastcos(wc);
@@ -115,88 +117,119 @@ namespace NonlinearFeedbackFilter
       // other coefficients, and multiplication by reciprocal is cheaper than dividing.
       const float a0r  = 1.0f / (1.0f + alpha);
 
-      if(type == fut_nonlinearfb_n){ // notch
-         C[nlf_a1] = -2.0f * wcos   * a0r;
-         C[nlf_a2] = (1.0f - alpha) * a0r;
-         C[nlf_b0] = a0r;
-         C[nlf_b1] = -2.0f * wcos   * a0r;
-         C[nlf_b2] = C[nlf_b0];
-      }
-      else{ // bandpass
-         C[nlf_a1] = -2.0f * wcos   * a0r;
-         C[nlf_a2] = (1.0f - alpha) * a0r;
-         C[nlf_b0] = wsin * 0.5f    * a0r;
-         C[nlf_b1] = 0.0f;
-         C[nlf_b2] = -C[nlf_b0];
+      C[nlf_a1] = -2.0f * wcos    * a0r;
+      C[nlf_a2] = (1.0f - alpha)  * a0r;
+
+      switch(type){
+         case fut_nonlinearfb_lp: // lowpass
+         case fut_nonlinearfb_lp_os:
+            C[nlf_b1] =  (1.0f - wcos) * a0r;
+            C[nlf_b0] = C[nlf_b1] *  0.5f;
+            C[nlf_b2] = C[nlf_b0];
+            break;
+         case fut_nonlinearfb_hp: // highpass
+         case fut_nonlinearfb_hp_os:
+            C[nlf_b1] = -(1.0f + wcos) * a0r;
+            C[nlf_b0] = C[nlf_b1] * -0.5f;
+            C[nlf_b2] = C[nlf_b0];
+            break;
+         case fut_nonlinearfb_n: // notch
+         case fut_nonlinearfb_n_os:
+            C[nlf_b0] = a0r;
+            C[nlf_b1] = -2.0f * wcos   * a0r;
+            C[nlf_b2] = C[nlf_b0];
+            break;
+         default: // bandpass
+            C[nlf_b0] = wsin * 0.5f    * a0r;
+            C[nlf_b1] = 0.0f;
+            C[nlf_b2] = -C[nlf_b0];
+            break;
       }
 
       cm->FromDirect(C);
    }
 
-
    __m128 process( QuadFilterUnitState * __restrict f, __m128 input )
    {
-      for(int i=0; i <= nlf_b2; ++i){ \
-         f->C[i] = A(f->C[i], f->dC[i]); \
+      // lower 2 bits of subtype is the stage count
+      const int stages = f->WP[0] & 3;
+      // next two bits after that select the saturator
+      const int sat = ((f->WP[0] >> 2) & 3);
+
+      // n.b. stages is zero-indexed so use <=
+      for(int stage = 0; stage <= stages; ++stage){
+         input =
+            doFilter(input,
+                  f->C[nlf_a1],
+                  f->C[nlf_a2],
+                  f->C[nlf_b0],
+                  f->C[nlf_b1],
+                  f->C[nlf_b2],
+                  sat,
+                  f->R[nlf_z1 + stage*2],
+                  f->R[nlf_z2 + stage*2]);
       }
 
-      const int stages = f->WP[0] & 3; // lower 2 bits of subtype is the stage count
-
-      const __m128 result1 =
-         doFilter(input,
-               f->C[nlf_a1],
-               f->C[nlf_a2],
-               f->C[nlf_b0],
-               f->C[nlf_b1],
-               f->C[nlf_b2],
-               f->R[nlf_z1],
-               f->R[nlf_z2]);
-
-      if(stages == 0){ // if 1-stage
-         // then we're done, return result1
-         return result1;
+      for(int i=0; i < n_nlf_coeff; ++i){
+         f->C[i] = A(f->C[i], f->dC[i]);
       }
 
-      // otherwise we calculate and return the second stage
-      const __m128 result2 =
-         doFilter(result1,
-               f->C[nlf_a1],
-               f->C[nlf_a2],
-               f->C[nlf_b0],
-               f->C[nlf_b1],
-               f->C[nlf_b2],
-               f->R[nlf_z3],
-               f->R[nlf_z4]);
-      // and so on
+      return input;
+   }
 
-      if(stages == 1){
-         return result2;
+   __m128 process_oversampled( QuadFilterUnitState * __restrict f, __m128 input )
+   {
+      // lower 2 bits of subtype is the stage count
+      const int stages = f->WP[0] & 3;
+      // next two bits after that select the saturator
+      const int sat = ((f->WP[0] >> 2) & 3);
+
+      // oversampling method copied from VintageLadders.cpp, look there for better explanation
+
+      // prescale f->dC so it's for each oversampled sample
+      static const __m128 dFac = F(extraOversampleInv);
+      for(int i=0; i < n_nlf_coeff; ++i){
+         f->dC[i] = M(f->dC[i], dFac);
       }
 
-      const __m128 result3 =
-         doFilter(result2,
-               f->C[nlf_a1],
-               f->C[nlf_a2],
-               f->C[nlf_b0],
-               f->C[nlf_b1],
-               f->C[nlf_b2],
-               f->R[nlf_z5],
-               f->R[nlf_z6]);
+      __m128 outputOS[extraOversample];
+      for(int osi = 0; osi < extraOversample; ++osi){
+         // n.b. stages is zero-indexed so use <=
+         for(int stage = 0; stage <= stages; ++stage){
+            input =
+               doFilter(input,
+                     f->C[nlf_a1],
+                     f->C[nlf_a2],
+                     f->C[nlf_b0],
+                     f->C[nlf_b1],
+                     f->C[nlf_b2],
+                     sat,
+                     f->R[nlf_z1 + stage*2],
+                     f->R[nlf_z2 + stage*2]);
+         }
 
-      if(stages == 2){
-         return result3;
+         for(int i=0; i < n_nlf_coeff; ++i){
+            f->C[i] = A(f->C[i], f->dC[i]);
+         }
+
+         outputOS[osi] = input;
+
+         // Zero stuffing
+         input = _mm_setzero_ps();
       }
 
-      const __m128 result4 =
-         doFilter(result3,
-               f->C[nlf_a1],
-               f->C[nlf_a2],
-               f->C[nlf_b0],
-               f->C[nlf_b1],
-               f->C[nlf_b2],
-               f->R[nlf_z7],
-               f->R[nlf_z8]);
+      static const __m128 windowFactors[extraOversample] = {
+         F(-0.0636844f),
+         _mm_setzero_ps(),
+         F(0.57315917f),
+         F(1.0f)
+      };
 
-      return result4;
+      __m128 ov = _mm_setzero_ps();
+      for(int i=0; i < extraOversample; ++i ){
+         ov = A(ov, M(outputOS[i], windowFactors[i]));
+      }
+
+      return M(F(1.5f), ov);
    }
 }

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -214,7 +214,7 @@ namespace NonlinearFeedbackFilter
 
          outputOS[osi] = input;
 
-         // Zero stuffing
+         // Zero stuffing ... hang on, I don't think this can work for things other than lowpass!
          input = _mm_setzero_ps();
       }
 

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -230,6 +230,6 @@ namespace NonlinearFeedbackFilter
          ov = A(ov, M(outputOS[i], windowFactors[i]));
       }
 
-      return M(F(1.5f), ov);
+      return M(F(2.0f), ov);
    }
 }

--- a/src/common/dsp/filters/NonlinearFeedback.h
+++ b/src/common/dsp/filters/NonlinearFeedback.h
@@ -6,7 +6,7 @@ class SurgeStorage;
 
 namespace NonlinearFeedbackFilter 
 {
-   void makeCoefficientsLPHP( FilterCoefficientMaker *cm, float freq, float reso, int subtype, SurgeStorage *storage );
-   void makeCoefficientsNBP ( FilterCoefficientMaker *cm, float freq, float reso, int subtype, SurgeStorage *storage );
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, int subtype, bool oversample, SurgeStorage *storage );
    __m128 process( QuadFilterUnitState * __restrict f, __m128 in );
+   __m128 process_oversampled( QuadFilterUnitState * __restrict f, __m128 in );
 }


### PR DESCRIPTION
Also corrects a bug, forgot to put a `break` in `FilterCoefficientMaker.cpp` so everything was using notch and bandpass coefficients (!!)

Oversampling is optional, added as separate filter types. As we may decide to remove oversampling or make it default, it would be unwise to save patches when using these types.