### PR TITLE
Make NL filter oversampling slightly less bad, replace hardclip with fastsin

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -554,7 +554,7 @@ const char fut_nlf_saturators[4][6] =
 {
    "tanh",
    "soft",
-   "hard",
+   "sine",
    "asinh",
 };
 

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -103,7 +103,7 @@ static inline __m128 doNLFilter(
       case SAT_SOFT:
          nf = softclip_ps(out); // note, this is a bit different to Jatin's softclipper
          break;
-      case SAT_FASTSIN:
+      case SAT_SINE:
          nf = fastsin_ps(out);
          break;
       default: // SAT_ASINH

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -27,15 +27,59 @@ static float clampedFrequency( float pitch, SurgeStorage *storage )
 enum Saturator {
     SAT_TANH = 0,
     SAT_SOFT,
-    SAT_HARD,
+    SAT_SINE,
     SAT_ASINH
 };
+
+// sine each element of a __m128 by breaking it into floats then reassembling
+static inline __m128 fastsin_ps(const __m128 in) noexcept {
+   float f[4];
+   _mm_storeu_ps(f, in);
+   f[0] = Surge::DSP::fastsin(f[0]);
+   f[1] = Surge::DSP::fastsin(f[1]);
+   f[2] = Surge::DSP::fastsin(f[2]);
+   f[3] = Surge::DSP::fastsin(f[3]);
+   return _mm_load_ps(f);
+}
+
+// asinh each element of a __m128 by breaking it into floats then reassembling
+static inline __m128 asinh_ps(const __m128 in) noexcept {
+   float f[4];
+   _mm_storeu_ps(f, in);
+   f[0] = asinhf(f[0]);
+   f[1] = asinhf(f[1]);
+   f[2] = asinhf(f[2]);
+   f[3] = asinhf(f[3]);
+   return _mm_load_ps(f);
+}
 
 // do not change this without also recalculating windowFactors!
 static constexpr int extraOversample = 4;
 static constexpr float extraOversampleInv = 1.0f / (float)extraOversample;
 
+// biquad without nonlinearity - used for upsampling
+// note, b2 optimised out because it will be the same as b0 for what we use it for
 static inline __m128 doFilter(
+      const __m128 input,
+      const __m128 a1,
+      const __m128 a2,
+      const __m128 b0,
+      const __m128 b1,
+      __m128 &z1,
+      __m128 &z2)
+   noexcept
+{
+   // out = z1 + b0 * input
+   const __m128 out = A(z1, M(b0, input));
+   // z1 = z2 + b1 * input - a1 * out
+   z1 = A(z2, S(M(b1, input), M(a1, out)));
+   // z2 = b2 * input - a2 * out
+   z2 = S(M(b0, input), M(a2, out));
+   return out;
+}
+
+// filter with a nonlinearity - what we actually want to hear
+static inline __m128 doNLFilter(
       const __m128 input,
       const __m128 a1,
       const __m128 a2,
@@ -59,14 +103,11 @@ static inline __m128 doFilter(
       case SAT_SOFT:
          nf = softclip_ps(out); // note, this is a bit different to Jatin's softclipper
          break;
-      case SAT_HARD:
-         nf = hardclip_ps(out);
+      case SAT_FASTSIN:
+         nf = fastsin_ps(out);
          break;
       default: // SAT_ASINH
-         // for some reason the necessary SSE intrinsic is missing.
-         // until we sort this out, just pass `out` through without saturation.
-         // nf = _mm_asinh_ps(out);
-         nf = out;
+         nf = asinh_ps(out);
          break;
    }
 
@@ -96,7 +137,10 @@ namespace NonlinearFeedbackFilter
       nlf_z5, // 1st z-1 state for third  stage
       nlf_z6, // 2nd z-1 state for third  stage
       nlf_z7, // 1st z-1 state for fourth stage
-      nlf_z8  // 2nd z-1 state for fourth stage
+      nlf_z8, // 2nd z-1 state for fourth stage
+      nlf_upz1, // 1st z-1 state for upsampling filter
+      nlf_upz2, // 2nd z-2 state for upsampling filter
+      // rest of the R[] state used for 3 more upsampling filter stages
    };
 
    void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, int type, bool oversample, SurgeStorage *storage )
@@ -159,7 +203,7 @@ namespace NonlinearFeedbackFilter
       // n.b. stages is zero-indexed so use <=
       for(int stage = 0; stage <= stages; ++stage){
          input =
-            doFilter(input,
+            doNLFilter(input,
                   f->C[nlf_a1],
                   f->C[nlf_a2],
                   f->C[nlf_b0],
@@ -192,12 +236,51 @@ namespace NonlinearFeedbackFilter
          f->dC[i] = M(f->dC[i], dFac);
       }
 
+      // do a crappy chain of 4 butterworth biquads for post-upsampling filter.
+      // calculated with python code:
+      // import math
+      // w0 = math.tau * 1/8  # 1/8 of the 4x sample rate is 1/2 of the original sample rate
+      // Q = 1/math.sqrt(2)   # Butterworth Q
+      // alpha = math.sin(w0)/(2*Q)
+      // b1 = (1 - math.cos(w0))
+      // b0 = b1 / 2
+      // a0 = 1 + alpha
+      // a1 = -2 * math.cos(w0) * (1/a0)
+      // a2 = (1-alpha) * (1/a0)
+      // print(a1, a2, b0, b1)
+      static const __m128 upsample_a1 = F(-0.9428090415820634f);
+      static const __m128 upsample_a2 = F( 0.3333333333333333f);
+      static const __m128 upsample_b0 = F( 0.1464466094067262f);
+      static const __m128 upsample_b1 = F( 0.2928932188134524f);
+
       __m128 outputOS[extraOversample];
       for(int osi = 0; osi < extraOversample; ++osi){
-         // n.b. stages is zero-indexed so use <=
-         for(int stage = 0; stage <= stages; ++stage){
+         for(int stage = 0; stage < 4; ++stage){
             input =
                doFilter(input,
+                     upsample_a1,
+                     upsample_a2,
+                     upsample_b0,
+                     upsample_b1,
+                     f->R[nlf_upz1 + stage*2],
+                     f->R[nlf_upz2 + stage*2]);
+         }
+
+         outputOS[osi] = input;
+
+         // Zero stuffing
+         input = _mm_setzero_ps();
+      }
+
+      for(int osi = 0; osi < extraOversample; ++osi){
+         for(int i=0; i < n_nlf_coeff; ++i){
+            f->C[i] = A(f->C[i], f->dC[i]);
+         }
+
+         // n.b. stages is zero-indexed so use <=
+         for(int stage = 0; stage <= stages; ++stage){
+            outputOS[osi] =
+               doNLFilter(outputOS[osi],
                      f->C[nlf_a1],
                      f->C[nlf_a2],
                      f->C[nlf_b0],
@@ -207,15 +290,6 @@ namespace NonlinearFeedbackFilter
                      f->R[nlf_z1 + stage*2],
                      f->R[nlf_z2 + stage*2]);
          }
-
-         for(int i=0; i < n_nlf_coeff; ++i){
-            f->C[i] = A(f->C[i], f->dC[i]);
-         }
-
-         outputOS[osi] = input;
-
-         // Zero stuffing ... hang on, I don't think this can work for things other than lowpass!
-         input = _mm_setzero_ps();
       }
 
       static const __m128 windowFactors[extraOversample] = {
@@ -230,6 +304,6 @@ namespace NonlinearFeedbackFilter
          ov = A(ov, M(outputOS[i], windowFactors[i]));
       }
 
-      return M(F(2.0f), ov);
+      return ov;
    }
 }


### PR DESCRIPTION
Use 4 chained Butterworth biquads as a crappy interpolation filter after upsampling so that oversampled highpass actually does highpass. This isn't good but it shows what needs to be done - we need proper upsampling, if we're going to oversample at all.

Also replaces hardclip (which sounded pretty bad) with fastsin, and makes the asinh saturator actually work. If nobody can tell the difference between the two, we don't need asinh.