### PR TITLE
Continue applying kNonIntegral mode consistently on LInux

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -293,7 +293,7 @@ void CLFOGui::draw(CDrawContext* dc)
       tf.transform(top1);
       tf.transform(bot0);
       tf.transform(bot1);
-      dc->setDrawMode(VSTGUI::kAntiAliasing | VSTGUI::kNonIntegralMode);
+      Surge::UI::NonIntegralAntiAliasGuard niaag(dc);
 
       dc->setLineWidth(1.0);
       // LFO bg center line
@@ -571,7 +571,7 @@ enum
 
 void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp, VSTGUI::CRect &leftpanel)
 {
-   dc->setDrawMode(VSTGUI::kAntiAliasing | VSTGUI::kNonIntegralMode);
+   Surge::UI::NonIntegralAntiAliasGuard naag(dc);
 
    auto size = getViewSize();
 

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -23,6 +23,7 @@
 #include "SkinColors.h"
 
 #include "filesystem/import.h"
+#include "guihelpers.h"
 
 using namespace VSTGUI;
 
@@ -129,10 +130,10 @@ void COscillatorDisplay::draw(CDrawContext* dc)
    int averagingWindow = 4; // this must be both less than BLOCK_SIZE_OS and BLOCK_SIZE_OS must be an integer multiple of it
 
 #if LINUX
-   float valScale = 10000.0f;
-#else
-   float valScale = 100.0f;
+   Surge::UI::NonIntegralAntiAliasGuard naag(dc);
 #endif
+
+   float valScale = 100.0f;
 
    auto size = getViewSize();
 
@@ -277,12 +278,12 @@ void COscillatorDisplay::draw(CDrawContext* dc)
          }
       }
 
-#if LINUX
-      dc->setLineWidth(130);
-#else
       dc->setLineWidth(1.3);
-#endif
+#if LINUX
+      dc->setDrawMode(VSTGUI::kAntiAliasing| VSTGUI::kNonIntegralMode);
+#else
       dc->setDrawMode(VSTGUI::kAntiAliasing);
+#endif
       if (c == 1)
          dc->setFrameColor(VSTGUI::CColor(100, 100, 180, 0xFF));
       else

--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -1,4 +1,5 @@
 #include "globals.h"
+#include "guihelpers.h"
 #include "CScalableBitmap.h"
 #include "SurgeError.h"
 #include "UserInteractions.h"
@@ -442,6 +443,10 @@ void CScalableBitmap::drawSVG(CDrawContext* dc,
            .translate(viewS.getTopLeft().x - offset.x, viewS.getTopLeft().y - offset.y)
            .scale(extraScaleFactor / 100.0, extraScaleFactor / 100.0);
    VSTGUI::CDrawContext::Transform t(*dc, tf);
+
+#if LINUX
+   Surge::UI::NonIntegralAntiAliasGuard naag(dc);
+#endif
 
    for (auto shape = svgImage->shapes; shape != NULL; shape = shape->next)
    {

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -27,6 +27,7 @@
 #include "SurgeGUIEditor.h"
 #include "RuntimeFont.h"
 #include "CursorControlGuard.h"
+#include "guihelpers.h"
 
 using namespace VSTGUI;
 
@@ -929,8 +930,9 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
       addP( fillpath, uniLimit, pathFirstY);
 
       // Make sure to restore this
-      auto drawMode = dc->getDrawMode();
-      dc->setDrawMode(kAntiAliasing|kNonIntegralMode);
+#if LINIX
+      Surge::UI::NonIntegralAntiAliasGuard naig(dc);
+#endif
 
       dc->fillLinearGradient(fillpath, *cg, CPoint(0, 0), CPoint(0, valpx(-1)), false, &tfpath);
       fillpath->forget();
@@ -1114,7 +1116,6 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
             }
          }
       }
-      dc->setDrawMode( drawMode );
    }
 
    CPoint mouseDownOrigin, cursorHideOrigin, lastPanZoomMousePos;

--- a/src/common/gui/guihelpers.h
+++ b/src/common/gui/guihelpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vstgui/vstgui.h>
 
 namespace Surge
 {
@@ -13,5 +14,22 @@ namespace Surge
                                    float p2_x, float p2_y,
                                    float p3_x, float p3_y,
                                    float* i_x, float* i_y);
+
+        struct NonIntegralAntiAliasGuard
+        {
+           NonIntegralAntiAliasGuard(VSTGUI::CDrawContext *dc )
+           {
+              this->mode = dc->getDrawMode();
+              this->dc = dc;
+              this->dc->setDrawMode(VSTGUI::kAntiAliasing|VSTGUI::kNonIntegralMode);
+           }
+
+           ~NonIntegralAntiAliasGuard() {
+              this->dc->setDrawMode(mode);
+           }
+
+           VSTGUI::CDrawContext *dc;
+           VSTGUI::CDrawMode mode;
+        };
     }
 }


### PR DESCRIPTION
We need this on all our path draws.

Closes #3305