### PR TITLE
Remove NLFB filter oversampling and replace asinh shaper with OJD

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2260,10 +2260,6 @@ void Parameter::get_display(char* txt, bool external, float ef)
                   case fut_nonlinearfb_hp:
                   case fut_nonlinearfb_n:
                   case fut_nonlinearfb_bp:
-                  case fut_nonlinearfb_lp_os:
-                  case fut_nonlinearfb_hp_os:
-                  case fut_nonlinearfb_n_os:
-                  case fut_nonlinearfb_bp_os:
                      // "i & 3" selects the lower two bits that represent the stage count.
                      // "(i >> 2) & 3" selects the next two bits that represent the saturator.
                      snprintf(txt, 32, "%s %s",

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -418,10 +418,6 @@ enum fu_type
    fut_nonlinearfb_hp,
    fut_nonlinearfb_n,
    fut_nonlinearfb_bp,
-   fut_nonlinearfb_lp_os,
-   fut_nonlinearfb_hp_os,
-   fut_nonlinearfb_n_os,
-   fut_nonlinearfb_bp_os,
    n_fu_types,
 };
 const char fut_names[n_fu_types][32] =
@@ -446,10 +442,6 @@ const char fut_names[n_fu_types][32] =
    "Highpass NL Feedback",
    "Notch NL Feedback",
    "Bandpass NL Feedback",
-   "Lowpass OS NL Feedback",
-   "Highpass OS NL Feedback",
-   "Notch OS NL Feedback",
-   "Bandpass OS NL Feedback",
    /* this is a ruler to ensure names do not exceed 31 characters
     0123456789012345678901234567890
    */
@@ -555,7 +547,7 @@ const char fut_nlf_saturators[4][6] =
    "tanh",
    "soft",
    "sine",
-   "asinh",
+   "OJD",
 };
 
 const int fut_subcount[n_fu_types] =
@@ -579,11 +571,7 @@ const int fut_subcount[n_fu_types] =
    16, // fut_nonlinearfb_lp
    16, // fut_nonlinearfb_hp
    16, // fut_nonlinearfb_n
-   16, // fut_nonlinearfb_bp
-   16, // fut_nonlinearfb_lp_os
-   16, // fut_nonlinearfb_hp_os
-   16, // fut_nonlinearfb_n_os
-   16, // fut_nonlinearfb_bp_os
+   16  // fut_nonlinearfb_bp
 };
 
 enum fu_subtype

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -102,14 +102,7 @@ void FilterCoefficientMaker::MakeCoeffs(
    case fut_nonlinearfb_hp:
    case fut_nonlinearfb_n:
    case fut_nonlinearfb_bp:
-      // false for no oversampling
-      NonlinearFeedbackFilter::makeCoefficients(this, Freq, Reso, Type, false, storageI);
-      break;
-   case fut_nonlinearfb_lp_os:
-   case fut_nonlinearfb_hp_os:
-   case fut_nonlinearfb_n_os:
-   case fut_nonlinearfb_bp_os:
-      NonlinearFeedbackFilter::makeCoefficients(this, Freq, Reso, Type, true, storageI);
+      NonlinearFeedbackFilter::makeCoefficients(this, Freq, Reso, Type, storageI);
       break;
 
 #if SURGE_EXTRA_FILTERS

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -818,12 +818,6 @@ FilterUnitQFPtr GetQFPtrFilterUnit(int type, int subtype)
    case fut_nonlinearfb_bp:
       return NonlinearFeedbackFilter::process;
       break;
-   case fut_nonlinearfb_lp_os:
-   case fut_nonlinearfb_hp_os:
-   case fut_nonlinearfb_n_os:
-   case fut_nonlinearfb_bp_os:
-      return NonlinearFeedbackFilter::process_oversampled;
-      break;
    default:
       // SOFTWARE ERROR
       break;

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1031,7 +1031,7 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
             if (scene->filterunit[u].type.val.i == fut_lpmoog ||
                 scene->filterunit[u].type.val.i == fut_diode  ||
                 (scene->filterunit[u].type.val.i >= fut_nonlinearfb_lp &&
-                 scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp_os))
+                 scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp))
             {
                Q->FU[u].WP[0] =
                    scene->filterunit[u].subtype.val.i; // LPMoog's output stage index is stored in
@@ -1056,7 +1056,7 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
                if (scene->filterunit[u].type.val.i == fut_lpmoog ||
                    scene->filterunit[u].type.val.i == fut_diode  ||
                    (scene->filterunit[u].type.val.i >= fut_nonlinearfb_lp &&
-                    scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp_os))
+                    scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp))
                {
                   Q->FU[u + 2].WP[0] = scene->filterunit[u].subtype.val.i;
                }

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -28,7 +28,7 @@ enum Saturator {
     SAT_TANH = 0,
     SAT_SOFT,
     SAT_SINE,
-    SAT_ASINH
+    SAT_OJD
 };
 
 // sine each element of a __m128 by breaking it into floats then reassembling
@@ -42,43 +42,38 @@ static inline __m128 fastsin_ps(const __m128 in) noexcept {
    return _mm_load_ps(f);
 }
 
+// waveshaper from https://github.com/JanosGit/Schrammel_OJD/blob/master/Source/Waveshaper.h
+static inline float ojd_waveshaper(float in) noexcept {
+   if (in <= -1.7f){
+      return -1.0f;
+   }
+   else if ((in > -1.7f) && (in < -0.3f)){
+      in += 0.3f;
+      return in + (in * in) / (4.0f * (1.0f - 0.3f)) - 0.3f;
+   }
+   else if ((in > 0.9f) && (in < 1.1f))
+   {
+      in -= 0.9f;
+      return in - (in * in) / (4.0f * (1.0f - 0.9f)) + 0.9f;
+   }
+   else if (in > 1.1f){
+      return 1.0f;
+   }
+
+   return in;
+};
+
 // asinh each element of a __m128 by breaking it into floats then reassembling
-static inline __m128 asinh_ps(const __m128 in) noexcept {
+static inline __m128 ojd_waveshaper_ps(const __m128 in) noexcept {
    float f[4];
    _mm_storeu_ps(f, in);
-   f[0] = asinhf(f[0]);
-   f[1] = asinhf(f[1]);
-   f[2] = asinhf(f[2]);
-   f[3] = asinhf(f[3]);
+   f[0] = ojd_waveshaper(f[0]);
+   f[1] = ojd_waveshaper(f[1]);
+   f[2] = ojd_waveshaper(f[2]);
+   f[3] = ojd_waveshaper(f[3]);
    return _mm_load_ps(f);
 }
 
-// do not change this without also recalculating windowFactors!
-static constexpr int extraOversample = 4;
-static constexpr float extraOversampleInv = 1.0f / (float)extraOversample;
-
-// biquad without nonlinearity - used for upsampling
-// note, b2 optimised out because it will be the same as b0 for what we use it for
-static inline __m128 doFilter(
-      const __m128 input,
-      const __m128 a1,
-      const __m128 a2,
-      const __m128 b0,
-      const __m128 b1,
-      __m128 &z1,
-      __m128 &z2)
-   noexcept
-{
-   // out = z1 + b0 * input
-   const __m128 out = A(z1, M(b0, input));
-   // z1 = z2 + b1 * input - a1 * out
-   z1 = A(z2, S(M(b1, input), M(a1, out)));
-   // z2 = b2 * input - a2 * out
-   z2 = S(M(b0, input), M(a2, out));
-   return out;
-}
-
-// filter with a nonlinearity - what we actually want to hear
 static inline __m128 doNLFilter(
       const __m128 input,
       const __m128 a1,
@@ -106,8 +101,8 @@ static inline __m128 doNLFilter(
       case SAT_SINE:
          nf = fastsin_ps(out);
          break;
-      default: // SAT_ASINH
-         nf = asinh_ps(out);
+      default: // SAT_OJD
+         nf = ojd_waveshaper_ps(out);
          break;
    }
 
@@ -138,20 +133,15 @@ namespace NonlinearFeedbackFilter
       nlf_z6, // 2nd z-1 state for third  stage
       nlf_z7, // 1st z-1 state for fourth stage
       nlf_z8, // 2nd z-1 state for fourth stage
-      nlf_upz1, // 1st z-1 state for upsampling filter
-      nlf_upz2, // 2nd z-2 state for upsampling filter
-      // rest of the R[] state used for 3 more upsampling filter stages
    };
 
-   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, int type, bool oversample, SurgeStorage *storage )
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, int type, SurgeStorage *storage )
    {
       float C[n_cm_coeffs];
 
       const float q = ((reso * reso * reso) * 18.0f + 0.1f);
 
-      const float oversampling = oversample ? extraOversample : 1.0f;
-
-      const float wc = 2.0f * M_PI * clampedFrequency(freq, storage) / (dsamplerate_os * oversampling);
+      const float wc = 2.0f * M_PI * clampedFrequency(freq, storage) / dsamplerate_os;
 
       const float wsin  = Surge::DSP::fastsin(wc);
       const float wcos  = Surge::DSP::fastcos(wc);
@@ -166,19 +156,16 @@ namespace NonlinearFeedbackFilter
 
       switch(type){
          case fut_nonlinearfb_lp: // lowpass
-         case fut_nonlinearfb_lp_os:
             C[nlf_b1] =  (1.0f - wcos) * a0r;
             C[nlf_b0] = C[nlf_b1] *  0.5f;
             C[nlf_b2] = C[nlf_b0];
             break;
          case fut_nonlinearfb_hp: // highpass
-         case fut_nonlinearfb_hp_os:
             C[nlf_b1] = -(1.0f + wcos) * a0r;
             C[nlf_b0] = C[nlf_b1] * -0.5f;
             C[nlf_b2] = C[nlf_b0];
             break;
          case fut_nonlinearfb_n: // notch
-         case fut_nonlinearfb_n_os:
             C[nlf_b0] = a0r;
             C[nlf_b1] = -2.0f * wcos   * a0r;
             C[nlf_b2] = C[nlf_b0];
@@ -219,91 +206,5 @@ namespace NonlinearFeedbackFilter
       }
 
       return input;
-   }
-
-   __m128 process_oversampled( QuadFilterUnitState * __restrict f, __m128 input )
-   {
-      // lower 2 bits of subtype is the stage count
-      const int stages = f->WP[0] & 3;
-      // next two bits after that select the saturator
-      const int sat = ((f->WP[0] >> 2) & 3);
-
-      // oversampling method copied from VintageLadders.cpp, look there for better explanation
-
-      // prescale f->dC so it's for each oversampled sample
-      static const __m128 dFac = F(extraOversampleInv);
-      for(int i=0; i < n_nlf_coeff; ++i){
-         f->dC[i] = M(f->dC[i], dFac);
-      }
-
-      // do a crappy chain of 4 butterworth biquads for post-upsampling filter.
-      // calculated with python code:
-      // import math
-      // w0 = math.tau * 1/8  # 1/8 of the 4x sample rate is 1/2 of the original sample rate
-      // Q = 1/math.sqrt(2)   # Butterworth Q
-      // alpha = math.sin(w0)/(2*Q)
-      // b1 = (1 - math.cos(w0))
-      // b0 = b1 / 2
-      // a0 = 1 + alpha
-      // a1 = -2 * math.cos(w0) * (1/a0)
-      // a2 = (1-alpha) * (1/a0)
-      // print(a1, a2, b0, b1)
-      static const __m128 upsample_a1 = F(-0.9428090415820634f);
-      static const __m128 upsample_a2 = F( 0.3333333333333333f);
-      static const __m128 upsample_b0 = F( 0.1464466094067262f);
-      static const __m128 upsample_b1 = F( 0.2928932188134524f);
-
-      __m128 outputOS[extraOversample];
-      for(int osi = 0; osi < extraOversample; ++osi){
-         for(int stage = 0; stage < 4; ++stage){
-            input =
-               doFilter(input,
-                     upsample_a1,
-                     upsample_a2,
-                     upsample_b0,
-                     upsample_b1,
-                     f->R[nlf_upz1 + stage*2],
-                     f->R[nlf_upz2 + stage*2]);
-         }
-
-         outputOS[osi] = input;
-
-         // Zero stuffing
-         input = _mm_setzero_ps();
-      }
-
-      for(int osi = 0; osi < extraOversample; ++osi){
-         for(int i=0; i < n_nlf_coeff; ++i){
-            f->C[i] = A(f->C[i], f->dC[i]);
-         }
-
-         // n.b. stages is zero-indexed so use <=
-         for(int stage = 0; stage <= stages; ++stage){
-            outputOS[osi] =
-               doNLFilter(outputOS[osi],
-                     f->C[nlf_a1],
-                     f->C[nlf_a2],
-                     f->C[nlf_b0],
-                     f->C[nlf_b1],
-                     f->C[nlf_b2],
-                     sat,
-                     f->R[nlf_z1 + stage*2],
-                     f->R[nlf_z2 + stage*2]);
-         }
-      }
-
-      static const __m128 windowFactors[extraOversample] = {
-         F(-0.0636844f),
-         _mm_setzero_ps(),
-         F(0.57315917f),
-         F(1.0f)
-      };
-
-      __m128 ov = _mm_setzero_ps();
-      for(int i=0; i < extraOversample; ++i ){
-         ov = A(ov, M(outputOS[i], windowFactors[i]));
-      }
-
-      return ov;
    }
 }

--- a/src/common/dsp/filters/NonlinearFeedback.h
+++ b/src/common/dsp/filters/NonlinearFeedback.h
@@ -6,7 +6,6 @@ class SurgeStorage;
 
 namespace NonlinearFeedbackFilter 
 {
-   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, int subtype, bool oversample, SurgeStorage *storage );
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, int subtype, SurgeStorage *storage );
    __m128 process( QuadFilterUnitState * __restrict f, __m128 in );
-   __m128 process_oversampled( QuadFilterUnitState * __restrict f, __m128 in );
 }


### PR DESCRIPTION
I didn't implement oversampling well and it didn't really improve the sound so it has been removed.

The asinh nonlinearity was basically the same as the fastsin based one except slower, so it has been replaced by the waveshaper from https://github.com/JanosGit/Schrammel_OJD (this is GPLv3)
https://github.com/JanosGit/Schrammel_OJD/blob/master/Source/Waveshaper.h