### PR TITLE
Filter and AW Mouse Wheel; Menu as Slider with Ordering

### DIFF
--- a/libs/airwindows/include/airwindows/AirWinBaseClass.h
+++ b/libs/airwindows/include/airwindows/AirWinBaseClass.h
@@ -100,4 +100,5 @@ struct AirWinBaseClass {
       {}
    };
    static std::vector<Registration> pluginRegistry();
+   static std::vector<int> pluginRegistryOrdering();
 };

--- a/src/common/FilterConfiguration.h
+++ b/src/common/FilterConfiguration.h
@@ -371,6 +371,14 @@ struct FilterSelectorMapper : public ParameterDiscreteIndexRemapper {
    virtual bool sortGroupNames() override {
       return false;
    }
+
+   virtual bool supportsTotalIndexOrdering() override { return true; }
+   virtual const std::vector<int> totalIndexOrdering() override {
+      auto res = std::vector<int>();
+      for( auto m : mapping ) res.push_back( m.first );
+      return res;
+   }
+
 };
 
 /*

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -183,6 +183,9 @@ struct ParameterDiscreteIndexRemapper : public ParamUserData
    virtual bool hasGroupNames() { return false; }
    virtual std::string groupNameAtStreamedIndex( int i ) { return ""; } // If you want menu grouping
    virtual bool sortGroupNames() { return true; }
+
+   virtual bool supportsTotalIndexOrdering() { return false; }
+   virtual const std::vector<int> totalIndexOrdering() { return std::vector<int>(); }
 };
 
 /*

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.cpp
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.cpp
@@ -89,6 +89,7 @@ void AirWindowsEffect::init_ctrltypes() {
    */
    Effect::init_ctrltypes();
    fxreg = AirWinBaseClass::pluginRegistry();
+   fxregOrdering = AirWinBaseClass::pluginRegistryOrdering();
 
    fxdata->p[0].set_name( "FX" );
    fxdata->p[0].set_type( ct_airwindows_fx );

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.h
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.h
@@ -49,9 +49,12 @@ public:
    int lastSelected = -1;
    
    std::vector<AirWinBaseClass::Registration> fxreg;
+   std::vector<int> fxregOrdering;
 
    struct AWFxSelectorMapper : public ParameterDiscreteIndexRemapper {
-      AWFxSelectorMapper( AirWindowsEffect *fx ) { this->fx = fx; };
+      AWFxSelectorMapper( AirWindowsEffect *fx ) {
+         this->fx = fx;
+      };
 
       virtual int remapStreamedIndexToDisplayIndex( int i ) override {
          return fx->fxreg[i].displayOrder;
@@ -63,6 +66,16 @@ public:
       
       virtual std::string groupNameAtStreamedIndex( int i ) override {
          return fx->fxreg[i].groupName;
+      }
+
+      bool supportsTotalIndexOrdering() override
+      {
+         return true;
+      }
+
+      const std::vector<int> totalIndexOrdering() override
+      {
+         return fx->fxregOrdering;
       }
       AirWindowsEffect *fx;
    };

--- a/src/common/gui/CMenuAsSlider.cpp
+++ b/src/common/gui/CMenuAsSlider.cpp
@@ -291,10 +291,30 @@ bool CMenuAsSlider::onWheel( const VSTGUI::CPoint &where, const float &distance,
 
    auto fv = [this](float v, int inc)
                 {
-                   int iv = floor( getValue() * ( iMax - iMin ) + 0.5 );
-                   iv = iv + inc;
-                   if( iv < 0 ) iv = iMax;
-                   if( iv > iMax ) iv = 0;
+                   int iv = Parameter::intUnscaledFromFloat(v, iMax, iMin );
+                   if( intOrdering.size() > 0 && iMax == intOrdering.size() - 1 )
+                   {
+                      int pidx = 0;
+                      for( int idx=0; idx<intOrdering.size(); idx++ )
+                         if( intOrdering[idx] == iv )
+                         {
+                            pidx = idx;
+                            break;
+                         }
+                      int nidx = pidx + inc;
+                      if( nidx < 0 ) nidx = intOrdering.size() - 1;
+                      else if( nidx >= intOrdering.size() ) nidx = 0;
+
+                      iv = intOrdering[nidx];
+                   }
+                   else
+                   {
+                      iv = iv + inc;
+                      if (iv < 0)
+                         iv = iMax;
+                      if (iv > iMax)
+                         iv = 0;
+                   }
                    // This is the get_value_f01 code
                    float r = Parameter::intScaledToFloat(iv, iMax, iMin );
                    return r;

--- a/src/common/gui/CMenuAsSlider.h
+++ b/src/common/gui/CMenuAsSlider.h
@@ -95,7 +95,9 @@ public:
       dglphyid = id; dglyphsize = size; onSkinChanged();
    }
    const int* glyphIndexMap = nullptr;
-   
+
+   std::vector<int> intOrdering;
+
 private:
    VSTGUI::CBitmap *pBackground = nullptr, *pBackgroundHover = nullptr, *pGlyph = nullptr, *pGlyphHover = nullptr;
    std::string label = "";

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -6991,6 +6991,11 @@ VSTGUI::CControl *SurgeGUIEditor::layoutComponentForSkin( std::shared_ptr<Surge:
                                      p->id + start_paramtags,
                                      bitmapStore,
                                      &(synth->storage));
+
+         auto *parm = dynamic_cast<ParameterDiscreteIndexRemapper*>(p->user_data);
+         if( parm && parm->supportsTotalIndexOrdering() )
+            hs->intOrdering = parm->totalIndexOrdering();
+
          hs->setSkin( currentSkin, bitmapStore );
          hs->setValue( p->get_value_f01() );
          hs->setMinMax( p->val_min.i, p->val_max.i );
@@ -7272,6 +7277,11 @@ VSTGUI::CControl *SurgeGUIEditor::layoutComponentForSkin( std::shared_ptr<Surge:
       auto rect = skinCtrl->getRect();
       auto hsw = new CMenuAsSlider(rect.getTopLeft(), CPoint(124, 21), this,
                                    p->id + start_paramtags, bitmapStore, &(synth->storage));
+
+      auto *parm = dynamic_cast<ParameterDiscreteIndexRemapper*>(p->user_data);
+      if( parm && parm->supportsTotalIndexOrdering() )
+         hsw->intOrdering = parm->totalIndexOrdering();
+
       hsw->setMinMax(0, n_fu_types - 1);
       hsw->setMouseableArea(rect);
       hsw->setLabel(p->get_name());


### PR DESCRIPTION
The MenuAsSlider class can obey an external ordering for
wheel operations. This operation can be generated by
the reordering object. Impement for both filters and
airwindows ordering helpers.

Closes #3328