### PR TITLE
Memory for Filter SubTypes

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -132,6 +132,24 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
                getPatch().scene[s].osc[o].wt.TableF32WeakPointers[i][j] = 0;
                getPatch().scene[s].osc[o].wt.TableI16WeakPointers[i][j] = 0;
             }
+
+   for( int s = 0; s < n_scenes; ++s)
+      for( int fu=0; fu<n_filterunits_per_scene; ++fu )
+         for( int t=0; t<n_fu_types; ++t )
+         {
+            switch( t )
+            {
+            case fut_lpmoog:
+            case fut_obxd_4pole:
+            case fut_diode:
+               subtypeMemory[s][fu][t] = 3;
+               break;
+            default:
+               subtypeMemory[s][fu][t] = 0;
+               break;
+            }
+         }
+
    init_tables();
    pitch_bend = 0;
    last_key[0] = 60;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -934,6 +934,8 @@ public:
    // Alterhately make this unordered and provide a hash
    std::map<std::pair<std::string,int>, std::string> helpURL_paramidentifier_typespecialized;
 
+   int subtypeMemory[n_scenes][n_filterunits_per_scene][n_fu_types];
+
 private:
    TiXmlDocument snapshotloader;
    std::vector<Parameter> clipboard_p;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1560,17 +1560,11 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
          {
             // Oh my goodness this is deeply sketchy code to not document! It assumes that subtype
             // is right after type in ID space without documenting it. So now documented!
-            switch (storage.getPatch().param_ptr[index]->val.i)
-            {
-            case fut_lpmoog:
-            case fut_obxd_4pole:
-            case fut_diode:
-               storage.getPatch().param_ptr[index + 1]->val.i = 3;
-               break;
-            default:
-               storage.getPatch().param_ptr[index + 1]->val.i = 0;
-               break;
-            }
+            auto typep = ( storage.getPatch().param_ptr[index]);
+            auto subtypep = storage.getPatch().param_ptr[index+1];
+
+            /* Used to be an lpmoog -> 3 type thing in here but that moved to the SurgeStorage ctor */
+            subtypep->val.i = storage.subtypeMemory[typep->scene-1][typep->ctrlgroup_entry][typep->val.i];
          }
          break;
       case ct_osctype: {
@@ -1605,13 +1599,15 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
       case ct_filtersubtype:
          // See above: We know the filter type for this subtype is at index - 1. Cap max to be the fut-subtype
          {
+            auto subp = storage.getPatch().param_ptr[index];
             auto filterType = storage.getPatch().param_ptr[index - 1]->val.i;
             auto maxIVal = fut_subcount[filterType];
             if (maxIVal == 0)
-               storage.getPatch().param_ptr[index]->val.i = 0;
+               subp->val.i = 0;
             else
-               storage.getPatch().param_ptr[index]->val.i =
-                   std::min(maxIVal - 1, storage.getPatch().param_ptr[index]->val.i);
+               subp->val.i = std::min(maxIVal - 1, subp->val.i);
+            storage.subtypeMemory[subp->scene-1][subp->ctrlgroup_entry][subp->val.i] = subp->val.i;
+
             switch_toggled_queued = true;
             break;
          }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3606,6 +3606,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
       csc->value_direction = 0;
 
       int a = synth->storage.getPatch().scene[current_scene].filterunit[idx].subtype.val.i + valdir;
+      int t = synth->storage.getPatch().scene[current_scene].filterunit[idx].type.val.i;
       int nn =
          fut_subcount[synth->storage.getPatch().scene[current_scene].filterunit[idx].type.val.i];
       if (a >= nn)
@@ -3613,6 +3614,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
       if( a < 0 )
          a = nn-1;
       synth->storage.getPatch().scene[current_scene].filterunit[idx].subtype.val.i = a;
+      synth->storage.subtypeMemory[current_scene][idx][t] = a;
       if( csc )
       {
          if (nn == 0)


### PR DESCRIPTION
If you change a filter subtype and then change type
it forgot the prior types filter subtype and now the
subtype of the prior type is reapplied as the subtype of
the current type when the current type retirns to the prior
type. Chuckle.

Closes #3348