### PR TITLE
Add a Mono Pedal mode for alternate release

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1778,8 +1778,13 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
                p->QueryIntAttribute("v",&ival) == TIXML_SUCCESS)
                dawExtraState.mpePitchBendRange = ival;
 
+          p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("monoPedalMode"));
+          if( p &&
+              p->QueryIntAttribute("v",&ival) == TIXML_SUCCESS)
+             dawExtraState.monoPedalMode = ival;
 
-           p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("hasTuning"));
+
+          p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("hasTuning"));
            if( p &&
                p->QueryIntAttribute("v",&ival) == TIXML_SUCCESS)
            {
@@ -2136,6 +2141,10 @@ unsigned int SurgePatch::save_xml(void** data) // allocates mem, must be freed b
        TiXmlElement mppb("mpePitchBendRange");
        mppb.SetAttribute("v", dawExtraState.mpePitchBendRange );
        dawExtraXML.InsertEndChild(mppb);
+
+       TiXmlElement mpm("monoPedalMode");
+       mpm.SetAttribute("v", dawExtraState.monoPedalMode );
+       dawExtraXML.InsertEndChild(mpm);
 
        TiXmlElement tun("hasTuning");
        tun.SetAttribute("v", dawExtraState.hasTuning ? 1 : 0 );

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -23,6 +23,7 @@
 #include <map>
 #include <queue>
 #include <vt_dsp/vt_dsp_endian.h>
+#include "UserDefaults.h"
 #if MAC
 #include <cstdlib>
 #include <sys/stat.h>
@@ -538,6 +539,10 @@ bailOnPortable:
          Surge::MSEG::rebuildCache( ms );
       }
    }
+
+   monoPedalMode = (MonoPedalMode)Surge::Storage::getUserDefaultValue(this,
+                                                                      "monoPedalMode",
+                                                                      MonoPedalMode::HOLD_ALL_NOTES );
 }
 
 SurgePatch& SurgeStorage::getPatch()

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -671,6 +671,8 @@ struct DAWExtraStateStorage
 
    std::unordered_map<int, int> midictrl_map; // param -> midictrl
    std::unordered_map<int, int> customcontrol_map; // custom controller number -> midicontrol
+
+   int monoPedalMode = 0;
 };
 
 
@@ -790,6 +792,22 @@ enum surge_copysource
 
    n_copysources,
 };
+
+/*
+ * How does the sustain pedal work in mono mode? Current modes for this are
+ *
+ * HOLD_ALL_NOTES (the default). If you release a note with the pedal down
+ * it does not release
+ *
+ * RELEASE_IF_OTHERS_HELD. If you release a note, and no other notes are down,
+ * do not release. But if you release and another note is down, return to that
+ * note (basically allow sustain pedal trills).
+ */
+enum MonoPedalMode {
+   HOLD_ALL_NOTES,
+   RELEASE_IF_OTHERS_HELD
+};
+
 
 /* STORAGE layer			*/
 
@@ -935,6 +953,7 @@ public:
    std::map<std::pair<std::string,int>, std::string> helpURL_paramidentifier_typespecialized;
 
    int subtypeMemory[n_scenes][n_filterunits_per_scene][n_fu_types];
+   MonoPedalMode monoPedalMode = HOLD_ALL_NOTES;
 
 private:
    TiXmlDocument snapshotloader;

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -1,6 +1,6 @@
 #include "UserDefaults.h"
 #include "UserInteractions.h"
-
+#include "SurgeStorage.h"
 
 #include <string>
 #include <iostream>

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <vector>
-#include "SurgeStorage.h"
 
 /*
 ** Surge has a variety of settings which users can update and save across
@@ -12,6 +11,8 @@
 ** persist this information.
 */
 
+
+class SurgeStorage;
 
 namespace Surge
 {

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -499,6 +499,7 @@ private:
    VSTGUI::COptionMenu* makeMidiMenu(VSTGUI::CRect &rect);
    VSTGUI::COptionMenu* makeDevMenu(VSTGUI::CRect &rect);
    VSTGUI::COptionMenu* makeLfoMenu(VSTGUI::CRect &rect);
+   VSTGUI::COptionMenu* makeMonoModeOptionsMenu(VSTGUI::CRect &rect, bool updateDefaults );
    bool scannedForMidiPresets = false;
 
    void resetSmoothing( ControllerModulationSource::SmoothingMode t );


### PR DESCRIPTION
Should a release allow mono pedal trills or not? That is if a release
occurs and another note is playable should you do the release if pedal
is held in mono modes? Well both answers are right, so add an option.

Closes #1459