### PR TITLE
Mono Voice Priority Modes

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -440,10 +440,35 @@ const char em_names[n_env_modes][16] =
    "Analog",
 };
 
+
+/*
+ * How does the sustain pedal work in mono mode? Current modes for this are
+ *
+ * HOLD_ALL_NOTES (the default). If you release a note with the pedal down
+ * it does not release
+ *
+ * RELEASE_IF_OTHERS_HELD. If you release a note, and no other notes are down,
+ * do not release. But if you release and another note is down, return to that
+ * note (basically allow sustain pedal trills).
+ */
+enum MonoPedalMode {
+   HOLD_ALL_NOTES,
+   RELEASE_IF_OTHERS_HELD
+};
+
+enum MonoVoicePriorityMode {
+   NOTE_ON_LATEST_RETRIGGER_HIGHEST, // The legacy mode for 1.7.1 and earlier
+   ALWAYS_LATEST, // Could also be called "NOTE_ON_LATEST_RETRIGGER_LATEST"
+   ALWAYS_HIGHEST,
+   ALWAYS_LOWEST,
+};
+
+
 struct MidiKeyState
 {
    int keystate;
    char lastdetune;
+   int64_t voiceOrder;
 };
 
 struct MidiChannelState
@@ -548,6 +573,8 @@ struct SurgeSceneStorage
    std::vector<ModulationSource*> modsources;
 
    bool modsource_doprocess[n_modsources];
+
+   MonoVoicePriorityMode monoVoicePriorityMode = ALWAYS_LATEST;
 };
 
 const int n_stepseqsteps = 16;
@@ -626,6 +653,8 @@ struct MSEGStorage {
 
 struct FormulaModulatorStorage { // Currently an unused placeholder
 };
+
+
 
 /*
 ** There are a collection of things we want your DAW to save about your particular instance
@@ -791,21 +820,6 @@ enum surge_copysource
    cp_oscmod,
 
    n_copysources,
-};
-
-/*
- * How does the sustain pedal work in mono mode? Current modes for this are
- *
- * HOLD_ALL_NOTES (the default). If you release a note with the pedal down
- * it does not release
- *
- * RELEASE_IF_OTHERS_HELD. If you release a note, and no other notes are down,
- * do not release. But if you release and another note is down, return to that
- * note (basically allow sustain pedal trills).
- */
-enum MonoPedalMode {
-   HOLD_ALL_NOTES,
-   RELEASE_IF_OTHERS_HELD
 };
 
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -140,6 +140,7 @@ public:
    void freeVoice(SurgeVoice*);
    std::array<std::array<SurgeVoice, MAX_VOICES>, 2> voices_array;
    unsigned int voices_usedby[2][MAX_VOICES]; // 0 indicates no user, 1 is scene A & 2 is scene B   // TODO: FIX SCENE ASSUMPTION!
+   int64_t voiceCounter = 1L;
 
 public:
 

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -70,7 +70,8 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
                        MidiKeyState* keyState,
                        MidiChannelState* mainChannelState,
                        MidiChannelState* voiceChannelState,
-                       bool mpeEnabled
+                       bool mpeEnabled,
+                       int64_t voiceOrder
     )
 //: fb(storage,oscene)
 {
@@ -83,6 +84,9 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    assert(oscene);
 
    memcpy(localcopy, paramptr, sizeof(localcopy));
+
+   // We want this on the keystate so it survives the voice for mono mode
+   keyState->voiceOrder = voiceOrder;
 
    age = 0;
    age_release = 0;
@@ -112,7 +116,7 @@ SurgeVoice::SurgeVoice(SurgeStorage* storage,
    else
       state.portasrc_key = storage->last_key[scene_id];
    state.priorpkey = state.portasrc_key;
-   
+
    storage->last_key[scene_id] = key;
    state.portaphase = 0;
    noisegenL[0] = 0.f;

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -48,7 +48,8 @@ public:
               MidiKeyState* keyState,
               MidiChannelState* mainChannelState,
               MidiChannelState* voiceChannelState,
-              bool mpeEnabled
+              bool mpeEnabled,
+              int64_t voiceOrder
        );
    ~SurgeVoice();
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2913,6 +2913,22 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                        p->val.i == pm_mono_fp ||
                        p->val.i == pm_mono_st_fp ))
                   {
+                     std::vector<std::string> labels = { "Latest", "Highest", "Lowest", "Latest On, Highest Off (Legacy)" };
+                     std::vector<MonoVoicePriorityMode> vals = { ALWAYS_LATEST, ALWAYS_HIGHEST, ALWAYS_LOWEST, NOTE_ON_LATEST_RETRIGGER_HIGHEST };
+                     contextMenu->addSeparator();
+                     for( int i=0; i<4; ++i )
+                     {
+                        auto m = addCallbackMenu(contextMenu,
+                                                 Surge::UI::toOSCaseForMenu("Priority: " + labels[i]),
+                                                 [this,vals,i] ()
+                                                 {
+                                                    synth->storage.getPatch().scene[current_scene].monoVoicePriorityMode =
+                                                    vals[i];
+                                                 }
+                        );
+                        if( vals[i] == synth->storage.getPatch().scene[current_scene].monoVoicePriorityMode )
+                           m->setChecked( true );
+                     }
                      contextMenu->addSeparator();
                      contextMenu->addEntry(makeMonoModeOptionsMenu(menuRect, false ),
                                            Surge::UI::toOSCaseForMenu("Mono Mode Options (Current Instance)"));

--- a/src/headless/UnitTestsIO.cpp
+++ b/src/headless/UnitTestsIO.cpp
@@ -727,3 +727,39 @@ TEST_CASE( "Patch Version Builder", "[io]")
       }
    }
 }
+
+TEST_CASE( "MonoVoicePriority Streams", "[io]" )
+{
+   auto fromto = [](std::shared_ptr<SurgeSynthesizer> src,
+                    std::shared_ptr<SurgeSynthesizer> dest)
+   {
+     void *d = nullptr;
+     auto sz = src->saveRaw( &d );
+
+     dest->loadRaw( d, sz, false );
+   };
+   SECTION( "MVP Streams Properly" )
+   {
+      int mvp = ALWAYS_LOWEST;
+      for( int i=0; i<20; ++i )
+      {
+         int r1 = rand() % (mvp + 1);
+         int r2 = rand() % (mvp + 1);
+         INFO( "Checking type " << r1 << " " << r2 );
+         auto ssrc = Surge::Headless::createSurge(44100);
+         ssrc->storage.getPatch().scene[0].monoVoicePriorityMode = (MonoVoicePriorityMode)r1;
+         ssrc->storage.getPatch().scene[1].monoVoicePriorityMode = (MonoVoicePriorityMode)r2;
+         auto sdst = Surge::Headless::createSurge(44100);
+
+         REQUIRE( sdst->storage.getPatch().scene[0].monoVoicePriorityMode == ALWAYS_LATEST );
+         REQUIRE( sdst->storage.getPatch().scene[1].monoVoicePriorityMode == ALWAYS_LATEST );
+
+         fromto( ssrc, sdst );
+
+         REQUIRE( sdst->storage.getPatch().scene[0].monoVoicePriorityMode == (MonoVoicePriorityMode)r1);
+         REQUIRE( sdst->storage.getPatch().scene[1].monoVoicePriorityMode == (MonoVoicePriorityMode)r2);
+
+      }
+   }
+
+}


### PR DESCRIPTION
This adds 3 new voice prioprity modes; always latest,highest, and lowest,
and adjusts the regular and MPE voice management to respect them.
It adds a collection of assertive regtests which test it, streams it
into the patch, and adds it to the UI.

Closes #3359