### PR TITLE
Patch an automation first-time problem in Live

### DIFF
--- a/src/common/gui/CHSwitch2.cpp
+++ b/src/common/gui/CHSwitch2.cpp
@@ -118,7 +118,6 @@ CMouseEventResult CHSwitch2::onMouseDown(CPoint& where, const CButtonState& butt
    }
    else
    {
-      beginEdit();
       auto res = onMouseMoved(where, buttons);
       if( res == kMouseDownEventHandledButDontNeedMovedOrUpEvents )
          mouseDowns --;
@@ -131,7 +130,6 @@ CMouseEventResult CHSwitch2::onMouseUp(CPoint& where, const CButtonState& button
 
    if (draggable)
    {
-      endEdit();
       return kMouseEventHandled;
    }
    return kMouseEventNotHandled;
@@ -167,13 +165,13 @@ CMouseEventResult CHSwitch2::onMouseMoved(CPoint& where, const CButtonState& but
       }
 
       invalid();
+      beginEdit();
       if (listener)
          listener->valueChanged(this);
-
+      endEdit();
       return kMouseEventHandled;
    }
 
-   
    return kMouseEventNotHandled;
 }
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4403,6 +4403,27 @@ void SurgeGUIEditor::controlBeginEdit(VSTGUI::CControl* control)
    }
 
 #endif
+
+#if TARGET_VST3
+   /*
+    * I am sure this is us doing something wrong, but the first time through
+    * of an edit of a discrete value (the digital/analog for instance) the
+    * beignEdit starts sending me the old value over and over which isn't what
+    * I want, and that old value is gotten when beginEdit is called, not when
+    * endEdit is called. So this code, in LIve, establishes the value as correct
+    * at the beginning of beginEdit. Which is odd but fixes issue #3283.
+    */
+   if( synth->hostProgram.find( "Ableton" ) != string::npos )
+   {
+      long tag = control->getTag();
+      int ptag = tag - start_paramtags;
+      if( ptag >= 0 && ptag < synth->storage.getPatch().param_ptr.size())
+      {
+         auto id = synth->idForParameter(synth->storage.getPatch().param_ptr[ptag]);
+         synth->setParameter01(id, control->getValue(), false);
+      }
+   }
+#endif
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
First time you adjusted a switch in Live it would use
the old value, force that on, and flicker. I think this
is because of a surge bug I can't find, but for now, and
only in live, in controlBeginEdit make sure the value
is set before you release the DAW to ask it of you
(which again it only does in Live first time round, I think
when it is putting the param in the little xy box thing).

Closes #3283 but not very satisfactorily