### PR TITLE
Add nonlinear feedback allpass filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,16 +176,6 @@ else()
   set( BUILD_LV2 false )
 endif()
 
-# Surge features at compile time
-if( NOT DEFINED SURGE_EXTRA_FILTERS )
-  set( SURGE_EXTRA_FILTERS False )
-  set( SURGE_EXTRA_FILTERS_DEFINITIONS SURGE_EXTRA_FILTERS=0 )
-else()
-  message( STATUS "Including Surge Extra Filters" )
-  set( SURGE_EXTRA_FILTERS True )
-  set( SURGE_EXTRA_FILTERS_DEFINITIONS SURGE_EXTRA_FILTERS=1 )
-endif()
-
 # Enumerate the sources into groups
 #    SURGE_SHARED_SOURCES - these are used to make the synth-free ui-free dsp and param lib
 #    SURGE_SYNTH_SOURCES - these are the synth classes which are target type dependant
@@ -430,7 +420,6 @@ if( APPLE )
     MAC_COCOA=1
     COCOA=1
     OBJC_OLD_DISPATCH_PROTOTYPES=1
-    ${SURGE_EXTRA_FILTERS_DEFINITIONS}
     )
   set(OS_LINK_LIBRARIES_NOGUI
     "-framework CoreServices"
@@ -508,7 +497,6 @@ elseif( UNIX AND NOT APPLE )
   set(OS_COMPILE_DEFINITIONS
     ${ARCH_COMPILE_DEFINITIONS}
     LINUX=1
-    ${SURGE_EXTRA_FILTERS_DEFINITIONS}
     )
 
   set(OS_INCLUDE_DIRECTORIES
@@ -582,7 +570,6 @@ elseif( WIN32 )
     _CRT_SECURE_NO_WARNINGS=1
     UNICODE
     _UNICODE
-    ${SURGE_EXTRA_FILTERS_DEFINITIONS}
     )
 
   if( ${CMAKE_SIZEOF_VOID_P} EQUAL 4 )

--- a/doc/AddingAFilter.md
+++ b/doc/AddingAFilter.md
@@ -1,20 +1,24 @@
 # HOw to add a filter
 
-0. For any of this to work right now `cmake -Bbuild -GXcode -DSURGE_EXTRA_FILTERS=True` before you build-osx. And equivalent on others.
-
 1. Create src/common/dsp/filters/(name).h and (name).cpp. Look at RKMoog as an example. It should have two functions, a coeff and a process
    function. You are making free function here not an object. The RKMoog signatures are good starting points. Add the cpp to CMakeLists.txt
    You will need at least two functions, "makeCoefficients" and "process". The Prototype for process is fixed; the prototype for makeCoefficients
    is up to you.
 
-2. In SurgeStorage.h add an enum to fu_type. ADD IT AT THE END. Then add a name to fut_names
+2. In FilterConfiguration.h:
+* add an enum to fu_type. ADD IT AT THE END.
+* add a name to fut_names and fut_menu_names
+* add an entry to fut_subcount for the number of subtypes your filter has
+* add any additional strings or other constants your subtypes might use to this file too
+* add a line to FilterSelectorMapper
+* add an entry to fut_glyph_index
 
 3. In FilterCoefficientMaker.h you get an opportunity to set up state variables. You have 8 coefficients C[8] you can set to - well - anything.
    This should redirect to the makeCoefficients function you put in your namespace.
    1. in FilterCoefficientMaker::MakeCoeffs call it in the switch
    2. This is called at most once every BLOCK_SIZE_OS and then only when F or R change
    
-4. In QuadFilterUnit.cpp you need to return a function which does the filtering from the setup.
+4. In QuadFilterUnit.cpp in GetQFPtrFilterUnit you need to return a function which does the filtering from the setup.
    1. It has to have the prototype `_m128 op( QuadFilterUnitState * __restrict, _m128 in )`
    2. The function to return is your namespaced process function. It will get a QuadFilterUnitState which
       has the coefficients you set in make Coeff (the "C") and also an array of registers R you can use.
@@ -24,5 +28,7 @@
       and we should aspire to those. But for now you can also see a manual unroll in RKMoog.cpp
     
 5. If you are adding subtypes you also want to add the stringification to Parameter.cpp again in an ifdef. RKMoog shows this too.
+
+6. If your subtype needs to be accessible to your SSE function, check out the switch statements in `SurgeVoice::SetQFB`.
 
 Then you can code up your filter. Again follow RKMoog as a worked example.

--- a/src/common/FilterConfiguration.h
+++ b/src/common/FilterConfiguration.h
@@ -101,6 +101,7 @@ enum fu_type
    fut_notch24,
    fut_comb_neg,
    fut_apf,
+   fut_nonlinearfb_ap,
    n_fu_types,
 };
 
@@ -112,36 +113,37 @@ enum fu_type
  */
 const char fut_names[n_fu_types][32] =
     {
-        "Off",
-        "LP 12 dB",
-        "LP 24 dB",
-        "LP Legacy Ladder",
-        "HP 12 dB",
-        "HP 24 dB",
-        "BP 12 dB",
-        "N 12 dB",
-        "FX Comb +",
-        "FX Sample & Hold",
-        "LP Vintage Ladder",
-        "LP OB-Xd 12 dB",
-        "LP OB-Xd 24 dB",
-        "LP K35",
-        "HP K35",
-        "LP Diode Ladder",
-        "LP NL Feedback",
-        "HP NL Feedback",
-        "N NL Feedback",
-        "BP NL Feedback",
-        "HP OB-Xd 12 dB",
-        "N OB-Xd 12 dB",
-        "BP OB-Xd 12 dB",
-        "BP 24 dB",
-        "N 24 dB",
-        "FX Comb -",
-        "FX Allpass",
+        "Off",              // fut_none
+        "LP 12 dB",         // fut_lp12
+        "LP 24 dB",         // fut_lp24
+        "LP Legacy Ladder", // fut_lpmoog
+        "HP 12 dB",         // fut_hp12
+        "HP 24 dB",         // fut_hp24
+        "BP 12 dB",         // fut_bp12
+        "N 12 dB",          // fut_notch12
+        "FX Comb +",        // fut_comb_pos
+        "FX Sample & Hold", // fut_SNH
+        "LP Vintage Ladder",// fut_vintageladder
+        "LP OB-Xd 12 dB",   // fut_obxd_2pole_lp
+        "LP OB-Xd 24 dB",   // fut_obxd_4pole
+        "LP K35",           // fut_k35_lp
+        "HP K35",           // fut_k35_hp
+        "LP Diode Ladder",  // fut_diode
+        "LP NL Feedback",   // fut_nonlinearfb_lp
+        "HP NL Feedback",   // fut_nonlinearfb_hp
+        "N NL Feedback",    // fut_nonlinearfb_n
+        "BP NL Feedback",   // fut_nonlinearfb_bp
+        "HP OB-Xd 12 dB",   // fut_obxd_2pole_hp
+        "N OB-Xd 12 dB",    // fut_obxd_2pole_n
+        "BP OB-Xd 12 dB",   // fut_obxd_2pole_bp
+        "BP 24 dB",         // fut_bp24
+        "N 24 dB",          // fut_notch24
+        "FX Comb -",        // fut_comb_neg
+        "FX Allpass",       // fut_apf
+        "FX NL Allpass",    // fut_nonlinearfb_ap
         /* this is a ruler to ensure names do not exceed 31 characters
-        0123456789012345678901234567890
-          */
+         0123456789012345678901234567890
+        */
     };
 
 const char fut_menu_names[n_fu_types][32] =
@@ -173,9 +175,10 @@ const char fut_menu_names[n_fu_types][32] =
         "24 dB", // N
         "Comb -",
         "Allpass",
+        "NL Feedback Allpass",
         /* this is a ruler to ensure names do not exceed 31 characters
-        0123456789012345678901234567890
-          */
+         0123456789012345678901234567890
+        */
     };
 
 const char fut_bp_subtypes[3][32] =
@@ -269,33 +272,34 @@ const char fut_nlf_saturators[4][6] =
 
 const int fut_subcount[n_fu_types] =
     {
-        0, // fut_none
-        3, // fut_lp12
-        3, // fut_lp24
-        4, // fut_lpmoog
-        3, // fut_hp12
-        3, // fut_hp24
-        3, // fut_bp12
-        2, // fut_notch12
-        2, // fut_comb_pos
-        0, // fut_SNH
-        4, // fut_vintageladder
-        2, // fut_obxd_2pole
-        4, // fut_obxd_4pole
-        5, // fut_k35_lp
-        5, // fut_k35_hp
-        4, // fut_diode
+        0,  // fut_none
+        3,  // fut_lp12
+        3,  // fut_lp24
+        4,  // fut_lpmoog
+        3,  // fut_hp12
+        3,  // fut_hp24
+        3,  // fut_bp12
+        2,  // fut_notch12
+        2,  // fut_comb_pos
+        0,  // fut_SNH
+        4,  // fut_vintageladder
+        2,  // fut_obxd_2pole
+        4,  // fut_obxd_4pole
+        5,  // fut_k35_lp
+        5,  // fut_k35_hp
+        4,  // fut_diode
         16, // fut_nonlinearfb_lp
         16, // fut_nonlinearfb_hp
         16, // fut_nonlinearfb_n
-        16,  // fut_nonlinearfb_bp
-        2, // fut_obxd_2pole_hp,
-        2, // fut_obxd_2pole_n,
-        2, // fut_obxd_2pole_bp,
-        3, // fut_bp24,
-        2, // fut_notch24,
-        2, // fut_comb_neg,
-        0, // fut_apf
+        16, // fut_nonlinearfb_bp
+        2,  // fut_obxd_2pole_hp,
+        2,  // fut_obxd_2pole_n,
+        2,  // fut_obxd_2pole_bp,
+        3,  // fut_bp24,
+        2,  // fut_notch24,
+        2,  // fut_comb_neg,
+        0,  // fut_apf
+        16, // fut_nonlinearfb_ap
     };
 
 enum fu_subtype
@@ -344,6 +348,7 @@ struct FilterSelectorMapper : public ParameterDiscreteIndexRemapper {
       p(fut_nonlinearfb_n, "Notch" );
 
       p(fut_apf, "Effect" );
+      p(fut_nonlinearfb_ap, "Effect" );
       p(fut_comb_pos, "Effect" );
       p(fut_comb_neg, "Effect" );
       p(fut_SNH, "Effect" );
@@ -390,18 +395,18 @@ struct FilterSelectorMapper : public ParameterDiscreteIndexRemapper {
 const int lprow = 1;
 const int bprow = 2;
 const int hprow = 3;
-const int nrow = 4;
+const int nrow  = 4;
 const int fxrow = 5;
 const int fut_glyph_index[n_fu_types][2] =
     {
-        { 0, 0 }, // fut_none
+        { 0,     0 }, // fut_none
         { 0, lprow }, // fut_lp12
         { 1, lprow }, // fut_lp24
         { 3, lprow }, // fut_lpmoog
         { 0, hprow }, // fut_hp12
         { 1, hprow }, // fut_hp24
         { 0, bprow }, // fut_bp12
-        { 0, nrow }, // fut_notch12
+        { 0,  nrow }, // fut_notch12
         { 1, fxrow }, // fut_comb_pos
         { 3, fxrow }, // fut_SNH
         { 4, lprow }, // fut_vintageladder
@@ -412,13 +417,14 @@ const int fut_glyph_index[n_fu_types][2] =
         { 5, lprow }, // fut_diode
         { 8, lprow }, // fut_nonlinearfb_lp
         { 4, hprow }, // fut_nonlinearfb_hp
-        { 3, nrow }, // fut_nonlinearfb_n
-        { 3, bprow },  // fut_nonlinearfb_bp
+        { 3,  nrow }, // fut_nonlinearfb_n
+        { 3, bprow }, // fut_nonlinearfb_bp
         { 3, hprow }, // fut_obxd_2pole_hp,
-        { 2, nrow }, // fut_obxd_2pole_n,
+        { 2,  nrow }, // fut_obxd_2pole_n,
         { 2, bprow }, // fut_obxd_2pole_bp,
         { 1, bprow }, // fut_bp24,
-        { 1, nrow }, // fut_notch24,
-        { 2, fxrow },  // fut_comb_neg,
-        { 0, fxrow }   // fut_apf
+        { 1,  nrow }, // fut_notch24,
+        { 2, fxrow }, // fut_comb_neg,
+        { 0, fxrow }, // fut_apf
+        { 0, fxrow }  // fut_nonlinearfb_ap (this is temporarily set to just use the regular AP glyph)
     };

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2269,15 +2269,14 @@ void Parameter::get_display(char* txt, bool external, float ef)
                   case fut_nonlinearfb_hp:
                   case fut_nonlinearfb_n:
                   case fut_nonlinearfb_bp:
+                  case fut_nonlinearfb_ap:
                      // "i & 3" selects the lower two bits that represent the stage count.
                      // "(i >> 2) & 3" selects the next two bits that represent the saturator.
                      snprintf(txt, 32, "%s %s",
                         fut_nlf_subtypes[i & 3],
                         fut_nlf_saturators[(i >> 2) & 3]);
                      break;
-#if SURGE_EXTRA_FILTERS
-#endif
-                     // don't default any more so compiler catches new ones we add
+                  // don't default any more so compiler catches new ones we add
                   case fut_none:
                   case fut_lp12:
                   case fut_lp24:

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -129,6 +129,7 @@ void FilterCoefficientMaker::MakeCoeffs(
    case fut_nonlinearfb_hp:
    case fut_nonlinearfb_n:
    case fut_nonlinearfb_bp:
+   case fut_nonlinearfb_ap:
       NonlinearFeedbackFilter::makeCoefficients(this, Freq, Reso, Type, storageI);
       break;
 

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -830,6 +830,7 @@ FilterUnitQFPtr GetQFPtrFilterUnit(int type, int subtype)
    case fut_nonlinearfb_hp:
    case fut_nonlinearfb_n:
    case fut_nonlinearfb_bp:
+   case fut_nonlinearfb_ap:
       return NonlinearFeedbackFilter::process;
       break;
    case fut_none:

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1032,14 +1032,22 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
 
             Q->FU[u].DB[e] = FBP.Delay[u];
             Q->FU[u].WP[e] = FBP.FU[u].WP;
-            if (scene->filterunit[u].type.val.i == fut_lpmoog ||
-                scene->filterunit[u].type.val.i == fut_diode  ||
-                (scene->filterunit[u].type.val.i >= fut_nonlinearfb_lp &&
-                 scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp))
-            {
-               Q->FU[u].WP[0] =
-                   scene->filterunit[u].subtype.val.i; // LPMoog's output stage index is stored in
-                                                       // WP[0] for the entire quad
+            switch(scene->filterunit[u].type.val.i){
+               case fut_lpmoog:
+               case fut_diode:
+               case fut_nonlinearfb_lp:
+               case fut_nonlinearfb_hp:
+               case fut_nonlinearfb_n:
+               case fut_nonlinearfb_bp:
+               case fut_nonlinearfb_ap:
+                  // subtype is stored in WP[0] for the entire quad.
+                  // this is fine because integer parameters like this are not modulatable, and
+                  // quads are only parallel across voices, so the quad would have identical
+                  // parameters anyway.
+                  Q->FU[u].WP[0] = scene->filterunit[u].subtype.val.i;
+                  break;
+               default: // do nothing
+                  break;
             }
 
             if (scene->filterblock_configuration.val.i == fc_wide)
@@ -1057,12 +1065,19 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
 
                Q->FU[u + 2].DB[e] = FBP.Delay[u + 2];
                Q->FU[u + 2].WP[e] = FBP.FU[u].WP;
-               if (scene->filterunit[u].type.val.i == fut_lpmoog ||
-                   scene->filterunit[u].type.val.i == fut_diode  ||
-                   (scene->filterunit[u].type.val.i >= fut_nonlinearfb_lp &&
-                    scene->filterunit[u].type.val.i <= fut_nonlinearfb_bp))
-               {
-                  Q->FU[u + 2].WP[0] = scene->filterunit[u].subtype.val.i;
+
+               switch(scene->filterunit[u].type.val.i){
+                  case fut_lpmoog:
+                  case fut_diode:
+                  case fut_nonlinearfb_lp:
+                  case fut_nonlinearfb_hp:
+                  case fut_nonlinearfb_n:
+                  case fut_nonlinearfb_bp:
+                  case fut_nonlinearfb_ap:
+                     Q->FU[u + 2].WP[0] = scene->filterunit[u].subtype.val.i;
+                     break;
+                  default:
+                     break;
                }
             }
          }

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -170,10 +170,15 @@ namespace NonlinearFeedbackFilter
             C[nlf_b1] = -2.0f * wcos   * a0r;
             C[nlf_b2] = C[nlf_b0];
             break;
-         default: // bandpass
+         case fut_nonlinearfb_bp: // bandpass
             C[nlf_b0] = wsin * 0.5f    * a0r;
             C[nlf_b1] = 0.0f;
             C[nlf_b2] = -C[nlf_b0];
+            break;
+         default: // allpass
+            C[nlf_b0] = C[nlf_a2];
+            C[nlf_b1] = C[nlf_a1];
+            C[nlf_b2] = 1.0f; // (1+a) / (1+a) = 1 (from normalising by a0)
             break;
       }
 


### PR DESCRIPTION
Note that currently the regular AP glyph is used (I don't know how to add more).

This PR also removes the now-unused SURGE_EXTRA_FILTERS stuff, and updates the documentation on adding filters. Further information on how to add glyphs ought to be added here too, but for now I've been vague about it (just "add an entry to `fut_glyph_index`") so that at least anyone who adds a filter knows how to make it not crash :wink: 