### PR TITLE
Add Nonlinear States filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ set(SURGE_SHARED_SOURCES
   src/common/dsp/filters/K35.cpp
   src/common/dsp/filters/DiodeLadder.cpp
   src/common/dsp/filters/NonlinearFeedback.cpp
+  src/common/dsp/filters/NonlinearStates.cpp
   src/common/dsp/AudioInputOscillator.cpp
   src/common/dsp/BiquadFilter.cpp
   src/common/dsp/BiquadFilterSSE2.cpp

--- a/src/common/FilterConfiguration.h
+++ b/src/common/FilterConfiguration.h
@@ -102,6 +102,11 @@ enum fu_type
    fut_comb_neg,
    fut_apf,
    fut_nonlinearfb_ap,
+   fut_nonlinearst_lp,
+   fut_nonlinearst_hp,
+   fut_nonlinearst_n,
+   fut_nonlinearst_bp,
+   fut_nonlinearst_ap,
    n_fu_types,
 };
 
@@ -140,7 +145,12 @@ const char fut_names[n_fu_types][32] =
         "N 24 dB",          // fut_notch24
         "FX Comb -",        // fut_comb_neg
         "FX Allpass",       // fut_apf
-        "FX NL Allpass",    // fut_nonlinearfb_ap
+        "FX NLFB Allpass",  // fut_nonlinearfb_ap
+        "LP NL States",     // fut_nonlinearst_lp
+        "HP NL States",     // fut_nonlinearst_hp
+        "N NL States",      // fut_nonlinearst_n
+        "BP NL States",     // fut_nonlinearst_bp
+        "FX NLST Allpass",  // fut_nonlinearst_ap
         /* this is a ruler to ensure names do not exceed 31 characters
          0123456789012345678901234567890
         */
@@ -165,9 +175,9 @@ const char fut_menu_names[n_fu_types][32] =
         "K35", // HP
         "Diode Ladder",
         "NL Feedback", // LP
-        "NL Feedback", // LP
-        "NL Feedback", // LP
-        "NL Feedback", // LP
+        "NL Feedback", // HP
+        "NL Feedback", // N
+        "NL Feedback", // BP
         "OB-Xd 12 dB", // HP
         "OB-Xd 12 dB", // N
         "OB-Xd 12 dB", // BP
@@ -176,6 +186,11 @@ const char fut_menu_names[n_fu_types][32] =
         "Comb -",
         "Allpass",
         "NL Feedback Allpass",
+        "NL States", // LP
+        "NL States", // HP
+        "NL States", // N
+        "NL States", // BP
+        "NL States Allpass",
         /* this is a ruler to ensure names do not exceed 31 characters
          0123456789012345678901234567890
         */
@@ -300,6 +315,11 @@ const int fut_subcount[n_fu_types] =
         2,  // fut_comb_neg,
         0,  // fut_apf
         16, // fut_nonlinearfb_ap
+        16, // fut_nonlinearst_lp
+        16, // fut_nonlinearst_hp
+        16, // fut_nonlinearst_n
+        16, // fut_nonlinearst_bp
+        16, // fut_nonlinearst_ap
     };
 
 enum fu_subtype
@@ -330,25 +350,30 @@ struct FilterSelectorMapper : public ParameterDiscreteIndexRemapper {
       p(fut_obxd_2pole_lp, "Lowpass" ); // ADJ
       p(fut_obxd_4pole, "Lowpass" );
       p(fut_nonlinearfb_lp, "Lowpass" );
+      p(fut_nonlinearst_lp, "Lowpass" );
 
       p(fut_bp12, "Bandpass" );
       p(fut_bp24, "Bandpass" );
       p(fut_obxd_2pole_bp, "Bandpass" );
       p(fut_nonlinearfb_bp, "Bandpass" );
+      p(fut_nonlinearst_bp, "Bandpass" );
 
       p(fut_hp12, "Highpass" );
       p(fut_hp24, "Highpass" );
       p(fut_k35_hp, "Highpass" );
       p(fut_obxd_2pole_hp, "Highpass" );
       p(fut_nonlinearfb_hp, "Highpass" );
+      p(fut_nonlinearst_hp, "Highpass" );
 
       p(fut_notch12, "Notch" );
       p(fut_notch24, "Notch" );
       p(fut_obxd_2pole_n, "Notch" );
       p(fut_nonlinearfb_n, "Notch" );
+      p(fut_nonlinearst_n, "Notch" );
 
       p(fut_apf, "Effect" );
       p(fut_nonlinearfb_ap, "Effect" );
+      p(fut_nonlinearst_ap, "Effect" );
       p(fut_comb_pos, "Effect" );
       p(fut_comb_neg, "Effect" );
       p(fut_SNH, "Effect" );
@@ -426,5 +451,10 @@ const int fut_glyph_index[n_fu_types][2] =
         { 1,  nrow }, // fut_notch24,
         { 2, fxrow }, // fut_comb_neg,
         { 0, fxrow }, // fut_apf
-        { 0, fxrow }  // fut_nonlinearfb_ap (this is temporarily set to just use the regular AP glyph)
+        { 0, fxrow }, // fut_nonlinearfb_ap (this is temporarily set to just use the regular AP glyph)
+        { 8, lprow }, // fut_nonlinearst_lp
+        { 4, hprow }, // fut_nonlinearst_hp
+        { 3,  nrow }, // fut_nonlinearst_n
+        { 3, bprow }, // fut_nonlinearst_bp
+        { 0, fxrow }, // fut_nonlinearst_ap (also temporarily set to just use the regular AP glyph)
     };

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2270,6 +2270,11 @@ void Parameter::get_display(char* txt, bool external, float ef)
                   case fut_nonlinearfb_n:
                   case fut_nonlinearfb_bp:
                   case fut_nonlinearfb_ap:
+                  case fut_nonlinearst_lp:
+                  case fut_nonlinearst_hp:
+                  case fut_nonlinearst_n:
+                  case fut_nonlinearst_bp:
+                  case fut_nonlinearst_ap:
                      // "i & 3" selects the lower two bits that represent the stage count.
                      // "(i >> 2) & 3" selects the next two bits that represent the saturator.
                      snprintf(txt, 32, "%s %s",

--- a/src/common/dsp/FilterCoefficientMaker.cpp
+++ b/src/common/dsp/FilterCoefficientMaker.cpp
@@ -7,6 +7,7 @@
 #include "filters/K35.h"
 #include "filters/DiodeLadder.h"
 #include "filters/NonlinearFeedback.h"
+#include "filters/NonlinearStates.h"
 
 using namespace std;
 
@@ -131,6 +132,13 @@ void FilterCoefficientMaker::MakeCoeffs(
    case fut_nonlinearfb_bp:
    case fut_nonlinearfb_ap:
       NonlinearFeedbackFilter::makeCoefficients(this, Freq, Reso, Type, storageI);
+      break;
+   case fut_nonlinearst_lp:
+   case fut_nonlinearst_hp:
+   case fut_nonlinearst_n:
+   case fut_nonlinearst_bp:
+   case fut_nonlinearst_ap:
+      NonlinearStatesFilter::makeCoefficients(this, Freq, Reso, Type, storageI);
       break;
 
    case n_fu_types:

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -9,6 +9,7 @@
 #include "filters/K35.h"
 #include "filters/DiodeLadder.h"
 #include "filters/NonlinearFeedback.h"
+#include "filters/NonlinearStates.h"
 
 __m128 SVFLP12Aquad(QuadFilterUnitState* __restrict f, __m128 in)
 {
@@ -832,6 +833,13 @@ FilterUnitQFPtr GetQFPtrFilterUnit(int type, int subtype)
    case fut_nonlinearfb_bp:
    case fut_nonlinearfb_ap:
       return NonlinearFeedbackFilter::process;
+      break;
+   case fut_nonlinearst_lp:
+   case fut_nonlinearst_hp:
+   case fut_nonlinearst_n:
+   case fut_nonlinearst_bp:
+   case fut_nonlinearst_ap:
+      return NonlinearStatesFilter::process;
       break;
    case fut_none:
    case n_fu_types:

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1040,6 +1040,11 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
                case fut_nonlinearfb_n:
                case fut_nonlinearfb_bp:
                case fut_nonlinearfb_ap:
+               case fut_nonlinearst_lp:
+               case fut_nonlinearst_hp:
+               case fut_nonlinearst_n:
+               case fut_nonlinearst_bp:
+               case fut_nonlinearst_ap:
                   // subtype is stored in WP[0] for the entire quad.
                   // this is fine because integer parameters like this are not modulatable, and
                   // quads are only parallel across voices, so the quad would have identical
@@ -1074,6 +1079,11 @@ void SurgeVoice::SetQFB(QuadFilterChainState* Q, int e) // Q == 0 means init(ial
                   case fut_nonlinearfb_n:
                   case fut_nonlinearfb_bp:
                   case fut_nonlinearfb_ap:
+                  case fut_nonlinearst_lp:
+                  case fut_nonlinearst_hp:
+                  case fut_nonlinearst_n:
+                  case fut_nonlinearst_bp:
+                  case fut_nonlinearst_ap:
                      Q->FU[u + 2].WP[0] = scene->filterunit[u].subtype.val.i;
                      break;
                   default:

--- a/src/common/dsp/filters/NonlinearStates.cpp
+++ b/src/common/dsp/filters/NonlinearStates.cpp
@@ -1,0 +1,221 @@
+#include "QuadFilterUnit.h"
+#include "FilterCoefficientMaker.h"
+#include "DebugHelpers.h"
+#include "SurgeStorage.h"
+#include "vt_dsp/basic_dsp.h"
+#include "FastMath.h"
+
+/*
+** This contains an adaptation of the filter found at
+** https://ccrma.stanford.edu/~jatin/ComplexNonlinearities/NLBiquad.html
+** with coefficient calculation from
+** https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html
+**
+** A lot of code here is duplicated from NonlinearFeedback.cpp, perhaps in future they
+** could be merged, but for the time being they're separate and nothing is shared.
+*/
+
+static float clampedFrequency( float pitch, SurgeStorage *storage )
+{
+   auto freq = storage->note_to_pitch_ignoring_tuning( pitch + 69 ) * Tunings::MIDI_0_FREQ;
+   freq = limit_range( (float)freq, 5.f, (float)( dsamplerate_os * 0.3f ) );
+   return freq;
+}
+
+#define F(a) _mm_set_ps1( a )
+#define M(a,b) _mm_mul_ps( a, b )
+#define A(a,b) _mm_add_ps( a, b )
+#define S(a,b) _mm_sub_ps( a, b )
+
+enum Saturator {
+    SAT_TANH = 0,
+    SAT_SOFT,
+    SAT_SINE,
+    SAT_OJD
+};
+
+// sine each element of a __m128 by breaking it into floats then reassembling
+static inline __m128 fastsin_ps(const __m128 in) noexcept {
+   float f[4];
+   _mm_storeu_ps(f, in);
+   f[0] = Surge::DSP::fastsin(f[0]);
+   f[1] = Surge::DSP::fastsin(f[1]);
+   f[2] = Surge::DSP::fastsin(f[2]);
+   f[3] = Surge::DSP::fastsin(f[3]);
+   return _mm_load_ps(f);
+}
+
+// waveshaper from https://github.com/JanosGit/Schrammel_OJD/blob/master/Source/Waveshaper.h
+static inline float ojd_waveshaper(float in) noexcept {
+   if (in <= -1.7f){
+      return -1.0f;
+   }
+   else if ((in > -1.7f) && (in < -0.3f)){
+      in += 0.3f;
+      return in + (in * in) / (4.0f * (1.0f - 0.3f)) - 0.3f;
+   }
+   else if ((in > 0.9f) && (in < 1.1f))
+   {
+      in -= 0.9f;
+      return in - (in * in) / (4.0f * (1.0f - 0.9f)) + 0.9f;
+   }
+   else if (in > 1.1f){
+      return 1.0f;
+   }
+
+   return in;
+};
+
+// asinh each element of a __m128 by breaking it into floats then reassembling
+static inline __m128 ojd_waveshaper_ps(const __m128 in) noexcept {
+   float f[4];
+   _mm_storeu_ps(f, in);
+   f[0] = ojd_waveshaper(f[0]);
+   f[1] = ojd_waveshaper(f[1]);
+   f[2] = ojd_waveshaper(f[2]);
+   f[3] = ojd_waveshaper(f[3]);
+   return _mm_load_ps(f);
+}
+
+static inline __m128 doNLFilter(
+      const __m128 input,
+      const __m128 a1,
+      const __m128 a2,
+      const __m128 b0,
+      const __m128 b1,
+      const __m128 b2,
+      const int sat,
+      __m128 &z1,
+      __m128 &z2)
+   noexcept
+{
+   // out = z1 + b0 * input
+   const __m128 out = A(z1, M(b0, input));
+
+   // z1 = z2 + b1 * input - a1 * out
+   z1 = A(z2, S(M(b1, input), M(a1, out)));
+   // z2 = b2 * input - a2 * out
+   z2 = S(M(b2, input), M(a2, out));
+
+   // now apply a nonlinearity to z1 and z2
+   switch(sat){
+      case SAT_TANH:
+         z1 = Surge::DSP::fasttanhSSEclamped(z1);
+         z2 = Surge::DSP::fasttanhSSEclamped(z2);
+         break;
+      case SAT_SOFT:
+         z1 = softclip_ps(z1); // note, this is a bit different to Jatin's softclipper
+         z2 = softclip_ps(z2);
+         break;
+      case SAT_SINE:
+         z1 = fastsin_ps(z1);
+         z2 = fastsin_ps(z2);
+         break;
+      default: // SAT_OJD
+         z1 = ojd_waveshaper_ps(z1);
+         z2 = ojd_waveshaper_ps(z2);
+         break;
+   }
+   return out;
+}
+
+namespace NonlinearStatesFilter
+{
+   enum nls_coeffs {
+      nls_a1 = 0,
+      nls_a2,
+      nls_b0,
+      nls_b1,
+      nls_b2,
+      n_nls_coeff
+   };
+
+   enum dlf_state {
+      nls_z1, // 1st z-1 state for first  stage
+      nls_z2, // 2nd z-1 state for first  stage
+      nls_z3, // 1st z-1 state for second stage
+      nls_z4, // 2nd z-1 state for second stage
+      nls_z5, // 1st z-1 state for third  stage
+      nls_z6, // 2nd z-1 state for third  stage
+      nls_z7, // 1st z-1 state for fourth stage
+      nls_z8, // 2nd z-1 state for fourth stage
+   };
+
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, int type, SurgeStorage *storage )
+   {
+      float C[n_cm_coeffs];
+
+      const float q = ((reso * reso * reso) * 18.0f + 0.1f);
+
+      const float wc = 2.0f * M_PI * clampedFrequency(freq, storage) / dsamplerate_os;
+
+      const float wsin  = Surge::DSP::fastsin(wc);
+      const float wcos  = Surge::DSP::fastcos(wc);
+      const float alpha = wsin / (2.0f * q);
+
+      // note we actually calculate the reciprocal of a0 because we only use a0 to normalize the
+      // other coefficients, and multiplication by reciprocal is cheaper than dividing.
+      const float a0r  = 1.0f / (1.0f + alpha);
+
+      C[nls_a1] = -2.0f * wcos    * a0r;
+      C[nls_a2] = (1.0f - alpha)  * a0r;
+
+      switch(type){
+         case fut_nonlinearst_lp: // lowpass
+            C[nls_b1] =  (1.0f - wcos) * a0r;
+            C[nls_b0] = C[nls_b1] *  0.5f;
+            C[nls_b2] = C[nls_b0];
+            break;
+         case fut_nonlinearst_hp: // highpass
+            C[nls_b1] = -(1.0f + wcos) * a0r;
+            C[nls_b0] = C[nls_b1] * -0.5f;
+            C[nls_b2] = C[nls_b0];
+            break;
+         case fut_nonlinearst_n: // notch
+            C[nls_b0] = a0r;
+            C[nls_b1] = -2.0f * wcos   * a0r;
+            C[nls_b2] = C[nls_b0];
+            break;
+         case fut_nonlinearst_bp: // bandpass
+            C[nls_b0] = wsin * 0.5f    * a0r;
+            C[nls_b1] = 0.0f;
+            C[nls_b2] = -C[nls_b0];
+            break;
+         default: // allpass
+            C[nls_b0] = C[nls_a2];
+            C[nls_b1] = C[nls_a1];
+            C[nls_b2] = 1.0f; // (1+a) / (1+a) = 1 (from normalising by a0)
+            break;
+      }
+
+      cm->FromDirect(C);
+   }
+
+   __m128 process( QuadFilterUnitState * __restrict f, __m128 input )
+   {
+      // lower 2 bits of subtype is the stage count
+      const int stages = f->WP[0] & 3;
+      // next two bits after that select the saturator
+      const int sat = ((f->WP[0] >> 2) & 3);
+
+      // n.b. stages is zero-indexed so use <=
+      for(int stage = 0; stage <= stages; ++stage){
+         input =
+            doNLFilter(input,
+                  f->C[nls_a1],
+                  f->C[nls_a2],
+                  f->C[nls_b0],
+                  f->C[nls_b1],
+                  f->C[nls_b2],
+                  sat,
+                  f->R[nls_z1 + stage*2],
+                  f->R[nls_z2 + stage*2]);
+      }
+
+      for(int i=0; i < n_nls_coeff; ++i){
+         f->C[i] = A(f->C[i], f->dC[i]);
+      }
+
+      return input;
+   }
+}

--- a/src/common/dsp/filters/NonlinearStates.h
+++ b/src/common/dsp/filters/NonlinearStates.h
@@ -1,0 +1,11 @@
+#pragma once
+
+struct QuadFilterUnitState;
+class FilterCoefficientMaker;
+class SurgeStorage;
+
+namespace NonlinearStatesFilter 
+{
+   void makeCoefficients( FilterCoefficientMaker *cm, float freq, float reso, int subtype, SurgeStorage *storage );
+   __m128 process( QuadFilterUnitState * __restrict f, __m128 in );
+}


### PR DESCRIPTION
Adds filters based on https://ccrma.stanford.edu/~jatin/ComplexNonlinearities/NLBiquad.html .

Lot of duplicated code from `NonlinearFeedback.cpp`, in future I could probably combine the source files for these and deduplicate if we decide to keep Nonlinear States (it's not really as interesting as Nonlinear Feedback).