### PR TITLE
Swap order of NLFB subtypes, restrict NLST subtypes

### DIFF
--- a/src/common/FilterConfiguration.h
+++ b/src/common/FilterConfiguration.h
@@ -281,8 +281,8 @@ const char fut_nlf_saturators[4][6] =
     {
         "tanh",
         "soft",
-        "sine",
         "OJD",
+        "sine",
     };
 
 const int fut_subcount[n_fu_types] =
@@ -315,11 +315,11 @@ const int fut_subcount[n_fu_types] =
         2,  // fut_comb_neg,
         0,  // fut_apf
         16, // fut_nonlinearfb_ap
-        16, // fut_nonlinearst_lp
-        16, // fut_nonlinearst_hp
-        16, // fut_nonlinearst_n
-        16, // fut_nonlinearst_bp
-        16, // fut_nonlinearst_ap
+        8, // fut_nonlinearst_lp
+        8, // fut_nonlinearst_hp
+        8, // fut_nonlinearst_n
+        8, // fut_nonlinearst_bp
+        8, // fut_nonlinearst_ap
     };
 
 enum fu_subtype

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -27,8 +27,8 @@ static float clampedFrequency( float pitch, SurgeStorage *storage )
 enum Saturator {
     SAT_TANH = 0,
     SAT_SOFT,
-    SAT_SINE,
-    SAT_OJD
+    SAT_OJD,
+    SAT_SINE
 };
 
 // sine each element of a __m128 by breaking it into floats then reassembling
@@ -98,11 +98,11 @@ static inline __m128 doNLFilter(
       case SAT_SOFT:
          nf = softclip_ps(out); // note, this is a bit different to Jatin's softclipper
          break;
-      case SAT_SINE:
-         nf = fastsin_ps(out);
-         break;
-      default: // SAT_OJD
+      case SAT_OJD:
          nf = ojd_waveshaper_ps(out);
+         break;
+      default: // SAT_SINE
+         nf = fastsin_ps(out);
          break;
    }
 


### PR DESCRIPTION
Sine is basically just softclip that breaks when gain is too high (because fastsin is only defined over a limited range). It needs to either be replaced or removed. Before going into beta, make the more-useful OJD be the lower subtype. However OJD makes Nonlinear States blow up. So it's more sensible for NLST to just have tanh and soft.