### PR TITLE
InfoWin from nonPopup parameters

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4101,6 +4101,13 @@ void SurgeGUIEditor::valueChanged(CControl* control)
          if( p->ctrltype == ct_lfotype )
             synth->refresh_editor = true;
 
+         if ((p->ctrlstyle & kNoPopup))
+         {
+            auto iw = dynamic_cast<CParameterTooltip*>(infowindow);
+            if( iw && iw->isVisible() )
+               iw->Hide();
+         }
+
          if (modsource && mod_editor && synth->isValidModulation(p->id, modsource) &&
              dynamic_cast<CSurgeSlider*>(control) != nullptr)
          {


### PR DESCRIPTION
If the infowindow is displayed (say from a click or wheel)
and you adjust a kNonPopup parameter it would udpate the
lingering infowindow. Now make an adjustment of a kNoPopup
hide the window if the window is shown.

Closes #3023