### PR TITLE
More MSEG Book of Work

### DIFF
--- a/src/common/gui/MSEGEditor.h
+++ b/src/common/gui/MSEGEditor.h
@@ -25,4 +25,5 @@ struct MSEGEditor : public VSTGUI::CViewContainer, public Surge::UI::SkinConsumi
    };
    MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, State *eds, Surge::UI::Skin::ptr_t skin, std::shared_ptr<SurgeBitmaps> b);
    ~MSEGEditor();
+   void forceRefresh();
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1687,6 +1687,14 @@ void SurgeGUIEditor::openOrRecreateEditor()
    if( editorOverlay )
    {
       frame->addView( editorOverlay );
+      /*
+       * This is a hack for 1.8 which we have to clean up in 1.9 when we do #3223
+       */
+      auto mse = dynamic_cast<MSEGEditor*>(editorOverlayContentsWeakReference);
+      if (mse)
+      {
+         mse->forceRefresh();
+      }
    }
    
    refresh_mod();
@@ -1863,6 +1871,7 @@ void SurgeGUIEditor::close()
       editorOverlayTagAtClose = editorOverlayTag;
       editorOverlayTag = "";
       editorOverlay = nullptr;
+      editorOverlayContentsWeakReference = nullptr;
    }
 #if TARGET_VST2 // && WINDOWS
    // We may need this in other hosts also; but for now
@@ -3987,6 +3996,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
          editorOverlay = nullptr;
          editorOverlayTag = "";
          editorOverlayTagAtClose = "";
+         editorOverlayContentsWeakReference = nullptr;
       }
    }
    break;
@@ -6618,6 +6628,7 @@ void SurgeGUIEditor::dismissEditorOverlay()
       editorOverlay = nullptr;
       editorOverlayTag = "";
       editorOverlayTagAtClose = "";
+      editorOverlayContentsWeakReference = nullptr;
    }
 }
 
@@ -6752,6 +6763,7 @@ void SurgeGUIEditor::setEditorOverlay(VSTGUI::CView *c, std::string editorTitle,
    editorOverlayOnClose = onClose;
    editorOverlayTag = editorTag;
    editorOverlayTagAtClose = editorTag;
+   editorOverlayContentsWeakReference = c;
 }
 
 std::string SurgeGUIEditor::getDisplayForTag( long tag )

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -432,6 +432,8 @@ private:
    std::string typeinResetLabel = "";
 
    VSTGUI::CViewContainer *editorOverlay = nullptr;
+   VSTGUI::CView* editorOverlayContentsWeakReference =
+       nullptr; // Use this very very carefully. It may hold a dangling ref until #3223
    std::function<void()> editorOverlayOnClose = [](){};
 
    VSTGUI::CViewContainer *minieditOverlay = nullptr;


### PR DESCRIPTION
- Update model if you load patch with editor open
- LFO sustain point guarantees at least one loop
- Nodes always right clickable even when edging outside draw area
- Draw mode initiates only in draw area, so axis zoom works in drawmode
- Don't draw ticks which are outside the draw area, making the lines
  and so on dissapear appropriately

Addresses #2474