### PR TITLE
Add makeup gain for nonlinear feedback filters

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Authors in the repository since 1.6 alpha was open-sourced (in alphabetical orde
 David Bata <oddy.o.trax@gmail.com>
 Alexandre Bique <bique.alexandre@gmail.com>
 Hendrik van Boetzelaer <http://opuswerk.com>
+Jatin Chowdhury <jatin@ccrma.stanford.edu>
 Jean Pierre Cimalando <jp-dev@inbox.ru>
 Filipe Coelho <falktx@falktx.com>
 Alec DiAstra <alecdiastra@gmail.com>


### PR DESCRIPTION
The nonlinear feedback filters had an issue where the cutoff frequency drastically affected the output volume (most noticeable when using multiple filter stages). I've added a "makeup gain" to the lowpass and highpass filters, that depends on the cutoff frequency. Off the top of my head, I can't think of a similar work-around for the bandpass or notch filters. Hoping for some second (and third) opinions on how this sounds in different use cases.

From a code perspective, this fix definitely feels a bit hack-y at the moment, but I'm more worried about getting it to sound right before trying to get the code perfect. Still, please let me know if I haven't quite nailed the Surge style, or if there are preferred functions to use over `std::pow`, `std::max`, etc.

Thanks,
Jatin