### PR TITLE
A more complete filter analyzer

### DIFF
--- a/scripts/misc/filterPdfPack.py
+++ b/scripts/misc/filterPdfPack.py
@@ -1,0 +1,65 @@
+import pandas as pd
+from io import StringIO
+import re
+from matplotlib.backends.backend_pdf import PdfPages
+import matplotlib.pyplot as plt
+import sys
+
+if len(sys.argv) != 3:
+    print( "Usage: python3 filterPdfPack.py infile outfile\n")
+    exit(1)
+
+fn = sys.argv[1]
+outf = sys.argv[2]
+
+with open( fn, 'r') as f:
+    ct = f.readlines()
+
+sections = []
+currsect = { 'data': [] }
+
+def tag(s):
+    return re.match(r'\[([^\]]+)\]', s ).group(1)
+
+
+def detag(s):
+    return re.sub( r'\[[^\]]+\]', '', s )
+
+
+for l in ct:
+    if l.startswith("#"):
+        continue
+
+    if l.startswith("[BEGIN]"):
+        currsect = { 'data' : [] }
+        continue
+    if l.startswith( "[END]"):
+        sections.append(currsect)
+        currsect = { 'data' : [] }
+        continue
+
+    if l.startswith( "[" ):
+        q = detag(l)
+        r = tag(l)
+        currsect[r] = q
+        continue
+
+    currsect['data'].append(l)
+
+
+# Create the PdfPages object to which we will save the pages:
+# The with statement makes sure that the PdfPages object is closed properly at
+# the end of the block, even if an Exception occurs.
+with PdfPages(outf) as pdf:
+
+    for sect in sections:
+        plt.figure( figsize=(5,5))
+        ds = StringIO("".join(sect['data']))
+        df = pd.read_csv( ds )
+
+        ly = False
+        if( 'YLOG' in sect ):
+            ly = True
+        df.plot(0, logy = ly, title=sect['SECTION'], ylabel = sect['YLAB'])
+        pdf.savefig()
+        plt.close()

--- a/src/headless/HeadlessNonTestFunctions.h
+++ b/src/headless/HeadlessNonTestFunctions.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <iostream>
 
 namespace Surge
 {
@@ -9,7 +10,7 @@ namespace NonTest
 void restreamTemplatesWithModifications();
 void statsFromPlayingEveryPatch();
 void playSomeBach();
-void filterAnalyzer( int ft, int fst, float cut = 12 /* in notes from note 69 */ );
+void filterAnalyzer( int ft, int fst, std::ostream &os );
 void generateNLFeedbackNorms();
 }
 }

--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -40,11 +40,12 @@ int main(int argc, char** argv)
          {
             if( argc < 4 )
             {
-               std::cout << "Usage: --filter-analyzer type subtype co res\n";
+               std::cout << "Usage: --filter-analyzer type subtype\n";
                return 1;
             }
             Surge::Headless::NonTest::filterAnalyzer(std::atoi(argv[3]),
-                                                     std::atoi(argv[4])
+                                                     std::atoi(argv[4]),
+                                                     std::cout
             );
          }
       }


### PR DESCRIPTION
This is a more complete filter analysis tool. Lets you make
plots if you have python3, matplotlib, pandas standard setup.

To use it

1. build headless
2. Run `surge-headless --non-test --filter-analyzer 5 0 > filter5_0_out.dat` where
   5 and 0 are the filter type and subtype
3. Run `python3 scripts/misc/filterPdfPack.py filter5_0out.dat out.pdf`

and out.pdf will have analysis plots