### PR TITLE
Update nonlinear feedback filter normalization

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Authors in the repository since 1.6 alpha was open-sourced (in alphabetical orde
 David Bata <oddy.o.trax@gmail.com>
 Alexandre Bique <bique.alexandre@gmail.com>
 Hendrik van Boetzelaer <http://opuswerk.com>
+Jatin Chowdhury <jatin@ccrma.stanford.edu>
 Jean Pierre Cimalando <jp-dev@inbox.ru>
 Filipe Coelho <falktx@falktx.com>
 Alec DiAstra <alecdiastra@gmail.com>

--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -143,8 +143,8 @@ namespace NonlinearFeedbackFilter
 
       const float q = ((reso * reso * reso) * 18.0f + 0.1f);
 
-      const float normalisedFreq = clampedFrequency(freq, storage) / dsamplerate_os;
-      const float wc = 2.0f * M_PI * normalisedFreq;
+      const float normalisedFreq = 2.0f * clampedFrequency(freq, storage) / dsamplerate_os;
+      const float wc = M_PI * normalisedFreq;
 
       const float wsin  = Surge::DSP::fastsin(wc);
       const float wcos  = Surge::DSP::fastcos(wc);
@@ -161,36 +161,23 @@ namespace NonlinearFeedbackFilter
       /*
        * To see where this table comes from look in the HeadlessNonTestFunctions.
        */
-      const bool useNormalization = true;
+      constexpr bool useNormalization = true;
       float normNumerator = 1.0f;
 
       // tweaked these by hand/ear after the RMS measuring program did its thing... this world still needs humans! :) - EvilDragon
-      const float lpNormTable[12] = {
-          1.12215,
-          0.946168,
-          0.803073,
-          0.852984,
-          0.685058,
-          0.598567,
-          0.574069,
-          0.555141,
-          0.2764,
-          0.234219,
-          0.235227
-      };
-      const float hpNormTable[12] = {
-          4.18885,
-          3.11128,
-          2.69236,
-          2.06871,
-          3.16804,
-          2.36259,
-          2.1021,
-          1.64437,
-          1.44636,
-          1.3442,
-          1.19402,
-          1.07743
+      constexpr float lpNormTable[12] = {
+         1.53273,
+         1.33407,
+         1.08197,
+         0.958219,
+         1.27374,
+         0.932342,
+         0.761765,
+         0.665462,
+         0.776856,
+         0.597575,
+         0.496207,
+         0.471714
       };
 
       switch(type){
@@ -203,7 +190,7 @@ namespace NonlinearFeedbackFilter
             {
                normNumerator = lpNormTable[subtype];
             }
-            C[nlf_makeup] = normNumerator / std::pow(std::max(normalisedFreq, 0.001f), 0.333f);
+            C[nlf_makeup] = normNumerator / std::pow(std::max(normalisedFreq, 0.001f), 0.1f);
             
             break;
          case fut_cutoffwarp_hp: // highpass
@@ -213,9 +200,9 @@ namespace NonlinearFeedbackFilter
 
             if (useNormalization)
             {
-               normNumerator = hpNormTable[subtype];
+               normNumerator = lpNormTable[subtype];
             }
-            C[nlf_makeup] = normNumerator / std::pow(std::max(1.0f - normalisedFreq, 0.001f), 0.333f);
+            C[nlf_makeup] = normNumerator / std::pow(std::max(1.0f - normalisedFreq, 0.001f), 0.1f);
 
             break;
          case fut_cutoffwarp_n: // notch

--- a/src/headless/HeadlessNonTestFunctions.cpp
+++ b/src/headless/HeadlessNonTestFunctions.cpp
@@ -432,7 +432,7 @@ void generateNLFeedbackNorms()
       }
       surge->storage.getPatch().scene[0].filterunit[0].type.val.i = type;
       surge->storage.getPatch().scene[0].filterunit[0].subtype.val.i = subtype;
-      surge->storage.getPatch().scene[0].filterunit[0].cutoff.val.f = -9;
+      surge->storage.getPatch().scene[0].filterunit[0].cutoff.val.f = 30;
       surge->storage.getPatch().scene[0].filterunit[0].resonance.val.f = 0.95;
       for (auto i = 0; i < 10; ++i)
       {
@@ -515,14 +515,14 @@ void generateNLFeedbackNorms()
    }
    std::cout << "      bool useNormalization = true;\n"
              << "      float normNumerator = 1.0f;\n"
-             << "      float " << ( genLowpass ? "lp" : "hp" ) << "NormTable[12] = {";
+             << "      constexpr float " << ( genLowpass ? "lp" : "hp" ) << "NormTable[12] = {";
    std::string pfx = "\n         ";
    for( auto v : results ) {
       std::cout << pfx << basecaseRMS / v;
       pfx = ",\n         ";
    }
-   std::cout << "\n       };\n"
-             << "       if (useNormalization) normNumerator = lpNormTable[subtype];\n";
+   std::cout << "\n      };\n"
+             << "      if (useNormalization) normNumerator = lpNormTable[subtype];\n";
 }
 
 }


### PR DESCRIPTION
A few folks had pointed out how the previous normalization for nonlinear feedback filters could create some "unstable" settings, particularly for highpass filters. I adjusted the `normalizedFreq` to be between [0, 1], and tweaked the exponential factor, which fixed that issue, and then re-ran the script to generate the makeup gains. For whatever reason, I wasn't able to generate makeup gains for the HPF that I was happy with, but I think the LPF gains work pretty well for both. Could probably use a bit more testing, and second or third opinion on how they sound.

Also, I made `useNormalization` a `constexpr` since that should set at compile-time.