### PR TITLE
NL Feedback filters: add resonance makeup term for OJD subtypes

### DIFF
--- a/src/common/dsp/filters/NonlinearFeedback.cpp
+++ b/src/common/dsp/filters/NonlinearFeedback.cpp
@@ -180,6 +180,10 @@ namespace NonlinearFeedbackFilter
          0.471714
       };
 
+      // extra resonance makeup term for OJD subtypes
+      float expMin = type == fut_cutoffwarp_lp ? 0.1f : 0.35f;
+      float resMakeup = subtype < 8 ? 1.0f : 1.0f / std::pow(std::max(reso, expMin), 0.5f);
+
       switch(type){
          case fut_cutoffwarp_lp: // lowpass
             C[nlf_b1] =  (1.0f - wcos) * a0r;
@@ -190,7 +194,7 @@ namespace NonlinearFeedbackFilter
             {
                normNumerator = lpNormTable[subtype];
             }
-            C[nlf_makeup] = normNumerator / std::pow(std::max(normalisedFreq, 0.001f), 0.1f);
+            C[nlf_makeup] = resMakeup * normNumerator / std::pow(std::max(normalisedFreq, 0.001f), 0.1f);
             
             break;
          case fut_cutoffwarp_hp: // highpass
@@ -202,7 +206,7 @@ namespace NonlinearFeedbackFilter
             {
                normNumerator = lpNormTable[subtype];
             }
-            C[nlf_makeup] = normNumerator / std::pow(std::max(1.0f - normalisedFreq, 0.001f), 0.1f);
+            C[nlf_makeup] = resMakeup * normNumerator / std::pow(std::max(1.0f - normalisedFreq, 0.001f), 0.1f);
 
             break;
          case fut_cutoffwarp_n: // notch


### PR DESCRIPTION
Addresses #3438.

Previously, when using the Cutoff Warp filters with the OJD waveshaper, the output volume was highly dependent on the resonance control. Here I've added another normalization factor make that less drastic.

Could probably use a bit more testing, in particular using a HPF with the cutoff and resonance controls all the way down can be a little finnicky on some patches.