### PR TITLE
MSEG Book of Work Close to the End

### DIFF
--- a/src/common/dsp/MSEGModulationHelper.cpp
+++ b/src/common/dsp/MSEGModulationHelper.cpp
@@ -899,8 +899,12 @@ void constrainControlPointAt( MSEGStorage* ms, int idx )
    ms->segments[idx].cpv = limit_range( ms->segments[idx].cpv, -1.f, 1.f );
 }
 
-void scaleDurations(MSEGStorage* ms, float factor)
+void scaleDurations(MSEGStorage* ms, float factor, float maxDuration)
 {
+   if( maxDuration > 0 && ms->totalDuration * factor > maxDuration)
+   {
+      factor = maxDuration / ms->totalDuration;
+   }
    for (int i = 0; i < ms->n_activeSegments; i++)
       ms->segments[i].duration *= factor;
 
@@ -1124,7 +1128,7 @@ void adjustDurationInternal( MSEGStorage* ms, int idx, float d, float snapResolu
    }
 }
 
-void adjustDurationShiftingSubsequent(MSEGStorage* ms, int idx, float dx, float snap)
+void adjustDurationShiftingSubsequent(MSEGStorage* ms, int idx, float dx, float snap, float maxDuration)
 {
    if( ms->editMode == MSEGStorage::LFO )
    {
@@ -1134,6 +1138,11 @@ void adjustDurationShiftingSubsequent(MSEGStorage* ms, int idx, float dx, float 
          dx = ms->segmentEnd[idx];
       if( -dx > ms->segments[idx].duration )
          dx = -ms->segments[idx].duration;
+   }
+
+   if( maxDuration > 0 && dx > 0 && ms->totalDuration + dx > maxDuration )
+   {
+      dx = maxDuration - ms->totalDuration;
    }
 
    float durationChange = dx;

--- a/src/common/dsp/MSEGModulationHelper.h
+++ b/src/common/dsp/MSEGModulationHelper.h
@@ -52,14 +52,14 @@ namespace Surge
       void deleteSegment( MSEGStorage* ms, float t );
       void deleteSegment( MSEGStorage* ms, int idx );
 
-      void adjustDurationShiftingSubsequent( MSEGStorage* ms, int idx, float dx, float snap = 0);
+      void adjustDurationShiftingSubsequent( MSEGStorage* ms, int idx, float dx, float snap = 0, float maxDuration = -1);
       void adjustDurationConstantTotalDuration( MSEGStorage* ms, int idx, float dx, float snap = 0);
 
       void resetControlPoint( MSEGStorage* ms, float t );
       void resetControlPoint( MSEGStorage* ms, int idx );
       void constrainControlPointAt( MSEGStorage* ms, int idx );
 
-      void scaleDurations(MSEGStorage* ms, float factor);
+      void scaleDurations(MSEGStorage* ms, float factor, float maxDuration = -1);
       void scaleValues(MSEGStorage* ms, float factor);
       void setAllDurationsTo(MSEGStorage* ms, float value);
       void mirrorMSEG(MSEGStorage* ms);

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -342,7 +342,9 @@ public:
    void showMSEGEditor();
    void closeMSEGEditor();
    void toggleMSEGEditor();
-   MSEGEditor::State msegEditState[n_lfos];
+   void broadcastMSEGState();
+   int msegIsOpenFor = -1, msegIsOpenInScene = -1;
+   MSEGEditor::State msegEditState[n_scenes][n_lfos];
 
    void updateStateOnSynth();
 


### PR DESCRIPTION
- Limit to Phase 128 consistently
- Fix a hovered segment start draw
- Limit loop end drag to mseg end
- ShiftRM/MB3 drag in draw mode pans
- Hovers not triggered by errant mouse moves when hidden for axis drags
- Constrain start point appropriately in both directions
- Endpoint start degeneracy limited out (see #3462)
- TimeEditMode is per-editor not per LFO

And, amazingly

Closes #2474