### PR TITLE
Defer MSEG Open until Valid UI state on restore

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -495,6 +495,12 @@ void SurgeGUIEditor::idle()
       resizeFromIdleSentinel();
 #endif
 
+      if( showMSEGEditorOnNextIdleOrOpen )
+      {
+         showMSEGEditor();
+         showMSEGEditorOnNextIdleOrOpen = false;
+      }
+
       /*static CDrawContext drawContext
         (frame, NULL, systemWindow);*/
       // CDrawContext *drawContext = frame->createDrawContext();
@@ -1695,6 +1701,12 @@ void SurgeGUIEditor::openOrRecreateEditor()
       {
          mse->forceRefresh();
       }
+   }
+
+   if( showMSEGEditorOnNextIdleOrOpen )
+   {
+      showMSEGEditor();
+      showMSEGEditorOnNextIdleOrOpen = false;
    }
    
    refresh_mod();

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -258,7 +258,7 @@ public:
            }
            if( des->editor.isMSEGOpen )
            {
-              showMSEGEditor();
+              showMSEGEditorOnNextIdleOrOpen = true;
            }
        }
    }
@@ -344,6 +344,8 @@ public:
    void toggleMSEGEditor();
    void broadcastMSEGState();
    int msegIsOpenFor = -1, msegIsOpenInScene = -1;
+   bool showMSEGEditorOnNextIdleOrOpen = false;
+
    MSEGEditor::State msegEditState[n_scenes][n_lfos];
 
    void updateStateOnSynth();


### PR DESCRIPTION
When restoring from DAW extra state, in a few cases you could
show MSEG before the UI was ready. This lead to crashes in
LPX and probably eslewhere. So have the loadFromDawExtra set a toggle
which open or idle uses to pop the mseg at the right time.

Closes #3465