### PR TITLE
Move Beginedit to point where value consistent in switch

### DIFF
--- a/src/common/gui/CSwitchControl.cpp
+++ b/src/common/gui/CSwitchControl.cpp
@@ -81,7 +81,6 @@ CMouseEventResult CSwitchControl::onMouseDown(CPoint& where, const CButtonState&
    if( unValueClickable )
       return kMouseDownEventHandledButDontNeedMovedOrUpEvents;
 
-   beginEdit();
 
    if (is_itype)
    {
@@ -92,6 +91,7 @@ CMouseEventResult CSwitchControl::onMouseDown(CPoint& where, const CButtonState&
       down = !down;
       value = down ? 1 : 0;
    }
+   beginEdit();
 
    value_direction = 1;
    if (listener)


### PR DESCRIPTION
Live has a problem which we haven't diagnosed over in #3283 where
our beginEdit needs to set value from control less we get a peculiar
setValue from VST3. This is the beginEdit / VST3 / Live. To do that
the control needs the right value before beginEdit is called which
all our controls do excelyt a binary switch which basically made
solo do the wrong thing in live. This fix to move beginEdit to after
the value change accomplishes that.

Closes #3283 again