### PR TITLE
A Collection of MSEG Improvements

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -125,6 +125,24 @@ float CubicInterpolate(float y0, float y1, float y2, float y3, float mu)
    return (a0 * mu * mu2 + a1 * mu2 + a2 * mu + a3);
 }
 
+void LfoModulationSource::msegEnvelopePhaseAdjustment()
+{
+   /*
+   * If we have an envelope MSEG length above 1 we want phase to span the duration
+   */
+   if( lfo->shape.val.i == lt_mseg &&
+       ms->editMode == MSEGStorage::ENVELOPE &&
+       ms->totalDuration > 1.0 )
+   {
+      // extend the phase
+      phase *= ms->totalDuration;
+      double epi, epd;
+      epd = modf( phase, &epi );
+      phase = epd;
+      unwrappedphase_intpart = epi;
+   }
+}
+
 void LfoModulationSource::initPhaseFromStartPhase()
 {
    phase = localcopy[startphase].f;
@@ -136,6 +154,8 @@ void LfoModulationSource::initPhaseFromStartPhase()
    while( phase > 1.f )
       phase -= 1.f;
    unwrappedphase_intpart = 0;
+
+   msegEnvelopePhaseAdjustment();
 }
 
 void LfoModulationSource::attack()
@@ -167,6 +187,7 @@ void LfoModulationSource::attack()
       if (lfo->shape.val.i == lt_stepseq )
          phase = 0.f;
       step = 0;
+      msegEnvelopePhaseAdjustment();
    }
    else
    {
@@ -188,9 +209,11 @@ void LfoModulationSource::attack()
       case lm_keytrigger:
          phase = phaseslider;
          step = 0;
+         msegEnvelopePhaseAdjustment();
          break;
       case lm_random:
          phase = (float)rand() / (float)RAND_MAX;
+         msegEnvelopePhaseAdjustment();
          if( ss->loop_end == 0 )
             step = 0;
          else
@@ -304,6 +327,7 @@ void LfoModulationSource::attack()
          }
       }
    }
+
    break;
    }
 }

--- a/src/common/dsp/LfoModulationSource.h
+++ b/src/common/dsp/LfoModulationSource.h
@@ -82,6 +82,7 @@ private:
    pdata* localcopy;
    bool phaseInitialized;
    void initPhaseFromStartPhase();
+   void msegEnvelopePhaseAdjustment();
 
    float phase, target, noise, noised1, env_phase, priorPhase;
    int unwrappedphase_intpart;

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -1455,7 +1455,15 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
                   switch (h.zoneSubType)
                   {
                   case hotzone::SEGMENT_ENDPOINT: {
-                     Surge::MSEG::unsplitSegment(ms, t);
+
+                     if( buttons & kShift && h.associatedSegment >= 0 )
+                     {
+                        Surge::MSEG::deleteSegment(ms, ms->segmentStart[h.associatedSegment]);
+                     }
+                     else
+                     {
+                        Surge::MSEG::unsplitSegment(ms, t);
+                     }
                      modelChanged();
                      return kMouseEventHandled;
                   }
@@ -1475,7 +1483,14 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
 
             if (t < ms->totalDuration)
             {
-               Surge::MSEG::splitSegment(ms, t, v);
+               if( buttons & kShift )
+               {
+                  Surge::MSEG::deleteSegment(ms, t);
+               }
+               else
+               {
+                  Surge::MSEG::splitSegment(ms, t, v);
+               }
                modelChanged();
                return kMouseEventHandled;
             }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2621,6 +2621,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             addCallbackMenu(contextMenu, "Copy", [this, sc, lfo_id]() {
                                                     if (lfo_id >= 0)
                                                        synth->storage.clipboard_copy(cp_lfo, sc, lfo_id);
+                                                    mostRecentCopiedMSEGState = msegEditState[sc][lfo_id];
                                                  });
             eid++;
 
@@ -2629,6 +2630,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                addCallbackMenu(contextMenu, "Paste", [this, sc, lfo_id]() {
                                                         if (lfo_id >= 0)
                                                            synth->storage.clipboard_paste(cp_lfo, sc, lfo_id);
+                                                        msegEditState[sc][lfo_id] = mostRecentCopiedMSEGState;
                                                         queue_refresh = true;
                                                      });
                eid++;

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -369,8 +369,7 @@ public:
    bool showMSEGEditorOnNextIdleOrOpen = false;
 
    MSEGEditor::State msegEditState[n_scenes][n_lfos];
-
-   void updateStateOnSynth();
+   MSEGEditor::State mostRecentCopiedMSEGState;
 
    int oscilatorMenuIndex[n_scenes][n_oscs] = {0};
 


### PR DESCRIPTION
Some late beta feedback and bugs in the MSEG

- Shift-double-click to delete a segment. Closes #3481
- Envelope MSEG phase spans the entire envelope (but be careful
  with loops of course!). Closes #3479
- MSEG Edit State carris with LFO Copy / Paste. Closes #3478