### PR TITLE
populateDawExtraState on close

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1869,6 +1869,7 @@ bool PLUGIN_API SurgeGUIEditor::open(void* parent, const PlatformType& platformT
 
 void SurgeGUIEditor::close()
 {
+   populateDawExtraState(synth);
    if( editorOverlay )
    {
       frame->removeView( editorOverlay );


### PR DESCRIPTION
Some DAWs, I think, call ::close and never ~ on the editor
object so the DAW extra state doesn't update. Particularly
FL exhibits this, so this fix defacto fixes clone and
various toggles in FL

Closes #3480