### PR TITLE
Lock access to the synth->fx object

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2121,9 +2121,10 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
             memcpy((void*)&storage.getPatch().fx[s].p, (void*)&fxsync[s].p, sizeof(Parameter) * n_fx_params);
 
          // std::cout << "About to call reset with " << _D(initp) << " at " << s << " to " << fxsync[s].type.val.i << std::endl;
-         fx[s].reset(spawn_effect(storage.getPatch().fx[s].type.val.i, &storage,
-                              &storage.getPatch().fx[s], storage.getPatch().globaldata));
+         std::lock_guard<std::mutex> g(fxSpawnMutex);
 
+         fx[s].reset(spawn_effect(storage.getPatch().fx[s].type.val.i, &storage,
+                                  &storage.getPatch().fx[s], storage.getPatch().globaldata));
          if (fx[s])
          {
             fx[s]->init_ctrltypes();
@@ -2210,6 +2211,7 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
             memcpy((void*)&storage.getPatch().fx[s].p, (void*)&fxsync[s].p, sizeof(Parameter) * n_fx_params);
          if (fx[s])
          {
+            std::lock_guard<std::mutex> g(fxSpawnMutex);
             fx[s]->suspend();
             fx[s]->init();
          }

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -124,7 +124,11 @@ public:
    bool loadOscalgos();
    bool load_fx_needed;
 
-   // We have to push this onto the audio thread so have an enqueue and so on
+   /*
+    * FX Lifecycle events happen on the audio thread but is read in the openOrRecreateEditor
+    * so if you swpan or init the fx[s] object lock this mutex
+    */
+   std::mutex fxSpawnMutex;
    enum FXReorderMode { NONE, SWAP, COPY, MOVE };
    void reorderFx( int source, int target, FXReorderMode m  ); // This is safe to call from the UI thread since it just edits the sync
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1263,41 +1263,45 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
 
    // fx vu-meters & labels. This is all a bit hacky still
-   if (synth->fx[current_fx])
    {
-      auto fxpp = currentSkin->getOrCreateControlForConnector("fx.param.panel");
-      CRect fxRect = CRect( CPoint( fxpp->x, fxpp->y ), CPoint( 123, 13 ) );
-      for (int i = 0; i < 15; i++)
+      std::lock_guard<std::mutex> g(synth->fxSpawnMutex);
+
+      if (synth->fx[current_fx])
       {
-         int t = synth->fx[current_fx]->vu_type(i);
-         if (t)
+         auto fxpp = currentSkin->getOrCreateControlForConnector("fx.param.panel");
+         CRect fxRect = CRect(CPoint(fxpp->x, fxpp->y), CPoint(123, 13));
+         for (int i = 0; i < 15; i++)
          {
-            CRect vr(fxRect); // FIXME (vurect);
-            vr.offset(6, yofs * synth->fx[current_fx]->vu_ypos(i));
-            vr.offset(0, -14);
-            vu[i + 1] = new CSurgeVuMeter(vr, this);
-            ((CSurgeVuMeter*)vu[i + 1])->setSkin(currentSkin,bitmapStore);
-            ((CSurgeVuMeter*)vu[i + 1])->setType(t);
-            frame->addView(vu[i + 1]);
-         }
-         else
-         {
-            vu[i + 1] = 0;
-         }
+            int t = synth->fx[current_fx]->vu_type(i);
+            if (t)
+            {
+               CRect vr(fxRect); // FIXME (vurect);
+               vr.offset(6, yofs * synth->fx[current_fx]->vu_ypos(i));
+               vr.offset(0, -14);
+               vu[i + 1] = new CSurgeVuMeter(vr, this);
+               ((CSurgeVuMeter*)vu[i + 1])->setSkin(currentSkin, bitmapStore);
+               ((CSurgeVuMeter*)vu[i + 1])->setType(t);
+               frame->addView(vu[i + 1]);
+            }
+            else
+            {
+               vu[i + 1] = 0;
+            }
 
-         const char* label = synth->fx[current_fx]->group_label(i);
+            const char* label = synth->fx[current_fx]->group_label(i);
 
-         if (label)
-         {
-            CRect vr(fxRect); // (vurect);
-            vr.top += 1;
-            vr.right += 5;
-            vr.offset(5, -12);
-            vr.offset(0, yofs * synth->fx[current_fx]->group_label_ypos(i));
-            CEffectLabel* lb = new CEffectLabel(vr);
-            lb->setLabel(label);
-            lb->setSkin(currentSkin,bitmapStore);
-            frame->addView(lb);
+            if (label)
+            {
+               CRect vr(fxRect); // (vurect);
+               vr.top += 1;
+               vr.right += 5;
+               vr.offset(5, -12);
+               vr.offset(0, yofs * synth->fx[current_fx]->group_label_ypos(i));
+               CEffectLabel* lb = new CEffectLabel(vr);
+               lb->setLabel(label);
+               lb->setSkin(currentSkin, bitmapStore);
+               frame->addView(lb);
+            }
          }
       }
    }


### PR DESCRIPTION
The synth->fx object could be reset while being read in the
UI thread. Add an appropriate lock.

Closes #3488