### PR TITLE
Enqueue Loads with the VST3

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2995,6 +2995,8 @@ void SurgeSynthesizer::resetStateFromTimeData()
 }
 void SurgeSynthesizer::processControl()
 {
+   processEnqueuedPatchIfNeeded();
+
    storage.perform_queued_wtloads();
    int sm = storage.getPatch().scenemode.val.i;
    // TODO: FIX SCENE ASSUMPTION

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -311,6 +311,13 @@ public:
    void clear_osc_modulation(
        int scene, int entry); // clear the modulation routings on the algorithm-specific sliders
 public:
+   std::atomic<bool> rawLoadEnqueued {false}, rawLoadNeedsUIDawExtraState {false};
+   std::mutex rawLoadQueueMutex;
+   void* enqueuedLoadData { nullptr }; // if this is set I need to free it
+   int   enqueuedLoadSize { 0 };
+   void  enqueuePatchForLoad( void* data, int size ); // safe from any thread
+   void  processEnqueuedPatchIfNeeded(); // only safe from audio thread
+
    void loadRaw(const void* data, int size, bool preset = false);
    void loadPatch(int id);
    bool loadPatchByPath(const char* fxpPath, int categoryId, const char* name );

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -462,6 +462,15 @@ void SurgeGUIEditor::idle()
       }
       removeFromFrame.clear();
 
+      {
+         bool expected = true;
+         if (synth->rawLoadNeedsUIDawExtraState.compare_exchange_weak(expected, true) && expected)
+         {
+            std::lock_guard<std::mutex> g(synth->rawLoadQueueMutex);
+            synth->rawLoadNeedsUIDawExtraState = false;
+            loadFromDAWExtraState(synth);
+         }
+      }
 
       if( patchCountdown >= 0 )
       {

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -236,18 +236,24 @@ tresult PLUGIN_API SurgeVst3Processor::setState(IBStream* state)
 
       if( isSub3 )
       {
+         // This is the code which used to load on the VST thread. See #3494
+         /*
          surgeInstance->loadRaw(data, numBytes, false);
          surgeInstance->loadFromDawExtraState();
          for( auto e : viewsSet )
             e->loadFromDAWExtraState(surgeInstance.get());
+            */
+         surgeInstance->enqueuePatchForLoad(data, numBytes);
       }
       else
       {
-         //printf( "Skipping load where I was handed non-sub3 block\n" );
+         free(data);
       }
    }
-
-   free(data);
+   else
+   {
+      free(data);
+   }
 
    return (result == kResultOk) ? kResultOk : kInternalError;
 }


### PR DESCRIPTION
Loads happened on the VST3 thread which meant focing an unstream
from your DAW while surge was playing could crash. Push the
load onto the UI thread. Handle locking carefully using a
std::atomic<bool> sentinel and weak compares since we get
lots of chances.

Closes #3494