### PR TITLE
Force VST3 resize in fixed zoom case

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -5983,7 +5983,22 @@ void SurgeGUIEditor::reloadFromSkin()
    frame->setSize( wsx * sf, wsy * sf );
 
 #if TARGET_VST3
-   sf = getZoomFactor() / 100.0;
+   float uzf = getZoomFactor();
+   if( currentSkin->hasFixedZooms() )
+   {
+       for( auto z : currentSkin->getFixedZooms() )
+       {
+          if( z <= zoomFactor )
+          {
+             uzf = z;
+          }
+       }
+   }
+   if( uzf != getZoomFactor() )
+   {
+      resizeToOnIdle = VSTGUI::CPoint( wsx * uzf / 100.0, wsy * uzf / 100.0 );
+   }
+   sf = uzf / 100.0;
 #endif
 
    rect.right = wsx * sf;


### PR DESCRIPTION
In the fixed zoom case the VST3 would not complete its resize.
Force it by detecting the zoom constraint and updating the
resizeToOnIdle.

Closes #3501