### PR TITLE
A number of skin engine related tweaks

### DIFF
--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -125,7 +125,6 @@
     <color id="filtermenu.value" value="white"/>
     <color id="filtermenu.value.hover" value="white"/>
 
-    <color id="patchbrowser.background" value="lightgray"/>
     <color id="patchbrowser.text" value="lightgray"/>
 
     <color id="slider.light.label" value="lightgray"/>
@@ -175,7 +174,7 @@
 
   <controls>
     <!-- Global & Scene -->
-    <control ui_identifier="global.master_volume" class="def-hslider"/>
+    <control ui_identifier="global.volume" class="def-hslider"/>
 
     <control ui_identifier="scene.drift" class="def-hslider"/>
     <control ui_identifier="scene.noise_color" class="def-hslider"/>

--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -293,8 +293,7 @@ namespace Colors
 
    namespace PatchBrowser
    {
-      const Surge::Skin::Color Background("patchbrowser.background", 255, 255, 255),
-                               Text("patchbrowser.text", 0, 0, 0);
+      const Surge::Skin::Color Text("patchbrowser.text", 0, 0, 0);
    }
 
    namespace Scene

--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -216,7 +216,7 @@ namespace Colors
 
    namespace PatchBrowser
    {
-      extern const Surge::Skin::Color Background, Text;
+      extern const Surge::Skin::Color Text;
    }
 
    namespace Scene

--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -39,7 +39,7 @@ namespace Surge
                    .withHSwitch2Properties(IDB_FX_GLOBAL_BYPASS, 4, 1, 4);
          Connector character = Connector("global.character", 607, 42, 135, 12, Connector::HSWITCH2)
                    .withHSwitch2Properties(IDB_OSC_CHARACTER, 3, 1, 3);
-         Connector master_volume = Connector("global.master_volume", 756, 29);
+         Connector master_volume = Connector("global.volume", 756, 29);
 
          Connector fx1_return = Connector("global.fx1_return", 759, 141);
          Connector fx2_return = Connector("global.fx2_return", 759, 162);
@@ -305,7 +305,7 @@ namespace Surge
                    .withProperty(Connector::BACKGROUND, IDB_MAIN_MENU)
                    .withProperty(Connector::DRAGGABLE_HSWITCH, false);
 
-         Connector patch_browser = Connector("controls.patch_browser", 156, 11, 547-156, 28, Connector::CUSTOM, Connector::PATCH_BROWSER);
+         Connector patch_browser = Connector("controls.patch_browser", 157, 12, 390, 28, Connector::CUSTOM, Connector::PATCH_BROWSER);
          Connector patch_category_jog = Connector("controls.category.prevnext", 157, 42, Connector::JOG_PATCHCATEGORY).asJogPlusMinus();
          Connector patch_jog = Connector("controls.patch.prevnext", 246, 42, Connector::JOG_PATCH).asJogPlusMinus();
          Connector patch_store = Connector("controls.patch.store", 510, 42, 37, 12, Connector::HSWITCH2, Connector::STORE_PATCH)

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -29,33 +29,36 @@ extern CFontRef patchNameFont;
 
 void CPatchBrowser::draw(CDrawContext* dc)
 {
-   CRect size = getViewSize();
-   CRect ar(size);
-   ar.inset(1, 0);
-   // dc->fillRect(ar);
-   ar = size;
-   ar.inset(0, 1);
-   // dc->fillRect(ar);
-   ar = size;
-   ar.inset(2, 2);
-   dc->setFillColor(skin->getColor(Colors::PatchBrowser::Background));
-   // dc->fillRect(ar);
-   // ar.top += 2;
-   CRect al(ar);
-   // ar.left += 68;
-   ar.left += 2;
-   al.right = al.left + 150;
-   al.left += 3;
-   // al.top += 2;
-   al.bottom = al.top + 12;
-   dc->setFontColor(skin->getColor(Colors::PatchBrowser::Text));
-   dc->setFont(patchNameFont);
-   dc->drawString(pname.c_str(), ar, kCenterText, true);
+   CRect pbrowser = getViewSize();
+   CRect cat(pbrowser), auth(pbrowser);
+   
+   cat.left += 3;
+   cat.right = cat.left + 150;
+   cat.setHeight(pbrowser.getHeight() / 2);
 
+   auth = cat;
+   auth.offset(0, pbrowser.getHeight() / 2);
+
+   cat.offset(0, 1);
+   auth.offset(0, -1);
+
+   // debug draws
+   //dc->drawRect(pbrowser);
+   //dc->drawRect(cat);
+   //dc->drawRect(auth);
+
+   // patch browser text color
+   dc->setFontColor(skin->getColor(Colors::PatchBrowser::Text));
+
+   // patch name
+   dc->setFont(patchNameFont);
+   dc->drawString(pname.c_str(), pbrowser, kCenterText, true);
+
+   // category/author name
    dc->setFont(displayFont);
-   dc->drawString(category.c_str(), al, kLeftText, true);
-   al.offset(0, 12);
-   dc->drawString(author.c_str(), al, kLeftText, true);
+   dc->drawString(category.c_str(), cat, kLeftText, true);
+   dc->drawString(author.c_str(), auth, kLeftText, true);
+
    setDirty(false);
 }
 

--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -60,7 +60,7 @@ public:
       {
          std::string s = l;
          // for (int i=0; i<s.length(); i++) s[i] = toupper(s[i]);
-         author = "Creator: " + s;
+         author = "Author: " + s;
       }
       else
          author = "";

--- a/src/common/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/common/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -432,7 +432,7 @@ std::string SurgeGUIEditor::skinInspectorHtml(SkinInspectorFlags f)
         <ul>
           <li><a href="#colors">Color Database</a>
           <li><a href="#imageid">Image IDs</a>
-          <li><a href="#skinConectors">Skin Component Connectors</a>
+          <li><a href="#skinConnectors">Skin Component Connectors</a>
           <li><a href="#loadedImages">Runtime Loaded Images</a>
         </ul>
       </div>
@@ -490,7 +490,7 @@ std::string SurgeGUIEditor::skinInspectorHtml(SkinInspectorFlags f)
       )HTML";
 
    // Skin Connectors
-   startSection( "skinConectors", "Skin Component Connectors" );
+   startSection( "skinConnectors", "Skin Component Connectors" );
    {
       auto imgid = Surge::UI::createIdNameMap();
 


### PR DESCRIPTION
About page now positions text labels based on skin width/height with consistent margins
Patch browser frame now matches the dimensions of the frame used on the background
"Creator" changed to "Author" in patch browser for consistency with patch store dialog
Positioning of Category/Author labels adapts to the height of patch browser
Removed `patchbrowser.background` skin color because it's not used
Renamed `global.master_volume` skin color to `global.volume`
Added developer menu option to use F5 key for reloading current skin