### PR TITLE
When we rebuild UI if we aren't on an mseg, clsoe MSEG

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1736,7 +1736,21 @@ void SurgeGUIEditor::openOrRecreateEditor()
       showMSEGEditor();
       showMSEGEditorOnNextIdleOrOpen = false;
    }
-   
+
+   // We need this here in case we rebuild when opening a new patch.
+   // closeMSEGEditor does nothing if the mseg editor isn't open
+   auto lfoidx = modsource_editor[current_scene]-ms_lfo1;
+   if( lfoidx >= 0 && lfoidx <= n_lfos )
+   {
+      auto ld = &(synth->storage.getPatch()
+                      .scene[current_scene]
+                      .lfo[lfoidx]);
+      if (ld->shape.val.i != lt_mseg)
+      {
+         closeMSEGEditor();
+      }
+   }
+
    refresh_mod();
 
    editor_open = true;


### PR DESCRIPTION
There were some states where an open MSEG editor could linger
into a state where you no longer had an MSEG selected, epsecially
with patch changes. If our current LFO isn't an MSEG in rebuild,
close the MSEG.

Closes #3504