### PR TITLE
Force VST3 resize in fixed zoom case even for the same zoom level

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -6040,26 +6040,25 @@ void SurgeGUIEditor::reloadFromSkin()
 
 #if TARGET_VST3
    float uzf = getZoomFactor();
-   if( currentSkin->hasFixedZooms() )
+
+   if (currentSkin->hasFixedZooms())
    {
-       for( auto z : currentSkin->getFixedZooms() )
+       for (auto z : currentSkin->getFixedZooms())
        {
-          if( z <= zoomFactor )
+          if (z <= zoomFactor)
           {
              uzf = z;
           }
        }
    }
-   if( uzf != getZoomFactor() )
-   {
-      resizeToOnIdle = VSTGUI::CPoint( wsx * uzf / 100.0, wsy * uzf / 100.0 );
-   }
+
+   resizeToOnIdle = VSTGUI::CPoint(wsx * uzf / 100.0, wsy * uzf / 100.0);
+
    sf = uzf / 100.0;
 #endif
 
    rect.right = wsx * sf;
    rect.bottom = wsy * sf;
-
 
    setZoomFactor( getZoomFactor() );
 


### PR DESCRIPTION
In case of going from non-fixed-zooms skin to a fixed-zooms skin, and fixed-zooms skin actually supporting the currently set zoom level, @baconpaul's fix in #3502 didn't force the recalculation of skin width and height. So remove that `if` and just recalculate skin width and height at all times.