### PR TITLE
Refresh mod when swapping alternates

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2284,6 +2284,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                contextMenu, offLab, [this, modsource, cms]() {
                                        cms->setUseAlternate( ! cms->useAlternate );
                                        modsource_is_alternate[modsource] = cms->useAlternate;
+                                       this->refresh_mod();
                                     }
                );
             if( activeMod )


### PR DESCRIPTION
Forces colors to change when you activate an alternate which already
modulates sliders. Closes #3519