### PR TITLE
loadDawExtra in Enqueue

### DIFF
--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -300,6 +300,8 @@ void SurgeSynthesizer::processEnqueuedPatchIfNeeded()
       std::lock_guard<std::mutex> g(rawLoadQueueMutex);
       rawLoadEnqueued = false;
       loadRaw( enqueuedLoadData, enqueuedLoadSize );
+      loadFromDawExtraState();
+
       freeThis = enqueuedLoadData;
       enqueuedLoadData = nullptr;
       rawLoadNeedsUIDawExtraState = true;


### PR DESCRIPTION
When we moved to defered VST3 loads I forgot to do the dawExtraState
so tuning, MPE, etc... didn't load properly. Restore the missing line.

Closes #3526