### PR TITLE
Don't enqueue patch load on Init or without Audio

### DIFF
--- a/src/vst3/SurgeVst3Processor.h
+++ b/src/vst3/SurgeVst3Processor.h
@@ -121,6 +121,7 @@ public:
    void uithreadIdleActivity();
 
 protected:
+   bool isFirstLoad = true;
    void setExtraScaleFactor(VSTGUI::CBitmap *bg, float zf);
 
    void createSurge();


### PR DESCRIPTION
If you are in the init sequence or if audio isn't running
process the enequeued load immediately on the VST3 thread
since some DAWs (like bitwig for instance) send setParameters
immediately after setState, and if we enqueue the setParameters
end up before the setState and get overwritten.

Closes #3531