### PR TITLE
Defend against invalid FX drags

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3657,6 +3657,9 @@ void SurgeSynthesizer::changeModulatorSmoothing( ControllerModulationSource::Smo
 
 void SurgeSynthesizer::reorderFx(int source, int target, FXReorderMode m )
 {
+   if (source < 0 || source >= n_fx_slots || target < 0 || target >= n_fx_slots)
+      return;
+
    FxStorage so, to;
    memcpy((void*)&so, (void*)(&storage.getPatch().fx[source]), sizeof(FxStorage));
    memcpy((void*)&to, (void*)(&storage.getPatch().fx[target]), sizeof(FxStorage));

--- a/src/common/gui/CEffectSettings.cpp
+++ b/src/common/gui/CEffectSettings.cpp
@@ -71,7 +71,7 @@ void CEffectSettings::draw(CDrawContext* dc)
       }
    }
 
-   if( mouseActionMode == drag )
+   if (mouseActionMode == drag && dragSource >= 0 && dragSource < n_fx_slots)
    {
       auto vs = getViewSize();
       vs = vs.inset(1,1);
@@ -106,6 +106,7 @@ CMouseEventResult CEffectSettings::onMouseDown(CPoint& where, const CButtonState
 
    mouseActionMode = click;
    dragStart = where;
+   dragSource = -1;
    for (int i = 0; i < n_fx_slots; i++)
    {
       CRect size = getViewSize();
@@ -123,7 +124,7 @@ CMouseEventResult CEffectSettings::onMouseDown(CPoint& where, const CButtonState
 
 CMouseEventResult CEffectSettings::onMouseUp(CPoint& where, const CButtonState& buttons)
 {
-   if( mouseActionMode == drag )
+   if (mouseActionMode == drag && dragSource >= 0 && dragSource < n_fx_slots)
    {
       int droppedOn = -1;
       for (int i = 0; i < n_fx_slots; i++)
@@ -190,7 +191,8 @@ CMouseEventResult CEffectSettings::onMouseMoved(CPoint& where, const CButtonStat
       float dy = dragStart.y - where.y;
       float dist = sqrt( dx * dx + dy * dy );
 
-      if( dist > 3 ) {
+      if (dist > 3 && dragSource >= 0 && dragSource < n_fx_slots)
+      {
          mouseActionMode = drag;
       }
    }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -7671,6 +7671,9 @@ bool SurgeGUIEditor::onDrop( const std::string& fname)
 
 void SurgeGUIEditor::swapFX(int source, int target, SurgeSynthesizer::FXReorderMode m)
 {
+   if (source < 0 || source >= n_fx_slots || target < 0 || target >= n_fx_slots)
+      return;
+
    auto t = fxPresetName[target];
    fxPresetName[target] = fxPresetName[source];
    if( m == SurgeSynthesizer::SWAP )


### PR DESCRIPTION
The CEFfectSettings allowed us to initiate invalid drags
which would cause a crash. Fix that by being defensive in
several places and not initiating drags unless an item
is selected.