### PR TITLE
Add an environment to stop test from hitting network

### DIFF
--- a/src/headless/UnitTestsIO.cpp
+++ b/src/headless/UnitTestsIO.cpp
@@ -768,6 +768,16 @@ TEST_CASE( "MonoVoicePriority Streams", "[io]" )
 
 TEST_CASE("Deferred Asset Loader", "[io]")
 {
+   auto skipThisTest = ( getenv("SURGE_DISABLE_NETWORK_TESTS") != nullptr );
+   if( skipThisTest )
+   {
+      SECTION( "Skipping Network Tests" )
+      {
+         REQUIRE(skipThisTest);
+      }
+      return;
+   }
+
    SECTION("Retrieve a single image")
    {
       auto surge = Surge::Headless::createSurge(44100);


### PR DESCRIPTION
Environment is SURGE_DISABLE_NETWORK_TESTS

closes #3539