### PR TITLE
filesystem: Minor cleanups

### DIFF
--- a/libs/filesystem/include/filesystem/directory_iterator.h
+++ b/libs/filesystem/include/filesystem/directory_iterator.h
@@ -36,7 +36,7 @@ public:
    // member functions                                                          [fs.dir.itr.members]
    directory_iterator() = default;
    explicit directory_iterator(const path& p);
-   directory_iterator(const path& p, std::error_code& ec) noexcept;
+   directory_iterator(const path& p, std::error_code& ec);
 
    const value_type& operator*() const noexcept;
    const value_type* operator->() const noexcept { return &**this; }

--- a/libs/filesystem/include/filesystem/filesystem_error.h
+++ b/libs/filesystem/include/filesystem/filesystem_error.h
@@ -26,7 +26,7 @@ public:
    : system_error(ec, std::string{"filesystem error: "} + what_arg) {}
 
    filesystem_error(int errnum, const std::string& what_arg) // non-standard convenience overload
-   : filesystem_error(what_arg, std::error_code(errnum, std::generic_category()))
+   : filesystem_error(what_arg, std::error_code{errnum, std::generic_category()})
    {}
 };
 

--- a/libs/filesystem/include/filesystem/recursive_directory_iterator.h
+++ b/libs/filesystem/include/filesystem/recursive_directory_iterator.h
@@ -34,7 +34,7 @@ public:
    // constructors and destructor                                           [fs.rec.dir.itr.members]
    recursive_directory_iterator() = default;
    explicit recursive_directory_iterator(const path& p);
-   recursive_directory_iterator(const path& p, std::error_code& ec) noexcept;
+   recursive_directory_iterator(const path& p, std::error_code& ec);
 
    // observers
    const value_type& operator*() const noexcept;

--- a/libs/filesystem/src/directory_iterator.cpp
+++ b/libs/filesystem/src/directory_iterator.cpp
@@ -73,13 +73,13 @@ directory_iterator::directory_iterator(const path& p)
    ++*this;
 }
 
-directory_iterator::directory_iterator(const path& p, std::error_code& ec) noexcept
+directory_iterator::directory_iterator(const path& p, std::error_code& ec)
 : directory_iterator{p.native()}
 {
    if (d)
       ++*this;
    else
-      ec = std::error_code(errno, std::system_category());
+      ec = std::error_code{errno, std::system_category()};
 }
 
 const directory_iterator::value_type& directory_iterator::operator*() const noexcept

--- a/libs/filesystem/src/path.cpp
+++ b/libs/filesystem/src/path.cpp
@@ -31,7 +31,7 @@ struct slice
 
    bool empty() const noexcept { return !len; }
 
-   path as_path() const
+   path to_path() const
    {
       if (empty())
          return path{};
@@ -73,7 +73,7 @@ const path::value_type* extension_internal(const path& p) noexcept
       return nullptr;
    if (is_dot_or_dotdot(filename))
       return nullptr;
-   while (period[1] && period[1] == '.')
+   while (period[1] == '.')
       ++period;
    return period;
 }
@@ -128,23 +128,14 @@ path path::filename() const
 
 path path::stem() const
 {
-   return stem_internal(*this).as_path();
+   return stem_internal(*this).to_path();
 }
 
 path path::extension() const
 {
-   const auto* filename = filename_internal(*this);
-   auto period_idx = pth.find_last_of('.');
-   if (period_idx == string_type::npos)
-      return path{};
-   const auto* period = pth.c_str() + period_idx;
-   if (period <= filename)
-      return path{};
-   if (is_dot_or_dotdot(filename))
-      return path{};
-   while (period[1] && period[1] == '.')
-      ++period;
-   return path{period};
+   if (auto* const pext = extension_internal(*this))
+      return path{pext};
+   return path{};
 }
 
 bool path::has_stem() const noexcept

--- a/libs/filesystem/src/recursive_directory_iterator.cpp
+++ b/libs/filesystem/src/recursive_directory_iterator.cpp
@@ -56,7 +56,7 @@ recursive_directory_iterator::recursive_directory_iterator(const path& p)
       d = std::make_shared<Impl>(std::move(it));
 }
 
-recursive_directory_iterator::recursive_directory_iterator(const path& p, std::error_code& ec) noexcept
+recursive_directory_iterator::recursive_directory_iterator(const path& p, std::error_code& ec)
 {
    directory_iterator it{p, ec};
    if (!ec && it != directory_iterator{})
@@ -72,7 +72,7 @@ recursive_directory_iterator& recursive_directory_iterator::operator++()
 {
    auto& stack = d->stack;
 
-   if (stack.top() != directory_iterator())
+   if (stack.top() != directory_iterator{})
    {
       if (d->descend(stack.top()->path()))
          return *this;


### PR DESCRIPTION
- Remove invalid "noexcept" from allocating ctors
- Fix redundancy in fs::path
- (More) consistent brace initialization