### PR TITLE
Disable the Deferred Asset Loader

### DIFF
--- a/src/common/DeferredAssetLoader.cpp
+++ b/src/common/DeferredAssetLoader.cpp
@@ -13,6 +13,8 @@
 ** open source in September 2018.
 */
 
+#if BUILD_DEFERRED_ASSET_LOADER
+
 #include <string>
 #include <sstream>
 #include <thread>
@@ -353,3 +355,5 @@ void DeferredAssetLoader::retrieveSingleAsset(
 
 } // namespace Storage
 } // namespace Surge
+
+#endif

--- a/src/common/DeferredAssetLoader.h
+++ b/src/common/DeferredAssetLoader.h
@@ -25,7 +25,7 @@ namespace Surge
 {
 namespace Storage
 {
-
+#if BUILD_DEFERRED_ASSET_LOADER
 class DeferredAssetLoader
 {
 public:
@@ -50,6 +50,7 @@ public:
 private:
    fs::path cacheDir;
 };
+#endif
 
 } // namespace Storage
 } // namespace Surge

--- a/src/headless/UnitTestsIO.cpp
+++ b/src/headless/UnitTestsIO.cpp
@@ -766,6 +766,7 @@ TEST_CASE( "MonoVoicePriority Streams", "[io]" )
    }
 }
 
+#if BUILD_DEFERRED_ASSET_LOADER
 TEST_CASE("Deferred Asset Loader", "[io]")
 {
    auto skipThisTest = ( getenv("SURGE_DISABLE_NETWORK_TESTS") != nullptr );
@@ -856,3 +857,4 @@ TEST_CASE("Deferred Asset Loader", "[io]")
       REQUIRE(!dal.hasCachedCopyOf(testUrl));
    }
 }
+#endif


### PR DESCRIPTION
Since we are headed into 1.8 without using the DeferredAssetLoader,
do a hard-disable of it at compile time to avoid the extra deps
on various platforms