### PR TITLE
Subtype Iteration for CSnapshotMenu sub types

### DIFF
--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -189,7 +189,7 @@ VSTGUI::COptionMenu* CSnapshotMenu::populateSubmenuFromTypeElement(TiXmlElement 
     ** Next see if we have any subordinate types
     */
     TiXmlElement* subType = TINYXML_SAFE_TO_ELEMENT(type->FirstChild("type"));
-    if (subType)
+    while (subType)
     {
         populateSubmenuFromTypeElement(subType, subMenu, main, sub, max_sub, idx);
         subType = TINYXML_SAFE_TO_ELEMENT(subType->NextSibling("type"));


### PR DESCRIPTION
We had an if (first only) vs while (do them all) "loop"
accidentally so as soon as we tried two subtypes it
didn't work.

Addresses #3569