### PR TITLE
Correct parameter_normalized for bools

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2560,7 +2560,7 @@ float Parameter::value_to_normalized(float value)
       return ((float)value - (float)val_min.i) / ((float)val_max.i - (float)val_min.i);
       break;
    case vt_bool:
-      return val.b ? 1.f : 0.f;
+      return ( value > 0.5 ) ? 1.f : 0.f;
       break;
    };
    return 0;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3714,3 +3714,17 @@ void SurgeSynthesizer::reorderFx(int source, int target, FXReorderMode m )
    fx_reload[target] = true;
    refresh_editor = true;
 }
+
+bool SurgeSynthesizer::getParameterIsBoolean(const ID& id)
+{
+   auto index = id.getSynthSideId();
+
+   if ((index >= 0) && (index < storage.getPatch().param_ptr.size()))
+   {
+      auto t = storage.getPatch().param_ptr[index]->valtype;
+      if (t == vt_bool)
+         return true;
+   }
+
+   return false;
+}

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -260,6 +260,8 @@ public:
       return setParameter01( index.getSynthSideId(), value, external, force_integer );
    }
 
+   bool getParameterIsBoolean(const ID &index);
+
    float normalizedToValue( const ID &index, float val )
    {
       return normalizedToValue( index.getSynthSideId(), val );


### PR DESCRIPTION
parameter_normalized for bools ignored the input value.
This meant Ardour automation didn't work, but was also
just plain wrong.

Along the way we thought it was the stepCount so I added
SS functions to allow us to do a public queriy of boolean
but didn't use them in 18. See #3577

Closes #3576