### PR TITLE
init rather than set_target on Controllers on load

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1708,7 +1708,7 @@ void SurgePatch::load_xml(const void* data, int datasize, bool is_preset)
             scene[0].modsources[ms_ctrl1 + cont]->set_bipolar(j);
          if (p->QueryDoubleAttribute("v", &d) == TIXML_SUCCESS)
          {
-            ((ControllerModulationSource*)scene[0].modsources[ms_ctrl1 + cont])->set_target(d);
+            ((ControllerModulationSource*)scene[0].modsources[ms_ctrl1 + cont])->init(d);
          }
 
          const char* lbl = p->Attribute("label");


### PR DESCRIPTION
The load path for ControllerModulationSources would call
set_target on the modulator. This meant the modulators
after a load would need to snap up to target. Fine. ALmost
noone would ever notice that. *Except* the VST3 getParamNormalized
asks for output, not target, of the controller, which is correct.

But if you have a DAW which asks for the paramNormalized then sets
that back on at load time, like Ardour can in teh VST3, that means your
saved value get overridden

So change ->set_target to ->init which has the sole difference
of snapping the output to targe ton load, which is correct

Closes #3561