### PR TITLE
Move Function from Coming in 1.9 to Coming soon

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -391,7 +391,7 @@ const char lt_names[n_lfo_types][32] =
    "Envelope",
    "Step Sequencer",
    "MSEG",
-   "Function (coming in 1.9!)",
+   "Function (work in progress!)",
 };
 
 const int lt_num_deforms[n_lfo_types] =


### PR DESCRIPTION
So many things might change
We might call it surge 2 or surge 2021.2
We might want to do a 1.9 release before function is done
We might never do a 1.9 release (but then soon would also be a lie :) )
So hedge a bit on this UI point