### PR TITLE
Rework the midi key modulators

### DIFF
--- a/resources/data/skins/Tutorial/06 Using PNG.surge-skin/skin.xml
+++ b/resources/data/skins/Tutorial/06 Using PNG.surge-skin/skin.xml
@@ -44,7 +44,7 @@
         Using the technique described in Tutorial 02, we are replacing the default horizontal
         slider handle image in with this scalable image.
     [doc]-->
-    <multi-image id="FADERH_HANDLE">
+    <multi-image id="SLIDER_HORIZ_HANDLE">
       <image zoom-level="100" resource="PNG/horiz_handles_100.png"/>
       <image zoom-level="200" resource="PNG/horiz_handles_200.png"/>
       <image zoom-level="400" resource="PNG/horiz_handles_400.png"/>

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -367,6 +367,9 @@ public:
    int mpeVoices = 0;
    int mpeGlobalPitchBendRange = 0;
 
+   std::array<uint64_t, 128> midiKeyPressedForScene[n_scenes];
+   uint64_t orderedMidiKey = 0;
+
    bool hardclipEnabled = true;
 
    int current_category_id = 0;

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -180,8 +180,10 @@ private:
 
    std::unique_ptr<Oscillator> osc[3];
 
+public: // this is public, but only for the regtests
    std::array<ModulationSource*, n_modsources> modsources;
 
+private:
    ModulationSource velocitySource, releaseVelocitySource;
    ModulationSource keytrackSource;
    ControllerModulationSource polyAftertouchSource;


### PR DESCRIPTION
The midi key modulators interacting with voice were a source of
constaint pain since the voice modes are optimizing for voice
management not midi state management. As a resul thtings like
"highest" on mono mode with priority mode at lowest didn't work.

So maintain an array of which key is activating which scene
(after all the channel resolution) with a count of midi number
and use that for highest.

Also add extensive regtests

Closes #3597