### PR TITLE
Pipeline for Extra Content part 1: Surge-side

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ endif()
 set(SURGE_PRODUCT_DIR ${CMAKE_BINARY_DIR}/surge_products)
 file(MAKE_DIRECTORY ${SURGE_PRODUCT_DIR})
 
+include(cmake/stage-extra-content.cmake)
+
 add_library(surge-shared src/common/FilterConfiguration.h)
 add_library(surge-tests INTERFACE)
 
@@ -1475,3 +1477,16 @@ if(MSVC)
   endforeach()
   target_compile_options( surge-shared PRIVATE /FIprecompiled.h )
 endif()
+
+
+# We have a special target here which the PR pipeline uses to make sure things
+# are of the appropriate code quality. This allows us to write CMAKE rules which
+# become linters and stuff. The code will run on macos in the pipeline. I suppose
+# you could run it locally to, but really, you should know what you are doing if you
+# do that. And I'll document it so you can know that when I use it earnest in 1.9
+add_custom_target(code-quality-pipeline-checks)
+
+# Check 1: The extra content is properly specified.
+add_dependencies(code-quality-pipeline-checks download-extra-content)
+
+# Coming in 1.9: CLang Format checks and others

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,11 @@ jobs:
         isMac: True
         cmakeArguments: "-GXcode -DBUILD_SURGE_JUCE_PLUGINS=True"
         cmakeTarget: "Surge-Effects-Bank-Packaged"
+      macOS-codequality:
+        imageName: 'macos-10.15'
+        isMac: True
+        cmakeArguments: ""
+        cmakeTarget: "code-quality-pipeline-checks"
       windows-x64:
         imageName: 'windows-2019'
         isWindows: True

--- a/cmake/stage-extra-content.cmake
+++ b/cmake/stage-extra-content.cmake
@@ -1,0 +1,31 @@
+#
+# This file is used to provide targets which stage the extra content external repo
+#
+
+set(SURGE_EXTRA_CONTENT_REPO https://github.com/surge-synthesizer/surge-extra-content.git)
+set(SURGE_EXTRA_CONTENT_HASH 59aafa2af2c02eeb7bdcbede4cae216a22e12c74)
+
+find_package(Git)
+if( ${Git_FOUND} )
+    message(STATUS "Adding download-extra-content target from ${SURGE_EXTRA_CONTENT_REPO}" )
+    add_custom_target(download-extra-content)
+    add_custom_command(TARGET download-extra-content
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            COMMAND cmake -E make_directory surge-extra-content
+            COMMAND ${GIT_EXECUTABLE} clone ${SURGE_EXTRA_CONTENT_REPO} surge-extra-content
+            )
+    add_custom_command(TARGET download-extra-content
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/surge-extra-content
+            COMMAND ${GIT_EXECUTABLE} checkout ${SURGE_EXTRA_CONTENT_HASH}
+            )
+
+    # I explicitly do NOT make this depend on download since download twice in a row fails
+    add_custom_target(stage-extra-content)
+    add_custom_command(TARGET stage-extra-content
+            POST_BUILD
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMAND cmake -E copy_directory ${CMAKE_BINARY_DIR}/surge-extra-content/Skins/ resources/data/skins
+            )
+endif()


### PR DESCRIPTION
This commit adds a couple of pipeline rules to download,
stage extra content. Also it adds a pipeline-checks target
so we can trigger a special VM just to do code quality checks
in the PR pipeline

Addresses #3517