### PR TITLE
Invalidate OffScreen caches first idle after zoom

### DIFF
--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -56,6 +56,17 @@ public:
       extraScaleFactor = a;
    }
 
+   void clearOffscreenCaches()
+   {
+      for (auto const& pair : offscreenCache)
+      {
+         auto val = pair.second;
+         if (val)
+            val->forget();
+      }
+      offscreenCache.clear();
+   }
+
    int resourceID;
    std::string fname;
 

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -42,6 +42,22 @@ SurgeBitmaps::~SurgeBitmaps()
    // std::cout << "Destroying a SurgeBitmaps; Instances is " << instances << std::endl;
 }
 
+void SurgeBitmaps::clearAllBitmapOffscreenCaches()
+{
+   for (auto pair : bitmap_registry)
+   {
+      pair.second->clearOffscreenCaches();
+   }
+   for (auto pair : bitmap_file_registry)
+   {
+      pair.second->clearOffscreenCaches();
+   }
+   for (auto pair : bitmap_stringid_registry)
+   {
+      pair.second->clearOffscreenCaches();
+   }
+}
+
 void SurgeBitmaps::setupBitmapsForFrame(VSTGUI::CFrame* f)
 {
    frame = f;

--- a/src/common/gui/SurgeBitmaps.h
+++ b/src/common/gui/SurgeBitmaps.h
@@ -16,6 +16,7 @@ public:
 
    void setupBitmapsForFrame(VSTGUI::CFrame* f);
    void setPhysicalZoomFactor(int pzf);
+   void clearAllBitmapOffscreenCaches();
 
    CScalableBitmap* getBitmap(int id);
    CScalableBitmap* getBitmapByPath(std::string filename);

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -462,6 +462,16 @@ void SurgeGUIEditor::idle()
       }
       removeFromFrame.clear();
 
+      if (clearOffscreenCachesAtZero == 0)
+      {
+         bitmapStore->clearAllBitmapOffscreenCaches();
+         frame->invalid();
+      }
+      if (clearOffscreenCachesAtZero >= 0)
+      {
+         clearOffscreenCachesAtZero--;
+      }
+
       {
          bool expected = true;
          if (synth->rawLoadNeedsUIDawExtraState.compare_exchange_weak(expected, true) && expected)
@@ -6085,6 +6095,7 @@ void SurgeGUIEditor::reloadFromSkin()
    rect.bottom = wsy * sf;
 
    setZoomFactor( getZoomFactor() );
+   clearOffscreenCachesAtZero = 1;
 
    // update MSEG editor if opened
    if (editorOverlay && editorOverlayTag == "msegEditor")

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -368,6 +368,14 @@ public:
 
    bool hasIdleRun = false;
    VSTGUI::CPoint resizeToOnIdle = VSTGUI::CPoint(-1,-1);
+   /*
+    * A countdown which will clearr the bitmap store offscreen caches
+    * after N idles if set to a positive N. This is needed as some
+    * DAWS (cough cough LIVE) handle draw and resize events in a
+    * different order so the offscren cache when going classic->royal
+    * at 100% (for instance) is the wrong size.
+    */
+   int clearOffscreenCachesAtZero = -1;
 
 private:
    SGEDropAdapter *dropAdapter = nullptr;


### PR DESCRIPTION
In some DAWs you have a resize at open event not order quite properly
with the offscreen cache setup which meant, at 100% in live with the
royal skin on windows, you got a black bar on the background outside
where the classic skin was. There's probably all sorts of clever fixes
involving re-ordering the draws and stuff, but I took a more basic
approach of after any reloadSkin event, blow away my offscreen caches
and repaint on the first subsequent idle. This is just a teensy
CPU impact on most daws, but on live fixes the paint too.