### PR TITLE
Handle RingMod + FM + Mute case

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -723,7 +723,8 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
    clear_block(output[0], BLOCK_SIZE_OS_QUAD);
    clear_block(output[1], BLOCK_SIZE_OS_QUAD);
 
-   if (osc3 || ring23 || ((osc1 || osc2) && (FMmode == fm_3to2to1)) || (osc1 && (FMmode == fm_2and3to1)))
+   if (osc3 || ring23 || ((osc1 || osc2 || ring12) && (FMmode == fm_3to2to1)) ||
+       ((osc1 || ring12) && (FMmode == fm_2and3to1)))
    {
        osc[2]->process_block(noteShiftFromPitchParam((scene->osc[2].keytrack.val.b ? state.pitch : ktrkroot + state.scenepbpitch) +
                                                       octaveSize * scene->osc[2].octave.val.i, 2), drift, is_wide);


### PR DESCRIPTION
If OSC123 were muted, Ring12 was not, and FM mode was
set to anything involving oscillator 3, you got a click
because the right oscillators weren't evaluated. Fix by
making ring12 an oscillator in the ifs at the same hierarchy as
osc1 basically.