### PR TITLE
1.8.2 MERGEABLE - A structured multi-overlay API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ set(SURGE_GUI_SOURCES
   src/common/gui/SkinImageMaps.h
   src/common/gui/CSurgeHyperlink.cpp
   src/common/ModulatorPresetManager.cpp
-        src/common/gui/CTextButtonWithHover.cpp src/common/gui/CTextButtonWithHover.h)
+        src/common/gui/CTextButtonWithHover.cpp src/common/gui/CTextButtonWithHover.h src/common/gui/RefreshableOverlay.h)
 
 set(SURGE_VST3_SOURCES
   src/vst3/SurgeVst3Processor.cpp

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -1183,7 +1183,7 @@ void CLFOGui::openPopup(CPoint &where)
    contextMenu->addSeparator();
 
    auto sge = dynamic_cast<SurgeGUIEditor*>(listener);
-   std::string openname = (sge->editorOverlayTag != "msegEditor") ? "Open MSEG Editor" : "Close MSEG Editor";
+   std::string openname = (sge && sge->isAnyOverlayPresent(SurgeGUIEditor::MSEG_EDITOR)) ? "Open MSEG Editor" : "Close MSEG Editor";
    addCb(contextMenu, Surge::UI::toOSCaseForMenu(openname), [this, sge]()
                                  {
                                     if (sge)
@@ -1195,7 +1195,7 @@ void CLFOGui::openPopup(CPoint &where)
    auto lpoff = addCb(contextMenu, Surge::UI::toOSCaseForMenu("No Looping"), [this, sge]()
                                    {
                                       ms->loopMode = MSEGStorage::LoopMode::ONESHOT;
-                                      if (sge->editorOverlayTag == "msegEditor")
+                                      if (sge && sge->isAnyOverlayPresent(SurgeGUIEditor::MSEG_EDITOR))
                                       {
                                          sge->closeMSEGEditor();
                                          sge->showMSEGEditor();
@@ -1207,7 +1207,7 @@ void CLFOGui::openPopup(CPoint &where)
    auto lpon = addCb(contextMenu, Surge::UI::toOSCaseForMenu("Loop Always"), [this, sge]()
                                    {
                                       ms->loopMode = MSEGStorage::LoopMode::LOOP;
-                                      if (sge->editorOverlayTag == "msegEditor")
+                                      if (sge && sge->isAnyOverlayPresent(SurgeGUIEditor::MSEG_EDITOR))
                                       {
                                          sge->closeMSEGEditor();
                                          sge->showMSEGEditor();
@@ -1219,7 +1219,7 @@ void CLFOGui::openPopup(CPoint &where)
    auto lpgate = addCb(contextMenu, Surge::UI::toOSCaseForMenu("Loop Until Release"), [this, sge]()
                                    {
                                       ms->loopMode = MSEGStorage::LoopMode::GATED_LOOP;
-                                      if (sge->editorOverlayTag == "msegEditor")
+                                      if (sge && sge->isAnyOverlayPresent(SurgeGUIEditor::MSEG_EDITOR))
                                       {
                                          sge->closeMSEGEditor();
                                          sge->showMSEGEditor();

--- a/src/common/gui/MSEGEditor.h
+++ b/src/common/gui/MSEGEditor.h
@@ -17,8 +17,9 @@
 #include "vstcontrols.h"
 #include "SurgeStorage.h"
 #include "SkinSupport.h"
+#include "RefreshableOverlay.h"
 
-struct MSEGEditor : public VSTGUI::CViewContainer, public Surge::UI::SkinConsumingComponent {
+struct MSEGEditor : public VSTGUI::CViewContainer, public Surge::UI::SkinConsumingComponent, public RefreshableOverlay {
    /*
     * Because this is 'late' in the build (in the gui) there is a copy of this structure in
     * the DawExtraState. If you add something to this state, add it there too. Revisit that

--- a/src/common/gui/RefreshableOverlay.h
+++ b/src/common/gui/RefreshableOverlay.h
@@ -1,0 +1,24 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#ifndef SURGE_REFRESHABLEOVERLAY_H
+#define SURGE_REFRESHABLEOVERLAY_H
+
+class RefreshableOverlay {
+public:
+   virtual void forceRefresh() = 0;
+};
+
+#endif // SURGE_REFRESHABLEOVERLAY_H


### PR DESCRIPTION
editorOverlay is now a list so you can have multiple, and the
tags which identify it are an enum so you know the overlay classes
and can write less buggy code, and generallly everything is better.

Although there is inevitably more work we want to do on overlays
and positioning, this commit makes the API a good enough starting
point to add other overlays, so it Closes #3223