### PR TITLE
Initialize msegstate on attack

### DIFF
--- a/src/common/dsp/LfoModulationSource.cpp
+++ b/src/common/dsp/LfoModulationSource.cpp
@@ -160,6 +160,9 @@ void LfoModulationSource::initPhaseFromStartPhase()
 
 void LfoModulationSource::attack()
 {
+   // For VLFO you don't need this but SLFO get recycled, so you do
+   msegstate = Surge::MSEG::EvaluatorState();
+
    if( ! phaseInitialized )
    {
       initPhaseFromStartPhase();


### PR DESCRIPTION
The msegsetage is initialized in the constructor so for a VLFO
the attack resets the state properly since it is a 1:1 with construction
but since SLFOs get multi-use we need to reset state when attacking
an SLFO also

Closes #3631