### PR TITLE
Copy WaveTable Display Name in OSC and Scene copy

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1064,6 +1064,7 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry)
       if (uses_wavetabledata(getPatch().scene[scene].osc[entry].type.val.i))
       {
          clipboard_wt[0].Copy(&getPatch().scene[scene].osc[entry].wt);
+         strncpy(clipboard_wt_names[0], getPatch().scene[scene].osc[entry].wavetable_display_name, 256 );
       }
       break;
    case cp_lfo:
@@ -1090,6 +1091,7 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry)
       for (int i = 0; i < n_oscs; i++)
       {
          clipboard_wt[i].Copy(&getPatch().scene[scene].osc[i].wt);
+         strncpy(clipboard_wt_names[i], getPatch().scene[scene].osc[i].wavetable_display_name, 256 );
       }
       clipboard_primode = getPatch().scene[scene].monoVoicePriorityMode;
    }
@@ -1194,6 +1196,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry)
       for (int i = 0; i < n_oscs; i++)
       {
          getPatch().scene[scene].osc[i].wt.Copy(&clipboard_wt[i]);
+         strncpy(getPatch().scene[scene].osc[i].wavetable_display_name, clipboard_wt_names[i], 256 );
       }
       getPatch().scene[scene].monoVoicePriorityMode = clipboard_primode;
    }
@@ -1227,6 +1230,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry)
          if (uses_wavetabledata(getPatch().scene[scene].osc[entry].type.val.i))
          {
             getPatch().scene[scene].osc[entry].wt.Copy(&clipboard_wt[0]);
+            strncpy(getPatch().scene[scene].osc[entry].wavetable_display_name, clipboard_wt_names[0], 256 );
          }
 
          // copy modroutings

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1011,6 +1011,7 @@ private:
    MSEGStorage clipboard_msegs[n_lfos];
    std::vector<ModulationRouting> clipboard_modulation_scene, clipboard_modulation_voice;
    Wavetable clipboard_wt[n_oscs];
+   char clipboard_wt_names[n_oscs][256];
    MonoVoicePriorityMode clipboard_primode = NOTE_ON_LATEST_RETRIGGER_HIGHEST;
 
 public:


### PR DESCRIPTION
The WaveTable display name was not included in the copy/paste
buffer. Fix.

Closes #3637