### PR TITLE
Oscillator type preserve on Wave/WT drop/load

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -903,7 +903,12 @@ void SurgeStorage::perform_queued_wtloads()
          }
          else if (patch.scene[sc].osc[o].wt.queue_filename[0])
          {
-            patch.scene[sc].osc[o].queue_type = ot_wavetable;
+            if (!(patch.scene[sc].osc[o].type.val.i == ot_wavetable ||
+                  patch.scene[sc].osc[o].type.val.i == ot_window))
+            {
+               patch.scene[sc].osc[o].queue_type = ot_wavetable;
+            }
+
             patch.scene[sc].osc[o].wt.current_id = -1;
             load_wt(patch.scene[sc].osc[o].wt.queue_filename, &patch.scene[sc].osc[o].wt, &patch.scene[sc].osc[o]);
             patch.scene[sc].osc[o].wt.refresh_display = true;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -7688,7 +7688,6 @@ bool SurgeGUIEditor::canDropTarget(const std::string& fname)
 }
 bool SurgeGUIEditor::onDrop( const std::string& fname)
 {
-   std::cout << "Dropped " << fname << std::endl;
    fs::path fPath(fname);
    std::string fExt(path_to_string(fPath.extension()));
    std::transform(fExt.begin(), fExt.end(), fExt.begin(),


### PR DESCRIPTION
If you are already on window or wavetable when you drop
or load a wave, don't force a change to wavetable.

Closes #3657