### PR TITLE
Handle the case of modpreset with no presets but subdirs

### DIFF
--- a/src/common/ModulatorPresetManager.cpp
+++ b/src/common/ModulatorPresetManager.cpp
@@ -256,6 +256,32 @@ std::vector<Category> getPresets( SurgeStorage *s )
                resMap[rd].name = catName;
                resMap[rd].parentPath = pd;
                resMap[rd].path = rd;
+
+               /*
+                * We only create categories if we find a preset. So that means parent directories
+                * with just subdirs need categories made. This recurses up as far as we need to go
+                */
+               while (pd != "" && resMap.find(pd) == resMap.end())
+               {
+                  auto cd = pd;
+                  catName = cd;
+                  ppos = cd.rfind(fs::path::preferred_separator);
+
+                  if (ppos != std::string::npos)
+                  {
+                     pd = cd.substr(0, ppos);
+                     catName = cd.substr(ppos + 1);
+                  }
+                  else
+                  {
+                     pd = "";
+                  }
+
+                  resMap[cd] = Category();
+                  resMap[cd].name = catName;
+                  resMap[cd].parentPath = pd;
+                  resMap[cd].path = cd;
+               }
             }
 
             Preset prs;
@@ -269,6 +295,7 @@ std::vector<Category> getPresets( SurgeStorage *s )
          // That's OK!
       }
    }
+
    std::vector<Category> res;
    for (auto& m : resMap)
    {


### PR DESCRIPTION
We would add categories only if we found a preset; but that
meant pure-directory organization would be mis-leveled

Closes #3392