### PR TITLE
Fix an infrequent patch browser crash

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -442,8 +442,21 @@ void SurgeGUIEditor::idle()
    if (!synth)
       return;
 
+   if( pause_idle_updates )
+      return;
+
    if (editor_open && frame && !synth->halt_engine)
    {
+      /*
+       * USEFUL for testing stress patch changes
+       *
+      static int runct = 0;
+      if( runct++ == 5 )
+      {
+         synth->patchid_queue = rand() % 1800;
+         runct = 0;
+      }
+        */
       hasIdleRun = true;
       if( firstIdleCountdown )
       {
@@ -483,7 +496,7 @@ void SurgeGUIEditor::idle()
          }
       }
 
-      if( patchCountdown >= 0 )
+      if( patchCountdown >= 0 && ! pause_idle_updates )
       {
          patchCountdown --;
          if( patchCountdown < 0 && synth->patchid_queue >= 0 )

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -141,7 +141,7 @@ public:
 
 #endif
 
-
+   bool pause_idle_updates = false;
 protected:
    int32_t onKeyDown(const VstKeyCode& code,
                      VSTGUI::CFrame* frame) override; ///< should return 1 if no further key down processing


### PR DESCRIPTION
Very infrequently, the patch browser could reload the patch
before the popup dismisses, causing the popup dismiss to be
attached to an invalid UI. Work around this by pausing idle
upodates while the patch browser is open.

Closes #3648