### PR TITLE
MSEG loop start/end menu entries not shown in one valid case

### DIFF
--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -2088,7 +2088,7 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
 
       if (ms->editMode != MSEGStorage::LFO && ms->loopMode != MSEGStorage::LoopMode::ONESHOT)
       {
-         if (tts <= ms->loop_end && tts != ms->loop_start)
+         if (tts <= ms->loop_end + 1 && tts != ms->loop_start)
          {
             auto cbStart = addCb(contextMenu, Surge::UI::toOSCaseForMenu("Set Loop Start"), [this, tts]()
                {
@@ -2097,7 +2097,7 @@ struct MSEGCanvas : public CControl, public Surge::UI::SkinConsumingComponent, p
                });
          }
    
-         if (tts >= ms->loop_start && tts != ms->loop_end)
+         if (tts >= ms->loop_start - 1 && tts != ms->loop_end)
          {
             auto cbEnd = addCb(contextMenu, Surge::UI::toOSCaseForMenu("Set Loop End"), [this, tts, t]()
                {


### PR DESCRIPTION
So when we drag the loop markers in the ruler, we can have loop start = loop end, so that they overlap at the exact same node. This was not possible to achieve with menu entries, so this PR fixes that.