### PR TITLE
A failed load of a .wav file does not change WT display name

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -939,30 +939,32 @@ void SurgeStorage::load_wt(int id, Wavetable* wt, OscillatorStorage *osc)
 
 void SurgeStorage::load_wt(string filename, Wavetable* wt, OscillatorStorage *osc)
 {
-   if( osc )
-   {
-      char sep = PATH_SEPARATOR;
-      auto fn = filename.substr(filename.find_last_of(sep) + 1, filename.npos);
-      std::string fnnoext = fn.substr( 0, fn.find_last_of('.' ) );
-      
-      if( fnnoext.length() > 0 )
-      {
-         strncpy( osc->wavetable_display_name, fnnoext.c_str(), 256 );
-      }
-   }
    wt->queue_filename[0] = 0;
    string extension = filename.substr(filename.find_last_of('.'), filename.npos);
    for (unsigned int i = 0; i < extension.length(); i++)
       extension[i] = tolower(extension[i]);
+   bool loaded = false;
    if (extension.compare(".wt") == 0)
-      load_wt_wt(filename, wt);
+      loaded = load_wt_wt(filename, wt);
    else if (extension.compare(".wav") == 0)
-      load_wt_wav_portable(filename, wt);
+      loaded = load_wt_wav_portable(filename, wt);
    else
    {
        std::ostringstream oss;
        oss << "Unable to load file with extension " << extension << "! Surge only supports .wav and .wt wavetable files!";
        Surge::UserInteractions::promptError(oss.str(), "Error" );
+   }
+
+   if( osc && loaded )
+   {
+      char sep = PATH_SEPARATOR;
+      auto fn = filename.substr(filename.find_last_of(sep) + 1, filename.npos);
+      std::string fnnoext = fn.substr( 0, fn.find_last_of('.' ) );
+
+      if( fnnoext.length() > 0 )
+      {
+         strncpy( osc->wavetable_display_name, fnnoext.c_str(), 256 );
+      }
    }
 }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -914,7 +914,7 @@ public:
    void load_wt(std::string filename, Wavetable* wt, OscillatorStorage *);
    bool load_wt_wt(std::string filename, Wavetable* wt);
    // void load_wt_wav(std::string filename, Wavetable* wt);
-   void load_wt_wav_portable(std::string filename, Wavetable *wt);
+   bool load_wt_wav_portable(std::string filename, Wavetable *wt);
    void export_wt_wav_portable(std::string fbase, Wavetable *wt);
    void clipboard_copy(int type, int scene, int entry);
    void clipboard_paste(int type, int scene, int entry);

--- a/src/common/WavSupport.cpp
+++ b/src/common/WavSupport.cpp
@@ -59,7 +59,8 @@ struct FcloseGuard {
     }
                 
 };
-void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
+
+bool SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
 {
    std::string uitag = "Wavetable Import Error";
 #if WAV_STDOUT_INFO
@@ -73,7 +74,7 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
         std::ostringstream oss;
         oss << "Unable to open file '" << fn << "'!";
         Surge::UserInteractions::promptError(oss.str(), uitag );
-        return;
+        return false;
     }
     FcloseGuard closeOnReturn(fp);
     
@@ -86,7 +87,7 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
        std::ostringstream oss;
        oss << "'" << fn << "' does not contain a valid RIFF header chunk!";
        Surge::UserInteractions::promptError(oss.str(), uitag );
-       return;
+       return false;
     }
 
     if( ! four_chars(riff, 'R', 'I', 'F', 'F' ) &&
@@ -96,7 +97,7 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
        oss << "'" << fn << "' is not a standard RIFF/WAVE file. Header is: " << riff[0] << riff[1] << riff[2]
            << riff[3] << " " << wav[0] << wav[1] << wav[2] << wav[3] << ".";
        Surge::UserInteractions::promptError(oss.str(), uitag );
-       return;
+       return false;
     }
     
     // WAV HEADER
@@ -180,7 +181,7 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
                     << numChannels << "-channel file.";
                 
                 Surge::UserInteractions::promptError( oss.str(), uitag );
-                return;
+                return false;
             }
         }
         else if( four_chars(chunkType, 'c', 'l', 'm', ' '))
@@ -338,7 +339,7 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
         Surge::UserInteractions::promptError( oss.str(), uitag );
                                               
         if (wavdata) free(wavdata);
-        return;
+        return false;
     }
     
     int loopCount = datasamples / loopLen;
@@ -411,7 +412,7 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
         Surge::UserInteractions::promptError( oss.str(), uitag );
                                               
         if (wavdata) free(wavdata);
-        return;
+        return false;
     }
 
     wh.n_samples = 1 << sh;
@@ -458,7 +459,7 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
         Surge::UserInteractions::promptError( oss.str(), uitag );
                                               
         if( wavdata ) free( wavdata );
-        return;
+        return false;
     }
 
     if( wavdata && wt )
@@ -468,7 +469,7 @@ void SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
         waveTableDataMutex.unlock();
         free( wavdata );
     }
-    return;
+    return true;
 }
 
 void SurgeStorage::export_wt_wav_portable(std::string fbase, Wavetable *wt)


### PR DESCRIPTION
Used to be the name changed first. Now it changes last. Had to
add a status return from the wav load also, making the diff a bit
noisy for such a small change.