### PR TITLE
Reposition category/author fields in patch browser

### DIFF
--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -35,12 +35,12 @@ void CPatchBrowser::draw(CDrawContext *dc)
     cat.left += 3;
     cat.right = cat.left + 150;
     cat.setHeight(pbrowser.getHeight() / 2);
+    cat.offset(0, (pbrowser.getHeight() / 2) - 1);
 
-    auth = cat;
-    auth.offset(0, pbrowser.getHeight() / 2);
-
-    cat.offset(0, 1);
-    auth.offset(0, -1);
+    auth.right -= 3;
+    auth.left = auth.right - 150;
+    auth.top = cat.top;
+    auth.bottom = cat.bottom;
 
     // debug draws
     // dc->drawRect(pbrowser);
@@ -57,7 +57,7 @@ void CPatchBrowser::draw(CDrawContext *dc)
     // category/author name
     dc->setFont(displayFont);
     dc->drawString(category.c_str(), cat, kLeftText, true);
-    dc->drawString(author.c_str(), auth, kLeftText, true);
+    dc->drawString(author.c_str(), auth, kRightText, true);
 
     setDirty(false);
 }

--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -32,38 +32,44 @@ class CPatchBrowser : public VSTGUI::CControl, public Surge::UI::SkinConsumingCo
         current_patch = -1;
         current_category = -1;
     }
+
     void setIDs(int category, int patch)
     {
         current_category = category;
         current_patch = patch;
     }
+
     void setLabel(std::string l)
     {
         pname = l;
         setDirty(true);
     }
+
     void setCategory(std::string l)
     {
         if (l.length())
         {
-            std::string s = l;
-            // for (int i=0; i<s.length(); i++) s[i] = toupper(s[i]);
-            category = "Category: " + s;
+            category = "Category: " + path_to_string(string_to_path(l).filename());
         }
         else
+        {
             category = "";
+        }
+
         setDirty(true);
     }
+
     void setAuthor(std::string l)
     {
         if (l.length())
         {
-            std::string s = l;
-            // for (int i=0; i<s.length(); i++) s[i] = toupper(s[i]);
-            author = "Author: " + s;
+            author = "By: " + l;
         }
         else
+        {
             author = "";
+        }
+
         setDirty(true);
     }
 


### PR DESCRIPTION
Only show the last subfolder name (i.e. just Leads instead of Psiome Send Sound/Leads)