### PR TITLE
Copy the wavetable ID when copying

### DIFF
--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -146,6 +146,8 @@ void Wavetable::Copy(Wavetable *wt)
                 TableI16WeakPointers[i][j] = NULL;
         }
     }
+
+    current_id = wt->current_id;
 }
 
 bool Wavetable::BuildWT(void *wdata, wt_header &wh, bool AppendSilence)


### PR DESCRIPTION
Defacto gives the effect of jog position is preserved in OSC
copy.

Closes #3710