### PR TITLE
JUCE/XT: Memory management starting to work; Sliders work

### DIFF
--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -24,6 +24,13 @@ SurgeBitmaps::~SurgeBitmaps()
 #ifdef INSTRUMENT_UI
     Surge::Debug::record("SurgeBitmaps::~SurgeBitmaps");
 #endif
+    clearAllLoadedBitmaps();
+    instances--;
+    // std::cout << "Destroying a SurgeBitmaps; Instances is " << instances << std::endl;
+}
+
+void SurgeBitmaps::clearAllLoadedBitmaps()
+{
     for (auto pair : bitmap_registry)
     {
         pair.second->forget();
@@ -39,8 +46,6 @@ SurgeBitmaps::~SurgeBitmaps()
     bitmap_registry.clear();
     bitmap_file_registry.clear();
     bitmap_stringid_registry.clear();
-    instances--;
-    // std::cout << "Destroying a SurgeBitmaps; Instances is " << instances << std::endl;
 }
 
 void SurgeBitmaps::clearAllBitmapOffscreenCaches()

--- a/src/common/gui/SurgeBitmaps.h
+++ b/src/common/gui/SurgeBitmaps.h
@@ -17,6 +17,7 @@ class SurgeBitmaps
   public:
     SurgeBitmaps();
     virtual ~SurgeBitmaps();
+    void clearAllLoadedBitmaps(); // Call very carefully.
 
     void setupBitmapsForFrame(VSTGUI::CFrame *f);
     void setPhysicalZoomFactor(int pzf);

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -430,6 +430,10 @@ SurgeGUIEditor::~SurgeGUIEditor()
         dropAdapter = nullptr;
     }
 #endif
+
+#if TARGET_JUCE_UI
+    frame->forget();
+#endif
 }
 
 void SurgeGUIEditor::idle()
@@ -1970,6 +1974,7 @@ bool PLUGIN_API SurgeGUIEditor::open(void *parent, const PlatformType &platformT
 
 #if TARGET_JUCE_UI
     nframe->juceComponent()->setTransform(juce::AffineTransform().scaled(1.25));
+    nframe->remember();
 #endif
 
     bitmapStore.reset(new SurgeBitmaps());

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -477,8 +477,10 @@ class SurgeGUIEditor : public EditorType,
     int selectedFX[8];
     std::string fxPresetName[8];
 
+  public:
     std::shared_ptr<SurgeBitmaps> bitmapStore = nullptr;
 
+  private:
     bool modsource_is_alternate[n_modsources];
 
   public:

--- a/src/surge_synth_juce/SurgeSynthEditor.cpp
+++ b/src/surge_synth_juce/SurgeSynthEditor.cpp
@@ -130,6 +130,12 @@ SurgeSynthEditor::~SurgeSynthEditor()
 {
     idleTimer->stopTimer();
     adapter->close();
+    if (adapter->bitmapStore)
+        adapter->bitmapStore->clearAllLoadedBitmaps();
+    adapter.reset(nullptr);
+#if DEBUG_EFVG_MEMORY
+    EscapeNS::Internal::showMemoryOutstanding();
+#endif
 }
 
 void SurgeSynthEditor::handleAsyncUpdate() {}


### PR DESCRIPTION
- Memory management works better. We don't leak all the components
  when we quit, just a bunch of graphics assets and menus.
- Sliders go the right direction
- Some memory debugging infrastructure in place for the interim

Addresses #3737