### PR TITLE
Add option to link delay right channel time to left channel time

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -236,6 +236,7 @@ bool Parameter::can_temposync()
     case ct_lforate:
     case ct_lforate_deactivatable:
     case ct_envtime:
+    case ct_envtime_deactivatable:
     case ct_envtime_lfodecay:
     case ct_reverbpredelaytime:
         return true;
@@ -290,6 +291,7 @@ bool Parameter::can_deactivate()
     case ct_decibel_deactivatable:
     case ct_decibel_narrow_deactivatable:
     case ct_decibel_extra_narrow_deactivatable:
+    case ct_envtime_deactivatable:
         return true;
     }
     return false;
@@ -519,6 +521,7 @@ void Parameter::set_type(int ctrltype)
         val_default.f = -8;
         break;
     case ct_envtime:
+    case ct_envtime_deactivatable:
     case ct_envtime_lfodecay:
         valtype = vt_float;
         val_min.f = -8;
@@ -981,6 +984,7 @@ void Parameter::set_type(int ctrltype)
         // THERE IS NO BREAK HERE ON PURPOSE so we group to the others
     case ct_portatime:
     case ct_envtime:
+    case ct_envtime_deactivatable:
     case ct_reverbtime:
     case ct_reverbpredelaytime:
     case ct_chorusmodtime:
@@ -1226,6 +1230,7 @@ void Parameter::bound_value(bool force_integer)
         }
         case ct_portatime:
         case ct_envtime:
+        case ct_envtime_deactivatable:
         case ct_envtime_lfodecay:
         case ct_reverbtime:
         case ct_reverbpredelaytime:
@@ -2915,6 +2920,7 @@ bool Parameter::can_setvalue_from_string()
     case ct_decibel_fmdepth:
     case ct_decibel_extendable:
     case ct_decibel_deactivatable:
+    case ct_envtime_deactivatable:
     case ct_freq_audible:
     case ct_freq_audible_deactivatable:
     case ct_freq_reson_band1:

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -236,7 +236,7 @@ bool Parameter::can_temposync()
     case ct_lforate:
     case ct_lforate_deactivatable:
     case ct_envtime:
-    case ct_envtime_deactivatable:
+    case ct_envtime_linkable_delay:
     case ct_envtime_lfodecay:
     case ct_reverbpredelaytime:
         return true;
@@ -291,7 +291,7 @@ bool Parameter::can_deactivate()
     case ct_decibel_deactivatable:
     case ct_decibel_narrow_deactivatable:
     case ct_decibel_extra_narrow_deactivatable:
-    case ct_envtime_deactivatable:
+    case ct_envtime_linkable_delay:
         return true;
     }
     return false;
@@ -521,7 +521,7 @@ void Parameter::set_type(int ctrltype)
         val_default.f = -8;
         break;
     case ct_envtime:
-    case ct_envtime_deactivatable:
+    case ct_envtime_linkable_delay:
     case ct_envtime_lfodecay:
         valtype = vt_float;
         val_min.f = -8;
@@ -984,7 +984,7 @@ void Parameter::set_type(int ctrltype)
         // THERE IS NO BREAK HERE ON PURPOSE so we group to the others
     case ct_portatime:
     case ct_envtime:
-    case ct_envtime_deactivatable:
+    case ct_envtime_linkable_delay:
     case ct_reverbtime:
     case ct_reverbpredelaytime:
     case ct_chorusmodtime:
@@ -1230,7 +1230,7 @@ void Parameter::bound_value(bool force_integer)
         }
         case ct_portatime:
         case ct_envtime:
-        case ct_envtime_deactivatable:
+        case ct_envtime_linkable_delay:
         case ct_envtime_lfodecay:
         case ct_reverbtime:
         case ct_reverbpredelaytime:
@@ -2920,7 +2920,7 @@ bool Parameter::can_setvalue_from_string()
     case ct_decibel_fmdepth:
     case ct_decibel_extendable:
     case ct_decibel_deactivatable:
-    case ct_envtime_deactivatable:
+    case ct_envtime_linkable_delay:
     case ct_freq_audible:
     case ct_freq_audible_deactivatable:
     case ct_freq_reson_band1:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -146,7 +146,7 @@ enum ctrltypes
     ct_freq_reson_band2,
     ct_freq_reson_band3,
     ct_reson_mode,
-    ct_envtime_deactivatable,
+    ct_envtime_linkable_delay,
     num_ctrltypes,
 };
 

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -146,6 +146,7 @@ enum ctrltypes
     ct_freq_reson_band2,
     ct_freq_reson_band3,
     ct_reson_mode,
+    ct_envtime_deactivatable,
     num_ctrltypes,
 };
 

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -71,8 +71,8 @@ void DualDelayEffect::setvars(bool init)
     {
         timeL.newValue(
             samplerate *
-                ((fxdata->p[isLinked].temposync ? storage->temposyncratio_inv : 1.f) *
-                 storage->note_to_pitch_ignoring_tuning(12 * fxdata->p[isLinked].val.f)) +
+                ((fxdata->p[dly_time_left].temposync ? storage->temposyncratio_inv : 1.f) *
+                 storage->note_to_pitch_ignoring_tuning(12 * fxdata->p[dly_time_left].val.f)) +
             LFOval - FIRoffset);
         timeR.newValue(
             samplerate * ((fxdata->p[isLinked].temposync ? storage->temposyncratio_inv : 1.f) *
@@ -258,7 +258,7 @@ void DualDelayEffect::init_ctrltypes()
     fxdata->p[dly_time_left].set_name("Left");
     fxdata->p[dly_time_left].set_type(ct_envtime);
     fxdata->p[dly_time_right].set_name("Right");
-    fxdata->p[dly_time_right].set_type(ct_envtime_deactivatable);
+    fxdata->p[dly_time_right].set_type(ct_envtime_linkable_delay);
     fxdata->p[dly_feedback].set_name("Feedback");
     fxdata->p[dly_feedback].set_type(ct_percent);
     fxdata->p[dly_crossfeed].set_name("Crossfeed");

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -65,17 +65,18 @@ void DualDelayEffect::setvars(bool init)
     else
         LFOval = ca * LFOval - lfo_increment;
 
+    auto isLinked = fxdata->p[dly_time_right].deactivated ? dly_time_left : dly_time_right;
+
     if (init)
     {
         timeL.newValue(
             samplerate *
-                ((fxdata->p[dly_time_left].temposync ? storage->temposyncratio_inv : 1.f) *
-                 storage->note_to_pitch_ignoring_tuning(12 * fxdata->p[dly_time_left].val.f)) +
+                ((fxdata->p[isLinked].temposync ? storage->temposyncratio_inv : 1.f) *
+                 storage->note_to_pitch_ignoring_tuning(12 * fxdata->p[isLinked].val.f)) +
             LFOval - FIRoffset);
         timeR.newValue(
-            samplerate *
-                ((fxdata->p[dly_time_right].temposync ? storage->temposyncratio_inv : 1.f) *
-                 storage->note_to_pitch_ignoring_tuning(12 * fxdata->p[dly_time_right].val.f)) -
+            samplerate * ((fxdata->p[isLinked].temposync ? storage->temposyncratio_inv : 1.f) *
+                          storage->note_to_pitch_ignoring_tuning(12 * fxdata->p[isLinked].val.f)) -
             LFOval - FIRoffset);
     }
     else
@@ -85,9 +86,8 @@ void DualDelayEffect::setvars(bool init)
                           storage->note_to_pitch_ignoring_tuning(12 * *f[dly_time_left])) +
             LFOval - FIRoffset);
         timeR.newValue(
-            samplerate *
-                ((fxdata->p[dly_time_right].temposync ? storage->temposyncratio_inv : 1.f) *
-                 storage->note_to_pitch_ignoring_tuning(12 * *f[dly_time_right])) -
+            samplerate * ((fxdata->p[isLinked].temposync ? storage->temposyncratio_inv : 1.f) *
+                          storage->note_to_pitch_ignoring_tuning(12 * *f[isLinked])) -
             LFOval - FIRoffset);
     }
 
@@ -258,7 +258,7 @@ void DualDelayEffect::init_ctrltypes()
     fxdata->p[dly_time_left].set_name("Left");
     fxdata->p[dly_time_left].set_type(ct_envtime);
     fxdata->p[dly_time_right].set_name("Right");
-    fxdata->p[dly_time_right].set_type(ct_envtime);
+    fxdata->p[dly_time_right].set_type(ct_envtime_deactivatable);
     fxdata->p[dly_feedback].set_name("Feedback");
     fxdata->p[dly_feedback].set_type(ct_percent);
     fxdata->p[dly_crossfeed].set_name("Crossfeed");
@@ -294,10 +294,12 @@ void DualDelayEffect::init_ctrltypes()
     fxdata->p[dly_mix].posy_offset = 9;
     fxdata->p[dly_width].posy_offset = 5;
 }
+
 void DualDelayEffect::init_default_values()
 {
     fxdata->p[dly_time_left].val.f = -2.f;
     fxdata->p[dly_time_right].val.f = -2.f;
+    fxdata->p[dly_time_right].deactivated = false;
     fxdata->p[dly_feedback].val.f = 0.0f;
     fxdata->p[dly_crossfeed].val.f = 0.0f;
     fxdata->p[dly_lowcut].val.f = -24.f;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3431,16 +3431,36 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                 }
                 if (p->can_deactivate())
                 {
+                    std::string txt;
+
                     if (p->deactivated)
                     {
-                        addCallbackMenu(contextMenu, "Activate", [this, p]() {
+                        if (p->ctrltype == ct_envtime_deactivatable)
+                        {
+                            txt = Surge::UI::toOSCaseForMenu("Unlink from Left Channel");
+                        }
+                        else
+                        {
+                            txt = Surge::UI::toOSCaseForMenu("Activate");
+                        }
+
+                        addCallbackMenu(contextMenu, txt.c_str(), [this, p]() {
                             p->deactivated = false;
                             this->synth->refresh_editor = true;
                         });
                     }
                     else
                     {
-                        addCallbackMenu(contextMenu, "Deactivate", [this, p]() {
+                        if (p->ctrltype == ct_envtime_deactivatable)
+                        {
+                            txt = Surge::UI::toOSCaseForMenu("Link to Left Channel");
+                        }
+                        else
+                        {
+                            txt = Surge::UI::toOSCaseForMenu("Deactivate");
+                        }
+
+                        addCallbackMenu(contextMenu, txt.c_str(), [this, p]() {
                             p->deactivated = true;
                             this->synth->refresh_editor = true;
                         });
@@ -6749,7 +6769,7 @@ void SurgeGUIEditor::promptForUserValueEntry(Parameter *p, CControl *c, int ms)
         if (!p->can_setvalue_from_string())
         {
             typeinValue->setFontColor(VSTGUI::kRedCColor);
-            typeinValue->setText("Edit coming soon!");
+            typeinValue->setText("Not available");
         }
     }
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3435,7 +3435,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                     if (p->deactivated)
                     {
-                        if (p->ctrltype == ct_envtime_deactivatable)
+                        if (p->ctrltype == ct_envtime_linkable_delay)
                         {
                             txt = Surge::UI::toOSCaseForMenu("Unlink from Left Channel");
                         }
@@ -3451,7 +3451,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                     }
                     else
                     {
-                        if (p->ctrltype == ct_envtime_deactivatable)
+                        if (p->ctrltype == ct_envtime_linkable_delay)
                         {
                             txt = Surge::UI::toOSCaseForMenu("Link to Left Channel");
                         }


### PR DESCRIPTION
Right-click the right channel delay time and choose option to Link to left channel. This (ab)uses the deactivatable parameters trick!
Closes #3613