### PR TITLE
Warnings are Errors on gcc; resonator fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "^GNU$")
     # GCC only
+    add_compile_options(
+      -Werror
+    )
   endif()
 endif()
 

--- a/src/common/dsp/effect/ResonatorEffect.cpp
+++ b/src/common/dsp/effect/ResonatorEffect.cpp
@@ -235,12 +235,18 @@ void ResonatorEffect::process(float *dataL, float *dataR)
     /* and preserve those registers and stuff. This all works */
     for (int c = 0; c < 2; ++c)
     {
+        for (int i = 0; i < n_cm_coeffs; i++)
+        {
+            for (int e = 0; e < 3; ++e)
+            {
+                coeff[e][c].C[i] = get1f(qfus[c].C[i], e);
+            }
+        }
         for (int i = 0; i < n_filter_registers; i++)
         {
             for (int e = 0; e < 3; ++e)
             {
                 Reg[e][c][i] = get1f(qfus[c].R[i], e);
-                coeff[e][c].C[i] = get1f(qfus[c].C[i], e);
             }
         }
     }


### PR DESCRIPTION
1. Warnings are errors on gcc builds
2. Fix the warning that gcc threw on the resonator (which was a correct
   one) but which I didn't see in the pipelines, because 1