### PR TITLE
JUCE/XT: Jan 29 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ buildwin/
 build-arm/
 buildiwyu/
 cmake-build-*/
+bwd/
 
 # Reaper
 *.RPP-bak
@@ -94,3 +95,6 @@ VERSION_GIT_INFO
 
 # Juce until we add a submodule
 libs/juce-*
+
+# A place for BP to store stuff
+ignore/*

--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -7,6 +7,7 @@ CScalableBitmap::CScalableBitmap(VSTGUI::CResourceDescription d, VSTGUI::CFrame 
 {
     if (d.u.type == VSTGUI::CResourceDescription::kIntegerType)
     {
+        resourceID = d.u.id;
         std::string fn = "bmp00" + std::to_string(d.u.id) + "_svg";
         int bds;
         auto bd = BinaryData::getNamedResource(fn.c_str(), bds);
@@ -20,6 +21,8 @@ CScalableBitmap::CScalableBitmap(VSTGUI::CResourceDescription d, VSTGUI::CFrame 
 CScalableBitmap::CScalableBitmap(std::string fname, VSTGUI::CFrame *f)
     : VSTGUI::CBitmap(VSTGUI::CResourceDescription(0))
 {
+    this->fname = fname;
+    drawable = juce::Drawable::createFromImageFile(juce::File(fname));
 }
 
 CScalableBitmap::~CScalableBitmap() = default;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4887,10 +4887,6 @@ void SurgeGUIEditor::draw_infowindow(int ptag, CControl *control, bool modulate,
     }
 
     CRect r2 = control->getViewSize();
-#if TARGET_JUCE_UI
-    auto tl = control->getTopLeft();
-    r2.offset(tl.x, tl.y);
-#endif
 
     // OK this is a heuristic to stop deform overpainting and stuff
     if (r2.bottom > getWindowSizeY() - r.getHeight() - 2)

--- a/src/surge_synth_juce/SurgeSynthEditor.cpp
+++ b/src/surge_synth_juce/SurgeSynthEditor.cpp
@@ -14,82 +14,6 @@
 #include "CScalableBitmap.h"
 #include "SurgeGUIEditor.h"
 
-#if NONSENSE_TEST
-struct ARedBox : public VSTGUI::CView
-{
-    std::unique_ptr<SurgeBitmaps> bitmapStore;
-
-    explicit ARedBox(const VSTGUI::CRect &r) : VSTGUI::CView(r)
-    {
-        bitmapStore = std::make_unique<SurgeBitmaps>();
-        bitmapStore->setupBitmapsForFrame(nullptr);
-    }
-    ~ARedBox() = default;
-    VSTGUI::CColor bg = VSTGUI::CColor(0, 0, 0);
-    void draw(VSTGUI::CDrawContext *dc) override
-    {
-        auto s = getViewSize();
-
-        dc->setFillColor(bg);
-        dc->drawRect(s, VSTGUI::kDrawFilled);
-        dc->setFrameColor(VSTGUI::kBlueCColor);
-        dc->drawRect(s, VSTGUI::kDrawStroked);
-
-        auto r = VSTGUI::CRect(VSTGUI::CPoint(20, 20), VSTGUI::CPoint(10, 15));
-
-        dc->setFillColor(VSTGUI::kRedCColor);
-        dc->setFrameColor(VSTGUI::CColor(0, 255, 0));
-        dc->drawRect(r, VSTGUI::kDrawFilledAndStroked);
-
-        dc->setFrameColor(VSTGUI::CColor(255, 180, 0));
-        dc->drawLine(VSTGUI::CPoint(0, 0), VSTGUI::CPoint(40, 40));
-
-        auto bmp = bitmapStore->getBitmap(IDB_FILTER_CONFIG);
-        auto newLoc = mouseLoc;
-        newLoc.x -= 15;
-        newLoc.y -= 15;
-        bmp->draw(dc, VSTGUI::CRect(newLoc, VSTGUI::CPoint(40, 40)), VSTGUI::CPoint(), 1);
-    }
-
-    VSTGUI::CMouseEventResult onMouseEntered(VSTGUI::CPoint &where,
-                                             const VSTGUI::CButtonState &buttons) override
-    {
-        bg = VSTGUI::CColor(40, 20, 0);
-        invalid();
-        return VSTGUI::kMouseEventHandled;
-    }
-    VSTGUI::CMouseEventResult onMouseExited(VSTGUI::CPoint &where,
-                                            const VSTGUI::CButtonState &buttons) override
-    {
-        bg = VSTGUI::CColor(0, 0, 0);
-        invalid();
-        return VSTGUI::kMouseEventHandled;
-    }
-    VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint &where,
-                                          const VSTGUI::CButtonState &buttons) override
-    {
-        bg = VSTGUI::CColor(200, 100, 0);
-        invalid();
-        return VSTGUI::kMouseEventHandled;
-    }
-    VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint &where,
-                                        const VSTGUI::CButtonState &buttons) override
-    {
-        bg = VSTGUI::CColor(70, 20, 0);
-        invalid();
-        return VSTGUI::kMouseEventHandled;
-    }
-    VSTGUI::CPoint mouseLoc;
-    VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint &where,
-                                           const VSTGUI::CButtonState &buttons) override
-    {
-        mouseLoc = where;
-        invalid();
-        return VSTGUI::kMouseEventHandled;
-    }
-};
-#endif
-
 //==============================================================================
 SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
     : AudioProcessorEditor(&p), processor(p), EscapeFromVSTGUI::JuceVSTGUIEditorAdapter(this)
@@ -99,28 +23,6 @@ SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
 
     adapter = std::make_unique<SurgeGUIEditor>(this, processor.surge.get());
     adapter->open(nullptr);
-
-#if NONSENSE_TEST
-    auto r = VSTGUI::CRect(getBounds());
-    vstguiFrame = std::make_unique<VSTGUI::CFrame>(r, adapter.get());
-
-    auto textRect = VSTGUI::CRect(VSTGUI::CPoint(10, 10), VSTGUI::CPoint(200, 10));
-    auto text = new VSTGUI::CTextLabel(textRect, "Howdy");
-    vstguiFrame->addView(text);
-
-    auto myThing = new ARedBox(VSTGUI::CRect(40, 40, 700, 250));
-    vstguiFrame->addView(myThing);
-
-    int bds = 0;
-    auto fn = BinaryData::getNamedResourceOriginalFilename("bmp00158_svg");
-    auto bd = BinaryData::getNamedResource("bmp00158_svg", bds);
-    logo = juce::Drawable::createFromImageData(bd, bds);
-    // logo = juce::Drawable::createFromImageFile(juce::File("/Users/paul/Downloads/PREVIEW.svg"));
-    logo->setBounds(40, 300, 500, 500);
-    addAndMakeVisible(logo.get());
-
-    auto b = new SurgeBitmaps();
-#endif
 
     idleTimer = std::make_unique<IdleTimer>(this);
     idleTimer->startTimer(1000 / 60);


### PR DESCRIPTION
Addresses #3737

1. Fix coordinate system so the sensible JUCE system gets replaced
   with the annoying VSTGUI one. Upshot: LFO GUI Draws
2. Adjust image loads so hovers lookup and skin images load
3. Adjust 'removeAll' so it removes only children, solving the bg issue