### PR TITLE
Resonator further tweaks

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -262,6 +262,7 @@ bool Parameter::can_extend_range()
     case ct_osc_feedback_negative:
     case ct_lfoamplitude:
     case ct_fmratio:
+    case ct_reson_res_extendable:
         return true;
     }
     return false;
@@ -776,6 +777,12 @@ void Parameter::set_type(int ctrltype)
         valtype = vt_int;
         val_default.i = 1;
         break;
+    case ct_reson_res_extendable:
+        val_min.f = 0;
+        val_max.f = 1;
+        valtype = vt_float;
+        val_default.f = 0.75f;
+        break;
     case ct_vocoder_bandcount:
         val_min.i = 4;
         val_max.i = 20;
@@ -923,6 +930,7 @@ void Parameter::set_type(int ctrltype)
     case ct_rotarydrive:
     case ct_countedset_percent:
     case ct_lfoamplitude:
+    case ct_reson_res_extendable:
         displayType = LinearWithScale;
         sprintf(displayInfo.unit, "%%");
         displayInfo.scale = 100;
@@ -2961,6 +2969,7 @@ bool Parameter::can_setvalue_from_string()
     case ct_freq_mod:
     case ct_airwindows_param:
     case ct_airwindows_param_bipolar:
+    case ct_reson_res_extendable:
     {
         return true;
         break;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -147,6 +147,7 @@ enum ctrltypes
     ct_freq_reson_band3,
     ct_reson_mode,
     ct_envtime_linkable_delay,
+    ct_reson_res_extendable,
     num_ctrltypes,
 };
 

--- a/src/common/dsp/effect/ResonatorEffect.h
+++ b/src/common/dsp/effect/ResonatorEffect.h
@@ -75,8 +75,8 @@ class ResonatorEffect : public Effect
     HalfRateFilter halfbandOUT, halfbandIN;
     FilterCoefficientMaker coeff[3][2];
     lag<float, true> cutoff[3], resonance[3], bandGain[3];
-    float filterDelay[3][2][MAX_FB_COMB + FIRipol_N];
-    float WP[3][2];
+    //float filterDelay[3][2][MAX_FB_COMB + FIRipol_N];
+    //float WP[3][2];
     float Reg[3][2][n_filter_registers];
 
   private:

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3393,7 +3393,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                 {
                     if (!(p->ctrltype == ct_fmratio && p->can_be_absolute() && p->absolute))
                     {
-                        addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Extend Range"),
+                        std::string txt = p->ctrltype == ct_reson_res_extendable ? "Modulation Extends into Self-oscillation" : "Extend Range";
+
+                        addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu(txt),
                                         [this, p]() {
                                             p->extend_range = !p->extend_range;
                                             this->synth->refresh_editor = true;


### PR DESCRIPTION
Added extend mode for resonance to allow for self-oscillation (by using modulation)
Input signal is preprocessed with asymmetric waveshaper at unity gain
Each filter band goes through a soft-clip waveshaper at the end as well