### PR TITLE
Allow extended Comb; use it in Combulator

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -418,6 +418,12 @@ void Parameter::set_type(int ctrltype)
         val_max.f = 70;
         val_default.f = 3;
         break;
+    case ct_freq_audible_with_very_low_lowerbound:
+        valtype = vt_float;
+        val_min.f = -116; // half a hz
+        val_max.f = 70;
+        val_default.f = 3;
+        break;
     case ct_freq_hpf:
         valtype = vt_float;
         val_min.f = -72;
@@ -987,6 +993,7 @@ void Parameter::set_type(int ctrltype)
     case ct_freq_hpf:
     case ct_freq_audible:
     case ct_freq_audible_deactivatable:
+    case ct_freq_audible_with_very_low_lowerbound:
     case ct_freq_reson_band1:
     case ct_freq_reson_band2:
     case ct_freq_reson_band3:
@@ -2146,6 +2153,7 @@ void Parameter::get_display_alt(char *txt, bool external, float ef)
     case ct_freq_hpf:
     case ct_freq_audible:
     case ct_freq_audible_deactivatable:
+    case ct_freq_audible_with_very_low_lowerbound:
     case ct_freq_reson_band1:
     case ct_freq_reson_band2:
     case ct_freq_reson_band3:
@@ -2995,6 +3003,7 @@ bool Parameter::can_setvalue_from_string()
     case ct_envtime_linkable_delay:
     case ct_freq_audible:
     case ct_freq_audible_deactivatable:
+    case ct_freq_audible_with_very_low_lowerbound:
     case ct_freq_reson_band1:
     case ct_freq_reson_band2:
     case ct_freq_reson_band3:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -64,6 +64,7 @@ enum ctrltypes
     ct_decibel_deactivatable,
     ct_freq_audible,
     ct_freq_audible_deactivatable,
+    ct_freq_audible_with_very_low_lowerbound,
     ct_freq_mod,
     ct_freq_hpf,
     ct_freq_shift,

--- a/src/common/dsp/QuadFilterUnit.h
+++ b/src/common/dsp/QuadFilterUnit.h
@@ -18,3 +18,19 @@ typedef __m128 (*WaveshaperQFPtr)(__m128 in, __m128 drive);
 
 FilterUnitQFPtr GetQFPtrFilterUnit(int type, int subtype);
 WaveshaperQFPtr GetQFPtrWaveshaper(int type);
+
+/*
+ * Subtypes are integers below 16 - maybe one day go as high as 32. So we have space in the
+ * int for more informatino and we mask on higher bits to allow us to
+ * programatically change features we don't expose to users, in things like
+ * FX. So far this is only used to extend the COMB time in the combulator.
+ *
+ * These should obvioulsy be distinct per type but can overlap in values otherwise
+ *
+ * Try and use above 2^16
+ */
+enum QFUSubtypeMasks : int32_t
+{
+    UNMASK_SUBTYPE = (1 << 8) - 1,
+    EXTENDED_COMB = 1 << 9
+};

--- a/src/common/dsp/effect/CombulatorEffect.cpp
+++ b/src/common/dsp/effect/CombulatorEffect.cpp
@@ -34,7 +34,7 @@ CombulatorEffect::CombulatorEffect(SurgeStorage *storage, FxStorage *fxdata, pda
             }
         }
     }
-    memset(filterDelay, 0, 3 * 2 * (MAX_FB_COMB + FIRipol_N) * sizeof(float));
+    memset(filterDelay, 0, 3 * 2 * (MAX_FB_COMB_EXTENDED + FIRipol_N) * sizeof(float));
 }
 
 CombulatorEffect::~CombulatorEffect() { _aligned_free(qfus); }
@@ -110,7 +110,7 @@ void CombulatorEffect::process(float *dataL, float *dataR)
      */
     int type = fut_comb_pos, subtype = 1;
 
-    FilterUnitQFPtr filtptr = GetQFPtrFilterUnit(type, subtype);
+    FilterUnitQFPtr filtptr = GetQFPtrFilterUnit(type, subtype | QFUSubtypeMasks::EXTENDED_COMB);
 
     /*
      * So now set up across the voices (e for 'entry' to match SurgeVoice) and the channels (c)
@@ -119,7 +119,8 @@ void CombulatorEffect::process(float *dataL, float *dataR)
     {
         for (int c = 0; c < 2; ++c)
         {
-            coeff[e][c].MakeCoeffs(cutoff[e].v, resonance.v, type, subtype, storage);
+            coeff[e][c].MakeCoeffs(cutoff[e].v, resonance.v, type,
+                                   subtype | QFUSubtypeMasks::EXTENDED_COMB, storage);
 
             for (int i = 0; i < n_cm_coeffs; i++)
             {
@@ -277,7 +278,7 @@ void CombulatorEffect::init_ctrltypes()
     fxdata->p[combulator_noise_mix].posy_offset = 1;
 
     fxdata->p[combulator_freq1].set_name("Frequency 1");
-    fxdata->p[combulator_freq1].set_type(ct_freq_audible);
+    fxdata->p[combulator_freq1].set_type(ct_freq_audible_with_very_low_lowerbound);
     fxdata->p[combulator_freq1].posy_offset = 3;
     fxdata->p[combulator_freq2].set_name("Frequency 2 Offset");
     fxdata->p[combulator_freq2].set_type(ct_pitch);
@@ -286,7 +287,7 @@ void CombulatorEffect::init_ctrltypes()
     fxdata->p[combulator_freq3].set_type(ct_pitch);
     fxdata->p[combulator_freq3].posy_offset = 3;
     fxdata->p[combulator_feedback].set_name("Feedback");
-    fxdata->p[combulator_feedback].set_type(ct_percent);
+    fxdata->p[combulator_feedback].set_type(ct_percent_bidirectional);
     fxdata->p[combulator_feedback].posy_offset = 3;
 
     fxdata->p[combulator_gain1].set_name("Comb 1");
@@ -306,7 +307,7 @@ void CombulatorEffect::init_ctrltypes()
     fxdata->p[combulator_width].set_type(ct_decibel_narrow);
     fxdata->p[combulator_width].posy_offset = 7;
     fxdata->p[combulator_mix].set_name("Mix");
-    fxdata->p[combulator_mix].set_type(ct_percent);
+    fxdata->p[combulator_mix].set_type(ct_percent_bidirectional);
     fxdata->p[combulator_mix].posy_offset = 7;
 }
 

--- a/src/common/dsp/effect/CombulatorEffect.h
+++ b/src/common/dsp/effect/CombulatorEffect.h
@@ -65,7 +65,7 @@ class CombulatorEffect : public Effect
     HalfRateFilter halfbandOUT, halfbandIN;
     FilterCoefficientMaker coeff[3][2];
     lag<float, true> cutoff[3], resonance, bandGain[3];
-    float filterDelay[3][2][MAX_FB_COMB + FIRipol_N];
+    float filterDelay[3][2][MAX_FB_COMB_EXTENDED + FIRipol_N];
     float WP[3][2];
     float Reg[3][2][n_filter_registers];
 

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -76,6 +76,7 @@ const int OB_LENGTH_QUAD = OB_LENGTH >> 2;
 const float BLOCK_SIZE_INV = (1.f / BLOCK_SIZE);
 const float BLOCK_SIZE_OS_INV = (1.f / BLOCK_SIZE_OS);
 const int MAX_FB_COMB = 2048; // must be 2^n
+const int MAX_FB_COMB_EXTENDED = 2048 * 64; // Only exposed in Combulator
 const int MAX_VOICES = 64;
 const int MAX_UNISON = 16;
 const int N_OUTPUTS = 2;


### PR DESCRIPTION
By masking off the subtype, I can choose to allow the comb
an extended buffer withotu blowing up the filter bank, and then
I can let the combulator do combs down to .25hz at 441k.

Addresses #3773