### PR TITLE
Retrigger in Snapshot; Sin/FM2/FM3 get retrigger on

### DIFF
--- a/resources/data/configuration.xml
+++ b/resources/data/configuration.xml
@@ -7,9 +7,9 @@
     </type>
     <type i="2" name="Wavetable" />
     <type i="7" name="Window" />
-    <type i="1" name="Sine" />
-    <type i="6" name="FM2" />
-    <type i="5" name="FM3" />
+    <type i="1" name="Sine" retrigger="1"/>
+    <type i="6" name="FM2" retrigger="1"/>
+    <type i="5" name="FM3" retrigger="1"/>
     <type i="3" name="S&amp;H Noise" />
     <type i="4" name="Audio Input">
         <snapshot name="Left" p0="-1.0" p1="0.0" p2="0.0" p3="0.0" p4="0.0" />

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2306,7 +2306,6 @@ bool SurgeSynthesizer::loadOscalgos()
             }
 
             TiXmlElement *e = (TiXmlElement *)storage.getPatch().scene[s].osc[i].queue_xmldata;
-
             if (e)
             {
                 resend = true;
@@ -2327,6 +2326,12 @@ bool SurgeSynthesizer::loadOscalgos()
                             storage.getPatch().scene[s].osc[i].p[k].val.i = j;
                     }
                 }
+                int rt;
+                if (e->QueryIntAttribute("retrigger", &rt) == TIXML_SUCCESS)
+                {
+                    storage.getPatch().scene[s].osc[i].retrigger.val.b = rt;
+                }
+
                 storage.getPatch().scene[s].osc[i].queue_xmldata = 0;
             }
             if (resend)

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -209,14 +209,14 @@ VSTGUI::COptionMenu *CSnapshotMenu::populateSubmenuFromTypeElement(TiXmlElement 
         if (firstSnapshotByType.find(type_id) == firstSnapshotByType.end())
             firstSnapshotByType[type_id] = idx;
 
-        auto action = [this, type_id, idx](CCommandMenuItem *item) {
+        auto action = [this, type_id, type, idx](CCommandMenuItem *item) {
             this->selectedIdx = 0;
-            this->loadSnapshot(type_id, nullptr, idx);
+            this->loadSnapshot(type_id, type, idx);
             if (this->listenerNotForParent)
                 this->listenerNotForParent->valueChanged(this);
         };
 
-        loadArgsByIndex.push_back(std::make_pair(type_id, nullptr));
+        loadArgsByIndex.push_back(std::make_pair(type_id, type));
         idx++;
         actionItem->setActions(action, nullptr);
         parent->addEntry(actionItem);


### PR DESCRIPTION
The snapshot menu can store retrigger
All the load paths give the synth a shot at the XML
The XML contains retrigger information