### PR TITLE
JUCE/XT: Feb 1 fixes

### DIFF
--- a/src/common/gui/CSwitchControl.cpp
+++ b/src/common/gui/CSwitchControl.cpp
@@ -62,7 +62,7 @@ void CSwitchControl::setValue(float f)
 
 CMouseEventResult CSwitchControl::onMouseDown(CPoint &where, const CButtonState &buttons)
 {
-    if (listener && (buttons & (kMButton | kButton4 | kButton5)))
+    if (listener && (buttons & (kRButton | kMButton | kButton4 | kButton5)))
     {
         listener->controlModifierClicked(this, buttons);
         return kMouseDownEventHandledButDontNeedMovedOrUpEvents;

--- a/src/common/gui/CursorControlGuard.cpp
+++ b/src/common/gui/CursorControlGuard.cpp
@@ -65,17 +65,20 @@ CursorControlGuard::~CursorControlGuard()
     if (hideCount == 0)
     {
         resetToShowLocation();
+#if !TARGET_JUCE_UI
 #if MAC
         CGDisplayShowCursor(kCGDirectMainDisplay);
 #elif WINDOWS
         ShowCursor(true);
 #elif LINUX
 #endif
+#endif
     }
 }
 
 bool CursorControlGuard::resetToShowLocation()
 {
+#if !TARGET_JUCE_UI
 #if MAC
     if (motionMode == SHOW_AT_LOCATION)
     {
@@ -93,16 +96,19 @@ bool CursorControlGuard::resetToShowLocation()
     }
 #elif LINUX
 #endif
+#endif
     return false;
 }
 
 void CursorControlGuard::doHide()
 {
+#if !TARGET_JUCE_UI
 #if MAC
     CGDisplayHideCursor(kCGDirectMainDisplay);
 #elif WINDOWS
     ShowCursor(false);
 #elif LINUX
+#endif
 #endif
 }
 

--- a/src/common/gui/CursorControlGuard.h
+++ b/src/common/gui/CursorControlGuard.h
@@ -79,8 +79,12 @@ struct CursorControlAdapter
 {
     CursorControlAdapter(SurgeStorage *s)
     {
+#if !TARGET_JUCE_UI
         if (s)
             hideCursor = !Surge::Storage::getUserDefaultValue(s, "showCursorWhileEditing", 0);
+#else
+        hideCursor = false;
+#endif
     }
 
     void startCursorHide()

--- a/src/common/gui/MSEGEditor.cpp
+++ b/src/common/gui/MSEGEditor.cpp
@@ -29,6 +29,12 @@
 #include "CursorControlGuard.h"
 #include "guihelpers.h"
 
+#if LINUX || TARGET_JUCE_UI
+#define DISABLE_CURSOR_HIDING 1
+#else
+#define DISABLE_CURSOR_HIDING 0
+#endif
+
 using namespace VSTGUI;
 
 struct MSEGCanvas;
@@ -1238,9 +1244,14 @@ struct MSEGCanvas : public CControl,
         Surge::UI::NonIntegralAntiAliasGuard naig(dc);
 #endif
 
+#if TARGET_JUCE_UI
+        std::cout << "FIX GRADIENT" << std::endl;
+#else
         dc->fillLinearGradient(fillpath, *cg, CPoint(0, 0), CPoint(0, valpx(-1)), false, &tfpath);
+#endif
         fillpath->forget();
-        cg->forget();
+        if (cg)
+            cg->forget();
 
         dc->setLineWidth(1);
 
@@ -1655,7 +1666,7 @@ struct MSEGCanvas : public CControl,
 
         if (!gotHZ)
         {
-#if !LINUX
+#if !DISABLE_CURSOR_HIDING
             // Lin doesn't cursor hide so this hand is bad there
             getFrame()->setCursor(kCursorHand);
 #endif
@@ -1891,7 +1902,7 @@ struct MSEGCanvas : public CControl,
                     dragY *= 0.2;
                 }
                 h.onDrag(dragX, dragY, where);
-#if !LINUX
+#if !DISABLE_CURSOR_HIDING
                 float dx = where.x - cursorHideOrigin.x;
                 float dy = where.y - cursorHideOrigin.y;
                 if (dx * dx + dy * dy > 100 && cursorResetPosition)


### PR DESCRIPTION
Addresses #3737

- getFrame checks parents so mseg opens
- Transform implemented so StepSeq draws properly
- drawPolygon moved to OK with a non-working impl
- Overlays at least paint if not reposition
- More events working, including wheel and double click
- No more crashes on store or mseg