### PR TITLE
JUCE/XT: Feb 2 changes

### DIFF
--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -245,7 +245,7 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint &where, const CButtonState &
 
         sge->pause_idle_updates = false;
 
-#if !LINUX
+#if !LINUX || TARGET_JUCE_UI
         // on linux none of this matters because popup always returns right away
         // so if we flush now it actually crashes us for the above reason.
         // INstead linux should flush in the valueChanged callback

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1975,7 +1975,6 @@ bool PLUGIN_API SurgeGUIEditor::open(void *parent, const PlatformType &platformT
     CFrame *nframe = new CFrame(wsize, this);
 
 #if TARGET_JUCE_UI
-    nframe->juceComponent()->setTransform(juce::AffineTransform().scaled(1.25));
     nframe->remember();
 #endif
 
@@ -4042,7 +4041,7 @@ void SurgeGUIEditor::valueChanged(CControl *control)
         // synth->load_patch(id);
         enqueuePatchId = id;
 
-#if LINUX
+#if LINUX || TARGET_JUCE_UI
         // On linux the popup memny will be gon eso we gotta process
         flushEnqueuedPatchId();
 #endif
@@ -5114,6 +5113,13 @@ void SurgeGUIEditor::setZoomFactor(float zf) { setZoomFactor(zf, false); }
 
 void SurgeGUIEditor::setZoomFactor(float zf, bool resizeWindow)
 {
+#if TARGET_JUCE_UI
+    zoomFactor = zf;
+    if (currentSkin && resizeWindow)
+        parentEd->setSize(currentSkin->getWindowSizeX(), currentSkin->getWindowSizeY());
+    parentEd->setScaleFactor(zf * 0.01);
+#else
+
     if (zf < minimumZoom)
     {
         zf = minimumZoom;
@@ -5163,6 +5169,7 @@ void SurgeGUIEditor::setZoomFactor(float zf, bool resizeWindow)
     zoom_callback(this, resizeWindow);
 
     setBitmapZoomFactor(zoomFactor);
+#endif
 }
 
 void SurgeGUIEditor::setBitmapZoomFactor(float zf)
@@ -6427,7 +6434,11 @@ void SurgeGUIEditor::reloadFromSkin()
     rect.right = wsx * sf;
     rect.bottom = wsy * sf;
 
+#if TARGET_JUCE_UI
+    setZoomFactor(getZoomFactor(), true);
+#else
     setZoomFactor(getZoomFactor());
+#endif
     clearOffscreenCachesAtZero = 1;
 
     // update MSEG editor if opened

--- a/src/surge_synth_juce/SurgeSynthEditor.cpp
+++ b/src/surge_synth_juce/SurgeSynthEditor.cpp
@@ -18,8 +18,8 @@
 SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
     : AudioProcessorEditor(&p), processor(p), EscapeFromVSTGUI::JuceVSTGUIEditorAdapter(this)
 {
-    setSize(1200, 800);
-    setResizable(false, false); // For now
+    setSize(BASE_WINDOW_SIZE_X, BASE_WINDOW_SIZE_Y);
+    setResizable(true, false); // For now
 
     adapter = std::make_unique<SurgeGUIEditor>(this, processor.surge.get());
     adapter->open(nullptr);
@@ -50,6 +50,24 @@ void SurgeSynthEditor::resized()
 {
     // This is generally where you'll want to lay out the positions of any
     // subcomponents in your editor..
+}
+
+void SurgeSynthEditor::IdleTimer::timerCallback()
+{
+    VSTGUI::efvgIdle();
+    ed->idle();
+}
+
+void SurgeSynthEditor::populateForStreaming(SurgeSynthesizer *s)
+{
+    if (adapter)
+        adapter->populateDawExtraState(s);
+}
+
+void SurgeSynthEditor::populateFromStreaming(SurgeSynthesizer *s)
+{
+    if (adapter)
+        adapter->loadFromDAWExtraState(s);
 }
 
 namespace Surge

--- a/src/surge_synth_juce/SurgeSynthEditor.h
+++ b/src/surge_synth_juce/SurgeSynthEditor.h
@@ -39,11 +39,14 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     void controlBeginEdit(VSTGUI::CControl *c) override {}
     void controlEndEdit(VSTGUI::CControl *c) override {}
 
+    void populateForStreaming(SurgeSynthesizer *s);
+    void populateFromStreaming(SurgeSynthesizer *s);
+
     struct IdleTimer : juce::Timer
     {
         IdleTimer(SurgeSynthEditor *ed) : ed(ed) {}
         ~IdleTimer() = default;
-        void timerCallback() override { ed->idle(); }
+        void timerCallback() override;
         SurgeSynthEditor *ed;
     };
     void idle();


### PR DESCRIPTION
Addresses #3737

- Percolate up the parent heirarcy for more mouse events; About box dimsisses
- Skn swapping changes work (menu async to avoid self-destruction)
- Framework for an evfg idle loop even though I didn't use it
- Label can show an image so about is more complete
- Positioning of subcomponents works
- Handle asunc menu more gracefully in Patch
- Recursive remove to stop leaks on subwindows
- Typeins work (some formatting still to do tho)
- StateSaving including DawExtra and Editor
- Zoom impelmentatoin started