### PR TITLE
JUCE/XT: Build in pipeline all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1328,6 +1328,8 @@ endif()
 if( ${BUILD_SURGE_JUCE_PLUGINS} )
   include( cmake/get-juce.cmake )
 
+  add_custom_target(surge-juce-pipeline-targets)
+
   message( STATUS "Building JUCE targets with ${JUCE_LIB_DIR}" )
   add_subdirectory( ${JUCE_LIB_DIR} )
 
@@ -1419,6 +1421,7 @@ if( ${BUILD_SURGE_JUCE_PLUGINS} )
     add_dependencies( Surge-Effects-Bank-Packaged surge-fx_VST3 )
     add_dependencies( Surge-Effects-Bank-Packaged surge-fx_Standalone )
 
+    add_dependencies(surge-juce-pipeline-targets surge-fx_Standalone)
     add_custom_command(
             TARGET Surge-Effects-Bank-Packaged
             POST_BUILD
@@ -1542,6 +1545,13 @@ if( ${BUILD_SURGE_JUCE_PLUGINS} )
             TARGET_JUCE_SYNTH=1
             TARGET_HEADLESS=1
             TARGET_JUCE_UI=1)
+
+    if( WIN32 )
+      target_compile_options(surge-xt PRIVATE /FIprecompiled.h)
+    endif()
+
+    add_dependencies(surge-juce-pipeline-targets surge-xt_Standalone)
+   
   endif()
 endif()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,16 +25,11 @@ jobs:
         cmakeArguments: "-GXcode -D\"CMAKE_OSX_ARCHITECTURES=arm64;x86_64\""
         cmakeTarget: "Surge-AU-Packaged"
         xcodePath: "/Applications/Xcode_12.2.app"
-      macOS-fxbank:
+      macOS-juce-targets:
         imageName: 'macos-10.15'
         isMac: True
         cmakeArguments: "-GXcode -DBUILD_SURGE_JUCE_PLUGINS=True"
-        cmakeTarget: "Surge-Effects-Bank-Packaged"
-      macOS-surge-xt:
-        imageName: 'macos-10.15'
-        isMac: True
-        cmakeArguments: "-DBUILD_ONLY_SURGE_XT=True"
-        cmakeTarget: "surge-xt_Standalone"
+        cmakeTarget: "surge-juce-pipeline-targets"
       macOS-codequality:
         imageName: 'macos-10.15'
         isMac: True
@@ -56,11 +51,11 @@ jobs:
         isWindowsUnitTest: True
         cmakeArguments: "-A x64"
         cmakeTarget: "surge-headless"
-      windows-fxbank:
+      windows-juce-targets:
         imageName: 'windows-2019'
         isWindows: True
         cmakeArguments: "-A x64 -DBUILD_SURGE_JUCE_PLUGINS=True"
-        cmakeTarget: "Surge-Effects-Bank-Packaged"
+        cmakeTarget: "surge-juce-pipeline-targets"
       linux-vst3:
         imageName: 'ubuntu-20.04'
         isLinux: True
@@ -79,11 +74,11 @@ jobs:
         aptGetExtras: ""
         cmakeArguments: "-GNinja"
         cmakeTarget: "Surge-LV2-Packaged"
-      linux-fxbank:
+      linux-juce-targets:
         imageName: 'ubuntu-20.04'
         isLinux: True
         cmakeArguments: "-GNinja -DBUILD_SURGE_JUCE_PLUGINS=True"
-        cmakeTarget: "Surge-Effects-Bank-Packaged"
+        cmakeTarget: "surge-juce-pipeline-targets"
       linux-clang:
         imageName: 'ubuntu-20.04'
         isLinux: True

--- a/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
+++ b/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
@@ -1420,6 +1420,8 @@ struct CTextEdit : public CControl, public juce::TextEditor::Listener
             listener->valueChanged(this);
     }
 
+    void setTextInset(const CPoint &inset) { OKUNIMPL; }
+
     std::unique_ptr<juceCViewConnector<juce::TextEditor>> texted;
     juce::Component *juceComponent() override { return texted.get(); }
 


### PR DESCRIPTION
1. Windows build works
2. Pipeline target for all platforms spanning fx and xt
3. That's turned on for win64 and lin as well as mac

Addresses #3737