### PR TITLE
Update get_notename() function to allow note names below MIDI note 0

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -426,7 +426,7 @@ void Parameter::set_type(int ctrltype)
         break;
     case ct_freq_audible_with_very_low_lowerbound:
         valtype = vt_float;
-        val_min.f = -116; // half a hz
+        val_min.f = -117.3763;    // 0.5 Hz
         val_max.f = 70;
         val_default.f = 3;
         break;
@@ -438,8 +438,8 @@ void Parameter::set_type(int ctrltype)
         break;
     case ct_freq_reson_band1:
         valtype = vt_float;
-        val_min.f = -34.4936f;   // 60 Hz
-        val_max.f = -6.6305f;    // 300 Hz
+        val_min.f = -34.4936f;     // 60 Hz
+        val_max.f = -6.6305f;      // 300 Hz
         val_default.f = -18.6305f; // 150 Hz
         break;
     case ct_freq_reson_band2:
@@ -2198,13 +2198,14 @@ void Parameter::get_display_alt(char *txt, bool external, float ef)
     {
         float f = val.f;
         int i_value = round(f) + 69;
-        if (i_value < 0)
-            i_value = 0;
-
         int oct_offset = 1;
-        if (storage)
-            oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
         char notename[16];
+
+        if (storage)
+        {
+            oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
+        }
+
         sprintf(txt, "~%s", get_notename(notename, i_value, oct_offset));
 
         break;
@@ -2213,13 +2214,14 @@ void Parameter::get_display_alt(char *txt, bool external, float ef)
     {
         float f = val.f;
         int i_value = (int)(f);
-        if (i_value < 0)
-            i_value = 0;
-
         int oct_offset = 1;
-        if (storage)
-            oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
         char notename[16];
+
+        if (storage)
+        {
+            oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
+        }
+
         sprintf(txt, "~%s", get_notename(notename, i_value, oct_offset));
 
         break;
@@ -2466,10 +2468,15 @@ void Parameter::get_display(char *txt, bool external, float ef)
         case ct_midikey:
         {
             int oct_offset = 1;
-            if (storage)
-                oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
             char notename[16];
+            
+            if (storage)
+            {
+                oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
+            }
+
             sprintf(txt, "%s", get_notename(notename, val.i, oct_offset));
+
             break;
         }
         case ct_osctype:

--- a/src/common/unitconversion.h
+++ b/src/common/unitconversion.h
@@ -38,9 +38,13 @@ inline float seconds_to_envtime(float in) // ff rev2
 
 inline char *get_notename(char *s, int i_value, int i_offset)
 {
-    int octave = (i_value / 12) - i_offset;
-    char notenames[12][3] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
-    sprintf(s, "%s%i", notenames[i_value % 12], octave);
+    int ival = i_value < 0 ? i_value - 11 : i_value;
+    int octave = (ival / 12) - i_offset;
+    char notenames[13][3] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B", "C"};
+    // make sure to read the notenames array in reverse for negative i_values
+    int note = (i_value < 0) ? (12 - abs(i_value % 12)) : (i_value % 12);
+
+    sprintf(s, "%s%i", notenames[note], octave);
     return s;
 }
 


### PR DESCRIPTION
This will show actual note name for the Combulator center frequency, which goes all the way down to 0.5 Hz!
Also updated bottom range of that parameter to be exactly 0.500000 Hz.