### PR TITLE
No longer invalidate param names

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -53,6 +53,7 @@
 #include <unordered_map>
 #include <codecvt>
 #include "MSEGEditor.h"
+#include "version.h"
 
 #if TARGET_VST3
 #include "pluginterfaces/vst/ivstcontextmenu.h"
@@ -1840,7 +1841,8 @@ void SurgeGUIEditor::openOrRecreateEditor()
      *
      * UPDATE: Might as well keep a reference to the object though so we can touch it in idle
      */
-    auto lb = new CTextLabel(CRect(CPoint(310, 39), CPoint(195, 15)), "DEBUG BUILD");
+    auto dl = std::string("D ") + Surge::Build::BuildTime + " " + Surge::Build::GitBranch;
+    auto lb = new CTextLabel(CRect(CPoint(310, 39), CPoint(195, 15)), dl.c_str());
     lb->setTransparency(false);
     lb->setBackColor(kRedCColor);
     lb->setFontColor(kWhiteCColor);

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -419,8 +419,10 @@ void Vst2PluginInstance::processT(float **inputs, float **outputs, VstInt32 samp
         checkNamesEvery = 0;
         if (std::atomic_exchange(&parameterNameUpdated, false))
         {
-            if (!isFruity)
+            /*
+             * if (!isFruity)
                 updateDisplay();
+                */
         }
     }
 

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -1071,7 +1071,7 @@ void SurgeVst3Processor::uithreadIdleActivity()
             auto comph = getComponentHandler();
             if (comph)
             {
-                comph->restartComponent(kParamTitlesChanged | kParamValuesChanged);
+                // comph->restartComponent(kParamTitlesChanged | kParamValuesChanged );
             }
         }
     }


### PR DESCRIPTION
the way we invalidated param names and values was probably wrong but
definitely screwed up bitwig automation. Disable until we get
to JUCE

Closes #3783