### PR TITLE
Add skin connector for positioning the Store Patch dialog

### DIFF
--- a/cmake/stage-extra-content.cmake
+++ b/cmake/stage-extra-content.cmake
@@ -3,7 +3,7 @@
 #
 
 set(SURGE_EXTRA_CONTENT_REPO https://github.com/surge-synthesizer/surge-extra-content.git)
-set(SURGE_EXTRA_CONTENT_HASH f95fff006b0c46c7c4884c63b8017bfc0c2ec385)
+set(SURGE_EXTRA_CONTENT_HASH 6fb883a69a19dabfa3383d1b00c93c16ff63d59f)
 
 find_package(Git)
 if( ${Git_FOUND} )

--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -385,6 +385,9 @@ Connector vu_meter =
 Connector mseg_editor = Connector("msegeditor.window", 0, 57, 750, 365, Connector::CUSTOM,
                                   Connector::MSEG_EDITOR_WINDOW);
 
+Connector store_patch_dialog = Connector("controls.patch.store.window", 157, 57, 390, 143, Connector::CUSTOM,
+                                  Connector::STORE_PATCH_DIALOG);
+
 // modulation panel is special, so it shows up as 'CUSTOM' with no connector and is special-cased in
 // SurgeGUIEditor
 Connector modulation_panel = Connector("controls.modulation.panel", 2, 402, Connector::CUSTOM);

--- a/src/common/SkinModel.h
+++ b/src/common/SkinModel.h
@@ -138,6 +138,7 @@ struct Connector
         JOG_FX,
 
         STORE_PATCH,
+        STORE_PATCH_DIALOG,
 
         STATUS_MPE,
         STATUS_TUNE,
@@ -313,6 +314,8 @@ extern Surge::Skin::Connector vu_meter;
 extern Surge::Skin::Connector patch_browser;
 
 extern Surge::Skin::Connector mseg_editor;
+
+extern Surge::Skin::Connector store_patch_dialog;
 
 // In surge 1.8, the modulation panel is moveable en-masse but individual modulators
 // are not relocatable. This item gives you the location of the modulators

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1609,6 +1609,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             break;
         }
         case Surge::Skin::Connector::NonParameterConnection::PARAMETER_CONNECTED:
+        case Surge::Skin::Connector::NonParameterConnection::STORE_PATCH_DIALOG:
         case Surge::Skin::Connector::NonParameterConnection::MSEG_EDITOR_WINDOW:
         case Surge::Skin::Connector::NonParameterConnection::N_NONCONNECTED:
             break;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -7504,7 +7504,14 @@ void SurgeGUIEditor::resetPitchSmoothing(ControllerModulationSource::SmoothingMo
 
 void SurgeGUIEditor::makeStorePatchDialog()
 {
+    auto npc = Surge::Skin::Connector::NonParameterConnection::STORE_PATCH_DIALOG;
+    auto conn = Surge::Skin::Connector::connectorByNonParameterConnection(npc);
+    auto skinCtrl = currentSkin->getOrCreateControlForConnector(conn);
+
+    // TODO: add skin connectors for all Store Patch dialog widgets
+    // let's have fixed dialog size for now, once TODO is done use the commented out line instead
     CRect dialogSize(CPoint(0, 0), CPoint(390, 143));
+    //CRect dialogSize(CPoint(0, 0), CPoint(skinCtrl->w, skinCtrl->h));
 
     auto saveDialog = new CViewContainer(dialogSize);
     saveDialog->setBackgroundColor(currentSkin->getColor(Colors::Dialog::Background));
@@ -7658,8 +7665,8 @@ void SurgeGUIEditor::makeStorePatchDialog()
     saveDialog->addView(cb);
     saveDialog->addView(kb);
 
-    addEditorOverlay(saveDialog, "Store Patch", STORE_PATCH, CPoint(157, 57), false, false,
-                     [this]() {});
+    addEditorOverlay(saveDialog, "Store Patch", STORE_PATCH, CPoint(skinCtrl->x, skinCtrl->y),
+                     false, false, [this]() {});
 }
 
 VSTGUI::CControl *


### PR DESCRIPTION
Prior to this PR, the Store Patch dialog had a fixed position and size. This PR introduces a new skin connector which will allow repositioning that dialog.
No size adjustment yet (but the code to do so is commented out and ready for introducing it later on if need be).

Also updated Royal Surge skin so that the Store Patch dialog is nicely centered, and updated the hash for staging extra content.