### PR TITLE
Only show the midi overlay if it is actually needed

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1375,7 +1375,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             }
 
             frame->addView(gui_modsrc[ms]);
-            if (synth->learn_custom == ms - ms_ctrl1)
+            if (ms >= ms_ctrl1 && ms <= ms_ctrl8 && synth->learn_custom == ms - ms_ctrl1)
             {
                 showMidiLearnOverlay(r);
             }


### PR DESCRIPTION
When I mived the block to restore the overlay in rebuild
I missed a condition. Ooops