### PR TITLE
Aborting MIDI learn can only be done from the slider that enabled it

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2775,7 +2775,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                 eid++;
 
-                if (synth->learn_custom > -1)
+                if (synth->learn_custom > -1 && synth->learn_custom == ccid)
                     cancellearn = true;
 
                 std::string learnTag =
@@ -3597,7 +3597,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                 eid++;
 
-                if (synth->learn_param > -1)
+                if (synth->learn_param > -1 && synth->learn_param == p->id)
                     cancellearn = true;
 
                 std::string learnTag =


### PR DESCRIPTION
Allows easy shifting of MIDI learn target to a different slider rather than requiring a repeated visit to the context menu to first abort current MIDI learn, then set it on again for the new slider.