### PR TITLE
Add option for tunings and modulation

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1652,7 +1652,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
         if (displayInfo.customFeatures & ParamDisplayFeatures::kUnitsAreSemitonesOrKeys)
         {
             u = "semitones";
-            if (storage && !storage->isStandardTuning)
+            if (storage && !storage->isStandardTuning &&
+                storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL)
                 u = "keys";
         }
         if (can_extend_range())
@@ -1782,7 +1783,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
             if (displayInfo.customFeatures & ParamDisplayFeatures::kUnitsAreSemitonesOrKeys)
             {
                 u = "semitones";
-                if (storage && !storage->isStandardTuning)
+                if (storage && !storage->isStandardTuning &&
+                    storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL)
                     u = "keys";
             }
 
@@ -2299,7 +2301,8 @@ void Parameter::get_display(char *txt, bool external, float ef)
             if (displayInfo.customFeatures & ParamDisplayFeatures::kUnitsAreSemitonesOrKeys)
             {
                 u = "semitones";
-                if (storage && !storage->isStandardTuning)
+                if (storage && !storage->isStandardTuning &&
+                    storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL)
                     u = "keys";
             }
 
@@ -2352,7 +2355,8 @@ void Parameter::get_display(char *txt, bool external, float ef)
             if (displayInfo.customFeatures & ParamDisplayFeatures::kUnitsAreSemitonesOrKeys)
             {
                 u = "semitones";
-                if (storage && !storage->isStandardTuning)
+                if (storage && !storage->isStandardTuning &&
+                    storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL)
                     u = "keys";
             }
 

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -493,6 +493,8 @@ bailOnPortable:
     // Tunings Library Support
     currentScale = Tunings::evenTemperament12NoteScale();
     currentMapping = Tunings::KeyboardMapping();
+    twelveToneStandardMapping =
+        Tunings::Tuning(Tunings::evenTemperament12NoteScale(), Tunings::KeyboardMapping());
 
     // Load the XML DocStrings if we are loading startup data
     if (loadWtAndPatch)
@@ -1644,7 +1646,16 @@ bool SurgeStorage::retuneToScale(const Tunings::Scale &s)
     currentScale = s;
     isStandardTuning = false;
 
-    Tunings::Tuning t(currentScale, currentMapping);
+    currentTuning = Tunings::Tuning(currentScale, currentMapping);
+
+    auto t = currentTuning;
+
+    if (tuningApplicationMode == RETUNE_MIDI_ONLY)
+    {
+        tuningPitch = 32.0;
+        tuningPitchInv = 1.0 / 32.0;
+        t = twelveToneStandardMapping;
+    }
 
     for (int i = 0; i < 512; ++i)
     {
@@ -1655,7 +1666,6 @@ bool SurgeStorage::retuneToScale(const Tunings::Scale &s)
         table_note_omega[1][i] =
             (float)cos(2 * M_PI * min(0.5, 440 * table_pitch[i] * dsamplerate_os_inv));
     }
-
     return true;
 }
 
@@ -1675,6 +1685,25 @@ bool SurgeStorage::remapToStandardKeyboard()
         retuneToScale(currentScale);
     }
     return true;
+}
+
+bool SurgeStorage::retuneAndRemapToScaleAndMapping(const Tunings::Scale &s,
+                                                   const Tunings::KeyboardMapping &k)
+{
+    currentMapping = k;
+    currentScale = s;
+    isStandardMapping = false;
+
+    tuningPitch = k.tuningFrequency / Tunings::MIDI_0_FREQ;
+    tuningPitchInv = 1.0 / tuningPitch;
+    retuneToScale(currentScale);
+    return true;
+}
+
+void SurgeStorage::setTuningApplicationMode(const TuningApplicationMode m)
+{
+    tuningApplicationMode = m;
+    retuneAndRemapToScaleAndMapping(currentScale, currentMapping);
 }
 
 bool SurgeStorage::remapToKeyboard(const Tunings::KeyboardMapping &k)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -80,7 +80,8 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 //                            add ability to configure vocoder modulator mono/sterao/L/R
 //                            add comb filter tuning and compatibility block
 // 14 -> 15 (1.8.0 release) apply the great filter remap (GitHub issue #3006)
-// 15 -> 16 (1.8.2 release) implement oscillator retrigger consistently (GitHub issue #3171)
+// 15 -> 16 (1.9.0 release) implement oscillator retrigger consistently (GitHub issue #3171)
+//                          add tuningApplicationMode to patch
 
 const int ff_revision = 16;
 
@@ -932,6 +933,10 @@ class alignas(16) SurgeStorage
 
     bool remapToKeyboard(const Tunings::KeyboardMapping &k);
     bool remapToStandardKeyboard();
+
+    bool retuneAndRemapToScaleAndMapping(const Tunings::Scale &s,
+                                         const Tunings::KeyboardMapping &k);
+
     inline int scaleConstantNote() { return currentMapping.tuningConstantNote; }
     inline float scaleConstantPitch() { return tuningPitch; }
     inline float scaleConstantPitchInv()
@@ -940,7 +945,16 @@ class alignas(16) SurgeStorage
     } // Obviously that's the inverse of the above
 
     Tunings::Scale currentScale;
+    Tunings::Tuning twelveToneStandardMapping;
+    Tunings::Tuning currentTuning;
+
     bool isStandardTuning;
+    enum TuningApplicationMode
+    {
+        RETUNE_ALL = 0, // These values are streamed so don't change them if you add
+        RETUNE_MIDI_ONLY = 1
+    } tuningApplicationMode = RETUNE_ALL;
+    void setTuningApplicationMode(const TuningApplicationMode m);
 
     Tunings::KeyboardMapping currentMapping;
     bool isStandardMapping = true;

--- a/src/common/dsp/SurgeVoiceState.h
+++ b/src/common/dsp/SurgeVoiceState.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+class SurgeStorage;
+
 struct SurgeVoiceState
 {
     bool gate;
@@ -32,5 +34,5 @@ struct SurgeVoiceState
     ControllerModulationSource mpePitchBend;
     float mpePitchBendRange;
 
-    float getPitch();
+    float getPitch(SurgeStorage *storage);
 };

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -5711,6 +5711,29 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect, boo
                               });
         });
 
+    auto mod = addCallbackMenu(
+        tuningSubMenu, Surge::UI::toOSCaseForMenu("Tuning Applies To Modulation"), [this]() {
+            if (this->synth->storage.tuningApplicationMode == SurgeStorage::RETUNE_ALL)
+            {
+                this->synth->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
+            }
+            else
+            {
+                this->synth->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+            }
+        });
+    if (this->synth->storage.isStandardTuning)
+    {
+        mod->setEnabled(false);
+    }
+    if (this->synth->storage.tuningApplicationMode == SurgeStorage::RETUNE_ALL)
+    {
+        mod->setChecked(true);
+    }
+    else
+    {
+        mod->setChecked(false);
+    }
     tuningSubMenu->addSeparator();
     tid++;
     auto *sct = addCallbackMenu(


### PR DESCRIPTION
Surge has traditionally retuned pitch 'at the last minute', that is post
modulation. You usually want that, but you could make another choice, to retune
the keyboard and retain pitch in semitones. This change allows you to do that.

Closes #3826