### PR TITLE
Unix/Linux: Fix error message during LV2 packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -981,7 +981,9 @@ if( BUILD_LV2 )
       COMMAND echo "Packaging up LV2 component"
       COMMAND ${CMAKE_COMMAND} -E make_directory ${SURGE_PRODUCT_DIR}/Surge.lv2
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:surge-lv2-dll> ${SURGE_PRODUCT_DIR}/Surge.lv2/Surge.so
-      COMMAND scripts/linux/generate-lv2-ttl ${SURGE_PRODUCT_DIR}/Surge.lv2/Surge.so
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/lintemp
+      COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/resources/data ${CMAKE_BINARY_DIR}/lintemp/surge
+      COMMAND XDG_DATA_HOME=${CMAKE_BINARY_DIR}/lintemp scripts/linux/generate-lv2-ttl ${SURGE_PRODUCT_DIR}/Surge.lv2/Surge.so
       )
   endif()
 


### PR DESCRIPTION
Since 91a01de3ee5788754d82e3118ee17515209ee0b4 binaries no longer
contain configuration.xml. However, during LV2 packaging SurgeStorage is
instantiated, and if Surge is not installed, it shows an error message.
The packaging succeeds, but on desktops this can cause a build-stalling
zenity message box. This change adds a workaround.