### PR TITLE
Improve patch save path checking

### DIFF
--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -425,9 +425,45 @@ void SurgeSynthesizer::savePatch()
         storage.getPatch().category = "Default";
 
     fs::path savepath = string_to_path(getUserPatchDirectory());
-    savepath /= (string_to_path(storage.getPatch().category));
 
-    create_directories(savepath);
+    try
+    {
+        std::string tempCat = storage.getPatch().category;
+        printf("before: [%s]\n", tempCat.c_str());
+#if WINDOWS
+        if (tempCat[0] == '\\' || tempCat[0] == '/')
+        {
+            tempCat.erase(0, 1);
+        }
+#endif
+        printf("after: [%s]\n", tempCat.c_str());
+
+        fs::path catPath = (string_to_path(tempCat));
+
+        printf("path: [%s]\n", catPath.generic_string());
+
+        if (!catPath.is_relative())
+        {
+            Surge::UserInteractions::promptError(
+                "Please use relative paths when saving patches. Referring to drive names directly "
+                "and using absolute paths is not allowed!",
+                "Error");
+            return;
+        }
+        savepath /= catPath;
+
+        printf("savepath: [%s]\n", savepath.generic_string());
+
+        create_directories(savepath);
+    }
+    catch (...)
+    {
+        Surge::UserInteractions::promptError(
+            "Exception occured while creating category folder! Most likely, invalid characters "
+            "were used to name the category. Please remove suspicious characters and try again!",
+            "Error");
+        return;
+    }
 
     fs::path filename = savepath;
     filename /= string_to_path(storage.getPatch().name + ".fxp");

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -429,31 +429,8 @@ void SurgeSynthesizer::savePatch()
 
     create_directories(savepath);
 
-    string legalname = storage.getPatch().name;
-    for (int i = 0; i < legalname.length(); i++)
-    {
-        switch (legalname[i])
-        {
-        case '<':
-            legalname[i] = '[';
-            break;
-        case '>':
-            legalname[i] = ']';
-            break;
-        case '*':
-        case '?':
-        case '"':
-        case '\\':
-        case '|':
-        case '/':
-        case ':':
-            legalname[i] = ' ';
-            break;
-        }
-    }
-
     fs::path filename = savepath;
-    filename /= string_to_path(legalname + ".fxp");
+    filename /= string_to_path(storage.getPatch().name + ".fxp");
 
     bool checkExists = true;
 #if LINUX
@@ -475,8 +452,14 @@ void SurgeSynthesizer::savePatch()
 void SurgeSynthesizer::savePatchToPath(fs::path filename)
 {
     std::ofstream f(filename, std::ios::out | std::ios::binary);
+
     if (!f)
+    {
+        Surge::UserInteractions::promptError(
+            "Unable to save the patch to the specified path! Maybe it contains invalid characters?",
+            "Error");
         return;
+    }
 
     fxChunkSetCustom fxp;
     fxp.chunkMagic = vt_write_int32BE('CcnK');

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -429,18 +429,14 @@ void SurgeSynthesizer::savePatch()
     try
     {
         std::string tempCat = storage.getPatch().category;
-        printf("before: [%s]\n", tempCat.c_str());
 #if WINDOWS
         if (tempCat[0] == '\\' || tempCat[0] == '/')
         {
             tempCat.erase(0, 1);
         }
 #endif
-        printf("after: [%s]\n", tempCat.c_str());
 
         fs::path catPath = (string_to_path(tempCat));
-
-        printf("path: [%s]\n", catPath.generic_string());
 
         if (!catPath.is_relative())
         {
@@ -450,10 +446,8 @@ void SurgeSynthesizer::savePatch()
                 "Error");
             return;
         }
+
         savepath /= catPath;
-
-        printf("savepath: [%s]\n", savepath.generic_string());
-
         create_directories(savepath);
     }
     catch (...)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4309,58 +4309,32 @@ void SurgeGUIEditor::valueChanged(CControl *control)
         // FIXME: baconpaul will know a better and more correct way to fix this
         if (isAnyOverlayPresent(STORE_PATCH))
         {
-            /*
-            ** Don't allow a blank patch
-            */
-            std::string whatIsBlank = "";
-            bool haveBlanks = false;
+            synth->storage.getPatch().name = patchName->getText();
+            synth->storage.getPatch().author = patchCreator->getText();
+            synth->storage.getPatch().category = patchCategory->getText();
+            synth->storage.getPatch().comment = patchComment->getText();
 
-            if (!Surge::Storage::isValidName(patchName->getText().getString()))
+            synth->storage.getPatch().patchTuning.tuningStoredInPatch =
+                patchTuning->getValue() > 0.5;
+            if (synth->storage.getPatch().patchTuning.tuningStoredInPatch)
             {
-                whatIsBlank = "name";
-                haveBlanks = true;
-            }
-            if (!Surge::Storage::isValidName(patchCategory->getText().getString()))
-            {
-                whatIsBlank = whatIsBlank + (haveBlanks ? " and category" : "category");
-                haveBlanks = true;
-            }
-            if (haveBlanks)
-            {
-                Surge::UserInteractions::promptError(
-                    std::string("Unable to store a patch due to invalid ") + whatIsBlank +
-                        ". Please save again and provide a complete " + whatIsBlank + ".",
-                    "Patch Saving Error");
-            }
-            else
-            {
-                synth->storage.getPatch().name = patchName->getText();
-                synth->storage.getPatch().author = patchCreator->getText();
-                synth->storage.getPatch().category = patchCategory->getText();
-                synth->storage.getPatch().comment = patchComment->getText();
-
-                synth->storage.getPatch().patchTuning.tuningStoredInPatch =
-                    patchTuning->getValue() > 0.5;
-                if (synth->storage.getPatch().patchTuning.tuningStoredInPatch)
+                synth->storage.getPatch().patchTuning.tuningContents =
+                    synth->storage.currentScale.rawText;
+                if (synth->storage.isStandardMapping)
                 {
-                    synth->storage.getPatch().patchTuning.tuningContents =
-                        synth->storage.currentScale.rawText;
-                    if (synth->storage.isStandardMapping)
-                    {
-                        synth->storage.getPatch().patchTuning.mappingContents = "";
-                    }
-                    else
-                    {
-                        synth->storage.getPatch().patchTuning.mappingContents =
-                            synth->storage.currentMapping.rawText;
-                    }
+                    synth->storage.getPatch().patchTuning.mappingContents = "";
                 }
-
-                synth->storage.getPatch().dawExtraState.isPopulated =
-                    false; // Ignore whatever comes from the DAW
-
-                synth->savePatch();
+                else
+                {
+                    synth->storage.getPatch().patchTuning.mappingContents =
+                        synth->storage.currentMapping.rawText;
+                }
             }
+
+            // Ignore whatever comes from the DAW
+            synth->storage.getPatch().dawExtraState.isPopulated = false;
+
+            synth->savePatch();
 
             closeStorePatchDialog();
             frame->setDirty();


### PR DESCRIPTION
Closes #3673

Sanitizes user input on category names. This disallows paths starting with \ or / on Windows, and also disallows using absolute paths or OS-disallowed characters as category names.
