### PR TITLE
Toggling touchscreen mode retains previously used mouse settings

### DIFF
--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -1358,8 +1358,7 @@ CMouseEventResult CLFOGui::onMouseDown(CPoint &where, const CButtonState &button
         if (rect_steps.pointInside(where))
         {
             if (storage)
-                this->hideCursor =
-                    !Surge::Storage::getUserDefaultValue(storage, "showCursorWhileEditing", 0);
+                this->hideCursor = !Surge::UI::showCursor(storage);
 
             if (buttons.isRightButton())
             {

--- a/src/common/gui/CModulationSourceButton.cpp
+++ b/src/common/gui/CModulationSourceButton.cpp
@@ -2,6 +2,7 @@
 #include "CSurgeSlider.h"
 #include "MouseCursorControl.h"
 #include "globals.h"
+#include "guihelpers.h"
 #include "ModulationSource.h"
 #include "CScalableBitmap.h"
 #include "SurgeBitmaps.h"
@@ -312,8 +313,7 @@ CMouseEventResult CModulationSourceButton::onMouseDown(CPoint &where, const CBut
     hasMovedBar = false;
 
     if (storage)
-        this->hideCursor =
-            Surge::Storage::getUserDefaultValue(storage, "showCursorWhileEditing", 0);
+        this->hideCursor = !Surge::UI::showCursor(storage);
 
     if (!getMouseEnabled())
         return kMouseDownEventHandledButDontNeedMovedOrUpEvents;

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -15,6 +15,7 @@
 
 #include "SurgeGUIEditor.h"
 #include "CSurgeSlider.h"
+#include "guihelpers.h"
 #include "resource.h"
 #include "DspUtilities.h"
 #include "MouseCursorControl.h"
@@ -700,8 +701,7 @@ CMouseEventResult CSurgeSlider::onMouseDown(CPoint &where, const CButtonState &b
         }
     }
     if (storage)
-        this->hideCursor =
-            !Surge::Storage::getUserDefaultValue(storage, "showCursorWhileEditing", 0);
+        this->hideCursor = !Surge::UI::showCursor(storage);
 
     hasBeenDraggedDuringMouseGesture = false;
     if (wheelInitiatedEdit)

--- a/src/common/gui/CursorControlGuard.h
+++ b/src/common/gui/CursorControlGuard.h
@@ -21,6 +21,7 @@
 #endif
 #include "SurgeStorage.h"
 #include "UserDefaults.h"
+#include "guihelpers.h"
 
 namespace Surge
 {
@@ -81,7 +82,7 @@ struct CursorControlAdapter
     {
 #if !TARGET_JUCE_UI
         if (s)
-            hideCursor = !Surge::Storage::getUserDefaultValue(s, "showCursorWhileEditing", 0);
+            hideCursor = !Surge::UI::showCursor(s);
 #else
         hideCursor = false;
 #endif

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -6042,18 +6042,11 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
 
 #if SUPPORTS_TOUCH_MENU
     mouseSubMenu->addSeparator();
-    menuItem = addCallbackMenu(
-        mouseSubMenu, Surge::UI::toOSCaseForMenu("Touchscreen Mode"), [this, touchMode]() {
-            Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "touchMouseMode",
-                                                   !touchMode);
-            if (!touchMode)
-            {
-                Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                       "showCursorWhileEditing", true);
-                Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                       "sliderMoveRateState", CSurgeSlider::kExact);
-            }
-        });
+    menuItem = addCallbackMenu(mouseSubMenu, Surge::UI::toOSCaseForMenu("Touchscreen Mode"),
+                               [this, touchMode]() {
+                                   Surge::Storage::updateUserDefaultValue(
+                                       &(this->synth->storage), "touchMouseMode", !touchMode);
+                               });
     menuItem->setChecked(touchMode);
 #endif
 

--- a/src/common/gui/guihelpers.cpp
+++ b/src/common/gui/guihelpers.cpp
@@ -2,7 +2,12 @@
 
 #include <cctype>
 
-std::string Surge::UI::toOSCaseForMenu(std::string menuName)
+namespace Surge
+{
+namespace UI
+{
+
+std::string toOSCaseForMenu(std::string menuName)
 {
 #if WINDOWS
     for (auto i = 1; i < menuName.length() - 1; ++i)
@@ -14,10 +19,18 @@ std::string Surge::UI::toOSCaseForMenu(std::string menuName)
     return menuName;
 }
 
+bool showCursor(SurgeStorage *storage)
+{
+    bool sc = Surge::Storage::getUserDefaultValue(storage, "showCursorWhileEditing", 0);
+    bool tm = Surge::Storage::getUserDefaultValue(storage, "touchMouseMode", false);
+
+    return sc || tm;
+};
+
 // Returns 1 if the lines intersect, otherwise 0. In addition, if the lines
 // intersect, the intersection point may be stored in the floats i_x and i_y.
-bool Surge::UI::get_line_intersection(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x,
-                                      float p2_y, float p3_x, float p3_y, float *i_x, float *i_y)
+bool get_line_intersection(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
+                           float p3_x, float p3_y, float *i_x, float *i_y)
 {
     float s1_x, s1_y, s2_x, s2_y;
     float s, t;
@@ -41,3 +54,6 @@ bool Surge::UI::get_line_intersection(float p0_x, float p0_y, float p1_x, float 
     }
     return false; // No collision
 }
+
+} // namespace UI
+} // namespace Surge

--- a/src/common/gui/guihelpers.h
+++ b/src/common/gui/guihelpers.h
@@ -6,12 +6,16 @@
 #else
 #include <vstgui/vstgui.h>
 #endif
+#include "SurgeStorage.h"
+#include "UserDefaults.h"
 
 namespace Surge
 {
 namespace UI
 {
 std::string toOSCaseForMenu(std::string menuName);
+
+extern bool showCursor(SurgeStorage *storage);
 
 bool get_line_intersection(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
                            float p3_x, float p3_y, float *i_x, float *i_y);


### PR DESCRIPTION
Instead of destructively changing mouse speed and show cursor while editing options when enabling Touchscreen mode, add a `showCursor` function that tests whether Show cursor while editing or Touchscreen mode options were enabled and act upon it then. Mouse speed using Exact mode was already solved in CSurgeSlider by querying `buttons.isTouch()`.