### PR TITLE
Skin Group XML Ordering Bug Resolved

### DIFF
--- a/resources/data/skins/Tutorial/09 Skin Version 2 Expansion.surge-skin/skin.xml
+++ b/resources/data/skins/Tutorial/09 Skin Version 2 Expansion.surge-skin/skin.xml
@@ -42,5 +42,15 @@ Also: This tutorial is not copmlete as of Feb 15 2021. Work in progress.
     <control ui_identifier="filter.f2_offset_mode" class="none"/>
     <control ui_identifier="filter.f2_link_resonance" class="none"/>
 
+    <!--[doc]
+    Version 9 fixed a problem with groups where making a group would blow up subsequent group move.
+    The below would fail in skin version 1 / surge 1.8
+    [doc]-->
+    <group x="306" y="212">
+      <control ui_identifier="filter.cutoff_1" x="0" y="0"/>
+      <control ui_identifier="filter.resonance_1" x="10" y="26"/>
+    </group>
+
+    <control ui_identifier="mixer.panel" x="170" y="280"/>
   </controls>
 </surge-skin>

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -385,7 +385,7 @@ class Skin
     std::unordered_map<std::string, ComponentClass::ptr_t> componentClasses;
     std::vector<int> zooms;
     bool recursiveGroupParse(ControlGroup::ptr_t parent, TiXmlElement *groupList,
-                             std::string pfx = "");
+                             bool topLevel = true);
 };
 
 class SkinDB


### PR DESCRIPTION
A skin group tag would mean subsequent items in the
xml would fail to be positioned properly, since the
recursion would build global top level data structures
on a sub-recursion.

Closes #3855