### PR TITLE
Move the factored ModControl out of chow

### DIFF
--- a/src/common/dsp/effect/ModControl.h
+++ b/src/common/dsp/effect/ModControl.h
@@ -15,9 +15,9 @@
 
 #pragma once
 
-#include <vt_dsp/lipol.h>
+#include "lipol.h"
 
-namespace chowdsp
+namespace Surge
 {
 
 class ModControl
@@ -111,14 +111,13 @@ class ModControl
     inline void post_process() { depth.process(); }
 
   private:
-    lipol<float, true> lfoval;
-    lipol<float, true> depth;
+    lipol<float, true> lfoval{};
+    lipol<float, true> depth{};
     float lfophase;
     float lfosandhtarget;
 
     static constexpr int LFO_TABLE_SIZE = 8192;
     static constexpr int LFO_TABLE_MASK = LFO_TABLE_SIZE - 1;
-    float sin_lfo_table[LFO_TABLE_SIZE];
+    float sin_lfo_table[LFO_TABLE_SIZE]{};
 };
-
-} // namespace chowdsp
+} // namespace Surge

--- a/src/common/dsp/effect/chowdsp/Neuron.h
+++ b/src/common/dsp/effect/chowdsp/Neuron.h
@@ -18,7 +18,7 @@
 #include "../Effect.h"
 #include "BiquadFilter.h"
 #include "shared/DelayLine.h"
-#include "shared/ModControl.h"
+#include "dsp/effect/ModControl.h"
 #include "shared/Oversampling.h"
 #include "shared/SmoothedValue.h"
 
@@ -108,7 +108,7 @@ class Neuron : public Effect
     chowdsp::DelayLine<float, chowdsp::DelayLineInterpolationTypes::Linear> delay2{1 << 18};
     Oversampling<2, BLOCK_SIZE> os;
 
-    ModControl modLFO;
+    Surge::ModControl modLFO;
 };
 
 } // namespace chowdsp


### PR DESCRIPTION
jatin kindly factored the LFO mod control out of flanger but
put it in chow-land; move it back up a bit so we can
use it in flanger, phaser, etc...