### PR TITLE
Fix DPW dynamic name problem

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1415,7 +1415,20 @@ void Parameter::bound_value(bool force_integer)
     };
 }
 
-const char *Parameter::get_name() { return dispname; }
+const char *Parameter::get_name()
+{
+    // We only even want to try this for specific types we know support it
+    switch (ctrltype)
+    {
+    case ct_dpw_trimix:
+        if (dynamicName)
+            return dynamicName->getName(this);
+        break;
+    default:
+        break;
+    }
+    return dispname;
+}
 
 const char *Parameter::get_full_name() { return fullname; }
 

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -208,6 +208,12 @@ struct ParameterDiscreteIndexRemapper : public ParamUserData
     virtual const std::vector<int> totalIndexOrdering() { return std::vector<int>(); }
 };
 
+class Parameter;
+struct ParameterDynamicNameFunction
+{
+    virtual const char *getName(Parameter *p) = 0;
+};
+
 /*
 ** It used to be parameters were assigned IDs in SurgePatch using an int which we ++ed along the
 ** way. If we want to 'add at the end' but 'cluster together' we need a different data strcture
@@ -432,6 +438,8 @@ class Parameter
     ParamUserData *user_data = nullptr;    // I know this is a bit gross but we have a runtime type
     void set_user_data(ParamUserData *ud); // I take a shallow copy and don't assume ownership and
                                            // assume i am referencable
+
+    ParameterDynamicNameFunction *dynamicName = nullptr;
 
     bool hasSkinConnector = false;
 

--- a/src/common/dsp/DPWOscillator.h
+++ b/src/common/dsp/DPWOscillator.h
@@ -83,7 +83,6 @@ class DPWOscillator : public Oscillator
     float driftlfo[MAX_UNISON], driftlfo2[MAX_UNISON];
 
     int cachedDeform = -1;
-    static std::string multitypeNameForIntValue(int flag);
 };
 
 const char dpw_multitype_names[3][16] = {"Triangle", "Square", "Sine"};

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3479,9 +3479,6 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                 contextMenu, dpw_multitype_names[m], [p, m, this]() {
                                     // p->deform_type = m;
                                     p->deform_type = (p->deform_type & 0xFFF0) | m;
-                                    std::string nm =
-                                        DPWOscillator::multitypeNameForIntValue(p->deform_type);
-                                    p->set_name(nm.c_str());
                                     synth->refresh_editor = true;
                                 });
                             mtm->setChecked((p->deform_type & 0x0F) == m);
@@ -3499,9 +3496,6 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                             if (p->deform_type & val)
                                 uval = 0;
                             p->deform_type = (p->deform_type & 0xF) | uval;
-                            std::string nm =
-                                DPWOscillator::multitypeNameForIntValue(p->deform_type);
-                            p->set_name(nm.c_str());
 
                             synth->refresh_editor = true;
                         });


### PR DESCRIPTION
The DPW dynamic name is now done properly, with Parameter
supporting generic dynamic names. This also means that
a bug where adding things could reset deform is fixed.

Closes #3929