### PR TITLE
User-defined groups set default position to 0,0

### DIFF
--- a/resources/data/skins/Tutorial/09 Skin Version 2 Expansion.surge-skin/skin.xml
+++ b/resources/data/skins/Tutorial/09 Skin Version 2 Expansion.surge-skin/skin.xml
@@ -51,6 +51,16 @@ Also: This tutorial is not copmlete as of Feb 15 2021. Work in progress.
       <control ui_identifier="filter.resonance_1" x="10" y="26"/>
     </group>
 
+    <!--[doc]
+    Similarly version 9 resets default positions for controls in user defined groups to 0,0.
+    Lets use this to purposefully mis-position a few things
+    [doc]-->
+    <group x="3" y="17">
+      <control ui_identifier="global.active_scene"/> <!-- should be at 3,17 -->
+      <control ui_identifier="global.scene_mode" y="10"/> <!-- should be at 3,27 -->
+      <control ui_identifier="scene.polylimit" x="15"/> <!-- should be at 3,23 -->
+    </group>
+
     <control ui_identifier="mixer.panel" x="170" y="280"/>
   </controls>
 </surge-skin>

--- a/src/common/gui/SkinSupport.h
+++ b/src/common/gui/SkinSupport.h
@@ -190,6 +190,8 @@ class Skin
 
         int x = 0, y = 0, w = -1, h = -1;
 
+        bool userGroup = false;
+
         props_t allprops;
     };
 


### PR DESCRIPTION
In all things skin, a control takes the parent values for
unspecified properties. This is correct in every case
*except* user defined groups where you expect the internal
controls to be 0,0 based. This change does that.