### PR TITLE
Ensemble Rough Out

### DIFF
--- a/src/common/dsp/SSESincDelayLine.h
+++ b/src/common/dsp/SSESincDelayLine.h
@@ -30,6 +30,8 @@ struct SSESincDelayLine
     float buffer alignas(16)[COMB_SIZE + FIRipol_N];
     int wp = 0;
 
+    SSESincDelayLine() { memset((void *)buffer, 0, (COMB_SIZE + FIRipol_N) * sizeof(float)); }
+
     inline void write(float f)
     {
         buffer[wp] = f;
@@ -65,6 +67,14 @@ struct SSESincDelayLine
         _mm_store_ss(&res, sum_ps_to_ss(o));
 
         return res;
+    }
+
+    float readLinear(float delay)
+    {
+        auto iDelay = (int)delay;
+        auto frac = delay - iDelay;
+        int RP = (wp - iDelay) & (COMB_SIZE - 1);
+        return buffer[RP] * (1 - frac) + buffer[RP + 1] * frac;
     }
 };
 

--- a/src/common/dsp/effect/BBDEnsembleEffect.h
+++ b/src/common/dsp/effect/BBDEnsembleEffect.h
@@ -23,6 +23,8 @@
 
 #include <vt_dsp/halfratefilter.h>
 #include <vt_dsp/lipol.h>
+#include "ModControl.h"
+#include "SSESincDelayLine.h"
 
 class BBDEnsembleEffect : public Effect
 {
@@ -62,5 +64,6 @@ class BBDEnsembleEffect : public Effect
     virtual int group_label_ypos(int id) override;
 
   private:
-    int bi; // block increment (to keep track of events not occurring every n blocks)
+    Surge::ModControl modlfos[2][3]; // 2 LFOs differening by 120 degree in phase at outputs
+    SSESincDelayLine<8192> delL, delR;
 };


### PR DESCRIPTION
Rough out the ensemble modulation stages. The modulators
are in place and they read from a (non-BBD sinc implemented)
delay line.

Addresses #3743