### PR TITLE
Fix a Tape crash on Linux (and probably win32 too)

### DIFF
--- a/src/common/dsp/effect/chowdsp/tape/LossFilter.h
+++ b/src/common/dsp/effect/chowdsp/tape/LossFilter.h
@@ -35,7 +35,7 @@ class LossFilter
     int activeFilter = 0;
     int fadeCount = 0;
     static constexpr int fadeLength = 1024;
-    float fadeBufferL[BLOCK_SIZE], fadeBufferR[BLOCK_SIZE];
+    float fadeBufferL alignas(16)[BLOCK_SIZE], fadeBufferR alignas(16)[BLOCK_SIZE];
 
     // parameter values
     float curSpeed, prevSpeed;


### PR DESCRIPTION
Blocks used in SSE need to be 16 byte aligned. The GCC layout
of this class knocked fadeBuffer out causing a core dump on
linux. Add alignas() directive