### PR TITLE
Correct WG tuning; and also correct SSESincLine

### DIFF
--- a/src/common/dsp/SSESincDelayLine.h
+++ b/src/common/dsp/SSESincDelayLine.h
@@ -46,7 +46,7 @@ struct SSESincDelayLine
         delay = delay;
         auto iDelay = (int)delay;
         auto fracDelay = delay - iDelay;
-        auto sincTableOffset = (int)(fracDelay * FIRipol_N) * (FIRipol_N << 1);
+        auto sincTableOffset = (int)((1 - fracDelay) * FIRipol_M) * FIRipol_N * 2;
 
         // So basically we interpolate around FIRipol_N (the 12 sample sinc)
         // remembering that FIRoffset is the offset to center your table at
@@ -77,7 +77,8 @@ struct SSESincDelayLine
         auto iDelay = (int)delay;
         auto frac = delay - iDelay;
         int RP = (wp - iDelay) & (COMB_SIZE - 1);
-        return buffer[RP] * (1 - frac) + buffer[RP + 1] * frac;
+        int RPP = RP == 0 ? COMB_SIZE - 1 : RP - 1;
+        return buffer[RP] * (1 - frac) + buffer[RPP] * frac;
     }
 
     inline void clear() { memset((void *)buffer, 0, (COMB_SIZE + FIRipol_N) * sizeof(float)); }

--- a/src/common/dsp/WaveguideOscillator.cpp
+++ b/src/common/dsp/WaveguideOscillator.cpp
@@ -266,7 +266,7 @@ void WaveguideOscillator::process_block(float pitch, float drift, bool stereo, b
             if (FM)
                 v *= Surge::DSP::fastexp(limit_range(fmdepth.v * master_osc[i] * 3, -6.f, 4.f));
 
-            val[t] = delayLine[t].read(v - 0.5);
+            val[t] = delayLine[t].read(v);
 
             // Add continuous excitation
             switch (mode)

--- a/src/headless/UnitTestsDSP.cpp
+++ b/src/headless/UnitTestsDSP.cpp
@@ -594,6 +594,45 @@ TEST_CASE("Sinc Delay Line", "[dsp]")
             val += dRamp;
         }
     }
+
+#if 0
+// This prints output I used for debugging
+    SECTION( "Generate Output" )
+    {
+        float dRamp = 0.01;
+        SSESincDelayLine<4096> dl4096;
+
+        float v = 0;
+        int nsamp = 500;
+        for( int i=0; i<nsamp; ++i )
+        {
+            dl4096.write(v);
+            v += dRamp;
+        }
+
+        for( int i=100; i<300; ++i )
+        {
+            auto bi = dl4096.buffer[i];
+            auto off = nsamp - i;
+            auto bsv = dl4096.read(off - 1);
+            auto bsl = dl4096.readLinear(off);
+
+            auto bsvh = dl4096.read(off - 1 - 0.5);
+            auto bslh = dl4096.readLinear(off - 0.0 );
+            std::cout << off << ", " << bi << ", " << bsv
+                      << ", " << bsl << ", " << bi -bsv << ", " << bi-bsl
+                      << ", " << bslh << ", " << bi - bslh << std::endl;
+
+            for( int q=0; q<111; ++q )
+            {
+                std::cout << " " << q << " "
+                          << ( dl4096.read(off - q * 0.1) - bi ) / dRamp
+                          << " " << ( dl4096.readLinear(off - q * 0.1) - bi ) / dRamp
+                          << std::endl;
+            }
+        }
+    }
+#endif
 }
 
 // When we return to #1514 this is a good starting point


### PR DESCRIPTION
SSESincLine was a new port of our sinc interpolator. That port
got it wrong. Now it has it right. And as a result the waveguide
oscillator is also now in tune far better.