### PR TITLE
Parsimonous WT load on patch change

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -549,7 +549,19 @@ void SurgePatch::init_default_values()
             osc.queue_type = -1;
             osc.keytrack.val.b = true;
             osc.retrigger.val.b = false;
-            osc.wt.queue_id = 0;
+            /*
+             * init-default-values is called at load_raw. load_raw will
+             * replace any wavetables *but* if it doesn't have a wt osc that
+             * wavetable load is pointless. So unless there's no wavetable at
+             * all ever loaded, keep what's there.
+             *
+             * We need to do something if there's nothing otherwise swapping
+             * to the wavetable oscilltor will core you out
+             */
+            if (osc.wt.current_id == -1)
+                osc.wt.queue_id = 0;
+            else
+                osc.wt.queue_id = -1;
             osc.wt.queue_filename[0] = 0;
         }
         scene[sc].fm_depth.val.f = -24.f;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3345,6 +3345,7 @@ void SurgeSynthesizer::process()
         {
             std::lock_guard<std::mutex> mg(patchLoadSpawnMutex);
             // spawn patch-loading thread
+            allNotesOff();
             halt_engine = true;
 
 #if MAC || LINUX


### PR DESCRIPTION
See the comment in SurgePatch and the profile in #3119 but
basically if a wavetable is loaded, don't reload the default
on every patch change to either not use it or overwrite it.

Addresses #3119