### PR TITLE
Integrate libsamplerate ahead of Nimbus/Twist SR correction

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 [submodule "libs/oddsound-mts/MTS-ESP"]
 	path = libs/oddsound-mts/MTS-ESP
 	url = https://github.com/ODDSound/MTS-ESP
+[submodule "libs/libsamplerate"]
+	path = libs/libsamplerate
+	url = https://github.com/libsndfile/libsamplerate.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
 
+if(NOT BUILD_TESTING)
+  set(BUILD_TESTING "False" CACHE STRING "" FORCE)
+endif()
+
 project(Surge VERSION 1.9.0.0 LANGUAGES CXX ASM)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -34,7 +38,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
 
     # PE/COFF doesn't support visibility
     $<$<NOT:$<BOOL:${WIN32}>>:-fvisibility=hidden>
-    $<$<NOT:$<BOOL:${WIN32}>>:-fvisibility-inlines-hidden>
+    # Inlines visibility is only relevant with C++
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<COMPILE_LANGUAGE:CXX>>:-fvisibility-inlines-hidden>
   )
   # Enable SSE2 on x86-32 only. It's implied on x86-64 and N/A elsewhere.
   if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
@@ -120,6 +125,7 @@ add_subdirectory(libs/filesystem)
 add_subdirectory(libs/tinyxml)
 add_subdirectory(libs/escape-from-vstgui)
 add_subdirectory(libs/oddsound-mts)
+add_subdirectory(libs/libsamplerate)
 
 target_link_libraries(surge-shared PUBLIC
   surge::airwindows
@@ -127,6 +133,7 @@ target_link_libraries(surge-shared PUBLIC
   surge::filesystem
   surge::tinyxml
   surge::oddsound-mts
+  samplerate
 )
 
 # We want to run this once alas, since JUCE needs it even though it is a byproduct of a phase to build the

--- a/src/headless/UnitTestsDSP.cpp
+++ b/src/headless/UnitTestsDSP.cpp
@@ -13,6 +13,8 @@
 
 #include "SSESincDelayLine.h"
 
+#include "samplerate.h"
+
 using namespace Surge::Test;
 
 TEST_CASE("Simple Single Oscillator is Constant", "[dsp]")
@@ -633,6 +635,76 @@ TEST_CASE("Sinc Delay Line", "[dsp]")
         }
     }
 #endif
+}
+
+TEST_CASE("libsamplerate basics", "[dsp]")
+{
+    for (auto tsr : {44100, 48000}) // { 44100, 48000, 88200, 96000, 192000 })
+    {
+        for (auto ssr : {44100, 48000, 88200})
+        {
+            DYNAMIC_SECTION("libsamplerate from " << ssr << " to " << tsr)
+            {
+                int error;
+                auto state = src_new(SRC_SINC_FASTEST, 1, &error);
+                REQUIRE(state);
+                REQUIRE(error == 0);
+
+                static constexpr int buffer_size = 1024 * 100;
+                static constexpr int output_block = 64;
+
+                float input_data[buffer_size];
+                float copied_output[buffer_size];
+
+                int cwp = 0, irp = 0;
+                float output_data[output_block];
+
+                float dPhase = 440.0 / ssr * 2.0 * M_PI;
+                float phase = 0;
+                for (int i = 0; i < buffer_size; ++i)
+                {
+                    input_data[i] = std::sin(phase);
+                    phase += dPhase;
+                    if (phase >= 2.0 * M_PI)
+                        phase -= 2.0 * M_PI;
+                }
+
+                SRC_DATA sdata;
+                sdata.end_of_input = 0;
+                while (irp + output_block < buffer_size && cwp + output_block < buffer_size)
+                {
+                    sdata.data_in = &(input_data[irp]);
+                    sdata.data_out = output_data;
+                    sdata.input_frames = 64;
+                    sdata.output_frames = 64;
+                    sdata.src_ratio = 1.0 * tsr / ssr;
+
+                    auto res = src_process(state, &sdata);
+                    memcpy((void *)(copied_output + cwp), (void *)output_data,
+                           sdata.output_frames_gen * sizeof(float));
+                    irp += sdata.input_frames_used;
+                    cwp += sdata.output_frames_gen;
+                    REQUIRE(res == 0);
+                    REQUIRE(sdata.input_frames_used + sdata.output_frames_gen > 0);
+                }
+
+                state = src_delete(state);
+                REQUIRE(!state);
+
+                // At this point the output block should be a 440hz sine wave at the target rate
+                dPhase = 440.0 / tsr * 2.0 * M_PI;
+                phase = 0;
+                for (int i = 0; i < cwp; ++i)
+                {
+                    auto cw = std::sin(phase);
+                    REQUIRE(copied_output[i] == Approx(cw).margin(1e-2));
+                    phase += dPhase;
+                    if (phase >= 2.0 * M_PI)
+                        phase -= 2.0 * M_PI;
+                }
+            }
+        }
+    }
 }
 
 // When we return to #1514 this is a good starting point


### PR DESCRIPTION
The eurorack modules need SR conversion to and from 48khz.
This integrates libsamplerate and writes an assertive test
which shows it is integrated properly, but does not fix the
nimbus SR issue, just adds the dep, build, and test.