### PR TITLE
Replace a bunch of unsafe string operations with safer alternatives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   # Any Clang or any GCC
   add_compile_options(
     -Wno-multichar
-    -Wno-format-truncation # squelch warning about snprintf truncating strings (see PR #3977)
+    -Wformat-truncation=0 # squelch warning about snprintf truncating strings (see PR #3977)
     # Targetting Windows with GCC/Clang is experimental
     $<$<NOT:$<BOOL:${WIN32}>>:-Werror>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   # Any Clang or any GCC
   add_compile_options(
     -Wno-multichar
-    -Wformat-truncation=0 # squelch warning about snprintf truncating strings (see PR #3977)
     # Targetting Windows with GCC/Clang is experimental
     $<$<NOT:$<BOOL:${WIN32}>>:-Werror>
 
@@ -71,6 +70,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "^GNU$")
     # GCC only
+    add_compile_options(
+        -Wformat-truncation=0 # squelch warning about snprintf truncating strings (see PR #3977)
+    )
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   # Any Clang or any GCC
   add_compile_options(
     -Wno-multichar
-
+    -Wno-format-truncation # squelch warning about snprintf truncating strings (see PR #3977)
     # Targetting Windows with GCC/Clang is experimental
     $<$<NOT:$<BOOL:${WIN32}>>:-Werror>
 

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -41,8 +41,7 @@ Parameter::~Parameter() = default;
 
 void get_prefix(char *txt, ControlGroup ctrlgroup, int ctrlgroup_entry, int scene)
 {
-// despite being 16 elsewhere, prefix was 19 bytes here. Oh well, make the others fit this too.
-#define PREFIX_SIZE 19
+#define PREFIX_SIZE 16
     char prefix[PREFIX_SIZE];
     switch (ctrlgroup)
     {

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1764,7 +1764,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
             return;
         case Menu:
             if (isBipolar)
-                snprintf(txt, TXT_SIZE, "%s %.*f %s", (mf >= 0 ? "+/-" : "-/+"), dp, fabs(mf), u.c_str());
+                snprintf(txt, TXT_SIZE, "%s %.*f %s", (mf >= 0 ? "+/-" : "-/+"), dp, fabs(mf),
+                         u.c_str());
             else
                 snprintf(txt, TXT_SIZE, "%.*f %s", dp, mf, u.c_str());
             return;
@@ -1788,8 +1789,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
                     snprintf(itxt, ITXT_SIZE, "%s%.*f", (mf < 0 ? "+" : ""), dp, -mf);
                     iw->dvalminus = itxt;
                 }
-                snprintf(txt, TXT_SIZE, "%.*f %s %.*f %s %.*f %s", dp, f - mf, lowersep, dp, f, uppersep, dp,
-                        f + mf, u.c_str());
+                snprintf(txt, TXT_SIZE, "%.*f %s %.*f %s %.*f %s", dp, f - mf, lowersep, dp, f,
+                         uppersep, dp, f + mf, u.c_str());
             }
             else
             {
@@ -1827,7 +1828,7 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
                 break;
             case Menu:
                 snprintf(txt, TXT_SIZE, "%s%.*f %s", (modulationDepth > 0) ? "+" : "", dp,
-                        modulationDepth * 100, "%");
+                         modulationDepth * 100, "%");
                 break;
             case InfoWindow:
                 if (iw)
@@ -1886,7 +1887,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
                 // if( isBipolar )
                 //   snprintf( txt, TXT_SIZE, "%.*f / %.*f %s", dp, mn-v, dp, mp-v, u.c_str() );
                 // else
-                snprintf(txt, TXT_SIZE, "%s%.*f %s", (mp - v > 0) ? "+" : "", dp, mp - v, u.c_str());
+                snprintf(txt, TXT_SIZE, "%s%.*f %s", (mp - v > 0) ? "+" : "", dp, mp - v,
+                         u.c_str());
                 if (displayInfo.customFeatures & ParamDisplayFeatures::kHasCustomMaxString &&
                     mp > val_max.f)
                 {
@@ -1927,8 +1929,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
                         }
                     }
 
-                    snprintf(txt, TXT_SIZE, "%.*f %s %.*f %s %.*f %s", dp, mn, lowersep, dp, v, uppersep, dp,
-                            mp, u.c_str());
+                    snprintf(txt, TXT_SIZE, "%.*f %s %.*f %s %.*f %s", dp, mn, lowersep, dp, v,
+                             uppersep, dp, mp, u.c_str());
                 }
                 else
                 {
@@ -1985,8 +1987,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
         case TypeIn:
         case Menu:
             snprintf(txt, TXT_SIZE, "%.*f %s", dp,
-                    limit_range(mp, -192.f, 500.f) - limit_range(v, -192.f, 500.f),
-                    displayInfo.unit);
+                     limit_range(mp, -192.f, 500.f) - limit_range(v, -192.f, 500.f),
+                     displayInfo.unit);
             break;
         case InfoWindow:
             if (iw)
@@ -1997,18 +1999,19 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
 
                 char dtxt[TXT_SIZE];
                 snprintf(dtxt, TXT_SIZE, "%s%.*f %s", (mp - v > 0 ? "+" : ""), dp,
-                        limit_range(mp, -192.f, 500.f) - limit_range(v, -192.f, 500.f),
-                        displayInfo.unit);
+                         limit_range(mp, -192.f, 500.f) - limit_range(v, -192.f, 500.f),
+                         displayInfo.unit);
                 iw->dvalplus = dtxt;
 
                 snprintf(dtxt, TXT_SIZE, "%s%.*f %s", (mn - v > 0 ? "+" : ""), dp,
-                        limit_range(mn, -192.f, 500.f) - limit_range(v, -192.f, 500.f),
-                        displayInfo.unit);
+                         limit_range(mn, -192.f, 500.f) - limit_range(v, -192.f, 500.f),
+                         displayInfo.unit);
                 iw->dvalminus = isBipolar ? dtxt : "";
             }
             if (isBipolar)
             {
-                snprintf(txt, TXT_SIZE, "%s %s %s %s %s dB", negval, lowersep, val, uppersep, posval);
+                snprintf(txt, TXT_SIZE, "%s %s %s %s %s dB", negval, lowersep, val, uppersep,
+                         posval);
             }
             else
             {
@@ -2059,7 +2062,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
                     put(iw->valminus, freqdn);
                     put(iw->dvalplus, frequp - freq);
                     put(iw->dvalminus, freq - freqdn);
-                    snprintf(txt, TXT_SIZE, "%.*f Hz %.*f Hz %.*f Hz", dp, freqdn, dp, freq, dp, frequp);
+                    snprintf(txt, TXT_SIZE, "%.*f Hz %.*f Hz %.*f Hz", dp, freqdn, dp, freq, dp,
+                             frequp);
                     break;
                 }
             }
@@ -2101,7 +2105,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
             {
                 if (isBipolar)
                 {
-                    snprintf(txt, TXT_SIZE, "C : %s %.*f", (mf >= 0 ? "+/-" : "-/+"), dp, fabs(qq * 32));
+                    snprintf(txt, TXT_SIZE, "C : %s %.*f", (mf >= 0 ? "+/-" : "-/+"), dp,
+                             fabs(qq * 32));
                 }
                 else
                 {
@@ -2217,8 +2222,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
                 std::string vs = tempoSyncNotationValue(val.f);
                 if (isBipolar)
                 {
-                    snprintf(txt, TXT_SIZE, "%.*f %s %s %s %.*f %c", dp, mn, lowersep, vs.c_str(), uppersep,
-                            dp, mp, '%');
+                    snprintf(txt, TXT_SIZE, "%.*f %s %s %s %.*f %c", dp, mn, lowersep, vs.c_str(),
+                             uppersep, dp, mp, '%');
                 }
                 else
                 {
@@ -2251,8 +2256,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
             {
                 if (isBipolar)
                 {
-                    snprintf(txt, TXT_SIZE, "%.*f %s %.*f %s %.*f %c", dp, mn, lowersep, dp, v, uppersep, dp,
-                            mp, '%');
+                    snprintf(txt, TXT_SIZE, "%.*f %s %.*f %s %.*f %c", dp, mn, lowersep, dp, v,
+                             uppersep, dp, mp, '%');
                 }
                 else
                     snprintf(txt, TXT_SIZE, "%.*f %s %.*f %c", dp, v, uppersep, dp, mp, '%');
@@ -2454,7 +2459,7 @@ void Parameter::get_display(char *txt, bool external, float ef)
                 u = displayInfo.absoluteUnit;
             }
             snprintf(txt, TXT_SIZE, "%.*f %s", (detailedMode ? 6 : displayInfo.decimals),
-                    displayInfo.scale * f, u.c_str());
+                     displayInfo.scale * f, u.c_str());
 
             if (f >= val_max.f &&
                 (displayInfo.customFeatures & ParamDisplayFeatures::kHasCustomMaxString))
@@ -2522,7 +2527,8 @@ void Parameter::get_display(char *txt, bool external, float ef)
                     dval = displayInfo.minLabelValue;
                 }
             }
-            snprintf(txt, TXT_SIZE, "%.*f %s", (detailedMode ? 6 : displayInfo.decimals), dval, u.c_str());
+            snprintf(txt, TXT_SIZE, "%.*f %s", (detailedMode ? 6 : displayInfo.decimals), dval,
+                     u.c_str());
             return;
             break;
         }
@@ -2557,7 +2563,8 @@ void Parameter::get_display(char *txt, bool external, float ef)
 
                 if (extend_range && q < 0)
                 {
-                    snprintf(txt, TXT_SIZE, "C : 1 / %.*f", (detailedMode ? 6 : 2), -get_extended(f));
+                    snprintf(txt, TXT_SIZE, "C : 1 / %.*f", (detailedMode ? 6 : 2),
+                             -get_extended(f));
                 }
                 else
                 {
@@ -2750,17 +2757,20 @@ void Parameter::get_display(char *txt, bool external, float ef)
             snprintf(txt, TXT_SIZE, "%s", lt_names[limit_range(i, 0, (int)n_lfo_types - 1)]);
             break;
         case ct_scenemode:
-            snprintf(txt, TXT_SIZE, "%s", scene_mode_names[limit_range(i, 0, (int)n_scene_modes - 1)]);
+            snprintf(txt, TXT_SIZE, "%s",
+                     scene_mode_names[limit_range(i, 0, (int)n_scene_modes - 1)]);
             break;
         case ct_polymode:
-            snprintf(txt, TXT_SIZE, "%s", play_mode_names[limit_range(i, 0, (int)n_play_modes - 1)]);
+            snprintf(txt, TXT_SIZE, "%s",
+                     play_mode_names[limit_range(i, 0, (int)n_play_modes - 1)]);
             break;
         case ct_lfotrigmode:
             snprintf(txt, TXT_SIZE, "%s",
-                    lfo_trigger_mode_names[limit_range(i, 0, (int)n_lfo_trigger_modes - 1)]);
+                     lfo_trigger_mode_names[limit_range(i, 0, (int)n_lfo_trigger_modes - 1)]);
             break;
         case ct_character:
-            snprintf(txt, TXT_SIZE, "%s", character_names[limit_range(i, 0, (int)n_character_modes - 1)]);
+            snprintf(txt, TXT_SIZE, "%s",
+                     character_names[limit_range(i, 0, (int)n_character_modes - 1)]);
             break;
         case ct_fmratio_int:
             snprintf(txt, TXT_SIZE, "C : %d", i);

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -417,9 +417,10 @@ class Parameter
         kUnitsAreSemitonesOrKeys = 1U << 5U
     };
 
+#define DISPLAYINFO_TXT_SIZE 128
     struct DisplayInfo
     {
-        char unit[128]{}, absoluteUnit[128]{};
+        char unit[DISPLAYINFO_TXT_SIZE]{}, absoluteUnit[DISPLAYINFO_TXT_SIZE]{};
         float scale = 1;
         float a = 1.0, b = 1.0;
         int decimals = 2;
@@ -427,7 +428,7 @@ class Parameter
 
         float tempoSyncNotationMultiplier = 1.f;
 
-        char minLabel[128]{}, maxLabel[128]{}, defLabel[128]{};
+        char minLabel[DISPLAYINFO_TXT_SIZE]{}, maxLabel[DISPLAYINFO_TXT_SIZE]{}, defLabel[DISPLAYINFO_TXT_SIZE]{};
         float minLabelValue = 0.f, maxLabelValue = 0.f;
 
         float modulationCap = -1.f;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -428,7 +428,8 @@ class Parameter
 
         float tempoSyncNotationMultiplier = 1.f;
 
-        char minLabel[DISPLAYINFO_TXT_SIZE]{}, maxLabel[DISPLAYINFO_TXT_SIZE]{}, defLabel[DISPLAYINFO_TXT_SIZE]{};
+        char minLabel[DISPLAYINFO_TXT_SIZE]{}, maxLabel[DISPLAYINFO_TXT_SIZE]{},
+            defLabel[DISPLAYINFO_TXT_SIZE]{};
         float minLabelValue = 0.f, maxLabelValue = 0.f;
 
         float modulationCap = -1.f;

--- a/src/common/StringOps.h
+++ b/src/common/StringOps.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/*
+ * There are a number of places in Surge where raw C strings are copied around.
+ * Ideally these would be replaced with something safer, but for the time being, a replacement
+ * for dangerous strcpy operations at least was needed.
+ *
+ * strncpy is no good - the destination buffer can end up being non-NULL-terminated, and it also
+ * writes zeros the length of the whole buffer for no reason.
+ * bsd strlcpy is also no good, it performs a length check on the source string for no reason.
+ *
+ * So, here's strxcpy:
+ * a function that copies a string to dst from src
+ * while ensuring that dst does not exceed n bytes
+ *
+ * that's it. it returns nothing.
+ * that suits Surge's purposes fine, as we don't care if a string gets truncated, only that we
+ * don't crash.
+ *
+ * the current implementation just uses snprintf.
+*/
+
+static inline void strxcpy(char *const dst, const char *const src, const size_t n){
+    snprintf(dst, n, "%s", src);
+}
+
+/*
+ * There are also a whole mess of 'txt' buffers scattered through the code - sometimes different
+ * lengths. For now, standardize on 256 bytes to get rid of the magic constants.
+ *
+ * If something breaks - check the TXT_SIZE constants versus what they were in earlier revisions!
+ *
+ * In some cases, buffers that were not called txt but served a similar purpose and were also 256 bytes now
+ * also use this constant.
+*/
+#define TXT_SIZE 256

--- a/src/common/StringOps.h
+++ b/src/common/StringOps.h
@@ -18,9 +18,10 @@
  * don't crash.
  *
  * the current implementation just uses snprintf.
-*/
+ */
 
-static inline void strxcpy(char *const dst, const char *const src, const size_t n){
+static inline void strxcpy(char *const dst, const char *const src, const size_t n)
+{
     snprintf(dst, n, "%s", src);
 }
 
@@ -30,7 +31,7 @@ static inline void strxcpy(char *const dst, const char *const src, const size_t 
  *
  * If something breaks - check the TXT_SIZE constants versus what they were in earlier revisions!
  *
- * In some cases, buffers that were not called txt but served a similar purpose and were also 256 bytes now
- * also use this constant.
-*/
+ * In some cases, buffers that were not called txt but served a similar purpose and were also 256
+ * bytes now also use this constant.
+ */
 #define TXT_SIZE 256

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -21,6 +21,7 @@
 #include <vt_dsp/vt_dsp_endian.h>
 #include "MSEGModulationHelper.h"
 #include "DebugHelpers.h"
+#include "StringOps.h"
 #include "SkinModel.h"
 #include "UserInteractions.h"
 #include "UserDefaults.h"
@@ -86,10 +87,11 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
         {
             auto conn = Surge::Skin::Connector::connectorByID("fx.param_" + std::to_string(p + 1));
 
-            char label[16];
-            sprintf(label, "p%i", p);
-            char dawlabel[32];
-            sprintf(dawlabel, "Param %i", p + 1);
+#define LABEL_SIZE 32
+            char label[LABEL_SIZE];
+            snprintf(label, LABEL_SIZE, "p%i", p);
+            char dawlabel[LABEL_SIZE];
+            snprintf(dawlabel, LABEL_SIZE, "Param %i", p + 1);
             param_ptr.push_back(this->fx[fx].p[p].assign(
                 p_id.next(), 0, label, dawlabel, ct_none, conn, 0, cg_FX, fx, true,
                 Surge::ParamConfig::kHorizontal | kHide | ((fx == 0) ? kEasy : 0)));
@@ -138,8 +140,8 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
                 Surge::Skin::Osc::pitch, sc_id, cg_OSC, osc, true, kSemitone | sceasy));
             for (int i = 0; i < n_osc_params; i++)
             {
-                char label[16];
-                sprintf(label, "param%i", i);
+                char label[LABEL_SIZE];
+                snprintf(label, LABEL_SIZE, "param%i", i);
                 a->push_back(scene[sc].osc[osc].p[i].assign(
                     p_id.next(), id_s++, label, "-", ct_none,
                     Surge::Skin::Connector::connectorByID("osc.param_" + std::to_string(i + 1)),
@@ -385,61 +387,61 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
 
         for (int l = 0; l < n_lfos; l++)
         {
-            char label[32];
+            char label[LABEL_SIZE];
 
-            sprintf(label, "lfo%i_shape", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_shape", l);
             a->push_back(scene[sc].lfo[l].shape.assign(p_id.next(), id_s++, label, "Type",
                                                        ct_lfotype, Surge::Skin::LFO::shape, sc_id,
                                                        cg_LFO, ms_lfo1 + l));
 
-            sprintf(label, "lfo%i_rate", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_rate", l);
             a->push_back(scene[sc].lfo[l].rate.assign(
                 p_id.next(), id_s++, label, "Rate", ct_lforate_deactivatable,
                 Surge::Skin::LFO::rate, sc_id, cg_LFO, ms_lfo1 + l, true, sceasy, false));
-            sprintf(label, "lfo%i_phase", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_phase", l);
             a->push_back(scene[sc].lfo[l].start_phase.assign(
                 p_id.next(), id_s++, label, "Phase / Shuffle", ct_percent, Surge::Skin::LFO::phase,
                 // Surge::Skin::LfoSection::phase,
                 sc_id, cg_LFO, ms_lfo1 + l, true));
-            sprintf(label, "lfo%i_magnitude", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_magnitude", l);
             a->push_back(scene[sc].lfo[l].magnitude.assign(
                 p_id.next(), id_s++, label, "Amplitude", ct_lfoamplitude,
                 Surge::Skin::LFO::amplitude, sc_id, cg_LFO, ms_lfo1 + l, true, sceasy));
-            sprintf(label, "lfo%i_deform", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_deform", l);
             a->push_back(scene[sc].lfo[l].deform.assign(p_id.next(), id_s++, label, "Deform",
                                                         ct_lfodeform, Surge::Skin::LFO::deform,
                                                         sc_id, cg_LFO, ms_lfo1 + l, true));
 
-            sprintf(label, "lfo%i_trigmode", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_trigmode", l);
             a->push_back(scene[sc].lfo[l].trigmode.assign(
                 p_id.next(), id_s++, label, "Trigger Mode", ct_lfotrigmode,
                 Surge::Skin::LFO::trigger_mode, sc_id, cg_LFO, ms_lfo1 + l, false, kNoPopup));
-            sprintf(label, "lfo%i_unipolar", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_unipolar", l);
             a->push_back(scene[sc].lfo[l].unipolar.assign(
                 p_id.next(), id_s++, label, "Unipolar", ct_bool_unipolar,
                 Surge::Skin::LFO::unipolar, sc_id, cg_LFO, ms_lfo1 + l, false));
 
-            sprintf(label, "lfo%i_delay", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_delay", l);
             a->push_back(scene[sc].lfo[l].delay.assign(p_id.next(), id_s++, label, "Delay",
                                                        ct_envtime, Surge::Skin::LFO::delay, sc_id,
                                                        cg_LFO, ms_lfo1 + l, true, kMini));
-            sprintf(label, "lfo%i_attack", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_attack", l);
             a->push_back(scene[sc].lfo[l].attack.assign(p_id.next(), id_s++, label, "Attack",
                                                         ct_envtime, Surge::Skin::LFO::attack, sc_id,
                                                         cg_LFO, ms_lfo1 + l, true, kMini));
-            sprintf(label, "lfo%i_hold", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_hold", l);
             a->push_back(scene[sc].lfo[l].hold.assign(p_id.next(), id_s++, label, "Hold",
                                                       ct_envtime, Surge::Skin::LFO::hold, sc_id,
                                                       cg_LFO, ms_lfo1 + l, true, kMini));
-            sprintf(label, "lfo%i_decay", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_decay", l);
             a->push_back(scene[sc].lfo[l].decay.assign(p_id.next(), id_s++, label, "Decay",
                                                        ct_envtime, Surge::Skin::LFO::decay, sc_id,
                                                        cg_LFO, ms_lfo1 + l, true, kMini));
-            sprintf(label, "lfo%i_sustain", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_sustain", l);
             a->push_back(scene[sc].lfo[l].sustain.assign(p_id.next(), id_s++, label, "Sustain",
                                                          ct_percent, Surge::Skin::LFO::sustain,
                                                          sc_id, cg_LFO, ms_lfo1 + l, true, kMini));
-            sprintf(label, "lfo%i_release", l);
+            snprintf(label, LABEL_SIZE, "lfo%i_release", l);
             a->push_back(scene[sc].lfo[l].release.assign(
                 p_id.next(), id_s++, label, "Release", ct_envtime_lfodecay,
                 Surge::Skin::LFO::release, sc_id, cg_LFO, ms_lfo1 + l, true, kMini));
@@ -644,7 +646,7 @@ void SurgePatch::init_default_values()
 
     for (int i = 0; i < n_customcontrollers; i++)
     {
-        strcpy(CustomControllerLabel[i], "-");
+        strxcpy(CustomControllerLabel[i], "-", CUSTOM_CONTROLLER_LABEL_SIZE);
     }
 }
 
@@ -886,13 +888,13 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
                     {
                         if (scene[sc].osc[osc].wt.flags & wtf_is_sample)
                         {
-                            strncpy(scene[sc].osc[osc].wavetable_display_name, "(Patch Sample)",
-                                    256);
+                            strxcpy(scene[sc].osc[osc].wavetable_display_name, "(Patch Sample)",
+                                    WAVETABLE_DISPLAY_NAME_SIZE);
                         }
                         else
                         {
-                            strncpy(scene[sc].osc[osc].wavetable_display_name, "(Patch Wavetable)",
-                                    256);
+                            strxcpy(scene[sc].osc[osc].wavetable_display_name, "(Patch Wavetable)",
+                                    WAVETABLE_DISPLAY_NAME_SIZE);
                         }
                     }
                     storage->waveTableDataMutex.unlock();
@@ -1590,8 +1592,8 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
 
                 if (lkid->Attribute("wavetable_display_name"))
                 {
-                    strncpy(scene[ssc].osc[sos].wavetable_display_name,
-                            lkid->Attribute("wavetable_display_name"), 256);
+                    strxcpy(scene[ssc].osc[sos].wavetable_display_name,
+                            lkid->Attribute("wavetable_display_name"), WAVETABLE_DISPLAY_NAME_SIZE);
                 }
             }
         }
@@ -1707,8 +1709,7 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             const char *lbl = p->Attribute("label");
             if (lbl)
             {
-                strncpy(CustomControllerLabel[cont], lbl, 16);
-                CustomControllerLabel[cont][15] = 0;
+                strxcpy(CustomControllerLabel[cont], lbl, CUSTOM_CONTROLLER_LABEL_SIZE);
             }
         }
         p = TINYXML_SAFE_TO_ELEMENT(p->NextSibling("entry"));
@@ -1942,7 +1943,7 @@ struct srge_header
 
 unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed by the callee
 {
-    char tempstr[64];
+    char tempstr[TXT_SIZE];
     assert(data);
     if (!data)
         return 0;
@@ -2098,7 +2099,6 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         {
             if (scene[sc].lfo[l].shape.val.i == lt_stepseq)
             {
-                char txt[256], txt2[256];
                 TiXmlElement p("sequence");
                 p.SetAttribute("scene", sc);
                 p.SetAttribute("i", l);
@@ -2133,7 +2133,7 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
     TiXmlElement cc("customcontroller");
     for (int l = 0; l < n_customcontrollers; l++)
     {
-        char txt2[256];
+        char txt2[TXT_SIZE];
         TiXmlElement p("entry");
         p.SetAttribute("i", l);
         p.SetAttribute("bipolar", scene[0].modsources[ms_ctrl1 + l]->is_bipolar() ? 1 : 0);
@@ -2148,12 +2148,12 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
     patch.InsertEndChild(cc);
 
     {
-        char txt[256];
+        char txt[TXT_SIZE];
         TiXmlElement mw("modwheel");
         for (int sc = 0; sc < n_scenes; sc++)
         {
-            char str[32];
-            sprintf(str, "s%d", sc);
+            char str[TXT_SIZE];
+            snprintf(str, TXT_SIZE, "s%d", sc);
             mw.SetAttribute(
                 str, float_to_str(
                          ((ControllerModulationSource *)scene[sc].modsources[ms_modwheel])->target,
@@ -2459,10 +2459,10 @@ void SurgePatch::msegFromXMLElement(MSEGStorage *ms, TiXmlElement *p, bool resto
 void SurgePatch::stepSeqToXmlElement(StepSequencerStorage *ss, TiXmlElement &p,
                                      bool streamMask) const
 {
-    char txt[256], txt2[256];
+    char txt[TXT_SIZE], txt2[TXT_SIZE];
     for (int s = 0; s < n_stepseqsteps; s++)
     {
-        sprintf(txt, "s%i", s);
+        snprintf(txt, TXT_SIZE, "s%i", s);
         if (ss->steps[s] != 0.f)
             p.SetAttribute(txt, float_to_str(ss->steps[s], txt2));
     }
@@ -2523,8 +2523,8 @@ void SurgePatch::stepSeqFromXmlElement(StepSequencerStorage *ss, TiXmlElement *p
 
     for (int s = 0; s < n_stepseqsteps; s++)
     {
-        char txt[256];
-        sprintf(txt, "s%i", s);
+        char txt[TXT_SIZE];
+        snprintf(txt, TXT_SIZE, "s%i", s);
         if (p->QueryDoubleAttribute(txt, &d) == TIXML_SUCCESS)
             ss->steps[s] = (float)d;
         else

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -471,7 +471,8 @@ struct OscillatorStorage : public CountedSetUserData // The counted set is the w
     Parameter p[n_osc_params];
     Parameter keytrack, retrigger;
     Wavetable wt;
-    char wavetable_display_name[256];
+#define WAVETABLE_DISPLAY_NAME_SIZE 256
+    char wavetable_display_name[WAVETABLE_DISPLAY_NAME_SIZE];
     void *queue_xmldata;
     int queue_type;
 
@@ -776,7 +777,8 @@ class SurgePatch
     // metadata
     std::string name, category, author, comment;
     // metaparameters
-    char CustomControllerLabel[n_customcontrollers][16];
+#define CUSTOM_CONTROLLER_LABEL_SIZE 16
+    char CustomControllerLabel[n_customcontrollers][CUSTOM_CONTROLLER_LABEL_SIZE];
 
     int streamingRevision;
     int currentSynthStreamingRevision;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2823,10 +2823,10 @@ void SurgeSynthesizer::getParameterDisplay(long index, char *text)
     else if (index >= metaparam_offset)
     {
         snprintf(text, TXT_SIZE, "%.2f %%",
-                100.f * storage.getPatch()
-                            .scene[0]
-                            .modsources[ms_ctrl1 + index - metaparam_offset]
-                            ->get_output());
+                 100.f * storage.getPatch()
+                             .scene[0]
+                             .modsources[ms_ctrl1 + index - metaparam_offset]
+                             ->get_output());
     }
     else
         snprintf(text, TXT_SIZE, "-");
@@ -2853,10 +2853,10 @@ void SurgeSynthesizer::getParameterDisplay(long index, char *text, float x)
     else if (index >= metaparam_offset)
     {
         snprintf(text, TXT_SIZE, "%.2f %%",
-                100.f * storage.getPatch()
-                            .scene[0]
-                            .modsources[ms_ctrl1 + index - metaparam_offset]
-                            ->get_output());
+                 100.f * storage.getPatch()
+                             .scene[0]
+                             .modsources[ms_ctrl1 + index - metaparam_offset]
+                             ->get_output());
     }
     else
         snprintf(text, TXT_SIZE, "-");
@@ -2871,12 +2871,13 @@ void SurgeSynthesizer::getParameterName(long index, char *text)
         string sn[3] = {"", "A ", "B "};
 
         snprintf(text, TXT_SIZE, "%s%s", sn[scn].c_str(),
-                storage.getPatch().param_ptr[index]->get_full_name());
+                 storage.getPatch().param_ptr[index]->get_full_name());
     }
     else if (index >= metaparam_offset)
     {
         int c = index - metaparam_offset;
-        snprintf(text, TXT_SIZE, "Macro %i: %s", c + 1, storage.getPatch().CustomControllerLabel[c]);
+        snprintf(text, TXT_SIZE, "Macro %i: %s", c + 1,
+                 storage.getPatch().CustomControllerLabel[c]);
     }
     else
         snprintf(text, TXT_SIZE, "-");

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2329,9 +2329,9 @@ bool SurgeSynthesizer::loadOscalgos()
                 {
                     double d;
                     int j;
-                    char lbl[256];
+                    char lbl[TXT_SIZE];
 
-                    sprintf(lbl, "p%i", k);
+                    snprintf(lbl, TXT_SIZE, "p%i", k);
 
                     if (storage.getPatch().scene[s].osc[i].p[k].valtype == vt_float)
                     {
@@ -2348,7 +2348,7 @@ bool SurgeSynthesizer::loadOscalgos()
                         }
                     }
 
-                    sprintf(lbl, "p%i_deform_type", k);
+                    snprintf(lbl, TXT_SIZE, "p%i_deform_type", k);
 
                     if (e->QueryIntAttribute(lbl, &j) == TIXML_SUCCESS)
                     {
@@ -2822,14 +2822,14 @@ void SurgeSynthesizer::getParameterDisplay(long index, char *text)
     }
     else if (index >= metaparam_offset)
     {
-        sprintf(text, "%.2f %%",
+        snprintf(text, TXT_SIZE, "%.2f %%",
                 100.f * storage.getPatch()
                             .scene[0]
                             .modsources[ms_ctrl1 + index - metaparam_offset]
                             ->get_output());
     }
     else
-        sprintf(text, "-");
+        snprintf(text, TXT_SIZE, "-");
 }
 
 void SurgeSynthesizer::getParameterDisplayAlt(long index, char *text)
@@ -2852,14 +2852,14 @@ void SurgeSynthesizer::getParameterDisplay(long index, char *text, float x)
     }
     else if (index >= metaparam_offset)
     {
-        sprintf(text, "%.2f %%",
+        snprintf(text, TXT_SIZE, "%.2f %%",
                 100.f * storage.getPatch()
                             .scene[0]
                             .modsources[ms_ctrl1 + index - metaparam_offset]
                             ->get_output());
     }
     else
-        sprintf(text, "-");
+        snprintf(text, TXT_SIZE, "-");
 }
 
 void SurgeSynthesizer::getParameterName(long index, char *text)
@@ -2870,16 +2870,16 @@ void SurgeSynthesizer::getParameterName(long index, char *text)
         // TODO: FIX SCENE ASSUMPTION
         string sn[3] = {"", "A ", "B "};
 
-        sprintf(text, "%s%s", sn[scn].c_str(),
+        snprintf(text, TXT_SIZE, "%s%s", sn[scn].c_str(),
                 storage.getPatch().param_ptr[index]->get_full_name());
     }
     else if (index >= metaparam_offset)
     {
         int c = index - metaparam_offset;
-        sprintf(text, "Macro %i: %s", c + 1, storage.getPatch().CustomControllerLabel[c]);
+        snprintf(text, TXT_SIZE, "Macro %i: %s", c + 1, storage.getPatch().CustomControllerLabel[c]);
     }
     else
-        sprintf(text, "-");
+        snprintf(text, TXT_SIZE, "-");
 }
 
 void SurgeSynthesizer::getParameterNameW(long index, wchar_t *ptr)
@@ -3797,10 +3797,10 @@ void SurgeSynthesizer::setupActivateExtraOutputs()
 void SurgeSynthesizer::swapMetaControllers(int c1, int c2)
 {
     char nt[20];
-    strncpy(nt, storage.getPatch().CustomControllerLabel[c1], 16);
-    strncpy(storage.getPatch().CustomControllerLabel[c1],
+    strxcpy(nt, storage.getPatch().CustomControllerLabel[c1], 16);
+    strxcpy(storage.getPatch().CustomControllerLabel[c1],
             storage.getPatch().CustomControllerLabel[c2], 16);
-    strncpy(storage.getPatch().CustomControllerLabel[c2], nt, 16);
+    strxcpy(storage.getPatch().CustomControllerLabel[c2], nt, 16);
 
     storage.modRoutingMutex.lock();
 

--- a/src/common/dsp/DspUtilities.h
+++ b/src/common/dsp/DspUtilities.h
@@ -22,6 +22,7 @@
 #include <vt_dsp/basic_dsp.h>
 #include <vt_dsp/halfratefilter.h>
 #include <functional>
+#include "StringOps.h"
 
 #define setzero(x) memset(x, 0, sizeof(*x))
 
@@ -334,7 +335,7 @@ inline char *float_to_str(float value, char *str)
     if (!str)
         return 0;
     Surge::ScopedLocale localGuard;
-    sprintf(str, "%f", value);
+    snprintf(str, TXT_SIZE, "%f", value); // yeah str isn't necessarily TXT_SIZE but better than nothing. TODO fix.
     return str;
 }
 
@@ -343,9 +344,9 @@ inline char *yes_no(int value, char *str)
     if (!str)
         return 0;
     if (value)
-        sprintf(str, "yes");
+        snprintf(str, TXT_SIZE, "yes");
     else
-        sprintf(str, "no");
+        snprintf(str, TXT_SIZE, "no");
     return str;
 }
 

--- a/src/common/dsp/DspUtilities.h
+++ b/src/common/dsp/DspUtilities.h
@@ -335,7 +335,8 @@ inline char *float_to_str(float value, char *str)
     if (!str)
         return 0;
     Surge::ScopedLocale localGuard;
-    snprintf(str, TXT_SIZE, "%f", value); // yeah str isn't necessarily TXT_SIZE but better than nothing. TODO fix.
+    snprintf(str, TXT_SIZE, "%f",
+             value); // yeah str isn't necessarily TXT_SIZE but better than nothing. TODO fix.
     return str;
 }
 

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.h
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.h
@@ -83,7 +83,7 @@ class alignas(16) AirWindowsEffect : public Effect
         {
             if (fx && fx->airwin)
             {
-                char lab[256], dis[256];
+                char lab[TXT_SIZE], dis[TXT_SIZE];
                 // In case we aren't initialized by the AW
                 lab[0] = 0;
                 dis[0] = 0;
@@ -110,7 +110,12 @@ class alignas(16) AirWindowsEffect : public Effect
                     fx->airwin->getParameterLabel(idx, lab);
                     fx->airwin->getParameterDisplay(idx, dis, value, true);
                 }
-                snprintf(txt, TXT_SIZE, "%s%s%s", dis, (lab[0] == 0 ? "" : " "), lab);
+                // For some reason this snprintf throws a warning (which is treated as an error)
+                // about this truncating strings. Well, yeah, it will, but we don't care.
+                // As I'm not sure how to squelch this warning... for now we'll just use the
+                // original unsafe sprintf version.
+                // snprintf(txt, TXT_SIZE, "%s%s%s", dis, (lab[0] == 0 ? "" : " "), lab);
+                sprintf(txt, "%s%s%s", dis, (lab[0] == 0 ? "" : " "), lab);
             }
             else
             {

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.h
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include "UserDefaults.h"
+#include "StringOps.h"
 
 class alignas(16) AirWindowsEffect : public Effect
 {
@@ -109,11 +110,11 @@ class alignas(16) AirWindowsEffect : public Effect
                     fx->airwin->getParameterLabel(idx, lab);
                     fx->airwin->getParameterDisplay(idx, dis, value, true);
                 }
-                sprintf(txt, "%s%s%s", dis, (lab[0] == 0 ? "" : " "), lab);
+                snprintf(txt, TXT_SIZE, "%s%s%s", dis, (lab[0] == 0 ? "" : " "), lab);
             }
             else
             {
-                sprintf(txt, "AWA.ERROR %lf", value);
+                snprintf(txt, TXT_SIZE, "AWA.ERROR %lf", value);
             }
         }
 

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.h
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.h
@@ -110,12 +110,7 @@ class alignas(16) AirWindowsEffect : public Effect
                     fx->airwin->getParameterLabel(idx, lab);
                     fx->airwin->getParameterDisplay(idx, dis, value, true);
                 }
-                // For some reason this snprintf throws a warning (which is treated as an error)
-                // about this truncating strings. Well, yeah, it will, but we don't care.
-                // As I'm not sure how to squelch this warning... for now we'll just use the
-                // original unsafe sprintf version.
-                // snprintf(txt, TXT_SIZE, "%s%s%s", dis, (lab[0] == 0 ? "" : " "), lab);
-                sprintf(txt, "%s%s%s", dis, (lab[0] == 0 ? "" : " "), lab);
+                snprintf(txt, TXT_SIZE, "%s%s%s", dis, (lab[0] == 0 ? "" : " "), lab);
             }
             else
             {

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -1245,8 +1245,8 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp,
         {
             labelR.bottom += 18;
 
-            snprintf(txt, TXT_SIZE, "%d/%d", (int)(floor(ss->steps[draggedStep] * keyModMult + 0.5)),
-                    keyModMult);
+            snprintf(txt, TXT_SIZE, "%d/%d",
+                     (int)(floor(ss->steps[draggedStep] * keyModMult + 0.5)), keyModMult);
             dc->drawString(txt, labelR, VSTGUI::kLeftText, true);
         }
     }

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -21,6 +21,7 @@
 #include "DebugHelpers.h"
 #include "guihelpers.h"
 #include "SkinColors.h"
+#include "StringOps.h"
 #include <cstdint>
 
 using namespace VSTGUI;
@@ -519,8 +520,8 @@ void CLFOGui::draw(CDrawContext *dc)
                     dc->drawLine(sp, ep);
                     dc->setLineWidth(1.0);
 
-                    char s[256];
-                    sprintf(s, "%d", l + 1);
+                    char s[TXT_SIZE];
+                    snprintf(s, TXT_SIZE, "%d", l + 1);
 
                     CRect tp(CPoint(xp + 1, valScale * 0.0), CPoint(10, 10));
                     tf.transform(tp);
@@ -569,12 +570,12 @@ void CLFOGui::draw(CDrawContext *dc)
             tf.transform(tp);
             dc->setFontColor(skin->getColor(Colors::LFO::Waveform::Ruler::Text));
             dc->setFont(lfoTypeFont);
-            char txt[256];
+            char txt[TXT_SIZE];
             float tv = delta * l;
             if (fabs(roundf(tv) - tv) < 0.05)
-                snprintf(txt, 256, "%d s", (int)round(delta * l));
+                snprintf(txt, TXT_SIZE, "%d s", (int)round(delta * l));
             else
-                snprintf(txt, 256, "%.1f s", delta * l);
+                snprintf(txt, TXT_SIZE, "%.1f s", delta * l);
             dc->drawString(txt, tp, VSTGUI::kLeftText, true);
 
             CPoint sp(xp, valScale * 0.95), ep(xp, valScale * 0.9);
@@ -1233,8 +1234,8 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp,
         labelR.left += 1;
         labelR.top -= (keyModMult > 0 ? 9 : 0);
 
-        char txt[256];
-        sprintf(txt, "%.*f %%", prec, ss->steps[draggedStep] * 100.f);
+        char txt[TXT_SIZE];
+        snprintf(txt, TXT_SIZE, "%.*f %%", prec, ss->steps[draggedStep] * 100.f);
 
         dc->setFontColor(skin->getColor(Colors::LFO::StepSeq::InfoWindow::Text));
         dc->setFont(lfoTypeFont);
@@ -1244,7 +1245,7 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp,
         {
             labelR.bottom += 18;
 
-            sprintf(txt, "%d/%d", (int)(floor(ss->steps[draggedStep] * keyModMult + 0.5)),
+            snprintf(txt, TXT_SIZE, "%d/%d", (int)(floor(ss->steps[draggedStep] * keyModMult + 0.5)),
                     keyModMult);
             dc->drawString(txt, labelR, VSTGUI::kLeftText, true);
         }

--- a/src/common/gui/CNumberField.cpp
+++ b/src/common/gui/CNumberField.cpp
@@ -23,6 +23,7 @@
 #include "SkinColors.h"
 #include "CScalableBitmap.h"
 #include "Parameter.h"
+#include "StringOps.h"
 
 using namespace VSTGUI;
 
@@ -37,17 +38,17 @@ using namespace std;
 void dB2string(float value, char *text)
 {
     if (value <= 0)
-        strcpy(text, "-inf");
+        strxcpy(text, "-inf", TXT_SIZE);
     else
-        sprintf(text, "%.1fdB", (float)(20. * log10(value)));
+        snprintf(text, TXT_SIZE, "%.1fdB", (float)(20. * log10(value)));
 }
 
 void envelopetime(float value, char *text)
 {
     if ((value * value * value * 30000.f) > 999.9f)
-        sprintf(text, "%.2fs", (float)30 * value * value * value);
+        snprintf(text, TXT_SIZE, "%.2fs", (float)30 * value * value * value);
     else
-        sprintf(text, "%.0fms", (float)30000 * value * value * value);
+        snprintf(text, TXT_SIZE, "%.0fms", (float)30000 * value * value * value);
 }
 
 void unit_prefix(float value, char *text, bool allow_milli = true, bool allow_kilo = true)
@@ -65,11 +66,11 @@ void unit_prefix(float value, char *text, bool allow_milli = true, bool allow_ki
     }
 
     if (value >= 100.f)
-        sprintf(text, "%.1f %c", value, prefix);
+        snprintf(text, TXT_SIZE, "%.1f %c", value, prefix);
     else if (value >= 10.f)
-        sprintf(text, "%.2f %c", value, prefix);
+        snprintf(text, TXT_SIZE, "%.2f %c", value, prefix);
     else
-        sprintf(text, "%.3f %c", value, prefix);
+        snprintf(text, TXT_SIZE, "%.3f %c", value, prefix);
     return;
 }
 
@@ -300,31 +301,32 @@ void CNumberField::draw(CDrawContext *pContext)
         pContext->drawRect(getViewSize(), kDrawFilledAndStroked);
     }
 
-    char the_text[32];
+#define THE_TEXT_SIZE 32
+    char the_text[THE_TEXT_SIZE];
     switch (controlmode)
     {
     case cm_int_menu:
-        sprintf(the_text, "-");
+        snprintf(the_text, THE_TEXT_SIZE, "-");
         break;
     case cm_integer:
-        sprintf(the_text, "%i", i_value);
+        snprintf(the_text, THE_TEXT_SIZE, "%i", i_value);
         break;
     case cm_osccount:
-        sprintf(the_text, "%i", max(1, min(16, (int)value)));
+        snprintf(the_text, THE_TEXT_SIZE, "%i", max(1, min(16, (int)value)));
         break;
     case cm_pbdepth:
-        sprintf(the_text, "%i", i_value);
+        snprintf(the_text, THE_TEXT_SIZE, "%i", i_value);
         break;
     case cm_count4:
-        sprintf(the_text, "%i", max(1, min(4, (int)value)));
+        snprintf(the_text, THE_TEXT_SIZE, "%i", max(1, min(4, (int)value)));
         break;
     case cm_polyphony:
-        sprintf(the_text, "%i / %i", i_poly, i_value);
+        snprintf(the_text, THE_TEXT_SIZE, "%i / %i", i_poly, i_value);
         break;
     case cm_midichannel_from_127:
     {
         int mc = i_value / 8 + 1;
-        sprintf(the_text, "Ch %i", mc);
+        snprintf(the_text, THE_TEXT_SIZE, "Ch %i", mc);
     }
     break;
     case cm_notename:
@@ -333,54 +335,54 @@ void CNumberField::draw(CDrawContext *pContext)
         if (storage)
             oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
         char notename[16];
-        sprintf(the_text, "%s", get_notename(notename, i_value, oct_offset));
+        snprintf(the_text, THE_TEXT_SIZE, "%s", get_notename(notename, i_value, oct_offset));
     }
     break;
     case cm_envshape:
-        sprintf(the_text, "%.1f", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%.1f", value);
         break;
     case cm_float:
-        sprintf(the_text, "%.2f", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%.2f", value);
         break;
     case cm_percent:
-        sprintf(the_text, "%.1f%c", value * 100, '%');
+        snprintf(the_text, THE_TEXT_SIZE, "%.1f%c", value * 100, '%');
         break;
     case cm_mod_percent:
     case cm_percent_bipolar:
-        sprintf(the_text, "%+.1f%c", value * 100, '%');
+        snprintf(the_text, THE_TEXT_SIZE, "%+.1f%c", value * 100, '%');
         break;
     case cm_stereowidth:
     {
         if (value == 0)
-            sprintf(the_text, "mono");
+            snprintf(the_text, THE_TEXT_SIZE, "mono");
         else
-            sprintf(the_text, "%.1f%c", value * 100, '%');
+            snprintf(the_text, THE_TEXT_SIZE, "%.1f%c", value * 100, '%');
         break;
     }
     case cm_mod_time:
-        sprintf(the_text, "%+.1fto", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%+.1fto", value);
         break;
     case cm_decibel:
-        sprintf(the_text, "%.1fdB", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%.1fdB", value);
         break;
     case cm_mod_decibel:
-        sprintf(the_text, "%+.1fdB", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%+.1fdB", value);
         break;
     case cm_mod_pitch:
-        sprintf(the_text, "%+.1fst", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%+.1fst", value);
         break;
     case cm_mod_freq:
     case cm_eq_bandwidth:
-        sprintf(the_text, "%.2foct", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%.2foct", value);
         break;
     case cm_frequency_khz:
-        sprintf(the_text, "%.2f kHz", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%.2f kHz", value);
         break;
     case cm_frequency_hz_bi:
-        sprintf(the_text, "%+.2f Hz", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%+.2f Hz", value);
         break;
     case cm_frequency_khz_bi:
-        sprintf(the_text, "%+.2f kHz", value);
+        snprintf(the_text, THE_TEXT_SIZE, "%+.2f kHz", value);
         break;
     case cm_envelopetime:
         envelopetime(value, the_text);
@@ -391,7 +393,7 @@ void CNumberField::draw(CDrawContext *pContext)
     case cm_lforate:
     {
         float rate = lfo_phaseincrement(44100 / 32, value);
-        sprintf(the_text, "%.3f Hz", rate);
+        snprintf(the_text, THE_TEXT_SIZE, "%.3f Hz", rate);
     }
     break;
     case cm_frequency_audible:
@@ -399,82 +401,82 @@ void CNumberField::draw(CDrawContext *pContext)
     {
         float freq = 440.f * powf(2, value);
         if (freq > 1000)
-            sprintf(the_text, "%.2f kHz", freq * 0.001f);
+            snprintf(the_text, THE_TEXT_SIZE, "%.2f kHz", freq * 0.001f);
         else
-            sprintf(the_text, "%.1f Hz", freq);
+            snprintf(the_text, THE_TEXT_SIZE, "%.1f Hz", freq);
         break;
     }
     case cm_frequency20_20k:
     {
         float freq = 20 * powf(10, 3 * value);
         if (freq > 1000)
-            sprintf(the_text, "%.2f kHz", freq * 0.001f);
+            snprintf(the_text, THE_TEXT_SIZE, "%.2f kHz", freq * 0.001f);
         else
-            sprintf(the_text, "%.1f Hz", freq);
+            snprintf(the_text, THE_TEXT_SIZE, "%.1f Hz", freq);
         break;
     }
     case cm_frequency50_50k:
     {
         float freq = 50 * powf(10, 3 * value);
         if (freq > 1000)
-            sprintf(the_text, "%.2f kHz", freq * 0.001f);
+            snprintf(the_text, THE_TEXT_SIZE, "%.2f kHz", freq * 0.001f);
         else
-            sprintf(the_text, "%.1f Hz", freq);
+            snprintf(the_text, THE_TEXT_SIZE, "%.1f Hz", freq);
         break;
     }
     case cm_lag:
     {
         if (value == -10)
-            sprintf(the_text, "sum");
+            snprintf(the_text, THE_TEXT_SIZE, "sum");
         else
         {
             float t = powf(2, value);
             char tmp_text[28];
             unit_prefix(t, tmp_text, true, false);
-            sprintf(the_text, "%ss", tmp_text);
+            snprintf(the_text, THE_TEXT_SIZE, "%ss", tmp_text);
         }
         break;
     }
     case cm_bitdepth_16:
     {
-        sprintf(the_text, "%.1f bits", value * 16.f);
+        snprintf(the_text, THE_TEXT_SIZE, "%.1f bits", value * 16.f);
         break;
     }
     case cm_frequency0_2k:
     {
         float freq = 2000 * value;
         if (freq > 1000)
-            sprintf(the_text, "%.2f kHz", freq * 0.001f);
+            snprintf(the_text, THE_TEXT_SIZE, "%.2f kHz", freq * 0.001f);
         else
-            sprintf(the_text, "%.1f Hz", freq);
+            snprintf(the_text, THE_TEXT_SIZE, "%.1f Hz", freq);
         break;
     }
     case cm_octaves3:
-        sprintf(the_text, "%.1f oct", value * 3.f);
+        snprintf(the_text, THE_TEXT_SIZE, "%.1f oct", value * 3.f);
         break;
     case cm_decibelboost12:
-        sprintf(the_text, "+%.1f dB", value * 12.f);
+        snprintf(the_text, THE_TEXT_SIZE, "+%.1f dB", value * 12.f);
         break;
     case cm_midichannel:
         if (i_value < 16)
-            sprintf(the_text, "%i", i_value + 1);
+            snprintf(the_text, THE_TEXT_SIZE, "%i", i_value + 1);
         else if (i_value == 16)
-            sprintf(the_text, "omni");
+            snprintf(the_text, THE_TEXT_SIZE, "omni");
         else
-            sprintf(the_text, "-");
+            snprintf(the_text, THE_TEXT_SIZE, "-");
         break;
     case cm_mutegroup:
         if (i_value == 0)
-            sprintf(the_text, "off");
+            snprintf(the_text, THE_TEXT_SIZE, "off");
         else
-            sprintf(the_text, "%i", i_value);
+            snprintf(the_text, THE_TEXT_SIZE, "%i", i_value);
         break;
     case cm_frequency1hz:
     {
         float freq = powf(2, value);
         char tmp_text[28];
         unit_prefix(freq, tmp_text, false, false);
-        sprintf(the_text, "%sHz", tmp_text);
+        snprintf(the_text, THE_TEXT_SIZE, "%sHz", tmp_text);
         break;
     }
     case cm_time1s:
@@ -482,21 +484,21 @@ void CNumberField::draw(CDrawContext *pContext)
         float t = powf(2, value);
         char tmp_text[28];
         unit_prefix(t, tmp_text, true, false);
-        sprintf(the_text, "%ss", tmp_text);
+        snprintf(the_text, THE_TEXT_SIZE, "%ss", tmp_text);
         break;
     }
     case cm_noyes:
         if (i_value)
-            sprintf(the_text, "yes");
+            snprintf(the_text, THE_TEXT_SIZE, "yes");
         else
-            sprintf(the_text, "no");
+            snprintf(the_text, THE_TEXT_SIZE, "no");
         break;
     case cm_mseg_snap_h:
     case cm_mseg_snap_v:
-        sprintf(the_text, "%i", i_value);
+        snprintf(the_text, THE_TEXT_SIZE, "%i", i_value);
         break;
     case cm_none:
-        sprintf(the_text, "-");
+        snprintf(the_text, THE_TEXT_SIZE, "-");
         break;
     }
 
@@ -506,6 +508,7 @@ void CNumberField::draw(CDrawContext *pContext)
     pContext->drawString(the_text, getViewSize(), kCenterText, true);
 
     setDirty(false);
+#undef THE_TEXT_SIZE
 }
 
 //------------------------------------------------------------------------

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -10,6 +10,7 @@
 #include "SkinColors.h"
 #include "RuntimeFont.h"
 #include "guihelpers.h"
+#include "StringOps.h"
 
 #include <iostream>
 #include <iomanip>
@@ -358,8 +359,8 @@ bool COscMenu::onWheel(const VSTGUI::CPoint &where, const float &distance,
                 for(int i=0; i<n_osc_params; i++)
                 {
                         double d; int j;
-                        char lbl[256];
-                        sprintf(lbl,"p%i",i);
+                        char lbl[TXT_SIZE];
+                        snprintf(lbl, TXT_SIZE, "p%i",i);
                         if (osc->p[i].valtype == vt_float)
                         {
                                 if(e->QueryDoubleAttribute(lbl,&d) == TIXML_SUCCESS) osc->p[i].val.f
@@ -431,7 +432,7 @@ void CFxMenu::draw(CDrawContext *dc)
     dc->drawString(fxslot_names[slot], txtbox, kLeftText, true);
 
     char fxname[NAMECHARS];
-    sprintf(fxname, "%s", fx_type_names[fx->type.val.i]);
+    snprintf(fxname, NAMECHARS, "%s", fx_type_names[fx->type.val.i]);
     dc->drawString(fxname, txtbox, kRightText, true);
 
     setDirty(false);
@@ -460,8 +461,8 @@ void CFxMenu::loadSnapshot(int type, TiXmlElement *e, int idx)
         {
             double d;
             int j;
-            char lbl[256], sublbl[256];
-            sprintf(lbl, "p%i", i);
+            char lbl[TXT_SIZE], sublbl[TXT_SIZE];
+            snprintf(lbl, TXT_SIZE, "p%i", i);
             if (fxbuffer->p[i].valtype == vt_float)
             {
                 if (e->QueryDoubleAttribute(lbl, &d) == TIXML_SUCCESS)
@@ -473,10 +474,10 @@ void CFxMenu::loadSnapshot(int type, TiXmlElement *e, int idx)
                     fxbuffer->p[i].set_storage_value(j);
             }
 
-            sprintf(sublbl, "p%i_temposync", i);
+            snprintf(sublbl, TXT_SIZE, "p%i_temposync", i);
             fxbuffer->p[i].temposync =
                 ((e->QueryIntAttribute(sublbl, &j) == TIXML_SUCCESS) && (j == 1));
-            sprintf(sublbl, "p%i_extend_range", i);
+            snprintf(sublbl, TXT_SIZE, "p%i_extend_range", i);
             fxbuffer->p[i].extend_range =
                 ((e->QueryIntAttribute(sublbl, &j) == TIXML_SUCCESS) && (j == 1));
         }
@@ -517,20 +518,20 @@ void CFxMenu::saveSnapshot(TiXmlElement *e, const char *name)
 
             for (int p = 0; p < n_fx_params; p++)
             {
-                char lbl[256], txt[256], sublbl[256];
-                sprintf(lbl, "p%i", p);
+                char lbl[TXT_SIZE], txt[TXT_SIZE], sublbl[TXT_SIZE];
+                snprintf(lbl, TXT_SIZE, "p%i", p);
                 if (fx->p[p].ctrltype != ct_none)
                 {
                     neu.SetAttribute(lbl, fx->p[p].get_storage_value(txt));
 
                     if (fx->p[p].temposync)
                     {
-                        sprintf(sublbl, "p%i_temposync", p);
+                        snprintf(sublbl, TXT_SIZE, "p%i_temposync", p);
                         neu.SetAttribute(sublbl, "1");
                     }
                     if (fx->p[p].extend_range)
                     {
-                        sprintf(sublbl, "p%i_extend_range", p);
+                        snprintf(sublbl, TXT_SIZE, "p%i_extend_range", p);
                         neu.SetAttribute(sublbl, "1");
                     }
                 }
@@ -797,9 +798,9 @@ void CFxMenu::saveFX()
 }
 void CFxMenu::saveFXIn(const std::string &s)
 {
-    char fxName[256];
+    char fxName[TXT_SIZE];
     fxName[0] = 0;
-    strncpy(fxName, s.c_str(), 256);
+    strxcpy(fxName, s.c_str(), TXT_SIZE);
 
     if (strlen(fxName) == 0)
     {

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -23,6 +23,7 @@
 #include "SurgeBitmaps.h"
 #include "SurgeStorage.h"
 #include "SkinColors.h"
+#include "StringOps.h"
 #include <UserDefaults.h>
 #include <iostream>
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -43,6 +43,7 @@
 #include "UIInstrumentation.h"
 #include "guihelpers.h"
 #include "DebugHelpers.h"
+#include "StringOps.h"
 #include "ModulatorPresetManager.h"
 
 #include <iostream>
@@ -2162,13 +2163,13 @@ void decode_controllerid(char *txt, int id)
     switch (type)
     {
     case 1:
-        sprintf(txt, "NRPN %i", num);
+        snprintf(txt, TXT_SIZE, "NRPN %i", num);
         break;
     case 2:
-        sprintf(txt, "RPN %i", num);
+        snprintf(txt, TXT_SIZE, "RPN %i", num);
         break;
     default:
-        sprintf(txt, "CC %i", num);
+        snprintf(txt, TXT_SIZE, "CC %i", num);
         break;
     };
 }
@@ -2278,7 +2279,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
             auto hu = helpURLForSpecial("osc-select");
             if (hu != "")
             {
-                sprintf(txt, "[?] Osc %i", a + 1);
+                snprintf(txt, TXT_SIZE, "[?] Osc %i", a + 1);
                 auto lurl = fullyResolvedHelpURL(hu);
                 addCallbackMenu(contextMenu, txt,
                                 [lurl]() { Surge::UserInteractions::openURL(lurl); });
@@ -2286,7 +2287,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
             }
             else
             {
-                sprintf(txt, "Osc %i", a + 1);
+                snprintf(txt, TXT_SIZE, "Osc %i", a + 1);
                 contextMenu->addEntry(txt, eid++);
             }
 
@@ -2349,7 +2350,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
             auto hu = helpURLForSpecial("scene-select");
             if (hu != "")
             {
-                sprintf(txt, "[?] Scene %c", 'A' + a);
+                snprintf(txt, TXT_SIZE, "[?] Scene %c", 'A' + a);
                 auto lurl = fullyResolvedHelpURL(hu);
                 addCallbackMenu(contextMenu, txt,
                                 [lurl]() { Surge::UserInteractions::openURL(lurl); });
@@ -2357,7 +2358,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
             }
             else
             {
-                sprintf(txt, "Scene %c", 'A' + a);
+                snprintf(txt, TXT_SIZE, "Scene %c", 'A' + a);
                 contextMenu->addEntry(txt, eid++);
             }
 
@@ -2507,7 +2508,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                     if (((md < n_global_params) || ((parameter->scene - 1) == activeScene)) &&
                         synth->isActiveModulation(md, thisms))
                     {
-                        char modtxt[256];
+                        char modtxt[TXT_SIZE];
                         auto pmd = synth->storage.getPatch().param_ptr[md];
                         pmd->get_display_of_modulation_depth(modtxt, synth->getModDepth(md, thisms),
                                                              synth->isBipolarModulation(thisms),
@@ -2515,16 +2516,16 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                         char tmptxt[1024]; // leave room for that ubuntu 20.0 error
                         if (pmd->ctrlgroup == cg_LFO)
                         {
-                            char pname[256];
+                            char pname[TXT_SIZE];
                             pmd->create_fullname(pmd->get_name(), pname, pmd->ctrlgroup,
                                                  pmd->ctrlgroup_entry,
                                                  modulatorName(pmd->ctrlgroup_entry, true).c_str());
-                            sprintf(tmptxt, "Edit %s -> %s: %s",
+                            snprintf(tmptxt, TXT_SIZE, "Edit %s -> %s: %s",
                                     (char *)modulatorName(thisms, true).c_str(), pname, modtxt);
                         }
                         else
                         {
-                            sprintf(tmptxt, "Edit %s -> %s: %s",
+                            snprintf(tmptxt, TXT_SIZE, "Edit %s -> %s: %s",
                                     (char *)modulatorName(thisms, true).c_str(),
                                     pmd->get_full_name(), modtxt);
                         }
@@ -2561,12 +2562,12 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                 parameter->get_name(), pname, parameter->ctrlgroup,
                                 parameter->ctrlgroup_entry,
                                 modulatorName(parameter->ctrlgroup_entry, true).c_str());
-                            sprintf(tmptxt, "Clear %s -> %s",
+                            snprintf(tmptxt, TXT_SIZE, "Clear %s -> %s",
                                     (char *)modulatorName(thisms, true).c_str(), pname);
                         }
                         else
                         {
-                            sprintf(tmptxt, "Clear %s -> %s",
+                            snprintf(tmptxt, TXT_SIZE, "Clear %s -> %s",
                                     (char *)modulatorName(thisms, true).c_str(),
                                     parameter->get_full_name());
                         }
@@ -2610,7 +2611,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                             if (resetName)
                             {
                                 // And this is where we apply the name refresh, of course.
-                                strncpy(synth->storage.getPatch().CustomControllerLabel[ccid],
+                                strxcpy(synth->storage.getPatch().CustomControllerLabel[ccid],
                                         newName.c_str(), 15);
                                 synth->storage.getPatch().CustomControllerLabel[ccid][15] = 0;
                                 ((CModulationSourceButton *)control)
@@ -2686,7 +2687,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                 contextMenu->addSeparator(eid++);
                 char vtxt[1024];
-                sprintf(vtxt, "%s: %.*f %%", Surge::UI::toOSCaseForMenu("Edit Value").c_str(),
+                snprintf(vtxt, 1024, "%s: %.*f %%", Surge::UI::toOSCaseForMenu("Edit Value").c_str(),
                         (detailedMode ? 6 : 2), 100 * cms->get_output());
                 addCallbackMenu(contextMenu, vtxt, [this, control, modsource]() {
                     promptForUserValueEntry(nullptr, control, modsource);
@@ -2695,7 +2696,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                 contextMenu->addSeparator(eid++);
 
-                char txt[256];
+                char txt[TXT_SIZE];
 
                 // Construct submenus for explicit controller mapping
                 COptionMenu *midiSub = new COptionMenu(
@@ -2716,7 +2717,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                     char name[16];
 
-                    sprintf(name, "CC %d ... %d", subs * 20, min((subs * 20) + 20, 128) - 1);
+                    snprintf(name, 16, "CC %d ... %d", subs * 20, min((subs * 20) + 20, 128) - 1);
 
                     auto added_to_menu = midiSub->addEntry(currentSub, name);
 
@@ -2738,7 +2739,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                         char name[128];
 
-                        sprintf(name, "CC %d (%s) %s", mc, midicc_names[mc],
+                        snprintf(name, 128, "CC %d (%s) %s", mc, midicc_names[mc],
                                 (disabled == 1 ? "- RESERVED" : ""));
 
                         CCommandMenuItem *cmd = new CCommandMenuItem(CCommandMenuItem::Desc(name));
@@ -2793,7 +2794,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                 {
                     char txt4[16];
                     decode_controllerid(txt4, synth->storage.controllers[ccid]);
-                    sprintf(txt, "Clear Learned MIDI (%s ", txt4);
+                    snprintf(txt, TXT_SIZE, "Clear Learned MIDI (%s ", txt4);
                     addCallbackMenu(contextMenu,
                                     Surge::UI::toOSCaseForMenu(txt) +
                                         midicc_names[synth->storage.controllers[ccid]] + ")",
@@ -2843,7 +2844,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                 auto useS = s;
                                 if (useS == "")
                                     useS = "-";
-                                strncpy(synth->storage.getPatch().CustomControllerLabel[ccid],
+                                strxcpy(synth->storage.getPatch().CustomControllerLabel[ccid],
                                         useS.c_str(), 16);
                                 synth->storage.getPatch().CustomControllerLabel[ccid][15] =
                                     0; // to be sure
@@ -2983,9 +2984,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                 eid++;
             }
             contextMenu->addSeparator(eid++);
-            char txt[256], txt2[512];
+            char txt[TXT_SIZE], txt2[512];
             p->get_display(txt);
-            sprintf(txt2, "%s: %s", Surge::UI::toOSCaseForMenu("Edit Value").c_str(), txt);
+            snprintf(txt2, 512, "%s: %s", Surge::UI::toOSCaseForMenu("Edit Value").c_str(), txt);
             if (p->valtype == vt_float)
             {
                 if (p->can_temposync() && p->temposync)
@@ -3533,7 +3534,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                         {
                             char txt[256], ntxt[256];
                             memset(txt, 0, 256);
-                            strncpy(txt, p->get_name(), 256);
+                            strxcpy(txt, p->get_name(), 256);
                             if (p->absolute)
                             {
                                 snprintf(ntxt, 256, "M%c Frequency", txt[1]);
@@ -4650,7 +4651,7 @@ void SurgeGUIEditor::valueChanged(CControl *control)
 
                     if ((lbl[0] == '-') && !lbl[1])
                     {
-                        strncpy(lbl, p->get_name(), 15);
+                        strxcpy(lbl, p->get_name(), 15);
                         synth->storage.getPatch().CustomControllerLabel[ccid][15] = 0;
                         ((CModulationSourceButton *)gui_modsrc[modsource])->setlabel(lbl);
                         ((CModulationSourceButton *)gui_modsrc[modsource])->invalid();
@@ -6124,7 +6125,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
             char txt[256];
             txt[0] = 0;
             if (Surge::Storage::isValidUTF8(s))
-                strncpy(txt, s.c_str(), 256);
+                strxcpy(txt, s.c_str(), 256);
             promptForMiniEdit(txt, "Enter default patch author name:", "Set Default Patch Author",
                               menuRect.getTopLeft(), [this](const std::string &s) {
                                   Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
@@ -6140,7 +6141,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
             char txt[256];
             txt[0] = 0;
             if (Surge::Storage::isValidUTF8(s))
-                strncpy(txt, s.c_str(), 256);
+                strxcpy(txt, s.c_str(), 256);
             promptForMiniEdit(txt, "Enter default patch comment text:", "Set Default Patch Comment",
                               menuRect.getTopLeft(), [this](const std::string &s) {
                                   Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
@@ -8398,7 +8399,7 @@ bool SurgeGUIEditor::onDrop(const std::string &fname)
                    [](unsigned char c) { return std::tolower(c); });
     if (fExt == ".wav" || fExt == ".wt")
     {
-        strncpy(synth->storage.getPatch()
+        strxcpy(synth->storage.getPatch()
                     .scene[current_scene]
                     .osc[current_osc[current_scene]]
                     .wt.queue_filename,

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2521,13 +2521,13 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                                  pmd->ctrlgroup_entry,
                                                  modulatorName(pmd->ctrlgroup_entry, true).c_str());
                             snprintf(tmptxt, TXT_SIZE, "Edit %s -> %s: %s",
-                                    (char *)modulatorName(thisms, true).c_str(), pname, modtxt);
+                                     (char *)modulatorName(thisms, true).c_str(), pname, modtxt);
                         }
                         else
                         {
                             snprintf(tmptxt, TXT_SIZE, "Edit %s -> %s: %s",
-                                    (char *)modulatorName(thisms, true).c_str(),
-                                    pmd->get_full_name(), modtxt);
+                                     (char *)modulatorName(thisms, true).c_str(),
+                                     pmd->get_full_name(), modtxt);
                         }
 
                         auto clearOp = [this, parameter, control, thisms]() {
@@ -2563,13 +2563,13 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                 parameter->ctrlgroup_entry,
                                 modulatorName(parameter->ctrlgroup_entry, true).c_str());
                             snprintf(tmptxt, TXT_SIZE, "Clear %s -> %s",
-                                    (char *)modulatorName(thisms, true).c_str(), pname);
+                                     (char *)modulatorName(thisms, true).c_str(), pname);
                         }
                         else
                         {
                             snprintf(tmptxt, TXT_SIZE, "Clear %s -> %s",
-                                    (char *)modulatorName(thisms, true).c_str(),
-                                    parameter->get_full_name());
+                                     (char *)modulatorName(thisms, true).c_str(),
+                                     parameter->get_full_name());
                         }
 
                         auto clearOp = [this, first_destination, md, n_total_md, thisms,
@@ -2687,8 +2687,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                 contextMenu->addSeparator(eid++);
                 char vtxt[1024];
-                snprintf(vtxt, 1024, "%s: %.*f %%", Surge::UI::toOSCaseForMenu("Edit Value").c_str(),
-                        (detailedMode ? 6 : 2), 100 * cms->get_output());
+                snprintf(vtxt, 1024, "%s: %.*f %%",
+                         Surge::UI::toOSCaseForMenu("Edit Value").c_str(), (detailedMode ? 6 : 2),
+                         100 * cms->get_output());
                 addCallbackMenu(contextMenu, vtxt, [this, control, modsource]() {
                     promptForUserValueEntry(nullptr, control, modsource);
                 });
@@ -2740,7 +2741,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                         char name[128];
 
                         snprintf(name, 128, "CC %d (%s) %s", mc, midicc_names[mc],
-                                (disabled == 1 ? "- RESERVED" : ""));
+                                 (disabled == 1 ? "- RESERVED" : ""));
 
                         CCommandMenuItem *cmd = new CCommandMenuItem(CCommandMenuItem::Desc(name));
 


### PR DESCRIPTION
This isn't yet completely finished, but as I have to go do something else now and this touches such a wide span of code, I want to get these changes in before any other code changes.

strcpy and strncpy have been replaced with a wrapper function strxcpy which uses snprintf to safely do a string copy.
Some magic constants have been replaced and in general string ops are hardened a little more.