### PR TITLE
Add Phaser/Neuron rate deactivation (scrub LFO phase)

### DIFF
--- a/src/common/dsp/effect/FlangerEffect.cpp
+++ b/src/common/dsp/effect/FlangerEffect.cpp
@@ -64,6 +64,7 @@ void FlangerEffect::process(float *dataL, float *dataR)
 
     int mode = *pdata_ival[fl_mode];
     int mwave = *pdata_ival[fl_wave];
+    float depth_val = limit_range(*f[fl_depth], 0.f, 2.f);
 
     float v0 = *f[fl_voice_basepitch];
     vzeropitch.newValue(v0);
@@ -190,7 +191,7 @@ void FlangerEffect::process(float *dataL, float *dataR)
 
             // OK so biggest tap = delaybase[c][i].v * ( 1.0 + lfoval[c][i].v * depth.v ) + 1;
             // Assume lfoval is [-1,1] and depth is known
-            float maxtap = nv * (1.0 + limit_range(*f[fl_depth], 0.f, 2.f)) + 1;
+            float maxtap = nv * (1.0 + depth_val) + 1;
             if (maxtap >= InterpDelay::DELAY_SIZE)
             {
                 nv = nv * 0.999 * InterpDelay::DELAY_SIZE / maxtap;
@@ -202,14 +203,14 @@ void FlangerEffect::process(float *dataL, float *dataR)
     averageDelayBase /= (2 * COMBS_PER_CHANNEL);
     vzeropitch.process();
 
-    float dApprox = rate * samplerate / BLOCK_SIZE * averageDelayBase * *f[fl_depth];
+    float dApprox = rate * samplerate / BLOCK_SIZE * averageDelayBase * depth_val;
 
-    depth.newValue(limit_range(*f[fl_depth], 0.f, 2.f));
+    depth.newValue(depth_val);
     mix.newValue(*f[fl_mix]);
     voices.newValue(limit_range(*f[fl_voices], 1.f, 4.f));
     float feedbackScale = 0.4 * sqrt((limit_range(dApprox, 2.f, 60.f) + 30) / 100.0);
 
-    // Feedbackadjust based on mode
+    // Feedback adjust based on mode
     switch (mode)
     {
     case flm_classic:

--- a/src/common/dsp/effect/ModControl.h
+++ b/src/common/dsp/effect/ModControl.h
@@ -160,7 +160,7 @@ class ModControl
 
             break;
         }
-        case mod_snh: // Sample & Hold random
+        case mod_snh:   // Sample & Hold random
         case mod_noise: // noise (Sample & Glide smoothed random)
         {
             if (lforeset)

--- a/src/common/dsp/effect/ModControl.h
+++ b/src/common/dsp/effect/ModControl.h
@@ -37,7 +37,7 @@ class ModControl
         mod_sine = 0,
         mod_tri,
         mod_saw,
-        mod_sng,
+        mod_noise,
         mod_snh,
         mod_square,
     };
@@ -45,17 +45,38 @@ class ModControl
     inline void pre_process(int mwave, float rate, float depth_val, float phase_offset)
     {
         bool lforeset = false;
+        bool rndreset = false;
         float lfoout = lfoval.v;
         float phofs = fmod(fabs(phase_offset), 1.0);
+        float thisrate = std::max(0.f, rate);
+        float thisphase;
 
-        lfophase += rate;
-
-        if (lfophase > 1)
+        if (thisrate > 0)
         {
-            lfophase = fmod(lfophase, 1.0);
-        }
+            lfophase += thisrate;
 
-        float thisphase = lfophase + phofs;
+            if (lfophase > 1)
+            {
+                lfophase = fmod(lfophase, 1.0);
+            }
+
+            thisphase = lfophase + phofs;
+        }
+        else
+        {
+            thisphase = phofs;
+
+            if (mwave == mod_noise || mwave == mod_snh)
+            {
+                thisphase *= 16.f;
+
+                if ((int)thisphase != (int)lfophase)
+                {
+                    rndreset = true;
+                    lfophase = (float)((int)thisphase);
+                }
+            }
+        }
 
         if (thisphase > 1)
         {
@@ -64,7 +85,7 @@ class ModControl
 
         /* We want to catch the first time that thisphase trips over the threshold. There's a couple
          * of ways to do this (like have a state variable), but this should work just as well. */
-        if (thisphase - rate <= 0)
+        if ((thisrate > 0 && thisphase - thisrate <= 0) || (thisrate == 0 && rndreset))
         {
             lforeset = true;
         }
@@ -140,18 +161,21 @@ class ModControl
             break;
         }
         case mod_snh: // Sample & Hold random
-        case mod_sng: // Sample & Glide smoothed random
+        case mod_noise: // noise (Sample & Glide smoothed random)
         {
             if (lforeset)
             {
                 lfosandhtarget = 1.f * rand() / (float)RAND_MAX - 1.f;
             }
 
-            if (mwave == mod_sng)
+            if (mwave == mod_noise)
             {
                 // FIXME - exponential creep up. We want to get there in a time related to our rate
                 auto cv = lfoval.v;
-                auto diff = (lfosandhtarget - cv) * rate * 2;
+                // thisphase * 0.98 prevents a glitch when LFO rate is disabled and phase offset is
+                // 1 which constantly retriggers S&G
+                thisrate = (rate == 0) ? thisphase * 0.98 : thisrate;
+                auto diff = (lfosandhtarget - cv) * thisrate * 2;
                 lfoval.newValue(cv + diff);
             }
             else

--- a/src/common/dsp/effect/PhaserEffect.cpp
+++ b/src/common/dsp/effect/PhaserEffect.cpp
@@ -122,8 +122,8 @@ void PhaserEffect::setvars()
             double omega = biquad[2 * i]->calc_omega(2 * *f[ph_center] + *f[ph_spread] * center +
                                                      2.0 / (i + 1) * modLFOL.value());
             biquad[2 * i]->coeff_APF(omega, 1.0 + 0.8 * *f[ph_sharpness]);
-            omega = biquad[2 * i + 1]->calc_omega(
-                2 * *f[ph_center] + *f[ph_spread] * center + (2.0 / (i + 1) * modLFOR.value()));
+            omega = biquad[2 * i + 1]->calc_omega(2 * *f[ph_center] + *f[ph_spread] * center +
+                                                  (2.0 / (i + 1) * modLFOR.value()));
             biquad[2 * i + 1]->coeff_APF(omega, 1.0 + 0.8 * *f[ph_sharpness]);
         }
     }

--- a/src/common/dsp/effect/chowdsp/Neuron.cpp
+++ b/src/common/dsp/effect/chowdsp/Neuron.cpp
@@ -126,7 +126,7 @@ void Neuron::set_params()
     float rate = envelope_rate_linear(-limit_range(*f[neuron_lfo_rate], -8.f, 10.f)) *
                  (fxdata->p[neuron_lfo_rate].temposync ? storage->temposyncratio : 1.f);
     float depth_val = limit_range(*f[neuron_lfo_depth], 0.f, 2.f);
-    
+
     if (fxdata->p[neuron_lfo_rate].deactivated)
     {
         auto rmin = fxdata->p[neuron_lfo_rate].val_min.f;


### PR DESCRIPTION
Right-click Deactivate will kill the LFO and turn Rate slider into a phase scrubber, so that the control can be modulated internally via modulators or externally via host automation.
Flanger implementation would benefit from finishing #3770 first.
Closes #2465

Also fixed a bug where bringing Spread parameter in the phaser to 0% would only result in modulation happening in left channel only (which is not expected behavior).