### PR TITLE
A few tuning features; MTS skip key and pull tuning lib

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -364,6 +364,14 @@ void SurgeSynthesizer::playNote(char channel, char key, char velocity, char detu
     if (halt_engine)
         return;
 
+    if (storage.oddsound_mts_client && storage.oddsound_mts_active)
+    {
+        if (MTS_ShouldFilterNote(storage.oddsound_mts_client, key, channel))
+        {
+            return;
+        }
+    }
+
     // For split/dual
     // MIDI Channel 1 plays the split/dual
     // MIDI Channel 2 plays A


### PR DESCRIPTION
1. ODDSound MTS-ESP can skip a key play if disabled
2. Pull the tuning library to get new names

Closes #3988
Closes #3986