### PR TITLE
Defensive Code around AU Patch Change

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -122,6 +122,7 @@ void aulayer::InitializePlugin()
                 if (s->storage.patch_list[p].category == c)
                 {
                     presetOrderToPatchList.push_back(p);
+                    surgePatchToAUPatch[p] = presetOrderToPatchList.size() - 1;
                 }
             }
         }

--- a/src/au/aulayer.h
+++ b/src/au/aulayer.h
@@ -148,6 +148,7 @@ class aulayer : public AUInstrumentBase
     CFStringRef parameterIDlist_CFString[n_total_params + num_metaparameters];
     float sampleRateCache;
     std::vector<int> presetOrderToPatchList;
+    std::unordered_map<int, int> surgePatchToAUPatch;
 
     int checkNamesEvery = 0;
 };

--- a/src/au/aulayer_cocoaui.mm
+++ b/src/au/aulayer_cocoaui.mm
@@ -375,8 +375,13 @@ ComponentResult aulayer::GetProperty(AudioUnitPropertyID iID, AudioUnitScope iSc
 
 void aulayer::setPresetByID(int pid)
 {
+    if (surgePatchToAUPatch.find(pid) == surgePatchToAUPatch.end())
+    {
+        return;
+    }
+
     AUPreset preset;
-    preset.presetNumber = pid;
+    preset.presetNumber = surgePatchToAUPatch[pid];
     preset.presetName = CFStringCreateWithCString(
         NULL, plugin_instance->storage.patch_list[pid].name.c_str(), kCFStringEncodingUTF8);
     SetAFactoryPresetAsCurrent(preset);

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -381,7 +381,7 @@ void CPatchBrowser::loadPatch(int id)
 {
     if (listener && (id >= 0))
     {
-        sel_id = id;
+        enqueue_sel_id = id;
         listener->valueChanged(this);
     }
 }

--- a/src/common/gui/CPatchBrowser.h
+++ b/src/common/gui/CPatchBrowser.h
@@ -29,6 +29,7 @@ class CPatchBrowser : public VSTGUI::CControl, public Surge::UI::SkinConsumingCo
         setCategory("Init");
         this->storage = storage;
         sel_id = -1;
+        enqueue_sel_id = -1;
         current_patch = -1;
         current_category = -1;
     }
@@ -77,7 +78,7 @@ class CPatchBrowser : public VSTGUI::CControl, public Surge::UI::SkinConsumingCo
     VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint &where,
                                           const VSTGUI::CButtonState &button) override;
     void loadPatch(int id);
-    int sel_id = 0;
+    int sel_id = 0, enqueue_sel_id = 0;
 
   protected:
     std::string pname;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -4187,7 +4187,7 @@ void SurgeGUIEditor::valueChanged(CControl *control)
     break;
     case tag_patchname:
     {
-        int id = ((CPatchBrowser *)control)->sel_id;
+        int id = ((CPatchBrowser *)control)->enqueue_sel_id;
         // synth->load_patch(id);
         enqueuePatchId = id;
 


### PR DESCRIPTION
I had a report of occasional Reaper AU crashes in setPresetID
and realized there was a situation where it could go out of bound.
Make this change to address that.