### PR TITLE
Add class="none" to modbutton panel

### DIFF
--- a/src/common/dsp/DPWOscillator.cpp
+++ b/src/common/dsp/DPWOscillator.cpp
@@ -574,7 +574,7 @@ static struct DPWTriName : public ParameterDynamicNameFunction
         static char tx[1024];
 
         std::string subs = sub ? " Sub" : "";
-        std::string res = std::string("Multi - ") + dpw_multitype_names[mt] + subs;
+        std::string res = dpw_multitype_names[mt] + subs;
 
         strncpy(tx, res.c_str(), 1024);
         tx[1023] = 0;

--- a/src/common/dsp/EuroTwist.cpp
+++ b/src/common/dsp/EuroTwist.cpp
@@ -34,7 +34,7 @@ std::string eurotwist_engine_name(int i)
     case 1:
         return "Waveshaper";
     case 2:
-        return "2-OP FM";
+        return "2-Operator FM";
     case 3:
         return "Formant/PD";
     case 4:
@@ -44,7 +44,7 @@ std::string eurotwist_engine_name(int i)
     case 6:
         return "Chords";
     case 7:
-        return "Spech";
+        return "Vowels/Speech";
     case 8:
         return "Granular Cloud";
     case 9:


### PR DESCRIPTION
Prevent entering mod assign mode if modbutton panel is hidden
Minor rename of a couple of Twist osc modes
Remove "Multi - " from Modern osc slider, for brevity