### PR TITLE
Reinstate FX grid slot positions for v1 skins

### DIFF
--- a/src/common/gui/CEffectSettings.cpp
+++ b/src/common/gui/CEffectSettings.cpp
@@ -81,7 +81,7 @@ void CEffectSettings::draw(CDrawContext *dc)
             {
                 CRect r(0, 0, 17, 9);
                 r.offset(size.left, size.top);
-                r.offset(fxslotpos[i][0], fxslotpos[i][1]);
+                r.offset(blocks[i][0], blocks[i][1]);
                 int stype = 0;
                 if (disabled & (1 << i))
                     stype = 4;

--- a/src/common/gui/CEffectSettings.h
+++ b/src/common/gui/CEffectSettings.h
@@ -34,6 +34,11 @@ class CEffectSettings : public VSTGUI::CControl, public Surge::UI::SkinConsuming
     VSTGUI::CBitmap *bg, *labels;
     VSTGUI::CPoint dragStart, dragCurrent, dragCornerOff;
 
+    // skin version 1 FX slot positions
+    const int blocks[n_fx_slots][2] = {{18, 1},  {44, 1},  {18, 41}, {44, 41},
+                                       {18, 21}, {44, 21}, {89, 11}, {89, 31}};
+
+    // skin version 2 FX slot positions
     // pixel offsets of all FX slots:     A IFX1, A IFX2, B IFX1,   B IFX2,
     //                                    Send 1, Send 2, Global 1, Global 2
     const int fxslotpos[n_fx_slots][2] = {{17, 0},  {43, 0},  {17, 40}, {43, 40},


### PR DESCRIPTION
Remove non-linear shaping of Twist osc > Classic > Harmonics param