### PR TITLE
Fix Neuron crashing with Surge XT

### DIFF
--- a/src/common/dsp/effect/chowdsp/Neuron.cpp
+++ b/src/common/dsp/effect/chowdsp/Neuron.cpp
@@ -40,8 +40,8 @@ void Neuron::init()
 
     os.reset();
 
-    delay1.prepare(dsamplerate * os.getOSRatio(), BLOCK_SIZE, 2);
-    delay2.prepare(dsamplerate * os.getOSRatio(), BLOCK_SIZE, 2);
+    delay1.prepare(dsamplerate * os.getOSRatio(), BLOCK_SIZE);
+    delay2.prepare(dsamplerate * os.getOSRatio(), BLOCK_SIZE);
     delay1.setDelay(0.0f);
     delay2.setDelay(0.0f);
 

--- a/src/common/dsp/effect/chowdsp/Neuron.h
+++ b/src/common/dsp/effect/chowdsp/Neuron.h
@@ -104,8 +104,8 @@ class Neuron : public Effect
 
     BiquadFilter dc_blocker;
     lipol_ps makeup alignas(16), width alignas(16), outgain alignas(16);
-    chowdsp::DelayLine<float, chowdsp::DelayLineInterpolationTypes::Linear> delay1{1 << 18};
-    chowdsp::DelayLine<float, chowdsp::DelayLineInterpolationTypes::Linear> delay2{1 << 18};
+    chowdsp::DelayLine<float, chowdsp::DelayLineInterpolationTypes::Linear> delay1{1 << 18, 2};
+    chowdsp::DelayLine<float, chowdsp::DelayLineInterpolationTypes::Linear> delay2{1 << 18, 2};
     Oversampling<2, BLOCK_SIZE> os;
 
     Surge::ModControl modLFO;

--- a/src/common/dsp/effect/chowdsp/shared/DelayLine.cpp
+++ b/src/common/dsp/effect/chowdsp/shared/DelayLine.cpp
@@ -33,14 +33,18 @@ namespace chowdsp
 
 //==============================================================================
 template <typename SampleType, typename InterpolationType>
-DelayLine<SampleType, InterpolationType>::DelayLine() : DelayLine(0)
+DelayLine<SampleType, InterpolationType>::DelayLine() : DelayLine(0, 1)
 {
 }
 
 template <typename SampleType, typename InterpolationType>
-DelayLine<SampleType, InterpolationType>::DelayLine(size_t maximumDelayInSamples)
+DelayLine<SampleType, InterpolationType>::DelayLine(size_t maximumDelayInSamples, size_t nChannels)
 {
     totalSize = std::max((size_t)4, maximumDelayInSamples + 1);
+
+    this->bufferData.resize(nChannels);
+    for (size_t ch = 0; ch < nChannels; ++ch)
+        this->bufferData[ch] = std::vector<SampleType>(totalSize);
 }
 
 //==============================================================================
@@ -64,12 +68,9 @@ SampleType DelayLine<SampleType, InterpolationType>::getDelay() const
 
 //==============================================================================
 template <typename SampleType, typename InterpolationType>
-void DelayLine<SampleType, InterpolationType>::prepare(double sampleRate, size_t blockSize,
-                                                       size_t numChannels)
+void DelayLine<SampleType, InterpolationType>::prepare(double sampleRate, size_t blockSize)
 {
-    this->bufferData.clear();
-    for (size_t ch = 0; ch < numChannels; ++ch)
-        this->bufferData.push_back(std::vector<SampleType>(totalSize, (SampleType)0));
+    const auto numChannels = this->bufferData.size();
 
     this->writePos.resize(numChannels);
     this->readPos.resize(numChannels);

--- a/src/common/dsp/effect/chowdsp/shared/DelayLine.h
+++ b/src/common/dsp/effect/chowdsp/shared/DelayLine.h
@@ -40,7 +40,7 @@ template <typename SampleType> class DelayLineBase
     virtual void setDelay(SampleType /* newDelayInSamples */) = 0;
     virtual SampleType getDelay() const = 0;
 
-    virtual void prepare(double sampleRate, size_t blockSize, size_t nChannels) = 0;
+    virtual void prepare(double sampleRate, size_t blockSize) = 0;
     virtual void reset() = 0;
 
     virtual void pushSample(size_t /* channel */, SampleType /* sample */) = 0;
@@ -88,7 +88,7 @@ class DelayLine : public DelayLineBase<SampleType>
     DelayLine();
 
     /** Constructor. */
-    explicit DelayLine(size_t maximumDelayInSamples);
+    explicit DelayLine(size_t maximumDelayInSamples, size_t nChannels);
 
     //==============================================================================
     /** Sets the delay in samples. */
@@ -99,7 +99,7 @@ class DelayLine : public DelayLineBase<SampleType>
 
     //==============================================================================
     /** Initialises the processor. */
-    void prepare(double sampleRate, size_t blockSize, size_t nChannels) override;
+    void prepare(double sampleRate, size_t blockSize) override;
 
     /** Resets the internal state variables of the processor. */
     void reset() override;


### PR DESCRIPTION
Basically, the problem was as follows:
- `Neuron` allocates the memory for it's delay lines in the `init()` function.
- With Surge XT, Neuron's `process()` sometimes gets called before `init()`, or maybe in parallel threads.
- `process()` tries to push samples into the delay line, but the delay line doesn't have it's memory allocated yet!
- segfault

For now, my solution is to allocate the required memory in the constructor, rather than in `init()`, but if this is an issue that potentiall affects other effects as well, we may need to take a look at which threads are calling each function, and make sure we don't try to `process()` an effect before it has been `init()`ed.