### PR TITLE
Common Oscillator Code Refactoring and Use

### DIFF
--- a/src/common/dsp/DPWOscillator.h
+++ b/src/common/dsp/DPWOscillator.h
@@ -18,6 +18,7 @@
 
 #include "OscillatorBase.h"
 #include "DspUtilities.h"
+#include "OscillatorCommonFunctions.h"
 
 class DPWOscillator : public Oscillator
 {
@@ -72,8 +73,8 @@ class DPWOscillator : public Oscillator
         subdpbase, subdpsbase, detune, pitchlag, fmdepth;
 
     // character filter
-    bool dofilter = true;
-    double charfiltB0 = 0.0, charfiltB1 = 0.0, charfiltA1 = 0.0;
+    Surge::Oscillator::CharacterFilter<double> charFilt;
+    // double charfiltB0 = 0.0, charfiltB1 = 0.0, charfiltA1 = 0.0;
     double priorY_L = 0.0, priorY_R = 0.0, priorX_L = 0.0, priorX_R = 0.0;
 
     int n_unison = 1;
@@ -84,7 +85,7 @@ class DPWOscillator : public Oscillator
     double unisonOffsets[MAX_UNISON];
     double mixL[MAX_UNISON], mixR[MAX_UNISON];
 
-    float driftlfo[MAX_UNISON], driftlfo2[MAX_UNISON];
+    Surge::Oscillator::DriftLFO driftLFO[MAX_UNISON];
 
     int cachedDeform = -1;
 };

--- a/src/common/dsp/EuroTwist.h
+++ b/src/common/dsp/EuroTwist.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include "basic_dsp.h"
 #include "DspUtilities.h"
+#include "OscillatorCommonFunctions.h"
 
 namespace plaits
 {
@@ -80,7 +81,8 @@ class EuroTwist : public Oscillator
 
     lag<float, true> harm, timb, morph, lpgcol, lpgdec, auxmix;
 
-    float driftlfo, driftlfo2;
+    Surge::Oscillator::DriftLFO driftLFO;
+    Surge::Oscillator::CharacterFilter<float> charFilt;
 };
 
 #endif // SURGE_EUROTWIST_H

--- a/src/common/dsp/FM2Oscillator.cpp
+++ b/src/common/dsp/FM2Oscillator.cpp
@@ -31,10 +31,7 @@ void FM2Oscillator::init(float pitch, bool is_display, bool nonzero_init_drift)
     phase =
         (is_display || oscdata->retrigger.val.b) ? 0.f : (2.0 * M_PI * rand() / RAND_MAX - M_PI);
     lastoutput = 0.0;
-    driftlfo = 0;
-    driftlfo2 = 0;
-    if (nonzero_init_drift)
-        driftlfo2 = 0.0005 * ((float)rand() / (float)(RAND_MAX));
+    driftLFO.init(nonzero_init_drift);
     fb_val = 0.0;
     double ph = (localcopy[oscdata->p[fm2_m12phase].param_id_in_scene].f + phase) * 2.0 * M_PI;
     RM1.set_phase(ph);
@@ -48,7 +45,7 @@ FM2Oscillator::~FM2Oscillator() {}
 
 void FM2Oscillator::process_block(float pitch, float drift, bool stereo, bool FM, float fmdepth)
 {
-    driftlfo = drift_noise(driftlfo2) * drift;
+    auto driftlfo = driftLFO.next() * drift;
     fb_val = oscdata->p[fm2_feedback].get_extended(
         localcopy[oscdata->p[fm2_feedback].param_id_in_scene].f);
 

--- a/src/common/dsp/FM2Oscillator.h
+++ b/src/common/dsp/FM2Oscillator.h
@@ -19,6 +19,7 @@
 #include "DspUtilities.h"
 #include <vt_dsp/lipol.h>
 #include "BiquadFilter.h"
+#include "OscillatorCommonFunctions.h"
 
 class FM2Oscillator : public Oscillator
 {
@@ -44,7 +45,7 @@ class FM2Oscillator : public Oscillator
     virtual void init_default_values() override;
     double phase, lastoutput;
     quadr_osc RM1, RM2;
-    float driftlfo, driftlfo2;
+    Surge::Oscillator::DriftLFO driftLFO;
     float fb_val;
     lag<double> FMdepth, RelModDepth1, RelModDepth2, FeedbackDepth, PhaseOffset;
     virtual void handleStreamingMismatches(int streamingRevision,

--- a/src/common/dsp/FM3Oscillator.cpp
+++ b/src/common/dsp/FM3Oscillator.cpp
@@ -29,10 +29,7 @@ void FM3Oscillator::init(float pitch, bool is_display, bool nonzero_init_drift)
     phase =
         (is_display || oscdata->retrigger.val.b) ? 0.f : (2.0 * M_PI * rand() / RAND_MAX - M_PI);
     lastoutput = 0.f;
-    driftlfo = 0.f;
-    driftlfo2 = 0;
-    if (nonzero_init_drift)
-        driftlfo2 = 0.0005 * ((float)rand() / (float)(RAND_MAX));
+    driftLFO.init(nonzero_init_drift);
     fb_val = 0.f;
     AM.set_phase(phase);
     RM1.set_phase(phase);
@@ -43,7 +40,7 @@ FM3Oscillator::~FM3Oscillator() {}
 
 void FM3Oscillator::process_block(float pitch, float drift, bool stereo, bool FM, float fmdepth)
 {
-    driftlfo = drift_noise(driftlfo2) * drift;
+    auto driftlfo = driftLFO.next() * drift;
     fb_val = oscdata->p[fm3_feedback].get_extended(
         localcopy[oscdata->p[fm3_feedback].param_id_in_scene].f);
 

--- a/src/common/dsp/FM3Oscillator.h
+++ b/src/common/dsp/FM3Oscillator.h
@@ -19,6 +19,7 @@
 #include "DspUtilities.h"
 #include <vt_dsp/lipol.h>
 #include "BiquadFilter.h"
+#include "OscillatorCommonFunctions.h"
 
 class FM3Oscillator : public Oscillator
 {
@@ -44,7 +45,7 @@ class FM3Oscillator : public Oscillator
     virtual void init_default_values() override;
     double phase, lastoutput;
     quadr_osc RM1, RM2, AM;
-    float driftlfo, driftlfo2;
+    Surge::Oscillator::DriftLFO driftLFO;
     float fb_val;
     lag<double> FMdepth, AbsModDepth, RelModDepth1, RelModDepth2, FeedbackDepth;
     virtual void handleStreamingMismatches(int streamingRevision,

--- a/src/common/dsp/OscillatorBase.h
+++ b/src/common/dsp/OscillatorBase.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "SurgeStorage.h"
+#include "OscillatorCommonFunctions.h"
 
 class alignas(16) Oscillator
 {
@@ -81,7 +82,7 @@ class AbstractBlitOscillator : public Oscillator
     int n_unison;
     float out_attenuation, out_attenuation_inv, detune_bias, detune_offset;
     float oscstate[MAX_UNISON], syncstate[MAX_UNISON], rate[MAX_UNISON];
-    float driftlfo[MAX_UNISON], driftlfo2[MAX_UNISON];
+    Surge::Oscillator::DriftLFO driftLFO[MAX_UNISON];
     float panL[MAX_UNISON], panR[MAX_UNISON];
     int state[MAX_UNISON];
 };

--- a/src/common/dsp/OscillatorCommonFunctions.h
+++ b/src/common/dsp/OscillatorCommonFunctions.h
@@ -1,0 +1,214 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#ifndef SURGE_OSCILLATORCOMMONFUNCTIONS_H
+#define SURGE_OSCILLATORCOMMONFUNCTIONS_H
+
+#include "DspUtilities.h"
+#include "SurgeStorage.h"
+
+namespace Surge
+{
+namespace Oscillator
+{
+struct DriftLFO
+{
+    DriftLFO() noexcept : d(0), d2(0) {}
+
+    inline void init(bool nzi)
+    {
+        d = 0;
+        d2 = 0;
+        if (nzi)
+            d2 = 0.0005 * ((float)rand() / (float)(RAND_MAX));
+    }
+
+    inline float next()
+    {
+        d = drift_noise(d2);
+        return d;
+    }
+
+    inline float val() const { return d; }
+
+    float d, d2;
+};
+
+/*
+ * Generate coefficients and, in non-sse cases, operate the character filter
+ */
+template <typename valtype> struct CharacterFilter
+{
+    CharacterFilter() noexcept {}
+
+    void init(int itype)
+    {
+        type = itype;
+        switch (type)
+        {
+        case 0:
+        {
+            valtype filt = 1.0 - 2.0 * 5000.0 * dsamplerate_inv;
+            filt *= filt;
+            CoefB0 = 1.0 - filt;
+            CoefB1 = 0.0;
+            CoefA1 = filt;
+            doFilter = true;
+        }
+        break;
+        case 2:
+        {
+            valtype filt = 1.0 - 2.0 * 5000.0 * dsamplerate_inv;
+            filt *= filt;
+            valtype A0 = 1.0 / (1.0 - filt);
+            CoefB0 = 1.0 * A0;
+            CoefB1 = -filt * A0;
+            CoefA1 = 0.0;
+            doFilter = true;
+        }
+        break;
+        default:
+        case 1:
+        {
+            CoefB0 = 1.0;
+            CoefB1 = 0.0;
+            CoefA1 = 0.0;
+            doFilter = false;
+        }
+        break;
+        }
+    }
+
+    int type = 1;
+    bool doFilter = false;
+    valtype CoefB0 = 1.0, CoefB1 = 0.0, CoefA1 = 0.0;
+
+    inline void process_block(float *output, size_t size)
+    {
+        if (!doFilter)
+            return;
+        if (starting)
+        {
+            priorY_L = output[0];
+            priorX_L = output[0];
+        }
+        starting = false;
+        for (auto i = 0; i < size; ++i)
+        {
+            auto pfL = CoefA1 * priorY_L + CoefB0 * output[i] + CoefB1 * priorX_L;
+            priorY_L = pfL;
+            priorX_L = output[i];
+            output[i] = pfL;
+        }
+    }
+
+    inline void process_block_stereo(float *output, float *outputR, size_t size)
+    {
+        if (!doFilter)
+            return;
+
+        if (starting)
+        {
+            priorY_L = output[0];
+            priorX_L = output[0];
+            priorY_R = outputR[0];
+            priorX_R = outputR[0];
+        }
+        starting = false;
+        for (auto i = 0; i < size; ++i)
+        {
+            auto pfL = CoefA1 * priorY_L + CoefB0 * output[i] + CoefB1 * priorX_L;
+            priorY_L = pfL;
+            priorX_L = output[i];
+            output[i] = pfL;
+
+            auto pfR = CoefA1 * priorY_R + CoefB0 * outputR[i] + CoefB1 * priorX_R;
+            priorY_R = pfR;
+            priorX_R = outputR[i];
+            outputR[i] = pfR;
+        }
+    }
+
+    bool starting = false;
+    valtype priorY_L = 0.0, priorX_L = 0.0, priorY_R = 0.0, priorX_R = 0.0;
+};
+
+template <typename valtype> struct UnisonSetup
+{
+    UnisonSetup(int nv) : n_unison(nv)
+    {
+        auto voices = n_unison;
+        sqrt_uni = sqrt(1.0 * n_unison);
+        sqrt_uni_inv = 1.0 / sqrt_uni;
+
+        odd = voices & 1;
+        mid = voices * 0.5 - 0.5;
+        half = voices >> 1;
+    }
+
+    inline valtype detuneBias() const
+    {
+        if (n_unison == 1)
+            return 1.0;
+        return 2.0 / (n_unison - 1);
+    }
+    inline valtype detuneOffset() const
+    {
+        if (n_unison == 1)
+            return 0;
+        return -1;
+    }
+    inline valtype detune(int voice) const { return detuneBias() * voice + detuneOffset(); }
+
+    inline void panLaw(int voice, valtype &panL, valtype &panR) const
+    {
+        if (n_unison == 1)
+        {
+            panL = 1.0;
+            panR = 1.0;
+            return;
+        }
+        float d = fabs((valtype)voice - mid) / mid;
+        if (odd && (voice >= half))
+            d = -d;
+        if (voice & 1)
+            d = -d;
+
+        panL = (1.f - d);
+        panR = (1.f + d);
+    }
+
+    inline valtype attenuation() const { return sqrt_uni_inv; }
+
+    inline valtype attenuation_inv() const { return sqrt_uni; }
+
+    inline void attenuatedPanLaw(int voice, valtype &panL, valtype &panR) const
+    {
+        panLaw(voice, panL, panR);
+        panL *= attenuation();
+        panR *= attenuation();
+    }
+
+    bool odd;
+    valtype mid;
+    int half;
+    int n_unison = 1;
+    double sqrt_uni, sqrt_uni_inv;
+};
+
+} // namespace Oscillator
+} // namespace Surge
+
+#endif // SURGE_OSCILLATORCOMMONFUNCTIONS_H

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -110,10 +110,7 @@ void SampleAndHoldOscillator::init(float pitch, bool is_display, bool nonzero_in
         state[i] = 0;
         last_level[i] = 0.0;
         pwidth[i] = limit_range(l_pw.v, 0.001, 0.999);
-        driftlfo[i] = 0.f;
-        driftlfo2[i] = 0.f;
-        if (nonzero_init_drift)
-            driftlfo2[i] = 0.0005 * ((float)rand() / (float)(RAND_MAX));
+        driftLFO[i].init(nonzero_init_drift);
     }
 
     hp.coeff_instantize();
@@ -156,7 +153,7 @@ void SampleAndHoldOscillator::init_default_values()
 
 void SampleAndHoldOscillator::convolute(int voice, bool FM, bool stereo)
 {
-    float detune = drift * driftlfo[voice];
+    float detune = drift * driftLFO[voice].val();
     if (n_unison > 1)
         detune += oscdata->p[shn_unison_detune].get_extended(localcopy[id_detune].f) *
                   (detune_bias * float(voice) + detune_offset);
@@ -376,7 +373,7 @@ void SampleAndHoldOscillator::process_block(float pitch0, float drift, bool ster
     {
         for (l = 0; l < n_unison; l++)
         {
-            driftlfo[l] = drift_noise(driftlfo2[l]);
+            driftLFO[l].next();
         }
 
         for (int s = 0; s < BLOCK_SIZE_OS; s++)
@@ -406,7 +403,7 @@ void SampleAndHoldOscillator::process_block(float pitch0, float drift, bool ster
 
         for (l = 0; l < n_unison; l++)
         {
-            driftlfo[l] = drift_noise(driftlfo2[l]);
+            driftLFO[l].next();
 
             while ((syncstate[l] < a) || (oscstate[l] < a))
             {

--- a/src/common/dsp/SineOscillator.h
+++ b/src/common/dsp/SineOscillator.h
@@ -19,6 +19,7 @@
 #include "DspUtilities.h"
 #include <vt_dsp/lipol.h>
 #include "BiquadFilter.h"
+#include "OscillatorCommonFunctions.h"
 
 class SineOscillator : public Oscillator
 {
@@ -51,7 +52,8 @@ class SineOscillator : public Oscillator
 
     quadr_osc sine[MAX_UNISON];
     double phase[MAX_UNISON];
-    float driftlfo[MAX_UNISON], driftlfo2[MAX_UNISON];
+    Surge::Oscillator::DriftLFO driftLFO[MAX_UNISON];
+    Surge::Oscillator::CharacterFilter<float> charFilt;
     float fb_val;
     float playingramp[MAX_UNISON], dplaying;
     lag<double> FMdepth;

--- a/src/common/dsp/SurgeSuperOscillator.h
+++ b/src/common/dsp/SurgeSuperOscillator.h
@@ -56,5 +56,5 @@ class SurgeSuperOscillator : public AbstractBlitOscillator
     int FMdelay;
     float FMmul_inv;
     float FMphase alignas(16)[BLOCK_SIZE_OS + 4];
-    float CoefB0, CoefB1, CoefA1;
+    Surge::Oscillator::CharacterFilter<float> charFilt;
 };

--- a/src/common/dsp/WaveguideOscillator.h
+++ b/src/common/dsp/WaveguideOscillator.h
@@ -21,6 +21,7 @@
 #include "DspUtilities.h"
 #include "SSESincDelayLine.h"
 #include "BiquadFilter.h"
+#include "OscillatorCommonFunctions.h"
 
 class WaveguideOscillator : public Oscillator
 {
@@ -58,7 +59,8 @@ class WaveguideOscillator : public Oscillator
 
     SSESincDelayLine<16384> delayLine[2];
     float priorSample[2] = {0, 0};
-    float driftlfo[2] = {0, 0}, driftlfo2[2] = {0, 0};
+    Surge::Oscillator::DriftLFO driftLFO[2];
+    Surge::Oscillator::CharacterFilter<float> charFilt;
 
     BiquadFilter lp;
 };

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -69,9 +69,7 @@ void WindowOscillator::init(float pitch, bool is_display, bool nonzero_init_drif
                             << 16;
         }
 
-        Window.DriftLFO[0][1] = 0;
-        if (nonzero_init_drift)
-            Window.DriftLFO[0][1] = 0.0005 * ((float)rand() / (float)(RAND_MAX));
+        Window.driftLFO[0].init(nonzero_init_drift);
     }
     else
     {
@@ -105,7 +103,7 @@ void WindowOscillator::init(float pitch, bool is_display, bool nonzero_init_drif
                                 << 16;
             }
 
-            Window.DriftLFO[i][1] = 0.0005 * ((float)rand() / (float)(RAND_MAX));
+            Window.driftLFO[i].init(true); // Window has always started uni voices with non zero
         }
     }
 
@@ -315,12 +313,12 @@ void WindowOscillator::process_block(float pitch, float drift, bool stereo, bool
 
     for (int l = 0; l < NumUnison; l++)
     {
-        Window.DriftLFO[l][0] = drift_noise(Window.DriftLFO[l][1]);
+        Window.driftLFO[l].next();
         /*
         ** This original code uses note 57 as a center point with a frequency of 220.
         */
 
-        float f = storage->note_to_pitch(pitch + drift * Window.DriftLFO[l][0] +
+        float f = storage->note_to_pitch(pitch + drift * Window.driftLFO[l].val() +
                                          Detune * (DetuneOffset + DetuneBias * (float)l));
         int Ratio = Float2Int(8.175798915f * 32768.f * f * (float)(storage->WindowWT.size) *
                               samplerate_inv); // (65536.f*0.5f), 0.5 for oversampling
@@ -334,7 +332,7 @@ void WindowOscillator::process_block(float pitch, float drift, bool stereo, bool
             for (int i = 0; i < BLOCK_SIZE_OS; ++i)
             {
                 float fmadj = (1.0 + FMdepth[l].v * master_osc[i]);
-                float f = storage->note_to_pitch(pitch + drift * Window.DriftLFO[l][0] +
+                float f = storage->note_to_pitch(pitch + drift * Window.driftLFO[l].val() +
                                                  Detune * (DetuneOffset + DetuneBias * (float)l));
                 int Ratio =
                     Float2Int(8.175798915f * 32768.f * f * fmadj * (float)(storage->WindowWT.size) *

--- a/src/common/dsp/WindowOscillator.h
+++ b/src/common/dsp/WindowOscillator.h
@@ -19,6 +19,7 @@
 #include "DspUtilities.h"
 #include <vt_dsp/lipol.h>
 #include "BiquadFilter.h"
+#include "OscillatorCommonFunctions.h"
 
 class WindowOscillator : public Oscillator
 {
@@ -58,7 +59,7 @@ class WindowOscillator : public Oscillator
         unsigned int DispatchDelay[MAX_UNISON]; // samples until playback should start (for
                                                 // per-sample scheduling)
         unsigned char Gain[MAX_UNISON][2];
-        float DriftLFO[MAX_UNISON][2];
+        Surge::Oscillator::DriftLFO driftLFO[MAX_UNISON];
 
         int FMRatio[MAX_UNISON][BLOCK_SIZE_OS];
     } Window alignas(16);


### PR DESCRIPTION
Closes #4032

1. Drift is encapsulated in a class and used consistently
2. Unify the character filter; and add character to String,
   Twist, and Sine (but only for patch versions >= 16 for Sine)
3. Refactored standarized pan/unison laws