### PR TITLE
Allow OddSound MTS-ESP to snap at note-on only

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1873,6 +1873,12 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
                 dawExtraState.monoPedalMode = ival;
 
+            p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("oddsoundRetuneMode"));
+            if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
+                dawExtraState.oddsoundRetuneMode = ival;
+            else
+                dawExtraState.oddsoundRetuneMode = SurgeStorage::RETUNE_CONSTANT;
+
             p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("hasTuning"));
             if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
             {
@@ -2280,6 +2286,10 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         TiXmlElement mpm("monoPedalMode");
         mpm.SetAttribute("v", dawExtraState.monoPedalMode);
         dawExtraXML.InsertEndChild(mpm);
+
+        TiXmlElement osd("oddsoundRetuneMode");
+        osd.SetAttribute("v", dawExtraState.oddsoundRetuneMode);
+        dawExtraXML.InsertEndChild(osd);
 
         TiXmlElement tun("hasTuning");
         tun.SetAttribute("v", dawExtraState.hasTuning ? 1 : 0);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -710,6 +710,7 @@ struct DAWExtraStateStorage
     std::unordered_map<int, int> customcontrol_map; // custom controller number -> midicontrol
 
     int monoPedalMode = 0;
+    int oddsoundRetuneMode = 0;
 };
 
 struct PatchTuningStorage
@@ -1005,6 +1006,11 @@ class alignas(16) SurgeStorage
     MTSClient *oddsound_mts_client = nullptr;
     std::atomic<bool> oddsound_mts_active;
     uint32_t oddsound_mts_on_check = 0;
+    enum OddsoundRetuneMode
+    {
+        RETUNE_CONSTANT = 0,
+        RETUNE_NOTE_ON_ONLY = 1
+    } oddsoundRetuneMode = RETUNE_CONSTANT;
 
     /*
      * If we tune at keyboard or with MTS, we don't reset the internal tuning table.

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3720,6 +3720,7 @@ void SurgeSynthesizer::populateDawExtraState()
     }
 
     storage.getPatch().dawExtraState.monoPedalMode = storage.monoPedalMode;
+    storage.getPatch().dawExtraState.oddsoundRetuneMode = storage.oddsoundRetuneMode;
 }
 
 void SurgeSynthesizer::loadFromDawExtraState()
@@ -3731,6 +3732,8 @@ void SurgeSynthesizer::loadFromDawExtraState()
         storage.mpePitchBendRange = storage.getPatch().dawExtraState.mpePitchBendRange;
 
     storage.monoPedalMode = (MonoPedalMode)storage.getPatch().dawExtraState.monoPedalMode;
+    storage.oddsoundRetuneMode =
+        (SurgeStorage::OddsoundRetuneMode)storage.getPatch().dawExtraState.oddsoundRetuneMode;
 
     if (storage.getPatch().dawExtraState.hasTuning)
     {

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -49,7 +49,13 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
 
     if (storage->oddsound_mts_client && storage->oddsound_mts_active)
     {
-        auto rkey = MTS_RetuningInSemitones(storage->oddsound_mts_client, key, channel);
+        if (storage->oddsoundRetuneMode == SurgeStorage::RETUNE_CONSTANT ||
+            key != keyRetuningForKey)
+        {
+            keyRetuningForKey = key;
+            keyRetuning = MTS_RetuningInSemitones(storage->oddsound_mts_client, key, channel);
+        }
+        auto rkey = keyRetuning;
 
         return res + rkey;
     }
@@ -93,6 +99,7 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
     age = 0;
     age_release = 0;
     state.key = key;
+    state.keyRetuningForKey = -1000;
     state.channel = channel;
 
     state.velocity = velocity;

--- a/src/common/dsp/SurgeVoiceState.h
+++ b/src/common/dsp/SurgeVoiceState.h
@@ -29,6 +29,10 @@ struct SurgeVoiceState
     float portasrc_key, portaphase;
     bool porta_doretrigger;
 
+    // These items support the tuning-snap mode in MTS mode
+    float keyRetuning;
+    int keyRetuningForKey = -1000;
+
     // note that this does not replace the regular pitch bend modulator, only used to smooth MPE
     // pitch
     ControllerModulationSource mpePitchBend;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -5777,8 +5777,24 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect, boo
         std::string mtsScale = MTS_GetScaleName(synth->storage.oddsound_mts_client);
         mm = addCallbackMenu(tuningSubMenu, mtsScale, []() {});
         mm->setEnabled(false);
-        // a 'turn mts off' menu
 
+        // an MTS tuning tyode tygle
+        mm = addCallbackMenu(
+            tuningSubMenu, Surge::UI::toOSCaseForMenu("Query Tuning Only At Note On"), [this]() {
+                if (this->synth->storage.oddsoundRetuneMode == SurgeStorage::RETUNE_CONSTANT)
+                {
+                    this->synth->storage.oddsoundRetuneMode = SurgeStorage::RETUNE_NOTE_ON_ONLY;
+                }
+                else
+                {
+                    this->synth->storage.oddsoundRetuneMode = SurgeStorage::RETUNE_CONSTANT;
+                }
+            });
+        mm->setEnabled(true);
+        mm->setChecked(this->synth->storage.oddsoundRetuneMode ==
+                       SurgeStorage::RETUNE_NOTE_ON_ONLY);
+
+        // a 'turn mts off' menu
         addCallbackMenu(tuningSubMenu, Surge::UI::toOSCaseForMenu("Disconnect from MTS-ESP"),
                         [this]() {
                             auto q = this->synth->storage.oddsound_mts_client;


### PR DESCRIPTION
This allows held notes to not participate in tuning changes