### PR TITLE
Sine, FM2, FM3 with Extend on feedback by default

### DIFF
--- a/resources/data/configuration.xml
+++ b/resources/data/configuration.xml
@@ -13,12 +13,12 @@
     </type>
     <type i="2" name="Wavetable" retrigger="0" />
     <type i="7" name="Window" retrigger="0" />
-    <type i="1" name="Sine" retrigger="1" />
-    <type i="6" name="FM2" retrigger="1" />
-    <type i="5" name="FM3" retrigger="1" />
+    <type i="1" name="Sine" retrigger="1" p1_extend_range="1" />
+    <type i="6" name="FM2" retrigger="1" p6_extend_range="1" />
+    <type i="5" name="FM3" retrigger="1" p6_extend_range="1" />
     <type i="9" name="String"/>
-    <type i="10" name="Twist" retrigger="1"/>
     <type i="3" name="S&amp;H Noise" />
+    <type i="10" name="Twist"/>
     <type i="4" name="Audio Input">
         <snapshot name="Left" p0="-1.0" p1="0.0" p2="0.0" p3="0.0" p4="0.0" retrigger="0" />
         <snapshot name="Right" p0="1.0" p1="0.0" p2="0.0" p3="0.0" p4="0.0" retrigger="0" />
@@ -104,7 +104,7 @@
         <snapshot name="Init" />
         <snapshot name="Crusher" p0="11" p1="60" p2="0.0714279" p3="2" p4="0.205357" p5="0.767857" p6="-60" p7="38.2131" p8="0.776786" />
     </type>
-    <type i="24" name="TreeMonster">
+    <type i="24" name="Treemonster">
         <snapshot name="Init" />
     </type>
     <type i="10" name="Vocoder">

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2362,6 +2362,13 @@ bool SurgeSynthesizer::loadOscalgos()
                     {
                         storage.getPatch().scene[s].osc[i].p[k].deform_type = j;
                     }
+
+                    snprintf(lbl, TXT_SIZE, "p%i_extend_range", k);
+
+                    if (e->QueryIntAttribute(lbl, &j) == TIXML_SUCCESS)
+                    {
+                        storage.getPatch().scene[s].osc[i].p[k].extend_range = j;
+                    }
                 }
 
                 int rt;

--- a/src/common/gui/CSnapshotMenu.cpp
+++ b/src/common/gui/CSnapshotMenu.cpp
@@ -61,15 +61,24 @@ void CSnapshotMenu::populate()
             if (type->Value() && strcmp(type->Value(), "type") == 0)
             {
                 auto sm = populateSubmenuFromTypeElement(type, this, main, sub, max_sub, idx);
+
                 if (sm)
+                {
                     addToTopLevelTypeMenu(type, sm, idx);
+                }
             }
             else if (type->Value() && strcmp(type->Value(), "separator") == 0)
+            {
                 addSeparator();
+            }
+
             type = type->NextSiblingElement();
             main++;
+
             if (main >= max_main)
+            {
                 break;
+            }
         }
     }
     maxIdx = idx;
@@ -144,6 +153,7 @@ VSTGUI::COptionMenu *CSnapshotMenu::populateSubmenuFromTypeElement(TiXmlElement 
     type->Attribute("i", &type_id);
     sub = 0;
     COptionMenu *subMenu = new COptionMenu(getViewSize(), 0, main, 0, 0, kNoDrawStyle);
+    subMenu->setNbItemsPerColumn(20);
     TiXmlElement *snapshot = TINYXML_SAFE_TO_ELEMENT(type->FirstChild("snapshot"));
     while (snapshot)
     {
@@ -832,7 +842,9 @@ void CFxMenu::saveFXIn(const std::string &s)
         return;
     }
 
-    pfile << "<single-fx streaming_versio=\"" << ff_revision << "\">\n";
+    // this used to say streaming_versio before (was a typo)
+    // make sure both variants are checked when checking sv in the future on patch load
+    pfile << "<single-fx streaming_version=\"" << ff_revision << "\">\n";
 
     // take care of 5 special XML characters
     std::string fxNameSub(fxName);


### PR DESCRIPTION
Multiple columns for FX preset subfolders (Windows only)
Fix typo in FX preset streaming version token name
Closes #4064