### PR TITLE
Return of hardclip menu (A/B boxes only)

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -287,7 +287,7 @@ const char fx_type_names[n_fx_types][16] = {
 };
 
 const char fx_type_shortnames[n_fx_types][8] = {
-    "-",  "DLY", "RV1", "PH",  "ROT", "DIST", "EQ",  "FRQ", "DYN", "CH",  "VOC",  "RV2", "FL",
+    "/",  "DLY", "RV1", "PH",  "ROT", "DIST", "EQ",  "FRQ", "DYN", "CH",  "VOC",  "RV2", "FL",
     "RM", "AW",  "NEU", "GEQ", "RES", "CHW",  "XCT", "ENS", "CMB", "NIM", "TAPE", "TM",
 };
 

--- a/src/common/gui/CEffectSettings.cpp
+++ b/src/common/gui/CEffectSettings.cpp
@@ -269,7 +269,7 @@ CMouseEventResult CEffectSettings::onMouseDown(CPoint &where, const CButtonState
     for (int i = 0; i < n_fx_slots; i++)
     {
         CRect size = getViewSize();
-        CRect r(0, 0, fxslotWidth - 2.f, fxslotHeight - 2.f);
+        CRect r(0, 0, fxslotWidth, fxslotHeight);
         r.offset(size.left, size.top);
         r.offset(fxslotpos[i][0], fxslotpos[i][1]);
 
@@ -277,6 +277,24 @@ CMouseEventResult CEffectSettings::onMouseDown(CPoint &where, const CButtonState
         {
             dragSource = i;
             dragCornerOff = where - r.getTopLeft();
+        }
+    }
+
+    for (int i = 0; i < n_scenes; i++)
+    {
+        CRect size = getViewSize();
+        CRect r(0, 0, scenelabelboxWidth, scenelabelboxHeight);
+        r.offset(size.left, size.top);
+        r.offset(scenelabelbox[i][0], scenelabelbox[i][1]);
+
+        if (r.pointInside(where) && (buttons & kRButton))
+        {
+            auto sge = dynamic_cast<SurgeGUIEditor *>(listener);
+
+            if (sge)
+            {
+                sge->effectSettingsBackgroundClick();
+            }
         }
     }
 
@@ -292,7 +310,7 @@ CMouseEventResult CEffectSettings::onMouseUp(CPoint &where, const CButtonState &
         for (int i = 0; i < n_fx_slots; i++)
         {
             CRect size = getViewSize();
-            CRect r(0, 0, fxslotWidth - 2.f, fxslotHeight - 2.f);
+            CRect r(0, 0, fxslotWidth, fxslotHeight);
             r.offset(size.left, size.top);
             r.offset(fxslotpos[i][0], fxslotpos[i][1]);
 
@@ -343,7 +361,7 @@ CMouseEventResult CEffectSettings::onMouseUp(CPoint &where, const CButtonState &
         for (int i = 0; i < n_fx_slots; i++)
         {
             CRect size = getViewSize();
-            CRect r(0, 0, fxslotWidth - 2.f, fxslotHeight - 2.f);
+            CRect r(0, 0, fxslotWidth, fxslotHeight);
             r.offset(size.left, size.top);
             r.offset(fxslotpos[i][0], fxslotpos[i][1]);
 


### PR DESCRIPTION
Expand the hitzone area for FX grid mouse clicks/drags (now matches actual box dimensions)
Replace the - character used for "no effect" with /