### PR TITLE
Only relevant scene hardclip options shown on A/B scene boxes

### DIFF
--- a/cmake/stage-extra-content.cmake
+++ b/cmake/stage-extra-content.cmake
@@ -3,7 +3,7 @@
 #
 
 set(SURGE_EXTRA_CONTENT_REPO https://github.com/surge-synthesizer/surge-extra-content.git)
-set(SURGE_EXTRA_CONTENT_HASH b66794c08d7e1f0e6dee50d81b9754e8457b0283)
+set(SURGE_EXTRA_CONTENT_HASH b71755dfd56b849afe305e0db10fd4ff39b7b186)
 
 find_package(Git)
 if( ${Git_FOUND} )

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -36,14 +36,14 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
 
     ParameterIDCounter p_id;
     {
-        param_ptr.push_back(fx[4].return_level.assign(p_id.next(), 0, "volume_FX1",
-                                                      "Send FX 1 Return", ct_amplitude,
-                                                      Surge::Skin::Global::fx1_return, 0, cg_GLOBAL,
-                                                      0, true, Surge::ParamConfig::kHorizontal));
-        param_ptr.push_back(fx[5].return_level.assign(p_id.next(), 0, "volume_FX2",
-                                                      "Send FX 2 Return", ct_amplitude,
-                                                      Surge::Skin::Global::fx2_return, 0, cg_GLOBAL,
-                                                      0, true, Surge::ParamConfig::kHorizontal));
+        param_ptr.push_back(fx[fxslot_send1].return_level.assign(
+            p_id.next(), 0, "volume_FX1", "Send FX 1 Return", ct_amplitude,
+            Surge::Skin::Global::fx1_return, 0, cg_GLOBAL, 0, true,
+            Surge::ParamConfig::kHorizontal));
+        param_ptr.push_back(fx[fxslot_send2].return_level.assign(
+            p_id.next(), 0, "volume_FX2", "Send FX 2 Return", ct_amplitude,
+            Surge::Skin::Global::fx2_return, 0, cg_GLOBAL, 0, true,
+            Surge::ParamConfig::kHorizontal));
         // TODO don't store in the patch ?
         param_ptr.push_back(volume.assign(p_id.next(), 0, "volume", "Global Volume",
                                           ct_decibel_attenuation_clipper,
@@ -1331,6 +1331,7 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
     }
 
     TiXmlElement *nonparamconfig = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("nonparamconfig"));
+
     // Set the default for TAM before 16
     if (revision <= 15)
     {
@@ -1342,11 +1343,11 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
         storage->tuningApplicationMode = SurgeStorage::RETUNE_MIDI_ONLY;
     }
 
-    // Default to HC28
-    storage->hardclipMode = SurgeStorage::HARDCLIP_TO_EIGHT;
+    // Default hardclip value
+    storage->hardclipMode = SurgeStorage::HARDCLIP_TO_18DBFS;
     for (int sc = 0; sc < n_scenes; ++sc)
     {
-        storage->sceneHardclipMode[sc] = SurgeStorage::HARDCLIP_TO_EIGHT;
+        storage->sceneHardclipMode[sc] = SurgeStorage::HARDCLIP_TO_18DBFS;
     }
 
     if (nonparamconfig)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -937,11 +937,11 @@ class alignas(16) SurgeStorage
     // hardclip
     enum HardClipMode
     {
-        HARDCLIP_TO_EIGHT = 1,
-        HARDCLIP_TO_ONE,
+        HARDCLIP_TO_18DBFS = 1,
+        HARDCLIP_TO_0DBFS,
         BYPASS_HARDCLIP // scene only
-    } hardclipMode = HARDCLIP_TO_EIGHT,
-      sceneHardclipMode[n_scenes] = {HARDCLIP_TO_EIGHT, HARDCLIP_TO_EIGHT};
+    } hardclipMode = HARDCLIP_TO_18DBFS,
+      sceneHardclipMode[n_scenes] = {HARDCLIP_TO_18DBFS, HARDCLIP_TO_18DBFS};
 
     float note_to_pitch(float x);
     float note_to_pitch_inv(float x);

--- a/src/common/gui/CEffectSettings.cpp
+++ b/src/common/gui/CEffectSettings.cpp
@@ -258,8 +258,9 @@ void CEffectSettings::setColorsForFXSlot(CDrawContext *dc, CRect rect, int fxslo
     if (strcmp(selfx, "OFF") == 0)
     {
         CPoint center = rect.getCenter();
-        auto line = CRect(CPoint(center.x - 2, center.y - 1), CPoint(4, 2));
+        auto line = CRect(CPoint(center.x - 3, center.y - 1), CPoint(6, 2));
 
+        dc->setFrameColor(txtcol);
         dc->drawRect(line, kDrawStroked);
     }
     else
@@ -307,7 +308,7 @@ CMouseEventResult CEffectSettings::onMouseDown(CPoint &where, const CButtonState
 
             if (sge)
             {
-                sge->effectSettingsBackgroundClick();
+                sge->effectSettingsBackgroundClick(i);
             }
         }
     }

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3963,7 +3963,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                 std::string sc = std::string("Scene ") + (char)('A' + current_scene);
                 contextMenu->addSeparator(eid++);
                 // FIXME - add unified menu here
-                addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu(sc + " Disable Hard Clip"),
+                addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu(sc + " Hard Clip Disabled"),
                                 [this]() {
                                     synth->storage.sceneHardclipMode[current_scene] =
                                         SurgeStorage::BYPASS_HARDCLIP;
@@ -3972,22 +3972,23 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                                  SurgeStorage::BYPASS_HARDCLIP);
                 eid++;
 
-                addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu(sc + " 0 dBFS Hard Clip"),
-                                [this]() {
+                addCallbackMenu(contextMenu,
+                                Surge::UI::toOSCaseForMenu(sc + " Hard Clip at 0 dBFS"), [this]() {
                                     synth->storage.sceneHardclipMode[current_scene] =
-                                        SurgeStorage::HARDCLIP_TO_ONE;
+                                        SurgeStorage::HARDCLIP_TO_0DBFS;
                                 });
                 contextMenu->checkEntry(eid, synth->storage.sceneHardclipMode[current_scene] ==
-                                                 SurgeStorage::HARDCLIP_TO_ONE);
+                                                 SurgeStorage::HARDCLIP_TO_0DBFS);
                 eid++;
 
-                addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu(sc + " +18 dBFS Hard Clip"),
+                addCallbackMenu(contextMenu,
+                                Surge::UI::toOSCaseForMenu(sc + " Hard Clip at +18 dBFS"),
                                 [this]() {
                                     synth->storage.sceneHardclipMode[current_scene] =
-                                        SurgeStorage::HARDCLIP_TO_EIGHT;
+                                        SurgeStorage::HARDCLIP_TO_18DBFS;
                                 });
                 contextMenu->checkEntry(eid, synth->storage.sceneHardclipMode[current_scene] ==
-                                                 SurgeStorage::HARDCLIP_TO_EIGHT);
+                                                 SurgeStorage::HARDCLIP_TO_18DBFS);
                 eid++;
             }
 
@@ -3997,17 +3998,24 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                 // FIXME - add unified menu here
 
                 addCallbackMenu(
-                    contextMenu, Surge::UI::toOSCaseForMenu("Global 0 dBFS Hard Clip"),
-                    [this]() { synth->storage.hardclipMode = SurgeStorage::HARDCLIP_TO_ONE; });
+                    contextMenu, Surge::UI::toOSCaseForMenu("Global Hard Clip Disabled"),
+                    [this]() { synth->storage.hardclipMode = SurgeStorage::BYPASS_HARDCLIP; });
                 contextMenu->checkEntry(eid, synth->storage.hardclipMode ==
-                                                 SurgeStorage::HARDCLIP_TO_ONE);
+                                                 SurgeStorage::BYPASS_HARDCLIP);
                 eid++;
 
                 addCallbackMenu(
-                    contextMenu, Surge::UI::toOSCaseForMenu("Global +18 dBFS Hard Clip"),
-                    [this]() { synth->storage.hardclipMode = SurgeStorage::HARDCLIP_TO_EIGHT; });
-                contextMenu->checkEntry(eid, synth->storage.hardclipMode !=
-                                                 SurgeStorage::HARDCLIP_TO_ONE);
+                    contextMenu, Surge::UI::toOSCaseForMenu("Global Hard Clip at 0 dBFS"),
+                    [this]() { synth->storage.hardclipMode = SurgeStorage::HARDCLIP_TO_0DBFS; });
+                contextMenu->checkEntry(eid, synth->storage.hardclipMode ==
+                                                 SurgeStorage::HARDCLIP_TO_0DBFS);
+                eid++;
+
+                addCallbackMenu(
+                    contextMenu, Surge::UI::toOSCaseForMenu("Global Hard Clip at +18 dBFS"),
+                    [this]() { synth->storage.hardclipMode = SurgeStorage::HARDCLIP_TO_18DBFS; });
+                contextMenu->checkEntry(eid, synth->storage.hardclipMode ==
+                                                 SurgeStorage::HARDCLIP_TO_18DBFS);
                 eid++;
             }
 
@@ -4138,7 +4146,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
     return 0;
 }
 
-void SurgeGUIEditor::effectSettingsBackgroundClick()
+void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene)
 {
     CPoint where;
     CRect menuRect;
@@ -4157,45 +4165,31 @@ void SurgeGUIEditor::effectSettingsBackgroundClick()
 
     addCallbackMenu(effmen, "[?] Effect Settings",
                     [hurl]() { Surge::UserInteractions::openURL(hurl); });
+
     effmen->addSeparator();
 
-    txt = Surge::UI::toOSCaseForMenu("Global 0 dBFS Hard Clip");
-    auto hcmen = addCallbackMenu(effmen, txt.c_str(), [this]() {
-        this->synth->storage.hardclipMode = SurgeStorage::HARDCLIP_TO_ONE;
+    std::string sc = std::string("Scene ") + (char)('A' + whichScene);
+
+    txt = sc + Surge::UI::toOSCaseForMenu(" Hard Clip Disabled");
+    auto hcmen = addCallbackMenu(effmen, txt.c_str(), [this, whichScene]() {
+        this->synth->storage.sceneHardclipMode[whichScene] = SurgeStorage::BYPASS_HARDCLIP;
     });
-    hcmen->setChecked(synth->storage.hardclipMode == SurgeStorage::HARDCLIP_TO_ONE);
+    hcmen->setChecked(synth->storage.sceneHardclipMode[whichScene] ==
+                      SurgeStorage::BYPASS_HARDCLIP);
 
-    txt = Surge::UI::toOSCaseForMenu("Global +18 dBFS Hard Clip");
-    hcmen = addCallbackMenu(effmen, txt.c_str(), [this]() {
-        this->synth->storage.hardclipMode = SurgeStorage::HARDCLIP_TO_EIGHT;
+    txt = sc + Surge::UI::toOSCaseForMenu(" Hard Clip at 0 dBFS");
+    hcmen = addCallbackMenu(effmen, txt.c_str(), [this, whichScene]() {
+        this->synth->storage.sceneHardclipMode[whichScene] = SurgeStorage::HARDCLIP_TO_0DBFS;
     });
-    hcmen->setChecked(synth->storage.hardclipMode == SurgeStorage::HARDCLIP_TO_EIGHT ||
-                      synth->storage.hardclipMode == SurgeStorage::BYPASS_HARDCLIP);
+    hcmen->setChecked(synth->storage.sceneHardclipMode[whichScene] ==
+                      SurgeStorage::HARDCLIP_TO_0DBFS);
 
-    for (int i = 0; i < n_scenes; ++i)
-    {
-        std::string sc = std::string("Scene ") + (char)('A' + i);
-
-        effmen->addSeparator();
-
-        txt = sc + Surge::UI::toOSCaseForMenu(" Disable Hard Clip");
-        hcmen = addCallbackMenu(effmen, txt.c_str(), [this, i]() {
-            this->synth->storage.sceneHardclipMode[i] = SurgeStorage::BYPASS_HARDCLIP;
-        });
-        hcmen->setChecked(synth->storage.sceneHardclipMode[i] == SurgeStorage::BYPASS_HARDCLIP);
-
-        txt = sc + Surge::UI::toOSCaseForMenu(" 0 dBFS Hard Clip");
-        hcmen = addCallbackMenu(effmen, txt.c_str(), [this, i]() {
-            this->synth->storage.sceneHardclipMode[i] = SurgeStorage::HARDCLIP_TO_ONE;
-        });
-        hcmen->setChecked(synth->storage.sceneHardclipMode[i] == SurgeStorage::HARDCLIP_TO_ONE);
-
-        txt = sc + Surge::UI::toOSCaseForMenu(" +18 dBFS Hard Clip");
-        hcmen = addCallbackMenu(effmen, txt.c_str(), [this, i]() {
-            this->synth->storage.sceneHardclipMode[i] = SurgeStorage::HARDCLIP_TO_EIGHT;
-        });
-        hcmen->setChecked(synth->storage.sceneHardclipMode[i] == SurgeStorage::HARDCLIP_TO_EIGHT);
-    }
+    txt = sc + Surge::UI::toOSCaseForMenu(" Hard Clip at +18 dBFS");
+    hcmen = addCallbackMenu(effmen, txt.c_str(), [this, whichScene]() {
+        this->synth->storage.sceneHardclipMode[whichScene] = SurgeStorage::HARDCLIP_TO_18DBFS;
+    });
+    hcmen->setChecked(synth->storage.sceneHardclipMode[whichScene] ==
+                      SurgeStorage::HARDCLIP_TO_18DBFS);
 
     frame->addView(effmen);
     effmen->popup();

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -183,7 +183,7 @@ class SurgeGUIEditor : public EditorType,
     void refresh_mod();
     void forceautomationchangefor(Parameter *p);
 
-    void effectSettingsBackgroundClick();
+    void effectSettingsBackgroundClick(int whichScene);
 
 #if TARGET_VST3
   public:


### PR DESCRIPTION
Add global hardclip bypass option (consistency)
FX grid off state drawRect follows text color changes (plus it's wider by 2 px now)
Apply existing enum constants to fx[] array across SurgeSynthesizer and SurgePatch
Update Royal Surge skin with improved FX grid coloring (box borders follow text colors)