### PR TITLE
A number of waveguide fixes

### DIFF
--- a/src/common/dsp/WaveguideOscillator.h
+++ b/src/common/dsp/WaveguideOscillator.h
@@ -41,7 +41,7 @@ class WaveguideOscillator : public Oscillator
     };
 
     WaveguideOscillator(SurgeStorage *s, OscillatorStorage *o, pdata *p)
-        : Oscillator(s, o, p), lp(s), noiseLp(s)
+        : Oscillator(s, o, p), lp{s, s}, hp{s, s}, noiseLp(s)
     {
     }
 
@@ -69,7 +69,8 @@ class WaveguideOscillator : public Oscillator
     float dustBuffer[2][BLOCK_SIZE_OS];
     void fillDustBuffer(float tap0, float tap1);
 
-    BiquadFilter lp, noiseLp;
+    BiquadFilter lp[2], hp[2], noiseLp;
+    void configureLpAndHpFromTone();
 };
 
 #endif // SURGE_WAVEGUIDEOSCILLATOR_H


### PR DESCRIPTION
1. Apply the filter when we pre-load the excited delay line
2. Implement aboslute mode for the offset
3. Fix "stiffness" so that it has a proper symmetric LP/HP
   and also that the state of the LP is correctly managed
   across the two strings

This functionally does all the features we need for #894.
Now it's just profiling.