### PR TITLE
Dynamic slider deactivation and bipolarity

### DIFF
--- a/doc/DynamicNameActivationBipolar.md
+++ b/doc/DynamicNameActivationBipolar.md
@@ -1,0 +1,99 @@
+# Dynamic Names, Deactivation and Bipolarity
+
+In Surge 1.9 we finally (finally) implemented dynamic names, bipolarity, and activation
+status for sliders. This allows you to do things like rename on value changes and so forth at 
+draw time without having to trigger an entire UI re-build. The mechanism is made slightly
+complicated by the fact that Parameter can't have any complex object members (so you can't have
+a std::function as a member on Parameter). So here's how it works!
+
+## General Stuff
+
+1. You end up writing little static function objects with functions to determine
+   names and bools and stuff
+2. Those functions will be called a lot at render time. Make them snappy.
+3. Those functions belong to objects managed outside the lifecycle of Param.
+   Probably a pointer to a static is your best bet.
+
+## Dynamic Names
+
+The name of a parameter is what the slider shows. If your parameter supports a dynamic
+name you need to do the following
+
+1. In Parameter.cpp add the control type to Parameter::supportsDynamicName
+2. When you set up your parameter but *after* you set the control type set the
+   dynamicName object to a pointer to a class of type ParameterDynamicName. The
+   Parameter does *not* take ownership of the pointer so the common pattern is
+   to make a little static stateless class with the stateless name operator and
+   assign a pointer to that to the object.
+3. Usually a menu changes the nature of the names requiring a redraw (not a rebuild).
+   To make a param force a redraw on value change add it to the list in 
+   Parameter::is_nonlocal_on_change.
+
+A couple of good worked examples are in the code base. EuroTwist.cpp sets up a class
+which has dynamic names based on the engine type. It shows how you find the
+associated oscillator using control groups, use that to look up an engine,
+understand your parameter index, and return the right name.
+
+Similarly, the lfoPhaseName handler which is set up for all LFOs in SurgePatch
+creates a static handler and assignes it to all the start_phase dynamic
+names to swap Phase and Shuffle.
+
+## Dynamic Activation
+
+With Surge 1.7 we introduced deactivated sliders, and with Surge 1.9 we can make
+clusters of them. Clusters come in two forms
+
+1. "Follow deactivation" clusters. If parameter A is deactivated so is parameter B.
+   A good example is the LPG treatment in EuroTwist. In this case you want a menu to
+   activate the item.
+2. "Follow value" clusters. Based on some other value deactivate this slider. In this case
+   you don't want a menu, since the menu is the value driver.
+   
+### Follow Deactivation Pattern
+
+In this pattern we have a 'primary' parameter. This is the parameter which holds the
+deactivation status, which the DSP engine asks p.deactivated, etc.... The control type
+participates in can_deactivate and this is unchanged.
+
+To cluster other params with this one, you implement and set on the 
+ParameterDynamicDeactivationFunction which contains two methods,
+getValue() which returns true/false for deactivated, and
+getPrimaryActivationDriver which returns a pointer to the deactivation parent
+or null if there is no parent.
+
+So basically a good implementation of getValue is look up the parent param and
+return its decctivation status, and for getPrimary to look up the paranet param
+and return a poitner to it. The LGP handling in EuroTwist does precisely this.
+
+### Follow Value Pattern
+
+In this pattern you only need implements "getValue" based on your function.
+The LFO does this with rate and phase in envelope mode, as shown again in 
+SurgePatch. In this case do not advertise a leader param, since there isn't one
+(or at least, if there is one, you don't toggle it by setting deactivated)
+
+## Dynamic BiPolarity
+
+Dynamic bipolarity is much more complicated than name or activation since it
+changes not just the UI element but also the text formatting of the value.
+As such, dynamic bipolarity in 1.9 only works with percent sliders and they
+have a specific type. We may expand this in the future.
+
+The core decision we made with dynamic bipolarity is that we do not change the
+underlying value, but rather make a display-only change. So a dynamic-bipolar
+value has the internal val.f be +/- 1 always. Your DSP needs to assume that and
+clamp, model, etc... accordingly.
+
+As of this writing, dynamic bipolarity is also only available for type 
+`ct_percent_bipolar_w_dynamic_unipolar_formatting`.
+
+To use dynamic bipolarity, make your type the above type and then
+set the .dynamicBipolar member to a reference to a non-owned object.
+That implements a ParameterDynamicBool and its getValue member which,
+if it returns false, will *format* the parameter as unipolar (so bind 
+strings and modulations from 0 -> 100 not -100 to 100) and swap the slider
+bakground even though the underlying values will still be -1,1.
+
+A worked example of this is in EuroTwist.cpp and is implemented with
+the special flag kScaleBasedOnIsBiPolar on displayinfo.
+

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -512,11 +512,23 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
         }
     } lfoPhaseName;
 
+    static struct LfoRatePhaseDeact : public ParameterDynamicDeactivationFunction
+    {
+        const bool getValue(Parameter *p) override
+        {
+            auto cge = p->ctrlgroup_entry - ms_lfo1;
+            auto lf = &(p->storage->getPatch().scene[p->scene - 1].lfo[cge]);
+            return lf->shape.val.i == lt_envelope;
+        }
+    } lfoRatePhaseDeact;
+
     for (int sc = 0; sc < n_scenes; ++sc)
     {
         for (int lf = 0; lf < n_lfos; ++lf)
         {
             scene[sc].lfo[lf].start_phase.dynamicName = &lfoPhaseName;
+            scene[sc].lfo[lf].start_phase.dynamicDeactivation = &lfoRatePhaseDeact;
+            scene[sc].lfo[lf].rate.dynamicDeactivation = &lfoRatePhaseDeact;
         }
     }
 

--- a/src/common/gui/CSurgeSlider.cpp
+++ b/src/common/gui/CSurgeSlider.cpp
@@ -60,7 +60,6 @@ CSurgeSlider::CSurgeSlider(const CPoint &loc, long stylee, IControlListener *lis
 
     modmode = 0;
     disabled = false;
-    deactivated = false;
 
     label[0] = 0;
     pModHandle = 0;
@@ -187,13 +186,13 @@ void CSurgeSlider::draw(CDrawContext *dc)
     if (has_modulation_current)
         typex = 2;
 
-    float slider_alpha = (disabled || deactivated) ? 0.35 : 1.0;
+    float slider_alpha = (disabled || isDeactivatedFn()) ? 0.35 : 1.0;
     bool showHandle = true;
 #if LINUX
     // linux transparency is a bit broken (i have it patched to ignored) as described in
     // #2053. For now just disable handles on linux transparent sliders, which is a bummer
     // but better than a mispaint, then come back to this after 1.7.0
-    if (disabled || deactivated)
+    if (disabled || isDeactivatedFn())
     {
         showHandle = false;
         slider_alpha = 1.0;
@@ -512,7 +511,7 @@ void CSurgeSlider::draw(CDrawContext *dc)
         }
     }
 
-    if (pHandle && showHandle && (modmode != 2) && (!deactivated || !disabled))
+    if (pHandle && showHandle && (modmode != 2) && (!isDeactivatedFn() || !disabled))
     {
         draghandlecenter = hrect.getCenter();
 
@@ -555,7 +554,7 @@ void CSurgeSlider::draw(CDrawContext *dc)
                 }
             }
         }
-        else if ((!deactivated || !disabled))
+        else if ((!isDeactivatedFn() || !disabled))
         {
             pHandle->draw(
                 dc, hrect, CPoint(0, 28 * typehy),
@@ -605,7 +604,7 @@ void CSurgeSlider::draw(CDrawContext *dc)
     }
 
     // draw mod-fader
-    if (pHandle && showHandle && modmode && (!deactivated || !disabled))
+    if (pHandle && showHandle && modmode && (!isDeactivatedFn() || !disabled))
     {
         CRect hrect(headrect);
         handle_rect = handle_rect_orig;

--- a/src/common/gui/CSurgeSlider.h
+++ b/src/common/gui/CSurgeSlider.h
@@ -99,6 +99,13 @@ class CSurgeSlider : public VSTGUI::CControl,
         invalid();
     }
 
+    std::function<bool()> isDeactivatedFn = []() { return false; };
+    void setDeactivatedFn(std::function<bool()> f)
+    {
+        isDeactivatedFn = f;
+        invalid();
+    }
+
     virtual void setTempoSync(bool b) { is_temposync = b; }
 
     void SetQuantitizedDispValue(float f);
@@ -118,8 +125,7 @@ class CSurgeSlider : public VSTGUI::CControl,
 
     bool in_hover = false;
     bool is_mod;
-    bool disabled;    // means it can't be used unless something else changes
-    bool deactivated; // means it has been turned off by user action
+    bool disabled; // means it can't be used unless something else changes
     bool hasBeenDraggedDuringMouseGesture = false;
 
     bool isStepped = false;


### PR DESCRIPTION
Closes #4109
Closes #2151
Addresses #2089
Addresses #3810 

This commit provides dynamic deactivation and bipolarity support
into the Parameter / CSurgeSlider collaboration.

Deacivation clusters by deactivate and by value both work.
Bipolar display and typeins work.
Documentation and some worked examples show how to finish