### PR TITLE
Implement clock rate and feedback parameter for BBD Ensemble

### DIFF
--- a/src/common/dsp/BiquadFilter.cpp
+++ b/src/common/dsp/BiquadFilter.cpp
@@ -73,13 +73,9 @@ void BiquadFilter::coeff_LP2B(double omega, double Q)
             (w_sq * w_sq) + (M_PI * M_PI * M_PI * M_PI) + w_sq * (M_PI * M_PI) * (1 / Q - 2);
         double G1 = min(1.0, sqrt((w_sq * w_sq) / den) * 0.5);
 
-        double cosi = cos(omega), sinu = sin(omega),
-               // alpha = sinu*sinh((log(2.0)/2.0) * (BW) * omega / sinu),
-            alpha = sinu / (2 * Q),
-               // G1 = 0.05, //powf(2,-log(M_PI/omega)/log(2.0)),
-               // set aa to 6 db
+        double cosi = cos(omega), sinu = sin(omega), alpha = sinu / (2 * Q),
 
-            A = 2 * sqrt(G1) * sqrt(2 - G1), b0 = (1 - cosi + G1 * (1 + cosi) + A * sinu) * 0.5,
+               A = 2 * sqrt(G1) * sqrt(2 - G1), b0 = (1 - cosi + G1 * (1 + cosi) + A * sinu) * 0.5,
                b1 = (1 - cosi - G1 * (1 + cosi)),
                b2 = (1 - cosi + G1 * (1 + cosi) - A * sinu) * 0.5, a0 = (1 + alpha), a1 = -2 * cosi,
                a2 = 1 - alpha;

--- a/src/common/dsp/BiquadFilter.h
+++ b/src/common/dsp/BiquadFilter.h
@@ -61,6 +61,7 @@ class BiquadFilter
     BiquadFilter();
     BiquadFilter(SurgeStorage *storage);
     void coeff_LP(double omega, double Q);
+    /** Compared to coeff_LP, this version adds a small boost at high frequencies */
     void coeff_LP2B(double omega, double Q);
     void coeff_HP(double omega, double Q);
     void coeff_BP(double omega, double Q);

--- a/src/common/dsp/effect/BBDEnsembleEffect.cpp
+++ b/src/common/dsp/effect/BBDEnsembleEffect.cpp
@@ -16,37 +16,48 @@
 #include "BBDEnsembleEffect.h"
 #include "DebugHelpers.h"
 
-enum EnsembleStages
-{
-    ens_sinc = 0,
-    ens_128,
-    ens_256,
-    ens_512,
-    ens_1024,
-    ens_2048,
-    ens_4096,
-};
-
 std::string ensemble_stage_name(int i)
 {
     switch (i)
     {
-    case ens_sinc:
+    case BBDEnsembleEffect::ens_sinc:
         return "Digital Delay";
-    case ens_128:
+    case BBDEnsembleEffect::ens_128:
         return "BBD 128 Stages";
-    case ens_256:
+    case BBDEnsembleEffect::ens_256:
         return "BBD 256 Stages";
-    case ens_512:
+    case BBDEnsembleEffect::ens_512:
         return "BBD 512 Stages";
-    case ens_1024:
+    case BBDEnsembleEffect::ens_1024:
         return "BBD 1024 Stages";
-    case ens_2048:
+    case BBDEnsembleEffect::ens_2048:
         return "BBD 2048 Stages";
-    case ens_4096:
+    case BBDEnsembleEffect::ens_4096:
         return "BBD 4096 Stages";
     }
     return "Error";
+}
+
+int ensemble_num_stages(int i)
+{
+    switch (i)
+    {
+    case BBDEnsembleEffect::ens_sinc:
+        return 256; // faking it :)!
+    case BBDEnsembleEffect::ens_128:
+        return 128;
+    case BBDEnsembleEffect::ens_256:
+        return 256;
+    case BBDEnsembleEffect::ens_512:
+        return 512;
+    case BBDEnsembleEffect::ens_1024:
+        return 1024;
+    case BBDEnsembleEffect::ens_2048:
+        return 2048;
+    case BBDEnsembleEffect::ens_4096:
+        return 4096;
+    }
+    return 1;
 }
 
 int ensemble_stage_count() { return 7; }
@@ -55,14 +66,19 @@ namespace
 {
 constexpr float delay1Ms = 0.6f;
 constexpr float delay2Ms = 0.2f;
-constexpr float dlyTimeCenter = 5.0f;
 } // namespace
 
 BBDEnsembleEffect::BBDEnsembleEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd)
-    : Effect(storage, fxdata, pd)
+    : Effect(storage, fxdata, pd), ensembleFilterDeact(this)
 {
     width.set_blocksize(BLOCK_SIZE);
     mix.set_blocksize(BLOCK_SIZE);
+
+    for (int i = 0; i < 2; ++i)
+    {
+        dc_blocker[i].setBlockSize(BLOCK_SIZE);
+        dc_blocker[i].suspend();
+    }
 }
 
 BBDEnsembleEffect::~BBDEnsembleEffect() {}
@@ -77,7 +93,7 @@ void BBDEnsembleEffect::init()
         {
             del->prepare(samplerate);
             del->setFilterFreq(10000.0f);
-            del->setDelayTime(dlyTimeCenter * 0.001f);
+            del->setDelayTime(0.005f);
         }
     };
 
@@ -90,6 +106,16 @@ void BBDEnsembleEffect::init()
 
     bbd_saturation_sse.reset(samplerate);
     bbd_saturation_sse.setDrive(0.5f);
+
+    fbStateL = 0.0f;
+    fbStateR = 0.0f;
+
+    // Butterworth highpass
+    const auto dc_omega = 300.0f / samplerate;
+    dc_blocker[0].coeff_HP(dc_omega, 1.0 / 0.7654);
+    dc_blocker[0].coeff_instantize();
+    dc_blocker[1].coeff_HP(dc_omega, 1.0 / 1.8478);
+    dc_blocker[1].coeff_instantize();
 }
 
 void BBDEnsembleEffect::setvars(bool init)
@@ -104,19 +130,30 @@ void BBDEnsembleEffect::setvars(bool init)
     }
 }
 
-void BBDEnsembleEffect::process_sinc_delays(float *dataL, float *dataR)
+float BBDEnsembleEffect::getFeedbackGain(bool bbd) const noexcept
 {
-    float del1 = delay1Ms * 0.001 * samplerate;
-    float del2 = delay2Ms * 0.001 * samplerate;
-    float del0 = dlyTimeCenter * 0.001 * samplerate;
+    // normally we would just need the feedback to be less than 1
+    // however here we're adding the output of 2 delay lines so
+    // we need the feedback to be less than 0.5.
+    auto baseFeedbackParam = (bbd ? 0.2f : 1.0f) * *f[ens_delay_feedback];
+    return 0.49f * std::pow(baseFeedbackParam, 0.5f);
+}
+
+void BBDEnsembleEffect::process_sinc_delays(float *dataL, float *dataR, float delayCenterMs,
+                                            float delayScale)
+{
+    float del1 = delayScale * delay1Ms * 0.001 * samplerate;
+    float del2 = delayScale * delay2Ms * 0.001 * samplerate;
+    float del0 = delayCenterMs * 0.001 * samplerate;
 
     bbd_saturation_sse.setDrive(*f[ens_delay_sat]);
+    float fbGain = getFeedbackGain(false);
 
     for (int s = 0; s < BLOCK_SIZE; ++s)
     {
         // soft-clip input
-        dataL[s] = lookup_waveshape(wst_soft, dataL[s]);
-        dataR[s] = lookup_waveshape(wst_soft, dataR[s]);
+        dataL[s] = lookup_waveshape(wst_soft, dataL[s] + fbStateL);
+        dataR[s] = lookup_waveshape(wst_soft, dataR[s] + fbStateR);
 
         delL.write(dataL[s]);
         delR.write(dataR[s]);
@@ -137,6 +174,12 @@ void BBDEnsembleEffect::process_sinc_delays(float *dataL, float *dataR)
         delayOuts[2] = delR.read(rtap1);
         delayOuts[3] = delR.read(rtap2);
 
+        fbStateL = fbGain * (delayOuts[0] + delayOuts[1]);
+        fbStateR = fbGain * (delayOuts[1] + delayOuts[2]);
+        // avoid DC build-up in the feedback path
+        dc_blocker[0].process_sample_nolag(fbStateL, fbStateR);
+        dc_blocker[1].process_sample_nolag(fbStateL, fbStateR);
+
         auto delayOutsVec = vLoad(delayOuts);
         auto waveshaperOutsVec = bbd_saturation_sse.processSample(delayOutsVec);
 
@@ -146,12 +189,8 @@ void BBDEnsembleEffect::process_sinc_delays(float *dataL, float *dataR)
         R[s] = waveshaperOuts[2] + waveshaperOuts[3];
 
         for (int i = 0; i < 3; ++i)
-        {
             for (int j = 0; j < 2; ++j)
-            {
                 modlfos[j][i].post_process();
-            }
-        }
     }
 }
 
@@ -173,6 +212,13 @@ void BBDEnsembleEffect::process(float *dataL, float *dataR)
         roff += onethird;
     }
 
+    auto bbd_stages = *pdata_ival[ens_delay_type];
+    const auto clock_rate = std::max(*f[ens_delay_clockrate], 1.0f); // make sure this is not zero!
+    const auto numStages = ensemble_num_stages(bbd_stages);
+    const auto delayCenterMs = (float)numStages / (2.0f * clock_rate);
+    const auto delayScale =
+        0.95f * delayCenterMs / (delay1Ms + delay2Ms); // make sure total delay is always positive
+
     auto process_bbd_delays = [=](float *dataL, float *dataR, auto &delL1, auto &delL2, auto &delR1,
                                   auto &delR2) {
         // setting the filter frequency takes a while, so
@@ -190,16 +236,17 @@ void BBDEnsembleEffect::process(float *dataL, float *dataR)
         }
 
         bbd_saturation_sse.setDrive(*f[ens_delay_sat]);
+        float fbGain = getFeedbackGain(true);
 
-        float del1 = delay1Ms * 0.001;
-        float del2 = delay2Ms * 0.001;
-        float del0 = dlyTimeCenter * 0.001;
+        float del1 = delayScale * delay1Ms * 0.001;
+        float del2 = delayScale * delay2Ms * 0.001;
+        float del0 = delayCenterMs * 0.001;
 
         for (int s = 0; s < BLOCK_SIZE; ++s)
         {
             // soft-clip input
-            dataL[s] = lookup_waveshape(wst_soft, dataL[s]);
-            dataR[s] = lookup_waveshape(wst_soft, dataR[s]);
+            dataL[s] = lookup_waveshape(wst_soft, dataL[s] + fbStateL);
+            dataR[s] = lookup_waveshape(wst_soft, dataR[s] + fbStateR);
 
             // OK so look at the diagram in #3743
             float t1 = del1 * modlfos[0][0].value() + del2 * modlfos[1][0].value() + del0;
@@ -216,6 +263,12 @@ void BBDEnsembleEffect::process(float *dataL, float *dataR)
             delayOuts[1] = delL2.process(dataL[s]);
             delayOuts[2] = delR1.process(dataR[s]);
             delayOuts[3] = delR2.process(dataR[s]);
+
+            fbStateL = fbGain * (delayOuts[0] + delayOuts[1]);
+            fbStateR = fbGain * (delayOuts[1] + delayOuts[2]);
+            // avoid DC build-up in the feedback path
+            dc_blocker[0].process_sample_nolag(fbStateL, fbStateR);
+            dc_blocker[1].process_sample_nolag(fbStateL, fbStateR);
 
             auto delayOutsVec = vLoad(delayOuts);
             auto waveshaperOutsVec = bbd_saturation_sse.processSample(delayOutsVec);
@@ -234,12 +287,10 @@ void BBDEnsembleEffect::process(float *dataL, float *dataR)
         mul_block(R, db_to_linear(-8.0f), R, BLOCK_SIZE_QUAD);
     };
 
-    auto bbd_stages = *pdata_ival[ens_delay_type];
-
     switch (bbd_stages)
     {
     case ens_sinc:
-        process_sinc_delays(dataL, dataR);
+        process_sinc_delays(dataL, dataR, delayCenterMs, delayScale);
         break;
     case ens_128:
         process_bbd_delays(dataL, dataR, del_128L1, del_128L2, del_128R1, del_128R2);
@@ -315,6 +366,7 @@ void BBDEnsembleEffect::init_ctrltypes()
     fxdata->p[ens_input_filter].set_type(ct_freq_audible);
     fxdata->p[ens_input_filter].val_default.f = 3.65f * 12.f;
     fxdata->p[ens_input_filter].posy_offset = 1;
+    fxdata->p[ens_input_filter].dynamicDeactivation = &ensembleFilterDeact;
 
     fxdata->p[ens_lfo_freq1].set_name("Frequency 1");
     fxdata->p[ens_lfo_freq1].set_type(ct_ensemble_lforate);
@@ -337,7 +389,7 @@ void BBDEnsembleEffect::init_ctrltypes()
     fxdata->p[ens_delay_clockrate].posy_offset = 5;
     fxdata->p[ens_delay_sat].set_name("Saturation");
     fxdata->p[ens_delay_sat].set_type(ct_percent);
-    fxdata->p[ens_delay_sat].val_default.f = 0.5f;
+    fxdata->p[ens_delay_sat].val_default.f = 0.0f;
     fxdata->p[ens_delay_sat].posy_offset = 5;
     fxdata->p[ens_delay_feedback].set_name("Feedback");
     fxdata->p[ens_delay_feedback].set_type(ct_percent);
@@ -368,7 +420,7 @@ void BBDEnsembleEffect::init_default_values()
 
     fxdata->p[ens_delay_type].val.i = 2;
     fxdata->p[ens_delay_clockrate].val.f = 40.f;
-    fxdata->p[ens_delay_sat].val.f = 0.5f;
+    fxdata->p[ens_delay_sat].val.f = 0.0f;
     fxdata->p[ens_delay_feedback].val.f = 0.f;
 
     fxdata->p[ens_width].val.f = 1.f;

--- a/src/common/dsp/effect/BBDEnsembleEffect.h
+++ b/src/common/dsp/effect/BBDEnsembleEffect.h
@@ -54,6 +54,17 @@ class BBDEnsembleEffect : public Effect
         ens_num_ctrls,
     };
 
+    enum EnsembleStages
+    {
+        ens_sinc = 0,
+        ens_128,
+        ens_256,
+        ens_512,
+        ens_1024,
+        ens_2048,
+        ens_4096,
+    };
+
     BBDEnsembleEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
     virtual ~BBDEnsembleEffect();
     virtual const char *get_effectname() override { return "Ensemble"; }
@@ -67,7 +78,8 @@ class BBDEnsembleEffect : public Effect
     virtual int group_label_ypos(int id) override;
 
   private:
-    void process_sinc_delays(float *dataL, float *dataR);
+    float getFeedbackGain(bool bbd) const noexcept;
+    void process_sinc_delays(float *dataL, float *dataR, float delayCenterMs, float delayScale);
 
     Surge::ModControl modlfos[2][3]; // 2 LFOs differening by 120 degree in phase at outputs
     SSESincDelayLine<8192> delL, delR;
@@ -78,7 +90,26 @@ class BBDEnsembleEffect : public Effect
     BBDDelayLine<2048> del_2048L1, del_2048L2, del_2048R1, del_2048R2;
     BBDDelayLine<4096> del_4096L1, del_4096L2, del_4096R1, del_4096R2;
 
+    float fbStateL, fbStateR;
     BBDNonlin bbd_saturation_sse;
-
+    BiquadFilter dc_blocker[2];
     size_t block_counter;
+
+    // we want to be able to deactivate the input filter slider in Sinc delay mode
+    struct EnsembleFilterDeact : public ParameterDynamicDeactivationFunction
+    {
+        const BBDEnsembleEffect *effect;
+
+        EnsembleFilterDeact(const BBDEnsembleEffect *effect) noexcept : effect(effect) {}
+
+        const bool getValue(Parameter *p) override
+        {
+            return effect->fxdata->p[ens_delay_type].val.i == ens_sinc;
+        }
+
+        Parameter *getPrimaryDeactivationDriver(Parameter *p) override
+        {
+            return &effect->fxdata->p[ens_delay_type];
+        }
+    } ensembleFilterDeact;
 };

--- a/src/common/dsp/effect/BBDEnsembleEffect.h
+++ b/src/common/dsp/effect/BBDEnsembleEffect.h
@@ -90,26 +90,10 @@ class BBDEnsembleEffect : public Effect
     BBDDelayLine<2048> del_2048L1, del_2048L2, del_2048R1, del_2048R2;
     BBDDelayLine<4096> del_4096L1, del_4096L2, del_4096R1, del_4096R2;
 
-    float fbStateL, fbStateR;
     BBDNonlin bbd_saturation_sse;
-    BiquadFilter dc_blocker[2];
     size_t block_counter;
 
-    // we want to be able to deactivate the input filter slider in Sinc delay mode
-    struct EnsembleFilterDeact : public ParameterDynamicDeactivationFunction
-    {
-        const BBDEnsembleEffect *effect;
-
-        EnsembleFilterDeact(const BBDEnsembleEffect *effect) noexcept : effect(effect) {}
-
-        const bool getValue(Parameter *p) override
-        {
-            return effect->fxdata->p[ens_delay_type].val.i == ens_sinc;
-        }
-
-        Parameter *getPrimaryDeactivationDriver(Parameter *p) override
-        {
-            return &effect->fxdata->p[ens_delay_type];
-        }
-    } ensembleFilterDeact;
+    float fbStateL, fbStateR;
+    BiquadFilter dc_blocker[2];
+    BiquadFilter sincInputFilter;
 };

--- a/src/common/dsp/effect/chowdsp/bbd_utils/BBDNonlin.h
+++ b/src/common/dsp/effect/chowdsp/bbd_utils/BBDNonlin.h
@@ -75,17 +75,17 @@ class FastDiode : public chowdsp::WDF_SSE::WDFNode
 
 struct NonlinLUT
 {
-    NonlinLUT(double min, double max, int nPoints)
+    NonlinLUT(float min, float max, int nPoints)
     {
         table.resize(nPoints, 0.0f);
 
         offset = min;
-        scale = (double)nPoints / (max - min);
+        scale = (float)nPoints / (max - min);
 
         for (int i = 0; i < nPoints; ++i)
         {
-            auto x = (double)i / scale + offset;
-            table[i] = 2.0e-9 * pwrs(std::abs(x), 0.33);
+            auto x = (float)i / scale + offset;
+            table[i] = 2.0e-9 * pwrs(std::abs(x), 0.33f);
         }
     }
 
@@ -99,15 +99,15 @@ struct NonlinLUT
         return std::pow(std::abs(x), y);
     }
 
-    inline double operator()(double x) const noexcept
+    inline float operator()(float x) const noexcept
     {
         auto idx = size_t((x - offset) * scale);
         return sgn(x) * table[idx];
     }
 
   private:
-    std::vector<double> table;
-    double offset, scale;
+    std::vector<float> table;
+    float offset, scale;
 };
 
 static NonlinLUT bbdNonlinLUT{-5.0, 5.0, 1 << 16};
@@ -117,10 +117,10 @@ class BBDNonlin
   public:
     BBDNonlin() = default;
 
-    void reset(double sampleRate)
+    void reset(float sampleRate)
     {
         using namespace chowdsp::WDF_SSE;
-        constexpr double alpha = 0.4;
+        constexpr float alpha = 0.4;
 
         S2.port1 = std::make_unique<Resistor>(2.7e3f); // Rgk
 


### PR DESCRIPTION
Clock Rate: I tried to implement this based on @mkruselj's notes in `surge-development`. Not sure I nailed exactly what he was going for, but at the very least I got the center delay time to be correctly proportional to the clock rate and number of stages. I chose 256 stages for the Sinc delay mode, but that's completely arbitrary.

Feedback: I added a feedback path around the delay lines, along with a highpass filter to prevent DC build-up. There's a fair amount of hand-tuning in this implementation, which maybe someone with better ears than mine could try to improve.

I also tried to mangle Paul's parameter deactivation code to work for the input filter slider... I'm not totally sure I implemented it correctly though?