### PR TITLE
Fix a VST3 Operation Order Issue / API Issue

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2974,7 +2974,7 @@ void SurgeSynthesizer::getParameterStringW(long index, float value, wchar_t *ptr
     if ((index >= 0) && (index < storage.getPatch().param_ptr.size()))
     {
         char text[128];
-        storage.getPatch().param_ptr[index]->get_display(text);
+        storage.getPatch().param_ptr[index]->get_display(text, true, value);
 
         swprintf(ptr, 128, L"%s", text);
     }


### PR DESCRIPTION
The VST3 API passes me a value I want to stringify on a param.
I was ignoring that value and using the built-in value. This means
if you call getString before you call Set you appear to be off-by-one-tick
but if you call Set before getString you seem fine.

Bitwig calls getString before Set.

So this, defacto, fixes bitwig tiny resolution problem.

Closes #3818