### PR TITLE
Allow per-storage UserPref overrides; use in FX bank

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -18,21 +18,21 @@
 #include "Parameter.h"
 #include "ModulationSource.h"
 #include "Wavetable.h"
+
+#include "tinyxml/tinyxml.h"
+#include "filesystem/import.h"
+
 #include <vector>
 #include <memory>
 #include <mutex>
 #include <atomic>
-#include <stdint.h>
-
-#include "tinyxml/tinyxml.h"
-
-#include "filesystem/import.h"
-
+#include <cstdint>
 #include <fstream>
 #include <iterator>
 #include <functional>
 #include <unordered_map>
 #include <map>
+#include <utility>
 
 #include "Tunings.h"
 
@@ -1117,6 +1117,12 @@ class alignas(16) SurgeStorage
         res += " @ " + std::to_string(k.tuningFrequency) + "Hz";
         return res;
     }
+
+    /*
+     * Other users of surge may want to force clients to override user prefs.
+     * Really we just use this to force the FX bank to 2 decimals for now. But...
+     */
+    std::unordered_map<std::string, std::pair<int, std::string>> userPrefOverrides;
 
     ControllerModulationSource::SmoothingMode smoothingMode =
         ControllerModulationSource::SmoothingMode::LEGACY;

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -138,6 +138,11 @@ bool storeUserDefaultValue(SurgeStorage *storage, const std::string &key, const 
 std::string getUserDefaultValue(SurgeStorage *storage, const std::string &key,
                                 const std::string &valueIfMissing)
 {
+    if (storage->userPrefOverrides.find(key) != storage->userPrefOverrides.end())
+    {
+        return storage->userPrefOverrides[key].second;
+    }
+
     readDefaultsFile(defaultsFileName(storage));
 
     if (defaultsFileContents.find(key) != defaultsFileContents.end())
@@ -155,6 +160,11 @@ std::string getUserDefaultValue(SurgeStorage *storage, const std::string &key,
 
 int getUserDefaultValue(SurgeStorage *storage, const std::string &key, int valueIfMissing)
 {
+    if (storage->userPrefOverrides.find(key) != storage->userPrefOverrides.end())
+    {
+        return storage->userPrefOverrides[key].first;
+    }
+
     readDefaultsFile(defaultsFileName(storage));
 
     if (defaultsFileContents.find(key) != defaultsFileContents.end())

--- a/src/surge_effects_bank/SurgeFXProcessor.cpp
+++ b/src/surge_effects_bank/SurgeFXProcessor.cpp
@@ -21,6 +21,7 @@ SurgefxAudioProcessor::SurgefxAudioProcessor()
 {
     effectNum = fxt_delay;
     storage.reset(new SurgeStorage());
+    storage->userPrefOverrides["highPrecisionReadouts"] = std::make_pair(0, "");
 
     fxstorage = &(storage->getPatch().fx[0]);
     audio_thread_surge_effect.reset();


### PR DESCRIPTION
The FX Bank with high precision looks crummy but you want to
read it. So allow storage to opt into overriding user devaults
in non-mainline-surge use cases.

Addresses #3779