### PR TITLE
Tweak EuroTwist SRC resampler quality

### DIFF
--- a/src/common/dsp/EuroTwist.cpp
+++ b/src/common/dsp/EuroTwist.cpp
@@ -202,7 +202,7 @@ EuroTwist::EuroTwist(SurgeStorage *storage, OscillatorStorage *oscdata, pdata *l
     voice->Init(alloc.get());
     patch = std::make_unique<plaits::Patch>();
     int error;
-    srcstate = src_new(SRC_SINC_MEDIUM_QUALITY, 2, &error);
+    srcstate = src_new(SRC_SINC_FASTEST, 2, &error);
 
     if (error != 0)
     {


### PR DESCRIPTION
Since we are upsampling to downsample again SINC_FASTEST seems fine