### PR TITLE
Uniform and Defensive sample rate in SFX

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1387,6 +1387,27 @@ void SurgeStorage::save_midi_controllers()
     save_snapshots();
 }
 
+void SurgeStorage::setSamplerate(float sr)
+{
+    // If I am changing my sample rate I will change my internal tables, so this
+    // needs to be tuning aware and reapply tuning if needed
+    auto s = currentScale;
+    bool wasST = isStandardTuning;
+
+    samplerate = sr;
+    dsamplerate = sr;
+    samplerate_inv = 1.0 / sr;
+    dsamplerate_inv = 1.0 / sr;
+    dsamplerate_os = dsamplerate * OSC_OVERSAMPLING;
+    dsamplerate_os_inv = 1.0 / dsamplerate_os;
+    init_tables();
+
+    if (!wasST)
+    {
+        retuneToScale(s);
+    }
+}
+
 void SurgeStorage::load_midi_controllers()
 {
     TiXmlElement *mc = getSnapshotSection("midictrl");

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -878,6 +878,8 @@ class alignas(16) SurgeStorage
     int controllers[n_customcontrollers];
     float poly_aftertouch[2][128]; // TODO: FIX SCENE ASSUMPTION?
     float modsource_vu[n_modsources];
+    void setSamplerate(float sr);
+
     void refresh_wtlist();
     void refresh_wtlistAddDir(bool userDir, std::string subdir);
     void refresh_patchlist();

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1787,24 +1787,8 @@ void SurgeSynthesizer::allNotesOff()
 
 void SurgeSynthesizer::setSamplerate(float sr)
 {
-    // If I am changing my sample rate I will change my internal tables, so this
-    // needs to be tuning aware and reapply tuning if needed
-    auto s = storage.currentScale;
-    bool wasST = storage.isStandardTuning;
-
-    samplerate = sr;
-    dsamplerate = sr;
-    samplerate_inv = 1.0 / sr;
-    dsamplerate_inv = 1.0 / sr;
-    dsamplerate_os = dsamplerate * OSC_OVERSAMPLING;
-    dsamplerate_os_inv = 1.0 / dsamplerate_os;
-    storage.init_tables();
+    storage.setSamplerate(sr);
     sinus.set_rate(1000.0 * dsamplerate_inv);
-
-    if (!wasST)
-    {
-        storage.retuneToScale(s);
-    }
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
SurgeFX would read sampleRate from whatever was hanging around
which in the init path could leave things messy. Move the SR setting
into storage (since SFX doesn't have a synth instance) and
make sure in the constructor before we do anything we have it
set either to the lingering value in case we are in a process
or at least a default before we start playing

Closes #4097