### PR TITLE
Fix Nimbus 16k modes

### DIFF
--- a/src/common/dsp/effect/NimbusEffect.h
+++ b/src/common/dsp/effect/NimbusEffect.h
@@ -82,7 +82,8 @@ class NimbusEffect : public Effect
     static constexpr int raw_out_sz = BLOCK_SIZE_OS << 3; // power of 2 pls
     float resampled_output[raw_out_sz][2];                // at sr
     size_t resampReadPtr = 0, resampWritePtr = 1;         // see comment in init
-
+    float stub_input[2];                                  // This is the extra sample we ahve around
+    bool hasStubInput = false;
     int consumed = 0, created = 0;
 };
 


### PR DESCRIPTION
The Nimbus 16k crashes occured when an odd sample cound was
sent in. Stub around the odd sample til the next block.

Addresses #3756