### PR TITLE
Class and filename cleanup for ChowDSP effects (consistent naming format)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,16 +242,16 @@ set(SURGE_SHARED_SOURCES
   src/common/dsp/effect/VocoderEffect.cpp
   src/common/dsp/effect/airwindows/AirWindowsEffect.cpp
   src/common/dsp/effect/airwindows/AirWindowsEffect.h
-  src/common/dsp/effect/chowdsp/Chow.cpp
+  src/common/dsp/effect/chowdsp/CHOWEffect.cpp
+  src/common/dsp/effect/chowdsp/ExciterEffect.cpp
+  src/common/dsp/effect/chowdsp/NeuronEffect.cpp
+  src/common/dsp/effect/chowdsp/TapeEffect.cpp
   src/common/dsp/effect/chowdsp/bbd_utils/BBDDelayLine.cpp
-  src/common/dsp/effect/chowdsp/exciter/Exciter.cpp
   src/common/dsp/effect/chowdsp/exciter/LevelDetector.cpp
+  src/common/dsp/effect/chowdsp/shared/DelayLine.cpp
   src/common/dsp/effect/chowdsp/tape/HysteresisProcessing.cpp
   src/common/dsp/effect/chowdsp/tape/HysteresisProcessor.cpp
   src/common/dsp/effect/chowdsp/tape/LossFilter.cpp
-  src/common/dsp/effect/chowdsp/shared/DelayLine.cpp
-  src/common/dsp/effect/chowdsp/tape/Tape.cpp
-  src/common/dsp/effect/chowdsp/Neuron.cpp
   src/common/dsp/filters/VintageLadders.cpp
   src/common/dsp/filters/Obxd.cpp
   src/common/dsp/filters/K35.cpp

--- a/src/common/dsp/effect/BBDEnsembleEffect.cpp
+++ b/src/common/dsp/effect/BBDEnsembleEffect.cpp
@@ -43,7 +43,7 @@ int ensemble_num_stages(int i)
     switch (i)
     {
     case BBDEnsembleEffect::ens_sinc:
-        return 256; // faking it :)!
+        return 512; // faking it :)!
     case BBDEnsembleEffect::ens_128:
         return 128;
     case BBDEnsembleEffect::ens_256:
@@ -168,6 +168,10 @@ void BBDEnsembleEffect::process_sinc_delays(float *dataL, float *dataR, float de
 
     for (int s = 0; s < BLOCK_SIZE; ++s)
     {
+        // reduce input by 3 dB
+        dataL[s] *= 0.75f;
+        dataR[s] *= 0.75f;
+
         // soft-clip input
         dataL[s] = lookup_waveshape(wst_soft, dataL[s] + fbStateL);
         dataR[s] = lookup_waveshape(wst_soft, dataR[s] + fbStateR);
@@ -258,6 +262,10 @@ void BBDEnsembleEffect::process(float *dataL, float *dataR)
 
         for (int s = 0; s < BLOCK_SIZE; ++s)
         {
+            // reduce input by 3 dB
+            dataL[s] *= 0.75f;
+            dataR[s] *= 0.75f;
+
             // soft-clip input
             dataL[s] = lookup_waveshape(wst_soft, dataL[s] + fbStateL);
             dataR[s] = lookup_waveshape(wst_soft, dataR[s] + fbStateR);

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -18,10 +18,10 @@
 #include "TreemonsterEffect.h"
 #include "VocoderEffect.h"
 #include "airwindows/AirWindowsEffect.h"
-#include "chowdsp/Neuron.h"
-#include "chowdsp/Chow.h"
-#include "chowdsp/exciter/Exciter.h"
-#include "chowdsp/tape/Tape.h"
+#include "chowdsp/NeuronEffect.h"
+#include "chowdsp/ChowEffect.h"
+#include "chowdsp/ExciterEffect.h"
+#include "chowdsp/TapeEffect.h"
 #include "DebugHelpers.h"
 
 using namespace std;
@@ -61,7 +61,7 @@ Effect *spawn_effect(int id, SurgeStorage *storage, FxStorage *fxdata, pdata *pd
     case fxt_airwindows:
         return new AirWindowsEffect(storage, fxdata, pd);
     case fxt_neuron:
-        return new chowdsp::Neuron(storage, fxdata, pd);
+        return new chowdsp::NeuronEffect(storage, fxdata, pd);
     case fxt_geq11:
         return new GEQ11Effect(storage, fxdata, pd);
     case fxt_resonator:
@@ -69,13 +69,13 @@ Effect *spawn_effect(int id, SurgeStorage *storage, FxStorage *fxdata, pdata *pd
     case fxt_combulator:
         return new CombulatorEffect(storage, fxdata, pd);
     case fxt_chow:
-        return new chowdsp::Chow(storage, fxdata, pd);
+        return new chowdsp::CHOWEffect(storage, fxdata, pd);
     case fxt_nimbus:
         return new NimbusEffect(storage, fxdata, pd);
     case fxt_exciter:
-        return new chowdsp::Exciter(storage, fxdata, pd);
+        return new chowdsp::ExciterEffect(storage, fxdata, pd);
     case fxt_tape:
-        return new chowdsp::Tape(storage, fxdata, pd);
+        return new chowdsp::TapeEffect(storage, fxdata, pd);
     case fxt_ensemble:
         return new BBDEnsembleEffect(storage, fxdata, pd);
     case fxt_treemonster:

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -19,7 +19,7 @@
 #include "VocoderEffect.h"
 #include "airwindows/AirWindowsEffect.h"
 #include "chowdsp/NeuronEffect.h"
-#include "chowdsp/ChowEffect.h"
+#include "chowdsp/CHOWEffect.h"
 #include "chowdsp/ExciterEffect.h"
 #include "chowdsp/TapeEffect.h"
 #include "DebugHelpers.h"

--- a/src/common/dsp/effect/chowdsp/CHOWEffect.cpp
+++ b/src/common/dsp/effect/chowdsp/CHOWEffect.cpp
@@ -13,20 +13,21 @@
 ** open source in September 2018.
 */
 
-#include "Chow.h"
+#include "CHOWEffect.h"
 
 namespace chowdsp
 {
 
-Chow::Chow(SurgeStorage *storage, FxStorage *fxdata, pdata *pd) : Effect(storage, fxdata, pd)
+CHOWEffect::CHOWEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd)
+    : Effect(storage, fxdata, pd)
 {
     makeup.set_blocksize(BLOCK_SIZE);
     mix.set_blocksize(BLOCK_SIZE);
 }
 
-Chow::~Chow() {}
+CHOWEffect::~CHOWEffect() {}
 
-void Chow::init()
+void CHOWEffect::init()
 {
     os.reset();
     makeup.set_target(1.0f);
@@ -56,7 +57,7 @@ static inline float chowProcess(float x, const float threshGain, const float rat
     return y;
 }
 
-void Chow::process(float *dataL, float *dataR)
+void CHOWEffect::process(float *dataL, float *dataR)
 {
     set_params();
 
@@ -77,7 +78,7 @@ void Chow::process(float *dataL, float *dataR)
     mix.fade_2_blocks_to(L, dataL, R, dataR, dataL, dataR, BLOCK_SIZE_QUAD);
 }
 
-void Chow::set_params()
+void CHOWEffect::set_params()
 {
     auto thresh_clamped = limit_range(*f[chow_thresh], fxdata->p[chow_thresh].val_min.f,
                                       fxdata->p[chow_thresh].val_max.f);
@@ -95,7 +96,7 @@ void Chow::set_params()
     ratio_smooth.setTargetValue(ratio);
 }
 
-void Chow::process_block(float *dataL, float *dataR)
+void CHOWEffect::process_block(float *dataL, float *dataR)
 {
     for (int k = 0; k < BLOCK_SIZE; k++)
     {
@@ -108,7 +109,7 @@ void Chow::process_block(float *dataL, float *dataR)
     }
 }
 
-void Chow::process_block_os(float *dataL, float *dataR)
+void CHOWEffect::process_block_os(float *dataL, float *dataR)
 {
     os.upsample(dataL, dataR);
 
@@ -131,9 +132,9 @@ void Chow::process_block_os(float *dataL, float *dataR)
     os.downsample(dataL, dataR);
 }
 
-void Chow::suspend() { init(); }
+void CHOWEffect::suspend() { init(); }
 
-void Chow::init_ctrltypes()
+void CHOWEffect::init_ctrltypes()
 {
     Effect::init_ctrltypes();
 
@@ -155,7 +156,7 @@ void Chow::init_ctrltypes()
     fxdata->p[chow_mix].val_default.f = 1.f;
 }
 
-void Chow::init_default_values()
+void CHOWEffect::init_default_values()
 {
     fxdata->p[chow_thresh].val.f = -24.f;
     fxdata->p[chow_ratio].val.f = 10.f;
@@ -163,7 +164,7 @@ void Chow::init_default_values()
     fxdata->p[chow_mix].val.f = 1.f;
 }
 
-const char *Chow::group_label(int id)
+const char *CHOWEffect::group_label(int id)
 {
     switch (id)
     {
@@ -176,7 +177,7 @@ const char *Chow::group_label(int id)
     return 0;
 }
 
-int Chow::group_label_ypos(int id)
+int CHOWEffect::group_label_ypos(int id)
 {
     switch (id)
     {

--- a/src/common/dsp/effect/chowdsp/CHOWEffect.h
+++ b/src/common/dsp/effect/chowdsp/CHOWEffect.h
@@ -25,9 +25,9 @@ namespace chowdsp
 /*
 ** CHOW is a truculent distortion effect, with similar
 ** characteristic and controls as a compressor. The original
-** implentation can be found at: https://github.com/Chowdhury-DSP/CHOW
+** implementation can be found at: https://github.com/Chowdhury-DSP/CHOW
 */
-class Chow : public Effect
+class CHOWEffect : public Effect
 {
   public:
     enum chow_params
@@ -41,8 +41,8 @@ class Chow : public Effect
         chow_num_ctrls,
     };
 
-    Chow(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
-    virtual ~Chow();
+    CHOWEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
+    virtual ~CHOWEffect();
 
     virtual const char *get_effectname() override { return "CHOW"; }
 

--- a/src/common/dsp/effect/chowdsp/ExciterEffect.cpp
+++ b/src/common/dsp/effect/chowdsp/ExciterEffect.cpp
@@ -13,7 +13,7 @@
 ** open source in September 2018.
 */
 
-#include "Exciter.h"
+#include "ExciterEffect.h"
 
 namespace
 {
@@ -25,15 +25,15 @@ constexpr double q_val = 0.7071;
 namespace chowdsp
 {
 
-Exciter::Exciter(SurgeStorage *storage, FxStorage *fxdata, pdata *pd) : Effect(storage, fxdata, pd)
+ExciterEffect::ExciterEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd) : Effect(storage, fxdata, pd)
 {
     wet_gain.set_blocksize(BLOCK_SIZE);
     drive_gain.set_blocksize(BLOCK_SIZE);
 }
 
-Exciter::~Exciter() {}
+ExciterEffect::~ExciterEffect() {}
 
-void Exciter::init()
+void ExciterEffect::init()
 {
     toneFilter.suspend();
     toneFilter.coeff_HP(M_PI, q_val);
@@ -45,7 +45,7 @@ void Exciter::init()
     wet_gain.set_target(0.0f);
 }
 
-void Exciter::process(float *dataL, float *dataR)
+void ExciterEffect::process(float *dataL, float *dataR)
 {
     set_params();
 
@@ -67,7 +67,7 @@ void Exciter::process(float *dataL, float *dataR)
     add_block(dataR, dryR, dataR, BLOCK_SIZE_QUAD);
 }
 
-void Exciter::set_params()
+void ExciterEffect::set_params()
 {
     // "Tone" param
     auto cutoff =
@@ -96,9 +96,9 @@ void Exciter::set_params()
     wet_gain.set_target_smoothed(limit_range(*f[exciter_mix], 0.f, 1.f));
 }
 
-void Exciter::suspend() { init(); }
+void ExciterEffect::suspend() { init(); }
 
-void Exciter::init_ctrltypes()
+void ExciterEffect::init_ctrltypes()
 {
     Effect::init_ctrltypes();
 
@@ -137,7 +137,7 @@ void Exciter::init_ctrltypes()
     fxdata->p[exciter_mix].posy_offset = 5;
 }
 
-void Exciter::init_default_values()
+void ExciterEffect::init_default_values()
 {
     fxdata->p[exciter_drive].val.f = 0.5f;
     fxdata->p[exciter_tone].val.f = 0.5f;
@@ -146,7 +146,7 @@ void Exciter::init_default_values()
     fxdata->p[exciter_mix].val.f = 0.5f;
 }
 
-const char *Exciter::group_label(int id)
+const char *ExciterEffect::group_label(int id)
 {
     switch (id)
     {
@@ -161,7 +161,7 @@ const char *Exciter::group_label(int id)
     return 0;
 }
 
-int Exciter::group_label_ypos(int id)
+int ExciterEffect::group_label_ypos(int id)
 {
     switch (id)
     {

--- a/src/common/dsp/effect/chowdsp/ExciterEffect.cpp
+++ b/src/common/dsp/effect/chowdsp/ExciterEffect.cpp
@@ -25,7 +25,8 @@ constexpr double q_val = 0.7071;
 namespace chowdsp
 {
 
-ExciterEffect::ExciterEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd) : Effect(storage, fxdata, pd)
+ExciterEffect::ExciterEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd)
+    : Effect(storage, fxdata, pd)
 {
     wet_gain.set_blocksize(BLOCK_SIZE);
     drive_gain.set_blocksize(BLOCK_SIZE);

--- a/src/common/dsp/effect/chowdsp/ExciterEffect.h
+++ b/src/common/dsp/effect/chowdsp/ExciterEffect.h
@@ -16,8 +16,8 @@
 #pragma once
 #include <dsp/effect/Effect.h>
 #include "BiquadFilter.h"
-#include "../shared/Oversampling.h"
-#include "LevelDetector.h"
+#include "shared/Oversampling.h"
+#include "exciter/LevelDetector.h"
 #include <vt_dsp/basic_dsp.h>
 #include <vt_dsp/lipol.h>
 
@@ -29,7 +29,7 @@ namespace chowdsp
 ** For more information, see here:
 ** https://jatinchowdhury18.medium.com/complex-nonlinearities-epsiode-2-harmonic-exciter-cd883d888a43
 */
-class Exciter : public Effect
+class ExciterEffect : public Effect
 {
   public:
     enum exciter_params
@@ -43,8 +43,8 @@ class Exciter : public Effect
         exciter_num_ctrls,
     };
 
-    Exciter(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
-    virtual ~Exciter();
+    ExciterEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
+    virtual ~ExciterEffect();
 
     virtual const char *get_effectname() override { return "Exciter"; }
 

--- a/src/common/dsp/effect/chowdsp/NeuronEffect.cpp
+++ b/src/common/dsp/effect/chowdsp/NeuronEffect.cpp
@@ -13,21 +13,21 @@
 ** open source in September 2018.
 */
 
-#include "Neuron.h"
+#include "NeuronEffect.h"
 
 namespace chowdsp
 {
 
-Neuron::Neuron(SurgeStorage *storage, FxStorage *fxdata, pdata *pd) : Effect(storage, fxdata, pd)
+NeuronEffect::NeuronEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd) : Effect(storage, fxdata, pd)
 {
     dc_blocker.setBlockSize(BLOCK_SIZE);
     makeup.set_blocksize(BLOCK_SIZE);
     outgain.set_blocksize(BLOCK_SIZE);
 }
 
-Neuron::~Neuron() {}
+NeuronEffect::~NeuronEffect() {}
 
-void Neuron::init()
+void NeuronEffect::init()
 {
     Wf.reset(numSteps);
     Wh.reset(numSteps);
@@ -58,7 +58,7 @@ void Neuron::init()
     outgain.set_target(0.0f);
 }
 
-void Neuron::process(float *dataL, float *dataR)
+void NeuronEffect::process(float *dataL, float *dataR)
 {
     set_params();
 
@@ -80,7 +80,7 @@ void Neuron::process(float *dataL, float *dataR)
     modLFO.post_process();
 }
 
-void Neuron::process_internal(float *dataL, float *dataR, const int numSamples)
+void NeuronEffect::process_internal(float *dataL, float *dataR, const int numSamples)
 {
     for (int k = 0; k < numSamples; k++)
     {
@@ -98,7 +98,7 @@ void Neuron::process_internal(float *dataL, float *dataR, const int numSamples)
     }
 }
 
-void Neuron::set_params()
+void NeuronEffect::set_params()
 {
     auto bf_clamped = limit_range(*f[neuron_bias_bf], 0.0f, 1.0f);
     auto wh_clamped = limit_range(*f[neuron_drive_wh], 0.0f, 1.0f);
@@ -153,9 +153,9 @@ void Neuron::set_params()
     outgain.set_target_smoothed(db_to_linear(*f[neuron_gain]));
 }
 
-void Neuron::suspend() { init(); }
+void NeuronEffect::suspend() { init(); }
 
-const char *Neuron::group_label(int id)
+const char *NeuronEffect::group_label(int id)
 {
     switch (id)
     {
@@ -172,7 +172,7 @@ const char *Neuron::group_label(int id)
     return 0;
 }
 
-int Neuron::group_label_ypos(int id)
+int NeuronEffect::group_label_ypos(int id)
 {
     switch (id)
     {
@@ -188,7 +188,7 @@ int Neuron::group_label_ypos(int id)
     return 0;
 }
 
-void Neuron::init_ctrltypes()
+void NeuronEffect::init_ctrltypes()
 {
     Effect::init_ctrltypes();
 
@@ -245,7 +245,7 @@ void Neuron::init_ctrltypes()
     fxdata->p[neuron_gain].posy_offset = 7;
 }
 
-void Neuron::init_default_values()
+void NeuronEffect::init_default_values()
 {
     fxdata->p[neuron_drive_wh].val.f = 0.0f;
     fxdata->p[neuron_squash_wf].val.f = 0.5f;

--- a/src/common/dsp/effect/chowdsp/NeuronEffect.cpp
+++ b/src/common/dsp/effect/chowdsp/NeuronEffect.cpp
@@ -18,7 +18,8 @@
 namespace chowdsp
 {
 
-NeuronEffect::NeuronEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd) : Effect(storage, fxdata, pd)
+NeuronEffect::NeuronEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd)
+    : Effect(storage, fxdata, pd)
 {
     dc_blocker.setBlockSize(BLOCK_SIZE);
     makeup.set_blocksize(BLOCK_SIZE);

--- a/src/common/dsp/effect/chowdsp/NeuronEffect.h
+++ b/src/common/dsp/effect/chowdsp/NeuronEffect.h
@@ -36,7 +36,7 @@ namespace chowdsp
 ** please see this Medium article:
 *https://jatinchowdhury18.medium.com/complex-nonlinearities-episode-10-gated-recurrent-distortion-6d60948323cf
 */
-class Neuron : public Effect
+class NeuronEffect : public Effect
 {
   public:
     enum neuron_params
@@ -60,8 +60,8 @@ class Neuron : public Effect
         neuron_num_params,
     };
 
-    Neuron(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
-    virtual ~Neuron();
+    NeuronEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
+    virtual ~NeuronEffect();
 
     virtual const char *get_effectname() override { return "Neuron"; }
 

--- a/src/common/dsp/effect/chowdsp/TapeEffect.cpp
+++ b/src/common/dsp/effect/chowdsp/TapeEffect.cpp
@@ -13,20 +13,20 @@
 ** open source in September 2018.
 */
 
-#include "Tape.h"
+#include "TapeEffect.h"
 
 namespace chowdsp
 {
 
-Tape::Tape(SurgeStorage *storage, FxStorage *fxdata, pdata *pd)
+TapeEffect::TapeEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd)
     : Effect(storage, fxdata, pd), lossFilter(storage, 48)
 {
     mix.set_blocksize(BLOCK_SIZE);
 }
 
-Tape::~Tape() {}
+TapeEffect::~TapeEffect() {}
 
-void Tape::init()
+void TapeEffect::init()
 {
     hysteresis.reset(samplerate);
     lossFilter.prepare(samplerate, BLOCK_SIZE);
@@ -38,7 +38,7 @@ void Tape::init()
     mix.instantize();
 }
 
-void Tape::process(float *dataL, float *dataR)
+void TapeEffect::process(float *dataL, float *dataR)
 {
     for (int i = 0; i < BLOCK_SIZE; i++)
     {
@@ -62,9 +62,9 @@ void Tape::process(float *dataL, float *dataR)
     mix.fade_2_blocks_to(dataL, L, dataR, R, dataL, dataR, BLOCK_SIZE_QUAD);
 }
 
-void Tape::suspend() {}
+void TapeEffect::suspend() {}
 
-const char *Tape::group_label(int id)
+const char *TapeEffect::group_label(int id)
 {
     switch (id)
     {
@@ -81,7 +81,7 @@ const char *Tape::group_label(int id)
     return 0;
 }
 
-int Tape::group_label_ypos(int id)
+int TapeEffect::group_label_ypos(int id)
 {
     switch (id)
     {
@@ -98,13 +98,13 @@ int Tape::group_label_ypos(int id)
     return 0;
 }
 
-void Tape::init_ctrltypes()
+void TapeEffect::init_ctrltypes()
 {
     /*
      * The actualy deactivation status is on gain, so reflet that down
      * to freq and bw using the dynamic deactivation mechanism
      */
-    static struct TapeDeact : public ParameterDynamicDeactivationFunction
+    static struct TapeEffectDeact : public ParameterDynamicDeactivationFunction
     {
         const bool getValue(Parameter *p) override
         {
@@ -210,7 +210,7 @@ void Tape::init_ctrltypes()
     fxdata->p[tape_mix].val_default.f = 1.f;
 }
 
-void Tape::init_default_values()
+void TapeEffect::init_default_values()
 {
     fxdata->p[tape_drive].val.f = 0.5f;
     fxdata->p[tape_saturation].val.f = 0.5f;

--- a/src/common/dsp/effect/chowdsp/TapeEffect.h
+++ b/src/common/dsp/effect/chowdsp/TapeEffect.h
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <dsp/effect/Effect.h>
-#include "HysteresisProcessor.h"
-#include "LossFilter.h"
+#include "tape/HysteresisProcessor.h"
+#include "tape/LossFilter.h"
 
 #include <vt_dsp/lipol.h>
 
@@ -30,7 +30,7 @@ namespace chowdsp
 ** see https://github.com/jatinchowdhury18/AnalogTapeModel
 ** and http://dafx2019.bcu.ac.uk/papers/DAFx2019_paper_3.pdf
 */
-class Tape : public Effect
+class TapeEffect : public Effect
 {
     lipol_ps mix alignas(16);
     float L alignas(16)[BLOCK_SIZE], R alignas(16)[BLOCK_SIZE];
@@ -56,8 +56,8 @@ class Tape : public Effect
         tape_num_ctrls,
     };
 
-    Tape(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
-    virtual ~Tape();
+    TapeEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
+    virtual ~TapeEffect();
 
     virtual const char *get_effectname() override { return "Tape"; }
 


### PR DESCRIPTION
Set sinc delay in BBD to "512 stages", instead of 256
Reduce input signal in Ensemble by 3 dB (effect was louder than other modulation effects overall)
Update cmakelists