### PR TITLE
EuroRack to surge submodule, step 1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 	url = https://github.com/pybind/pybind11
 [submodule "libs/eurorack/eurorack"]
 	path = libs/eurorack/eurorack
-	url = https://github.com/pichenettes/eurorack.git
+	url = https://github.com/surge-synthesizer/eurorack.git
 [submodule "libs/filesystem/ghc-filesystem"]
 	path = libs/filesystem/ghc-filesystem
 	url = https://github.com/gulrak/filesystem.git


### PR DESCRIPTION
This is step 1 of moving EuroRack to a surge module.

1. Cloned eurorack into surge-synthesizer
2. Added a branch to said called "surge"
3. Made a single trivial change to README on that branch
4. Updated the main surge submodule

Addreses #4115