### PR TITLE
Tape: implement degradation and tone control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,8 @@ set(SURGE_SHARED_SOURCES
   src/common/dsp/effect/chowdsp/bbd_utils/BBDDelayLine.cpp
   src/common/dsp/effect/chowdsp/exciter/LevelDetector.cpp
   src/common/dsp/effect/chowdsp/shared/DelayLine.cpp
+  src/common/dsp/effect/chowdsp/tape/ChewProcessor.cpp
+  src/common/dsp/effect/chowdsp/tape/DegradeProcessor.cpp
   src/common/dsp/effect/chowdsp/tape/HysteresisProcessing.cpp
   src/common/dsp/effect/chowdsp/tape/HysteresisProcessor.cpp
   src/common/dsp/effect/chowdsp/tape/LossFilter.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ set(SURGE_SHARED_SOURCES
   src/common/dsp/effect/chowdsp/tape/HysteresisProcessing.cpp
   src/common/dsp/effect/chowdsp/tape/HysteresisProcessor.cpp
   src/common/dsp/effect/chowdsp/tape/LossFilter.cpp
+  src/common/dsp/effect/chowdsp/tape/ToneControl.cpp
   src/common/dsp/filters/VintageLadders.cpp
   src/common/dsp/filters/Obxd.cpp
   src/common/dsp/filters/K35.cpp

--- a/src/common/dsp/effect/chowdsp/TapeEffect.h
+++ b/src/common/dsp/effect/chowdsp/TapeEffect.h
@@ -20,6 +20,7 @@
 #include "tape/LossFilter.h"
 #include "tape/DegradeProcessor.h"
 #include "tape/ChewProcessor.h"
+#include "tape/ToneControl.h"
 
 #include <vt_dsp/lipol.h>
 
@@ -43,6 +44,7 @@ class TapeEffect : public Effect
         tape_drive = 0,
         tape_saturation,
         tape_bias,
+        tape_tone,
 
         tape_speed,
         tape_gap,
@@ -74,6 +76,7 @@ class TapeEffect : public Effect
 
   private:
     HysteresisProcessor hysteresis;
+    ToneControl toneControl;
     LossFilter lossFilter;
     DegradeProcessor degrade;
     ChewProcessor chew;

--- a/src/common/dsp/effect/chowdsp/TapeEffect.h
+++ b/src/common/dsp/effect/chowdsp/TapeEffect.h
@@ -18,6 +18,8 @@
 #include <dsp/effect/Effect.h>
 #include "tape/HysteresisProcessor.h"
 #include "tape/LossFilter.h"
+#include "tape/DegradeProcessor.h"
+#include "tape/ChewProcessor.h"
 
 #include <vt_dsp/lipol.h>
 
@@ -73,6 +75,8 @@ class TapeEffect : public Effect
   private:
     HysteresisProcessor hysteresis;
     LossFilter lossFilter;
+    DegradeProcessor degrade;
+    ChewProcessor chew;
 };
 
 } // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/shared/BilinearUtils.h
+++ b/src/common/dsp/effect/chowdsp/shared/BilinearUtils.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cmath>
+
+namespace chowdsp
+{
+
+namespace Bilinear
+{
+
+/** Dummy generic bilinear transform (@TODO: actually implement this) */
+template <typename T, size_t N> struct BilinearTransform
+{
+    static inline void call(T (&b)[N], T (&a)[N], T (&bs)[N], T (&as)[N], T K);
+};
+
+/** Bilinear transform for a first-order filter */
+template <typename T> struct BilinearTransform<T, 2>
+{
+    static inline void call(T (&b)[2], T (&a)[2], T (&bs)[2], T (&as)[2], T K)
+    {
+        const auto a0 = as[0] * K + as[1];
+        b[0] = (bs[0] * K + bs[1]) / a0;
+        b[1] = (-bs[0] * K + bs[1]) / a0;
+        a[0] = 1.0f;
+        a[1] = (-as[0] * K + as[1]) / a0;
+    }
+};
+
+/** Bilinear transform for a second-order filter */
+template <typename T> struct BilinearTransform<T, 3>
+{
+    static inline void call(T (&b)[3], T (&a)[3], T (&bs)[3], T (&as)[3], T K)
+    {
+        const auto KSq = K * K;
+        const float a0 = as[0] * KSq + as[1] * K + as[2];
+
+        a[0] = 1.0f;
+        a[1] = 2.0f * (as[2] - as[0] * KSq) / a0;
+        a[2] = (as[0] * KSq - as[1] * K + as[2]) / a0;
+        b[0] = (bs[0] * KSq + bs[1] * K + bs[2]) / a0;
+        b[1] = 2.0f * (bs[2] - bs[0] * KSq) / a0;
+        b[2] = (bs[0] * KSq - bs[1] * K + bs[2]) / a0;
+    }
+};
+
+/** Calculates a pole frequency from a set of filter coefficients */
+template <typename T> inline T calcPoleFreq(T a, T b, T c)
+{
+    auto radicand = b * b - 4 * a * c;
+    if (radicand >= (T)0)
+        return (T)0;
+
+    return std::sqrt(-radicand) / (2 * a);
+}
+
+} // namespace Bilinear
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/shared/Shelf.h
+++ b/src/common/dsp/effect/chowdsp/shared/Shelf.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "BilinearUtils.h"
+#include "chowdsp_IIR.h"
+
+namespace chowdsp
+{
+
+/** A first order shelving filter, with a set gain at DC,
+ * a set gain at high frequencies, and a transition frequency.
+ */
+template <typename T = float> class ShelfFilter : public IIRFilter<1, T>
+{
+  public:
+    ShelfFilter() = default;
+
+    /** Calculates the coefficients for the filter.
+     * @param lowGain: the gain of the filter at low frequencies
+     * @param highGain: the gain of the filter at high frequencies
+     * @param fc: the transition frequency of the filter
+     * @param fs: the sample rate for the filter
+     *
+     * For information on the filter coefficient derivation,
+     * see Abel and Berners dsp4dae, pg. 249
+     */
+    void calcCoefs(T lowGain, T highGain, T fc, T fs)
+    {
+        // reduce to simple gain element
+        if (lowGain == highGain)
+        {
+            this->b[0] = lowGain;
+            this->b[1] = (T)0;
+            this->a[0] = (T)1;
+            this->a[1] = (T)0;
+            return;
+        }
+
+        auto rho = std::sqrt(highGain / lowGain);
+        auto K = (T)1 / std::tan(M_PI * fc / fs);
+
+        T bs[2]{highGain / rho, lowGain};
+        T as[2]{1.0f / rho, 1.0f};
+        Bilinear::BilinearTransform<T, 2>::call(this->b, this->a, bs, as, K);
+    }
+};
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/shared/chowdsp_IIR.h
+++ b/src/common/dsp/effect/chowdsp/shared/chowdsp_IIR.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <algorithm>
+#include <type_traits>
+
+namespace chowdsp
+{
+
+/** IIR filter of arbirtary order.
+ * Uses Transposed Direct Form II:
+ * https://ccrma.stanford.edu/~jos/fp/Transposed_Direct_Forms.html
+ */
+template <size_t order, typename FloatType = float> class IIRFilter
+{
+  public:
+    IIRFilter() = default;
+
+    /** Reset filter state */
+    virtual void reset() { std::fill(z, &z[order + 1], 0.0f); }
+
+    /** Optimized processing call for first-order filter */
+    template <int N = order>
+    inline typename std::enable_if<N == 1, FloatType>::type processSample(FloatType x) noexcept
+    {
+        FloatType y = z[1] + x * b[0];
+        z[order] = x * b[order] - y * a[order];
+        return y;
+    }
+
+    /** Optimized processing call for second-order filter */
+    template <int N = order>
+    inline typename std::enable_if<N == 2, FloatType>::type processSample(FloatType x) noexcept
+    {
+        FloatType y = z[1] + x * b[0];
+        z[1] = z[2] + x * b[1] - y * a[1];
+        z[order] = x * b[order] - y * a[order];
+        return y;
+    }
+
+    /** Generalized processing call for Nth-order filter */
+    template <int N = order>
+    inline typename std::enable_if<(N > 2), FloatType>::type processSample(FloatType x) noexcept
+    {
+        FloatType y = z[1] + x * b[0];
+
+        for (int i = 1; i < order; ++i)
+            z[i] = z[i + 1] + x * b[i] - y * a[i];
+
+        z[order] = x * b[order] - y * a[order];
+
+        return y;
+    }
+
+    /** Process block of samples */
+    virtual void processBlock(FloatType *block, const int numSamples) noexcept
+    {
+        for (int n = 0; n < numSamples; ++n)
+            block[n] = processSample(block[n]);
+    }
+
+    /** Set coefficients to new values */
+    virtual void setCoefs(const FloatType (&newB)[order + 1], const FloatType (&newA)[order + 1])
+    {
+        std::copy(newB, &newB[order + 1], b);
+        std::copy(newA, &newA[order + 1], a);
+    }
+
+  protected:
+    FloatType a[order + 1];
+    FloatType b[order + 1];
+    FloatType z[order + 1];
+};
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/tape/ChewDropout.h
+++ b/src/common/dsp/effect/chowdsp/tape/ChewDropout.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cmath>
+#include "../shared/SmoothedValue.h"
+
+namespace chowdsp
+{
+
+class ChewDropout
+{
+  public:
+    ChewDropout() = default;
+
+    void setMix(float newMix) { mixSmooth.setTargetValue(newMix); }
+
+    void setPower(float newPow)
+    {
+        for (int ch = 0; ch < 2; ++ch)
+            powerSmooth[ch].setTargetValue(newPow);
+    }
+
+    void prepare(double sr)
+    {
+        mixSmooth.reset(sr, 0.01);
+        mixSmooth.setCurrentAndTargetValue(mixSmooth.getTargetValue());
+
+        for (int ch = 0; ch < 2; ++ch)
+        {
+            powerSmooth[ch].reset(sr, 0.005);
+            powerSmooth[ch].setCurrentAndTargetValue(powerSmooth[ch].getTargetValue());
+        }
+    }
+
+    void process(float *dataL, float *dataR)
+    {
+        if (mixSmooth.getTargetValue() == 0.0f && !mixSmooth.isSmoothing())
+            return;
+
+        for (int n = 0; n < BLOCK_SIZE; ++n)
+        {
+            auto mix = mixSmooth.getNextValue();
+            dataL[n] = mix * dropout(dataL[n], 0) + (1.0f - mix) * dataL[n];
+            dataR[n] = mix * dropout(dataR[n], 1) + (1.0f - mix) * dataR[n];
+        }
+    }
+
+    inline float dropout(float x, int ch)
+    {
+        float sign = 0.0f;
+        if (x > 0.0f)
+            sign = 1.0f;
+        else if (x < 0.0f)
+            sign = -1.0f;
+
+        return std::pow(std::abs(x), powerSmooth[ch].getNextValue()) * sign;
+    }
+
+  private:
+    SmoothedValue<float, chowdsp::ValueSmoothingTypes::Linear> mixSmooth;
+    SmoothedValue<float, chowdsp::ValueSmoothingTypes::Linear> powerSmooth[2];
+};
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/tape/ChewProcessor.cpp
+++ b/src/common/dsp/effect/chowdsp/tape/ChewProcessor.cpp
@@ -1,0 +1,96 @@
+#include "ChewProcessor.h"
+#include <random>
+
+namespace chowdsp
+{
+
+ChewProcessor::ChewProcessor()
+{
+    std::random_device rd;
+    auto gen = std::minstd_rand(rd());
+    std::uniform_real_distribution<float> distro02(0.0f, 2.0f);
+    std::uniform_real_distribution<float> distro01(0.0f, 1.0f);
+    urng02 = std::bind(distro02, gen);
+    urng01 = std::bind(distro01, gen);
+}
+
+void ChewProcessor::set_params(float new_freq, float new_depth, float new_var)
+{
+    freq = new_freq;
+    depth = new_depth;
+    var = new_var;
+}
+
+void ChewProcessor::prepare(double sr, int samplesPerBlock)
+{
+    sampleRate = (float)sr;
+
+    dropout.prepare(sr);
+    filt[0].reset(sampleRate, int(sr * 0.02));
+    filt[1].reset(sampleRate, int(sr * 0.02));
+
+    isCrinkled = false;
+    samplesUntilChange = getDryTime();
+    sampleCounter = 0;
+}
+
+void ChewProcessor::process_block(float *dataL, float *dataR)
+{
+    const float highFreq = std::min(22000.0f, 0.49f * sampleRate);
+    const float freqChange = highFreq - 5000.0f;
+
+    if (freq == 0.0f)
+    {
+        mix = 0.0f;
+        filt[0].setFreq(highFreq);
+        filt[1].setFreq(highFreq);
+    }
+    else if (freq == 1.0f)
+    {
+        mix = 1.0f;
+        power = 3.0f * depth;
+        filt[0].setFreq(highFreq - freqChange * depth);
+        filt[1].setFreq(highFreq - freqChange * depth);
+    }
+    else if (sampleCounter >= samplesUntilChange)
+    {
+        sampleCounter = 0;
+        isCrinkled = !isCrinkled;
+
+        if (isCrinkled) // start crinkle
+        {
+            mix = 1.0f;
+            power = (1.0f + urng02()) * depth;
+            filt[0].setFreq(highFreq - freqChange * depth);
+            filt[1].setFreq(highFreq - freqChange * depth);
+            samplesUntilChange = getWetTime();
+        }
+        else // end crinkle
+        {
+            mix = 0.0f;
+            filt[0].setFreq(highFreq);
+            filt[1].setFreq(highFreq);
+            samplesUntilChange = getDryTime();
+        }
+    }
+    else
+    {
+        power = (1.0f + urng02()) * depth;
+        if (isCrinkled)
+        {
+            filt[0].setFreq(highFreq - freqChange * depth);
+            filt[1].setFreq(highFreq - freqChange * depth);
+        }
+    }
+
+    dropout.setMix(mix);
+    dropout.setPower(1.0f + power);
+
+    dropout.process(dataL, dataR);
+    filt[0].process(dataL, BLOCK_SIZE);
+    filt[1].process(dataR, BLOCK_SIZE);
+
+    sampleCounter += BLOCK_SIZE;
+}
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/tape/ChewProcessor.h
+++ b/src/common/dsp/effect/chowdsp/tape/ChewProcessor.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "ChewDropout.h"
+#include "DegradeFilter.h"
+#include <functional>
+
+namespace chowdsp
+{
+
+class ChewProcessor
+{
+  public:
+    ChewProcessor();
+
+    void set_params(float freq, float depth, float var);
+    void prepare(double sr, int samplesPerBlock);
+    void process_block(float *dataL, float *dataR);
+
+  private:
+    float freq = 0.0f;
+    float depth = 0.0f;
+    float var = 0.0f;
+    float mix = 0.0f;
+    float power = 0.0f;
+
+    ChewDropout dropout;
+    DegradeFilter filt[2];
+
+    std::function<float()> urng02; // A uniform 0,2 RNG
+    std::function<float()> urng01; // A uniform 0,1 RNG
+    int samplesUntilChange = 1000;
+    bool isCrinkled = false;
+    int sampleCounter = 0;
+
+    float sampleRate = 44100.0f;
+
+    inline int getDryTime()
+    {
+        auto tScale = std::pow(freq, 0.1f);
+        auto varScale = std::pow(urng02(), var);
+
+        const auto lowSamples = (int)((1.0 - tScale) * sampleRate * varScale);
+        const auto highSamples = (int)((2 - 1.99 * tScale) * sampleRate * varScale);
+        return lowSamples + int(urng01() * float(highSamples - lowSamples));
+    }
+
+    inline int getWetTime()
+    {
+        auto tScale = std::pow(freq, 0.1f);
+        auto start = 0.2f + 0.8f * depth;
+        auto end = start - (0.001f + 0.01f * depth);
+        auto varScale = pow(urng02(), var);
+
+        const auto lowSamples = (int)((1.0 - tScale) * sampleRate * varScale);
+        const auto highSamples =
+            (int)(((1.0 - tScale) + start - end * tScale) * sampleRate * varScale);
+        return lowSamples + int(urng01() * float(highSamples - lowSamples));
+    }
+};
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/tape/DegradeFilter.h
+++ b/src/common/dsp/effect/chowdsp/tape/DegradeFilter.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cmath>
+#include "../shared/SmoothedValue.h"
+
+namespace chowdsp
+{
+
+/** Lowpass filter for tape degrade effect */
+class DegradeFilter
+{
+  public:
+    DegradeFilter() { freq.reset(numSteps); }
+    ~DegradeFilter() {}
+
+    void reset(float sampleRate, int steps = 0)
+    {
+        fs = sampleRate;
+        for (int n = 0; n < 2; ++n)
+            z[n] = 0.0f;
+
+        if (steps > 0)
+            freq.reset(steps);
+
+        freq.setCurrentAndTargetValue(freq.getTargetValue());
+        calcCoefs(freq.getCurrentValue());
+    }
+
+    inline void calcCoefs(float fc)
+    {
+        float wc = 2 * M_PI * fc / fs;
+        float c = 1.0f / std::tan(wc / 2.0f);
+        float a0 = c + 1.0f;
+
+        b[0] = 1 / a0;
+        b[1] = b[0];
+        a[1] = (1.0f - c) / a0;
+    }
+
+    inline void process(float *buffer, int numSamples)
+    {
+        for (int n = 0; n < numSamples; ++n)
+        {
+            if (freq.isSmoothing())
+                calcCoefs(freq.getNextValue());
+
+            buffer[n] = processSample(buffer[n]);
+        }
+    }
+
+    inline float processSample(float x)
+    {
+        float y = z[1] + x * b[0];
+        z[1] = x * b[1] - y * a[1];
+        return y;
+    }
+
+    void setFreq(float newFreq) { freq.setTargetValue(newFreq); }
+
+  private:
+    SmoothedValue<float, chowdsp::ValueSmoothingTypes::Multiplicative> freq = 20000.0f;
+    float fs = 44100.0f;
+    const int numSteps = 200;
+
+    float a[2] = {1.0f, 0.0f};
+    float b[2] = {1.0f, 0.0f};
+    float z[2] = {1.0f, 0.0f};
+};
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/tape/DegradeNoise.h
+++ b/src/common/dsp/effect/chowdsp/tape/DegradeNoise.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <random>
+#include <functional>
+
+namespace chowdsp
+{
+
+/** Noise for tape degrade effect */
+class DegradeNoise
+{
+  public:
+    DegradeNoise()
+    {
+        std::random_device rd;
+        auto gen = std::minstd_rand(rd());
+        std::uniform_real_distribution<float> distro(-0.5f, 0.5f);
+        urng = std::bind(distro, gen);
+    }
+
+    ~DegradeNoise() {}
+
+    void setGain(float newGain) { curGain = newGain; }
+
+    void prepare() { prevGain = curGain; }
+
+    void processBlock(float *buffer, int numSamples)
+    {
+        if (curGain == prevGain)
+        {
+            for (int n = 0; n < numSamples; ++n)
+                buffer[n] += urng() * curGain;
+        }
+        else
+        {
+            for (int n = 0; n < numSamples; ++n)
+                buffer[n] += urng() * ((curGain * (float)n / (float)numSamples) +
+                                       (prevGain * (1.0f - (float)n / (float)numSamples)));
+
+            prevGain = curGain;
+        }
+    }
+
+  private:
+    float curGain = 0.0f;
+    float prevGain = curGain;
+
+    std::function<float()> urng; // A uniform -0.5,0.5 RNG
+};
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/tape/DegradeProcessor.cpp
+++ b/src/common/dsp/effect/chowdsp/tape/DegradeProcessor.cpp
@@ -1,0 +1,55 @@
+#include "DegradeProcessor.h"
+
+namespace chowdsp
+{
+
+DegradeProcessor::DegradeProcessor()
+{
+    std::random_device rd;
+    auto gen = std::minstd_rand(rd());
+    std::uniform_real_distribution<float> distro(-0.5f, 0.5f);
+    urng = std::bind(distro, gen);
+
+    gain.set_blocksize(BLOCK_SIZE);
+    gain.set_target(1.0f);
+}
+
+void DegradeProcessor::set_params(float depthParam, float amtParam, float varParam)
+{
+    float freqHz = 200.0f * std::pow(20000.0f / 200.0f, 1.0f - amtParam);
+    float gainDB = -24.0f * depthParam;
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        noiseProc[ch].setGain(0.5f * depthParam * amtParam);
+        filterProc[ch].setFreq(
+            std::min(freqHz + (varParam * (freqHz / 0.6f) * urng()), 0.49f * fs));
+    }
+
+    gainDB = std::min(varParam * 36.0f * urng(), 3.0f);
+    gain.set_target_smoothed(std::pow(10.0f, gainDB * 0.05f));
+}
+
+void DegradeProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
+{
+    fs = (float)sampleRate;
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        noiseProc[ch].prepare();
+        filterProc[ch].reset((float)sampleRate, 20);
+    }
+}
+
+void DegradeProcessor::process_block(float *dataL, float *dataR)
+{
+    noiseProc[0].processBlock(dataL, BLOCK_SIZE);
+    noiseProc[1].processBlock(dataR, BLOCK_SIZE);
+
+    filterProc[0].process(dataL, BLOCK_SIZE);
+    filterProc[1].process(dataR, BLOCK_SIZE);
+
+    gain.multiply_2_blocks(dataL, dataR, BLOCK_SIZE_QUAD);
+}
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/tape/DegradeProcessor.h
+++ b/src/common/dsp/effect/chowdsp/tape/DegradeProcessor.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "DegradeFilter.h"
+#include "DegradeNoise.h"
+#include <vt_dsp/lipol.h>
+
+namespace chowdsp
+{
+
+class DegradeProcessor
+{
+  public:
+    DegradeProcessor();
+
+    void set_params(float depthParam, float amtParam, float varParam);
+    void prepareToPlay(double sampleRate, int samplesPerBlock);
+    void process_block(float *dataL, float *dataR);
+
+  private:
+    float depthParam;
+    float amtParam;
+    float varParam;
+
+    DegradeNoise noiseProc[2];
+    DegradeFilter filterProc[2];
+    lipol_ps gain alignas(16);
+
+    std::function<float()> urng; // A uniform -0.5,0.5 RNG
+
+    float fs = 44100.0f;
+};
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/tape/ToneControl.cpp
+++ b/src/common/dsp/effect/chowdsp/tape/ToneControl.cpp
@@ -1,0 +1,125 @@
+#include "ToneControl.h"
+
+namespace chowdsp
+{
+
+namespace
+{
+constexpr double slewTime = 0.05;
+} // namespace
+
+ToneStage::ToneStage()
+{
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        lowGain[ch] = 1.0f;
+        highGain[ch] = 1.0f;
+        tFreq[ch] = 500.0f;
+    }
+}
+
+void ToneStage::prepare(double sampleRate)
+{
+    fs = (float)sampleRate;
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        auto resetSmoothValue = [sampleRate](SmoothGain &value) {
+            value.reset(sampleRate, slewTime);
+            value.setCurrentAndTargetValue(value.getTargetValue());
+        };
+
+        resetSmoothValue(lowGain[ch]);
+        resetSmoothValue(highGain[ch]);
+        resetSmoothValue(tFreq[ch]);
+
+        tone[ch].reset();
+        tone[ch].calcCoefs(lowGain[ch].getTargetValue(), highGain[ch].getTargetValue(),
+                           tFreq[ch].getTargetValue(), fs);
+    }
+}
+
+void setSmoothValues(ToneStage::SmoothGain values[2], float newValue)
+{
+    if (newValue == values[0].getTargetValue())
+        return;
+
+    values[0].setTargetValue(newValue);
+    values[1].setTargetValue(newValue);
+}
+
+void ToneStage::setLowGain(float lowGainDB)
+{
+    setSmoothValues(lowGain, std::pow(10.0f, lowGainDB * 0.05f));
+}
+void ToneStage::setHighGain(float highGainDB)
+{
+    setSmoothValues(highGain, std::pow(10.0f, highGainDB * 0.05f));
+}
+void ToneStage::setTransFreq(float newTFreq) { setSmoothValues(tFreq, newTFreq); }
+
+void ToneStage::processBlock(float *dataL, float *dataR)
+{
+    float *buffer[] = {dataL, dataR};
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        if (lowGain[ch].isSmoothing() || highGain[ch].isSmoothing() || tFreq[ch].isSmoothing())
+        {
+            auto *x = buffer[ch];
+            for (int n = 0; n < BLOCK_SIZE; ++n)
+            {
+                tone[ch].calcCoefs(lowGain[ch].getNextValue(), highGain[ch].getNextValue(),
+                                   tFreq[ch].getNextValue(), fs);
+                x[n] = tone[ch].processSample(x[n]);
+            }
+        }
+        else
+        {
+            tone[ch].processBlock(buffer[ch], BLOCK_SIZE);
+        }
+    }
+}
+
+//===================================================
+void ToneControl::prepare(double sampleRate)
+{
+    toneIn.prepare(sampleRate);
+    toneOut.prepare(sampleRate);
+}
+
+void ToneControl::set_params(float tone)
+{
+    bass = 0.0f;
+    treble = 0.0f;
+    if (tone > 0.0f) // boost treble
+    {
+        treble = std::abs(tone);
+        bass = -0.5f * treble;
+    }
+    else if (tone < 0.0f) // boost bass
+    {
+        bass = std::abs(tone);
+        treble = -0.5f * bass;
+    }
+}
+
+void ToneControl::processBlockIn(float *dataL, float *dataR)
+{
+    toneIn.setLowGain(dbScale * bass);
+    toneIn.setHighGain(dbScale * treble);
+    toneIn.setTransFreq(800.0f); // @TODO: make this a parameter later...
+
+    toneIn.processBlock(dataL, dataR);
+}
+
+void ToneControl::processBlockOut(float *dataL, float *dataR)
+{
+    toneOut.setLowGain(-1.0f * dbScale * bass);
+    toneOut.setHighGain(-1.0f * dbScale * treble);
+    toneOut.setTransFreq(800.0f); // @TODO: make this a parameter later...
+
+    toneOut.processBlock(dataL, dataR);
+}
+
+} // namespace chowdsp

--- a/src/common/dsp/effect/chowdsp/tape/ToneControl.h
+++ b/src/common/dsp/effect/chowdsp/tape/ToneControl.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "../shared/SmoothedValue.h"
+#include "../shared/Shelf.h"
+
+namespace chowdsp
+{
+
+struct ToneStage
+{
+    using SmoothGain = SmoothedValue<float, ValueSmoothingTypes::Multiplicative>;
+    ShelfFilter<float> tone[2];
+    SmoothGain lowGain[2], highGain[2], tFreq[2];
+    float fs = 44100.0f;
+
+    ToneStage();
+
+    void prepare(double sampleRate);
+    void processBlock(float *dataL, float *dataR);
+    void setLowGain(float lowGainDB);
+    void setHighGain(float highGainDB);
+    void setTransFreq(float newTFreq);
+};
+
+class ToneControl
+{
+  public:
+    ToneControl() = default;
+
+    void set_params(float tone);
+    void prepare(double sampleRate);
+
+    void processBlockIn(float *dataL, float *dataR);
+    void processBlockOut(float *dataL, float *dataR);
+
+  private:
+    ToneStage toneIn, toneOut;
+    static constexpr float dbScale = 18.0f;
+    float bass, treble;
+};
+
+} // namespace chowdsp


### PR DESCRIPTION
I've now implemented the tone control, and chew/degrade sections from ChowTape. @mkruselj would you mind giving this a try and see if the Chew/Degrade match up with the parameter mappings you had in mind?

A note about the tone control: in the original plugin I use opposite frequency responses on each side of the tape distortion, similar to what you would have with a pre/post-EQ in an actual tape machine. In Surge, I found this made it pretty hard to hear the effects of the tone change, so I've removed the post-tape filters for now.