### PR TITLE
OSC type automation fix

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -753,7 +753,10 @@ void Parameter::set_type(int ctrltype)
         val_min.i = 0;
         val_default.i = 0;
         val_max.i = n_osc_types - 1;
-        affect_other_parameters = true;
+        /*
+         * BP: We do, but this isn't how we load osces
+         */
+        affect_other_parameters = false;
         break;
     case ct_reverbshape:
         valtype = vt_int;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1987,7 +1987,10 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
                     }
                 }
             }
-            switch_toggled_queued = true;
+            /*
+             * Since we are setting a Queue, we don't need to toggle controls
+             */
+            switch_toggled_queued = false;
             need_refresh = true;
             refresh_editor = true;
             break;


### PR DESCRIPTION
Since OSC type actually enqueues as opposed to forces a change
now, we don't need it to have the affect_other_params thing set

Addresses #4038