### PR TITLE
A number of tweaks on Alias oscillator

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -394,7 +394,7 @@ bool Parameter::is_discrete_selection()
     case ct_vocoder_bandcount:
     case ct_nimbusmode:
     case ct_nimbusquality:
-    case ct_waveguide_excitation_model:
+    case ct_stringosc_excitation_model:
     case ct_twist_engine:
     case ct_ensemble_stages:
     case ct_alias_wave:
@@ -1027,22 +1027,30 @@ void Parameter::set_type(int ctrltype)
         val_default.i = 0;
         break;
     }
-    case ct_waveguide_excitation_model:
+    case ct_stringosc_excitation_model:
     {
-        extern int waveguide_excitations_count();
+        extern int stringosc_excitations_count();
         valtype = vt_int;
         val_min.i = 0;
-        val_max.i = waveguide_excitations_count() - 1;
+        val_max.i = stringosc_excitations_count() - 1;
         val_default.i = 0;
         break;
     }
     case ct_alias_wave:
     {
-        extern const int ALIAS_OSCILLATOR_WAVE_TYPES;
+        extern int alias_waves_count();
         valtype = vt_int;
         val_min.i = 0;
-        val_max.i = 3; // TODO fix, should reference ao_n_types somehow
+        val_max.i = alias_waves_count() - 1;
         val_default.i = 0;
+        break;
+    }
+    case ct_alias_bits:
+    {
+        valtype = vt_float;
+        val_min.f = 1.f;
+        val_max.f = 8.f;
+        val_default.f = 8.f;
         break;
     }
     case ct_flangerspacing:
@@ -1387,6 +1395,13 @@ void Parameter::set_type(int ctrltype)
         displayInfo.scale = 1.f;
         displayInfo.decimals = 2;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "kHz");
+        break;
+
+    case ct_alias_bits:
+        displayType = LinearWithScale;
+        displayInfo.scale = 1.f;
+        displayInfo.decimals = 2;
+        snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "bits");
         break;
     }
 }
@@ -3211,17 +3226,17 @@ void Parameter::get_display(char *txt, bool external, float ef)
             }
         }
         break;
-        case ct_waveguide_excitation_model:
+        case ct_stringosc_excitation_model:
         {
-            extern std::string waveguide_excitation_name(int);
-            auto n = waveguide_excitation_name(i);
+            extern std::string stringosc_excitation_name(int);
+            auto n = stringosc_excitation_name(i);
             snprintf(txt, TXT_SIZE, "%s", n.c_str());
         }
         break;
         case ct_alias_wave:
         {
-            extern const char *ao_type_names[4];
-            snprintf(txt, TXT_SIZE, "%s", ao_type_names[i & 3]); // TODO: don't hardcode type limit
+            extern const char *alias_wave_name[];
+            snprintf(txt, TXT_SIZE, "%s", alias_wave_name[i]);
         }
         break;
         case ct_twist_engine:
@@ -3605,6 +3620,7 @@ bool Parameter::can_setvalue_from_string()
     case ct_freq_ringmod:
     case ct_modern_trimix:
     case ct_ensemble_clockrate:
+    case ct_alias_bits:
     {
         return true;
         break;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -166,12 +166,13 @@ enum ctrltypes
     ct_freq_ringmod,
     ct_modern_trimix,
     ct_percent_oscdrift,
-    ct_waveguide_excitation_model,
+    ct_stringosc_excitation_model,
     ct_ensemble_lforate,
     ct_twist_engine,
     ct_ensemble_stages,
     ct_ensemble_clockrate,
     ct_alias_wave,
+    ct_alias_bits,
     num_ctrltypes,
 };
 

--- a/src/common/dsp/AliasOscillator.cpp
+++ b/src/common/dsp/AliasOscillator.cpp
@@ -95,6 +95,11 @@ void AliasOscillator::process_block(float pitch, float drift, bool stereo, bool 
 
     const double two32 = 4294967296.0;
 
+    // bit depth related
+    auto bits = limit_range(localcopy[oscdata->p[ao_depth].param_id_in_scene].f, 1.f, 8.f);
+    auto quant = powf(2, bits);
+    auto dequant = 1.f / quant;
+
     // compute once for each unison voice here, then apply per sample
     uint32_t phase_increments[MAX_UNISON];
 
@@ -164,10 +169,6 @@ void AliasOscillator::process_block(float pitch, float drift, bool stereo, bool 
         }
 
         // bitcrush output
-        auto bits = limit_range(localcopy[oscdata->p[ao_depth].param_id_in_scene].f, 1.f, 8.f);
-        auto quant = powf(2, bits);
-        auto dequant = 1.f / quant;
-
         output[i] = dequant * (int)(vL * quant);
         outputR[i] = dequant * (int)(vR * quant);
 

--- a/src/common/dsp/AliasOscillator.cpp
+++ b/src/common/dsp/AliasOscillator.cpp
@@ -57,11 +57,8 @@ void AliasOscillator::init(float pitch, bool is_display, bool nonzero_init_drift
 
         phase[u] = oscdata->retrigger.val.b || is_display ? 0.f : rng(gen);
 
-        printf("%d ", phase[u]);
-
         driftLFO[u].init(nonzero_init_drift);
     }
-    printf("\n");
 
     charFilt.init(storage->getPatch().character.val.i);
 }
@@ -117,6 +114,7 @@ void AliasOscillator::process_block(float pitch, float drift, bool stereo, bool 
         }
 
         float vL = 0.0f, vR = 0.0f;
+
         for (int u = 0; u < n_unison; ++u)
         {
             const uint32_t upper = phase[u] >> (32 - bit_depth);

--- a/src/common/dsp/AliasOscillator.h
+++ b/src/common/dsp/AliasOscillator.h
@@ -32,14 +32,14 @@ class AliasOscillator : public Oscillator
         ao_unison_voices,
     };
 
-    enum ao_types
+    enum ao_waves
     {
-        aot_saw,
-        aot_tri,
-        aot_pulse,
-        aot_sine,
+        aow_sawtooth,
+        aow_triangle,
+        aow_pulse,
+        aow_sine,
 
-        ao_n_types
+        ao_n_waves
     };
 
     AliasOscillator(SurgeStorage *s, OscillatorStorage *o, pdata *p) : Oscillator(s, o, p)
@@ -59,7 +59,7 @@ class AliasOscillator : public Oscillator
     virtual void process_block(float pitch, float drift = 0.f, bool stereo = false, bool FM = false,
                                float FMdepth = 0.f);
 
-    template <ao_types wavetype, bool subOctave, bool FM>
+    template <ao_waves wavetype, bool subOctave, bool FM>
     void process_sblk(float pitch, float drift = 0.f, bool stereo = false, float FMdepth = 0.f);
 
     lag<float, true> fmdepth;

--- a/src/common/dsp/StringOscillator.cpp
+++ b/src/common/dsp/StringOscillator.cpp
@@ -38,9 +38,9 @@
 
 #include "StringOscillator.h"
 
-int waveguide_excitations_count() { return 15; }
+int stringosc_excitations_count() { return 15; }
 
-std::string waveguide_excitation_name(int i)
+std::string stringosc_excitation_name(int i)
 {
     auto m = (StringOscillator::exciter_modes)i;
 
@@ -640,7 +640,7 @@ void StringOscillator::process_block_internal(float pitch, float drift, bool ste
 void StringOscillator::init_ctrltypes()
 {
     oscdata->p[str_exciter_mode].set_name("Exciter");
-    oscdata->p[str_exciter_mode].set_type(ct_waveguide_excitation_model);
+    oscdata->p[str_exciter_mode].set_type(ct_stringosc_excitation_model);
 
     oscdata->p[str_exciter_level].set_name("Exciter Level");
     oscdata->p[str_exciter_level].set_type(ct_percent);


### PR DESCRIPTION
Bit Depth has its own ctype, range 1-8 bits, floating point
Bit Depth applied at the output of the oscillator rather than at phase accumulator
Restored `<random>` header but seeded it with `rand()` instead of using a system call
Reference to number of waves not hard-coded anymore but resolved through `extern`

Additionally, renamed waveguide... to stringosc... where applicable