### PR TITLE
Change LFO Shuffle to Phase when in Step seq mode and Rate is deactivated

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -497,7 +497,14 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
                 switch (tp)
                 {
                 case lt_stepseq:
-                    snprintf(res, TXT_SIZE, "Shuffle");
+                    if (lf->rate.deactivated)
+                    {
+                        snprintf(res, TXT_SIZE, "Phase");
+                    }
+                    else
+                    {
+                        snprintf(res, TXT_SIZE, "Shuffle"); 
+                    }
                     break;
                 default:
                     snprintf(res, TXT_SIZE, "Phase");

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -503,7 +503,7 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
                     }
                     else
                     {
-                        snprintf(res, TXT_SIZE, "Shuffle"); 
+                        snprintf(res, TXT_SIZE, "Shuffle");
                     }
                     break;
                 default:


### PR DESCRIPTION
When in StepSeq waveform **and the rate parameter is deactivated**, switch the label of the Phase/Shuffle parameter back to Phase. This change was made because when rate is deactivated, this parameter scrubs through the stationary waveform like it does with other LFO shapes, instead of "shuffling".