### PR TITLE
Add 'CanRamp' in addition to 'HiRes' to AU params

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -692,7 +692,7 @@ ComponentResult aulayer::GetParameterInfo(AudioUnitScope inScope,
     outParameterInfo.defaultValue = 0.f;
 
     outParameterInfo.flags = kAudioUnitParameterFlag_IsWritable |
-                             kAudioUnitParameterFlag_IsReadable |
+                             kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_CanRamp |
                              kAudioUnitParameterFlag_IsHighResolution;
 
     // kAudioUnitParameterFlag_IsGlobalMeta


### PR DESCRIPTION
Followign what JUCE does, add the CanRamp to non-discrete params
which seems to give us slightly better AU<>Param interaction in
logic. Not much more I can do until we are @ JUCE

Closes #3740