### PR TITLE
TapeEffect: improve output gain and chew dry/wet time calculation

### DIFF
--- a/src/common/dsp/effect/chowdsp/TapeEffect.cpp
+++ b/src/common/dsp/effect/chowdsp/TapeEffect.cpp
@@ -23,6 +23,7 @@ TapeEffect::TapeEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd)
     : Effect(storage, fxdata, pd), lossFilter(storage, 48)
 {
     mix.set_blocksize(BLOCK_SIZE);
+    makeup.set_blocksize(BLOCK_SIZE);
 }
 
 TapeEffect::~TapeEffect() {}
@@ -41,6 +42,9 @@ void TapeEffect::init()
 
     mix.set_target(1.f);
     mix.instantize();
+
+    makeup.set_target(std::pow(10.0f, 9.0f / 20.0f));
+    makeup.instantize();
 }
 
 void TapeEffect::process(float *dataL, float *dataR)
@@ -60,7 +64,8 @@ void TapeEffect::process(float *dataL, float *dataR)
 
         toneControl.processBlockIn(L, R);
         hysteresis.process_block(L, R);
-        // toneControl.processBlockOut(L, R);
+
+        makeup.multiply_2_blocks(L, R, BLOCK_SIZE_QUAD);
     }
 
     if (!fxdata->p[tape_speed].deactivated)
@@ -187,7 +192,7 @@ void TapeEffect::init_ctrltypes()
     fxdata->p[tape_drive].set_name("Drive");
     fxdata->p[tape_drive].set_type(ct_percent_deactivatable);
     fxdata->p[tape_drive].posy_offset = 1;
-    fxdata->p[tape_drive].val_default.f = 0.5f;
+    fxdata->p[tape_drive].val_default.f = 0.85f;
     fxdata->p[tape_drive].deactivated = false;
     fxdata->p[tape_saturation].set_name("Saturation");
     fxdata->p[tape_saturation].set_type(ct_percent);
@@ -250,7 +255,7 @@ void TapeEffect::init_ctrltypes()
 
 void TapeEffect::init_default_values()
 {
-    fxdata->p[tape_drive].val.f = 0.5f;
+    fxdata->p[tape_drive].val.f = 0.85f;
     fxdata->p[tape_saturation].val.f = 0.5f;
     fxdata->p[tape_bias].val.f = 0.5f;
     fxdata->p[tape_tone].val.f = 0.0f;

--- a/src/common/dsp/effect/chowdsp/TapeEffect.h
+++ b/src/common/dsp/effect/chowdsp/TapeEffect.h
@@ -35,7 +35,7 @@ namespace chowdsp
 */
 class TapeEffect : public Effect
 {
-    lipol_ps mix alignas(16);
+    lipol_ps mix alignas(16), makeup alignas(16);
     float L alignas(16)[BLOCK_SIZE], R alignas(16)[BLOCK_SIZE];
 
   public:

--- a/src/common/dsp/effect/chowdsp/tape/ChewProcessor.cpp
+++ b/src/common/dsp/effect/chowdsp/tape/ChewProcessor.cpp
@@ -7,11 +7,13 @@ namespace chowdsp
 ChewProcessor::ChewProcessor()
 {
     std::random_device rd;
-    auto gen = std::minstd_rand(rd());
+    auto gen02 = std::minstd_rand(rd());
     std::uniform_real_distribution<float> distro02(0.0f, 2.0f);
+    urng02 = std::bind(distro02, gen02);
+
+    auto gen01 = std::minstd_rand(rd());
     std::uniform_real_distribution<float> distro01(0.0f, 1.0f);
-    urng02 = std::bind(distro02, gen);
-    urng01 = std::bind(distro01, gen);
+    urng01 = std::bind(distro01, gen01);
 }
 
 void ChewProcessor::set_params(float new_freq, float new_depth, float new_var)


### PR DESCRIPTION
Fixed some issues with the "Chew" part of the tape effect (one of the random number generators used for calculating dry/wet times was not initialized right). I also adjusted the default parameters and added a makeup gain so that when you don't get a volume drop when initializing the effect.

@mkruselj, I played around with moving the tone filters to after the hysteresis. I ended up choosing not to, but I'm not married to that decision. If you think it sounds better after, I'd be happy to move it.