### PR TITLE
Add a thread-local independent RNG to SurgeStorage

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -96,6 +96,8 @@ std::string getDLLPath()
 }
 #endif
 
+thread_local SurgeStorage::RNGGen SurgeStorage::rngGen;
+
 SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
 {
     _patch.reset(new SurgePatch(this));

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3115,6 +3115,7 @@ DWORD WINAPI loadPatchInBackgroundThread(LPVOID lpParam)
 #if TARGET_LV2
     synth->getParent()->patchChanged();
 #endif
+
     synth->halt_engine = false;
 
     return 0;

--- a/src/common/dsp/DspUtilities.h
+++ b/src/common/dsp/DspUtilities.h
@@ -322,6 +322,10 @@ float correlated_noise_o2mk2(float &lastval, float &lastval2, float correlation)
 float correlated_noise_o2mk2_suppliedrng(float &lastval, float &lastval2, float correlation,
                                          std::function<float()> &urng);
 
+class SurgeStorage;
+float correlated_noise_o2mk2_storagerng(float &lastval, float &lastval2, float correlation,
+                                        SurgeStorage *storage);
+
 inline double hanning(int i, int n)
 {
     if (i >= n)

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -72,8 +72,7 @@ void SampleAndHoldOscillator::init(float pitch, bool is_display, bool nonzero_in
     }
     else
     {
-        std::random_device rd;
-        auto gen = std::minstd_rand(rd());
+        auto gen = std::minstd_rand(storage->rand());
         std::uniform_real_distribution<float> distro(-1.f, 1.f);
         urng = std::bind(distro, gen);
     }

--- a/src/common/dsp/StringOscillator.cpp
+++ b/src/common/dsp/StringOscillator.cpp
@@ -97,8 +97,7 @@ void StringOscillator::init(float pitch, bool is_display, bool nzi)
     }
     else
     {
-        std::random_device rd;
-        gen = std::minstd_rand(rd());
+        gen = std::minstd_rand(storage->rand());
     }
 
     urd = std::uniform_real_distribution<float>(0.0, 1.0);

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -927,12 +927,13 @@ bool SurgeVoice::process_block(QuadFilterChainState &Q, int Qe)
         float noisecol = limit_range(localcopy[scene->noise_colour.param_id_in_scene].f, -1.f, 1.f);
         for (int i = 0; i < BLOCK_SIZE_OS; i += 2)
         {
-            ((float *)tblock)[i] = correlated_noise_o2mk2(noisegenL[0], noisegenL[1], noisecol);
+            ((float *)tblock)[i] =
+                correlated_noise_o2mk2_storagerng(noisegenL[0], noisegenL[1], noisecol, storage);
             ((float *)tblock)[i + 1] = ((float *)tblock)[i];
             if (is_wide)
             {
-                ((float *)tblockR)[i] =
-                    correlated_noise_o2mk2(noisegenR[0], noisegenR[1], noisecol);
+                ((float *)tblockR)[i] = correlated_noise_o2mk2_storagerng(
+                    noisegenR[0], noisegenR[1], noisecol, storage);
                 ((float *)tblockR)[i + 1] = ((float *)tblockR)[i];
             }
         }

--- a/src/common/dsp/effect/CombulatorEffect.cpp
+++ b/src/common/dsp/effect/CombulatorEffect.cpp
@@ -223,8 +223,9 @@ void CombulatorEffect::process(float *dataL, float *dataR)
             else
                 e = envR * (e - v) + v;
             envV[c] = e;
-            noise[c] = noisemix.v * 3.f * envV[c] *
-                       correlated_noise_o2mk2(noiseGen[c][0], noiseGen[c][1], 0);
+            noise[c] =
+                noisemix.v * 3.f * envV[c] *
+                correlated_noise_o2mk2_storagerng(noiseGen[c][0], noiseGen[c][1], 0, storage);
         }
 
         auto l128 = _mm_setzero_ps();


### PR DESCRIPTION
SurgeStorage now has a static thread loca independent RNG which
acts as a dropin for std::rand but is threadlocalized properly
and also does not share seed state with std::rand.

Closes #4177