### PR TITLE
Temporarirly revert Storage Independent RNG

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -96,7 +96,9 @@ std::string getDLLPath()
 }
 #endif
 
+#if STORAGE_USES_INDEPENDENT_RNG
 thread_local SurgeStorage::RNGGen SurgeStorage::rngGen;
+#endif
 
 SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
 {

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -73,7 +73,12 @@ void SampleAndHoldOscillator::init(float pitch, bool is_display, bool nonzero_in
     else
     {
         std::uniform_real_distribution<float> distro(-1.f, 1.f);
+#ifdef STORAGE_USES_INDEPENDENT_RNG
         urng = std::bind(distro, storage->rngGen.g);
+#else
+        std::minstd_rand gen(std::rand());
+        urng = std::bind(distro, gen);
+#endif
     }
     prepare_unison(n_unison);
 


### PR DESCRIPTION
Keep the API (since the API is great) but make the implementation
use std::rand again since some windows weren't making any noise.

Addresses #4197