### PR TITLE
Use PatchID if loading or dnd a file from user or fact

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -947,8 +947,17 @@ void SurgeStorage::perform_queued_wtloads()
                 {
                     patch.scene[sc].osc[o].queue_type = ot_wavetable;
                 }
+                int wtidx = -1, ct = 0;
+                for (const auto &wti : wt_list)
+                {
+                    if (path_to_string(wti.path) == patch.scene[sc].osc[0].wt.queue_filename)
+                    {
+                        wtidx = ct;
+                    }
+                    ct++;
+                }
 
-                patch.scene[sc].osc[o].wt.current_id = -1;
+                patch.scene[sc].osc[o].wt.current_id = wtidx;
                 load_wt(patch.scene[sc].osc[o].wt.queue_filename, &patch.scene[sc].osc[o].wt,
                         &patch.scene[sc].osc[o]);
                 patch.scene[sc].osc[o].wt.refresh_display = true;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3110,7 +3110,25 @@ DWORD WINAPI loadPatchInBackgroundThread(LPVOID lpParam)
         auto s = path_to_string(p.stem());
         synth->has_patchid_file = false;
         synth->allNotesOff();
-        synth->loadPatchByPath(synth->patchid_file, -1, s.c_str());
+
+        int ptid = -1, ct = 0;
+        for (const auto &pti : synth->storage.patch_list)
+        {
+            if (path_to_string(pti.path) == synth->patchid_file)
+            {
+                ptid = ct;
+            }
+            ct++;
+        }
+
+        if (ptid >= 0)
+        {
+            synth->loadPatch(ptid);
+        }
+        else
+        {
+            synth->loadPatchByPath(synth->patchid_file, -1, s.c_str());
+        }
     }
 #if TARGET_LV2
     synth->getParent()->patchChanged();


### PR DESCRIPTION
If you load or open a WT or a Patch from the surge user or factory
so that it is already scanned into our internal system, use that
id to set state so things like next and prev and category all work.

Closes #4196