### PR TITLE
Alias oscillator improvements: pulse sync, alternate mask behaviour etc

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -324,6 +324,7 @@ bool Parameter::has_deformoptions()
     {
     case ct_lfodeform:
     case ct_modern_trimix:
+    case ct_alias_mask:
         return true;
     default:
         break;

--- a/src/common/dsp/AliasOscillator.h
+++ b/src/common/dsp/AliasOscillator.h
@@ -23,10 +23,10 @@ class AliasOscillator : public Oscillator
     enum ao_params
     {
         ao_wave = 0,
-        ao_shift,
+        ao_wrap,
         ao_mask,
         ao_threshold,
-        ao_depth,
+        ao_bit_depth,
 
         ao_unison_detune = 5,
         ao_unison_voices,
@@ -53,6 +53,8 @@ class AliasOscillator : public Oscillator
         aow_sine_tx6,
         aow_sine_tx7,
         aow_sine_tx8,
+
+        aow_stepseq_additive,
 
         ao_n_waves
     };
@@ -122,5 +124,13 @@ class AliasOscillator : public Oscillator
 
     Surge::Oscillator::DriftLFO driftLFO[MAX_UNISON];
 };
+
+struct Always255CountedSet
+    : public CountedSetUserData // Something to feed to a ct_countedset_percent control
+{
+    virtual int getCountedSetSize() { return 255; }
+};
+
+const Always255CountedSet ALWAYS255COUNTEDSET;
 
 extern const char *ao_type_names[];

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3582,6 +3582,25 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                         break;
                     }
+                    case ct_alias_mask:
+                    {
+                        contextMenu->addSeparator();
+                        eid++;
+
+                        auto trimask = addCallbackMenu(
+                            contextMenu,
+                            Surge::UI::toOSCaseForMenu("Triangle not masked after threshold point"),
+                            [p, this]() {
+                                p->deform_type = !p->deform_type;
+
+                                synth->refresh_editor = true;
+                            });
+
+                        trimask->setChecked(p->deform_type);
+                        eid++;
+
+                        break;
+                    }
                     default:
                     {
                         break;


### PR DESCRIPTION
Pulse mode wrap behaviour is now more what the user expects (although it works differently internally). Mask now also applies before pulse threshold tests, creating a sort of double-pulse effect. There is also now a mode where the triangle wave is only masked below the threshold point.

Also adds an additive mode, where Scene A LFO 0 step sequencer is used to generate a wavetable via additive synthesis. This will wrap and produce distortion when the harmonic sum exceeds [-1,1].

This currently uses sinf() naively, not even fastsin, but we'll hammer that down when we're sure there aren't any bugs currently.