### PR TITLE
Fix dry-wet mix in ring modulator effect

### DIFF
--- a/src/common/dsp/effect/RingModulatorEffect.h
+++ b/src/common/dsp/effect/RingModulatorEffect.h
@@ -71,4 +71,5 @@ class RingModulatorEffect : public Effect
 
     HalfRateFilter halfbandOUT, halfbandIN;
     BiquadFilter lp, hp;
+    lipol_ps mix alignas(16);
 };


### PR DESCRIPTION
Now it's executed after downsampling, rather than within oversampling branch.