### PR TITLE
Implement oscillator 'extra config'

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -152,12 +152,17 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
 
     for (int s = 0; s < n_scenes; s++)
         for (int o = 0; o < n_oscs; o++)
+        {
             for (int i = 0; i < max_mipmap_levels; i++)
                 for (int j = 0; j < max_subtables; j++)
                 {
                     getPatch().scene[s].osc[o].wt.TableF32WeakPointers[i][j] = 0;
                     getPatch().scene[s].osc[o].wt.TableI16WeakPointers[i][j] = 0;
                 }
+            getPatch().scene[s].osc[o].extraConfig.nData = 0;
+            memset(getPatch().scene[s].osc[0].extraConfig.data, 0,
+                   sizeof(float) * OscillatorStorage::ExtraConfigurationData::max_config);
+        }
 
     for (int s = 0; s < n_scenes; ++s)
         for (int fu = 0; fu < n_filterunits_per_scene; ++fu)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -484,6 +484,13 @@ struct OscillatorStorage : public CountedSetUserData // The counted set is the w
     void *queue_xmldata;
     int queue_type;
 
+    struct ExtraConfigurationData
+    {
+        static constexpr size_t max_config = 64;
+        int nData = 0;
+        float data[max_config];
+    } extraConfig;
+
     virtual int getCountedSetSize() { return wt.n_tables; }
 };
 

--- a/src/common/dsp/AliasOscillator.cpp
+++ b/src/common/dsp/AliasOscillator.cpp
@@ -25,7 +25,7 @@ int alias_waves_count() { return AliasOscillator::ao_waves::ao_n_waves; }
 const char *alias_wave_name[] = {
     "Sine",      "Triangle",      "Pulse",        "Noise",     "Alias Mem", "Osc Mem",
     "Scene Mem", "DAW Chunk Mem", "Step Seq Mem", "Audio In",  "TX 2 Wave", "TX 3 Wave",
-    "TX 4 Wave", "TX 5 Wave",     "TX 6 Wave",    "TX 7 Wave", "TX 8 Wave", "Step Seq Add"};
+    "TX 4 Wave", "TX 5 Wave",     "TX 6 Wave",    "TX 7 Wave", "TX 8 Wave", "Additive"};
 
 const uint8_t alias_sinetable[256] = {
     0x7F, 0x82, 0x85, 0x88, 0x8B, 0x8F, 0x92, 0x95, 0x98, 0x9B, 0x9E, 0xA1, 0xA4, 0xA7, 0xAA, 0xAD,
@@ -167,7 +167,7 @@ void AliasOscillator::process_block(float pitch, float drift, bool stereo, bool 
             dynamic_wavetable[4 * qs + 3] = rlong;
         }
         break;
-    case AliasOscillator::ao_waves::aow_stepseq_additive:
+    case AliasOscillator::ao_waves::aow_additive:
     {
         wavetable_mode = true;
         wavetable = (const uint8_t *)dynamic_wavetable;
@@ -185,8 +185,7 @@ void AliasOscillator::process_block(float pitch, float drift, bool stereo, bool 
         float norm = 0.f;
         for (int h = 0; h < n_stepseqsteps; h++)
         {
-            norm += storage->getPatch().stepsequences[0][0].steps[h] *
-                    storage->getPatch().stepsequences[0][0].steps[h];
+            norm += oscdata->extraConfig.data[h] * oscdata->extraConfig.data[h];
         }
         norm = 127.f / sqrtf(norm);
 
@@ -194,7 +193,7 @@ void AliasOscillator::process_block(float pitch, float drift, bool stereo, bool 
         int8_t amps[16];
         for (int h = 0; h < n_stepseqsteps; h++)
         {
-            amps[h] = storage->getPatch().stepsequences[0][0].steps[h] * norm;
+            amps[h] = oscdata->extraConfig.data[h] * norm;
         }
 
         // s for sample
@@ -410,8 +409,8 @@ void AliasOscillator::init_ctrltypes()
                 return "Step Sequencer Data";
             case aow_audiobuffer:
                 return "Audio In";
-            case aow_stepseq_additive:
-                return "Step Sequencer Additive";
+            case aow_additive:
+                return "Additive";
             default:
                 return "ERROR";
             }
@@ -419,7 +418,7 @@ void AliasOscillator::init_ctrltypes()
         bool hasGroupNames() override { return true; }
         std::string groupNameAtStreamedIndex(int i) override
         {
-            if (i <= aow_noise || i == aow_audiobuffer || i == aow_stepseq_additive)
+            if (i <= aow_noise || i == aow_audiobuffer || i == aow_additive)
                 return "";
             if (i < aow_sine_tx2)
                 return "Memory From...";

--- a/src/common/dsp/AliasOscillator.h
+++ b/src/common/dsp/AliasOscillator.h
@@ -54,7 +54,7 @@ class AliasOscillator : public Oscillator
         aow_sine_tx7,
         aow_sine_tx8,
 
-        aow_stepseq_additive,
+        aow_additive,
 
         ao_n_waves
     };
@@ -73,6 +73,12 @@ class AliasOscillator : public Oscillator
     virtual void init_ctrltypes(int scene, int oscnum) { init_ctrltypes(); };
     virtual void init_ctrltypes();
     virtual void init_default_values();
+    virtual void init_extra_config()
+    {
+        oscdata->extraConfig.nData = 16;
+        for (auto i = 0; i < oscdata->extraConfig.nData; ++i)
+            oscdata->extraConfig.data[i] = 1.f / (i + 1);
+    }
     virtual void process_block(float pitch, float drift = 0.f, bool stereo = false, bool FM = false,
                                float FMdepth = 0.f);
 

--- a/src/common/dsp/OscillatorBase.h
+++ b/src/common/dsp/OscillatorBase.h
@@ -33,6 +33,7 @@ class alignas(16) Oscillator
     virtual void init_ctrltypes(int scene, int oscnum) { init_ctrltypes(); };
     virtual void init_ctrltypes(){};
     virtual void init_default_values(){};
+    virtual void init_extra_config() { oscdata->extraConfig.nData = 0; }
     virtual void process_block(float pitch, float drift = 0.f, bool stereo = false, bool FM = false,
                                float FMdepth = 0.f)
     {

--- a/src/common/gui/COscillatorDisplay.h
+++ b/src/common/gui/COscillatorDisplay.h
@@ -83,7 +83,55 @@ class COscillatorDisplay : public VSTGUI::CControl, public Surge::UI::SkinConsum
         delete cdisurf;
 #endif
     }
+
+    /*
+     * Custom Editor Support where I can change this UI based on a type to allow edits
+     * Currently only used by alias oscillator
+     */
+    struct CustomEditor
+    {
+        CustomEditor(COscillatorDisplay *d) : disp(d) {}
+        virtual ~CustomEditor() = default;
+        virtual void draw(VSTGUI::CDrawContext *dc) = 0;
+
+        virtual VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint &where,
+                                                      const VSTGUI::CButtonState &buttons)
+        {
+            return VSTGUI::kMouseEventNotHandled;
+        };
+        virtual VSTGUI::CMouseEventResult onMouseUp(VSTGUI::CPoint &where,
+                                                    const VSTGUI::CButtonState &buttons)
+        {
+            return VSTGUI::kMouseEventNotHandled;
+        };
+        virtual VSTGUI::CMouseEventResult onMouseMoved(VSTGUI::CPoint &where,
+                                                       const VSTGUI::CButtonState &buttons)
+        {
+            return VSTGUI::kMouseEventNotHandled;
+        };
+        virtual VSTGUI::CMouseEventResult onMouseExited(VSTGUI::CPoint &where,
+                                                        const VSTGUI::CButtonState &buttons)
+        {
+            return VSTGUI::kMouseEventNotHandled;
+        };
+        virtual VSTGUI::CMouseEventResult onMouseEntered(VSTGUI::CPoint &where,
+                                                         const VSTGUI::CButtonState &buttons)
+        {
+            return VSTGUI::kMouseEventNotHandled;
+        };
+        // Entered and Exited too
+        COscillatorDisplay *disp;
+    };
+    bool canHaveCustomEditor();
+    void setupCustomEditor();
+    std::shared_ptr<CustomEditor> customEditor; // I really want unique but that
+    // clashes with the VSTGUI copy semantics
+    bool customEditorActive = false, editButtonHover = false;
+    VSTGUI::CRect customEditButtonRect;
+
     virtual void draw(VSTGUI::CDrawContext *dc) override;
+
+    void drawExtraEditButton(VSTGUI::CDrawContext *dc, const std::string &label);
 
     void loadWavetable(int id);
     void loadWavetableFromFile();


### PR DESCRIPTION
Oscillators are params + wavetables with nowhere else to store
stuff, so add an array of up to 64 floats which you can use to specify
extra config, add a pattern by which you can write little mini-editors
in the UI, and use this to make the additive mode for alias have
per-oscillator additives which don't eat a step seq.