### PR TITLE
Move MIDI Control Write from config.xml

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -888,7 +888,7 @@ class alignas(16) SurgeStorage
     int last_key[2]; // TODO: FIX SCENE ASSUMPTION?
     TiXmlElement *getSnapshotSection(const char *name);
     void load_midi_controllers();
-    void save_midi_controllers();
+    void write_midi_controllers_to_user_default();
     void save_snapshots();
     int controllers[n_customcontrollers];
     float poly_aftertouch[2][128]; // TODO: FIX SCENE ASSUMPTION?

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1666,14 +1666,12 @@ void SurgeSynthesizer::channelController(char channel, int cc, int value)
             storage.getPatch().param_ptr[a]->midictrl = cc_encoded;
             storage.getPatch().param_ptr[a + n_scene_params]->midictrl = cc_encoded;
         }
-        storage.save_midi_controllers();
         learn_param = -1;
     }
 
     if ((learn_custom >= 0) && (learn_custom < n_customcontrollers))
     {
         storage.controllers[learn_custom] = cc_encoded;
-        storage.save_midi_controllers();
         learn_custom = -1;
     }
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2753,7 +2753,6 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                         cmd->setActions([this, ccid, mc](CCommandMenuItem *men) {
                             synth->storage.controllers[ccid] = mc;
-                            synth->storage.save_midi_controllers();
                         });
                         cmd->setEnabled(!disabled);
 
@@ -2805,10 +2804,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                     addCallbackMenu(contextMenu,
                                     Surge::UI::toOSCaseForMenu(txt) +
                                         midicc_names[synth->storage.controllers[ccid]] + ")",
-                                    [this, ccid]() {
-                                        synth->storage.controllers[ccid] = -1;
-                                        synth->storage.save_midi_controllers();
-                                    });
+                                    [this, ccid]() { synth->storage.controllers[ccid] = -1; });
                     eid++;
                 }
 
@@ -3781,8 +3777,6 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                 synth->storage.getPatch().param_ptr[a + n_scene_params]->midictrl =
                                     mc;
                             }
-
-                            synth->storage.save_midi_controllers();
                         });
                         cmd->setEnabled(!disabled);
 
@@ -3852,8 +3846,6 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                 synth->storage.getPatch().param_ptr[a + n_scene_params]->midictrl =
                                     -1;
                             }
-
-                            synth->storage.save_midi_controllers();
                         });
                     eid++;
                 }
@@ -6871,6 +6863,10 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMidiMenu(VSTGUI::CRect &menuRect)
                           Surge::UI::toOSCaseForMenu("Sustain Pedal In Mono Mode"));
 
     midiSubMenu->addSeparator();
+
+    auto menuItem = addCallbackMenu(
+        midiSubMenu, Surge::UI::toOSCaseForMenu("Save MIDI Mapping As Global Default"),
+        [this]() { this->synth->storage.write_midi_controllers_to_user_default(); });
 
     addCallbackMenu(midiSubMenu, Surge::UI::toOSCaseForMenu("Save MIDI Mapping As..."),
                     [this, menuRect]() {


### PR DESCRIPTION
Wierdly, the system would write MIDI config to configuration.xml
which mostly failed but sometimes worked. Now we read it if there's
no user config, but write to the userdatapath in MIDIMappings/DefaultMIDIConfig.xml
on every change.

Closes #4194