### PR TITLE
Restore the RNG by reviewing all thread usages

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -96,10 +96,6 @@ std::string getDLLPath()
 }
 #endif
 
-#if STORAGE_USES_INDEPENDENT_RNG
-thread_local SurgeStorage::RNGGen SurgeStorage::rngGen;
-#endif
-
 SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
 {
     _patch.reset(new SurgePatch(this));

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3348,6 +3348,10 @@ void SurgeSynthesizer::processControl()
 
 void SurgeSynthesizer::process()
 {
+#if DEBUG_RNG_THREADING
+    storage.audioThreadID = pthread_self();
+#endif
+
     float mfade = 1.f;
 
     if (halt_engine)


### PR DESCRIPTION
So the RNG in storage is ONLY valid on the audio thread. But turns
out we had been careful enough to do that in all my tests, which is
good. So

1: Document that we are only good in the audio thread
2: Add a debug flag set which lets us check this
3: Remove the static and threadlocal
4: Turn on the Storage-local RNG again

Addresses #4197