### PR TITLE
Implement Shift+scroll and Double-Click to reset

### DIFF
--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -1235,7 +1235,7 @@ void COscillatorDisplay::openCustomEditor()
 
                         clamp1bp(f);
 
-                        if (buttons & kControl)
+                        if ((buttons & kControl) || (buttons & kDoubleClick))
                         {
                             f = 0;
                         }
@@ -1275,7 +1275,10 @@ void COscillatorDisplay::openCustomEditor()
                 if (s.pointInside(where))
                 {
                     auto f = disp->oscdata->extraConfig.data[idx];
-                    f += 0.1 * distance;
+                    if (buttons & kShift)
+                        f += 0.1 * distance / 3;
+                    else
+                        f += 0.1 * distance;
                     f = limit_range(f, -1.f, 1.f);
                     disp->oscdata->extraConfig.data[idx] = f;
                     disp->invalid();


### PR DESCRIPTION
In the Alias oscillator additive editor, Shift+scrollwheel now increments a step by 3x less than regular scrolling, just like in the Step Sequencer.

Double-click to reset maybe has been implemented earlier by @mkruselj , but apparently it broke sometime after that, so I added another check for double-click-to-reset which now makes it work.