### PR TITLE
Refresh editor if Filter type changes

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1965,6 +1965,7 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
                 subtypep->val.i =
                     storage.subtypeMemory[typep->scene - 1][typep->ctrlgroup_entry][typep->val.i];
             }
+            refresh_editor = true;
             break;
         case ct_osctype:
         {


### PR DESCRIPTION
This forces the subtype widget to redraw

Closes #4248