### PR TITLE
Address some of the races UI <-> Audio

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -3300,7 +3300,8 @@ void Parameter::get_display(char *txt, bool external, float ef)
         {
             extern const char *alias_wave_name[];
             extern int alias_waves_count();
-            snprintf(txt, TXT_SIZE, "%s", alias_wave_name[std::min(i, alias_waves_count() - 1)]);
+            snprintf(txt, TXT_SIZE, "%s",
+                     alias_wave_name[std::max(0, std::min(i, alias_waves_count() - 1))]);
         }
         break;
         case ct_twist_engine:

--- a/src/common/dsp/TwistOscillator.cpp
+++ b/src/common/dsp/TwistOscillator.cpp
@@ -122,7 +122,15 @@ static struct EngineDynamicName : public ParameterDynamicNameFunction
         }
 
         auto engp = &(oscs->p[TwistOscillator::twist_engine]);
+        if (engp->ctrltype != ct_twist_engine)
+        {
+            return "ERROR";
+        }
         auto eng = engp->val.i;
+        if (eng < 0 || eng >= engineLabels.size())
+        {
+            return "ERROR";
+        }
         auto idx = (p - engp);
         auto lab = engineLabels[eng][idx - 1];
 
@@ -178,7 +186,15 @@ static struct EngineDynamicBipolar : public ParameterDynamicBoolFunction
         }
 
         auto engp = &(oscs->p[TwistOscillator::twist_engine]);
+        if (engp->ctrltype != ct_twist_engine)
+        {
+            return "ERROR";
+        }
         auto eng = engp->val.i;
+        if (eng < 0 || eng >= engineBipolars.size())
+        {
+            return false;
+        }
         auto idx = (p - engp);
 
         auto res = engineBipolars[eng][idx - 1];

--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -340,6 +340,31 @@ void SurgeVst3Processor::processParameterChanges(int sampleOffset,
                                                  IParameterChanges *parameterChanges,
                                                  int &eventIndex)
 {
+#define DUMB_STRESS_TEST 0 // See issue 4038
+#if DUMB_STRESS_TEST
+    static int64_t cts = 0;
+    if (cts % 3 == 0)
+    {
+        SurgeSynthesizer::ID did;
+        /* OSC A1
+        for( int idE = 116; idE < 116 + 8; ++idE )
+        if (surgeInstance->fromDAWSideId(idE, did))
+        {
+            float r = 1.f * rand() / (float)RAND_MAX;
+            surgeInstance->setParameter01(did, r, true);
+        }*/
+        // FX A1
+        for (int idE = 9; idE < 9 + 12; ++idE)
+            if (surgeInstance->fromDAWSideId(idE, did))
+            {
+                float r = 1.f * rand() / (float)RAND_MAX;
+                surgeInstance->setParameter01(did, r, true);
+            }
+    }
+    cts++;
+    return;
+#endif
+
     if (parameterChanges)
     {
         int32 numParamsChanged = parameterChanges->getParameterCount();
@@ -419,7 +444,9 @@ void SurgeVst3Processor::processParameterChanges(int sampleOffset,
 
                         // VST3 wants to send me these events a LOT
                         if (surgeInstance->getParameter01(did) != value)
+                        {
                             surgeInstance->setParameter01(did, value, true);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
As shown in #4038, there's race conditions between the audio thread
and the UI thread under automation - which is a bummer.

This fixes most of the ones the oscillators showed. The FX is harder.
It also leaves my stress test code in place ifdefed out.