### PR TITLE
Deactivatable low/cut filters in a number of FX

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1435,7 +1435,7 @@ void Parameter::set_type(int ctrltype)
         displayType = LinearWithScale;
         displayInfo.scale = 1.0f;
         displayInfo.decimals = 2;
-        snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "μ");
+        snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "μm");
         break;
 
     case ct_tape_speed:

--- a/src/common/dsp/effect/ChorusEffect.h
+++ b/src/common/dsp/effect/ChorusEffect.h
@@ -58,6 +58,9 @@ template <int v> class ChorusEffect : public Effect
     virtual const char *group_label(int id) override;
     virtual int group_label_ypos(int id) override;
 
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
+
   private:
     lag<float, true> time[v];
     float voicepan[v][2];

--- a/src/common/dsp/effect/ChorusEffectImpl.h
+++ b/src/common/dsp/effect/ChorusEffectImpl.h
@@ -116,8 +116,16 @@ template <int v> void ChorusEffect<v>::process(float *dataL, float *dataR)
         _mm_store_ss(&tbufferR[k], R);
     }
 
-    lp.process_block(tbufferL, tbufferR);
-    hp.process_block(tbufferL, tbufferR);
+    if (!fxdata->p[ch_highcut].deactivated)
+    {
+        lp.process_block(tbufferL, tbufferR);
+    }
+
+    if (!fxdata->p[ch_lowcut].deactivated)
+    {
+        hp.process_block(tbufferL, tbufferR);
+    }
+
     add_block(tbufferL, tbufferR, fbblock, BLOCK_SIZE_QUAD);
     feedback.multiply_block(fbblock, BLOCK_SIZE_QUAD);
     hardclip_block(fbblock, BLOCK_SIZE_QUAD);
@@ -170,9 +178,9 @@ template <int v> void ChorusEffect<v>::init_ctrltypes()
     fxdata->p[ch_feedback].set_type(ct_percent);
 
     fxdata->p[ch_lowcut].set_name("Low Cut");
-    fxdata->p[ch_lowcut].set_type(ct_freq_audible);
+    fxdata->p[ch_lowcut].set_type(ct_freq_audible_deactivatable);
     fxdata->p[ch_highcut].set_name("High Cut");
-    fxdata->p[ch_highcut].set_type(ct_freq_audible);
+    fxdata->p[ch_highcut].set_type(ct_freq_audible_deactivatable);
 
     fxdata->p[ch_mix].set_name("Mix");
     fxdata->p[ch_mix].set_type(ct_percent);
@@ -229,7 +237,20 @@ template <int v> void ChorusEffect<v>::init_default_values()
     fxdata->p[ch_depth].val.f = 0.3f;
     fxdata->p[ch_feedback].val.f = 0.5f;
     fxdata->p[ch_lowcut].val.f = -3.f * 12.f;
+    fxdata->p[ch_lowcut].deactivated = false;
     fxdata->p[ch_highcut].val.f = 3.f * 12.f;
+    fxdata->p[ch_highcut].deactivated = false;
     fxdata->p[ch_mix].val.f = 1.f;
     fxdata->p[ch_width].val.f = 0.f;
+}
+
+template <int v>
+void ChorusEffect<v>::handleStreamingMismatches(int streamingRevision,
+                                                int currentSynthStreamingRevision)
+{
+    if (streamingRevision <= 15)
+    {
+        fxdata->p[ch_lowcut].deactivated = false;
+        fxdata->p[ch_highcut].deactivated = false;
+    }
 }

--- a/src/common/dsp/effect/ConditionerEffect.h
+++ b/src/common/dsp/effect/ConditionerEffect.h
@@ -48,6 +48,8 @@ class ConditionerEffect : public Effect
     virtual const char *group_label(int id) override;
     virtual int group_label_ypos(int id) override;
 
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
     enum cond_params
     {
         cond_bass = 0,

--- a/src/common/dsp/effect/DualDelayEffect.h
+++ b/src/common/dsp/effect/DualDelayEffect.h
@@ -44,6 +44,9 @@ class DualDelayEffect : public Effect
     virtual int group_label_ypos(int id) override;
     virtual int get_ringout_decay() override { return ringout_time; }
 
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
+
     enum delay_params
     {
         dly_time_left = 0,

--- a/src/common/dsp/effect/Reverb1Effect.h
+++ b/src/common/dsp/effect/Reverb1Effect.h
@@ -31,6 +31,22 @@ const int rev_taps = 1 << rev_tap_bits;
 
 class Reverb1Effect : public Effect
 {
+    enum rev1_params
+    {
+        rev1_predelay = 0,
+        rev1_shape,
+        rev1_roomsize,
+        rev1_decaytime,
+        rev1_damping,
+        rev1_lowcut,
+        rev1_freq1,
+        rev1_gain1,
+        rev1_highcut,
+        rev1_mix,
+        rev1_width,
+        // rev1_variation,
+    };
+
     float delay_pan_L alignas(16)[rev_taps], delay_pan_R alignas(16)[rev_taps];
     float delay_fb alignas(16)[rev_taps];
     float delay alignas(16)[rev_taps * max_rev_dly];
@@ -53,21 +69,8 @@ class Reverb1Effect : public Effect
     virtual int group_label_ypos(int id) override;
     virtual int get_ringout_decay() override { return ringout_time; }
 
-    enum rev1_params
-    {
-        rev1_predelay = 0,
-        rev1_shape,
-        rev1_roomsize,
-        rev1_decaytime,
-        rev1_damping,
-        rev1_lowcut,
-        rev1_freq1,
-        rev1_gain1,
-        rev1_highcut,
-        rev1_mix,
-        rev1_width,
-        // rev1_variation,
-    };
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
 
   private:
     void update_rtime();

--- a/src/common/dsp/effect/RingModulatorEffect.h
+++ b/src/common/dsp/effect/RingModulatorEffect.h
@@ -44,6 +44,9 @@ class RingModulatorEffect : public Effect
 
     virtual int get_ringout_decay() override { return ringout_value; }
 
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
+
     float diode_sim(float x);
 
     enum ringmod_params


### PR DESCRIPTION
This PR adds an option to disable low/high cut filters in effects that previously didn't have this option. Also includes streaming version handling, of course.
Also, use μm as unit for microns in Tape.
Also, Reverb 1 filters aren't using slowlag variant anymore.