### PR TITLE
Return of the multi-column patch browser on Windows!

### DIFF
--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -92,8 +92,6 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint &where, const CButtonState &
     int root_count = 0, usercat_pos = 0, col_breakpoint = 0;
     auto patch_cat_size = storage->patch_category.size();
 
-    printf("3P: %d | USR: %d\n", storage->firstThirdPartyCategory, storage->firstUserCategory);
-
     if (single_category)
     {
         contextMenu->setNbItemsPerColumn(32);

--- a/src/common/gui/CPatchBrowser.cpp
+++ b/src/common/gui/CPatchBrowser.cpp
@@ -87,8 +87,12 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint &where, const CButtonState &
 
     int main_e = 0;
     // if RMB is down, only show the current category
-    bool single_category = button & (kRButton | kControl);
+    bool single_category = button & (kRButton | kControl), has_3rdparty = false;
     int last_category = current_category;
+    int root_count = 0, usercat_pos = 0, col_breakpoint = 0;
+    auto patch_cat_size = storage->patch_category.size();
+
+    printf("3P: %d | USR: %d\n", storage->firstThirdPartyCategory, storage->firstUserCategory);
 
     if (single_category)
     {
@@ -123,11 +127,13 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint &where, const CButtonState &
     }
     else
     {
-        int root_count = 0, usercat_pos = 0;
-        auto factory_add = contextMenu->addEntry("FACTORY PATCHES");
-        factory_add->setEnabled(0);
+        if (patch_cat_size && storage->firstThirdPartyCategory > 0)
+        {
+            auto factory_add = contextMenu->addEntry("FACTORY PATCHES");
+            factory_add->setEnabled(0);
+        }
 
-        for (int i = 0; i < storage->patch_category.size(); i++)
+        for (int i = 0; i < patch_cat_size; i++)
         {
             if ((!single_category) || (i == last_category))
             {
@@ -136,10 +142,15 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint &where, const CButtonState &
                 {
                     string txt;
 
-                    if (i == storage->firstThirdPartyCategory)
+                    if (i == storage->firstThirdPartyCategory && storage->firstUserCategory != i)
+                    {
+                        has_3rdparty = true;
                         txt = "THIRD PARTY PATCHES";
+                    }
                     else
+                    {
                         txt = "USER PATCHES";
+                    }
 
                     auto add = contextMenu->addEntry(txt.c_str());
                     add->setEnabled(0);
@@ -165,17 +176,27 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint &where, const CButtonState &
 
 #if WINDOWS
         // make sure user category always ends up in second column
-        auto multicolmenu =
-            Surge::Storage::getUserDefaultValue(this->storage, "multiColumnPatchMenu", false);
-
-        if (multicolmenu)
-        {
-            contextMenu->setNbItemsPerColumn(usercat_pos - 1 + 2);
-        }
+        col_breakpoint = std::max(usercat_pos ? usercat_pos : (root_count + 1), 32);
+        contextMenu->setNbItemsPerColumn(col_breakpoint - 1 + 2);
 #endif
     }
 
-    contextMenu->addSeparator();
+#if WINDOWS
+    // since we're starting user presets on second column,
+    // we don't need this separator if we have no user presets,
+    // because then we'd have a dangling separator at the bottom of first column
+    if (usercat_pos || !has_3rdparty || storage->firstThirdPartyCategory == 0)
+    {
+        contextMenu->addSeparator();
+    }
+#else
+    // on Mac and Linux we cannot do multicolumns (at least not until JUCE!)
+    // so just add a separator and move on
+    if (!has_3rdparty || storage->firstThirdPartyCategory == 0)
+    {
+        contextMenu->addSeparator();
+    }
+#endif
 
     auto loadF = new CCommandMenuItem(
         CCommandMenuItem::Desc(Surge::UI::toOSCaseForMenu("Load Patch from File...")));
@@ -222,6 +243,8 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint &where, const CButtonState &
     contextMenu->addEntry(show3);
 
     contextMenu->addSeparator();
+
+    contextMenu->cleanupSeparators(false);
 
     auto *sge = dynamic_cast<SurgeGUIEditor *>(listener);
     if (sge)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -6556,20 +6556,6 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
         });
     menuItem->setChecked(patchJogWrap);
 
-    // multi-column patch browser menu (Windows only)
-#if WINDOWS
-    bool multiColumnPatchMenu =
-        Surge::Storage::getUserDefaultValue(&(this->synth->storage), "multiColumnPatchMenu", false);
-
-    menuItem = addCallbackMenu(
-        wfMenu, Surge::UI::toOSCaseForMenu("Use Multiple Columns in Patch Browser Menu"),
-        [this, multiColumnPatchMenu]() {
-            Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "multiColumnPatchMenu",
-                                                   !multiColumnPatchMenu);
-        });
-    menuItem->setChecked(multiColumnPatchMenu);
-#endif
-
     uiOptionsMenu->addEntry(wfMenu, Surge::UI::toOSCaseForMenu("Workflow"));
     wfMenu->forget();
 


### PR DESCRIPTION
The reason why multi-column menu didn't show properly on some machines was because they didn't have any user presets.
So some checks I did were quite wrong and not thought through very well.
Now we have a much more bulletproof solution, plus we now also construct the menu more properly as far as Factory and 3rd Party headers, and separators, in any combination of any of them missing/being removed by the user.

Thanks to KvR user `lkjb` for helping in debugging! [Link to post here!](https://www.kvraudio.com/forum/viewtopic.php?p=8076473#p8076473)