### PR TITLE
Fix for incorrectly located paste operation

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1256,8 +1256,6 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry)
 
         for (int i = 0; i < n_lfos; i++)
         {
-            memcpy(&getPatch().scene[scene].osc[i].extraConfig, &clipboard_extraconfig[i],
-                   sizeof(OscillatorStorage::ExtraConfigurationData));
             memcpy(&getPatch().stepsequences[scene][i], &clipboard_stepsequences[i],
                    sizeof(StepSequencerStorage));
             getPatch().msegs[scene][i] = clipboard_msegs[i];
@@ -1265,6 +1263,8 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry)
 
         for (int i = 0; i < n_oscs; i++)
         {
+            memcpy(&getPatch().scene[scene].osc[i].extraConfig, &clipboard_extraconfig[i],
+                   sizeof(OscillatorStorage::ExtraConfigurationData));
             getPatch().scene[scene].osc[i].wt.Copy(&clipboard_wt[i]);
             strncpy(getPatch().scene[scene].osc[i].wavetable_display_name, clipboard_wt_names[i],
                     256);


### PR DESCRIPTION
Oscillator extra config data was pasted in the LFO data loop, so it basically had invalid memory access.
Putting it to the proper loop bound by n_oscs solved it. Closes #4274