### PR TITLE
RMB on patch and cat jog buttons selects random patch

### DIFF
--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -332,6 +332,7 @@ class alignas(16) SurgeSynthesizer
     bool loadPatchByPath(const char *fxpPath, int categoryId, const char *name);
     void incrementPatch(bool nextPrev, bool insideCategory = true);
     void incrementCategory(bool nextPrev);
+    void selectRandomPatch();
 
     void swapMetaControllers(int ct1, int ct2);
 

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -183,6 +183,21 @@ void SurgeSynthesizer::incrementCategory(bool nextPrev)
     }
 }
 
+void SurgeSynthesizer::selectRandomPatch()
+{
+    if (patchid_queue >= 0)
+        return;
+    int p = storage.patch_list.size();
+
+    if (!p)
+    {
+        return;
+    }
+
+    auto r = storage.rand_u32() % p;
+    patchid_queue = r;
+}
+
 void SurgeSynthesizer::loadPatch(int id)
 {
     if (id < 0)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2193,6 +2193,12 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
     long tag = control->getTag();
 
+    if ((button & kControl) && (tag == tag_mp_patch || tag == tag_mp_category))
+    {
+        synth->selectRandomPatch();
+        return 1;
+    }
+
     // In these cases just move along with success. RMB does nothing on these switches
     if (tag == tag_mp_jogfx || tag == tag_mp_category || tag == tag_mp_patch || tag == tag_store ||
         tag == tag_store_cancel || tag == tag_store_ok)


### PR DESCRIPTION
RMB on the patch and cat jog buttons selects a random patch
for, you know, just sort of idly browsing through our 2000
odd patches.