### PR TITLE
Combulator PanLaw Index Error

### DIFF
--- a/src/common/dsp/effect/CombulatorEffect.cpp
+++ b/src/common/dsp/effect/CombulatorEffect.cpp
@@ -232,10 +232,10 @@ void CombulatorEffect::process(float *dataL, float *dataR)
         auto r128 = _mm_setzero_ps();
 
         // FIXME - we want to interpolate the non-integral part if we like this
-        int panIndex2 =
-            (int)((limit_range(pan2.v, -1.f, 1.f) + 1) * (PANLAW_SIZE / 2)) & (PANLAW_SIZE - 1);
-        int panIndex3 =
-            (int)((limit_range(pan3.v, -1.f, 1.f) + 1) * (PANLAW_SIZE / 2)) & (PANLAW_SIZE - 1);
+        int panIndex2 = (int)((limit_range(pan2.v, -1.f, 1.f) + 1) * ((PANLAW_SIZE - 1) / 2)) &
+                        (PANLAW_SIZE - 1);
+        int panIndex3 = (int)((limit_range(pan3.v, -1.f, 1.f) + 1) * ((PANLAW_SIZE - 1) / 2)) &
+                        (PANLAW_SIZE - 1);
 
         if (filtptr)
         {


### PR DESCRIPTION
The combulator when pan3.v was exactly 1 would end up wrapping
to the entire left channel rather than right since we were
off by one in an index range.

Closes #4295