### PR TITLE
SurgeXT: Allow raw juce components in hierarchy easily

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1876,6 +1876,30 @@ void SurgeGUIEditor::openOrRecreateEditor()
     lb->setAntialias(true);
     frame->addView(lb);
     debugLabel = lb;
+
+#if TARGET_JUCE_UI
+    struct TestC : public juce::Component
+    {
+        ~TestC() { std::cout << "TestC Cleaned Up" << std::endl; }
+        juce::Colour bg = juce::Colour(255, 0, 255);
+        void paint(juce::Graphics &g) override
+        {
+            g.fillAll(bg);
+            g.setColour(juce::Colour(255, 255, 255));
+            g.drawText("JUCE BUILD", getLocalBounds(), juce::Justification::centred);
+        }
+        void mouseDown(const juce::MouseEvent &e) override
+        {
+            auto q = rand() % 255;
+            bg = juce::Colour(255, q, 255 - q);
+            repaint();
+        }
+    };
+    auto pt = std::make_unique<TestC>();
+    frame->juceComponent()->addAndMakeVisible(*pt);
+    pt->setBounds(150, 2, 100, 10);
+    frame->takeOwnership(std::move(pt));
+#endif
 #endif
     for (auto el : editorOverlay)
     {


### PR DESCRIPTION
1. Reorganize the CView base classes a little so the CView
   has a more owned- vs isa- relationship with its juce component
2. Add a mechanims to CViewContainer to take owhership of a component
   which was directly added
3. Add an exapmle to this in the juce debug branch of SGE which
   shows us adding a clickable juce build label which, of course,
   we will remove eventually and is only on in debug builds anyway

Addresses #3737