### PR TITLE
Fix Exciter Bug running over End of Sample Memory

### DIFF
--- a/src/common/dsp/effect/chowdsp/ExciterEffect.cpp
+++ b/src/common/dsp/effect/chowdsp/ExciterEffect.cpp
@@ -26,7 +26,7 @@ namespace chowdsp
 {
 
 ExciterEffect::ExciterEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd)
-    : Effect(storage, fxdata, pd)
+    : Effect(storage, fxdata, pd), toneFilter(storage)
 {
     wet_gain.set_blocksize(BLOCK_SIZE);
     drive_gain.set_blocksize(BLOCK_SIZE);
@@ -54,7 +54,7 @@ void ExciterEffect::process(float *dataL, float *dataR)
     copy_block(dataL, dryL, BLOCK_SIZE_QUAD);
     copy_block(dataR, dryR, BLOCK_SIZE_QUAD);
 
-    drive_gain.multiply_2_blocks(dataL, dataR, BLOCK_SIZE_QUAD * os.getOSRatio());
+    drive_gain.multiply_2_blocks(dataL, dataR, BLOCK_SIZE_QUAD);
     os.upsample(dataL, dataR);
 
     for (int k = 0; k < os.getUpBlockSize(); k++)


### PR DESCRIPTION
The drive multiply application accidentally applied at oversample
size not at sample size, but worked on the non-versampled data
so it caused a buffer overrun. In FXSend 2 slot (the last slot in
the storage) this caused a crash. (In other slots it would cause a
overwrite of the next buffer but that would get fixed by the next
buffer process)

Closes #4313