### PR TITLE
Window Oscillator has optional Continuous morph

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -273,6 +273,7 @@ bool Parameter::can_extend_range()
     case ct_freq_audible_with_very_low_lowerbound:
     case ct_percent_oscdrift:
     case ct_twist_aux_mix:
+    case ct_countedset_percent_extendable:
         return true;
     }
     return false;
@@ -448,6 +449,7 @@ void Parameter::set_user_data(ParamUserData *ud)
     switch (ctrltype)
     {
     case ct_countedset_percent:
+    case ct_countedset_percent_extendable:
         if (dynamic_cast<CountedSetUserData *>(ud))
         {
             user_data = ud;
@@ -990,6 +992,7 @@ void Parameter::set_type(int ctrltype)
         val_default.i = 0;
         break;
     case ct_countedset_percent:
+    case ct_countedset_percent_extendable:
         val_min.f = 0;
         val_max.f = 1;
         valtype = vt_float;
@@ -1210,6 +1213,7 @@ void Parameter::set_type(int ctrltype)
     case ct_lfodeform:
     case ct_rotarydrive:
     case ct_countedset_percent:
+    case ct_countedset_percent_extendable:
     case ct_lfoamplitude:
     case ct_reson_res_extendable:
     case ct_modern_trimix:
@@ -1652,6 +1656,7 @@ void Parameter::bound_value(bool force_integer)
             break;
         }
         case ct_countedset_percent:
+        case ct_countedset_percent_extendable:
         {
             CountedSetUserData *cs = reinterpret_cast<CountedSetUserData *>(user_data);
             auto count = cs->getCountedSetSize();
@@ -2738,6 +2743,7 @@ void Parameter::get_display_alt(char *txt, bool external, float ef)
         break;
     }
     case ct_countedset_percent:
+    case ct_countedset_percent_extendable:
         if (user_data != nullptr)
         {
             // We check when set so the reinterpret cast is safe and fast
@@ -3665,6 +3671,7 @@ bool Parameter::can_setvalue_from_string()
     case ct_oscspread:
     case ct_oscspread_bipolar:
     case ct_countedset_percent:
+    case ct_countedset_percent_extendable:
     case ct_flangerpitch:
     case ct_flangervoices:
     case ct_flangerspacing:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -125,7 +125,8 @@ enum ctrltypes
     ct_character,
     ct_sineoscmode,
     ct_sinefmlegacy,
-    ct_countedset_percent, // what % through a counted set are you
+    ct_countedset_percent,            // what % through a counted set are you
+    ct_countedset_percent_extendable, // what % through a counted set are you
     ct_vocoder_bandcount,
     ct_distortion_waveshape,
     ct_flangerpitch,

--- a/src/common/dsp/WindowOscillator.h
+++ b/src/common/dsp/WindowOscillator.h
@@ -55,7 +55,7 @@ class WindowOscillator : public Oscillator
         unsigned int Pos[MAX_UNISON];
         unsigned int SubPos[MAX_UNISON];
         unsigned int Ratio[MAX_UNISON];
-        unsigned int Table[MAX_UNISON];
+        unsigned int Table[2][MAX_UNISON];
         unsigned int FormantMul[MAX_UNISON];
         unsigned char Gain[MAX_UNISON][2];
         // samples until playback should start (for per-sample scheduling)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -3677,6 +3677,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                         case ct_twist_aux_mix:
                             txt = "Pan Main and Auxilliary Signals";
                             break;
+                        case ct_countedset_percent_extendable:
+                            txt = "Continuous Morph";
+                            break;
                         default:
                             break;
                         }


### PR DESCRIPTION
The window oscillator can continuous morph. This is bound
to extend (labeled "Continous Morph") on the morph selector.
DSP changes appropriately. I chose to do a little extra math
than do a branch.

Closes #4184