### PR TITLE
Rudimentary ailas supression on Modern Sync

### DIFF
--- a/src/common/dsp/ModernOscillator.h
+++ b/src/common/dsp/ModernOscillator.h
@@ -77,7 +77,8 @@ class ModernOscillator : public Oscillator
 
     int n_unison = 1;
     bool starting = true;
-    double phase[MAX_UNISON], sphase[MAX_UNISON], subphase, subsphase;
+    double phase[MAX_UNISON], sphase[MAX_UNISON], sprior[MAX_UNISON], sTurnFrac[MAX_UNISON],
+        sTurnVal[MAX_UNISON], subphase, subsphase;
     bool sReset[MAX_UNISON];
     bool subReset;
     double unisonOffsets[MAX_UNISON];


### PR DESCRIPTION
Late in the cycle we discovered a bad aliasing artifact
in Modern but ONLY when using sync. This compensates
for it in a simple way. We may want to revisit this more
later per the comment in code.