### PR TITLE
XT CBitmap Memory Management

### DIFF
--- a/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
+++ b/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
@@ -825,6 +825,12 @@ struct CBitmap : public Internal::FakeRefcount
         dc->g.reduceClipRegion(r.asJuceIntRect());
         drawable->draw(dc->g, alpha, t);
     }
+
+    // The entire memory management of these happens through SurgeBitmaps so deal
+    // with it there
+    void remember() override {}
+    void forget() override {}
+
     CResourceDescription desc;
     std::unique_ptr<juce::Drawable> drawable;
 };

--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -54,32 +54,10 @@ class CScalableBitmap : public VSTGUI::CBitmap
     */
     void setExtraScaleFactor(int a) { extraScaleFactor = a; }
 
-    void clearOffscreenCaches()
-    {
-        for (auto const &pair : offscreenCache)
-        {
-            auto val = pair.second;
-            if (val)
-                val->forget();
-        }
-        offscreenCache.clear();
-    }
-
     int resourceID;
     std::string fname;
 
   private:
-    struct CPointCompare
-    {
-        bool operator()(const VSTGUI::CPoint &k1, const VSTGUI::CPoint &k2) const
-        {
-            if (k1.x == k2.x)
-                return k1.y < k2.y;
-            return k1.x < k2.x;
-        }
-    };
-
-    std::map<VSTGUI::CPoint, VSTGUI::CBitmap *, CPointCompare> offscreenCache;
     static std::atomic<int> instances;
 
     int lastSeenZoom, bestFitScaleGroup;
@@ -87,16 +65,10 @@ class CScalableBitmap : public VSTGUI::CBitmap
 
     VSTGUI::CFrame *frame;
 
-    struct NSVGimage *svgImage;
-    void drawSVG(VSTGUI::CDrawContext *context, const VSTGUI::CRect &rect,
-                 const VSTGUI::CPoint &offset, float alpha);
-    VSTGUI::CColor svgColorToCColor(int svgColor, float opacity = 1.0);
-
     /*
      * The zoom 100 bitmap and optional higher resolution bitmaps for zooms
      * map vs unordered is on purpose here - we need this ordered for our zoom search
      */
     std::map<int, std::pair<std::string, std::unique_ptr<VSTGUI::CBitmap>>> pngZooms;
-
     int currentPhysicalZoomFactor;
 };

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -33,35 +33,19 @@ void SurgeBitmaps::clearAllLoadedBitmaps()
 {
     for (auto pair : bitmap_registry)
     {
-        pair.second->forget();
+        delete pair.second;
     }
     for (auto pair : bitmap_file_registry)
     {
-        pair.second->forget();
+        delete pair.second;
     }
     for (auto pair : bitmap_stringid_registry)
     {
-        pair.second->forget();
+        delete pair.second;
     }
     bitmap_registry.clear();
     bitmap_file_registry.clear();
     bitmap_stringid_registry.clear();
-}
-
-void SurgeBitmaps::clearAllBitmapOffscreenCaches()
-{
-    for (auto pair : bitmap_registry)
-    {
-        pair.second->clearOffscreenCaches();
-    }
-    for (auto pair : bitmap_file_registry)
-    {
-        pair.second->clearOffscreenCaches();
-    }
-    for (auto pair : bitmap_stringid_registry)
-    {
-        pair.second->clearOffscreenCaches();
-    }
 }
 
 void SurgeBitmaps::setupBitmapsForFrame(VSTGUI::CFrame *f)
@@ -162,7 +146,7 @@ CScalableBitmap *SurgeBitmaps::loadBitmapByPath(std::string path)
 {
     if (bitmap_file_registry.find(path) != bitmap_file_registry.end())
     {
-        bitmap_file_registry[path]->forget();
+        delete bitmap_file_registry[path];
     }
     bitmap_file_registry[path] = new CScalableBitmap(path, frame);
     return bitmap_file_registry[path];
@@ -172,7 +156,7 @@ CScalableBitmap *SurgeBitmaps::loadBitmapByPathForID(std::string path, int id)
 {
     if (bitmap_registry.find(id) != bitmap_registry.end())
     {
-        bitmap_registry[id]->forget();
+        delete bitmap_registry[id];
     }
     bitmap_registry[id] = new CScalableBitmap(path, frame);
     return bitmap_registry[id];
@@ -182,7 +166,7 @@ CScalableBitmap *SurgeBitmaps::loadBitmapByPathForStringID(std::string path, std
 {
     if (bitmap_stringid_registry.find(id) != bitmap_stringid_registry.end())
     {
-        bitmap_stringid_registry[id]->forget();
+        delete bitmap_stringid_registry[id];
     }
     bitmap_stringid_registry[id] = new CScalableBitmap(path, frame);
     return bitmap_stringid_registry[id];

--- a/src/common/gui/SurgeBitmaps.h
+++ b/src/common/gui/SurgeBitmaps.h
@@ -22,7 +22,6 @@ class SurgeBitmaps
 
     void setupBitmapsForFrame(VSTGUI::CFrame *f);
     void setPhysicalZoomFactor(int pzf);
-    void clearAllBitmapOffscreenCaches();
 
     CScalableBitmap *getBitmap(int id);
     CScalableBitmap *getBitmapByPath(std::string filename);
@@ -56,6 +55,7 @@ class SurgeBitmaps
     static std::atomic<int> instances;
 
     void addEntry(int id, VSTGUI::CFrame *f);
+    // I own and am responsible for deleting these
     std::map<int, CScalableBitmap *> bitmap_registry;
     std::map<std::string, CScalableBitmap *> bitmap_file_registry;
 

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -410,16 +410,6 @@ void SurgeGUIEditor::idle()
         }
         removeFromFrame.clear();
 
-        if (clearOffscreenCachesAtZero == 0)
-        {
-            bitmapStore->clearAllBitmapOffscreenCaches();
-            frame->invalid();
-        }
-        if (clearOffscreenCachesAtZero >= 0)
-        {
-            clearOffscreenCachesAtZero--;
-        }
-
         {
             bool expected = true;
             if (synth->rawLoadNeedsUIDawExtraState.compare_exchange_weak(expected, true) &&
@@ -1791,7 +1781,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
 #if TARGET_JUCE_UI
     struct TestC : public juce::Component
     {
-        ~TestC() { std::cout << "TestC Cleaned Up" << std::endl; }
+        ~TestC() {}
         juce::Colour bg = juce::Colour(255, 0, 255);
         void paint(juce::Graphics &g) override
         {
@@ -7053,7 +7043,6 @@ void SurgeGUIEditor::reloadFromSkin()
 #else
     setZoomFactor(getZoomFactor());
 #endif
-    clearOffscreenCachesAtZero = 1;
 
     // update MSEG editor if opened
     if (isAnyOverlayPresent(MSEG_EDITOR))
@@ -8552,6 +8541,14 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::UI::Skin::Control>
             return slfo;
         }
     }
+
+#if DEBUG_JUCE_XT_LEAK_STUFF
+    if (skinCtrl->ultimateparentclassname == "CFXMenu")
+        return nullptr;
+    if (skinCtrl->ultimateparentclassname == "COSCMenu")
+        return nullptr;
+#endif
+
     if (skinCtrl->ultimateparentclassname == "COSCMenu")
     {
         CRect rect(0, 0, skinCtrl->w, skinCtrl->h);
@@ -8605,6 +8602,7 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::UI::Skin::Control>
         fxmenu = m;
         return m;
     }
+
     if (skinCtrl->ultimateparentclassname == "CNumberField")
     {
         CRect rect(0, 0, skinCtrl->w, skinCtrl->h);

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -424,14 +424,6 @@ class SurgeGUIEditor : public EditorType,
 
     bool hasIdleRun = false;
     VSTGUI::CPoint resizeToOnIdle = VSTGUI::CPoint(-1, -1);
-    /*
-     * A countdown which will clearr the bitmap store offscreen caches
-     * after N idles if set to a positive N. This is needed as some
-     * DAWS (cough cough LIVE) handle draw and resize events in a
-     * different order so the offscren cache when going classic->royal
-     * at 100% (for instance) is the wrong size.
-     */
-    int clearOffscreenCachesAtZero = -1;
 
   private:
     SGEDropAdapter *dropAdapter = nullptr;


### PR DESCRIPTION
Free ourselves from the steinberg-esque remember/forget/delete
and instead just have the SurgeBitmaps own the images and manage
their lifecycle appropriately.

Addresses #4351
Addresses #3737