### PR TITLE
Allow explicit directory datapath setting Linux environment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,14 +83,13 @@ jobs:
         cmakeArguments: "-DCMAKE_BUILD_TYPE=Release"
         cmakeConfig: "Release"
         cmakeTarget: "surge-headless"
-      # See #4030 for why this is commented out
-      #linux-lv2:
-      #  imageName: 'ubuntu-20.04'
-      #  isLinux: True
-      #  needsLV2: True
-      #  cmakeArguments: "-DCMAKE_BUILD_TYPE=Debug -DJUCE_SUPPORTS_LV2=True -DSURGE_ALTERNATE_JUCE=libs/JUCE-lv2"
-      #  cmakeConfig: "Debug"
-      #  cmakeTarget: "surge-xt_LV2"
+      linux-lv2:
+        imageName: 'ubuntu-20.04'
+        isLinux: True
+        needsLV2: True
+        cmakeArguments: "-DCMAKE_BUILD_TYPE=Debug -DJUCE_SUPPORTS_LV2=True -DSURGE_ALTERNATE_JUCE=libs/JUCE-lv2"
+        cmakeConfig: "Debug"
+        cmakeTarget: "surge-xt_LV2"
 
   pool:
     vmImage: $(imageName)
@@ -197,11 +196,7 @@ jobs:
   - bash: |
       set -e
 
-      echo "Starting Xvfb on 9898"
-      nohup Xvfb :9898 &
-      export DISPLAY=:9898
-      sleep 3
-
+      export PIPELINE_OVERRIDE_DATA_HOME=`pwd`/resources/data
       cmake --build build --config $(cmakeConfig) --target $(cmakeTarget) --parallel 8
     displayName: all - build with cmake
     condition: variables.needsLV2

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -257,6 +257,7 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
 #elif LINUX
     if (!hasSuppliedDataPath)
     {
+        const char *buildOverrideDataPath = getenv("PIPELINE_OVERRIDE_DATA_HOME");
         const char *xdgDataPath = getenv("XDG_DATA_HOME");
         std::string localDataPath = std::string(homePath) + "/.local/share/surge/";
         if (xdgDataPath)
@@ -296,6 +297,13 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
                 else
                     datapath = "/usr/share/Surge/";
             }
+        }
+
+        if (buildOverrideDataPath)
+        {
+            datapath = std::string(buildOverrideDataPath);
+            std::cout << "WARNING: Surge Overriding DataPath to " << datapath << std::endl;
+            std::cout << "         Only use this in build pipelines please" << std::endl;
         }
     }
     else


### PR DESCRIPTION
This is a temporary feature I bet but for now we can set
the variable PIPLINE_OVERRIDE_DATA_HOME and have that be
the surge DataPath. Use that in the LV2 build stage to
let the TTL generator locate presets.