### PR TITLE
Add a JUCE LookAndFeel default class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ set(SURGE_GUI_SOURCES
   src/common/gui/SurgeBitmaps.cpp
   src/common/gui/SurgeGUIEditor.cpp
   src/common/gui/SurgeGUIEditorHtmlGenerators.cpp
+  src/common/gui/SurgeJUCELookAndFeel.cpp
   src/common/gui/UIInstrumentation.cpp)
 
 # Includes and Compiler Flags

--- a/src/common/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/common/gui/SurgeJUCELookAndFeel.cpp
@@ -1,0 +1,9 @@
+//
+// Created by Paul Walker on 4/24/21.
+//
+
+#include "SurgeJUCELookAndFeel.h"
+void SurgeJUCELookAndFeel::drawLabel(juce::Graphics &graphics, juce::Label &label)
+{
+    LookAndFeel_V4::drawLabel(graphics, label);
+}

--- a/src/common/gui/SurgeJUCELookAndFeel.h
+++ b/src/common/gui/SurgeJUCELookAndFeel.h
@@ -1,0 +1,16 @@
+//
+// Created by Paul Walker on 4/24/21.
+//
+
+#ifndef SURGE_XT_SURGEJUCELOOKANDFEEL_H
+#define SURGE_XT_SURGEJUCELOOKANDFEEL_H
+
+#include <JuceHeader.h>
+
+class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4
+{
+  public:
+    void drawLabel(juce::Graphics &graphics, juce::Label &label) override;
+};
+
+#endif // SURGE_XT_SURGEJUCELOOKANDFEEL_H

--- a/src/surge_synth_juce/SurgeSynthEditor.cpp
+++ b/src/surge_synth_juce/SurgeSynthEditor.cpp
@@ -14,11 +14,14 @@
 #include "CScalableBitmap.h"
 #include "SurgeGUIEditor.h"
 #include "SurgeSynthFlavorExtensions.h"
+#include "SurgeJUCELookAndFeel.h"
 
 //==============================================================================
 SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
     : AudioProcessorEditor(&p), processor(p), EscapeFromVSTGUI::JuceVSTGUIEditorAdapter(this)
 {
+    surgeLF = std::make_unique<SurgeJUCELookAndFeel>();
+    juce::LookAndFeel::setDefaultLookAndFeel(surgeLF.get());
     setSize(BASE_WINDOW_SIZE_X, BASE_WINDOW_SIZE_Y);
     setResizable(true, false); // For now
 

--- a/src/surge_synth_juce/SurgeSynthEditor.h
+++ b/src/surge_synth_juce/SurgeSynthEditor.h
@@ -17,6 +17,7 @@
 #include "SurgeSynthProcessor.h"
 
 class SurgeGUIEditor;
+class SurgeJUCELookAndFeel;
 
 //==============================================================================
 /**
@@ -68,6 +69,8 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
 
     std::unique_ptr<VSTGUI::CFrame> vstguiFrame;
     std::unique_ptr<juce::Drawable> logo;
+
+    std::unique_ptr<SurgeJUCELookAndFeel> surgeLF;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SurgeSynthEditor)
 };


### PR DESCRIPTION
I added this as part of debugging unicode and it didn't
fix it but didn't want to throw away the (basically
unused currently) hook.