### PR TITLE
UserDefault goes to Enum; XT gets new File

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2002,7 +2002,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
     int detailedMode = false;
 
     if (storage)
-        detailedMode = Surge::Storage::getUserDefaultValue(storage, "highPrecisionReadouts", 0);
+        detailedMode =
+            Surge::Storage::getUserDefaultValue(storage, Surge::Storage::HighPrecisionReadouts, 0);
 
     int dp = (detailedMode ? 6 : displayInfo.decimals);
 
@@ -2719,7 +2720,7 @@ void Parameter::get_display_alt(char *txt, bool external, float ef)
 
         if (storage)
         {
-            oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
+            oct_offset = Surge::Storage::getUserDefaultValue(storage, Surge::Storage::MiddleC, 1);
         }
 
         snprintf(txt, TXT_SIZE, "~%s", get_notename(notename, i_value, oct_offset));
@@ -2735,7 +2736,7 @@ void Parameter::get_display_alt(char *txt, bool external, float ef)
 
         if (storage)
         {
-            oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
+            oct_offset = Surge::Storage::getUserDefaultValue(storage, Surge::Storage::MiddleC, 1);
         }
 
         snprintf(txt, TXT_SIZE, "~%s", get_notename(notename, i_value, oct_offset));
@@ -2788,7 +2789,8 @@ void Parameter::get_display(char *txt, bool external, float ef)
     int detailedMode = 0;
 
     if (storage)
-        detailedMode = Surge::Storage::getUserDefaultValue(storage, "highPrecisionReadouts", 0);
+        detailedMode =
+            Surge::Storage::getUserDefaultValue(storage, Surge::Storage::HighPrecisionReadouts, 0);
 
     switch (valtype)
     {
@@ -3016,7 +3018,8 @@ void Parameter::get_display(char *txt, bool external, float ef)
 
             if (storage)
             {
-                oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
+                oct_offset =
+                    Surge::Storage::getUserDefaultValue(storage, Surge::Storage::MiddleC, 1);
             }
 
             snprintf(txt, TXT_SIZE, "%s", get_notename(notename, val.i, oct_offset));
@@ -3811,7 +3814,8 @@ bool Parameter::set_value_from_string_onto(std::string s, pdata &onto)
                 // construct the integer note value
                 int oct_offset = 1;
                 if (storage)
-                    oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
+                    oct_offset =
+                        Surge::Storage::getUserDefaultValue(storage, Surge::Storage::MiddleC, 1);
 
                 ni = ((oct + oct_offset) * 12 * neg) + val;
             }
@@ -3884,7 +3888,8 @@ bool Parameter::set_value_from_string_onto(std::string s, pdata &onto)
                 int oct_offset = 0;
                 if (storage)
                 {
-                    oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
+                    oct_offset =
+                        Surge::Storage::getUserDefaultValue(storage, Surge::Storage::MiddleC, 1);
                 }
                 int note = 0, sf = 0;
                 if (s[0] >= 'a' && s[0] <= 'g')

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1781,8 +1781,8 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
     }
 
     // restore msegs. We optionally don't restore the snap from patch
-    bool userPrefRestoreMSEGFromPatch =
-        Surge::Storage::getUserDefaultValue(storage, "restoreMSEGSnapFromPatch", true);
+    bool userPrefRestoreMSEGFromPatch = Surge::Storage::getUserDefaultValue(
+        storage, Surge::Storage::RestoreMSEGSnapFromPatch, true);
     for (int s = 0; s < n_scenes; ++s)
         for (int m = 0; m < n_lfos; ++m)
         {

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -431,7 +431,7 @@ bailOnPortable:
     userDefaultFilePath = userDataPath;
 
     std::string userSpecifiedDataPath =
-        Surge::Storage::getUserDefaultValue(this, "userDataPath", "UNSPEC");
+        Surge::Storage::getUserDefaultValue(this, Surge::Storage::UserDataPath, "UNSPEC");
     if (userSpecifiedDataPath != "UNSPEC")
     {
         userDataPath = userSpecifiedDataPath;
@@ -602,14 +602,14 @@ bailOnPortable:
     }
 
     monoPedalMode = (MonoPedalMode)Surge::Storage::getUserDefaultValue(
-        this, "monoPedalMode", MonoPedalMode::HOLD_ALL_NOTES);
+        this, Surge::Storage::MonoPedalMode, MonoPedalMode::HOLD_ALL_NOTES);
 
     for (int s = 0; s < n_scenes; ++s)
     {
         getPatch().scene[s].drift.extend_range = true;
     }
 
-    bool mtsMode = Surge::Storage::getUserDefaultValue(this, "useODDMTS", false);
+    bool mtsMode = Surge::Storage::getUserDefaultValue(this, Surge::Storage::UseODDMTS, false);
     if (mtsMode)
     {
         initialize_oddsound();

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -39,6 +39,7 @@
 #include "Tunings.h"
 #include "PatchDB.h"
 #include <unordered_set>
+#include "UserDefaults.h"
 
 #if WINDOWS
 #define PATH_SEPARATOR '\\'
@@ -1185,7 +1186,7 @@ class alignas(16) SurgeStorage
      * Other users of surge may want to force clients to override user prefs.
      * Really we just use this to force the FX bank to 2 decimals for now. But...
      */
-    std::unordered_map<std::string, std::pair<int, std::string>> userPrefOverrides;
+    std::unordered_map<Surge::Storage::DefaultKey, std::pair<int, std::string>> userPrefOverrides;
 
     ControllerModulationSource::SmoothingMode smoothingMode =
         ControllerModulationSource::SmoothingMode::LEGACY;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -92,10 +92,11 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, std::string suppliedData
 
     storage.smoothingMode =
         (ControllerModulationSource::SmoothingMode)(int)Surge::Storage::getUserDefaultValue(
-            &storage, "smoothingMode", (int)(ControllerModulationSource::SmoothingMode::LEGACY));
+            &storage, Surge::Storage::SmoothingMode,
+            (int)(ControllerModulationSource::SmoothingMode::LEGACY));
     storage.pitchSmoothingMode =
         (ControllerModulationSource::SmoothingMode)(int)Surge::Storage::getUserDefaultValue(
-            &storage, "pitchSmoothingMode",
+            &storage, Surge::Storage::PitchSmoothingMode,
             (int)(ControllerModulationSource::SmoothingMode::DIRECT));
 
     patch.polylimit.val.i = DEFAULT_POLYLIMIT;
@@ -222,7 +223,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, std::string suppliedData
     mpeEnabled = false;
     mpeVoices = 0;
     storage.mpePitchBendRange =
-        (float)Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
+        (float)Surge::Storage::getUserDefaultValue(&storage, Surge::Storage::MPEPitchBendRange, 48);
     mpeGlobalPitchBendRange = 0;
 }
 
@@ -1393,8 +1394,8 @@ void SurgeSynthesizer::onRPN(int channel, int lsbRPN, int msbRPN, int lsbValue, 
         mpeEnabled = msbValue > 0;
         mpeVoices = msbValue & 0xF;
         if (storage.mpePitchBendRange < 0.0f)
-            storage.mpePitchBendRange =
-                Surge::Storage::getUserDefaultValue(&storage, "mpePitchBendRange", 48);
+            storage.mpePitchBendRange = Surge::Storage::getUserDefaultValue(
+                &storage, Surge::Storage::MPEPitchBendRange, 48);
         mpeGlobalPitchBendRange = 0;
         return;
     }
@@ -3845,8 +3846,8 @@ void SurgeSynthesizer::setupActivateExtraOutputs()
     if (hostProgram.find("Fruit") == 0) // FruityLoops default off
         defval = false;
 
-    activateExtraOutputs =
-        Surge::Storage::getUserDefaultValue(&(storage), "activateExtraOutputs", defval ? 1 : 0);
+    activateExtraOutputs = Surge::Storage::getUserDefaultValue(
+        &(storage), Surge::Storage::ActivateExtraOutputs, defval ? 1 : 0);
 }
 
 void SurgeSynthesizer::swapMetaControllers(int c1, int c2)

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -18,6 +18,35 @@ namespace Surge
 namespace Storage
 {
 
+enum DefaultKey // streamed as strings so feel free to change the order to whatever you want
+{
+    HighPrecisionReadouts,
+    SmoothingMode,
+    PitchSmoothingMode,
+    MiddleC,
+    MPEPitchBendRange,
+    RestoreMSEGSnapFromPatch,
+    UserDataPath,
+    UseODDMTS,
+    ActivateExtraOutputs,
+    MonoPedalMode,
+    ShowCursorWhileEditing,
+    TouchMouseMode,
+    ShowGhostedLFOWaveReference,
+    DefaultSkin,
+    DefaultSkinRootType,
+    DefaultZoom,
+    SliderMoveRateState,
+    RememberTabPositionsPerScene,
+    PatchJogWraparound,
+    DefaultPatchAuthor,
+    DefaultPatchComment,
+    ModWindowShowsValues,
+    SkinReloadViaF5,
+    LayoutGridResolution,
+
+    nKeys
+};
 /**
  * getUserDefaultValue
  *
@@ -25,18 +54,17 @@ namespace Storage
  * If no such key is persisted, return the value "valueIfMissing". There is a variation
  * on this for both std::string and int stored values.
  */
-std::string getUserDefaultValue(SurgeStorage *storage, const std::string &key,
+std::string getUserDefaultValue(SurgeStorage *storage, const DefaultKey &key,
                                 const std::string &valueIfMissing);
-int getUserDefaultValue(SurgeStorage *storage, const std::string &key, int valueIfMissing);
+int getUserDefaultValue(SurgeStorage *storage, const DefaultKey &key, int valueIfMissing);
 
 /**
  * updateUserDefaultValue
  *
  * Given a key and a value, update the user default file
  */
-bool updateUserDefaultValue(SurgeStorage *storage, const std::string &key,
-                            const std::string &value);
-bool updateUserDefaultValue(SurgeStorage *storage, const std::string &key, const int value);
+bool updateUserDefaultValue(SurgeStorage *storage, const DefaultKey &key, const std::string &value);
+bool updateUserDefaultValue(SurgeStorage *storage, const DefaultKey &key, const int value);
 
 } // namespace Storage
 } // namespace Surge

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.cpp
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.cpp
@@ -251,7 +251,8 @@ void AirWindowsEffect::setupSubFX(int sfx, bool useStreamedValues)
 
     bool detailedMode = false;
     if (storage)
-        detailedMode = Surge::Storage::getUserDefaultValue(storage, "highPrecisionReadouts", 0);
+        detailedMode =
+            Surge::Storage::getUserDefaultValue(storage, Surge::Storage::HighPrecisionReadouts, 0);
 
     int dp = (detailedMode ? 6 : 2);
 

--- a/src/common/dsp/effect/airwindows/AirWindowsEffect.h
+++ b/src/common/dsp/effect/airwindows/AirWindowsEffect.h
@@ -102,7 +102,7 @@ class alignas(16) AirWindowsEffect : public Effect
                     if (fx->storage)
                     {
                         auto detailedMode = Surge::Storage::getUserDefaultValue(
-                            fx->storage, "highPrecisionReadouts", 0);
+                            fx->storage, Surge::Storage::HighPrecisionReadouts, 0);
 
                         fx->airwin->displayPrecision = (detailedMode ? 6 : 2);
                     }

--- a/src/common/gui/CLFOGui.cpp
+++ b/src/common/gui/CLFOGui.cpp
@@ -173,8 +173,8 @@ void CLFOGui::draw(CDrawContext *dc)
         else if (lfodata->magnitude.val.f != lfodata->magnitude.val_max.f &&
                  skin->getVersion() >= 2)
         {
-            bool useAmpWave =
-                Surge::Storage::getUserDefaultValue(storage, "showGhostedLFOWaveReference", 1);
+            bool useAmpWave = Surge::Storage::getUserDefaultValue(
+                storage, Surge::Storage::ShowGhostedLFOWaveReference, 1);
             if (useAmpWave)
             {
                 hasFullWave = true;
@@ -1149,8 +1149,8 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp,
 
         if (storage)
         {
-            int detailedMode =
-                Surge::Storage::getUserDefaultValue(storage, "highPrecisionReadouts", 0);
+            int detailedMode = Surge::Storage::getUserDefaultValue(
+                storage, Surge::Storage::HighPrecisionReadouts, 0);
             if (detailedMode)
             {
                 prec = 6;

--- a/src/common/gui/CNumberField.cpp
+++ b/src/common/gui/CNumberField.cpp
@@ -333,7 +333,7 @@ void CNumberField::draw(CDrawContext *pContext)
     {
         int oct_offset = 1;
         if (storage)
-            oct_offset = Surge::Storage::getUserDefaultValue(storage, "middleC", 1);
+            oct_offset = Surge::Storage::getUserDefaultValue(storage, Surge::Storage::MiddleC, 1);
         char notename[16];
         snprintf(the_text, THE_TEXT_SIZE, "%s", get_notename(notename, i_value, oct_offset));
     }

--- a/src/common/gui/SkinSupport.cpp
+++ b/src/common/gui/SkinSupport.cpp
@@ -52,13 +52,13 @@ SkinDB::~SkinDB()
 std::shared_ptr<Skin> SkinDB::defaultSkin(SurgeStorage *storage)
 {
     rescanForSkins(storage);
-    auto uds = Surge::Storage::getUserDefaultValue(storage, "defaultSkin", "");
+    auto uds = Surge::Storage::getUserDefaultValue(storage, Surge::Storage::DefaultSkin, "");
     if (uds == "")
         return getSkin(defaultSkinEntry);
     else
     {
-        auto st = (Entry::RootType)(
-            Surge::Storage::getUserDefaultValue(storage, "defaultSkinRootType", Entry::UNKNOWN));
+        auto st = (Entry::RootType)(Surge::Storage::getUserDefaultValue(
+            storage, Surge::Storage::DefaultSkinRootType, Entry::UNKNOWN));
 
         for (auto e : availableSkins)
         {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -141,7 +141,8 @@ SurgeGUIEditor::SurgeGUIEditor(PARENT_PLUGIN_TYPE *effect, SurgeSynthesizer *syn
     mod_editor = false;
 
     // init the size of the plugin
-    initialZoomFactor = Surge::Storage::getUserDefaultValue(&(synth->storage), "defaultZoom", 100);
+    initialZoomFactor =
+        Surge::Storage::getUserDefaultValue(&(synth->storage), Surge::Storage::DefaultZoom, 100);
     int instanceZoomFactor = synth->storage.getPatch().dawExtraState.editor.instanceZoomFactor;
     if (instanceZoomFactor > 0)
     {
@@ -900,7 +901,8 @@ int32_t SurgeGUIEditor::onKeyDown(const VstKeyCode &code, CFrame *frame)
         switch (code.virt)
         {
         case VKEY_F5:
-            if (Surge::Storage::getUserDefaultValue(&(this->synth->storage), "skinReloadViaF5", 0))
+            if (Surge::Storage::getUserDefaultValue(&(this->synth->storage),
+                                                    Surge::Storage::SkinReloadViaF5, 0))
             {
                 bitmapStore.reset(new SurgeBitmaps());
                 bitmapStore->setupBitmapsForFrame(frame);
@@ -1552,7 +1554,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
     if (CSurgeSlider::sliderMoveRateState == CSurgeSlider::kUnInitialized)
         CSurgeSlider::sliderMoveRateState =
             (CSurgeSlider::MoveRateState)Surge::Storage::getUserDefaultValue(
-                &(synth->storage), "sliderMoveRateState", (int)CSurgeSlider::kLegacy);
+                &(synth->storage), Surge::Storage::SliderMoveRateState, (int)CSurgeSlider::kLegacy);
 
     /*
     ** Skin Labels
@@ -2138,8 +2140,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
             bool cancellearn = false;
             int ccid = 0;
 
-            int detailedMode = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                                   "highPrecisionReadouts", 0);
+            int detailedMode = Surge::Storage::getUserDefaultValue(
+                &(this->synth->storage), Surge::Storage::HighPrecisionReadouts, 0);
 
             // should start at 0, but started at 1 before.. might be a reason but don't remember
             // why...
@@ -4110,7 +4112,7 @@ void SurgeGUIEditor::valueChanged(CControl *control)
                 if (modsource_editor[current_scene] != newsource)
                 {
                     auto tabPosMem = Surge::Storage::getUserDefaultValue(
-                        &(this->synth->storage), "rememberTabPositionsPerScene", 0);
+                        &(this->synth->storage), Surge::Storage::RememberTabPositionsPerScene, 0);
 
                     if (tabPosMem)
                         modsource_editor[current_scene] = newsource;
@@ -4232,8 +4234,8 @@ void SurgeGUIEditor::valueChanged(CControl *control)
             closeStorePatchDialog();
         }
 
-        auto insideCategory =
-            Surge::Storage::getUserDefaultValue(&(this->synth->storage), "patchJogWraparound", 1);
+        auto insideCategory = Surge::Storage::getUserDefaultValue(
+            &(this->synth->storage), Surge::Storage::PatchJogWraparound, 1);
 
         if (control->getValue() > 0.5f)
             synth->incrementPatch(true, insideCategory);
@@ -4298,8 +4300,8 @@ void SurgeGUIEditor::valueChanged(CControl *control)
     break;
     case tag_osc_select:
     {
-        auto tabPosMem = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                             "rememberTabPositionsPerScene", 0);
+        auto tabPosMem = Surge::Storage::getUserDefaultValue(
+            &(this->synth->storage), Surge::Storage::RememberTabPositionsPerScene, 0);
 
         if (tabPosMem)
             current_osc[current_scene] = (int)(control->getValue() * 2.f + 0.5f);
@@ -4372,10 +4374,10 @@ void SurgeGUIEditor::valueChanged(CControl *control)
         p.author = synth->storage.getPatch().author;
         p.comments = synth->storage.getPatch().comment;
 
-        string defaultAuthor =
-            Surge::Storage::getUserDefaultValue(&(this->synth->storage), "defaultPatchAuthor", "");
-        string defaultComment =
-            Surge::Storage::getUserDefaultValue(&(this->synth->storage), "defaultPatchComment", "");
+        string defaultAuthor = Surge::Storage::getUserDefaultValue(
+            &(this->synth->storage), Surge::Storage::DefaultPatchAuthor, "");
+        string defaultComment = Surge::Storage::getUserDefaultValue(
+            &(this->synth->storage), Surge::Storage::DefaultPatchComment, "");
         string oldAuthor = "";
 
         if (!Surge::Storage::isValidUTF8(defaultAuthor))
@@ -4971,8 +4973,8 @@ void SurgeGUIEditor::draw_infowindow(int ptag, CControl *control, bool modulate,
     if (ml > 24)
         iff += (ml - 24) * 5;
 
-    auto modValues =
-        Surge::Storage::getUserDefaultValue(&(this->synth->storage), "modWindowShowsValues", 0);
+    auto modValues = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
+                                                         Surge::Storage::ModWindowShowsValues, 0);
 
     ((CParameterTooltip *)infowindow)->setExtendedMDIWS(modValues);
     CRect r(0, 0, iff, 18);
@@ -5487,7 +5489,8 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMpeMenu(VSTGUI::CRect &menuRect, bool s
     });
 
     std::ostringstream oss2;
-    int def = Surge::Storage::getUserDefaultValue(&(synth->storage), "mpePitchBendRange", 48);
+    int def = Surge::Storage::getUserDefaultValue(&(synth->storage),
+                                                  Surge::Storage::MPEPitchBendRange, 48);
     oss2 << "Change Default MPE Pitch Bend Range (Current: " << def << " Semitones)";
     addCallbackMenu(mpeSubMenu, Surge::UI::toOSCaseForMenu(oss2.str().c_str()), [this, menuRect]() {
         // FIXME! This won't work on linux
@@ -5495,13 +5498,14 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMpeMenu(VSTGUI::CRect &menuRect, bool s
         promptForMiniEdit(c, "Enter default MPE pitch bend range:", "Default MPE Pitch Bend Range",
                           menuRect.getTopLeft(), [this](const std::string &s) {
                               int newVal = ::atoi(s.c_str());
-                              Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                                     "mpePitchBendRange", newVal);
+                              Surge::Storage::updateUserDefaultValue(
+                                  &(this->synth->storage), Surge::Storage::MPEPitchBendRange,
+                                  newVal);
                               this->synth->storage.mpePitchBendRange = newVal;
                           });
     });
 
-    auto men = makeSmoothMenu(menuRect, "pitchSmoothingMode",
+    auto men = makeSmoothMenu(menuRect, Surge::Storage::PitchSmoothingMode,
                               (int)ControllerModulationSource::SmoothingMode::DIRECT,
                               [this](auto md) { this->resetPitchSmoothing(md); });
     mpeSubMenu->addEntry(men, Surge::UI::toOSCaseForMenu("MPE Pitch Bend Smoothing"));
@@ -5520,7 +5524,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMonoModeOptionsMenu(VSTGUI::CRect &menu
     auto mode = synth->storage.monoPedalMode;
     if (updateDefaults)
         mode = (MonoPedalMode)Surge::Storage::getUserDefaultValue(
-            &(this->synth->storage), "monoPedalMode", (int)HOLD_ALL_NOTES);
+            &(this->synth->storage), Surge::Storage::MonoPedalMode, (int)HOLD_ALL_NOTES);
 
     auto cb = addCallbackMenu(
         monoSubMenu,
@@ -5528,20 +5532,21 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMonoModeOptionsMenu(VSTGUI::CRect &menu
         [this, updateDefaults]() {
             this->synth->storage.monoPedalMode = HOLD_ALL_NOTES;
             if (updateDefaults)
-                Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "monoPedalMode",
-                                                       (int)HOLD_ALL_NOTES);
+                Surge::Storage::updateUserDefaultValue(
+                    &(this->synth->storage), Surge::Storage::MonoPedalMode, (int)HOLD_ALL_NOTES);
         });
     if (mode == HOLD_ALL_NOTES)
         cb->setChecked(true);
 
-    cb = addCallbackMenu(
-        monoSubMenu, Surge::UI::toOSCaseForMenu("Sustain Pedal Allows Note Off Retrigger"),
-        [this, updateDefaults]() {
-            this->synth->storage.monoPedalMode = RELEASE_IF_OTHERS_HELD;
-            if (updateDefaults)
-                Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "monoPedalMode",
-                                                       (int)RELEASE_IF_OTHERS_HELD);
-        });
+    cb = addCallbackMenu(monoSubMenu,
+                         Surge::UI::toOSCaseForMenu("Sustain Pedal Allows Note Off Retrigger"),
+                         [this, updateDefaults]() {
+                             this->synth->storage.monoPedalMode = RELEASE_IF_OTHERS_HELD;
+                             if (updateDefaults)
+                                 Surge::Storage::updateUserDefaultValue(
+                                     &(this->synth->storage), Surge::Storage::MonoPedalMode,
+                                     (int)RELEASE_IF_OTHERS_HELD);
+                         });
     if (mode == RELEASE_IF_OTHERS_HELD)
         cb->setChecked(true);
 
@@ -5721,7 +5726,8 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect, boo
                     });
     tid++;
 
-    int oct = 5 - Surge::Storage::getUserDefaultValue(&(this->synth->storage), "middleC", 1);
+    int oct = 5 - Surge::Storage::getUserDefaultValue(&(this->synth->storage),
+                                                      Surge::Storage::MiddleC, 1);
     string middle_A = "A" + to_string(oct);
 
     addCallbackMenu(
@@ -5764,11 +5770,13 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeTuningMenu(VSTGUI::CRect &menuRect, boo
 
     tuningSubMenu->addSeparator();
 
-    bool tsMode = Surge::Storage::getUserDefaultValue(&(this->synth->storage), "useODDMTS", false);
+    bool tsMode = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
+                                                      Surge::Storage::UseODDMTS, false);
     std::string txt = "Use ODDSound" + Surge::UI::toOSCaseForMenu(" MTS-ESP (if Loaded in DAW)");
 
     auto menuItem = addCallbackMenu(tuningSubMenu, txt, [this, tsMode]() {
-        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "useODDMTS", !tsMode);
+        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), Surge::Storage::UseODDMTS,
+                                               !tsMode);
         if (tsMode)
         {
             // We toggled to false
@@ -5932,8 +5940,8 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeZoomMenu(VSTGUI::CRect &menuRect, bool 
 
         zoomSubMenu->addSeparator(zid++);
 
-        auto dzf =
-            Surge::Storage::getUserDefaultValue(&(synth->storage), "defaultZoom", zoomFactor);
+        auto dzf = Surge::Storage::getUserDefaultValue(&(synth->storage),
+                                                       Surge::Storage::DefaultZoom, zoomFactor);
         std::ostringstream dss;
         dss << "Zoom to Default (" << dzf << "%)";
         auto todefaultZ = std::make_shared<CCommandMenuItem>(
@@ -5946,7 +5954,8 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeZoomMenu(VSTGUI::CRect &menuRect, bool 
     auto defaultZ = std::make_shared<CCommandMenuItem>(
         CCommandMenuItem::Desc(Surge::UI::toOSCaseForMenu("Set Current Zoom Level as Default")));
     defaultZ->setActions([this](CCommandMenuItem *m) {
-        Surge::Storage::updateUserDefaultValue(&(synth->storage), "defaultZoom", zoomFactor);
+        Surge::Storage::updateUserDefaultValue(&(synth->storage), Surge::Storage::DefaultZoom,
+                                               zoomFactor);
     });
     zoomSubMenu->addEntry(defaultZ);
     zid++;
@@ -5955,15 +5964,14 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeZoomMenu(VSTGUI::CRect &menuRect, bool 
     {
         addCallbackMenu(zoomSubMenu, Surge::UI::toOSCaseForMenu("Set Default Zoom Level to..."),
                         [this, menuRect]() {
-                            // FIXME! This won't work on linux
                             char c[256];
                             snprintf(c, 256, "%d", (int)zoomFactor);
                             promptForMiniEdit(
                                 c, "Enter a default zoom level value:", "Set Default Zoom Level",
                                 menuRect.getTopLeft(), [this](const std::string &s) {
                                     int newVal = ::atoi(s.c_str());
-                                    Surge::Storage::updateUserDefaultValue(&(synth->storage),
-                                                                           "defaultZoom", newVal);
+                                    Surge::Storage::updateUserDefaultValue(
+                                        &(synth->storage), Surge::Storage::DefaultZoom, newVal);
                                     resizeWindow(newVal);
                                 });
                         });
@@ -5986,8 +5994,8 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
 #endif
 
 #if SUPPORTS_TOUCH_MENU
-    bool touchMode =
-        Surge::Storage::getUserDefaultValue(&(synth->storage), "touchMouseMode", false);
+    bool touchMode = Surge::Storage::getUserDefaultValue(&(synth->storage),
+                                                         Surge::Storage::TouchMouseMode, false);
 #else
     bool touchMode = false;
 #endif
@@ -6005,7 +6013,8 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
 
     auto menuItem = addCallbackMenu(mouseSubMenu, mouseLegacy.c_str(), [this]() {
         CSurgeSlider::sliderMoveRateState = CSurgeSlider::kLegacy;
-        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
+        Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                               Surge::Storage::SliderMoveRateState,
                                                CSurgeSlider::sliderMoveRateState);
     });
     menuItem->setChecked((CSurgeSlider::sliderMoveRateState == CSurgeSlider::kLegacy));
@@ -6014,7 +6023,8 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
 
     menuItem = addCallbackMenu(mouseSubMenu, mouseSlow.c_str(), [this]() {
         CSurgeSlider::sliderMoveRateState = CSurgeSlider::kSlow;
-        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
+        Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                               Surge::Storage::SliderMoveRateState,
                                                CSurgeSlider::sliderMoveRateState);
     });
     menuItem->setChecked((CSurgeSlider::sliderMoveRateState == CSurgeSlider::kSlow));
@@ -6023,7 +6033,8 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
 
     menuItem = addCallbackMenu(mouseSubMenu, mouseMedium.c_str(), [this]() {
         CSurgeSlider::sliderMoveRateState = CSurgeSlider::kMedium;
-        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
+        Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                               Surge::Storage::SliderMoveRateState,
                                                CSurgeSlider::sliderMoveRateState);
     });
     menuItem->setChecked((CSurgeSlider::sliderMoveRateState == CSurgeSlider::kMedium));
@@ -6032,7 +6043,8 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
 
     menuItem = addCallbackMenu(mouseSubMenu, mouseExact.c_str(), [this]() {
         CSurgeSlider::sliderMoveRateState = CSurgeSlider::kExact;
-        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "sliderMoveRateState",
+        Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                               Surge::Storage::SliderMoveRateState,
                                                CSurgeSlider::sliderMoveRateState);
     });
     menuItem->setChecked((CSurgeSlider::sliderMoveRateState == CSurgeSlider::kExact));
@@ -6042,23 +6054,23 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
     mouseSubMenu->addSeparator(mid++);
 
     bool tsMode = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                      "showCursorWhileEditing", true);
+                                                      Surge::Storage::ShowCursorWhileEditing, true);
 
     menuItem = addCallbackMenu(
         mouseSubMenu, Surge::UI::toOSCaseForMenu("Show Cursor While Editing"), [this, tsMode]() {
             Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                   "showCursorWhileEditing", !tsMode);
+                                                   Surge::Storage::ShowCursorWhileEditing, !tsMode);
         });
     menuItem->setChecked(tsMode);
     menuItem->setEnabled(!touchMode);
 
 #if SUPPORTS_TOUCH_MENU
     mouseSubMenu->addSeparator();
-    menuItem = addCallbackMenu(mouseSubMenu, Surge::UI::toOSCaseForMenu("Touchscreen Mode"),
-                               [this, touchMode]() {
-                                   Surge::Storage::updateUserDefaultValue(
-                                       &(this->synth->storage), "touchMouseMode", !touchMode);
-                               });
+    menuItem = addCallbackMenu(
+        mouseSubMenu, Surge::UI::toOSCaseForMenu("Touchscreen Mode"), [this, touchMode]() {
+            Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                                   Surge::Storage::TouchMouseMode, !touchMode);
+        });
     menuItem->setChecked(touchMode);
 #endif
 
@@ -6076,15 +6088,16 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
         patchDefMenu, Surge::UI::toOSCaseForMenu("Set Default Patch Author..."),
         [this, menuRect]() {
             string s = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                           "defaultPatchAuthor", "");
+                                                           Surge::Storage::DefaultPatchAuthor, "");
             char txt[256];
             txt[0] = 0;
             if (Surge::Storage::isValidUTF8(s))
                 strxcpy(txt, s.c_str(), 256);
             promptForMiniEdit(txt, "Enter default patch author name:", "Set Default Patch Author",
                               menuRect.getTopLeft(), [this](const std::string &s) {
-                                  Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                                         "defaultPatchAuthor", s);
+                                  Surge::Storage::updateUserDefaultValue(
+                                      &(this->synth->storage), Surge::Storage::DefaultPatchAuthor,
+                                      s);
                               });
         });
 
@@ -6092,15 +6105,16 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
         patchDefMenu, Surge::UI::toOSCaseForMenu("Set Default Patch Comment..."),
         [this, menuRect]() {
             string s = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                           "defaultPatchComment", "");
+                                                           Surge::Storage::DefaultPatchComment, "");
             char txt[256];
             txt[0] = 0;
             if (Surge::Storage::isValidUTF8(s))
                 strxcpy(txt, s.c_str(), 256);
             promptForMiniEdit(txt, "Enter default patch comment text:", "Set Default Patch Comment",
                               menuRect.getTopLeft(), [this](const std::string &s) {
-                                  Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                                         "defaultPatchComment", s);
+                                  Surge::Storage::updateUserDefaultValue(
+                                      &(this->synth->storage), Surge::Storage::DefaultPatchComment,
+                                      s);
                               });
         });
 
@@ -6112,38 +6126,38 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
                                             VSTGUI::COptionMenu::kMultipleCheckStyle);
 
     // high precision value readouts
-    bool precReadout = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                           "highPrecisionReadouts", false);
+    bool precReadout = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::HighPrecisionReadouts, false);
 
-    menuItem =
-        addCallbackMenu(dispDefMenu, Surge::UI::toOSCaseForMenu("High Precision Value Readouts"),
-                        [this, precReadout]() {
-                            Surge::Storage::updateUserDefaultValue(
-                                &(this->synth->storage), "highPrecisionReadouts", !precReadout);
-                        });
+    menuItem = addCallbackMenu(
+        dispDefMenu, Surge::UI::toOSCaseForMenu("High Precision Value Readouts"),
+        [this, precReadout]() {
+            Surge::Storage::updateUserDefaultValue(
+                &(this->synth->storage), Surge::Storage::HighPrecisionReadouts, !precReadout);
+        });
     menuItem->setChecked(precReadout);
 
     // modulation value readout shows bounds
-    bool modValues =
-        Surge::Storage::getUserDefaultValue(&(this->synth->storage), "modWindowShowsValues", false);
+    bool modValues = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::ModWindowShowsValues, false);
 
-    menuItem = addCallbackMenu(dispDefMenu,
-                               Surge::UI::toOSCaseForMenu("Modulation Value Readout Shows Bounds"),
-                               [this, modValues]() {
-                                   Surge::Storage::updateUserDefaultValue(
-                                       &(this->synth->storage), "modWindowShowsValues", !modValues);
-                               });
+    menuItem = addCallbackMenu(
+        dispDefMenu, Surge::UI::toOSCaseForMenu("Modulation Value Readout Shows Bounds"),
+        [this, modValues]() {
+            Surge::Storage::updateUserDefaultValue(
+                &(this->synth->storage), Surge::Storage::ModWindowShowsValues, !modValues);
+        });
     menuItem->setChecked(modValues);
 
     // lfoone. I think this is a display thing. But could be workflowalso?
-    bool lfoone = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                      "showGhostedLFOWaveReference", true);
+    bool lfoone = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::ShowGhostedLFOWaveReference, true);
 
     menuItem = addCallbackMenu(
         dispDefMenu, Surge::UI::toOSCaseForMenu("Show Ghosted LFO Waveform Reference"),
         [this, lfoone]() {
-            Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                   "showGhostedLFOWaveReference", !lfoone);
+            Surge::Storage::updateUserDefaultValue(
+                &(this->synth->storage), Surge::Storage::ShowGhostedLFOWaveReference, !lfoone);
             this->frame->invalid();
         });
     menuItem->setChecked(lfoone);
@@ -6153,22 +6167,23 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
                                                   VSTGUI::COptionMenu::kNoDrawStyle |
                                                       VSTGUI::COptionMenu::kMultipleCheckStyle);
 
-    auto mcValue = Surge::Storage::getUserDefaultValue(&(this->synth->storage), "middleC", 1);
+    auto mcValue =
+        Surge::Storage::getUserDefaultValue(&(this->synth->storage), Surge::Storage::MiddleC, 1);
 
     auto mcItem = addCallbackMenu(middleCSubMenu, "C3", [this]() {
-        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "middleC", 2);
+        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), Surge::Storage::MiddleC, 2);
         synth->refresh_editor = true;
     });
     mcItem->setChecked(mcValue == 2);
 
     mcItem = addCallbackMenu(middleCSubMenu, "C4", [this]() {
-        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "middleC", 1);
+        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), Surge::Storage::MiddleC, 1);
         synth->refresh_editor = true;
     });
     mcItem->setChecked(mcValue == 1);
 
     mcItem = addCallbackMenu(middleCSubMenu, "C5", [this]() {
-        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "middleC", 0);
+        Surge::Storage::updateUserDefaultValue(&(this->synth->storage), Surge::Storage::MiddleC, 0);
         synth->refresh_editor = true;
     });
     mcItem->setChecked(mcValue == 0);
@@ -6187,43 +6202,44 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeUserSettingsMenu(VSTGUI::CRect &menuRec
     menuItem = addCallbackMenu(
         wfMenu, Surge::UI::toOSCaseForMenu("Activate Individual Scene Outputs"), [this]() {
             this->synth->activateExtraOutputs = !this->synth->activateExtraOutputs;
-            Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "activateExtraOutputs",
+            Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                                   Surge::Storage::ActivateExtraOutputs,
                                                    this->synth->activateExtraOutputs ? 1 : 0);
         });
     menuItem->setChecked(synth->activateExtraOutputs);
 
-    bool msegSnapMem = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                           "restoreMSEGSnapFromPatch", true);
+    bool msegSnapMem = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::RestoreMSEGSnapFromPatch, true);
 
-    menuItem =
-        addCallbackMenu(wfMenu, Surge::UI::toOSCaseForMenu("Load MSEG Snap State from Patch"),
-                        [this, msegSnapMem]() {
-                            Surge::Storage::updateUserDefaultValue(
-                                &(this->synth->storage), "restoreMSEGSnapFromPatch", !msegSnapMem);
-                        });
+    menuItem = addCallbackMenu(
+        wfMenu, Surge::UI::toOSCaseForMenu("Load MSEG Snap State from Patch"),
+        [this, msegSnapMem]() {
+            Surge::Storage::updateUserDefaultValue(
+                &(this->synth->storage), Surge::Storage::RestoreMSEGSnapFromPatch, !msegSnapMem);
+        });
     menuItem->setChecked(msegSnapMem);
 
     // remember tab positions per scene
-    bool tabPosMem = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                         "rememberTabPositionsPerScene", false);
+    bool tabPosMem = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::RememberTabPositionsPerScene, false);
 
     menuItem = addCallbackMenu(
         wfMenu, Surge::UI::toOSCaseForMenu("Remember Tab Positions Per Scene"),
         [this, tabPosMem]() {
-            Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                   "rememberTabPositionsPerScene", !tabPosMem);
+            Surge::Storage::updateUserDefaultValue(
+                &(this->synth->storage), Surge::Storage::RememberTabPositionsPerScene, !tabPosMem);
         });
     menuItem->setChecked(tabPosMem);
 
     // wrap around browsing patches within current category
-    bool patchJogWrap =
-        Surge::Storage::getUserDefaultValue(&(this->synth->storage), "patchJogWraparound", true);
+    bool patchJogWrap = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::PatchJogWraparound, true);
 
     menuItem = addCallbackMenu(
         wfMenu, Surge::UI::toOSCaseForMenu("Previous/Next Patch Constrained to Current Category"),
         [this, patchJogWrap]() {
-            Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "patchJogWraparound",
-                                                   !patchJogWrap);
+            Surge::Storage::updateUserDefaultValue(
+                &(this->synth->storage), Surge::Storage::PatchJogWraparound, !patchJogWrap);
         });
     menuItem->setChecked(patchJogWrap);
 
@@ -6285,10 +6301,10 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeSkinMenu(VSTGUI::CRect &menuRect)
             auto cb = addCallbackMenu(addToThis, dname, [this, entry]() {
                 setupSkinFromEntry(entry);
                 this->synth->refresh_editor = true;
-                Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "defaultSkin",
-                                                       entry.name);
                 Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                       "defaultSkinRootType", entry.rootType);
+                                                       Surge::Storage::DefaultSkin, entry.name);
+                Surge::Storage::updateUserDefaultValue(
+                    &(this->synth->storage), Surge::Storage::DefaultSkinRootType, entry.rootType);
             });
             cb->setChecked(entry.matchesSkin(currentSkin));
             tid++;
@@ -6303,21 +6319,21 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeSkinMenu(VSTGUI::CRect &menuRect)
 
     if (useDevMenu)
     {
-        auto f5Value =
-            Surge::Storage::getUserDefaultValue(&(this->synth->storage), "skinReloadViaF5", 0);
+        auto f5Value = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
+                                                           Surge::Storage::SkinReloadViaF5, 0);
 
         auto valItem = addCallbackMenu(
             skinSubMenu, Surge::UI::toOSCaseForMenu("Use F5 To Reload Current Skin"),
             [this, f5Value]() {
-                Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "skinReloadViaF5",
-                                                       f5Value ? 0 : 1);
+                Surge::Storage::updateUserDefaultValue(
+                    &(this->synth->storage), Surge::Storage::SkinReloadViaF5, f5Value ? 0 : 1);
             });
         valItem->setChecked(f5Value == 1);
 
         tid++;
 
-        int pxres =
-            Surge::Storage::getUserDefaultValue(&(synth->storage), "layoutGridResolution", 16);
+        int pxres = Surge::Storage::getUserDefaultValue(&(synth->storage),
+                                                        Surge::Storage::LayoutGridResolution, 16);
 
         auto m = std::string("Show Layout Grid (") + std::to_string(pxres) + " px)";
 
@@ -6332,9 +6348,9 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeSkinMenu(VSTGUI::CRect &menuRect)
                                 std::to_string(pxres),
                                 "Enter new resolution:", "Layout Grid Resolution", CPoint(400, 400),
                                 [this](const std::string &s) {
-                                    Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                                           "layoutGridResolution",
-                                                                           std::atoi(s.c_str()));
+                                    Surge::Storage::updateUserDefaultValue(
+                                        &(this->synth->storage),
+                                        Surge::Storage::LayoutGridResolution, std::atoi(s.c_str()));
                                 });
                         });
 
@@ -6427,21 +6443,22 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeDataMenu(VSTGUI::CRect &menuRect)
     });
     did++;
 
-    addCallbackMenu(
-        dataSubMenu, Surge::UI::toOSCaseForMenu("Set Custom User Data Folder..."), [this]() {
-            auto cb = [this](std::string f) {
-                // FIXME - check if f is a path
-                this->synth->storage.userDataPath = f;
-                Surge::Storage::updateUserDefaultValue(&(this->synth->storage), "userDataPath", f);
-                this->synth->storage.refresh_wtlist();
-                this->synth->storage.refresh_patchlist();
-            };
-            /*
-             * TODO: Implement JUCE direcotry picker
-            Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.userDataPath, "", "",
-                                                          cb, true, true);
-                                                          */
-        });
+    addCallbackMenu(dataSubMenu, Surge::UI::toOSCaseForMenu("Set Custom User Data Folder..."),
+                    [this]() {
+                        auto cb = [this](std::string f) {
+                            // FIXME - check if f is a path
+                            this->synth->storage.userDataPath = f;
+                            Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                                                   Surge::Storage::UserDataPath, f);
+                            this->synth->storage.refresh_wtlist();
+                            this->synth->storage.refresh_patchlist();
+                        };
+                        /*
+                         * TODO: Implement JUCE direcotry picker
+                        Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.userDataPath,
+                        "", "", cb, true, true);
+                                                                      */
+                    });
     did++;
 
     dataSubMenu->addSeparator(did++);
@@ -6483,7 +6500,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeDataMenu(VSTGUI::CRect &menuRect)
 // default is a value to default to,
 // setSmooth is a function called to set the smoothing value
 VSTGUI::COptionMenu *SurgeGUIEditor::makeSmoothMenu(
-    VSTGUI::CRect &menuRect, const std::string &key, int defaultValue,
+    VSTGUI::CRect &menuRect, const Surge::Storage::DefaultKey &key, int defaultValue,
     std::function<void(ControllerModulationSource::SmoothingMode)> setSmooth)
 {
     COptionMenu *smoothMenu = new COptionMenu(menuRect, 0, 0, 0, 0,
@@ -6511,7 +6528,7 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeMidiMenu(VSTGUI::CRect &menuRect)
                                                VSTGUI::COptionMenu::kNoDrawStyle |
                                                    VSTGUI::COptionMenu::kMultipleCheckStyle);
 
-    auto smen = makeSmoothMenu(menuRect, "smoothingMode",
+    auto smen = makeSmoothMenu(menuRect, Surge::Storage::SmoothingMode,
                                (int)ControllerModulationSource::SmoothingMode::LEGACY,
                                [this](auto md) { this->resetSmoothing(md); });
     midiSubMenu->addEntry(smen, Surge::UI::toOSCaseForMenu("Controller Smoothing"));
@@ -6806,8 +6823,8 @@ void SurgeGUIEditor::promptForUserValueEntry(Parameter *p, CControl *c, int ms)
     }
     else
     {
-        int detailedMode = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                               "highPrecisionReadouts", 0);
+        int detailedMode = Surge::Storage::getUserDefaultValue(
+            &(this->synth->storage), Surge::Storage::HighPrecisionReadouts, 0);
         auto cms = ((ControllerModulationSource *)synth->storage.getPatch()
                         .scene[current_scene]
                         .modsources[ms]);
@@ -7429,14 +7446,16 @@ void SurgeGUIEditor::openModTypeinOnDrop(int modt, CControl *sl, int slidertag)
 void SurgeGUIEditor::resetSmoothing(ControllerModulationSource::SmoothingMode t)
 {
     // Reset the default value and tell the synth it is updated
-    Surge::Storage::updateUserDefaultValue(&(synth->storage), "smoothingMode", (int)t);
+    Surge::Storage::updateUserDefaultValue(&(synth->storage), Surge::Storage::SmoothingMode,
+                                           (int)t);
     synth->changeModulatorSmoothing(t);
 }
 
 void SurgeGUIEditor::resetPitchSmoothing(ControllerModulationSource::SmoothingMode t)
 {
     // Reset the default value and update it in storage for newly created voices to use
-    Surge::Storage::updateUserDefaultValue(&(synth->storage), "pitchSmoothingMode", (int)t);
+    Surge::Storage::updateUserDefaultValue(&(synth->storage), Surge::Storage::PitchSmoothingMode,
+                                           (int)t);
     synth->storage.pitchSmoothingMode = t;
 }
 

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -491,7 +491,7 @@ class SurgeGUIEditor : public EditorType,
     addCallbackMenu(VSTGUI::COptionMenu *toThis, std::string label, std::function<void()> op);
 
     VSTGUI::COptionMenu *
-    makeSmoothMenu(VSTGUI::CRect &menuRect, const std::string &key, int defaultValue,
+    makeSmoothMenu(VSTGUI::CRect &menuRect, const Surge::Storage::DefaultKey &key, int defaultValue,
                    std::function<void(ControllerModulationSource::SmoothingMode)> setSmooth);
 
     VSTGUI::COptionMenu *makeMpeMenu(VSTGUI::CRect &rect, bool showhelp);

--- a/src/common/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/common/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -168,7 +168,8 @@ std::string SurgeGUIEditor::tuningToHtml()
     for (int i = 0; i < 128; ++i)
     {
         int oct_offset = 1;
-        oct_offset = Surge::Storage::getUserDefaultValue(&(this->synth->storage), "middleC", 1);
+        oct_offset = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
+                                                         Surge::Storage::MiddleC, 1);
         char notename[16];
 
         std::string rowstyle = "";

--- a/src/common/gui/guihelpers.cpp
+++ b/src/common/gui/guihelpers.cpp
@@ -21,8 +21,9 @@ std::string toOSCaseForMenu(std::string menuName)
 
 bool showCursor(SurgeStorage *storage)
 {
-    bool sc = Surge::Storage::getUserDefaultValue(storage, "showCursorWhileEditing", 0);
-    bool tm = Surge::Storage::getUserDefaultValue(storage, "touchMouseMode", false);
+    bool sc =
+        Surge::Storage::getUserDefaultValue(storage, Surge::Storage::ShowCursorWhileEditing, 0);
+    bool tm = Surge::Storage::getUserDefaultValue(storage, Surge::Storage::TouchMouseMode, false);
 
     return sc || tm;
 };

--- a/src/surge_effects_bank/SurgeFXProcessor.cpp
+++ b/src/surge_effects_bank/SurgeFXProcessor.cpp
@@ -32,7 +32,7 @@ SurgefxAudioProcessor::SurgefxAudioProcessor()
         // Just make sure it is all consistent since this is a global from a separate DLL
         storage->setSamplerate(samplerate);
     }
-    storage->userPrefOverrides["highPrecisionReadouts"] = std::make_pair(0, "");
+    storage->userPrefOverrides[Surge::Storage::HighPrecisionReadouts] = std::make_pair(0, "");
 
     fxstorage = &(storage->getPatch().fx[0]);
     audio_thread_surge_effect.reset();


### PR DESCRIPTION
1. UserDefault API is no longer an unrestrained string but is
   instead an enum. Closes #4085
2. SurgeXT puts its user prefs in a SurgeXT file. Addresses #4335