### PR TITLE
Add Continuous Morph to WT osc, bump sv to 17

### DIFF
--- a/resources/data/configuration.xml
+++ b/resources/data/configuration.xml
@@ -12,8 +12,8 @@
         <snapshot name="Sine" p0="0.0" p1="0.0" p2="1.0" p2_deform_type="2" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1" retrigger="0" />
     </type>
     <separator />
-    <type i="2" name="Wavetable" retrigger="0" p5_extend_range="0" />
-    <type i="7" name="Window" retrigger="0" p5_extend_range="0" />
+    <type i="2" name="Wavetable" retrigger="0" p0_extend_range="1" p5_extend_range="0" />
+    <type i="7" name="Window" retrigger="0" p0_extend_range="0" p5_extend_range="0" />
     <separator />
     <type i="1" name="Sine" retrigger="1" p1_extend_range="1" p5_extend_range="0" />
     <type i="6" name="FM2" retrigger="1" p6_extend_range="1" />

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -79,16 +79,19 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 // 10 -> 11 (1.6.2 release) added DAW extra state
 // 11 -> 12 (1.6.3 release) added new parameters to the Distortion effect
 // 12 -> 13 (1.7.0 release) slider deactivation
-//                          sine LP/HP filters
-//                          sine/FM2/FM3 feedback extension/bipolar
-// 13 -> 14 (1.8.0 nightlies) add phaser stages/center/spread parameters
-//                            add ability to configure vocoder modulator mono/sterao/L/R
+//                          Sine LP/HP filters
+//                          Sine/FM2/FM3 feedback extension/bipolar
+// 13 -> 14 (1.8.0 nightlies) add Phaser stages/center/spread parameters
+//                            add ability to configure Vocoder modulator mono/sterao/L/R input
 //                            add comb filter tuning and compatibility block
 // 14 -> 15 (1.8.0 release) apply the great filter remap (GitHub issue #3006)
 // 15 -> 16 (1.9.0 release) implement oscillator retrigger consistently (GitHub issue #3171)
 //                          add tuningApplicationMode to patch
+//                          add disable toggle to various low/high cut filters in various effects
+//                          add disable toggle to Phaser rate, and different waveform options
+// 16 -> 17 (XT 1.0 release) wavetable oscillator continuous morph toggle
 
-const int ff_revision = 16;
+const int ff_revision = 17;
 
 extern float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
 extern float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];

--- a/src/common/dsp/WavetableOscillator.cpp
+++ b/src/common/dsp/WavetableOscillator.cpp
@@ -283,11 +283,11 @@ void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
     float contmorph = oscdata->p[wt_morph].extend_range;
 
     // do the crossfade if Continous Morph toggle is enabled, otherwise... don't
-    newlevel = distort_level(
-        oscdata->wt.TableF32WeakPointers[mipmap[voice]][tableid][state[voice]] *
-            (1.f - (tblip_ipol * contmorph)) +
-        (oscdata->wt.TableF32WeakPointers[mipmap[voice]][tableid + 1][state[voice]] *
-                          tblip_ipol * contmorph));
+    newlevel =
+        distort_level((oscdata->wt.TableF32WeakPointers[mipmap[voice]][tableid][state[voice]] *
+                       (1.f - (tblip_ipol * contmorph))) +
+                      (oscdata->wt.TableF32WeakPointers[mipmap[voice]][tableid + 1][state[voice]] *
+                       tblip_ipol * contmorph));
 
     g = newlevel - last_level[voice];
     last_level[voice] = newlevel;

--- a/src/common/dsp/WavetableOscillator.h
+++ b/src/common/dsp/WavetableOscillator.h
@@ -43,6 +43,8 @@ class WavetableOscillator : public AbstractBlitOscillator
     virtual void process_block(float pitch, float drift = 0.f, bool stereo = false, bool FM = false,
                                float FMdepth = 0.f) override;
     virtual ~WavetableOscillator();
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
 
   private:
     void convolute(int voice, bool FM, bool stereo);

--- a/src/common/dsp/effect/PhaserEffect.cpp
+++ b/src/common/dsp/effect/PhaserEffect.cpp
@@ -272,13 +272,13 @@ void PhaserEffect::init_default_values()
 void PhaserEffect::handleStreamingMismatches(int streamingRevision,
                                              int currentSynthStreamingRevision)
 {
-    if (streamingRevision < 14)
+    if (streamingRevision <= 13)
     {
         fxdata->p[ph_stages].val.i = 4;
         fxdata->p[ph_width].val.f = 0.f;
     }
 
-    if (streamingRevision < 16)
+    if (streamingRevision <= 15)
     {
         fxdata->p[ph_mod_wave].val.i = 1;
         fxdata->p[ph_mod_rate].deactivated = false;

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -2468,29 +2468,29 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                 contextMenu->addSeparator(eid++);
 
-                addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Bipolar Mode"),
-                                [this, control, ccid]() {
-                                    bool bp = !synth->storage.getPatch()
-                                                   .scene[current_scene]
-                                                   .modsources[ms_ctrl1 + ccid]
-                                                   ->is_bipolar();
-                                    synth->storage.getPatch()
-                                        .scene[current_scene]
-                                        .modsources[ms_ctrl1 + ccid]
-                                        ->set_bipolar(bp);
-
-                                    float f = synth->storage.getPatch()
+                auto bp = addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Bipolar Mode"),
+                                          [this, control, ccid]() {
+                                              bool bp = !synth->storage.getPatch()
+                                                             .scene[current_scene]
+                                                             .modsources[ms_ctrl1 + ccid]
+                                                             ->is_bipolar();
+                                              synth->storage.getPatch()
                                                   .scene[current_scene]
                                                   .modsources[ms_ctrl1 + ccid]
-                                                  ->get_output01();
-                                    control->setValue(f);
-                                    ((CModulationSourceButton *)control)->setBipolar(bp);
-                                    refresh_mod();
-                                });
-                contextMenu->checkEntry(eid, synth->storage.getPatch()
-                                                 .scene[current_scene]
-                                                 .modsources[ms_ctrl1 + ccid]
-                                                 ->is_bipolar());
+                                                  ->set_bipolar(bp);
+
+                                              float f = synth->storage.getPatch()
+                                                            .scene[current_scene]
+                                                            .modsources[ms_ctrl1 + ccid]
+                                                            ->get_output01();
+                                              control->setValue(f);
+                                              ((CModulationSourceButton *)control)->setBipolar(bp);
+                                              refresh_mod();
+                                          });
+                bp->setChecked(synth->storage.getPatch()
+                                   .scene[current_scene]
+                                   .modsources[ms_ctrl1 + ccid]
+                                   ->is_bipolar());
                 eid++;
 
                 addCallbackMenu(
@@ -3098,37 +3098,42 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                 {
                     contextMenu->addSeparator(eid++);
 
-                    addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Constant Rate"),
-                                    [this, p]() { p->porta_constrate = !p->porta_constrate; });
-                    contextMenu->checkEntry(eid, p->porta_constrate);
+                    auto cr =
+                        addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Constant Rate"),
+                                        [this, p]() { p->porta_constrate = !p->porta_constrate; });
+                    cr->setChecked(p->porta_constrate);
                     eid++;
 
-                    addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Glissando"),
-                                    [this, p]() { p->porta_gliss = !p->porta_gliss; });
-                    contextMenu->checkEntry(eid, p->porta_gliss);
+                    auto gliss =
+                        addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Glissando"),
+                                        [this, p]() { p->porta_gliss = !p->porta_gliss; });
+                    gliss->setChecked(p->porta_gliss);
                     eid++;
 
-                    addCallbackMenu(contextMenu,
-                                    Surge::UI::toOSCaseForMenu("Retrigger at Scale Degrees"),
-                                    [this, p]() { p->porta_retrigger = !p->porta_retrigger; });
-                    contextMenu->checkEntry(eid, p->porta_retrigger);
+                    auto rtsd = addCallbackMenu(
+                        contextMenu, Surge::UI::toOSCaseForMenu("Retrigger at Scale Degrees"),
+                        [this, p]() { p->porta_retrigger = !p->porta_retrigger; });
+                    rtsd->setChecked(p->porta_retrigger);
                     eid++;
 
                     contextMenu->addSeparator(eid++);
 
-                    addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Logarithmic Curve"),
-                                    [this, p]() { p->porta_curve = -1; });
-                    contextMenu->checkEntry(eid, (p->porta_curve == -1));
+                    auto log = addCallbackMenu(contextMenu,
+                                               Surge::UI::toOSCaseForMenu("Logarithmic Curve"),
+                                               [this, p]() { p->porta_curve = -1; });
+                    log->setChecked(p->porta_curve == -1);
                     eid++;
 
-                    addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Linear Curve"),
-                                    [this, p]() { p->porta_curve = 0; });
-                    contextMenu->checkEntry(eid, (p->porta_curve == 0));
+                    auto lin =
+                        addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Linear Curve"),
+                                        [this, p]() { p->porta_curve = 0; });
+                    lin->setChecked(p->porta_curve == 0);
                     eid++;
 
-                    addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu("Exponential Curve"),
-                                    [this, p]() { p->porta_curve = 1; });
-                    contextMenu->checkEntry(eid, (p->porta_curve == 1));
+                    auto exp = addCallbackMenu(contextMenu,
+                                               Surge::UI::toOSCaseForMenu("Exponential Curve"),
+                                               [this, p]() { p->porta_curve = 1; });
+                    exp->setChecked(p->porta_curve == 1);
                     eid++;
                 }
 
@@ -3152,13 +3157,13 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                 char title[32];
                                 sprintf(title, "Deform Type %d", (i + 1));
 
-                                addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu(title),
-                                                [this, p, i]() {
-                                                    p->deform_type = i;
-                                                    if (frame)
-                                                        frame->invalid();
-                                                });
-                                contextMenu->checkEntry(eid, (p->deform_type == i));
+                                auto dm = addCallbackMenu(
+                                    contextMenu, Surge::UI::toOSCaseForMenu(title), [this, p, i]() {
+                                        p->deform_type = i;
+                                        if (frame)
+                                            frame->invalid();
+                                    });
+                                dm->setChecked(p->deform_type == i);
                                 eid++;
                             }
                         }
@@ -3301,7 +3306,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                                                           p->extend_range = !p->extend_range;
                                                           this->synth->refresh_editor = true;
                                                       });
-                            contextMenu->checkEntry(eid, p->extend_range);
+                            ee->setChecked(p->extend_range);
                             ee->setEnabled(enable);
                             eid++;
                         }
@@ -3310,7 +3315,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
 
                 if (p->can_be_absolute())
                 {
-                    addCallbackMenu(contextMenu, "Absolute", [this, p]() {
+                    auto abs = addCallbackMenu(contextMenu, "Absolute", [this, p]() {
                         p->absolute = !p->absolute;
 
                         // FIXME : What's a better aprpoach?
@@ -3332,7 +3337,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                             synth->refresh_editor = true;
                         }
                     });
-                    contextMenu->checkEntry(eid, p->absolute);
+                    abs->setChecked(p->absolute);
                     eid++;
                 }
 
@@ -3768,32 +3773,32 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                 std::string sc = std::string("Scene ") + (char)('A' + current_scene);
                 contextMenu->addSeparator(eid++);
                 // FIXME - add unified menu here
-                addCallbackMenu(contextMenu, Surge::UI::toOSCaseForMenu(sc + " Hard Clip Disabled"),
-                                [this]() {
-                                    synth->storage.sceneHardclipMode[current_scene] =
-                                        SurgeStorage::BYPASS_HARDCLIP;
-                                });
-                contextMenu->checkEntry(eid, synth->storage.sceneHardclipMode[current_scene] ==
-                                                 SurgeStorage::BYPASS_HARDCLIP);
+                auto hcmen = addCallbackMenu(
+                    contextMenu, Surge::UI::toOSCaseForMenu(sc + " Hard Clip Disabled"), [this]() {
+                        synth->storage.sceneHardclipMode[current_scene] =
+                            SurgeStorage::BYPASS_HARDCLIP;
+                    });
+                hcmen->setChecked(synth->storage.sceneHardclipMode[current_scene] ==
+                                  SurgeStorage::BYPASS_HARDCLIP);
                 eid++;
 
-                addCallbackMenu(contextMenu,
-                                Surge::UI::toOSCaseForMenu(sc + " Hard Clip at 0 dBFS"), [this]() {
-                                    synth->storage.sceneHardclipMode[current_scene] =
-                                        SurgeStorage::HARDCLIP_TO_0DBFS;
-                                });
-                contextMenu->checkEntry(eid, synth->storage.sceneHardclipMode[current_scene] ==
-                                                 SurgeStorage::HARDCLIP_TO_0DBFS);
+                hcmen = addCallbackMenu(
+                    contextMenu, Surge::UI::toOSCaseForMenu(sc + " Hard Clip at 0 dBFS"), [this]() {
+                        synth->storage.sceneHardclipMode[current_scene] =
+                            SurgeStorage::HARDCLIP_TO_0DBFS;
+                    });
+                hcmen->setChecked(synth->storage.sceneHardclipMode[current_scene] ==
+                                SurgeStorage::HARDCLIP_TO_0DBFS);
                 eid++;
 
-                addCallbackMenu(contextMenu,
-                                Surge::UI::toOSCaseForMenu(sc + " Hard Clip at +18 dBFS"),
-                                [this]() {
-                                    synth->storage.sceneHardclipMode[current_scene] =
-                                        SurgeStorage::HARDCLIP_TO_18DBFS;
-                                });
-                contextMenu->checkEntry(eid, synth->storage.sceneHardclipMode[current_scene] ==
-                                                 SurgeStorage::HARDCLIP_TO_18DBFS);
+                hcmen = addCallbackMenu(
+                    contextMenu, Surge::UI::toOSCaseForMenu(sc + " Hard Clip at +18 dBFS"),
+                    [this]() {
+                        synth->storage.sceneHardclipMode[current_scene] =
+                            SurgeStorage::HARDCLIP_TO_18DBFS;
+                    });
+                hcmen->setChecked(synth->storage.sceneHardclipMode[current_scene] ==
+                                 SurgeStorage::HARDCLIP_TO_18DBFS);
                 eid++;
             }
 
@@ -3802,25 +3807,22 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                 contextMenu->addSeparator(eid++);
                 // FIXME - add unified menu here
 
-                addCallbackMenu(
+                auto hcmen = addCallbackMenu(
                     contextMenu, Surge::UI::toOSCaseForMenu("Global Hard Clip Disabled"),
                     [this]() { synth->storage.hardclipMode = SurgeStorage::BYPASS_HARDCLIP; });
-                contextMenu->checkEntry(eid, synth->storage.hardclipMode ==
-                                                 SurgeStorage::BYPASS_HARDCLIP);
+                hcmen->setChecked(synth->storage.hardclipMode == SurgeStorage::BYPASS_HARDCLIP);
                 eid++;
 
-                addCallbackMenu(
+                hcmen = addCallbackMenu(
                     contextMenu, Surge::UI::toOSCaseForMenu("Global Hard Clip at 0 dBFS"),
                     [this]() { synth->storage.hardclipMode = SurgeStorage::HARDCLIP_TO_0DBFS; });
-                contextMenu->checkEntry(eid, synth->storage.hardclipMode ==
-                                                 SurgeStorage::HARDCLIP_TO_0DBFS);
+                hcmen->setChecked(synth->storage.hardclipMode == SurgeStorage::HARDCLIP_TO_0DBFS);
                 eid++;
 
-                addCallbackMenu(
+                hcmen = addCallbackMenu(
                     contextMenu, Surge::UI::toOSCaseForMenu("Global Hard Clip at +18 dBFS"),
                     [this]() { synth->storage.hardclipMode = SurgeStorage::HARDCLIP_TO_18DBFS; });
-                contextMenu->checkEntry(eid, synth->storage.hardclipMode ==
-                                                 SurgeStorage::HARDCLIP_TO_18DBFS);
+                hcmen->setChecked(synth->storage.hardclipMode == SurgeStorage::HARDCLIP_TO_18DBFS);
                 eid++;
             }
 

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -3788,17 +3788,17 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                             SurgeStorage::HARDCLIP_TO_0DBFS;
                     });
                 hcmen->setChecked(synth->storage.sceneHardclipMode[current_scene] ==
-                                SurgeStorage::HARDCLIP_TO_0DBFS);
+                                  SurgeStorage::HARDCLIP_TO_0DBFS);
                 eid++;
 
-                hcmen = addCallbackMenu(
-                    contextMenu, Surge::UI::toOSCaseForMenu(sc + " Hard Clip at +18 dBFS"),
-                    [this]() {
-                        synth->storage.sceneHardclipMode[current_scene] =
-                            SurgeStorage::HARDCLIP_TO_18DBFS;
-                    });
+                hcmen = addCallbackMenu(contextMenu,
+                                        Surge::UI::toOSCaseForMenu(sc + " Hard Clip at +18 dBFS"),
+                                        [this]() {
+                                            synth->storage.sceneHardclipMode[current_scene] =
+                                                SurgeStorage::HARDCLIP_TO_18DBFS;
+                                        });
                 hcmen->setChecked(synth->storage.sceneHardclipMode[current_scene] ==
-                                 SurgeStorage::HARDCLIP_TO_18DBFS);
+                                  SurgeStorage::HARDCLIP_TO_18DBFS);
                 eid++;
             }
 


### PR DESCRIPTION
Closes #4318 (however we might need to tweak the behavior so that it doesn't click so much at frame changes, to be discussed)

Also updated configuration.xml so that Continuous Morph is defaulted properly when loading those osc presets.

Also, fixed checkmarks not appearing for a bunch of entries in SGE.