### PR TITLE
Add (off-by-default) AUv3 extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9 CACHE STRING "Build for 10.9")
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.11 CACHE STRING "Build for 10.9")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -588,6 +588,10 @@ else()
   set(SURGE_JUCE_FORMATS AU VST3 Standalone)
 endif()
 
+if(SURGE_XT_BUILD_AUV3)
+  list(APPEND SURGE_JUCE_FORMATS AUv3)
+endif()
+
 if(JUCE_SUPPORTS_LV2)
   list(APPEND SURGE_JUCE_FORMATS LV2)
   message( STATUS "Including JUCE LV2 support. You will need a different JUCE than the submodule" )
@@ -860,6 +864,11 @@ if( BUILD_SURGE_XT )
     target_sources(surge-xt_AU PRIVATE
             src/surge_synth_juce/SurgeSynthAUExtensions.cpp
             )
+    if(TARGET surge-xt_AUv3)
+      target_sources(surge-xt_AUv3 PRIVATE
+              src/surge_synth_juce/SurgeSynthAUv3Extensions.cpp
+              )
+    endif()
   endif()
 
   target_link_libraries(surge-xt PUBLIC

--- a/src/surge_synth_juce/SurgeSynthAUv3Extensions.cpp
+++ b/src/surge_synth_juce/SurgeSynthAUv3Extensions.cpp
@@ -1,0 +1,29 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include <iostream>
+
+#include "SurgeSynthProcessor.h"
+#include "SurgeSynthEditor.h"
+#include "SurgeSynthFlavorExtensions.h"
+
+void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s)
+{
+    std::cout << "SynthProcessor: " << __FILE__ << std::endl;
+}
+void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed)
+{
+    std::cout << "SynthEditor: " << __FILE__ << std::endl;
+}


### PR DESCRIPTION
This lets us build an AUv3 but AUv3 is wierd so leave it
off for later exploration