### PR TITLE
JUCE patch to expose VST3 host context to AudioProcessor w/ CMake script

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ Vincent Zauhar <v.zauhar@bell.net>
 簡志瑋 <dppss92132@gmail.com>
 Marty Lake <matthieu@talbot.audio>
 David Carlier <devnexen@gmail.com>
+Gavin Ray <ray.gavin97@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ if( SURGE_ALTERNATE_JUCE )
   add_subdirectory( ${SURGE_ALTERNATE_JUCE} ${CMAKE_BINARY_DIR}/alternate-juce )
 else()
   message( STATUS "Using JUCE from submodule libs/JUCE" )
+  include("${CMAKE_CURRENT_LIST_DIR}/cmake/patch-juce.cmake")
   add_subdirectory( libs/JUCE )
 endif()
 

--- a/cmake/patch-juce.cmake
+++ b/cmake/patch-juce.cmake
@@ -3,27 +3,30 @@ set(FOUND_PATCH_EXECUTABLE 0)
 # Try to use FindPatch() and then find_program() to find a "patch" binary, fatal error if none found
 # [CMake +3.10] https://cmake.org/cmake/help/latest/module/FindPatch.html
 find_package(Patch)
+message("Searching for patch using FindPatch()")
 if(Patch_FOUND)
   message("Patch found: ${Patch_EXECUTABLE}")
-  set(FOUND_PATCH_EXECUTABLE Patch_EXECUTABLE)
+  set(FOUND_PATCH_EXECUTABLE ${Patch_EXECUTABLE})
 else()
+  message("Searching for patch using find_program()")
   find_program(
     PATCH_EXECUTABLE
     NAMES "patch"
     # This is for my personal use
     HINTS "C:\\Program Files\\Git\\usr\\bin"
   )
-  if(_PATCH_EXECUTABLE)
-    set(FOUND_PATCH_EXECUTABLE PATCH_EXECUTABLE)
+  if(PATCH_EXECUTABLE)
+    set(FOUND_PATCH_EXECUTABLE ${PATCH_EXECUTABLE})
   else()
     message(FATAL_ERROR "Unable to find a patch executable with either of FindPatch() or find_program()")
   endif()
 endif()
 
 # Sanity check
-if (not FOUND_PATCH_EXECUTABLE)
+if (NOT FOUND_PATCH_EXECUTABLE)
   message(FATAL_ERROR "Failed both patch executable searches but continued execution. Stopping, as this was unintended.")
 endif()
+message("FOUND_PATCH_EXECUTABLE=${FOUND_PATCH_EXECUTABLE}")
 
 ################################################################
 

--- a/cmake/patch-juce.cmake
+++ b/cmake/patch-juce.cmake
@@ -1,0 +1,41 @@
+find_package(
+  PATCH_EXECUTABLE "patch"
+  # Add something like below if no patch executable is found
+  # HINTS "C:\\Program Files\\Git\\usr\\bin"
+  REQUIRED
+)
+
+# Look for and apply patches to the third-party (and sub) repo.
+file(GLOB PATCHES "${CMAKE_SOURCE_DIR}/src/patches/juce/*.patch")
+
+if (PATCHES)
+  foreach(PATCH ${PATCHES})
+    message(STATUS "Applying ${PATCH}")
+    execute_process(
+      # The --binary flag here is a bit of a hack. It covers up problem with mixed line-endings CLRF/LF
+      # See: https://stackoverflow.com/a/10934047
+      # Really, gitattributes should be used to normalize these, and the below should be used to generate the patch files:
+      COMMAND ${PATCH_EXECUTABLE} -p1 --forward --ignore-whitespace --binary --input=${PATCH}
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/libs/juce"
+      OUTPUT_VARIABLE OUTPUT
+      RESULT_VARIABLE RESULT
+      COMMAND_ECHO STDOUT)
+    if (RESULT EQUAL 0)
+      message(STATUS "Patch applied: ${PATCH}")
+    else()
+      # Unfortunately although patch will recognise that a patch is already
+      # applied it will still return an error.
+      execute_process(
+        COMMAND ${PATCH_EXECUTABLE} -p1 --reverse --binary --dry-run --input=${PATCH}
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/libs/juce"
+        OUTPUT_VARIABLE OUTPUT
+        RESULT_VARIABLE RESULT2
+        COMMAND_ECHO STDOUT)
+      if (RESULT2 EQUAL 0)
+        message(STATUS "Patch was already applied: ${PATCH}")
+      else()
+        message(FATAL_ERROR "Error applying patch ${PATCH}")
+      endif()
+    endif()
+  endforeach(PATCH)
+endif()

--- a/src/patches/juce/juce_AudioProcessor.h.patch
+++ b/src/patches/juce/juce_AudioProcessor.h.patch
@@ -1,0 +1,38 @@
+diff --git a/modules/juce_audio_processors/processors/juce_AudioProcessor.h b/modules/juce_audio_processors/processors/juce_AudioProcessor.h
+index ad9bc4367..afb17c7cf 100644
+--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.h
++++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.h
+@@ -23,6 +23,19 @@
+   ==============================================================================
+ */
+ 
++#ifdef JUCE_VST3_ENABLE_PASS_HOST_CONTEXT_TO_AUDIO_PROCESSOR_ON_INITIALIZE
++namespace Steinberg {
++        class FUnknown;
++        namespace Vst {
++            class IHostApplication;
++        }
++}
++namespace juce {
++    class JuceVST3EditController;
++	class JuceAudioProcessor;
++}
++#endif
++
+ namespace juce
+ {
+ 
+@@ -71,6 +84,13 @@ protected:
+     }
+ 
+ public:
++#ifdef JUCE_VST3_ENABLE_PASS_HOST_CONTEXT_TO_AUDIO_PROCESSOR_ON_INITIALIZE
++    virtual void handleVST3HostContext(
++        Steinberg::FUnknown* hostContext,
++        Steinberg::Vst::IHostApplication* host,
++	    JuceAudioProcessor* comPluginInstance,
++	    JuceVST3EditController* juceVST3EditController) {};
++#endif
+     //==============================================================================
+     enum ProcessingPrecision
+     {

--- a/src/patches/juce/juce_VST3_Wrapper.cpp.patch
+++ b/src/patches/juce/juce_VST3_Wrapper.cpp.patch
@@ -1,0 +1,21 @@
+diff --git a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+index bb2ae6535..df37b6bf7 100644
+--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
++++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+@@ -2116,6 +2116,16 @@ public:
+         if (host != hostContext)
+             host.loadFrom (hostContext);
+ 
++    	
++#ifdef JUCE_VST3_ENABLE_PASS_HOST_CONTEXT_TO_AUDIO_PROCESSOR_ON_INITIALIZE
++        getPluginInstance().handleVST3HostContext(
++           hostContext,
++           this->host.get(),
++           this->comPluginInstance.get(),
++           this->juceVST3EditController.get()
++        );
++#endif
++
+         processContext.sampleRate = processSetup.sampleRate;
+         preparePlugin (processSetup.sampleRate, (int) processSetup.maxSamplesPerBlock);
+ 


### PR DESCRIPTION
This adds a new directory `./src/patches` with patches for JUCE under `/juce` that currently patch the `juce_AudioProcessor.h` and `juce_VST3_wrapper.cpp` to allow implementing the following method in a `juce::AudioProcessor`

```cpp
void handleVST3HostContext(
  Steinberg::FUnknown* hostContext,
  Steinberg::Vst::IHostApplication* host,
  juce::JuceAudioProcessor* comPluginInstance,
  juce::JuceVST3EditController* juceVST3EditController) override;

void AudioPluginAudioProcessor::handleVST3HostContext(
  Steinberg::FUnknown* hostContext,
  Steinberg::Vst::IHostApplication* host,
  juce::JuceAudioProcessor* comPluginInstance,
  juce::JuceVST3EditController* juceVST3EditController) 
{
  
}
```
