### PR TITLE
Repaint when defaulting frequency

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -3880,6 +3880,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl *control, CButtonState b
                         p->set_value_f01(p->get_default_value_f01());
                         control->setValue(p->get_value_f01());
                     }
+                    control->invalid();
                     return 0;
                 }
                 default:


### PR DESCRIPTION
Repaing when defaulting frequency. VSTG must have gotten a
repaint from elsewhere, but the missing invalidation here made
juce appear to not reset cutoff on double click.

Closes #4441