### PR TITLE
Turn on the PatchDB Scanner in XT-Alpha

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -619,15 +619,15 @@ bailOnPortable:
         oddsound_mts_client = nullptr;
         oddsound_mts_active = false;
     }
+}
 
-    /*
-     * Disable this for merge - come back here once I engage in getting this done
+void SurgeStorage::initializePatchDb()
+{
     patchDB = std::make_unique<Surge::PatchStorage::PatchDB>(this);
     for (auto p : patch_list)
     {
         patchDB->considerFXPForLoad(p.path, p.name, patch_category[p.category].name);
     }
-     */
 }
 
 SurgePatch &SurgeStorage::getPatch() { return *_patch.get(); }

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -924,6 +924,8 @@ class alignas(16) SurgeStorage
     ~SurgeStorage();
 
     std::unique_ptr<Surge::PatchStorage::PatchDB> patchDB;
+    void initializePatchDb();
+
     std::unique_ptr<SurgePatch> _patch;
 
     SurgePatch &getPatch();

--- a/src/gui/CPatchBrowser.cpp
+++ b/src/gui/CPatchBrowser.cpp
@@ -86,16 +86,6 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint &where, const CButtonState &
     COptionMenu *contextMenu =
         new COptionMenu(menurect, 0, 0, 0, 0, COptionMenu::kMultipleCheckStyle);
 
-    auto pdbF = std::make_shared<CCommandMenuItem>(
-        CCommandMenuItem::Desc(Surge::UI::toOSCaseForMenu("Open Patch Database...")));
-    pdbF->setActions([this](CCommandMenuItem *item) {
-        auto sge = dynamic_cast<SurgeGUIEditor *>(listener);
-        if (sge)
-            sge->showPatchBrowserDialog();
-    });
-    // contextMenu->addEntry(pdbF);
-    // contextMenu->addSeparator();
-
     int main_e = 0;
     // if RMB is down, only show the current category
     bool single_category = button & (kRButton | kControl), has_3rdparty = false;
@@ -200,10 +190,30 @@ CMouseEventResult CPatchBrowser::onMouseDown(CPoint &where, const CButtonState &
 
     auto initItem = std::make_shared<CCommandMenuItem>(
         CCommandMenuItem::Desc(Surge::UI::toOSCaseForMenu("Initialize Patch")));
-    auto initAction = [this](CCommandMenuItem *item) { /* load init state */ };
+    auto initAction = [this](CCommandMenuItem *item) {
+        int i = 0;
+        for (auto p : storage->patch_list)
+        {
+            if (p.name == "Init Saw" && storage->patch_category[p.category].name == "Templates")
+            {
+                loadPatch(i);
+                break;
+            }
+            ++i;
+        }
+    };
     initItem->setActions(initAction, nullptr);
     contextMenu->addEntry(initItem);
+    contextMenu->addSeparator();
 
+    auto pdbF = std::make_shared<CCommandMenuItem>(
+        CCommandMenuItem::Desc(Surge::UI::toOSCaseForMenu("Open Patch Database...")));
+    pdbF->setActions([this](CCommandMenuItem *item) {
+        auto sge = dynamic_cast<SurgeGUIEditor *>(listener);
+        if (sge)
+            sge->showPatchBrowserDialog();
+    });
+    contextMenu->addEntry(pdbF);
     contextMenu->addSeparator();
 
     auto refreshItem = std::make_shared<CCommandMenuItem>(

--- a/src/gui/PatchDBViewer.cpp
+++ b/src/gui/PatchDBViewer.cpp
@@ -26,7 +26,7 @@ class PatchDBSQLTableModel : public juce::TableListBoxModel
                    bool rowIsSelected) override
     {
         g.setColour(juce::Colour(100, 100, 100));
-        g.drawRect(juce::Rectangle<int>{0, 0, width - 1, height - 1});
+        g.drawRect(juce::Rectangle<int>{0, 0, width, height});
         g.setColour(juce::Colour(0, 0, 0));
         auto d = data[rowNumber];
         auto s = std::to_string(d.id);

--- a/src/surge_synth_juce/SurgeSynthProcessor.cpp
+++ b/src/surge_synth_juce/SurgeSynthProcessor.cpp
@@ -26,6 +26,7 @@ SurgeSynthProcessor::SurgeSynthProcessor()
 {
     std::cout << "SurgeXT : Version " << Surge::Build::FullVersionStr << std::endl;
     surge = std::make_unique<SurgeSynthesizer>(this);
+    surge->storage.initializePatchDb(); // In the UI branch we want the patch DB running
 
     std::map<unsigned int, std::vector<std::unique_ptr<juce::AudioProcessorParameter>>> parByGroup;
     for (auto par : surge->storage.getPatch().param_ptr)


### PR DESCRIPTION
1. Rewrite the SQL to only scan changed files and remove dups
2. Modify the SQL to add a schema version
3. Turn this on by default and expose the crude db browser

Addresses #2359