### PR TITLE
Ability to mute a modulation routing

### DIFF
--- a/src/common/ModulationSource.h
+++ b/src/common/ModulationSource.h
@@ -261,6 +261,7 @@ struct ModulationRouting
     int source_id;
     int destination_id;
     float depth;
+    bool muted = false;
 };
 
 class ModulationSource

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1362,6 +1362,12 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                     t.depth = (float)depth;
                     t.source_id = modsource;
 
+                    int muted = 0;
+                    if (mr->QueryIntAttribute("muted", &muted) == TIXML_SUCCESS)
+                        t.muted = muted;
+                    else
+                        t.muted = false;
+
                     if (sceneId != 0)
                         t.destination_id = paramIdInScene;
                     else
@@ -2175,6 +2181,7 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
                             TiXmlElement mr("modrouting");
                             mr.SetAttribute("source", r->at(b).source_id);
                             mr.SetAttribute("depth", float_to_str(r->at(b).depth, tempstr));
+                            mr.SetAttribute("muted", r->at(b).muted);
                             p.InsertEndChild(mr);
                         }
                     }

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -269,6 +269,8 @@ class alignas(16) SurgeSynthesizer
     ModulationRouting *getModRouting(long ptag, modsources modsource);
     bool setModulation(long ptag, modsources modsource, float value);
     float getModulation(long ptag, modsources modsource);
+    void muteModulation(long ptag, modsources modsource, bool mute);
+    bool isModulationMuted(long ptag, modsources modsource);
     float getModDepth(long ptag, modsources modsource);
     void clearModulation(long ptag, modsources modsource, bool clearEvenIfInvalid = false);
     void clear_osc_modulation(

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -338,7 +338,7 @@ void SurgeVoice::switch_toggled()
         float depth = iter->depth;
         if (modsources[src_id] && src_id == ms_keytrack)
         {
-            localcopy[dst_id].f += depth * modsources[ms_keytrack]->output;
+            localcopy[dst_id].f += depth * modsources[ms_keytrack]->output * (1 - iter->muted);
         }
         iter++;
     }
@@ -568,7 +568,7 @@ template <bool first> void SurgeVoice::calc_ctrldata(QuadFilterChainState *Q, in
 
         if (modsources[src_id])
         {
-            localcopy[dst_id].f += depth * modsources[src_id]->output;
+            localcopy[dst_id].f += depth * modsources[src_id]->output * (1.0 - iter->muted);
         }
         iter++;
     }
@@ -590,7 +590,7 @@ template <bool first> void SurgeVoice::calc_ctrldata(QuadFilterChainState *Q, in
                 if (dst_id >= 0 && dst_id < n_scene_params)
                 {
                     float depth = iter->depth;
-                    localcopy[dst_id].f += depth * modsources[src_id]->output;
+                    localcopy[dst_id].f += depth * modsources[src_id]->output * (1.0 - iter->muted);
                 }
             }
             iter++;

--- a/src/gui/ModulationEditor.cpp
+++ b/src/gui/ModulationEditor.cpp
@@ -97,6 +97,7 @@ struct ModulationListBoxModel : public juce::ListBoxModel
                            public juce::Button::Listener
     {
         std::unique_ptr<juce::Button> clearButton;
+        std::unique_ptr<juce::Button> muteButton;
         std::unique_ptr<juce::Slider> modSlider;
         EditComponent(ModulationListBoxModel *mod, int row) : mod(mod), row(row)
         {
@@ -104,6 +105,15 @@ struct ModulationListBoxModel : public juce::ListBoxModel
             clearButton->setButtonText("Clear");
             clearButton->addListener(this);
             addAndMakeVisible(*clearButton);
+
+            muteButton = std::make_unique<juce::ToggleButton>("Mute");
+            muteButton->setButtonText("Mute");
+            muteButton->addListener(this);
+            muteButton->setToggleState(
+                mod->moded->synth->isModulationMuted(mod->rows[row].dest_id,
+                                                     (modsources)mod->rows[row].source_id),
+                juce::NotificationType::dontSendNotification);
+            addAndMakeVisible(*muteButton);
 
             modSlider = std::make_unique<juce::Slider>("Modulation");
             modSlider->setSliderStyle(juce::Slider::LinearHorizontal);
@@ -133,6 +143,12 @@ struct ModulationListBoxModel : public juce::ListBoxModel
                 mod->updateRows();
                 mod->moded->listBox->updateContent();
             }
+            if (button == muteButton.get())
+            {
+                mod->moded->synth->muteModulation(mod->rows[row].dest_id,
+                                                  (modsources)mod->rows[row].source_id,
+                                                  button->getToggleState());
+            }
         }
         void resized() override
         {
@@ -140,7 +156,11 @@ struct ModulationListBoxModel : public juce::ListBoxModel
                 getBounds().getTopLeft().getX() + 50);
             clearButton->setBounds(b);
 
-            b = getBounds().withTrimmedLeft(15).withTrimmedLeft(50 + 3).expanded(-1).withRight(
+            b = getBounds().withTrimmedLeft(15).withTrimmedLeft(35).expanded(-1).withRight(
+                getBounds().getTopLeft().getX() + 97);
+            muteButton->setBounds(b);
+
+            b = getBounds().withTrimmedLeft(15).withTrimmedLeft(100 + 3).expanded(-1).withRight(
                 getWidth() / 2);
             modSlider->setBounds(b);
 


### PR DESCRIPTION
Individual modulation routings can be muted. This
gets saved in the patches and is editable by the
new modulation overview screen.