### PR TITLE
Modify the way we support AVX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
 #endif
     int main() {}" COMPILER_HAS_AVX_OR_IS_ARM)
   if (NOT COMPILER_HAS_AVX_OR_IS_ARM)
-    message(STATUS "Adding -mavx to allow __AVX__ compiles" )
-    add_compile_options("-mavx")
+    message(STATUS "Holding off on AVX support. See #4479 for the strategy" )
+    # add_compile_options("-mavx")
   endif()
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -112,7 +112,7 @@ if(MSVC)
     /Zc:alignedNew
     /bigobj
 
-    /arch:AVX
+    # /arch:AVX
 
     # Build with Multiple Processes (Clang-cl builds use Ninja instead)
     $<$<CXX_COMPILER_ID:MSVC>:/MP>

--- a/src/common/CPUFeatures.cpp
+++ b/src/common/CPUFeatures.cpp
@@ -172,10 +172,6 @@ bool hasAVX()
 #endif
 }
 
-#if !(__AVX__ || ARM_NEON)
-#error "You must compile SURGE with AVX support in compiler flags"
-#endif
-
 FPUStateGuard::FPUStateGuard()
 {
 #ifndef ARM_NEON

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -39,16 +39,6 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, std::string suppliedData
     : storage(suppliedDataPath), hpA(&storage), hpB(&storage), _parent(parent), halfbandA(6, true),
       halfbandB(6, true), halfbandIN(6, true)
 {
-    // Remember CPU features works on ARM also
-    if (!Surge::CPUFeatures::hasAVX())
-    {
-        storage.reportError(
-            "Surge XT in the future will require processor with AVX extensions. Surge Xt may"
-            " not work on this hardware in future versions. Enjoy Surge 1.9!",
-            "CPU Incompatability");
-        // Try anyway
-    }
-
     switch_toggled_queued = false;
     audio_processing_active = false;
     halt_engine = false;

--- a/src/gui/CAboutBox.cpp
+++ b/src/gui/CAboutBox.cpp
@@ -191,6 +191,15 @@ CAboutBox::CAboutBox(const CRect &size, SurgeGUIEditor *editor, SurgeStorage *st
     std::string flavor = wrapperType;
 
     std::string arch = Surge::CPUFeatures::cpuBrand();
+
+    if (Surge::CPUFeatures::hasAVX())
+    {
+        arch += " (including AVX)";
+    }
+    else
+    {
+        arch += " (no AVX support)";
+    }
 #if MAC
     std::string platform = "macOS";
 #elif WINDOWS


### PR DESCRIPTION
Blanket -mavx means that static initializers add avx intrinsics
and what not. Instead we want to use a conditional approapch through
splitting up libraries and only compiling the necessary program
units with -mavx as described in #4479.

We haven't done that yet, but we will. So even though this
Closes #4479, there's still work to be done when we use
AVX for the first time.