### PR TITLE
Fix Gradient Crash; Fix install-local targets; update README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1146,7 +1146,7 @@ if( APPLE )
           POST_BUILD
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           COMMAND echo "Installing local resources"
-          COMMAND rsync -r --delete "resources/data/" "\${HOME}/Library/Application Support/Surge/"
+          COMMAND rsync -r --delete "resources/data/" "\${HOME}/Library/Application Support/Surge XT/"
   )
 
   add_custom_target( install-resources-global )
@@ -1155,7 +1155,7 @@ if( APPLE )
           POST_BUILD
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           COMMAND echo "Installing global resources"
-          COMMAND rsync -r --delete "resources/data/" "/Library/Application Support/Surge/"
+          COMMAND rsync -r --delete "resources/data/" "/Library/Application Support/Surge XT/"
   )
 
 elseif( UNIX AND NOT APPLE )
@@ -1164,8 +1164,9 @@ elseif( UNIX AND NOT APPLE )
           TARGET install-resources-local
           POST_BUILD
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-          COMMAND echo "Installing local resources into ~/.local/share/surge"
-          COMMAND rsync -r --delete "resources/data/" "\${HOME}/.local/share/surge/"
+          COMMAND echo "Installing local resources into ~/.local/share/surge-xt"
+          COMMAND ${CMAKE_COMMAND} -E make_directory "\${HOME}/.local/share/surge-xt/"
+          COMMAND rsync -r --delete "resources/data/" "\${HOME}/.local/share/surge-xt/"
   )
 
   add_custom_target( install-resources-global )
@@ -1173,9 +1174,9 @@ elseif( UNIX AND NOT APPLE )
           TARGET install-resources-global
           POST_BUILD
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-          COMMAND echo "Installing local resources into ${CMAKE_INSTALL_PREFIX}/share/surge"
-          COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/share/surge
-          COMMAND rsync -r --delete "resources/data/" "${CMAKE_INSTALL_PREFIX}/share/surge/"
+          COMMAND echo "Installing local resources into ${CMAKE_INSTALL_PREFIX}/share/surge-xt"
+          COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_INSTALL_PREFIX}/share/surge-xt"
+          COMMAND rsync -r --delete "resources/data/" "${CMAKE_INSTALL_PREFIX}/share/surge-xt/"
   )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,41 @@ at the end of the build process. On Mac and Linux, the installer generator is bu
 into the platform; on Windows, our CMake file uses NuGet to download InnoSetup, so
 you will need the [nuget.exe CLI](https://nuget.org/) in your path.
 
+## Using CMake on the Command Line for More
+
+In Surge 1.6-1.9 we had a pair of scripts `build-osx.sh` and `build-linux.sh` which originated
+before Surge was a cmake project and contained a lot of utility functions. We have moved those
+to cmake and as a result, have a bunch of features our CMake file supports which make development
+easier on the command lines and in CMake aware IDEs.
+
+### Plugin Development 
+
+JUCE supports a mode where a plugin (AU, VST3, etc...) is copied to a local install area after a build.
+This is off by default with CMake JUCE but you can turn it on with `-DSURGE_COPY_AFTER_BUILD=True` at
+`cmake` time. If you do this on unixes, building the VST3 or AU targets will copy them to the appropriate local area
+(`~/.vst3` on linux, '~/Library/Audio/Plugins` on mac). On windows it will attempt to install the VST3
+so setting this option may require admin privileges in your build environment.
+
+### Installing assets (unixes only)
+
+The targets `install-resources-local` and `install-resources-global` install the plugin resources
+to the appropriate `surge-xt` or `Surge XT` directories on your system in the unixes. The global option 
+will require elevated priviledges.
+
+### Running the standalone from cmake directly
+
+For @baconpaul, at least, it is useful to have a cmake command that builds stuff and runs the standalone.
+The target `surge-xt-run-standalone` does this. Here's a sample cmake session (using the surge `ignore` 
+directory which we keep in our `.gitignore` file):
+
+```
+cmake -Bignore/lind -DCMAKE_BUILD_TYPE=Debug
+cmake --build ignore/lind/ --config Debug --target install-resources-local
+cmake --build ignore/lind/ --config Debug --target surge-xt-run-standalone --parallel 4
+```
+
+The second line is only needed if you've never installed resources, obviously.
+
 ## Platform Specific Choices
 
 ### Building 32- vs 64-bit on Windows

--- a/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
+++ b/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
@@ -1412,7 +1412,8 @@ struct CControl : public CView
     CGradient *getGradient() const { return mGradient; }
     virtual void setGradient(CGradient *g)
     {
-        g->remember();
+        if (g)
+            g->remember();
         if (mGradient)
             mGradient->forget();
         mGradient = g;
@@ -1422,7 +1423,8 @@ struct CControl : public CView
     CGradient *getGradientHighlighted() const { return mGradientHL; }
     virtual void setGradientHighlighted(CGradient *g)
     {
-        g->remember();
+        if (g)
+            g->remember();
         if (mGradientHL)
             mGradientHL->forget();
         mGradientHL = g;


### PR DESCRIPTION
1. can't remember a null! Handle the case where setGradient(null)
   happened with the fixes from prior commit which crashed about.
   Closes #4495

2. Update the install-local-blah targets to be susrge xt named

3. Update the README with more of the cmake tips and tricks