### PR TITLE
Fix LFO Menu Crash

### DIFF
--- a/src/common/ModulatorPresetManager.cpp
+++ b/src/common/ModulatorPresetManager.cpp
@@ -212,6 +212,9 @@ void loadPresetFrom(const fs::path &location, SurgeStorage *s, int scene, int lf
 static std::vector<Category> scanedPresets;
 static bool haveScanedPresets = false;
 
+/*
+ * Note: Clients rely on this being sorted by category path if you change it
+ */
 std::vector<Category> getPresets(SurgeStorage *s)
 {
     if (haveScanedPresets)

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -5396,30 +5396,6 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeLfoMenu(VSTGUI::CRect &menuRect)
             new COptionMenu(menuRect, 0, 0, 0, 0, VSTGUI::COptionMenu::kNoDrawStyle);
         subMenuMaps[cat.path] = std::make_pair(catSubMenu, false);
     }
-    for (auto const &cat : presetCategories)
-    {
-        if (subMenuMaps.find(cat.path) == subMenuMaps.end())
-        {
-            // should never happen
-            continue;
-        }
-        auto catSubMenu = subMenuMaps[cat.path].first;
-
-        auto parentMenu = lfoSubMenu;
-        if (subMenuMaps.find(cat.parentPath) != subMenuMaps.end())
-        {
-            parentMenu = subMenuMaps[cat.parentPath].first;
-            if (!subMenuMaps[cat.parentPath].second)
-            {
-                subMenuMaps[cat.parentPath].second = true;
-            }
-        }
-
-        auto catname = cat.name;
-
-        parentMenu->addEntry(catSubMenu, catname.c_str());
-        catSubMenu->forget();
-    }
 
     for (auto const &cat : presetCategories)
     {
@@ -5459,6 +5435,37 @@ VSTGUI::COptionMenu *SurgeGUIEditor::makeLfoMenu(VSTGUI::CRect &menuRect)
                 this->synth->refresh_editor = true;
             });
         }
+    }
+
+    /*
+     * With the escape menu hack need to add in child firstr order; this is
+     * sorted by string path so go backwards
+     */
+    for (auto it = presetCategories.rbegin(); it != presetCategories.rend(); it++)
+    {
+        const auto &cat = *it;
+
+        if (subMenuMaps.find(cat.path) == subMenuMaps.end())
+        {
+            // should never happen
+            continue;
+        }
+        auto catSubMenu = subMenuMaps[cat.path].first;
+
+        auto parentMenu = lfoSubMenu;
+        if (subMenuMaps.find(cat.parentPath) != subMenuMaps.end())
+        {
+            parentMenu = subMenuMaps[cat.parentPath].first;
+            if (!subMenuMaps[cat.parentPath].second)
+            {
+                subMenuMaps[cat.parentPath].second = true;
+            }
+        }
+
+        auto catname = cat.name;
+
+        parentMenu->addEntry(catSubMenu, catname.c_str());
+        catSubMenu->forget();
     }
 
     lfoSubMenu->addSeparator();


### PR DESCRIPTION
The add-order semantics in Escape for COptionMenu isn't quite
right so it is a bit tricky. Restructure this loop to work
around that. Am I super proud of this? No. but it fixes it.

Closes #4445