### PR TITLE
Remove final TARGET_JUCE_UI

### DIFF
--- a/src/gui/CursorControlGuard.cpp
+++ b/src/gui/CursorControlGuard.cpp
@@ -65,7 +65,7 @@ CursorControlGuard::~CursorControlGuard()
     if (hideCount == 0)
     {
         resetToShowLocation();
-#if !TARGET_JUCE_UI
+#if RESOLVED_ISSUE_4350
 #if MAC
         CGDisplayShowCursor(kCGDirectMainDisplay);
 #elif WINDOWS
@@ -78,7 +78,7 @@ CursorControlGuard::~CursorControlGuard()
 
 bool CursorControlGuard::resetToShowLocation()
 {
-#if !TARGET_JUCE_UI
+#if RESOLVED_ISSUE_4350
 #if MAC
     if (motionMode == SHOW_AT_LOCATION)
     {
@@ -102,7 +102,7 @@ bool CursorControlGuard::resetToShowLocation()
 
 void CursorControlGuard::doHide()
 {
-#if !TARGET_JUCE_UI
+#if RESOLVED_ISSUE_4350
 #if MAC
     CGDisplayHideCursor(kCGDirectMainDisplay);
 #elif WINDOWS

--- a/src/gui/CursorControlGuard.h
+++ b/src/gui/CursorControlGuard.h
@@ -80,7 +80,7 @@ struct CursorControlAdapter
 {
     CursorControlAdapter(SurgeStorage *s)
     {
-#if !TARGET_JUCE_UI
+#if RESOLVED_ISSUE_4350
         if (s)
             hideCursor = !Surge::UI::showCursor(s);
 #else

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -896,7 +896,7 @@ void SurgeGUIEditor::refresh_mod()
 
 int32_t SurgeGUIEditor::onKeyDown(const VstKeyCode &code, CFrame *frame)
 {
-#if !TARGET_JUCE_UI
+#if RESOLVED_ISSUE_4383
     if (code.virt != 0)
     {
         switch (code.virt)
@@ -7762,7 +7762,7 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::UI::Skin::Control>
 
         hs->setDeactivatedFn([p]() { return p->appears_deactivated(); });
 
-#if !TARGET_JUCE_UI && 0
+#if RESOLVED_ISSUE_2464
         auto ff = currentSkin->propertyValue(skinCtrl, "font-family", "");
         if (ff.size() > 0)
         {


### PR DESCRIPTION
Remove the final TARGET_JUCE_UI from the code. In the
places where it was protecting old non-ported VSTGUI
code replace it with RESOLVED_ISSUE_abcd pointing at the
open issue the ifdef is guarding against.

Closes #4340