### PR TITLE
Samplerate Startup Path adjustment

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -99,6 +99,24 @@ std::string getDLLPath()
 
 SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
 {
+    if (samplerate == 0)
+    {
+        setSamplerate(48000);
+    }
+    else if (samplerate < 12000 || samplerate > 48000 * 32)
+    {
+        std::ostringstream oss;
+        oss << "Warning: SurgeStorage constructed with invalid samplerate :" << samplerate
+            << " - resetting to 48000 until Audio System tells us otherwise" << std::endl;
+        reportError(oss.str(), "SampleRate Corrputed on Startup");
+        setSamplerate(48000);
+    }
+    else
+    {
+        // Just in case, make sure we are completely consistent in all tables etc
+        setSamplerate(samplerate);
+    }
+
     _patch.reset(new SurgePatch(this));
 
     float cutoff = 0.455f;

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -1731,18 +1731,6 @@ void SurgeGUIEditor::close_editor()
 
 bool SurgeGUIEditor::open(void *parent)
 {
-    if (samplerate == 0)
-    {
-        std::cout << "Sample rate was not set when editor opened. Defaulting to 44.1k" << std::endl;
-
-        /*
-        ** The oscillator displays need a sample rate; some test hosts don't call
-        ** setSampleRate so if we are in this state make the bad but reasonable
-        ** default choice
-        */
-        synth->setSamplerate(44100);
-    }
-
     super::open(parent);
 
     int platformType = 0;

--- a/src/surge_effects_bank/SurgeFXProcessor.cpp
+++ b/src/surge_effects_bank/SurgeFXProcessor.cpp
@@ -21,17 +21,6 @@ SurgefxAudioProcessor::SurgefxAudioProcessor()
 {
     effectNum = fxt_delay;
     storage.reset(new SurgeStorage());
-    if (samplerate < 10000 || samplerate > 96000 * 16)
-    {
-        // set the samplerate to *something* in case the initpath in resetFxType and so on
-        // reads the SR (which it can in some cases)
-        storage->setSamplerate(44100); // this will be replaced later but will stop nan on init
-    }
-    else
-    {
-        // Just make sure it is all consistent since this is a global from a separate DLL
-        storage->setSamplerate(samplerate);
-    }
     storage->userPrefOverrides[Surge::Storage::HighPrecisionReadouts] = std::make_pair(0, "");
 
     fxstorage = &(storage->getPatch().fx[0]);


### PR DESCRIPTION
When Storage is constructed, set a samplerate. This
generally doesn't matter since prepareToPlay will set it
to the rigth thing, but this means if juce calls a function
before a process block with samplerate, we can end up with
at least a mostly valid set o finternal tables.

Closes #4132