### PR TITLE
Load Init Saw at construction time, but super early

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -226,6 +226,20 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, std::string suppliedData
     storage.mpePitchBendRange =
         (float)Surge::Storage::getUserDefaultValue(&storage, Surge::Storage::MPEPitchBendRange, 48);
     mpeGlobalPitchBendRange = 0;
+
+    int pid = 0;
+    for (auto p : storage.patch_list)
+    {
+        if (p.name == "Init Saw" && storage.patch_category[p.category].name == "Templates")
+        {
+            patchid_queue = pid;
+            break;
+        }
+        pid++;
+    }
+    if (patchid_queue >= 0)
+        processThreadunsafeOperations(true); // DANGER MODE IS ON
+    patchid_queue = -1;
 }
 
 SurgeSynthesizer::~SurgeSynthesizer()
@@ -3076,9 +3090,9 @@ DWORD WINAPI loadPatchInBackgroundThread(LPVOID lpParam)
     return 0;
 }
 
-void SurgeSynthesizer::processThreadunsafeOperations()
+void SurgeSynthesizer::processThreadunsafeOperations(bool dangerMode)
 {
-    if (!audio_processing_active)
+    if (!audio_processing_active || dangerMode)
     {
         // if the audio processing is inactive, patchloading should occur anyway
         if (patchid_queue >= 0)

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -92,7 +92,14 @@ class alignas(16) SurgeSynthesizer
 
     void resetStateFromTimeData();
     void processControl();
-    void processThreadunsafeOperations();
+    /*
+     * processThreadunsafeOperations reloads a patch if the audio thread isn't running
+     * but if it is running lets the deferred queue handle it. But it has an option
+     * which is *extremely dangerous* to force you to load in the current thread immediately.
+     * If you use this option and dont' know what you are doing it will explode - basically
+     * we only use it in the startup constructor path.
+     */
+    void processThreadunsafeOperations(bool doItEvenIfAudioIsRunningDANGER = false);
     bool loadFx(bool initp, bool force_reload_all);
     bool loadOscalgos();
     bool load_fx_needed;


### PR DESCRIPTION
Load Init Saw from tempaltes at construction time, but
do it super duper early and force it to be loaded, avoiding
the various timing problems other attempts saw. Involves adding
a dangerous flag which defaults off.

Closes #1824