### PR TITLE
Add Install targets to CMake for non-apple Unixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,10 +136,10 @@ endif()
 
 if( SURGE_ALTERNATE_JUCE )
   message( STATUS "Using *Alternate* JUCE from ${SURGE_ALTERNATE_JUCE}" )
-  add_subdirectory( ${SURGE_ALTERNATE_JUCE} ${CMAKE_BINARY_DIR}/alternate-juce )
+  add_subdirectory( ${SURGE_ALTERNATE_JUCE} ${CMAKE_BINARY_DIR}/alternate-juce  EXCLUDE_FROM_ALL)
 else()
   message( STATUS "Using JUCE from submodule libs/JUCE" )
-  add_subdirectory( libs/JUCE )
+  add_subdirectory( libs/JUCE EXCLUDE_FROM_ALL )
 endif()
 
 include(cmake/stage-extra-content.cmake)
@@ -1075,6 +1075,30 @@ if( WIN32 )
   endif()
 endif()
 
+# Add CMake Install rules for LINUX only right now (mac and win use an installer)
+if( UNIX AND NOT APPLE)
+  if( BUILD_SURGE_XT)
+    install(TARGETS surge-xt_Standalone DESTINATION bin)
+    # Alas you would think you could just say 
+    # install(TARGETS surge-xt_VST3 DESTINATION lib/vst3 )
+    # but you can't because surge-xt_VST3 points to the .so inside the VST3 bundle so instead say
+    install( DIRECTORY "${SURGE_XT_OUTPUT_DIR}/VST3/Surge XT.vst3" DESTINATION lib/vst3 )
+    if( JUCE_SUPPORTS_LV2 )
+      install(TARGETS surge-xt_LV2 DESTINATION lib/lv2 )
+    endif()
+  endif()
+  if( BUILD_SURGE_EFFECTS_BANK )
+    install(TARGETS surge-fx_Standalone DESTINATION bin)
+    # and again
+    # install(TARGETS surge-fx_VST3 DESTINATION lib/vst3 )
+    install( DIRECTORY "${SURGE_FX_OUTPUT_DIR}/VST3/Surge XT Effects.vst3" DESTINATION lib/vst3 )
+   
+    if( JUCE_SUPPORTS_LV2 )
+      install(TARGETS surge-fx_LV2 DESTINATION lib/lv2)
+    endif()
+  endif()
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources/data/ DESTINATION share/surge-xt)
+endif()
 
 
 if( ${BUILD_SURGE_PYTHON_BINDINGS} )

--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ This is off by default with CMake JUCE but you can turn it on with `-DSURGE_COPY
 (`~/.vst3` on linux, '~/Library/Audio/Plugins` on mac). On windows it will attempt to install the VST3
 so setting this option may require admin privileges in your build environment.
 
+### CMake Install Targets (Linux and other non-apple unixes only)
+
+On systems which are `UNIX AND NOT APPLE`, the cmake file provides an install target which will install
+all needed assets to the `CMAKE_INSTALL_PREFIX`. This means a complete install can be accomplished by
+
+```
+cmake -Bignore/sxt -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build ignore/sxt --config Release --parallel 8
+sudo cmake --install ignore/sxt
+```
+
+and you should get a working install in `/usr/bin`, `/usr/share` and `/usr/lib`
+
 ### Installing assets (unixes only)
 
 The targets `install-resources-local` and `install-resources-global` install the plugin resources


### PR DESCRIPTION
Add CMAKE Install targets for non-apple unixes. Document
in the README

Closes #4359