### PR TITLE
Implement a dynamic alt for parameters; almost use it in twist.

### DIFF
--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -207,10 +207,17 @@ struct CountedSetUserData : public ParamUserData
     virtual int getCountedSetSize() = 0; // A constant time answer to the count of the set
 };
 
+class Parameter;
+
 struct ParameterExternalFormatter : public ParamUserData
 {
-    virtual void formatValue(float value, char *txt, int txtlen) = 0;
-    virtual bool stringToValue(const char *txt, float &outVal) = 0;
+    virtual bool formatValue(Parameter *p, float value, char *txt, int txtlen) = 0;
+    virtual bool formatAltValue(Parameter *p, float value, char *txt, int txtlen)
+    {
+        txt[0] = 0;
+        return true;
+    }
+    virtual bool stringToValue(Parameter *p, const char *txt, float &outVal) = 0;
 };
 
 struct ParameterDiscreteIndexRemapper : public ParamUserData

--- a/src/common/dsp/effects/airwindows/AirWindowsEffect.h
+++ b/src/common/dsp/effects/airwindows/AirWindowsEffect.h
@@ -79,7 +79,7 @@ class alignas(16) AirWindowsEffect : public Effect
     struct AWFxParamFormatter : public ParameterExternalFormatter
     {
         AWFxParamFormatter(AirWindowsEffect *fx, int i) : fx(fx), idx(i) {}
-        virtual void formatValue(float value, char *txt, int txtlen) override
+        virtual bool formatValue(Parameter *p, float value, char *txt, int txtlen) override
         {
             if (fx && fx->airwin)
             {
@@ -116,9 +116,10 @@ class alignas(16) AirWindowsEffect : public Effect
             {
                 snprintf(txt, TXT_SIZE, "AWA.ERROR %lf", value);
             }
+            return true;
         }
 
-        virtual bool stringToValue(const char *txt, float &outVal) override
+        virtual bool stringToValue(Parameter *p, const char *txt, float &outVal) override
         {
             if (fx && fx->airwin)
             {


### PR DESCRIPTION
Implement a dynamic alt for parameters. Code it up in twist for
chord names, but don't actually turn it on since there's a problem,
but keep this branch around anyway since it is a useful feature.

Addresses #4326