### PR TITLE
Creation of RPM package builder.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1048,6 +1048,17 @@ if( UNIX AND NOT APPLE )
           COMMAND ${CMAKE_COMMAND} -E echo ${CMAKE_SOURCE_DIR}/installer_linux/make_deb.sh "${SURGE_PRODUCT_DIR}" "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/${SURGE_XT_DIST_OUTPUT_DIR}" "${SXTVER}"
           COMMAND ${CMAKE_SOURCE_DIR}/scripts/installer_linux/make_deb.sh "${SURGE_PRODUCT_DIR}" "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/${SURGE_XT_DIST_OUTPUT_DIR}" "${SXTVER}"
           )
+
+add_custom_target(surge-xt-rpm)
+add_dependencies(surge-xt-rpm surge-staged-assets)
+
+  add_custom_command(TARGET surge-xt-rpm
+          POST_BUILD
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/${SURGE_XT_DIST_OUTPUT_DIR}
+          COMMAND ${CMAKE_COMMAND} -E echo ${CMAKE_SOURCE_DIR}/installer_linux/make_rpm.sh "${SURGE_PRODUCT_DIR}" "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/${SURGE_XT_DIST_OUTPUT_DIR}" "${SXTVER}"
+          COMMAND ${CMAKE_SOURCE_DIR}/scripts/installer_linux/make_rpm.sh "${SURGE_PRODUCT_DIR}" "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/${SURGE_XT_DIST_OUTPUT_DIR}" "${SXTVER}"
+          )
 endif()
 
 if( WIN32 )

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ You will also need to install a set of dependencies:
 - libxcb-cursor-dev
 - libxcb-keysyms1-dev
 - libxcb-util-dev
+- libxrander-dev
 
 # Continuous Integration
 

--- a/scripts/installer_linux/make_deb.sh
+++ b/scripts/installer_linux/make_deb.sh
@@ -73,7 +73,7 @@ gzip -9 -n ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc/changelog.Debian
 cp ${SOURCEDIR}/LICENSE ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc/copyright
 cp -r ${SOURCEDIR}/resources/data/* ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/
 
-# Copy the VST3 bundld 
+# Copy the VST3 bundle
 cp -r "${INDIR}/Surge XT.vst3" ${PACKAGE_NAME}/usr/lib/vst3/
 cp -r "${INDIR}/Surge XT Effects.vst3" ${PACKAGE_NAME}/usr/lib/vst3/
 cp -r "${INDIR}/Surge XT" ${PACKAGE_NAME}/usr/bin/
@@ -83,15 +83,21 @@ cp -r "${INDIR}/Surge XT Effects" ${PACKAGE_NAME}/usr/bin/
 # cp -r ../build/surge_products/Surge.lv2 ${PACKAGE_NAME}/usr/lib/lv2/
 
 # set permissions on shared libraries
-find ${PACKAGE_NAME}/usr/lib/vst3/ -type f -iname "*.so" | xargs chmod 0644
-# find ${PACKAGE_NAME}/usr/lib/lv2/ -type f -iname "*.so" | xargs chmod 0644
+find ${PACKAGE_NAME}/usr/lib/vst3/ -type f -iname "*.so" -exec chmod 0644 {} +
+# find ${PACKAGE_NAME}/usr/lib/lv2/ -type f -iname "*.so" -exec chmod 0644 {} +
 
 echo "----- LIBRARY CONTENTS (except resource) -----"
 find ${PACKAGE_NAME}/usr/lib -print
 
-# build package
-
+# build deb package
 dpkg-deb --verbose --build ${PACKAGE_NAME} ${TARGET_DIR}/${PACKAGE_NAME}-linux-x64-${VERSION}.deb
+
+# create a tarball of the {PACKAGE_NAME}/usr contents.
+pushd ${PACKAGE_NAME}/usr
+    tar -czf ${TARGET_DIR}/${PACKAGE_NAME}-linux-x64-${VERSION}.tar.gz *
+popd
+
+
 rm -rf ${PACKAGE_NAME}
 popd
 

--- a/scripts/installer_linux/make_rpm.sh
+++ b/scripts/installer_linux/make_rpm.sh
@@ -22,6 +22,7 @@ if [[ "$#" -ne 4 ]]; then
     echo "    TARGET_DIR  where to put the output"
     echo "    VERSION     build/rpm version"
     echo
+    exit -1
 fi
 
 # Intermediate build artifacts

--- a/scripts/installer_linux/make_rpm.sh
+++ b/scripts/installer_linux/make_rpm.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+#
+# create a Surge XT RPM package.
+# see the RPM Packaging guide at https://rpm-packaging-guide.github.io/
+
+
+# check to ensure rpm build tool exists
+if ! [[ -x "$(command -v rpmbuild)" ]]
+then
+    echo "rpmbuild not found! Please install rpm build tools"
+    exit -1
+fi
+
+# parameter check
+if [[ "$#" -ne 4 ]]; then
+    echo "ERROR: make_rpm.sh requires 4 parameters."
+    echo
+    echo "    make_rpm.sh INDIR SOURCEDIR TARGET_DIR VERSION"
+    echo
+    echo "    INDIR       Location of Intermediate build artifacts"
+    echo "    SOURCEDIR   Location of source code / license file"
+    echo "    TARGET_DIR  where to put the output"
+    echo "    VERSION     build/rpm version"
+    echo
+fi
+
+# Intermediate build artifacts
+INDIR=$1
+# license file location
+SOURCEDIR=$2
+# where to put the output
+TARGET_DIR=$3
+# Build version
+VERSION=$4
+
+echo running make_rpm.sh $INDIR $SOURCEDIR $TARGET_DIR $VERSION
+
+
+# generate/modify version
+if [[ ${VERSION:0:1} =~ [0-9] ]]; then
+    echo "Build Version (${VERSION})"
+elif [[ ${VERSION} = NIGHTLY* ]]; then
+    VERSION="9.${VERSION}"
+    echo "NIGHTLY; VERSION is ${VERSION}"
+else
+    VERSION="0.${VERSION}"
+    echo "VERSION is ${VERSION}"
+fi
+
+# TODO Do we want to parameterize this?
+RPM_RELEASE=1
+ARCH=$(uname -i)
+
+# create and enter temporary build package directory.
+mkdir -p ./installer-tmp
+pushd ./installer-tmp
+
+# Name of Package
+PACKAGE_NAME=surge-xt
+
+# Date in RFC formate for the Changelog
+DATE_RFC=`date --rfc-email`
+# Date in Day-of-Week Month Day Year format for the rpm config header.
+DATE_RPM=`date`
+MSG=`git log -n 1 --pretty="%s (git hash %H)"`
+
+# generate changelog to put in install package
+touch changelog.txt
+cat <<EOT > changelog.txt
+${PACKAGE_NAME} (${VERSION}) stable; urgency=medium
+
+   * ${MSG}
+   * For more details see https://github.com/surge-synthesizer/surge
+
+  -- Surge Synthesizer Team <noreply@github.com>  ${DATE_RFC}
+EOT
+
+
+# build rpm spec file
+RPM_SPEC_FILE=${PACKAGE_NAME}.spec
+
+touch ${RPM_SPEC_FILE}
+cat << EOT > ${RPM_SPEC_FILE}
+Name:       ${PACKAGE_NAME}
+Version:    $VERSION
+Release:    ${RPM_RELEASE}
+BuildArch:  ${ARCH}
+Summary:    Subtractive hybrid synthesizer virtual instrument
+License:    GPLv3+
+URL: https://surge-synthesizer.github.io/
+Source: https://github.com/surge-synthesizer/surge
+Provides: vst-plugin
+Group: sound
+
+
+%description
+Subtractive hybrid synthesizer virtual instrument.
+Surge XT includes VST3 instrument formats for use in compatible hosts and a standalone executable
+
+
+%install
+install -m 0755 -d %{buildroot}%{_bindir}/
+install -m 0755 -d %{buildroot}%{_datadir}/
+install -m 0755 -d %{buildroot}%{_defaultdocdir}/
+install -m 0755 -d %{buildroot}%{_libdir}/vst3/
+install -m 0755 -d %{buildroot}%{_datarootdir}
+install -m 0755 -d %{buildroot}%{_datarootdir}/surge-xt/
+install -m 0755 -d %{buildroot}%{_datarootdir}/surge-xt/doc
+install -m 0644 ${SOURCEDIR}/LICENSE %{buildroot}%{_datarootdir}/surge-xt/doc/copyright
+install -m 0644 $(pwd)/changelog.txt %{buildroot}%{_datarootdir}/surge-xt/doc/changelog.txt
+
+cp -r ${SOURCEDIR}/resources/data/* %{buildroot}%{_datarootdir}/surge-xt/
+cp -r "${INDIR}/Surge XT.vst3" %{buildroot}%{_libdir}/vst3/
+cp -r "${INDIR}/Surge XT Effects.vst3" %{buildroot}%{_libdir}/vst3/
+
+# install executable files as executable
+install -m 0755 "${INDIR}/Surge XT" %{buildroot}/%{_bindir}
+install -m 0755 "${INDIR}/Surge XT Effects" %{buildroot}/%{_bindir}
+
+# set permissions on shared libraries
+find %{buildroot}%{_libdir}/vst3/ -type f -iname "*.so" -exec chmod 0644 {} +
+
+
+%files
+%{_bindir}
+%{_libdir}/vst3/
+%{_datarootdir}/surge-xt/
+
+
+%changelog
+* ${DATE_RPM} Surge Synthesizer Team <noreply@github.com>  - ${VERSION}
+- Initial SurgeXT package
+- ${MSG} ${DATE_RFC}
+- For more details see https://github.com/surge-synthesizer/surge
+
+EOT
+
+# create the folders to build the rpm
+RPM_BUILD_DIR=$(pwd)/rpmbuild
+mkdir -p $RPM_BUILD_DIR/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+
+# build rpm package
+rpmbuild -bb --define "_topdir $RPM_BUILD_DIR" ${RPM_SPEC_FILE}
+
+# TODO add key signing, or sign as a post build step
+
+# move rpm to target directory
+mv $RPM_BUILD_DIR/RPMS/$ARCH/$PACKAGE_NAME-$VERSION-$RPM_RELEASE.$ARCH.rpm ${TARGET_DIR}/
+
+if [[ $? -ne 0 ]]
+then
+    echo ERROR moving rpm file, RPMBUILD Failed!
+    popd
+    exit -1
+fi
+
+popd


### PR DESCRIPTION
Added a script (make_rpm.sh) to support the ability to build an RPM on rpmbuild enabled systems.
Added a custom build rule (surge-xt-rpm) to CMakeLists to invoke the make_rpm script.
Added a build step to make_deb.sh to create a tarball of the same folder hierarchy used to build the deb package.
Modified call to find shared libraries to use -exec instead of piping to xargs as xargs was barfing on spaces. Alternatively, we could have passed -0 to xargs.
Added some additional build instructions to Readme.