### PR TITLE
Fix Nightly build version incompatibility

### DIFF
--- a/scripts/installer_linux/make_rpm.sh
+++ b/scripts/installer_linux/make_rpm.sh
@@ -41,7 +41,8 @@ echo running make_rpm.sh $INDIR $SOURCEDIR $TARGET_DIR $VERSION
 if [[ ${VERSION:0:1} =~ [0-9] ]]; then
     echo "Build Version (${VERSION})"
 elif [[ ${VERSION} = NIGHTLY* ]]; then
-    VERSION="9.${VERSION}"
+    # rpmbuild does not allow dashes in the rpm version.
+    VERSION="9.${VERSION//-/$'.'}"
     echo "NIGHTLY; VERSION is ${VERSION}"
 else
     VERSION="0.${VERSION}"


### PR DESCRIPTION
rpmbuild barfed when using dashes in the the nightly build version.
This change replaces the dashes with dot's so rpmbuild will proceed.

Addresses 4524