### PR TITLE
Add smoothing to Window oscillator's Morph slider

### DIFF
--- a/src/common/dsp/oscillators/WindowOscillator.h
+++ b/src/common/dsp/oscillators/WindowOscillator.h
@@ -67,9 +67,11 @@ class WindowOscillator : public Oscillator
 
     BiquadFilter lp, hp;
     void applyFilter();
+    template <bool is_init> void update_lagvals();
 
     void ProcessWindowOscs(bool stereo, bool FM);
     lag<double> FMdepth[MAX_UNISON];
+    lag<float> l_morph;
 
     float OutAttenuation;
     float DetuneBias, DetuneOffset;


### PR DESCRIPTION
Also restore the ifs removed in #4536 but add a condition so that they only happen in non-continuous morph mode.
Closes #4429 for good!