### PR TITLE
A variety of LUA scaffolding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,7 @@ set(SURGE_SHARED_SOURCES
   src/common/dsp/SurgeVoiceState.h
   src/common/CPUFeatures.cpp
   src/common/DebugHelpers.cpp
+  src/common/LuaSupport.cpp
   src/common/ModulatorPresetManager.cpp
   src/common/Parameter.cpp
   src/common/PatchDB.cpp

--- a/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
+++ b/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
@@ -965,7 +965,7 @@ struct CViewBase : public Internal::FakeRefcount
     void setMouseEnabled(bool b) { OKUNIMPL; }
     CPoint localToFrame(CPoint &w)
     {
-        UNIMPL;
+        OKUNIMPL;
         return w;
     }
 

--- a/src/common/LuaSupport.cpp
+++ b/src/common/LuaSupport.cpp
@@ -1,0 +1,74 @@
+/*
+ ** Surge Synthesizer is Free and Open Source Software
+ **
+ ** Surge is made available under the Gnu General Public License, v3.0
+ ** https://www.gnu.org/licenses/gpl-3.0.en.html
+ **
+ ** Copyright 2004-2021 by various individuals as described by the Git transaction log
+ **
+ ** All source at: https://github.com/surge-synthesizer/surge.git
+ **
+ ** Surge was a commercial product from 2004-2018, with Copyright and ownership
+ ** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+ ** open source in September 2018.
+ */
+
+#include "LuaSupport.h"
+#include <iostream>
+
+bool Surge::LuaSupport::setSurgeFunctionEnvironment(lua_State *L)
+{
+    if (!lua_isfunction(L, -1))
+    {
+        return false;
+    }
+
+    // Stack is ...>func
+    lua_createtable(L, 0, 10);
+    // stack is now func > table
+
+    lua_pushstring(L, "math");
+    lua_getglobal(L, "math");
+    // stack is now func > table > "math" > (math) so set math on table
+    lua_settable(L, -3);
+
+    // stack is now func > table again *BUT* now load math in stripped
+    lua_getglobal(L, "math");
+    lua_pushnil(L);
+
+    // func > table > (math) > nil so lua next -2 will iterate over (math)
+    while (lua_next(L, -2))
+    {
+        // stack is now f>t>(m)>k>v
+        lua_pushvalue(L, -2);
+        lua_pushvalue(L, -2);
+        // stack is now f>t>(m)>k>v>k>v and we want k>v in the table
+        lua_settable(L, -6); // that -6 reaches back to 2
+        // stack is now f>t>(m)>k>v and we want the key on top for next so
+        lua_pop(L, 1);
+    }
+    // when lua_next returns false it has nothing on stack so
+    // stack is now f>t>(m). Pop m
+    lua_pop(L, 1);
+
+    // and now we are back to f>t so we can setfenv it
+    lua_setfenv(L, -2);
+
+    // And now the stack is back to just the function wrapped
+    return true;
+}
+
+Surge::LuaSupport::SGLD::~SGLD()
+{
+    if (L)
+    {
+        auto nt = lua_gettop(L);
+        if (nt != top)
+        {
+            std::cout << "Guarded stack leak: [" << label << "] exit=" << nt << " enter=" << top
+                      << std::endl;
+            if (label == "valueAt")
+                std::cout << "Q" << std::endl;
+        }
+    }
+}

--- a/src/common/LuaSupport.h
+++ b/src/common/LuaSupport.h
@@ -1,0 +1,78 @@
+/*
+ ** Surge Synthesizer is Free and Open Source Software
+ **
+ ** Surge is made available under the Gnu General Public License, v3.0
+ ** https://www.gnu.org/licenses/gpl-3.0.en.html
+ **
+ ** Copyright 2004-2021 by various individuals as described by the Git transaction log
+ **
+ ** All source at: https://github.com/surge-synthesizer/surge.git
+ **
+ ** Surge was a commercial product from 2004-2018, with Copyright and ownership
+ ** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+ ** open source in September 2018.
+ */
+
+/*
+ * This header provides a set of LUA support functions which are used
+ * in the various places we deply lua (formula modulator, waveform
+ * generator, int he future mod mappers etc...)
+ */
+
+#ifndef SURGE_XT_LUASUPPORT_H
+#define SURGE_XT_LUASUPPORT_H
+
+#include <string>
+
+#if HAS_LUAJIT
+extern "C"
+{
+#include "lua.h"
+#include "lauxlib.h"
+#include "lualib.h"
+#include "luajit.h"
+
+#include "lj_arch.h"
+}
+
+#endif
+
+namespace Surge
+{
+namespace LuaSupport
+{
+#if HAS_LUAJIT
+
+/*
+ * Call this function with the top of your stack being a
+ * lua_function and the function will get wrapped in the standard
+ * surge environment (math imported, most things stripped, add
+ * our C++ functions, etc...)
+ */
+bool setSurgeFunctionEnvironment(lua_State *s);
+
+/*
+ * A little leak debugger. Make this on your stack and if you exit the
+ * block with a different stack than you start, it complains for you
+ * with both a print
+ */
+struct SGLD
+{
+    SGLD(const std::string &lab, lua_State *L) : label(lab), L(L)
+    {
+        if (L)
+        {
+            top = lua_gettop(L);
+        }
+    }
+    ~SGLD();
+
+    std::string label;
+    lua_State *L;
+    int top;
+};
+#endif
+} // namespace LuaSupport
+} // namespace Surge
+
+#endif // SURGE_XT_LUASUPPORT_H

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -126,6 +126,7 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
         {
             // Initialize the display name here
             scene[sc].osc[osc].wavetable_display_name[0] = '\0';
+            scene[sc].osc[osc].wavetable_formula = "";
 
             a->push_back(scene[sc].osc[osc].type.assign(p_id.next(), id_s++, "type", "Type",
                                                         ct_osctype, Surge::Skin::Osc::osc_type,
@@ -1715,6 +1716,7 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
         for (int osc = 0; osc < n_oscs; osc++)
         {
             scene[sc].osc[osc].wavetable_display_name[0] = '\0';
+            scene[sc].osc[osc].wavetable_formula = "";
         }
     }
 
@@ -1733,6 +1735,12 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 {
                     strxcpy(scene[ssc].osc[sos].wavetable_display_name,
                             lkid->Attribute("wavetable_display_name"), WAVETABLE_DISPLAY_NAME_SIZE);
+                }
+
+                if (lkid->Attribute("wavetable_formula"))
+                {
+                    scene[ssc].osc[sos].wavetable_formula =
+                        base64_decode(lkid->Attribute("wavetable_formula"));
                 }
 
                 auto ec = &(scene[ssc].osc[sos].extraConfig);
@@ -2308,6 +2316,10 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
             if (uses_wavetabledata(scene[sc].osc[os].type.val.i))
             {
                 on.SetAttribute("wavetable_display_name", scene[sc].osc[os].wavetable_display_name);
+                auto wtfo = scene[sc].osc[os].wavetable_formula;
+                auto wtfol = wtfo.length();
+                on.SetAttribute("wavetable_formula",
+                                base64_encode((unsigned const char *)wtfo.c_str(), wtfol));
             }
 
             auto ec = &(scene[sc].osc[os].extraConfig);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -487,6 +487,8 @@ struct OscillatorStorage : public CountedSetUserData // The counted set is the w
     Wavetable wt;
 #define WAVETABLE_DISPLAY_NAME_SIZE 256
     char wavetable_display_name[WAVETABLE_DISPLAY_NAME_SIZE];
+    std::string wavetable_formula = "";
+
     void *queue_xmldata;
     int queue_type;
 

--- a/src/gui/COscillatorDisplay.cpp
+++ b/src/gui/COscillatorDisplay.cpp
@@ -620,6 +620,17 @@ void COscillatorDisplay::populateMenu(COptionMenu *contextMenu, int selectedItem
     }
 
     contextMenu->addSeparator();
+    auto wtformItem = std::make_shared<CCommandMenuItem>(
+        CCommandMenuItem::Desc(Surge::GUI::toOSCaseForMenu("Open Wavetable Scripter...")));
+    auto owts = [this](CCommandMenuItem *item) {
+        auto sge = dynamic_cast<SurgeGUIEditor *>(listener);
+        if (sge)
+            sge->showWavetableScripter();
+    };
+    wtformItem->setActions(owts, nullptr);
+    contextMenu->addEntry(wtformItem);
+
+    contextMenu->addSeparator();
 
     auto refreshItem = std::make_shared<CCommandMenuItem>(
         CCommandMenuItem::Desc(Surge::GUI::toOSCaseForMenu("Refresh Wavetable List")));

--- a/src/gui/LuaEditors.h
+++ b/src/gui/LuaEditors.h
@@ -26,31 +26,61 @@
 
 class SurgeGUIEditor;
 
-class FormulaModulatorEditor : public juce::Component,
-                               public juce::CodeDocument::Listener,
-                               public juce::Button::Listener,
-                               public juce::KeyListener,
-                               public Surge::GUI::SkinConsumingComponent
+/*
+ * This is a base class that provides you an apply button, an editor, a document
+ * a tokenizer, etc... which you need to layout with yoru other components by
+ * having a superclass constructor and implementing resized; and where you have
+ * to handle the apply condition with applyCode()
+ */
+class CodeEditorContainerWithApply : public juce::Component,
+                                     public juce::CodeDocument::Listener,
+                                     public juce::Button::Listener,
+                                     public juce::KeyListener,
+                                     public Surge::GUI::SkinConsumingComponent
 {
   public:
-    FormulaModulatorEditor(SurgeGUIEditor *ed, SurgeStorage *s, FormulaModulatorStorage *fs,
-                           Surge::GUI::Skin::ptr_t sk);
+    CodeEditorContainerWithApply(SurgeGUIEditor *ed, SurgeStorage *s, Surge::GUI::Skin::ptr_t sk);
     std::unique_ptr<juce::CodeDocument> mainDocument;
     std::unique_ptr<juce::CodeEditorComponent> mainEditor;
     std::unique_ptr<juce::Button> applyButton;
-    std::unique_ptr<juce::Label> warningLabel;
-    std::unique_ptr<juce::Label> lesserWarningLabel;
-
     std::unique_ptr<juce::LuaTokeniser> tokenizer;
-
     void buttonClicked(juce::Button *button) override;
     void codeDocumentTextDeleted(int startIndex, int endIndex) override;
     void codeDocumentTextInserted(const juce::String &newText, int insertIndex) override;
     bool keyPressed(const juce::KeyPress &key, Component *originatingComponent) override;
-    void resized() override;
+
     SurgeGUIEditor *editor;
+    SurgeStorage *storage;
+
+    virtual void applyCode() = 0;
+};
+
+class FormulaModulatorEditor : public CodeEditorContainerWithApply
+{
+  public:
+    FormulaModulatorEditor(SurgeGUIEditor *ed, SurgeStorage *s, FormulaModulatorStorage *fs,
+                           Surge::GUI::Skin::ptr_t sk);
+    std::unique_ptr<juce::Label> warningLabel;
+    std::unique_ptr<juce::Label> lesserWarningLabel;
+
+    void resized() override;
+    void applyCode() override;
+
     FormulaModulatorStorage *formulastorage;
-    void applyToStorage();
+};
+
+class WavetableEquationEditor : public CodeEditorContainerWithApply
+{
+  public:
+    WavetableEquationEditor(SurgeGUIEditor *ed, SurgeStorage *s, OscillatorStorage *os,
+                            Surge::GUI::Skin::ptr_t sk);
+
+    std::unique_ptr<juce::Label> warningLabel;
+
+    void resized() override;
+    void applyCode() override;
+
+    OscillatorStorage *osc;
 };
 
 #endif // SURGE_XT_LUAEDITORS_H

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -8358,6 +8358,31 @@ void SurgeGUIEditor::closeFormulaEditorDialog()
     }
 }
 
+void SurgeGUIEditor::showWavetableScripter()
+{
+    int w = 750, h = 400;
+    auto *c = new CViewContainer(CRect(CPoint(0, 0), CPoint(w, h)));
+    auto os = &synth->storage.getPatch().scene[current_scene].osc[current_osc[current_scene]];
+
+    auto pt =
+        std::make_unique<WavetableEquationEditor>(this, &(this->synth->storage), os, currentSkin);
+    pt->setBounds(0, 0, w, h);
+    pt->setSkin(currentSkin, bitmapStore);
+    c->juceComponent()->addAndMakeVisible(*pt);
+    c->takeOwnership(std::move(pt));
+
+    addEditorOverlay(c, "Wavetable Scripter", FORMULA_EDITOR, CPoint(40, 40), false, true,
+                     [this]() {});
+}
+
+void SurgeGUIEditor::closeWavetableScripter()
+{
+    if (isAnyOverlayPresent(WAVETABLESCRIPTING_EDITOR))
+    {
+        dismissEditorOfType(WAVETABLESCRIPTING_EDITOR);
+    }
+}
+
 void SurgeGUIEditor::toggleFormulaEditorDialog()
 {
     if (isAnyOverlayPresent(FORMULA_EDITOR))

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -294,7 +294,8 @@ class SurgeGUIEditor : public EditorType,
         STORE_PATCH,
         PATCH_BROWSER,
         MODULATION_EDITOR,
-        FORMULA_EDITOR
+        FORMULA_EDITOR,
+        WAVETABLESCRIPTING_EDITOR,
     };
 
     void addEditorOverlay(
@@ -340,6 +341,9 @@ class SurgeGUIEditor : public EditorType,
     void closeFormulaEditorDialog();
     void showFormulaEditorDialog();
     void toggleFormulaEditorDialog();
+
+    void closeWavetableScripter();
+    void showWavetableScripter();
 
     void lfoShapeChanged(int prior, int curr);
     void showMSEGEditor();


### PR DESCRIPTION
This is mostly a checkpoint commit as I continue to move the
LUA implementation around.

1. Introduced a LuaSupport for common functions; move the env
   setup and stack leak detector there. Addresses #2048.
2. Add a common base class for the LuaEditors with functionality
3. Test that by adding a wavetable formula scripter which does nothing
   now other than show an editor and set a string value. Obviously
   more to come there. Starts to address #4539
4. Move localToFrame to OKUNIMPL to squash a message