### PR TITLE
Allow native JUCE wheel support if you want

### DIFF
--- a/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
+++ b/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
@@ -946,6 +946,10 @@ struct CViewBase : public Internal::FakeRefcount
         return kMouseEventNotHandled;
     }
 
+    virtual bool supportsJuceNativeWheel() { return false; }
+
+    virtual void mouseWheelMove(const juce::MouseEvent &e, const juce::MouseWheelDetails &wheel) {}
+
     virtual bool onWheel(const CPoint &where, const float &distance, const CButtonState &buttons)
     {
         return false;
@@ -1344,11 +1348,7 @@ struct CControl : public CView
     virtual void looseFocus() { UNIMPL; }
     virtual void takeFocus() { UNIMPL; }
     CButtonState getMouseButtons() { return CButtonState(); }
-    virtual float getRange()
-    {
-        UNIMPL;
-        return 0;
-    }
+    virtual float getRange() { return getMax() - getMin(); }
     virtual float getValue() { return value; }
     virtual void setValue(float v) { value = v; }
     virtual void setDefaultValue(float v) { vdef = v; }
@@ -1367,9 +1367,17 @@ struct CControl : public CView
     uint32_t tag;
     virtual uint32_t getTag() { return tag; }
     virtual void setMax(float f) { vmax = f; }
+    virtual float getMax() { return vmax; }
     void valueChanged() { UNIMPL; }
     virtual void setMin(float f) { vmin = f; }
-    virtual void bounceValue() { UNIMPL; }
+    virtual float getMin() { return vmin; }
+    virtual void bounceValue()
+    {
+        if (value < getMin())
+            value = getMin();
+        if (value > getMax())
+            value = getMax();
+    }
 
     virtual void beginEdit()
     {
@@ -1752,6 +1760,10 @@ template <typename T>
 inline void juceCViewConnector<T>::mouseWheelMove(const juce::MouseEvent &e,
                                                   const juce::MouseWheelDetails &wheel)
 {
+    if (viewCompanion->supportsJuceNativeWheel())
+    {
+        viewCompanion->mouseWheelMove(e, wheel);
+    }
     auto b = T::getBounds().getTopLeft();
     CPoint w(e.x + b.x, e.y + b.y);
 

--- a/src/gui/CHSwitch2.cpp
+++ b/src/gui/CHSwitch2.cpp
@@ -231,24 +231,37 @@ void CHSwitch2::calculateHoverValue(const CPoint &where)
         }
     }
 }
-bool CHSwitch2::onWheel(const CPoint &where, const float &distance, const CButtonState &buttons)
+
+void CHSwitch2::mouseWheelMove(const juce::MouseEvent &e, const juce::MouseWheelDetails &wheel)
 {
     if (usesMouseWheel)
     {
+#if 0
+        std::cout << "MouseWheelEvent native juce" << std::endl;
+        std::cout << "   Wheel Details:\n"
+                  << "     - deltaX     : " << wheel.deltaX << "\n"
+                  << "     - deltaY     : " << wheel.deltaY << "\n"
+                  << "     - isSmooth   : " << wheel.isSmooth << "\n"
+                  << "     - isInertial : " << wheel.isInertial << "\n"
+                  << "     - isReversed : " << wheel.isReversed << "\n"
+                  << "   Event Details: pos=" << e.x << "," << e.y << " and theres more"
+                  << std::endl;
+#endif
+
         float newVal = value;
         float rate = 1.0f;
+        float speedup = 3.0f; // just make it a bit more snappy really
         float range = getRange();
+        float distance = wheel.deltaX + (wheel.isReversed ? 1 : -1) * wheel.deltaY;
         if (columns > 1)
         {
-            rate = range / (float)(columns - 1); // Colums-1 = number of scroll steps
+            rate = speedup * range / (float)(columns - 1); // Colums-1 = number of scroll steps
             newVal += rate * distance;
         }
         else
         {
-            rate = range / (float)(rows - 1); // Rows-1 = Number of scroll steps
-            newVal +=
-                rate *
-                -distance; // flip distance (==direction) because it makes more sense when wheeling
+            rate = speedup * range / (float)(rows - 1); // Rows-1 = Number of scroll steps
+            newVal += rate * distance;
         }
         beginEdit();
         value = newVal;
@@ -258,8 +271,10 @@ bool CHSwitch2::onWheel(const CPoint &where, const float &distance, const CButto
             listener->valueChanged(this);
         setValue(value);
         endEdit();
-        return true;
+
+        // Note the JUCE handler needs to add an invalid
+        invalid();
     }
-    return false;
 }
+
 void CHSwitch2::setUsesMouseWheel(bool wheel) { usesMouseWheel = wheel; }

--- a/src/gui/CHSwitch2.h
+++ b/src/gui/CHSwitch2.h
@@ -60,9 +60,11 @@ class CHSwitch2 : public VSTGUI::CHorizontalSwitch, public Surge::GUI::SkinConsu
     virtual VSTGUI::CMouseEventResult onMouseMoved(
         VSTGUI::CPoint &where,
         const VSTGUI::CButtonState &buttons) override; ///< called when a mouse move event occurs
-    virtual bool onWheel(
-        const VSTGUI::CPoint &where, const float &distance,
-        const VSTGUI::CButtonState &buttons) override; ///< called when scrollwheel events occurs
+
+    // Support juce native wheel events
+    virtual bool supportsJuceNativeWheel() override { return true; }
+    virtual void mouseWheelMove(const juce::MouseEvent &e,
+                                const juce::MouseWheelDetails &wheel) override;
 
     virtual VSTGUI::CMouseEventResult onMouseEntered(VSTGUI::CPoint &where,
                                                      const VSTGUI::CButtonState &buttons) override


### PR DESCRIPTION
Rather than wedge through EFVG allow EFVG to call directly
into a juce api on the control class. Either works.
Demonstrate on CHSwitch2

Plus fill in  a couple of EFVG API points which wheels were
using

Addresses #4432