### PR TITLE
Add option to extend filter feedback range

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -282,10 +282,10 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
             p_id.next(), id_s++, "vca_velsense", "Velocity > VCA Gain", ct_decibel_attenuation,
             Surge::Skin::Scene::vel_sensitivity, sc_id, cg_GLOBAL, 0, false));
 
-        a->push_back(scene[sc].feedback.assign(p_id.next(), id_s++, "feedback", "Feedback",
-                                               ct_osc_feedback_negative, Surge::Skin::Filter::feedback,
-                                               sc_id, cg_GLOBAL, 0, true,
-                                               Surge::ParamConfig::kHorizontal | kWhite | sceasy));
+        a->push_back(scene[sc].feedback.assign(
+            p_id.next(), id_s++, "feedback", "Feedback", ct_osc_feedback_negative,
+            Surge::Skin::Filter::feedback, sc_id, cg_GLOBAL, 0, true,
+            Surge::ParamConfig::kHorizontal | kWhite | sceasy));
         a->push_back(scene[sc].filterblock_configuration.assign(
             p_id.next(), id_s++, "fb_config", "Filter Configuration", ct_fbconfig,
             Surge::Skin::Filter::config, sc_id, cg_GLOBAL, 0, false));

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -283,7 +283,7 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
             Surge::Skin::Scene::vel_sensitivity, sc_id, cg_GLOBAL, 0, false));
 
         a->push_back(scene[sc].feedback.assign(p_id.next(), id_s++, "feedback", "Feedback",
-                                               ct_percent_bipolar, Surge::Skin::Filter::feedback,
+                                               ct_osc_feedback_negative, Surge::Skin::Filter::feedback,
                                                sc_id, cg_GLOBAL, 0, true,
                                                Surge::ParamConfig::kHorizontal | kWhite | sceasy));
         a->push_back(scene[sc].filterblock_configuration.assign(

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1012,7 +1012,7 @@ void SurgeVoice::SetQFB(QuadFilterChainState *Q, int e) // Q == 0 means init(ial
     float Drive = db_to_linear(scene->wsunit.drive.get_extended(localcopy[id_drive].f));
     float Gain = db_to_linear(localcopy[id_vca].f + localcopy[id_vcavel].f * (1.f - state.fvel)) *
                  modsources[ms_ampeg]->output;
-    float FB = localcopy[id_feedback].f;
+    float FB = scene->feedback.get_extended(localcopy[id_feedback].f);
 
     if (Q)
     {


### PR DESCRIPTION
Closes #4354


It seems handling streaming is not needed for some reason - I tried loading a patch that's < sv17 even if in current patch I had Extend range enabled on filter feedback, but the patch loaded with Extend disabled. So I guess we're good?