### PR TITLE
Handle LUA errors more gracefully

### DIFF
--- a/src/common/LuaSupport.cpp
+++ b/src/common/LuaSupport.cpp
@@ -154,8 +154,6 @@ Surge::LuaSupport::SGLD::~SGLD()
         {
             std::cout << "Guarded stack leak: [" << label << "] exit=" << nt << " enter=" << top
                       << std::endl;
-            if (label == "valueAt")
-                std::cout << "Q" << std::endl;
         }
     }
 }

--- a/src/common/dsp/modulators/LFOModulationSource.cpp
+++ b/src/common/dsp/modulators/LFOModulationSource.cpp
@@ -874,7 +874,7 @@ void LFOModulationSource::process_block()
             auto em = formulastate.error;
             formulastate.error = "";
             formulastate.raisedError = false;
-            // storage->reportError(em, "Formula Evaluator Error" );
+            storage->reportError(em, "Formula Evaluator Error");
             std::cout << "ERROR: " << em << std::endl;
         }
         break;


### PR DESCRIPTION
If a LUA error occurs

1. Replace the cached function with a sentinle that returns 0 and
2. Show the error to the user

Addresses #2048