### PR TITLE
Commits to allow us to move to all-juce more quickly

### DIFF
--- a/src/gui/CAboutBox.cpp
+++ b/src/gui/CAboutBox.cpp
@@ -348,7 +348,7 @@ CMouseEventResult CAboutBox::onMouseUp(CPoint &where, const CButtonState &button
     return res;
 }
 
-void CAboutBox::valueChanged(CControl *pControl)
+void CAboutBox::valueChanged(CControlValueInterface *pControl)
 {
     if (pControl->getTag() == tag_copy)
     {

--- a/src/gui/CAboutBox.h
+++ b/src/gui/CAboutBox.h
@@ -29,7 +29,7 @@ class CAboutBox : public VSTGUI::CViewContainer, public VSTGUI::IControlListener
                                         const VSTGUI::CButtonState &buttons) override;
     VSTGUI::CMouseEventResult onMouseDown(VSTGUI::CPoint &where,
                                           const VSTGUI::CButtonState &buttons) override;
-    void valueChanged(VSTGUI::CControl *pControl) override;
+    void valueChanged(VSTGUI::CControlValueInterface *pControl) override;
 
     SurgeGUIEditor *editor;
     SurgeStorage *storage;

--- a/src/gui/MSEGEditor.cpp
+++ b/src/gui/MSEGEditor.cpp
@@ -67,8 +67,9 @@ struct MSEGControlRegion : public CViewContainer,
     };
 
     void rebuild();
-    virtual void valueChanged(CControl *p) override;
-    virtual int32_t controlModifierClicked(CControl *pControl, CButtonState button) override;
+    virtual void valueChanged(CControlValueInterface *p) override;
+    virtual int32_t controlModifierClicked(CControlValueInterface *pControl,
+                                           CButtonState button) override;
 
     virtual void draw(CDrawContext *dc) override
     {
@@ -2518,7 +2519,7 @@ struct MSEGCanvas : public CControl,
     CLASS_METHODS(MSEGCanvas, CControl);
 };
 
-void MSEGControlRegion::valueChanged(CControl *p)
+void MSEGControlRegion::valueChanged(CControlValueInterface *p)
 {
     auto tag = p->getTag();
     auto val = p->getValue();
@@ -2598,7 +2599,8 @@ void MSEGControlRegion::valueChanged(CControl *p)
     }
 }
 
-int32_t MSEGControlRegion::controlModifierClicked(CControl *pControl, CButtonState button)
+int32_t MSEGControlRegion::controlModifierClicked(CControlValueInterface *pControl,
+                                                  CButtonState button)
 {
     int tag = pControl->getTag();
 
@@ -2696,7 +2698,9 @@ int32_t MSEGControlRegion::controlModifierClicked(CControl *pControl, CButtonSta
                                 [pControl, val, this]() {
                                     pControl->setValue(val);
                                     pControl->valueChanged();
-                                    pControl->invalid();
+                                    auto iv = dynamic_cast<VSTGUI::BaseViewFunctions *>(pControl);
+                                    if (iv)
+                                        iv->invalid();
                                     canvas->invalid();
                                     invalid();
                                 });
@@ -2706,12 +2710,14 @@ int32_t MSEGControlRegion::controlModifierClicked(CControl *pControl, CButtonSta
             for (auto op : options)
             {
                 auto val = op.second;
-                contextMenu.addItem(op.first, true, (val == pControl->getValue()),
-                                    [val, pControl]() {
-                                        pControl->setValue(val);
-                                        pControl->invalid();
-                                        pControl->valueChanged();
-                                    });
+                contextMenu.addItem(
+                    op.first, true, (val == pControl->getValue()), [val, pControl]() {
+                        pControl->setValue(val);
+                        auto iv = dynamic_cast<VSTGUI::BaseViewFunctions *>(pControl);
+                        if (iv)
+                            iv->invalid();
+                        pControl->valueChanged();
+                    });
             }
         }
         contextMenu.showMenuAsync(juce::PopupMenu::Options());

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -102,11 +102,11 @@ class SurgeGUIEditor : public EditorType,
     virtual void setParameter(long index, float value);
 
     // listener class
-    void valueChanged(VSTGUI::CControl *control) override;
-    int32_t controlModifierClicked(VSTGUI::CControl *pControl,
+    void valueChanged(VSTGUI::CControlValueInterface *control) override;
+    int32_t controlModifierClicked(VSTGUI::CControlValueInterface *pControl,
                                    VSTGUI::CButtonState button) override;
-    void controlBeginEdit(VSTGUI::CControl *pControl) override;
-    void controlEndEdit(VSTGUI::CControl *pControl) override;
+    void controlBeginEdit(VSTGUI::CControlValueInterface *pControl) override;
+    void controlEndEdit(VSTGUI::CControlValueInterface *pControl) override;
 
   public:
     void refresh_mod();
@@ -135,7 +135,8 @@ class SurgeGUIEditor : public EditorType,
     int fxbypass_tag = 0, f1subtypetag = 0, f2subtypetag = 0, filterblock_tag = 0, fmconfig_tag = 0;
     double lastTempo = 0;
     int lastTSNum = 0, lastTSDen = 0;
-    void draw_infowindow(int ptag, VSTGUI::CControl *control, bool modulate, bool forceMB = false);
+    void draw_infowindow(int ptag, VSTGUI::BaseViewFunctions *control, bool modulate,
+                         bool forceMB = false);
     void adjustSize(float &width, float &height) const;
 
     struct patchdata
@@ -533,7 +534,8 @@ class SurgeGUIEditor : public EditorType,
     static std::string fullyResolvedHelpURL(std::string helpurl);
 
   private:
-    void promptForUserValueEntry(Parameter *p, VSTGUI::CControl *c, int modulationSource = -1);
+    void promptForUserValueEntry(Parameter *p, VSTGUI::BaseViewFunctions *c,
+                                 int modulationSource = -1);
 
     /*
     ** Skin support


### PR DESCRIPTION
This commit changes no functionality (I hope!) but adds smaller
interfaces for items to implement to participate in value and so on
in SGE. This will allow us to start writing 100% JUCE widgets which
interact fully with the value and position API in SGE. But that's not
in this commit; this commit is just changing names and functionalities
to leave this unblocked while I then go and rewrite switch or some such
with the new pattern.