### PR TITLE
Fix uninitialized memory for skin resourceID

### DIFF
--- a/src/gui/CScalableBitmap.h
+++ b/src/gui/CScalableBitmap.h
@@ -54,7 +54,7 @@ class CScalableBitmap : public VSTGUI::CBitmap
     */
     void setExtraScaleFactor(int a) { extraScaleFactor = a; }
 
-    int resourceID;
+    int resourceID = -1;
     std::string fname;
 
   private:

--- a/src/gui/widgets/MultiSwitch.cpp
+++ b/src/gui/widgets/MultiSwitch.cpp
@@ -97,7 +97,7 @@ void MultiSwitch::mouseDrag(const juce::MouseEvent &event)
     {
         int sel = coordinateToSelection(event.x, event.y);
         hoverSelection = sel;
-        setValue((float)sel / (rows * columns - 1));
+        setValue(limit_range((float)sel / (rows * columns - 1), 0.f, 1.f));
         notifyValueChanged();
     }
 }


### PR DESCRIPTION
Closes #4594
Closes #4423

Also limit the rangge of mouse drag on multiswitch so that it doesn't start showing nothing.