### PR TITLE
Rename and Type the _effect meneber in SGE

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -39,6 +39,8 @@
 #include "ModulationEditor.h"
 #include "LuaEditors.h"
 
+#include "SurgeSynthEditor.h"
+
 #include "widgets/AboutScreen.h"
 #include "widgets/EffectLabel.h"
 #include "widgets/MultiSwitch.h"
@@ -115,8 +117,7 @@ bool SurgeGUIEditor::fromSynthGUITag(SurgeSynthesizer *synth, int tag, SurgeSynt
     return synth->fromSynthSideIdWithGuiOffset(tag, start_paramtags, tag_mod_source0 + ms_ctrl1, q);
 }
 
-SurgeGUIEditor::SurgeGUIEditor(PARENT_PLUGIN_TYPE *effect, SurgeSynthesizer *synth, void *userdata)
-    : super(effect)
+SurgeGUIEditor::SurgeGUIEditor(SurgeSynthEditor *jEd, SurgeSynthesizer *synth) : super(jEd)
 {
     synth->storage.addErrorListener(this);
     synth->storage.okCancelProvider = [this](const std::string &msg, const std::string &title,
@@ -173,8 +174,7 @@ SurgeGUIEditor::SurgeGUIEditor(PARENT_PLUGIN_TYPE *effect, SurgeSynthesizer *syn
         fxPresetName[i] = "";
     }
 
-    _synth = effect;
-    _userdata = userdata;
+    juceEditor = jEd;
     this->synth = synth;
 
     minimumZoom = 50;
@@ -4912,7 +4912,7 @@ void SurgeGUIEditor::controlBeginEdit(VSTGUI::CControlValueInterface *control)
     int ptag = tag - start_paramtags;
     if (ptag >= 0 && ptag < synth->storage.getPatch().param_ptr.size())
     {
-        _synth->beginParameterEdit(synth->storage.getPatch().param_ptr[ptag]);
+        juceEditor->beginParameterEdit(synth->storage.getPatch().param_ptr[ptag]);
     }
 }
 
@@ -4924,7 +4924,7 @@ void SurgeGUIEditor::controlEndEdit(VSTGUI::CControlValueInterface *control)
     int ptag = tag - start_paramtags;
     if (ptag >= 0 && ptag < synth->storage.getPatch().param_ptr.size())
     {
-        _synth->endParameterEdit(synth->storage.getPatch().param_ptr[ptag]);
+        juceEditor->endParameterEdit(synth->storage.getPatch().param_ptr[ptag]);
     }
 
     if (((CParameterTooltip *)infowindow)->isVisible())
@@ -6490,7 +6490,7 @@ void SurgeGUIEditor::reloadFromSkin()
 
     // adjust JUCE look and feel colors
     auto setJUCEColour = [this](int id, juce::Colour x) {
-        _synth->getLookAndFeel().setColour(id, x);
+        juceEditor->getLookAndFeel().setColour(id, x);
     };
 
     setJUCEColour(juce::DocumentWindow::backgroundColourId, juce::Colour(48, 48, 48));

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -33,9 +33,8 @@
 #include <thread>
 #include <atomic>
 
-#include "SurgeSynthEditor.h"
 typedef EscapeFromVSTGUI::JuceVSTGUIEditorAdapter EditorType;
-#define PARENT_PLUGIN_TYPE SurgeSynthEditor
+class SurgeSynthEditor;
 
 class CSurgeSlider;
 class CModulationSourceButton;
@@ -65,7 +64,7 @@ class SurgeGUIEditor : public EditorType,
     using super = EditorType;
 
   public:
-    SurgeGUIEditor(PARENT_PLUGIN_TYPE *effect, SurgeSynthesizer *synth, void *userdata = nullptr);
+    SurgeGUIEditor(SurgeSynthEditor *juceEditor, SurgeSynthesizer *synth);
     virtual ~SurgeGUIEditor();
 
     std::atomic<int> errorItemCount{0};
@@ -545,8 +544,7 @@ class SurgeGUIEditor : public EditorType,
   private:
     float blinktimer = 0;
     bool blinkstate = false;
-    PARENT_PLUGIN_TYPE *_synth = nullptr;
-    void *_userdata = nullptr;
+    SurgeSynthEditor *juceEditor{nullptr};
     int firstIdleCountdown = 0;
 
     /*


### PR DESCRIPTION
The _effect member was a #define to SurgeSynthEditor but
we are never changing it so

1. Make it an explicit type
2. Rename it as juceEditor for clarity
3. Remove the unused _userdata