### PR TITLE
struct CColor becomes typedef juce::Colour

### DIFF
--- a/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
+++ b/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
@@ -241,7 +241,7 @@ typedef const char *UTF8String; // I know I know
 
 struct CFrame;
 struct CBitmap;
-struct CColor;
+typedef juce::Colour CColor;
 struct COptionMenu;
 
 typedef float CCoord;
@@ -378,25 +378,6 @@ struct CRect
     }
 };
 
-struct CColor
-{
-    constexpr CColor() : red(0), green(0), blue(0), alpha(255) {}
-    constexpr CColor(uint8_t r, uint8_t g, uint8_t b) : red(r), green(g), blue(b), alpha(255) {}
-    constexpr CColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-        : red(r), green(g), blue(b), alpha(a)
-    {
-    }
-
-    bool operator==(const CColor &that)
-    {
-        return red == that.red && green == that.green && blue == that.blue && alpha == that.alpha;
-    }
-    juce::Colour asJuceColour() const { return juce::Colour(red, green, blue, alpha); }
-
-    operator juce::Colour() const { return asJuceColour(); }
-    uint8_t red, green, blue, alpha;
-};
-
 struct CGradient : public Internal::FakeRefcount
 {
     std::unique_ptr<juce::ColourGradient> grad;
@@ -410,14 +391,8 @@ struct CGradient : public Internal::FakeRefcount
         res->remember();
         return res;
     };
-    void addColorStop(float pos, const CColor &c) { grad->addColour(pos, c.asJuceColour()); }
+    void addColorStop(float pos, const CColor &c) { grad->addColour(pos, c); }
 };
-
-constexpr const CColor kBlueCColor = CColor(0, 0, 255);
-constexpr const CColor kWhiteCColor = CColor(255, 255, 255);
-constexpr const CColor kRedCColor = CColor(255, 0, 0);
-constexpr const CColor kBlackCColor = CColor(0, 0, 0);
-constexpr const CColor kTransparentCColor = CColor(0, 0, 0, 0);
 
 enum CDrawModeFlags : uint32_t
 {
@@ -668,16 +643,16 @@ struct CDrawContext
 
     juce::Colour fillColor = juce::Colour(255, 0, 0), frameColor = juce::Colour(255, 0, 0),
                  fontColor = juce::Colour(255, 0, 0);
-    void setFontColor(const CColor &c) { fontColor = c.asJuceColour(); }
+    void setFontColor(const CColor &c) { fontColor = c; }
     CColor getFontColor()
     {
         UNIMPL;
         return CColor();
     }
 
-    void setFillColor(const CColor &c) { fillColor = c.asJuceColour(); }
+    void setFillColor(const CColor &c) { fillColor = c; }
 
-    void setFrameColor(const CColor &c) { frameColor = c.asJuceColour(); }
+    void setFrameColor(const CColor &c) { frameColor = c; }
 
     void drawRect(const CRect &r, CDrawStyle s = kDrawStroked)
     {
@@ -1530,7 +1505,7 @@ struct CTextLabel : public CControl
     {
         CControl::setBackColor(v);
         if (lab)
-            lab->setColour(juce::Label::backgroundColourId, v.asJuceColour());
+            lab->setColour(juce::Label::backgroundColourId, v);
     }
 
     void setHoriAlign(CHoriTxtAlign v) override
@@ -1576,7 +1551,7 @@ struct CTextLabel : public CControl
         CControl::setFontColor(v);
         if (lab)
         {
-            lab->setColour(juce::Label::ColourIds::textColourId, v.asJuceColour());
+            lab->setColour(juce::Label::ColourIds::textColourId, v);
         }
     }
 

--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -24,7 +24,7 @@ struct Color
     static std::vector<Color> getAllColors();
 
     std::string name;
-    int r, g, b, a;
+    uint8_t r, g, b, a;
 };
 } // namespace Skin
 } // namespace Surge

--- a/src/gui/CLFOGui.cpp
+++ b/src/gui/CLFOGui.cpp
@@ -529,7 +529,7 @@ void CLFOGui::draw(CDrawContext *dc)
                     tf.transform(ep);
                     dc->setLineWidth(0.5);
                     if (l % tsNum == 0)
-                        dc->setFrameColor(VSTGUI::kBlackCColor);
+                        dc->setFrameColor(juce::Colours::black);
                     else
                         // small ticks for the ruler
                         dc->setFrameColor(skin->getColor(Colors::LFO::Waveform::Ruler::SmallTicks));
@@ -591,7 +591,7 @@ void CLFOGui::draw(CDrawContext *dc)
             CPoint sp(xp, valScale * 0.9), ep(xp, valScale * 0.1);
             tf.transform(sp);
             tf.transform(ep);
-            dc->setFrameColor(kRedCColor);
+            dc->setFrameColor(juce::Colours::red);
             dc->drawLine(sp, ep);
         }
         dc->restoreGlobalState();
@@ -601,7 +601,7 @@ void CLFOGui::draw(CDrawContext *dc)
         edpath->forget();
     }
 
-    CColor cshadow = {0x5d, 0x5d, 0x5d, 0xff};
+    CColor cshadow = {0x5d, 0x5d, 0x5d};
     CColor cselected = skin->getColor(Colors::LFO::Type::SelectedBackground);
 
     dc->setFrameColor(cshadow);
@@ -866,9 +866,9 @@ void CLFOGui::drawStepSeq(VSTGUI::CDrawContext *dc, VSTGUI::CRect &maindisp,
             if (lfodata->rate.deactivated &&
                 (int)(lfodata->start_phase.val.f * n_stepseqsteps) % n_stepseqsteps == i)
             {
-                auto scolor = CColor(std::min(255, (int)(valuecolor.red * 1.3)),
-                                     std::min(255, (int)(valuecolor.green * 1.3)),
-                                     std::min(255, (int)(valuecolor.blue * 1.3)));
+                auto scolor = CColor(std::min(255, (int)(valuecolor.getRed() * 1.3)),
+                                     std::min(255, (int)(valuecolor.getGreen() * 1.3)),
+                                     std::min(255, (int)(valuecolor.getBlue() * 1.3)));
                 valuecolor = skin->getColor(Colors::LFO::StepSeq::Step::FillDeactivated);
             }
 

--- a/src/gui/CNumberField.cpp
+++ b/src/gui/CNumberField.cpp
@@ -269,7 +269,7 @@ void CNumberField::draw(CDrawContext *pContext)
     auto hoverColorName = skin->propertyValue(skinControl, Surge::Skin::Component::TEXT_HOVER_COLOR,
                                               Colors::NumberField::TextHover.name);
 
-    auto fontColor = kRedCColor;
+    auto fontColor = juce::Colours::red;
     if (hovered)
         fontColor = skin->getColor(hoverColorName);
     else
@@ -296,7 +296,7 @@ void CNumberField::draw(CDrawContext *pContext)
 
     if (!(bg || hoverBg))
     {
-        pContext->setFrameColor(kRedCColor);
+        pContext->setFrameColor(juce::Colours::red);
         pContext->setFillColor(VSTGUI::CColor(100, 100, 200));
         pContext->drawRect(getViewSize(), kDrawFilledAndStroked);
     }

--- a/src/gui/COscillatorDisplay.cpp
+++ b/src/gui/COscillatorDisplay.cpp
@@ -328,7 +328,7 @@ void COscillatorDisplay::draw(CDrawContext *dc)
         dc->setLineWidth(1.3);
         dc->setDrawMode(VSTGUI::kAntiAliasing);
         if (c == 1)
-            dc->setFrameColor(VSTGUI::CColor(100, 100, 180, 0xFF));
+            dc->setFrameColor(VSTGUI::CColor(100, 100, 180));
         else
             dc->setFrameColor(skin->getColor(Colors::Osc::Display::Wave));
 
@@ -465,7 +465,7 @@ void COscillatorDisplay::draw(CDrawContext *dc)
             }
             dc->drawRect(rnext, kDrawFilledAndStroked);
         }
-        dc->setFrameColor(kBlackCColor);
+        dc->setFrameColor(juce::Colours::black);
 
         dc->saveGlobalState();
 

--- a/src/gui/CSurgeSlider.cpp
+++ b/src/gui/CSurgeSlider.cpp
@@ -233,7 +233,7 @@ void CSurgeSlider::draw(CDrawContext *dc)
             else
                 dc->setFontColor(skin->getColor(Colors::Slider::Label::Dark));
             dc->setFont(labfont);
-            dc->setFrameColor(kRedCColor);
+            dc->setFrameColor(juce::Colours::red);
 
             // final x, y offset set from the skin
             trect.offset(text_hoffset, text_voffset);
@@ -279,8 +279,8 @@ void CSurgeSlider::draw(CDrawContext *dc)
         CColor ColBar = skin->getColor(Colors::Slider::Modulation::Positive);
         CColor ColBarNeg = skin->getColor(Colors::Slider::Modulation::Negative);
 
-        ColBar.alpha = (int)(slider_alpha * 255.f);
-        ColBarNeg.alpha = (int)(slider_alpha * 255.f);
+        ColBar = ColBar.withAlpha((uint8_t)(slider_alpha * 255.f));
+        ColBarNeg = ColBarNeg.withAlpha((uint8_t)(slider_alpha * 255.f));
 
         // We want modval + value to be bound by -1 and 1. So:
         float modup = modval;

--- a/src/gui/LuaEditors.cpp
+++ b/src/gui/LuaEditors.cpp
@@ -27,31 +27,29 @@ struct EditorColors
     {
         auto cs = comp->getColourScheme();
 
-        cs.set("Bracket", skin->getColor(Colors::FormulaEditor::Lua::Bracket).asJuceColour());
-        cs.set("Comment", skin->getColor(Colors::FormulaEditor::Lua::Comment).asJuceColour());
-        cs.set("Error", skin->getColor(Colors::FormulaEditor::Lua::Error).asJuceColour());
-        cs.set("Float", skin->getColor(Colors::FormulaEditor::Lua::Number).asJuceColour());
-        cs.set("Integer", skin->getColor(Colors::FormulaEditor::Lua::Number).asJuceColour());
-        cs.set("Identifier", skin->getColor(Colors::FormulaEditor::Lua::Identifier).asJuceColour());
-        cs.set("Keyword", skin->getColor(Colors::FormulaEditor::Lua::Keyword).asJuceColour());
-        cs.set("Operator",
-               skin->getColor(Colors::FormulaEditor::Lua::Interpunction).asJuceColour());
-        cs.set("Punctuation",
-               skin->getColor(Colors::FormulaEditor::Lua::Interpunction).asJuceColour());
-        cs.set("String", skin->getColor(Colors::FormulaEditor::Lua::String).asJuceColour());
+        cs.set("Bracket", skin->getColor(Colors::FormulaEditor::Lua::Bracket));
+        cs.set("Comment", skin->getColor(Colors::FormulaEditor::Lua::Comment));
+        cs.set("Error", skin->getColor(Colors::FormulaEditor::Lua::Error));
+        cs.set("Float", skin->getColor(Colors::FormulaEditor::Lua::Number));
+        cs.set("Integer", skin->getColor(Colors::FormulaEditor::Lua::Number));
+        cs.set("Identifier", skin->getColor(Colors::FormulaEditor::Lua::Identifier));
+        cs.set("Keyword", skin->getColor(Colors::FormulaEditor::Lua::Keyword));
+        cs.set("Operator", skin->getColor(Colors::FormulaEditor::Lua::Interpunction));
+        cs.set("Punctuation", skin->getColor(Colors::FormulaEditor::Lua::Interpunction));
+        cs.set("String", skin->getColor(Colors::FormulaEditor::Lua::String));
 
         comp->setColourScheme(cs);
 
         comp->setColour(juce::CodeEditorComponent::backgroundColourId,
-                        skin->getColor(Colors::FormulaEditor::Background).asJuceColour());
+                        skin->getColor(Colors::FormulaEditor::Background));
         comp->setColour(juce::CodeEditorComponent::highlightColourId,
-                        skin->getColor(Colors::FormulaEditor::Highlight).asJuceColour());
+                        skin->getColor(Colors::FormulaEditor::Highlight));
         comp->setColour(juce::CodeEditorComponent::defaultTextColourId,
-                        skin->getColor(Colors::FormulaEditor::Text).asJuceColour());
+                        skin->getColor(Colors::FormulaEditor::Text));
         comp->setColour(juce::CodeEditorComponent::lineNumberBackgroundId,
-                        skin->getColor(Colors::FormulaEditor::LineNumBackground).asJuceColour());
+                        skin->getColor(Colors::FormulaEditor::LineNumBackground));
         comp->setColour(juce::CodeEditorComponent::lineNumberTextId,
-                        skin->getColor(Colors::FormulaEditor::LineNumText).asJuceColour());
+                        skin->getColor(Colors::FormulaEditor::LineNumText));
 
         comp->retokenise(0, -1);
     }
@@ -109,6 +107,8 @@ bool CodeEditorContainerWithApply::keyPressed(const juce::KeyPress &key, juce::C
         return Component::keyPressed(key);
     }
 }
+
+void CodeEditorContainerWithApply::paint(juce::Graphics &g) { g.fillAll(juce::Colours::black); }
 
 FormulaModulatorEditor::FormulaModulatorEditor(SurgeGUIEditor *ed, SurgeStorage *s,
                                                FormulaModulatorStorage *fs,

--- a/src/gui/LuaEditors.h
+++ b/src/gui/LuaEditors.h
@@ -49,6 +49,7 @@ class CodeEditorContainerWithApply : public juce::Component,
     void codeDocumentTextInserted(const juce::String &newText, int insertIndex) override;
     bool keyPressed(const juce::KeyPress &key, Component *originatingComponent) override;
 
+    void paint(juce::Graphics &g) override;
     SurgeGUIEditor *editor;
     SurgeStorage *storage;
 

--- a/src/gui/MSEGEditor.cpp
+++ b/src/gui/MSEGEditor.cpp
@@ -3012,7 +3012,7 @@ MSEGEditor::MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *
         Surge::MSEG::createInitVoiceMSEG(ms);
     }
     setSkin(skin, b);
-    setBackgroundColor(kRedCColor);
+    setBackgroundColor(juce::Colours::red);
     addView(new MSEGMainEd(getViewSize(), storage, lfodata, ms, eds, skin, b));
 }
 

--- a/src/gui/SkinSupport.cpp
+++ b/src/gui/SkinSupport.cpp
@@ -624,7 +624,7 @@ bool Skin::reloadSkin(std::shared_ptr<SurgeBitmaps> bitmapStore)
             else
             {
                 c.second.type = ColorStore::COLOR;
-                c.second.color = VSTGUI::kRedCColor;
+                c.second.color = juce::Colours::red;
             }
         }
     }
@@ -968,20 +968,20 @@ VSTGUI::CColor Skin::colorFromHexString(const std::string &val) const
     sscanf(val.c_str() + 1, "%x", &rgb);
 
     auto l = strlen(val.c_str() + 1);
-    int a = 255;
+    uint8_t a = 255;
     if (l > 6)
     {
         a = rgb % 256;
         rgb = rgb >> 8;
     }
 
-    int b = rgb % 256;
+    uint8_t b = rgb % 256;
     rgb = rgb >> 8;
 
-    int g = rgb % 256;
+    uint8_t g = rgb % 256;
     rgb = rgb >> 8;
 
-    int r = rgb % 256;
+    uint8_t r = rgb % 256;
 
     return VSTGUI::CColor(r, g, b, a);
 }
@@ -1026,7 +1026,7 @@ VSTGUI::CColor Skin::getColor(const std::string &iid, const VSTGUI::CColor &def,
         case ColorStore::ALIAS:
             return getColor(c.alias, def, noLoops);
         case ColorStore::UNRESOLVED_ALIAS: // This should never occur
-            return VSTGUI::kRedCColor;
+            return juce::Colours::red;
         }
     }
 

--- a/src/gui/SkinSupport.h
+++ b/src/gui/SkinSupport.h
@@ -393,7 +393,7 @@ class Skin
         } Type;
 
         Type type;
-        ColorStore() : type(COLOR), color(VSTGUI::kBlackCColor) {}
+        ColorStore() : type(COLOR), color(juce::Colours::black) {}
         ColorStore(VSTGUI::CColor c) : type(COLOR), color(c) {}
         ColorStore(std::string a) : type(ALIAS), alias(a) {}
         ColorStore(std::string a, Type t) : type(t), alias(a) {}

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -1377,8 +1377,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             frame->juceComponent()->addAndMakeVisible(*lfoNameLabel);
             lfoNameLabel->setBounds(skinCtrl->getRect().asJuceIntRect());
             lfoNameLabel->setFont(Surge::GUI::getFontManager()->getLatoAtSize(10, kBoldFace));
-            lfoNameLabel->setFontColour(
-                currentSkin->getColor(Colors::LFO::Title::Text).asJuceColour());
+            lfoNameLabel->setFontColour(currentSkin->getColor(Colors::LFO::Title::Text));
             break;
         }
 
@@ -1586,9 +1585,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
             auto coln =
                 currentSkin->propertyValue(l, Surge::Skin::Component::TEXT_COLOR, "#FF0000");
-            auto col = currentSkin->getColor(coln, kRedCColor);
+            auto col = currentSkin->getColor(coln, juce::Colours::red);
 
-            auto dcol = VSTGUI::CColor(255, 255, 255, 0);
+            auto dcol = VSTGUI::CColor(255, 255, 255).withAlpha((uint8_t)0);
             auto bgcoln = currentSkin->propertyValue(l, Surge::Skin::Component::BACKGROUND_COLOR,
                                                      "#FFFFFF00");
             auto bgcol = currentSkin->getColor(bgcoln, dcol);
@@ -1633,8 +1632,8 @@ void SurgeGUIEditor::openOrRecreateEditor()
     auto dl = std::string("D ") + Surge::Build::BuildTime + " " + Surge::Build::GitBranch;
     auto lb = new CTextLabel(CRect(CPoint(310, 39), CPoint(195, 15)), dl.c_str());
     lb->setTransparency(false);
-    lb->setBackColor(kRedCColor);
-    lb->setFontColor(kWhiteCColor);
+    lb->setBackColor(juce::Colours::red);
+    lb->setFontColor(juce::Colours::white);
     lb->setFont(Surge::GUI::getFontManager()->displayFont);
     lb->setHoriAlign(VSTGUI::kCenterText);
     lb->setAntialias(true);
@@ -6720,7 +6719,7 @@ void SurgeGUIEditor::promptForUserValueEntry(Parameter *p, BaseViewFunctions *c,
     {
         if (!p->can_setvalue_from_string())
         {
-            typeinValue->setFontColor(VSTGUI::kRedCColor);
+            typeinValue->setFontColor(juce::Colours::red);
             typeinValue->setText("Not available");
         }
     }

--- a/src/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -496,7 +496,9 @@ std::string SurgeGUIEditor::skinInspectorHtml(SkinInspectorFlags f)
     {
         auto skincol = currentSkin->getColor(c);
         htmls << "<tr><td>" << c.name << "</td>" << htmlBlob(c.r, c.g, c.b, c.a)
-              << htmlBlob(skincol.red, skincol.green, skincol.blue, skincol.alpha) << "</tr>\n";
+              << htmlBlob(skincol.getRed(), skincol.getGreen(), skincol.getBlue(),
+                          skincol.getAlpha())
+              << "</tr>\n";
     }
     htmls << "</table>";
     endSection();


### PR DESCRIPTION
escape CColor class gets retired; and is now just a straight
typedef to juce::Colour