### PR TITLE
Thread bug; Keyboard in Standalone; Escape Cleanup

### DIFF
--- a/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
+++ b/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
@@ -2108,17 +2108,6 @@ struct JuceVSTGUIEditorAdapter : public JuceVSTGUIEditorAdapterBase
     juce::AudioProcessorEditor *parentEd;
 };
 
-struct JuceVSTGUIEditorAdapterConcreteTestOnly : public JuceVSTGUIEditorAdapter
-{
-    JuceVSTGUIEditorAdapterConcreteTestOnly(juce::AudioProcessorEditor *parentEd)
-        : JuceVSTGUIEditorAdapter(parentEd)
-    {
-    }
-    bool open(void *parent) override { return true; }
-    void close() override {}
-    void controlBeginEdit(VSTGUI::CControl *p) override {}
-    void controlEndEdit(VSTGUI::CControl *p) override {}
-};
 } // namespace EscapeFromVSTGUI
 
 #endif // SURGE_ESCAPE_FROM_VSTGUI_H

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -5128,7 +5128,15 @@ void SurgeGUIEditor::setZoomFactor(float zf, bool resizeWindow)
 {
     zoomFactor = std::max(zf, 25.f);
     if (currentSkin && resizeWindow)
-        parentEd->setSize(currentSkin->getWindowSizeX(), currentSkin->getWindowSizeY());
+    {
+        int yExtra = 0;
+        if (parentEd->processor.wrapperType ==
+            juce::AudioProcessor::WrapperType::wrapperType_Standalone)
+        {
+            yExtra = SurgeSynthEditor::extraYSpaceForStandalone;
+        }
+        parentEd->setSize(currentSkin->getWindowSizeX(), currentSkin->getWindowSizeY() + yExtra);
+    }
     parentEd->setScaleFactor(zoomFactor * 0.01);
 }
 

--- a/src/surge_synth_juce/LockFreeStack.h
+++ b/src/surge_synth_juce/LockFreeStack.h
@@ -1,0 +1,56 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#ifndef SURGE_XT_LOCKFREESTACK_H
+#define SURGE_XT_LOCKFREESTACK_H
+
+#include <JuceHeader.h>
+#include "LockFreeStack.h"
+
+template <typename T, int qSize = 4096> class LockFreeStack
+{
+  public:
+    LockFreeStack() : af(qSize) {}
+    bool push(const T &ad)
+    {
+        auto ret = false;
+        int start1, size1, start2, size2;
+        af.prepareToWrite(1, start1, size1, start2, size2);
+        if (size1 > 0)
+        {
+            dq[start1] = ad;
+            ret = true;
+        }
+        af.finishedWrite(size1 + size2);
+        return ret;
+    }
+    bool pop(T &ad)
+    {
+        bool ret = false;
+        int start1, size1, start2, size2;
+        af.prepareToRead(1, start1, size1, start2, size2);
+        if (size1 > 0)
+        {
+            ad = dq[start1];
+            ret = true;
+        }
+        af.finishedRead(size1 + size2);
+        return ret;
+    }
+    juce::AbstractFifo af;
+    T dq[qSize];
+};
+
+#endif // SURGE_XT_LOCKFREESTACK_H

--- a/src/surge_synth_juce/SurgeSynthEditor.h
+++ b/src/surge_synth_juce/SurgeSynthEditor.h
@@ -31,6 +31,8 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     SurgeSynthEditor(SurgeSynthProcessor &);
     ~SurgeSynthEditor();
 
+    static constexpr int extraYSpaceForStandalone = 50;
+
     //==============================================================================
     void paint(juce::Graphics &) override;
     void resized() override;
@@ -55,6 +57,11 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     };
     void idle();
     std::unique_ptr<IdleTimer> idleTimer;
+
+    bool drawExtendedControls{false};
+    std::unique_ptr<juce::MidiKeyboardComponent> keyboard;
+    std::unique_ptr<juce::Label> tempoLabel;
+    std::unique_ptr<juce::TextEditor> tempoTypein;
 
     /* Drag and drop */
     bool isInterestedInFileDrag(const juce::StringArray &files) override;

--- a/src/surge_synth_juce/SurgeSynthProcessor.h
+++ b/src/surge_synth_juce/SurgeSynthProcessor.h
@@ -14,6 +14,7 @@
 
 #include "SurgeSynthesizer.h"
 #include "SurgeStorage.h"
+#include "LockFreeStack.h"
 
 #include <functional>
 #include <unordered_map>
@@ -91,7 +92,9 @@ struct SurgeParamToJuceParamAdapter : juce::RangedAudioParameter
     Parameter *p;
 };
 
-class SurgeSynthProcessor : public juce::AudioProcessor, public SurgeSynthesizer::PluginLayer
+class SurgeSynthProcessor : public juce::AudioProcessor,
+                            public SurgeSynthesizer::PluginLayer,
+                            public juce::MidiKeyboardState::Listener
 {
   public:
     //==============================================================================
@@ -109,6 +112,21 @@ class SurgeSynthProcessor : public juce::AudioProcessor, public SurgeSynthesizer
     //==============================================================================
     juce::AudioProcessorEditor *createEditor() override;
     bool hasEditor() const override;
+
+    std::atomic<float> standaloneTempo{120};
+    struct midiR
+    {
+        midiR() {}
+        midiR(int c, int n, int v, bool o) : ch(c), note(n), vel(v), on(o) {}
+        int ch{0}, note{0}, vel{0};
+        bool on{false};
+    };
+    LockFreeStack<midiR, 4096> midiFromGUI;
+    bool isAddingFromMidi{false};
+    void handleNoteOn(juce::MidiKeyboardState *source, int midiChannel, int midiNoteNumber,
+                      float velocity) override;
+    void handleNoteOff(juce::MidiKeyboardState *source, int midiChannel, int midiNoteNumber,
+                       float velocity) override;
 
     //==============================================================================
     const juce::String getName() const override;
@@ -135,6 +153,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor, public SurgeSynthesizer
     std::unordered_map<SurgeSynthesizer::ID, SurgeParamToJuceParamAdapter *> paramsByID;
 
     std::string paramClumpName(int clumpid);
+    juce::MidiKeyboardState midiKeyboardState;
 
   private:
     std::vector<SurgeParamToJuceParamAdapter *> paramAdapters;


### PR DESCRIPTION
1. audio_processing-active was never set to true in XT
   which is why aptch changes sometimes crashed
2. In the standalone add a keyboard and a tempo control
3. Remove some cruft from EFVG