### PR TITLE
Make the Virutal Keyboard togglable; ubiquitous

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -117,6 +117,11 @@ void initMaps()
             case LayoutGridResolution:
                 r = "layoutGridResolution";
                 break;
+            case ShowVirtualKeyboard_Plugin:
+                r = "showVirtualKeyboardPlugin";
+                break;
+            case ShowVirtualKeyboard_Standalone:
+                r = "showVirtualKeyboardStandalone";
             case nKeys:
                 break;
             }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -45,6 +45,9 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     SkinReloadViaF5,
     LayoutGridResolution,
 
+    ShowVirtualKeyboard_Plugin,
+    ShowVirtualKeyboard_Standalone,
+
     nKeys
 };
 /**

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -585,6 +585,11 @@ class SurgeGUIEditor : public EditorType,
     juce::PopupMenu makeLfoMenu(VSTGUI::CRect &rect);
     VSTGUI::COptionMenu *makeMonoModeOptionsMenu(VSTGUI::CRect &rect, bool updateDefaults);
 
+  public:
+    bool getShowVirtualKeyboard();
+    void setShowVirtualKeyboard(bool b);
+
+  private:
     bool scannedForMidiPresets = false;
 
     void resetSmoothing(ControllerModulationSource::SmoothingMode t);

--- a/src/surge_synth_juce/SurgeSynthEditor.h
+++ b/src/surge_synth_juce/SurgeSynthEditor.h
@@ -31,7 +31,7 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     SurgeSynthEditor(SurgeSynthProcessor &);
     ~SurgeSynthEditor();
 
-    static constexpr int extraYSpaceForStandalone = 50;
+    static constexpr int extraYSpaceForVirtualKeyboard = 50;
 
     //==============================================================================
     void paint(juce::Graphics &) override;


### PR DESCRIPTION
The virutal keyboard can now toggle with a user pref to remeber
which you want. Separate pref for Standalone and Plugin.
Default off for all. In the workflow menu. Standalone also shows
the tempo adjuster but plugin does not.