### PR TITLE
Restore patchid on initial load

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -644,6 +644,11 @@ bailOnPortable:
         oddsound_mts_client = nullptr;
         oddsound_mts_active = false;
     }
+
+    initPatchName =
+        Surge::Storage::getUserDefaultValue(this, Surge::Storage::InitialPatchName, "Init Saw");
+    initPatchCategory = Surge::Storage::getUserDefaultValue(
+        this, Surge::Storage::InitialPatchCategory, "Templates");
 }
 
 void SurgeStorage::initializePatchDb()

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -936,6 +936,8 @@ class alignas(16) SurgeStorage
         };
     }
 
+    std::string initPatchName{"Init Saw"}, initPatchCategory{"Templates"};
+
     static constexpr int tuning_table_size = 512;
     float table_pitch alignas(16)[tuning_table_size];
     float table_pitch_inv alignas(16)[tuning_table_size];

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -229,7 +229,8 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, std::string suppliedData
     int pid = 0;
     for (auto p : storage.patch_list)
     {
-        if (p.name == "Init Saw" && storage.patch_category[p.category].name == "Templates")
+        if (p.name == storage.initPatchName &&
+            storage.patch_category[p.category].name == storage.initPatchCategory)
         {
             patchid_queue = pid;
             break;

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -122,6 +122,13 @@ void initMaps()
                 break;
             case ShowVirtualKeyboard_Standalone:
                 r = "showVirtualKeyboardStandalone";
+                break;
+            case InitialPatchName:
+                r = "initialPatchName";
+                break;
+            case InitialPatchCategory:
+                r = "initialPatchCategory";
+                break;
             case nKeys:
                 break;
             }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -48,6 +48,9 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     ShowVirtualKeyboard_Plugin,
     ShowVirtualKeyboard_Standalone,
 
+    InitialPatchName,
+    InitialPatchCategory,
+
     nKeys
 };
 /**

--- a/src/gui/widgets/PatchSelector.cpp
+++ b/src/gui/widgets/PatchSelector.cpp
@@ -18,6 +18,7 @@
 #include "SurgeGUIUtils.h"
 #include "SurgeGUIEditor.h"
 #include "RuntimeFont.h"
+#include "UserDefaults.h"
 
 namespace Surge
 {
@@ -193,7 +194,8 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
 
         for (auto p : storage->patch_list)
         {
-            if (p.name == "Init Saw" && storage->patch_category[p.category].name == "Templates")
+            if (p.name == storage->initPatchName &&
+                storage->patch_category[p.category].name == storage->initPatchCategory)
             {
                 loadPatch(i);
                 break;
@@ -204,6 +206,14 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
     };
 
     contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Initialize Patch"), initAction);
+
+    contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Set This Patch As Initial Patch"), [this]() {
+        Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::InitialPatchName,
+                                               storage->patch_list[current_patch].name);
+
+        Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::InitialPatchCategory,
+                                               storage->patch_category[current_category].name);
+    });
 
     contextMenu.addSeparator();
 


### PR DESCRIPTION
The initial load would ignore the patchid-from-name
guess since we had already found Init Saw. Make it so
we beleive the name with various checks to make sure
that is reasonable. Closes #4625.

Also puts the inti patch name and template as a member of
storage and uses that consistently, which is part of the
way to #4502.