### PR TITLE
Change LockFreeStack to use std::array

### DIFF
--- a/src/surge_synth_juce/LockFreeStack.h
+++ b/src/surge_synth_juce/LockFreeStack.h
@@ -17,7 +17,7 @@
 #define SURGE_XT_LOCKFREESTACK_H
 
 #include <JuceHeader.h>
-#include "LockFreeStack.h"
+#include <array>
 
 template <typename T, int qSize = 4096> class LockFreeStack
 {
@@ -50,7 +50,7 @@ template <typename T, int qSize = 4096> class LockFreeStack
         return ret;
     }
     juce::AbstractFifo af;
-    T dq[qSize];
+    std::array<T, qSize> dq;
 };
 
 #endif // SURGE_XT_LOCKFREESTACK_H


### PR DESCRIPTION
This silences GCC's confused warning about writes beyond the length of the array due to GCC failing to recognise the templating.