### PR TITLE
MiniEdit and Value/Mod Typein moved to JUCE Overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,9 +358,11 @@ set(SURGE_GUI_SOURCES
 
   src/gui/overlays/AboutScreen.cpp
   src/gui/overlays/LuaEditors.cpp
+  src/gui/overlays/MiniEdit.cpp
   src/gui/overlays/ModulationEditor.cpp
   src/gui/overlays/MSEGEditor.cpp
   src/gui/overlays/PatchDBViewer.cpp
+  src/gui/overlays/TypeinParamEditor.cpp
 
   src/gui/widgets/EffectChooser.cpp
   src/gui/widgets/MenuForDiscreteParams.cpp

--- a/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
+++ b/libs/escape-from-vstgui/include/efvg/escape_from_vstgui.h
@@ -116,6 +116,7 @@ inline std::unordered_map<FakeRefcount *, DebugAllocRecord> *getAllocMap()
 struct RefActivity
 {
     int creates = 0, deletes = 0;
+    std::map<std::string, int> createsByType;
 };
 inline RefActivity *getRefActivity()
 {
@@ -178,6 +179,9 @@ struct FakeRefcount
         {
             if (!alwaysLeak)
             {
+#if DEBUG_EFVG_MEMORY
+                getRefActivity()->createsByType[typeid(*this).name()]++;
+#endif
                 delete this;
             }
             else
@@ -201,6 +205,10 @@ inline void showMemoryOutstanding()
 {
     std::cout << "EscapeFromVSTGUI Memory Check:\n   - Total activity : Create="
               << getRefActivity()->creates << " Delete=" << getRefActivity()->deletes << std::endl;
+    for (auto &p : getRefActivity()->createsByType)
+    {
+        std::cout << "  | " << p.first << " -> " << p.second << std::endl;
+    }
     for (auto &p : *(getAllocMap()))
     {
         if (p.first->doDebug)

--- a/src/gui/SkinSupport.h
+++ b/src/gui/SkinSupport.h
@@ -497,10 +497,14 @@ class SkinConsumingComponent
     virtual void setSkin(Skin::ptr_t s, std::shared_ptr<SurgeBitmaps> b) { setSkin(s, b, nullptr); }
     virtual void setSkin(Skin::ptr_t s, std::shared_ptr<SurgeBitmaps> b, Skin::Control::ptr_t c)
     {
+        bool changed = (skin != s) || (associatedBitmapStore != b) || (skinControl != c);
         skin = s;
         associatedBitmapStore = b;
         skinControl = c;
-        onSkinChanged();
+        if (changed)
+        {
+            onSkinChanged();
+        }
     }
 
     virtual void onSkinChanged() {}

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -45,7 +45,6 @@ namespace Surge
 {
 namespace Widgets
 {
-struct AboutScreen;
 struct EffectChooser;
 struct EffectLabel;
 struct ModulatableControlInterface;
@@ -60,6 +59,13 @@ struct VuMeter;
 struct OscillatorMenu;
 struct FxMenu;
 } // namespace Widgets
+
+namespace Overlays
+{
+struct AboutScreen;
+struct TypeinParamEditor;
+struct MiniEdit;
+} // namespace Overlays
 } // namespace Surge
 
 struct SGEDropAdapter;
@@ -457,7 +463,7 @@ class SurgeGUIEditor : public EditorType,
 
     VSTGUI::CControlValueInterface *statusMPE = nullptr, *statusTune = nullptr,
                                    *statusZoom = nullptr;
-    std::unique_ptr<Surge::Widgets::AboutScreen> aboutScreen;
+    std::unique_ptr<Surge::Overlays::AboutScreen> aboutScreen;
 
     std::unique_ptr<juce::Drawable> midiLearnOverlay;
 
@@ -471,18 +477,20 @@ class SurgeGUIEditor : public EditorType,
     VSTGUI::CTextLabel *debugLabel = nullptr;
 #endif
 
+#if 0
     VSTGUI::CViewContainer *typeinDialog = nullptr;
     VSTGUI::CTextEdit *typeinValue = nullptr;
     VSTGUI::CTextLabel *typeinLabel = nullptr;
     VSTGUI::CTextLabel *typeinPriorValueLabel = nullptr;
     VSTGUI::CControl *typeinEditControl = nullptr;
+#endif
+    std::unique_ptr<Surge::Overlays::TypeinParamEditor> typeinParamEditor;
+    bool setParameterFromString(Parameter *p, const std::string &s);
+    bool setParameterModulationFromString(Parameter *p, modsources ms, const std::string &s);
+    bool setControlFromString(modsources ms, const std::string &s);
+    friend struct Surge::Overlays::TypeinParamEditor;
+
     VSTGUI::CControlValueInterface *msegEditSwitch = nullptr;
-    enum TypeInMode
-    {
-        Inactive,
-        Param,
-        Control
-    } typeinMode = Inactive;
     std::vector<VSTGUI::CView *> removeFromFrame;
     int typeinResetCounter = -1;
     std::string typeinResetLabel = "";
@@ -493,9 +501,7 @@ class SurgeGUIEditor : public EditorType,
         editorOverlayContentsWeakReference;
     std::unordered_map<VSTGUI::CViewContainer *, std::function<void()>> editorOverlayOnClose;
 
-    VSTGUI::CViewContainer *minieditOverlay = nullptr;
-    VSTGUI::CTextEdit *minieditTypein = nullptr;
-    std::function<void(const char *)> minieditOverlayDone = [](const char *) {};
+    std::unique_ptr<Surge::Overlays::MiniEdit> miniEdit;
 
   public:
     std::string editorOverlayTagAtClose; // FIXME what is this?

--- a/src/gui/SurgeGUIEditorTags.h
+++ b/src/gui/SurgeGUIEditorTags.h
@@ -40,9 +40,6 @@ enum SurgeGUIEditorTags
     tag_mp_jogfx,
     tag_value_typein,
     tag_editor_overlay_close,
-    tag_miniedit_ok,
-    tag_miniedit_cancel,
-
     tag_status_mpe,
     tag_status_zoom,
     tag_status_tune,

--- a/src/gui/overlays/AboutScreen.cpp
+++ b/src/gui/overlays/AboutScreen.cpp
@@ -22,7 +22,7 @@
 
 namespace Surge
 {
-namespace Widgets
+namespace Overlays
 {
 struct NoUrlHyperlinkButton : public juce::HyperlinkButton
 {
@@ -252,5 +252,5 @@ void AboutScreen::mouseUp(const juce::MouseEvent &e)
 
 void AboutScreen::onSkinChanged() { logo = associatedBitmapStore->getDrawable(IDB_ABOUT_BG); }
 
-} // namespace Widgets
+} // namespace Overlays
 } // namespace Surge

--- a/src/gui/overlays/AboutScreen.h
+++ b/src/gui/overlays/AboutScreen.h
@@ -24,7 +24,7 @@ class SurgeStorage;
 
 namespace Surge
 {
-namespace Widgets
+namespace Overlays
 {
 struct AboutScreen : public juce::Component,
                      public Surge::GUI::SkinConsumingComponent,
@@ -66,7 +66,7 @@ struct AboutScreen : public juce::Component,
 
     juce::Colour fillColour{juce::Colour(0, 0, 0).withAlpha(0.8f)};
 };
-} // namespace Widgets
+} // namespace Overlays
 } // namespace Surge
 
 #endif // SURGE_XT_ABOUTSCREEN_H

--- a/src/gui/overlays/MiniEdit.cpp
+++ b/src/gui/overlays/MiniEdit.cpp
@@ -1,0 +1,116 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "MiniEdit.h"
+#include "SkinModel.h"
+#include "SurgeBitmaps.h"
+#include "RuntimeFont.h"
+
+namespace Surge
+{
+namespace Overlays
+{
+MiniEdit::MiniEdit()
+{
+    typein = std::make_unique<juce::TextEditor>("minieditTypein");
+    typein->setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
+    addAndMakeVisible(*typein);
+
+    okButton = std::make_unique<juce::TextButton>("minieditOK");
+    okButton->setButtonText("OK");
+    okButton->addListener(this);
+    addAndMakeVisible(*okButton);
+
+    cancelButton = std::make_unique<juce::TextButton>("minieditOK");
+    cancelButton->setButtonText("Cancel");
+    cancelButton->addListener(this);
+    addAndMakeVisible(*cancelButton);
+}
+MiniEdit::~MiniEdit() {}
+juce::Rectangle<int> MiniEdit::getDisplayRegion()
+{
+    auto fullRect = juce::Rectangle<int>(0, 0, 160, 80).withCentre(getBounds().getCentre());
+    return fullRect;
+}
+void MiniEdit::paint(juce::Graphics &g)
+{
+    if (!skin || !associatedBitmapStore)
+    {
+        // This is a software error obvs
+        g.fillAll(juce::Colours::red);
+        return;
+    }
+    g.fillAll(skin->getColor(Colors::Overlay::Background));
+
+    auto fullRect = getDisplayRegion();
+
+    auto tbRect = fullRect.withHeight(18);
+    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Background));
+    g.fillRect(tbRect);
+    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Text));
+    g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(11));
+    g.drawText(title, tbRect, juce::Justification::centred);
+
+    auto d = associatedBitmapStore->getDrawable(IDB_SURGE_ICON);
+    if (d)
+    {
+        d->drawAt(g, fullRect.getX(), fullRect.getY(), 1.0);
+    }
+
+    auto bodyRect = fullRect.withTrimmedTop(18);
+    g.setColour(skin->getColor(Colors::Dialog::Background));
+    g.fillRect(bodyRect);
+
+    g.setColour(skin->getColor(Colors::Dialog::Label::Text));
+    g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
+    auto labelRect = bodyRect.withHeight(22).withTrimmedLeft(3).withTrimmedRight(3);
+    g.drawText(label, labelRect, juce::Justification::centredLeft);
+
+    g.setColour(skin->getColor(Colors::Dialog::Border));
+    g.drawRect(fullRect);
+}
+
+void MiniEdit::onSkinChanged() { repaint(); }
+void MiniEdit::resized()
+{
+    auto fullRect = getDisplayRegion();
+    auto eh = 18, mg = 2, bw = 40;
+
+    auto typeinBox = fullRect.translated(0, 2 * eh + mg * 2)
+                         .withHeight(eh)
+                         .withTrimmedLeft(2 * mg)
+                         .withTrimmedRight(2 * mg);
+    typein->setBounds(typeinBox);
+
+    auto buttonRow = fullRect.translated(0, 3 * eh + mg * 3)
+                         .withHeight(eh)
+                         .withTrimmedLeft(mg)
+                         .withTrimmedRight(mg);
+    auto okRect = buttonRow.withTrimmedLeft(40).withWidth(38);
+    auto canRect = buttonRow.withTrimmedLeft(80).withWidth(38);
+
+    okButton->setBounds(okRect);
+    cancelButton->setBounds(canRect);
+}
+void MiniEdit::buttonClicked(juce::Button *button)
+{
+    if (button == okButton.get())
+    {
+        callback(typein->getText().toStdString());
+    }
+    setVisible(false);
+}
+} // namespace Overlays
+} // namespace Surge

--- a/src/gui/overlays/MiniEdit.h
+++ b/src/gui/overlays/MiniEdit.h
@@ -1,0 +1,51 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#ifndef SURGE_XT_MINIEDIT_H
+#define SURGE_XT_MINIEDIT_H
+
+#include <JuceHeader.h>
+#include "SkinSupport.h"
+
+namespace Surge
+{
+namespace Overlays
+{
+struct MiniEdit : public juce::Component,
+                  public Surge::GUI::SkinConsumingComponent,
+                  public juce::Button::Listener
+{
+    MiniEdit();
+    ~MiniEdit();
+    void paint(juce::Graphics &g) override;
+    void onSkinChanged() override;
+    void mouseDown(const juce::MouseEvent &e) override { setVisible(false); }
+
+    std::string title, label;
+    void setTitle(const std::string t) { title = t; }
+    void setLabel(const std::string t) { label = t; }
+    void setValue(const std::string t) { typein->setText(t, juce::dontSendNotification); }
+    std::function<void(const std::string &s)> callback;
+
+    void resized() override;
+    void buttonClicked(juce::Button *button) override;
+    juce::Rectangle<int> getDisplayRegion();
+    std::unique_ptr<juce::TextEditor> typein;
+    std::unique_ptr<juce::TextButton> okButton;
+    std::unique_ptr<juce::TextButton> cancelButton;
+};
+} // namespace Overlays
+} // namespace Surge
+#endif // SURGE_XT_MINIEDIT_H

--- a/src/gui/overlays/TypeinParamEditor.cpp
+++ b/src/gui/overlays/TypeinParamEditor.cpp
@@ -1,0 +1,138 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "TypeinParamEditor.h"
+#include "RuntimeFont.h"
+#include "SurgeGUIEditor.h"
+
+namespace Surge
+{
+namespace Overlays
+{
+TypeinParamEditor::TypeinParamEditor()
+{
+    textEd = std::make_unique<juce::TextEditor>("typeinParamEditor");
+    textEd->addListener(this);
+    textEd->setSelectAllWhenFocused(true);
+    addAndMakeVisible(*textEd);
+}
+
+void TypeinParamEditor::paint(juce::Graphics &g)
+{
+    g.fillAll(skin->getColor(Colors::Dialog::Background));
+    g.setColour(skin->getColor(Colors::Dialog::Border));
+    g.drawRect(getLocalBounds());
+
+    g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(10));
+    g.setColour(skin->getColor(Colors::Slider::Label::Dark));
+    auto r = getLocalBounds().translated(0, 2).withHeight(14);
+    g.drawText(mainLabel, r, juce::Justification::centred);
+
+    g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(8));
+    if (isMod)
+    {
+        r = r.translated(0, 12);
+        g.drawText(modbyLabel, r, juce::Justification::centred);
+    }
+
+    r = r.translated(0, 12);
+    if (wasInputInvalid)
+    {
+        g.setColour(juce::Colours::red);
+        g.drawText("Input out of range", r, juce::Justification::centred);
+    }
+    else
+    {
+        g.drawText(primaryVal, r, juce::Justification::centred);
+    }
+
+    g.setColour(skin->getColor(Colors::Slider::Label::Dark));
+
+    if (isMod)
+    {
+        r = r.translated(0, 12);
+        g.drawText(secondaryVal, r, juce::Justification::centred);
+    }
+}
+
+void TypeinParamEditor::setBoundsToAccompany(const juce::Rectangle<int> &controlRect,
+                                             const juce::Rectangle<int> &parentRect)
+{
+    int ht = 56 + (isMod ? 22 : 0);
+    auto r = juce::Rectangle<int>(0, 0, 144, ht)
+                 .withX(controlRect.getX())
+                 .withY(controlRect.getY() - ht);
+    if (!parentRect.contains(r))
+    {
+        r = r.withTop(controlRect.getBottom());
+    }
+
+    auto ter = juce::Rectangle<int>(0, ht - 22, 144, 22).reduced(2);
+    textEd->setBounds(ter);
+
+    setBounds(r);
+}
+void TypeinParamEditor::onSkinChanged()
+{
+    textEd->setColour(juce::TextEditor::backgroundColourId,
+                      skin->getColor(Colors::Dialog::Entry::Background));
+    textEd->setColour(juce::TextEditor::textColourId, skin->getColor(Colors::Dialog::Entry::Text));
+    textEd->setColour(juce::TextEditor::highlightColourId,
+                      skin->getColor(Colors::Dialog::Entry::Focus));
+    textEd->setColour(juce::TextEditor::outlineColourId,
+                      skin->getColor(Colors::Dialog::Entry::Border));
+    repaint();
+}
+void TypeinParamEditor::textEditorReturnKeyPressed(juce::TextEditor &te)
+{
+    if (!editor)
+        return;
+
+    bool res = false;
+    if (typeinMode == Param)
+    {
+        if (p && ms > 0)
+        {
+            res = editor->setParameterModulationFromString(p, ms, te.getText().toStdString());
+        }
+        else
+        {
+            res = editor->setParameterFromString(p, te.getText().toStdString());
+        }
+    }
+    else
+    {
+        res = editor->setControlFromString(ms, te.getText().toStdString());
+    }
+    if (res)
+    {
+        setVisible(false);
+    }
+    else
+    {
+        wasInputInvalid = true;
+        repaint();
+        juce::Timer::callAfterDelay(2000, [this]() {
+            wasInputInvalid = false;
+            repaint();
+        });
+    }
+}
+
+void TypeinParamEditor::textEditorEscapeKeyPressed(juce::TextEditor &te) { setVisible(false); }
+
+void TypeinParamEditor::grabFocus() { textEd->grabKeyboardFocus(); }
+} // namespace Overlays
+} // namespace Surge

--- a/src/gui/overlays/TypeinParamEditor.h
+++ b/src/gui/overlays/TypeinParamEditor.h
@@ -1,0 +1,88 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#ifndef SURGE_XT_TYPEINPARAMEDITOR_H
+#define SURGE_XT_TYPEINPARAMEDITOR_H
+
+#include <JuceHeader.h>
+#include "Parameter.h"
+#include "SurgeStorage.h"
+#include "ModulationSource.h"
+#include "SkinSupport.h"
+
+class SurgeGUIEditor;
+
+namespace Surge
+{
+namespace Overlays
+{
+struct TypeinParamEditor : public juce::Component,
+                           public Surge::GUI::SkinConsumingComponent,
+                           public juce::TextEditor::Listener
+{
+    TypeinParamEditor();
+    void paint(juce::Graphics &g) override;
+
+    SurgeGUIEditor *editor{nullptr};
+    void setSurgeGUIEditor(SurgeGUIEditor *e) { editor = e; }
+    void grabFocus();
+    void setBoundsToAccompany(const juce::Rectangle<int> &controlRect,
+                              const juce::Rectangle<int> &parentRect);
+
+    Parameter *p{nullptr};
+    void setEditedParam(Parameter *pin) { p = pin; };
+    bool isMod{false};
+    modsources ms{ms_original};
+    void setModulation(bool isMod, modsources ms)
+    {
+        this->isMod = isMod;
+        this->ms = ms;
+    }
+
+    std::string mainLabel;
+    void setMainLabel(const std::string &s) { mainLabel = s; }
+    std::string primaryVal, secondaryVal;
+    void setValueLabels(const std::string &pri, const std::string &sec)
+    {
+        primaryVal = pri;
+        secondaryVal = sec;
+    }
+
+    std::string modbyLabel;
+    void setModByLabel(const std::string &by) { modbyLabel = by; }
+
+    void setEditableText(const std::string &et) { textEd->setText(et, juce::dontSendNotification); }
+
+    enum TypeinMode
+    {
+        Inactive,
+        Param,
+        Control
+    } typeinMode{Inactive};
+    void setTypeinMode(TypeinMode t) { typeinMode = t; }
+    TypeinMode getTypeinMode() const { return typeinMode; }
+
+    std::unique_ptr<juce::TextEditor> textEd;
+
+    void onSkinChanged() override;
+    bool wasInputInvalid{false};
+
+    // Text editor listener methods
+    void textEditorReturnKeyPressed(juce::TextEditor &editor) override;
+    void textEditorEscapeKeyPressed(juce::TextEditor &editor) override;
+};
+} // namespace Overlays
+} // namespace Surge
+#endif // SURGE_XT_TYPEINPARAMEDITOR_H


### PR DESCRIPTION
1. MiniEdit is a juce overlay
2. Value/Mod typein is a juce overlay

along the way I learned a lot about how to structure this
code more rationally. Also added on-mac per-class-whats-still-vg
report