### PR TITLE
Add a mechanism for pure JUCE Overlays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ set(SURGE_GUI_SOURCES
   src/gui/overlays/MSEGEditor.cpp
   src/gui/overlays/PatchDBViewer.cpp
   src/gui/overlays/TypeinParamEditor.cpp
+  src/gui/overlays/OverlayWrapper.cpp
 
   src/gui/widgets/EffectChooser.cpp
   src/gui/widgets/MenuForDiscreteParams.cpp

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -29,6 +29,7 @@
 #include "SkinColors.h"
 
 #include "overlays/MSEGEditor.h"
+#include "overlays/OverlayWrapper.h" // This needs to be concrete for inline functions for now
 #include "widgets/ModulatableControlInterface.h"
 
 #include <vector>
@@ -63,6 +64,8 @@ namespace Overlays
 struct AboutScreen;
 struct TypeinParamEditor;
 struct MiniEdit;
+
+struct OverlayWrapper;
 } // namespace Overlays
 } // namespace Surge
 
@@ -327,6 +330,15 @@ class SurgeGUIEditor : public EditorType,
         OverlayTags editorTag,   // A tag by editor class. Please unique, no spaces.
         const VSTGUI::CPoint &topleft = VSTGUI::CPoint(0, 0), bool modalOverlay = true,
         bool hasCloseButton = true, std::function<void()> onClose = []() {});
+
+    // I will be handed a pointer I need to keep around you know.
+    void addJuceEditorOverlay(
+        std::unique_ptr<juce::Component> c,
+        std::string editorTitle, // A window display title - whatever you want
+        OverlayTags editorTag,   // A tag by editor class. Please unique, no spaces.
+        const juce::Rectangle<int> &containerBounds, std::function<void()> onClose = []() {});
+    std::unordered_map<OverlayTags, std::unique_ptr<Surge::Overlays::OverlayWrapper>> juceOverlays;
+
     void dismissEditorOfType(OverlayTags ofType);
     OverlayTags topmostEditorTag()
     {
@@ -341,6 +353,10 @@ class SurgeGUIEditor : public EditorType,
             if (el.first == tag)
                 return true;
         }
+
+        if (juceOverlays.find(tag) != juceOverlays.end() && juceOverlays[tag])
+            return true;
+
         return false;
     }
 

--- a/src/gui/overlays/LuaEditors.cpp
+++ b/src/gui/overlays/LuaEditors.cpp
@@ -20,6 +20,10 @@
 #include "SkinColors.h"
 #include "WavetableScriptEvaluator.h"
 
+namespace Surge
+{
+namespace Overlays
+{
 struct EditorColors
 {
     static void setColorsFromSkin(juce::CodeEditorComponent *comp,
@@ -352,3 +356,6 @@ void WavetableEquationEditor::buttonClicked(juce::Button *button)
     }
     CodeEditorContainerWithApply::buttonClicked(button);
 }
+
+} // namespace Overlays
+} // namespace Surge

--- a/src/gui/overlays/LuaEditors.h
+++ b/src/gui/overlays/LuaEditors.h
@@ -26,6 +26,11 @@
 
 class SurgeGUIEditor;
 
+namespace Surge
+{
+namespace Overlays
+{
+
 /*
  * This is a base class that provides you an apply button, an editor, a document
  * a tokenizer, etc... which you need to layout with yoru other components by
@@ -104,5 +109,8 @@ class WavetableEquationEditor : public CodeEditorContainerWithApply,
 
     OscillatorStorage *osc;
 };
+
+} // namespace Overlays
+} // namespace Surge
 
 #endif // SURGE_XT_LUAEDITORS_H

--- a/src/gui/overlays/ModulationEditor.cpp
+++ b/src/gui/overlays/ModulationEditor.cpp
@@ -19,6 +19,10 @@
 #include "RuntimeFont.h"
 #include <sstream>
 
+namespace Surge
+{
+namespace Overlays
+{
 struct ModulationListBoxModel : public juce::ListBoxModel
 {
     struct Datum
@@ -347,20 +351,20 @@ struct ModulationListBoxModel : public juce::ListBoxModel
 ModulationEditor::ModulationEditor(SurgeGUIEditor *ed, SurgeSynthesizer *s)
     : ed(ed), synth(s), juce::Component("Modulation Editor")
 {
-    setSize(750, 450); // FIXME
-
     listBoxModel = std::make_unique<ModulationListBoxModel>(this);
     listBox = std::make_unique<juce::ListBox>("Mod Editor List", listBoxModel.get());
     listBox->setBounds(5, 5, 740, 440);
     listBox->setRowHeight(18);
     addAndMakeVisible(*listBox);
-
-    /*textBox = std::make_unique<juce::TextEditor>("Mod editor text box");
-    textBox->setMultiLine(true, false);
-    textBox->setBounds(5, 355, 740, 90);
-    textBox->setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
-    addAndMakeVisible(*textBox);
-    textBox->setText(listBoxModel->debugRows);*/
 }
 
+void ModulationEditor::paint(juce::Graphics &g) { g.fillAll(juce::Colours::black); }
+void ModulationEditor::resized()
+{
+    if (listBox)
+        listBox->setBounds(2, 2, getWidth() - 4, getHeight() - 4);
+}
 ModulationEditor::~ModulationEditor() = default;
+
+} // namespace Overlays
+} // namespace Surge

--- a/src/gui/overlays/ModulationEditor.h
+++ b/src/gui/overlays/ModulationEditor.h
@@ -21,6 +21,10 @@
 class SurgeGUIEditor;
 class SurgeSynthesizer;
 
+namespace Surge
+{
+namespace Overlays
+{
 class ModulationListBoxModel;
 
 class ModulationEditor : public juce::Component
@@ -34,6 +38,12 @@ class ModulationEditor : public juce::Component
     std::unique_ptr<juce::TextEditor> textBox;
     SurgeGUIEditor *ed;
     SurgeSynthesizer *synth;
+
+    void paint(juce::Graphics &g) override;
+    void resized() override;
 };
+
+} // namespace Overlays
+} // namespace Surge
 
 #endif // SURGE_XT_MODULATIONEDITOR_H

--- a/src/gui/overlays/OverlayWrapper.cpp
+++ b/src/gui/overlays/OverlayWrapper.cpp
@@ -1,0 +1,72 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "OverlayWrapper.h"
+#include "RuntimeFont.h"
+
+namespace Surge
+{
+namespace Overlays
+{
+OverlayWrapper::OverlayWrapper()
+{
+    closeButton = std::make_unique<juce::TextButton>("closeButton");
+    closeButton->addListener(this);
+    closeButton->setButtonText("Close");
+    addAndMakeVisible(*closeButton);
+}
+
+void OverlayWrapper::paint(juce::Graphics &g)
+{
+    g.fillAll(skin->getColor(Colors::Dialog::Titlebar::Background));
+    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Text));
+    g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(11, juce::Font::bold));
+    g.drawText(title, getLocalBounds().withHeight(titlebarSize + margin),
+               juce::Justification::centred);
+    if (icon)
+        icon->drawAt(g, 1, 1, 1);
+    g.setColour(skin->getColor(Colors::Dialog::Border));
+    g.drawRect(getLocalBounds(), 1);
+}
+
+void OverlayWrapper::addAndTakeOwnership(std::unique_ptr<juce::Component> c)
+{
+    auto q = getLocalBounds()
+                 .reduced(2 * margin, 2 * margin)
+                 .withTrimmedBottom(titlebarSize)
+                 .translated(0, titlebarSize + 0 * margin);
+    primaryChild = std::move(c);
+    primaryChild->setBounds(q);
+
+    auto buttonWidth = 50;
+    auto closeButtonBounds = getLocalBounds()
+                                 .withHeight(titlebarSize - 1)
+                                 .withLeft(getWidth() - buttonWidth)
+                                 .translated(-2, 2);
+
+    closeButton->setBounds(closeButtonBounds);
+    addAndMakeVisible(*primaryChild);
+}
+
+void OverlayWrapper::buttonClicked(juce::Button *button)
+{
+    if (button == closeButton.get())
+    {
+        closeOverlay();
+    }
+}
+
+} // namespace Overlays
+} // namespace Surge

--- a/src/gui/overlays/OverlayWrapper.h
+++ b/src/gui/overlays/OverlayWrapper.h
@@ -1,0 +1,58 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#ifndef SURGE_XT_OVERLAYWRAPPER_H
+#define SURGE_XT_OVERLAYWRAPPER_H
+
+#include <JuceHeader.h>
+#include "SkinSupport.h"
+
+class SurgeGUIEditor;
+
+namespace Surge
+{
+namespace Overlays
+{
+struct OverlayWrapper : public juce::Component,
+                        public Surge::GUI::SkinConsumingComponent,
+                        public juce::Button::Listener
+{
+    OverlayWrapper();
+
+    static constexpr int titlebarSize = 14, margin = 1;
+
+    std::string title;
+    void setTitle(const std::string t) { title = t; }
+
+    void paint(juce::Graphics &g) override;
+
+    SurgeGUIEditor *editor{nullptr};
+    void setSurgeGUIEditor(SurgeGUIEditor *e) { editor = e; }
+
+    std::unique_ptr<juce::Component> primaryChild;
+    void addAndTakeOwnership(std::unique_ptr<juce::Component> c);
+    std::unique_ptr<juce::TextButton> closeButton;
+    void buttonClicked(juce::Button *button) override;
+
+    juce::Drawable *icon{nullptr};
+    void setIcon(juce::Drawable *d) { icon = d; }
+
+    std::function<void()> closeOverlay = []() {};
+    void setCloseOverlay(std::function<void()> f) { closeOverlay = std::move(f); }
+};
+} // namespace Overlays
+} // namespace Surge
+
+#endif // SURGE_XT_OVERLAYWRAPPER_H

--- a/src/gui/overlays/PatchDBViewer.cpp
+++ b/src/gui/overlays/PatchDBViewer.cpp
@@ -18,6 +18,10 @@
 #include "SurgeGUIEditor.h"
 #include "RuntimeFont.h"
 
+namespace Surge
+{
+namespace Overlays
+{
 class PatchDBSQLTableModel : public juce::TableListBoxModel
 {
   public:
@@ -118,3 +122,16 @@ void PatchDBViewer::executeQuery()
     table->updateContent();
 }
 void PatchDBViewer::textEditorTextChanged(juce::TextEditor &editor) { executeQuery(); }
+
+void PatchDBViewer::paint(juce::Graphics &g) { g.fillAll(juce::Colours::black); }
+void PatchDBViewer::resized()
+{
+    if (nameTypein)
+        nameTypein->setBounds(10, 10, 400, 30);
+
+    if (table)
+        table->setBounds(2, 50, getWidth() - 4, getHeight() - 52);
+}
+
+} // namespace Overlays
+} // namespace Surge

--- a/src/gui/overlays/PatchDBViewer.h
+++ b/src/gui/overlays/PatchDBViewer.h
@@ -19,8 +19,13 @@
 #include <JuceHeader.h>
 #include "SurgeStorage.h"
 
-class PatchDBSQLTableModel;
 class SurgeGUIEditor;
+
+namespace Surge
+{
+namespace Overlays
+{
+class PatchDBSQLTableModel;
 
 class PatchDBViewer : public juce::Component, public juce::TextEditor::Listener
 {
@@ -30,6 +35,10 @@ class PatchDBViewer : public juce::Component, public juce::TextEditor::Listener
     void createElements();
     void executeQuery();
 
+    void paint(juce::Graphics &g) override;
+
+    void resized() override;
+
     void textEditorTextChanged(juce::TextEditor &editor) override;
     std::unique_ptr<juce::TextEditor> nameTypein;
     std::unique_ptr<juce::TableListBox> table;
@@ -38,5 +47,8 @@ class PatchDBViewer : public juce::Component, public juce::TextEditor::Listener
     SurgeStorage *storage;
     SurgeGUIEditor *editor;
 };
+
+} // namespace Overlays
+} // namespace Surge
 
 #endif // SURGE_PATCHDBVIEWER_H


### PR DESCRIPTION
Add a mechanism by which we can have 100% juce overlays
properly lifecycle managed etc... The current 100% juce
overlays (Patch, Mod Overview, Formula, WTEditor) are moved
but the unported ones (MSEG PatchStore) are not, so still
work to do of course.