### PR TITLE
Improve an error message in patch inferrence

### DIFF
--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -459,8 +459,15 @@ void SurgeSynthesizer::loadRaw(const void *data, int size, bool preset)
             /*
              * I don't see how this could ever happen. Punt.
              */
-            storage.reportError("Loading patch couldn't infer patch name. Please tell devs.",
-                                "Software Error");
+            std::ostringstream oss;
+            oss << "Error infering patch id. Prior patchid was " << patchid << " inferred id is "
+                << inferredPatchId << "."
+                << "patch_list[patchid].name/cat = '" << storage.patch_list[patchid].name << "'/'"
+                << storage.patch_list[patchid].name << "' and initPatchNameCat are '"
+                << storage.initPatchName << "'/'" << storage.initPatchCategory << "'. Please "
+                << "share this error with Surge devs.";
+            std::cout << oss.str() << std::endl;
+            storage.reportError(oss.str(), "Software Error");
             patchid = inferredPatchId;
         }
     }


### PR DESCRIPTION
A case I think should never happen actually happened so
improve the error message so we can find out why.