### PR TITLE
Match the look of modbuttons to VSTGUI version

### DIFF
--- a/src/gui/widgets/ModulationSourceButton.cpp
+++ b/src/gui/widgets/ModulationSourceButton.cpp
@@ -161,14 +161,14 @@ void ModulationSourceButton::paint(juce::Graphics &g)
         auto bottomRect = fillRect.withTrimmedTop(splitHeight - 2);
 
         // macro slider value fill
-        auto valRect = bottomRect;
+        auto valRect = bottomRect.toFloat();
         valRect.reduce(1, 1);
-        
-        //printf("Initial valRect || X: %d Y: %d, W: %d H: %d\n",valRect.getX(), valRect.getY(), valRect.getWidth(), valRect.getHeight());
+
+        auto sliderWidth = valRect.getWidth();
 
         // current value
-        auto valPoint = value * (valRect.getWidth() - 2);
-        
+        auto valPoint = value * sliderWidth;
+
         // macro slider background
         g.setColour(skin->getColor(Colors::ModSource::Macro::Background));
         g.fillRect(valRect);
@@ -181,30 +181,31 @@ void ModulationSourceButton::paint(juce::Graphics &g)
         {
             auto bipolarCenter = valRect.getCentreX();
 
-            if (valPoint <= bipolarCenter)
+            if (valPoint + 2 <= bipolarCenter)
             {
-                valRect = valRect.withLeft(valPoint).withRight(bipolarCenter);
+                valRect = valRect.withLeft(valPoint + 2).withRight(bipolarCenter + 1);
             }
             else
             {
-                valRect = valRect.withLeft(bipolarCenter).withRight(valPoint);
+                valRect = valRect.withLeft(bipolarCenter).withRight(valPoint + 2);
             }
         }
         else
         {
+            // make it so that the slider doesn't draw over its frame, but within it
             valRect.setX(2);
             valRect.setWidth(valPoint);
         }
-
-        //printf("VP: %.3f || X: %d Y: %d, W: %d H: %d\n", valPoint, valRect.getX(), valRect.getY(), valRect.getWidth(), valRect.getHeight());
 
         // draw macro slider value fill
         g.setColour(skin->getColor(Colors::ModSource::Macro::Fill));
         g.fillRect(valRect);
 
         // draw current value notch
+        valPoint = (valPoint == sliderWidth) ? sliderWidth - 1 : valPoint;
+
         g.setColour(skin->getColor(Colors::ModSource::Macro::CurrentValue));
-        //g.fillRect(juce::Rectangle<float>(2 + valPoint, valRect.getY(), 1, valRect.getHeight()));
+        g.fillRect(juce::Rectangle<float>(2 + valPoint, valRect.getY(), 1, valRect.getHeight()));
 
         // draw modbutton frame
         g.setColour(FrameCol);
@@ -271,7 +272,7 @@ void ModulationSourceButton::mouseDoubleClick(const juce::MouseEvent &event)
         auto topRect = getLocalBounds().withHeight(splitHeight);
 
         // TODO: double-click to rename macro?
-        //if (topRect.contains(event.position.toInt()))
+        // if (topRect.contains(event.position.toInt()))
         //{
         //    return;
         //}

--- a/src/gui/widgets/ModulationSourceButton.cpp
+++ b/src/gui/widgets/ModulationSourceButton.cpp
@@ -58,56 +58,84 @@ void ModulationSourceButton::paint(juce::Graphics &g)
     {
         FrameCol = skin->getColor(Colors::ModSource::Armed::Border);
         if (isHovered)
+        {
             FrameCol = skin->getColor(Colors::ModSource::Armed::BorderHover);
+        }
 
         FillCol = skin->getColor(Colors::ModSource::Armed::Background);
         FontCol = skin->getColor(Colors::ModSource::Armed::Text);
+
         if (isHovered)
+        {
             FontCol = skin->getColor(Colors::ModSource::Armed::TextHover);
+        }
     }
     else if (SelectedModSource)
     {
         FrameCol = isUsed ? skin->getColor(Colors::ModSource::Selected::Used::Border)
                           : skin->getColor(Colors::ModSource::Selected::Border);
         if (isHovered)
+        {
             FrameCol = isUsed ? skin->getColor(Colors::ModSource::Selected::Used::BorderHover)
                               : skin->getColor(Colors::ModSource::Selected::BorderHover);
+        }
+
         FillCol = isUsed ? skin->getColor(Colors::ModSource::Selected::Used::Background)
                          : skin->getColor(Colors::ModSource::Selected::Background);
         FontCol = isUsed ? skin->getColor(Colors::ModSource::Selected::Used::Text)
                          : skin->getColor(Colors::ModSource::Selected::Text);
+
         if (isHovered)
+        {
             FontCol = isUsed ? skin->getColor(Colors::ModSource::Selected::Used::TextHover)
                              : skin->getColor(Colors::ModSource::Selected::TextHover);
+        }
     }
     else if (isTinted)
     {
         FillCol = skin->getColor(Colors::ModSource::Unused::Background);
         FrameCol = skin->getColor(Colors::ModSource::Unused::Border);
+
         if (isHovered)
+        {
             FrameCol = skin->getColor(Colors::ModSource::Unused::BorderHover);
+        }
+
         FontCol = skin->getColor(Colors::ModSource::Unused::Text);
+
         if (isHovered)
+        {
             FontCol = skin->getColor(Colors::ModSource::Unused::TextHover);
+        }
     }
 
     if (secondaryHoverActive)
     {
         FontCol = skin->getColor(Colors::ModSource::Used::UsedModHover);
+
         if (ActiveModSource)
+        {
             FontCol = skin->getColor(Colors::ModSource::Armed::UsedModHover);
+        }
+
         if (SelectedModSource)
+        {
             FontCol = skin->getColor(Colors::ModSource::Selected::UsedModHover);
+        }
     }
 
-    g.fillAll(FillCol);
+    auto fillRect = getLocalBounds();
+    fillRect.reduce(1, 1);
+    g.setColour(FillCol);
+    g.fillRect(fillRect);
 
     if (!isMeta)
     {
-        g.setColour(FrameCol);
-        g.drawRect(getLocalBounds(), 1);
+        // modbutton name settings
         g.setColour(FontCol);
         g.setFont(Surge::GUI::getFontManager()->displayFont);
+
+        // modbutton name
         if (hasAlternate && useAlternate)
         {
             g.drawText(alternateLabel, getLocalBounds(), juce::Justification::centred);
@@ -116,46 +144,71 @@ void ModulationSourceButton::paint(juce::Graphics &g)
         {
             g.drawText(label, getLocalBounds(), juce::Justification::centred);
         }
+
+        // modbutton frame
+        g.setColour(FrameCol);
+        g.drawRect(getLocalBounds(), 1);
     }
     else
     {
-        auto topR = getLocalBounds().withHeight(splitHeight);
+        // macro name area
+        auto topRect = getLocalBounds().withHeight(splitHeight);
         g.setColour(FontCol);
         g.setFont(Surge::GUI::getFontManager()->displayFont);
-        g.drawText(label, topR, juce::Justification::centred);
+        g.drawText(label, topRect, juce::Justification::centred);
 
-        auto bottomR = getLocalBounds().withTrimmedTop(splitHeight);
+        // macro slider area
+        auto bottomRect = fillRect.withTrimmedTop(splitHeight - 2);
+
+        // macro slider value fill
+        auto valRect = bottomRect;
+        valRect.reduce(1, 1);
+        
+        //printf("Initial valRect || X: %d Y: %d, W: %d H: %d\n",valRect.getX(), valRect.getY(), valRect.getWidth(), valRect.getHeight());
+
+        // current value
+        auto valPoint = value * (valRect.getWidth() - 2);
+        
+        // macro slider background
         g.setColour(skin->getColor(Colors::ModSource::Macro::Background));
-        g.fillRect(bottomR);
+        g.fillRect(valRect);
 
-        auto valpt = value * bottomR.getWidth();
-        auto valRect = bottomR;
+        // macro slider frame
+        g.setColour(skin->getColor(Colors::ModSource::Used::Background));
+        g.drawRect(bottomRect);
 
         if (isBipolar)
         {
-            auto bctr = bottomR.getWidth() / 2;
-            if (valpt < bctr)
+            auto bipolarCenter = valRect.getCentreX();
+
+            if (valPoint <= bipolarCenter)
             {
-                valRect = valRect.withLeft(valpt).withRight(bctr);
+                valRect = valRect.withLeft(valPoint).withRight(bipolarCenter);
             }
             else
             {
-                valRect = valRect.withLeft(bctr).withRight(valpt);
+                valRect = valRect.withLeft(bipolarCenter).withRight(valPoint);
             }
         }
         else
         {
-            valRect = valRect.withRight(valpt);
+            valRect.setX(2);
+            valRect.setWidth(valPoint);
         }
 
+        //printf("VP: %.3f || X: %d Y: %d, W: %d H: %d\n", valPoint, valRect.getX(), valRect.getY(), valRect.getWidth(), valRect.getHeight());
+
+        // draw macro slider value fill
         g.setColour(skin->getColor(Colors::ModSource::Macro::Fill));
         g.fillRect(valRect);
 
+        // draw current value notch
+        g.setColour(skin->getColor(Colors::ModSource::Macro::CurrentValue));
+        //g.fillRect(juce::Rectangle<float>(2 + valPoint, valRect.getY(), 1, valRect.getHeight()));
+
+        // draw modbutton frame
         g.setColour(FrameCol);
         g.drawRect(getLocalBounds(), 1);
-
-        g.setColour(skin->getColor(Colors::ModSource::Macro::CurrentValue));
-        g.fillRect(juce::Rectangle<float>(valpt, bottomR.getY(), 1, bottomR.getHeight()));
     }
 
     if (modSource >= ms_lfo1 && modSource <= ms_slfo6)
@@ -172,17 +225,23 @@ void ModulationSourceButton::paint(juce::Graphics &g)
 void ModulationSourceButton::mouseDown(const juce::MouseEvent &event)
 {
     mouseMode = CLICK;
+
     if (event.mods.isPopupMenu())
     {
         mouseMode = NONE;
         notifyControlModifierClicked(event.mods);
+
         return;
     }
 
     if (isMeta)
     {
-        auto bottomR = getLocalBounds().withTrimmedTop(splitHeight);
-        if (bottomR.contains(event.position.toInt()))
+        // match the mouseable area to the painted macro slider area (including slider frame)
+        auto frameRect = getLocalBounds();
+        frameRect.reduce(1, 1);
+        auto bottomRect = frameRect.withTrimmedTop(splitHeight - 2);
+
+        if (bottomRect.contains(event.position.toInt()))
         {
             juce::Desktop::getInstance().getMainMouseSource().enableUnboundedMouseMovement(true);
             mouseMode = DRAG_VALUE;
@@ -194,13 +253,45 @@ void ModulationSourceButton::mouseDown(const juce::MouseEvent &event)
     if (modSource >= ms_lfo1 && modSource <= ms_slfo6)
     {
         auto arrSze = getLocalBounds().withLeft(getLocalBounds().getRight() - 14).withHeight(16);
+
         if (arrSze.contains(event.position.toInt()))
         {
             mouseMode = CLICK_ARROW;
         }
     }
+
     mouseDownBounds = getBounds();
     componentDragger.startDraggingComponent(this, event);
+}
+
+void ModulationSourceButton::mouseDoubleClick(const juce::MouseEvent &event)
+{
+    if (isMeta)
+    {
+        auto topRect = getLocalBounds().withHeight(splitHeight);
+
+        // TODO: double-click to rename macro?
+        //if (topRect.contains(event.position.toInt()))
+        //{
+        //    return;
+        //}
+
+        // match the mouseable area to the painted macro slider area (including slider frame)
+        auto frameRect = getLocalBounds();
+        frameRect.reduce(1, 1);
+        auto bottomRect = frameRect.withTrimmedTop(splitHeight - 2);
+
+        // TODO: make double-click reset more reliable, cursor hiding is cramping us up here
+        if (bottomRect.contains(event.position.toInt()))
+        {
+            value = isBipolar ? 0.5f : 0.f;
+
+            notifyValueChanged();
+            repaint();
+
+            return;
+        }
+    }
 }
 
 void ModulationSourceButton::mouseEnter(const juce::MouseEvent &event)
@@ -214,6 +305,7 @@ void ModulationSourceButton::mouseExit(const juce::MouseEvent &event)
     isHovered = false;
     repaint();
 }
+
 void ModulationSourceButton::onSkinChanged()
 {
     arrow = associatedBitmapStore->getDrawable(IDB_MODSOURCE_SHOW_LFO);
@@ -225,6 +317,7 @@ void ModulationSourceButton::mouseUp(const juce::MouseEvent &event)
     {
         notifyValueChanged();
     }
+
     if (mouseMode == DRAG_COMPONENT_HAPPEN)
     {
         auto sge = firstListenerOfType<SurgeGUIEditor>();
@@ -232,6 +325,7 @@ void ModulationSourceButton::mouseUp(const juce::MouseEvent &event)
         sge->modSourceButtonDroppedAt(this, q.toInt());
         setBounds(mouseDownBounds);
     }
+
     if (mouseMode == DRAG_VALUE)
     {
         juce::Desktop::getInstance().getMainMouseSource().enableUnboundedMouseMovement(false);
@@ -239,34 +333,45 @@ void ModulationSourceButton::mouseUp(const juce::MouseEvent &event)
         p = localPointToGlobal(p);
         juce::Desktop::getInstance().getMainMouseSource().setScreenPosition(p);
     }
+
     mouseMode = NONE;
+
     return;
 }
 
 void ModulationSourceButton::mouseDrag(const juce::MouseEvent &event)
 {
     if (mouseMode == NONE)
+    {
         return;
+    }
 
     if (mouseMode == DRAG_VALUE)
     {
         float mul = 1.f;
+
         if (event.mods.isShiftDown())
+        {
             mul = 0.1f;
+        }
 
         value = limit01(valAtMouseDown + mul * event.getDistanceFromDragStartX() / getWidth());
         notifyValueChanged();
         repaint();
+
         return;
     }
 
     if (event.getDistanceFromDragStart() < 2)
+    {
         return;
+    }
 
     toFront(false);
     mouseMode = DRAG_COMPONENT_HAPPEN;
     componentDragger.dragComponent(this, event, nullptr);
 }
+
 void ModulationSourceButton::mouseWheelMove(const juce::MouseEvent &event,
                                             const juce::MouseWheelDetails &wheel)
 {
@@ -288,6 +393,7 @@ void ModulationSourceButton::mouseWheelMove(const juce::MouseEvent &event,
         {
             speed = speed / 10.0;
         }
+
         value = limit01(value + speed * delta);
         mouseMode = DRAG_VALUE;
         notifyValueChanged();

--- a/src/gui/widgets/ModulationSourceButton.h
+++ b/src/gui/widgets/ModulationSourceButton.h
@@ -34,7 +34,11 @@ struct ModulationSourceButton : public juce::Component,
     void paint(juce::Graphics &g) override;
 
     float value{0};
-    void setValue(float v) override { value = v; }
+    void setValue(float v) override
+    {
+        value = v;
+        repaint();
+    }
     float getValue() const override { return value; }
     void valueChanged() override {}
 
@@ -95,7 +99,7 @@ struct ModulationSourceButton : public juce::Component,
         }
     }
 
-    static constexpr int splitHeight = 16;
+    static constexpr int splitHeight = 14;
 
     juce::Drawable *arrow{nullptr};
 
@@ -112,6 +116,7 @@ struct ModulationSourceButton : public juce::Component,
     juce::Rectangle<int> mouseDownBounds;
     float valAtMouseDown{0};
     void mouseDown(const juce::MouseEvent &event) override;
+    void mouseDoubleClick(const juce::MouseEvent &event) override;
     void mouseUp(const juce::MouseEvent &event) override;
     void mouseDrag(const juce::MouseEvent &event) override;
     void mouseWheelMove(const juce::MouseEvent &event,


### PR DESCRIPTION
Repaint macro slider when setting value (so that it responds to MIDI controllers etc.)
Add double-click reset macro value
Matched how the macro slider was drawn

