### PR TITLE
Remove one of the uses of CRect/CPoint in menus

### DIFF
--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -142,7 +142,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void effectSettingsBackgroundClick(int whichScene);
 
     void setDisabledForParameter(Parameter *p, Surge::Widgets::ModulatableControlInterface *s);
-    void showSettingsMenu(VSTGUI::CRect &menuRect);
+    void showSettingsMenu(const juce::Point<int> &menuRect);
 
     static bool fromSynthGUITag(SurgeSynthesizer *synth, int tag, SurgeSynthesizer::ID &q);
     // If n_scenes > 2, then this initialization and the modsource_editor one below will need to
@@ -264,10 +264,12 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     /*
     ** Callbacks from the Status Panel. If this gets to be too many perhaps make these an interface?
     */
-    void showMPEMenu(VSTGUI::CPoint &where);
-    void showTuningMenu(VSTGUI::CPoint &where);
-    void showZoomMenu(VSTGUI::CPoint &where);
-    void showLfoMenu(VSTGUI::CPoint &menuRect);
+    void showMPEMenu(const juce::Point<int> &where);
+    void showTuningMenu(const juce::Point<int> &where);
+    void showZoomMenu(const juce::Point<int> &where);
+    void showLfoMenu(const juce::Point<int> &menuRect);
+
+    juce::PopupMenu::Options optionsForPosition(const juce::Point<int> &where);
 
     void showHTML(const std::string &s);
 
@@ -556,22 +558,23 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     int firstIdleCountdown = 0;
 
     juce::PopupMenu
-    makeSmoothMenu(VSTGUI::CRect &menuRect, const Surge::Storage::DefaultKey &key, int defaultValue,
+    makeSmoothMenu(const juce::Point<int> &menuRect, const Surge::Storage::DefaultKey &key,
+                   int defaultValue,
                    std::function<void(ControllerModulationSource::SmoothingMode)> setSmooth);
 
-    juce::PopupMenu makeMpeMenu(VSTGUI::CRect &rect, bool showhelp);
-    juce::PopupMenu makeTuningMenu(VSTGUI::CRect &rect, bool showhelp);
-    juce::PopupMenu makeZoomMenu(VSTGUI::CRect &rect, bool showhelp);
-    juce::PopupMenu makeSkinMenu(VSTGUI::CRect &rect);
-    juce::PopupMenu makeMouseBehaviorMenu(VSTGUI::CRect &rect);
-    juce::PopupMenu makePatchDefaultsMenu(VSTGUI::CRect &rect);
-    juce::PopupMenu makeValueDisplaysMenu(VSTGUI::CRect &rect);
-    juce::PopupMenu makeWorkflowMenu(VSTGUI::CRect &rect);
-    juce::PopupMenu makeDataMenu(VSTGUI::CRect &rect);
-    juce::PopupMenu makeMidiMenu(VSTGUI::CRect &rect);
-    juce::PopupMenu makeDevMenu(VSTGUI::CRect &rect);
-    juce::PopupMenu makeLfoMenu(VSTGUI::CRect &rect);
-    juce::PopupMenu makeMonoModeOptionsMenu(VSTGUI::CRect &rect, bool updateDefaults);
+    juce::PopupMenu makeMpeMenu(const juce::Point<int> &rect, bool showhelp);
+    juce::PopupMenu makeTuningMenu(const juce::Point<int> &rect, bool showhelp);
+    juce::PopupMenu makeZoomMenu(const juce::Point<int> &rect, bool showhelp);
+    juce::PopupMenu makeSkinMenu(const juce::Point<int> &rect);
+    juce::PopupMenu makeMouseBehaviorMenu(const juce::Point<int> &rect);
+    juce::PopupMenu makePatchDefaultsMenu(const juce::Point<int> &rect);
+    juce::PopupMenu makeValueDisplaysMenu(const juce::Point<int> &rect);
+    juce::PopupMenu makeWorkflowMenu(const juce::Point<int> &rect);
+    juce::PopupMenu makeDataMenu(const juce::Point<int> &rect);
+    juce::PopupMenu makeMidiMenu(const juce::Point<int> &rect);
+    juce::PopupMenu makeDevMenu(const juce::Point<int> &rect);
+    juce::PopupMenu makeLfoMenu(const juce::Point<int> &rect);
+    juce::PopupMenu makeMonoModeOptionsMenu(const juce::Point<int> &rect, bool updateDefaults);
 
   public:
     bool getShowVirtualKeyboard();

--- a/src/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -115,40 +115,28 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
     if (tag == tag_lfo_menu)
     {
         control->setValue(0);
-        CPoint where;
-        frame->getCurrentMouseLocation(where);
-        frame->localToFrame(where);
-
+        juce::Point<int> where = control->asJuceComponent()->getBounds().getBottomLeft();
         showLfoMenu(where);
         return 1;
     }
 
     if (tag == tag_status_zoom)
     {
-        CPoint where;
-        frame->getCurrentMouseLocation(where);
-        frame->localToFrame(where);
-
+        juce::Point<int> where = control->asJuceComponent()->getBounds().getBottomLeft();
         showZoomMenu(where);
         return 1;
     }
 
     if (tag == tag_status_mpe)
     {
-        CPoint where;
-        frame->getCurrentMouseLocation(where);
-        frame->localToFrame(where);
-
+        juce::Point<int> where = control->asJuceComponent()->getBounds().getBottomLeft();
         showMPEMenu(where);
         return 1;
     }
 
     if (tag == tag_status_tune)
     {
-        CPoint where;
-        frame->getCurrentMouseLocation(where);
-        frame->localToFrame(where);
-
+        juce::Point<int> where = control->asJuceComponent()->getBounds().getBottomLeft();
         showTuningMenu(where);
         return 1;
     }
@@ -166,28 +154,17 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
     {
         if (tag == tag_settingsmenu)
         {
-            CRect r = viewSize;
-            CRect menuRect;
-            CPoint where;
-            frame->getCurrentMouseLocation(where);
-            frame->localToFrame(where);
-
-            menuRect.offset(where.x, where.y);
-
-            useDevMenu = true;
-            showSettingsMenu(menuRect);
+            showSettingsMenu(juce::Point<int>{});
             return 1;
         }
 
         if (tag == tag_osc_select)
         {
-            CRect r = viewSize;
+            auto r = control->asJuceComponent()->getBounds();
+            auto where =
+                frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
 
-            CPoint where;
-            frame->getCurrentMouseLocation(where);
-            frame->localToFrame(where);
-
-            int a = limit_range((int)((3 * (where.x - r.left)) / r.getWidth()), 0, 2);
+            int a = limit_range((int)((3 * (where.x - r.getX())) / r.getWidth()), 0, 2);
 
             auto contextMenu = juce::PopupMenu();
             auto hu = helpURLForSpecial("osc-select");
@@ -223,32 +200,28 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 });
             }
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options());
+            juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
+            contextMenu.showMenuAsync(optionsForPosition(cwhere));
 
             return 1;
         }
 
         if (tag == tag_scene_select)
         {
-            CRect r = viewSize;
-            CRect menuRect;
-            CPoint where;
-            frame->getCurrentMouseLocation(where);
-            frame->localToFrame(where);
-
+            auto where =
+                frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+            auto r = control->asJuceComponent()->getBounds();
             // Assume vertical alignment of the scene buttons
-            int a = limit_range((int)((2 * (where.y - r.top)) / r.getHeight()), 0, n_scenes);
+            int a = limit_range((int)((2 * (where.y - r.getY())) / r.getHeight()), 0, n_scenes);
 
             if (auto aschsw = dynamic_cast<Surge::Widgets::MultiSwitch *>(control))
             {
                 if (aschsw->getColumns() == n_scenes)
                 {
                     // We are horizontal due to skins or whatever so
-                    a = limit_range((int)((2 * (where.x - r.left)) / r.getWidth()), 0, n_scenes);
+                    a = limit_range((int)((2 * (where.x - r.getX())) / r.getWidth()), 0, n_scenes);
                 }
             }
-
-            menuRect.offset(where.x, where.y);
 
             auto contextMenu = juce::PopupMenu();
             auto hu = helpURLForSpecial("scene-select");
@@ -277,7 +250,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     queue_refresh = true;
                                 });
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options());
+            juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
+            contextMenu.showMenuAsync(optionsForPosition(cwhere));
 
             return 1;
         }
@@ -846,12 +820,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         // all the RMB context menus
         if (button & kRButton)
         {
-            CRect menuRect;
-            CPoint where;
-            frame->getCurrentMouseLocation(where);
-            frame->localToFrame(where);
-
-            menuRect.offset(where.x, where.y);
+            juce::Point<int> menuRect{};
 
             auto contextMenu = juce::PopupMenu();
             std::string helpurl = helpURLFor(p);
@@ -2146,10 +2115,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     if (tag == tag_status_zoom)
     {
         control->setValue(0);
-        CPoint where;
-        frame->getCurrentMouseLocation(where);
-        frame->localToFrame(where);
-
+        juce::Point<int> where = control->asJuceComponent()->getBounds().getBottomLeft();
         showZoomMenu(where);
         return;
     }
@@ -2157,9 +2123,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     if (tag == tag_lfo_menu)
     {
         control->setValue(0);
-        CPoint where;
-        frame->getCurrentMouseLocation(where);
-        frame->localToFrame(where);
+        juce::Point<int> where{};
 
         showLfoMenu(where);
         return;
@@ -2429,23 +2393,18 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     break;
     case tag_settingsmenu:
     {
-        CRect r = viewSize;
-        CRect menuRect;
-        CPoint where;
-        frame->getCurrentMouseLocation(where);
-        frame->localToFrame(where);
-
-        menuRect.offset(where.x, where.y);
+        juce::Point<int> menuPoint;
 
         // settings is a special case since it uses value here.
         if (auto msc = dynamic_cast<Surge::Widgets::MultiSwitch *>(control))
         {
             msc->isHovered = false;
             msc->repaint();
+            menuPoint = msc->getBounds().getTopLeft();
         }
 
         useDevMenu = false;
-        showSettingsMenu(menuRect);
+        showSettingsMenu(menuPoint);
     }
     break;
     case tag_osc_select:

--- a/src/gui/widgets/MainFrame.cpp
+++ b/src/gui/widgets/MainFrame.cpp
@@ -31,8 +31,7 @@ void MainFrame::mouseDown(const juce::MouseEvent &event)
     if (event.mods.isPopupMenu())
     {
         editor->useDevMenu = false;
-        auto r = VSTGUI::CRect();
-        editor->showSettingsMenu(r);
+        editor->showSettingsMenu(juce::Point<int>{});
     }
 }
 } // namespace Widgets

--- a/src/gui/widgets/MainFrame.h
+++ b/src/gui/widgets/MainFrame.h
@@ -44,25 +44,6 @@ struct MainFrame : public juce::Component
     }
 
     void mouseDown(const juce::MouseEvent &event) override;
-
-    /*
-     * Kill these before I'm done
-     */
-    void localToFrame(VSTGUI::CPoint &p) { UNIMPL; };
-    void setZoom(float z) { OKUNIMPL; }
-    void getPosition(float &x, float &y)
-    {
-        auto b = getScreenPosition();
-        x = b.x;
-        y = b.y;
-    }
-    void getCurrentMouseLocation(VSTGUI::CPoint &w)
-    {
-        auto pq = juce::Desktop::getInstance().getMainMouseSource().getScreenPosition();
-        auto b = getLocalPoint(nullptr, pq);
-        w.x = b.x;
-        w.y = b.y;
-    }
 };
 } // namespace Widgets
 } // namespace Surge


### PR DESCRIPTION
while at it add some menu alignment. if we don't like it we can
just turn it off in optionForPoint of course.