### PR TITLE
Fix an overlay ownership issue which crashed windows

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -199,6 +199,7 @@ void SurgeGUIEditor::idle()
     if (editor_open && frame && !synth->halt_engine)
     {
         idleInfowindow();
+        juceDeleteOnIdle.clear();
         /*
          * USEFUL for testing stress patch changes
          *
@@ -3520,6 +3521,7 @@ void SurgeGUIEditor::dismissEditorOfType(OverlayTags ofType)
         if (juceOverlays[ofType])
         {
             frame->removeChildComponent(juceOverlays[ofType].get());
+            juceDeleteOnIdle.push_back(std::move(juceOverlays[ofType]));
         }
         juceOverlays.erase(ofType);
     }

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -335,6 +335,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         const juce::Rectangle<int> &containerBounds, bool showCloseButton = true,
         std::function<void()> onClose = []() {});
     std::unordered_map<OverlayTags, std::unique_ptr<Surge::Overlays::OverlayWrapper>> juceOverlays;
+    std::vector<std::unique_ptr<Surge::Overlays::OverlayWrapper>> juceDeleteOnIdle;
 
     void dismissEditorOfType(OverlayTags ofType);
     OverlayTags topmostEditorTag()


### PR DESCRIPTION
The close button woujld delete the window using the
close callback which was owned by the close window.
You see the problem there right?

Anyway enqueu the overlay for close at idle instead