### PR TITLE
Move APIs to SurgeImage; Restore PNG Zoom support

### DIFF
--- a/src/gui/SkinSupport.cpp
+++ b/src/gui/SkinSupport.cpp
@@ -1305,34 +1305,34 @@ Skin::Control::Control()
     sessionid = sidc++;
 }
 
-std::array<juce::Drawable *, 3>
+std::array<SurgeImage *, 3>
 Skin::standardHoverAndHoverOnForControl(Skin::Control::ptr_t c, std::shared_ptr<SurgeImageStore> b)
 {
     auto csb = backgroundBitmapForControl(c, b);
     return standardHoverAndHoverOnForCSB(csb, c, b);
 }
-std::array<juce::Drawable *, 3>
-Skin::standardHoverAndHoverOnForIDB(int id, std::shared_ptr<SurgeImageStore> b)
+std::array<SurgeImage *, 3> Skin::standardHoverAndHoverOnForIDB(int id,
+                                                                std::shared_ptr<SurgeImageStore> b)
 {
     auto csb = b->getImage(id);
     return standardHoverAndHoverOnForCSB(csb, nullptr, b);
 }
-std::array<juce::Drawable *, 3>
-Skin::standardHoverAndHoverOnForCSB(SurgeImage *csb, Skin::Control::ptr_t c,
-                                    std::shared_ptr<SurgeImageStore> b)
+std::array<SurgeImage *, 3> Skin::standardHoverAndHoverOnForCSB(SurgeImage *csb,
+                                                                Skin::Control::ptr_t c,
+                                                                std::shared_ptr<SurgeImageStore> b)
 {
-    std::array<juce::Drawable *, 3> res;
-    res[0] = csb->getDrawable();
+    std::array<SurgeImage *, 3> res;
+    res[0] = csb;
 
     auto hoverBmp =
         hoverBitmapOverlayForBackgroundBitmap(c, csb, b, Surge::GUI::Skin::HoverType::HOVER);
 
-    res[1] = hoverBmp ? hoverBmp->getDrawable() : nullptr;
+    res[1] = hoverBmp ? hoverBmp : nullptr;
 
     auto hoverOnBmp = hoverBitmapOverlayForBackgroundBitmap(
         c, csb, b, Surge::GUI::Skin::HoverType::HOVER_OVER_ON);
 
-    res[2] = hoverOnBmp ? hoverOnBmp->getDrawable() : nullptr;
+    res[2] = hoverOnBmp ? hoverOnBmp : nullptr;
     return res;
 }
 

--- a/src/gui/SkinSupport.h
+++ b/src/gui/SkinSupport.h
@@ -333,13 +333,13 @@ class Skin
                                                       std::shared_ptr<SurgeImageStore> bitmapStore,
                                                       HoverType t);
 
-    std::array<juce::Drawable *, 3>
+    std::array<SurgeImage *, 3>
     standardHoverAndHoverOnForControl(Skin::Control::ptr_t c, std::shared_ptr<SurgeImageStore> b);
-    std::array<juce::Drawable *, 3>
-    standardHoverAndHoverOnForIDB(int id, std::shared_ptr<SurgeImageStore> b);
-    std::array<juce::Drawable *, 3>
-    standardHoverAndHoverOnForCSB(SurgeImage *csb, Skin::Control::ptr_t c,
-                                  std::shared_ptr<SurgeImageStore> b);
+    std::array<SurgeImage *, 3> standardHoverAndHoverOnForIDB(int id,
+                                                              std::shared_ptr<SurgeImageStore> b);
+    std::array<SurgeImage *, 3> standardHoverAndHoverOnForCSB(SurgeImage *csb,
+                                                              Skin::Control::ptr_t c,
+                                                              std::shared_ptr<SurgeImageStore> b);
 
     std::vector<Skin::Control::ptr_t> getLabels() const
     {

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -1227,7 +1227,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             fc->setBounds(skinCtrl->getRect());
             fc->setTag(tag_fx_select);
             fc->setSkin(currentSkin, bitmapStore);
-            fc->setBackgroundDrawable(bitmapStore->getImage(IDB_FX_GRID)->getDrawable());
+            fc->setBackgroundDrawable(bitmapStore->getImage(IDB_FX_GRID));
             fc->setCurrentEffect(current_fx);
 
             for (int fxi = 0; fxi < n_fx_slots; fxi++)
@@ -1439,7 +1439,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             auto image = currentSkin->propertyValue(l, Surge::Skin::Component::IMAGE);
             if (image.isJust())
             {
-                auto bmp = bitmapStore->getImageByStringID(image.fromJust())->getDrawable();
+                auto bmp = bitmapStore->getImageByStringID(image.fromJust());
                 if (bmp)
                 {
                     jassert(false);
@@ -1776,6 +1776,7 @@ void SurgeGUIEditor::setZoomFactor(float zf, bool resizeWindow)
         juceEditor->setSize(currentSkin->getWindowSizeX(), currentSkin->getWindowSizeY() + yExtra);
     }
     juceEditor->setScaleFactor(zoomFactor * 0.01);
+    setBitmapZoomFactor(zoomFactor);
 }
 
 void SurgeGUIEditor::setBitmapZoomFactor(float zf)
@@ -3108,12 +3109,12 @@ void SurgeGUIEditor::reloadFromSkin()
 
     if (bg != "")
     {
-        auto *cbm = bitmapStore->getImageByStringID(bg)->getDrawable();
+        auto *cbm = bitmapStore->getImageByStringID(bg);
         frame->setBackground(cbm);
     }
     else
     {
-        auto *cbm = bitmapStore->getImage(IDB_MAIN_BG)->getDrawable();
+        auto *cbm = bitmapStore->getImage(IDB_MAIN_BG);
         frame->setBackground(cbm);
     }
 
@@ -3538,7 +3539,7 @@ void SurgeGUIEditor::addJuceEditorOverlay(
     ol->setTitle(editorTitle);
     ol->setSkin(currentSkin, bitmapStore);
     ol->setSurgeGUIEditor(this);
-    ol->setIcon(bitmapStore->getImage(IDB_SURGE_ICON)->getDrawable());
+    ol->setIcon(bitmapStore->getImage(IDB_SURGE_ICON));
     ol->setShowCloseButton(showCloseButton);
     ol->setCloseOverlay([this, editorTag, onClose]() {
         this->dismissEditorOfType(editorTag);
@@ -4053,9 +4054,9 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
         oscMenu->addListener(this);
         oscMenu->setStorage(&(synth->storage));
         oscMenu->setSkin(currentSkin, bitmapStore, skinCtrl);
-        oscMenu->setBackgroundDrawable(bitmapStore->getImage(IDB_OSC_MENU)->getDrawable());
+        oscMenu->setBackgroundDrawable(bitmapStore->getImage(IDB_OSC_MENU));
         auto id = currentSkin->hoverImageIdForResource(IDB_OSC_MENU, Surge::GUI::Skin::HOVER);
-        auto bhov = bitmapStore->getImageByStringID(id)->getDrawable();
+        auto bhov = bitmapStore->getImageByStringID(id);
         oscMenu->setHoverBackgroundDrawable(bhov);
         oscMenu->setBounds(skinCtrl->x, skinCtrl->y, skinCtrl->w, skinCtrl->h);
         oscMenu->setOscillatorStorage(
@@ -4087,9 +4088,9 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
         fxMenu->addListener(this);
         fxMenu->setStorage(&(synth->storage));
         fxMenu->setSkin(currentSkin, bitmapStore, skinCtrl);
-        fxMenu->setBackgroundDrawable(bitmapStore->getImage(IDB_MENU_AS_SLIDER)->getDrawable());
+        fxMenu->setBackgroundDrawable(bitmapStore->getImage(IDB_MENU_AS_SLIDER));
         auto id = currentSkin->hoverImageIdForResource(IDB_MENU_AS_SLIDER, Surge::GUI::Skin::HOVER);
-        auto bhov = bitmapStore->getImageByStringID(id)->getDrawable();
+        auto bhov = bitmapStore->getImageByStringID(id);
         fxMenu->setHoverBackgroundDrawable(bhov);
         fxMenu->setBounds(skinCtrl->x, skinCtrl->y, skinCtrl->w, skinCtrl->h);
         fxMenu->setFxStorage(&synth->storage.getPatch().fx[current_fx]);
@@ -4201,16 +4202,15 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
         auto pv = currentSkin->propertyValue(skinCtrl, Surge::Skin::Component::BACKGROUND);
         if (pv.isJust())
         {
-            hsw->setBackgroundDrawable(
-                bitmapStore->getImageByStringID(pv.fromJust())->getDrawable());
+            hsw->setBackgroundDrawable(bitmapStore->getImageByStringID(pv.fromJust()));
             jassert(false); // hover
         }
         else
         {
-            hsw->setBackgroundDrawable(bitmapStore->getImage(IDB_FILTER_MENU)->getDrawable());
+            hsw->setBackgroundDrawable(bitmapStore->getImage(IDB_FILTER_MENU));
             auto id =
                 currentSkin->hoverImageIdForResource(IDB_FILTER_MENU, Surge::GUI::Skin::HOVER);
-            auto bhov = bitmapStore->getImageByStringID(id)->getDrawable();
+            auto bhov = bitmapStore->getImageByStringID(id);
             hsw->setHoverBackgroundDrawable(bhov);
         }
 
@@ -4249,12 +4249,10 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
                 auto drr = rect.withWidth(18);
 
                 hsw->setDragRegion(drr);
-                hsw->setDragGlyph(bitmapStore->getImage(IDB_FILTER_ICONS)->getDrawable(), 18);
+                hsw->setDragGlyph(bitmapStore->getImage(IDB_FILTER_ICONS), 18);
                 hsw->setDragGlyphHover(
-                    bitmapStore
-                        ->getImageByStringID(currentSkin->hoverImageIdForResource(
-                            IDB_FILTER_ICONS, Surge::GUI::Skin::HOVER))
-                        ->getDrawable());
+                    bitmapStore->getImageByStringID(currentSkin->hoverImageIdForResource(
+                        IDB_FILTER_ICONS, Surge::GUI::Skin::HOVER)));
             }
             else
             {
@@ -4584,7 +4582,7 @@ void SurgeGUIEditor::hideAboutScreen() { frame->removeChildComponent(aboutScreen
 
 void SurgeGUIEditor::showMidiLearnOverlay(const juce::Rectangle<int> &r)
 {
-    midiLearnOverlay = bitmapStore->getImage(IDB_MIDI_LEARN)->getDrawable()->createCopy();
+    midiLearnOverlay = bitmapStore->getImage(IDB_MIDI_LEARN)->createCopy();
     midiLearnOverlay->setInterceptsMouseClicks(false, false);
     midiLearnOverlay->setBounds(r);
     frame->addAndMakeVisible(midiLearnOverlay.get());

--- a/src/gui/SurgeImage.h
+++ b/src/gui/SurgeImage.h
@@ -26,18 +26,39 @@ class SurgeImage
     int resourceID = -1;
     std::string fname;
 
-    juce::Drawable *getDrawable() const
+    void draw(juce::Graphics &g, float opacity,
+              const juce::AffineTransform &transform = juce::AffineTransform()) const
     {
-        if (drawable)
-            return drawable.get();
-        return nullptr;
+        juce::Graphics::ScopedSaveState gs(g);
+        g.addTransform(scaleAdjustmentTransform());
+        internalDrawableResolved()->draw(g, opacity, transform);
+    }
+    void drawAt(juce::Graphics &g, float x, float y, float opacity) const
+    {
+        juce::Graphics::ScopedSaveState gs(g);
+        g.addTransform(scaleAdjustmentTransform());
+        internalDrawableResolved()->drawAt(g, x, y, opacity);
+    }
+    void drawWithin(juce::Graphics &g, juce::Rectangle<float> destArea,
+                    juce::RectanglePlacement placement, float opacity) const
+    {
+        juce::Graphics::ScopedSaveState gs(g);
+        g.addTransform(scaleAdjustmentTransform());
+        internalDrawableResolved()->drawWithin(g, destArea, placement, opacity);
+    }
+
+    std::unique_ptr<juce::Drawable> createCopy()
+    {
+        return internalDrawableResolved()->createCopy();
     }
 
   private:
-    static std::atomic<int> instances;
+    juce::Drawable *internalDrawableResolved() const;
+    juce::AffineTransform scaleAdjustmentTransform() const;
 
-    int lastSeenZoom, bestFitScaleGroup;
-    int extraScaleFactor;
+    static std::atomic<int> instances;
+    bool adjustForScale{false};
+    int resolvedZoomFactor{100};
 
     /*
      * The zoom 100 bitmap and optional higher resolution bitmaps for zooms
@@ -47,4 +68,5 @@ class SurgeImage
     int currentPhysicalZoomFactor;
 
     std::unique_ptr<juce::Drawable> drawable;
+    juce::Drawable *currentDrawable{nullptr};
 };

--- a/src/gui/SurgeImageStore.cpp
+++ b/src/gui/SurgeImageStore.cpp
@@ -137,30 +137,6 @@ SurgeImage *SurgeImageStore::getImageByStringID(const std::string &id)
     return bitmap_stringid_registry[id];
 }
 
-juce::Drawable *SurgeImageStore::getDrawable(int id)
-{
-    auto r = getImage(id);
-    if (r)
-        return r->getDrawable();
-    return nullptr;
-}
-
-juce::Drawable *SurgeImageStore::getDrawableByPath(const std::string &filename)
-{
-    auto r = getImageByPath(filename);
-    if (r)
-        return r->getDrawable();
-    return nullptr;
-}
-
-juce::Drawable *SurgeImageStore::getDrawableByStringID(const std::string &id)
-{
-    auto r = getImageByStringID(id);
-    if (r)
-        return r->getDrawable();
-    return nullptr;
-}
-
 SurgeImage *SurgeImageStore::loadImageByPath(const std::string &filename)
 {
     if (bitmap_file_registry.find(filename) != bitmap_file_registry.end())

--- a/src/gui/SurgeImageStore.h
+++ b/src/gui/SurgeImageStore.h
@@ -23,10 +23,6 @@ class SurgeImageStore
     SurgeImage *getImageByPath(const std::string &filename);
     SurgeImage *getImageByStringID(const std::string &id);
 
-    juce::Drawable *getDrawable(int id);
-    juce::Drawable *getDrawableByPath(const std::string &filename);
-    juce::Drawable *getDrawableByStringID(const std::string &id);
-
     SurgeImage *loadImageByPath(const std::string &filename);
     SurgeImage *loadImageByPathForID(const std::string &filename, int id);
     SurgeImage *loadImageByPathForStringID(const std::string &filename, std::string id);

--- a/src/gui/overlays/AboutScreen.cpp
+++ b/src/gui/overlays/AboutScreen.cpp
@@ -251,10 +251,7 @@ void AboutScreen::mouseUp(const juce::MouseEvent &e)
         editor->hideAboutScreen();
 }
 
-void AboutScreen::onSkinChanged()
-{
-    logo = associatedBitmapStore->getImage(IDB_ABOUT_BG)->getDrawable();
-}
+void AboutScreen::onSkinChanged() { logo = associatedBitmapStore->getImage(IDB_ABOUT_BG); }
 
 } // namespace Overlays
 } // namespace Surge

--- a/src/gui/overlays/AboutScreen.h
+++ b/src/gui/overlays/AboutScreen.h
@@ -53,7 +53,7 @@ struct AboutScreen : public juce::Component,
     void buttonClicked(juce::Button *button) override;
 
     void onSkinChanged() override;
-    juce::Drawable *logo{nullptr};
+    SurgeImage *logo{nullptr};
     int logoW{555}, logoH{179};
 
     // label, value, url

--- a/src/gui/overlays/MSEGEditor.cpp
+++ b/src/gui/overlays/MSEGEditor.cpp
@@ -96,7 +96,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         this->eds = eds;
         this->lfodata = lfodata;
         Surge::MSEG::rebuildCache(ms);
-        handleDrawable = b->getImage(IDB_MSEG_NODES)->getDrawable();
+        handleDrawable = b->getImage(IDB_MSEG_NODES);
         timeEditMode = (MSEGCanvas::TimeEdit)eds->timeEditMode;
     };
 
@@ -2349,7 +2349,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
     float loopDragTime = -1, loopDragEnd = -1;
     bool loopDragIsStart = false;
 
-    juce::Drawable *handleDrawable{nullptr};
+    SurgeImage *handleDrawable{nullptr};
 };
 
 void MSEGControlRegion::valueChanged(Surge::GUI::IComponentTagValue *p)
@@ -2733,11 +2733,11 @@ void MSEGControlRegion::rebuild()
         hSnapButton->setTag(tag_horizontal_snap);
         hSnapButton->setValue(ms->hSnap < 0.001 ? 0 : 1);
         auto hsbmp = associatedBitmapStore->getImage(IDB_MSEG_HORIZONTAL_SNAP);
-        hSnapButton->setSwitchDrawable(hsbmp->getDrawable());
+        hSnapButton->setSwitchDrawable(hsbmp);
         auto hoverBmp = skin->hoverBitmapOverlayForBackgroundBitmap(
             nullptr, dynamic_cast<SurgeImage *>(hsbmp), associatedBitmapStore,
             Surge::GUI::Skin::HoverType::HOVER);
-        hSnapButton->setHoverSwitchDrawable(hoverBmp->getDrawable());
+        hSnapButton->setHoverSwitchDrawable(hoverBmp);
         addAndMakeVisible(*hSnapButton);
 
         snprintf(svt, 255, "%d", (int)round(1.f / ms->hSnapDefault));
@@ -2767,10 +2767,10 @@ void MSEGControlRegion::rebuild()
         vSnapButton->setTag(tag_vertical_snap);
         vSnapButton->setValue(ms->vSnap < 0.001 ? 0 : 1);
         auto vsbmp = associatedBitmapStore->getImage(IDB_MSEG_VERTICAL_SNAP);
-        vSnapButton->setSwitchDrawable(vsbmp->getDrawable());
+        vSnapButton->setSwitchDrawable(vsbmp);
         hoverBmp = skin->hoverBitmapOverlayForBackgroundBitmap(
             nullptr, vsbmp, associatedBitmapStore, Surge::GUI::Skin::HoverType::HOVER);
-        vSnapButton->setHoverSwitchDrawable(hoverBmp->getDrawable());
+        vSnapButton->setHoverSwitchDrawable(hoverBmp);
         addAndMakeVisible(*vSnapButton);
 
         snprintf(svt, 255, "%d", (int)round(1.f / ms->vSnapDefault));

--- a/src/gui/overlays/MiniEdit.cpp
+++ b/src/gui/overlays/MiniEdit.cpp
@@ -67,7 +67,7 @@ void MiniEdit::paint(juce::Graphics &g)
     g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(11));
     g.drawText(title, tbRect, juce::Justification::centred);
 
-    auto d = associatedBitmapStore->getImage(IDB_SURGE_ICON)->getDrawable();
+    auto d = associatedBitmapStore->getImage(IDB_SURGE_ICON);
     if (d)
     {
         d->drawAt(g, fullRect.getX(), fullRect.getY(), 1.0);

--- a/src/gui/overlays/OverlayWrapper.cpp
+++ b/src/gui/overlays/OverlayWrapper.cpp
@@ -15,6 +15,7 @@
 
 #include "OverlayWrapper.h"
 #include "RuntimeFont.h"
+#include "SurgeImage.h"
 
 namespace Surge
 {

--- a/src/gui/overlays/OverlayWrapper.h
+++ b/src/gui/overlays/OverlayWrapper.h
@@ -20,6 +20,7 @@
 #include "SkinSupport.h"
 
 class SurgeGUIEditor;
+class SurgeImage;
 
 namespace Surge
 {
@@ -46,8 +47,8 @@ struct OverlayWrapper : public juce::Component,
     std::unique_ptr<juce::TextButton> closeButton;
     void buttonClicked(juce::Button *button) override;
 
-    juce::Drawable *icon{nullptr};
-    void setIcon(juce::Drawable *d) { icon = d; }
+    SurgeImage *icon{nullptr};
+    void setIcon(SurgeImage *d) { icon = d; }
 
     bool showCloseButton{true};
     void setShowCloseButton(bool b) { showCloseButton = b; }

--- a/src/gui/widgets/EffectChooser.cpp
+++ b/src/gui/widgets/EffectChooser.cpp
@@ -16,6 +16,7 @@
 
 #include "RuntimeFont.h"
 #include "SurgeGUIEditor.h"
+#include "SurgeImage.h"
 
 namespace Surge
 {

--- a/src/gui/widgets/EffectChooser.h
+++ b/src/gui/widgets/EffectChooser.h
@@ -79,8 +79,8 @@ struct EffectChooser : public juce::Component, public WidgetBaseMixin<EffectChoo
     int getDeactivatedBitmask() const { return deactivatedBitmask; }
     int deactivatedBitmask{0};
 
-    juce::Drawable *bg{nullptr};
-    void setBackgroundDrawable(juce::Drawable *b) { bg = b; }
+    SurgeImage *bg{nullptr};
+    void setBackgroundDrawable(SurgeImage *b) { bg = b; }
 
     juce::Rectangle<int> getSceneRectangle(int sceneNo);
     juce::Rectangle<int> getEffectRectangle(int fx);

--- a/src/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/gui/widgets/LFOAndStepDisplay.cpp
@@ -15,6 +15,7 @@
 
 #include "LFOAndStepDisplay.h"
 #include "SurgeImageStore.h"
+#include "SurgeImage.h"
 #include "SurgeGUIEditor.h"
 #include "RuntimeFont.h"
 #include <chrono>

--- a/src/gui/widgets/LFOAndStepDisplay.h
+++ b/src/gui/widgets/LFOAndStepDisplay.h
@@ -109,7 +109,7 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
 
     void onSkinChanged() override;
 
-    juce::Drawable *typeImg{nullptr}, *typeImgHover{nullptr}, *typeImgHoverOn{nullptr};
+    SurgeImage *typeImg{nullptr}, *typeImgHover{nullptr}, *typeImgHoverOn{nullptr};
 
     const static int margin = 2;
     const static int margin2 = 7;

--- a/src/gui/widgets/MainFrame.h
+++ b/src/gui/widgets/MainFrame.h
@@ -17,6 +17,7 @@
 #define SURGE_XT_MAINFRAME_H
 
 #include <JuceHeader.h>
+#include "SurgeImage.h"
 
 class SurgeGUIEditor;
 
@@ -29,8 +30,8 @@ struct MainFrame : public juce::Component
     SurgeGUIEditor *editor{nullptr};
     void setSurgeGUIEditor(SurgeGUIEditor *e) { editor = e; }
 
-    juce::Drawable *bg{nullptr};
-    void setBackground(juce::Drawable *d)
+    SurgeImage *bg{nullptr};
+    void setBackground(SurgeImage *d)
     {
         bg = d;
         repaint();

--- a/src/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/gui/widgets/MenuForDiscreteParams.cpp
@@ -17,6 +17,7 @@
 #include "SurgeGUIEditor.h"
 #include "SurgeGUIUtils.h"
 #include "RuntimeFont.h"
+#include "SurgeImage.h"
 
 namespace Surge
 {

--- a/src/gui/widgets/MenuForDiscreteParams.h
+++ b/src/gui/widgets/MenuForDiscreteParams.h
@@ -23,6 +23,7 @@
 #include "SurgeJUCEHelpers.h"
 #include <vector>
 
+class SurgeImage;
 class SurgeStorage;
 
 namespace Surge
@@ -64,7 +65,7 @@ struct MenuForDiscreteParams : public juce::Component,
     std::vector<std::pair<int, int>> gli;
     void addGlyphIndexMapEntry(int a, int b) { gli.emplace_back(a, b); }
 
-    juce::Drawable *dragGlyph{nullptr}, *dragGlyphHover{nullptr};
+    SurgeImage *dragGlyph{nullptr}, *dragGlyphHover{nullptr};
     int dragGlyphBoxSize{0};
     enum GlyphLocation
     {
@@ -73,20 +74,20 @@ struct MenuForDiscreteParams : public juce::Component,
         LEFT,
         RIGHT
     } glyphLocation = LEFT;
-    void setDragGlyph(juce::Drawable *d, int boxSize)
+    void setDragGlyph(SurgeImage *d, int boxSize)
     {
         dragGlyph = d;
         dragGlyphBoxSize = boxSize;
     }
-    void setDragGlyphHover(juce::Drawable *d) { dragGlyphHover = d; }
+    void setDragGlyphHover(SurgeImage *d) { dragGlyphHover = d; }
     juce::Rectangle<float> glyphPosition;
 
     void setGlyphMode(bool b) { glyphMode = b; }
     bool glyphMode{false};
 
-    void setBackgroundDrawable(juce::Drawable *d) { bg = d; }
-    void setHoverBackgroundDrawable(juce::Drawable *d) { bghover = d; }
-    juce::Drawable *bg{nullptr}, *bghover{nullptr};
+    void setBackgroundDrawable(SurgeImage *d) { bg = d; }
+    void setHoverBackgroundDrawable(SurgeImage *d) { bghover = d; }
+    SurgeImage *bg{nullptr}, *bghover{nullptr};
 
     void paint(juce::Graphics &g) override;
     bool isHovered{false};

--- a/src/gui/widgets/ModulatableSlider.cpp
+++ b/src/gui/widgets/ModulatableSlider.cpp
@@ -226,27 +226,26 @@ void ModulatableSlider::onSkinChanged()
 {
     if (orientation == ParamConfig::kHorizontal)
     {
-        pTray = associatedBitmapStore->getDrawable(IDB_SLIDER_HORIZ_BG);
-        pHandle = associatedBitmapStore->getDrawable(IDB_SLIDER_HORIZ_HANDLE);
-        pHandleHover = associatedBitmapStore->getDrawableByStringID(
+        pTray = associatedBitmapStore->getImage(IDB_SLIDER_HORIZ_BG);
+        pHandle = associatedBitmapStore->getImage(IDB_SLIDER_HORIZ_HANDLE);
+        pHandleHover = associatedBitmapStore->getImageByStringID(
             skin->hoverImageIdForResource(IDB_SLIDER_HORIZ_HANDLE, GUI::Skin::HOVER));
         jassert(pHandleHover);
         pTempoSyncHandle =
-            associatedBitmapStore->getDrawableByStringID("TEMPOSYNC_HORIZONTAL_OVERLAY");
+            associatedBitmapStore->getImageByStringID("TEMPOSYNC_HORIZONTAL_OVERLAY");
         pTempoSyncHoverHandle =
-            associatedBitmapStore->getDrawableByStringID("TEMPOSYNC_HORIZONTAL_HOVER_OVERLAY");
+            associatedBitmapStore->getImageByStringID("TEMPOSYNC_HORIZONTAL_HOVER_OVERLAY");
     }
     else
     {
-        pTray = associatedBitmapStore->getDrawable(IDB_SLIDER_VERT_BG);
-        pHandle = associatedBitmapStore->getDrawable(IDB_SLIDER_VERT_HANDLE);
-        pHandleHover = associatedBitmapStore->getDrawableByStringID(
+        pTray = associatedBitmapStore->getImage(IDB_SLIDER_VERT_BG);
+        pHandle = associatedBitmapStore->getImage(IDB_SLIDER_VERT_HANDLE);
+        pHandleHover = associatedBitmapStore->getImageByStringID(
             skin->hoverImageIdForResource(IDB_SLIDER_VERT_HANDLE, GUI::Skin::HOVER));
 
-        pTempoSyncHandle =
-            associatedBitmapStore->getDrawableByStringID("TEMPOSYNC_VERTICAL_OVERLAY");
+        pTempoSyncHandle = associatedBitmapStore->getImageByStringID("TEMPOSYNC_VERTICAL_OVERLAY");
         pTempoSyncHoverHandle =
-            associatedBitmapStore->getDrawableByStringID("TEMPOSYNC_VERTICAL_HOVER_OVERLAY");
+            associatedBitmapStore->getImageByStringID("TEMPOSYNC_VERTICAL_HOVER_OVERLAY");
     }
 
     if (skinControl.get())
@@ -254,29 +253,29 @@ void ModulatableSlider::onSkinChanged()
         auto htr = skin->propertyValue(skinControl, Surge::Skin::Component::SLIDER_TRAY);
         if (htr.isJust())
         {
-            pTray = associatedBitmapStore->getDrawableByStringID(htr.fromJust());
+            pTray = associatedBitmapStore->getImageByStringID(htr.fromJust());
         }
         auto hi = skin->propertyValue(skinControl, Surge::Skin::Component::HANDLE_IMAGE);
         if (hi.isJust())
         {
-            pHandle = associatedBitmapStore->getDrawableByStringID(hi.fromJust());
+            pHandle = associatedBitmapStore->getImageByStringID(hi.fromJust());
         }
         auto ho = skin->propertyValue(skinControl, Surge::Skin::Component::HANDLE_HOVER_IMAGE);
         if (ho.isJust())
         {
-            pHandleHover = associatedBitmapStore->getDrawableByStringID(ho.fromJust());
+            pHandleHover = associatedBitmapStore->getImageByStringID(ho.fromJust());
         }
         auto ht = skin->propertyValue(skinControl, Surge::Skin::Component::HANDLE_TEMPOSYNC_IMAGE);
         if (ht.isJust())
         {
-            pTempoSyncHandle = associatedBitmapStore->getDrawableByStringID(ht.fromJust());
+            pTempoSyncHandle = associatedBitmapStore->getImageByStringID(ht.fromJust());
         }
 
         auto hth =
             skin->propertyValue(skinControl, Surge::Skin::Component::HANDLE_TEMPOSYNC_HOVER_IMAGE);
         if (hth.isJust())
         {
-            pTempoSyncHoverHandle = associatedBitmapStore->getDrawableByStringID(hth.fromJust());
+            pTempoSyncHoverHandle = associatedBitmapStore->getImageByStringID(hth.fromJust());
         }
     }
 

--- a/src/gui/widgets/ModulatableSlider.h
+++ b/src/gui/widgets/ModulatableSlider.h
@@ -100,7 +100,7 @@ struct ModulatableSlider : public juce::Component,
 
     void onSkinChanged() override;
 
-    juce::Drawable *pTray, *pHandle, *pHandleHover, *pTempoSyncHandle, *pTempoSyncHoverHandle;
+    SurgeImage *pTray, *pHandle, *pHandleHover, *pTempoSyncHandle, *pTempoSyncHoverHandle;
 
   private:
     // I know right Here I am using private!

--- a/src/gui/widgets/ModulationSourceButton.cpp
+++ b/src/gui/widgets/ModulationSourceButton.cpp
@@ -310,7 +310,7 @@ void ModulationSourceButton::mouseExit(const juce::MouseEvent &event)
 
 void ModulationSourceButton::onSkinChanged()
 {
-    arrow = associatedBitmapStore->getDrawable(IDB_MODSOURCE_SHOW_LFO);
+    arrow = associatedBitmapStore->getImage(IDB_MODSOURCE_SHOW_LFO);
 }
 
 void ModulationSourceButton::mouseUp(const juce::MouseEvent &event)

--- a/src/gui/widgets/ModulationSourceButton.h
+++ b/src/gui/widgets/ModulationSourceButton.h
@@ -111,7 +111,7 @@ struct ModulationSourceButton : public juce::Component,
 
     static constexpr int splitHeight = 14;
 
-    juce::Drawable *arrow{nullptr};
+    SurgeImage *arrow{nullptr};
 
     enum MouseState
     {

--- a/src/gui/widgets/MultiSwitch.cpp
+++ b/src/gui/widgets/MultiSwitch.cpp
@@ -14,6 +14,7 @@
 */
 
 #include "MultiSwitch.h"
+#include "SurgeImage.h"
 #include "basic_dsp.h"
 
 namespace Surge

--- a/src/gui/widgets/MultiSwitch.h
+++ b/src/gui/widgets/MultiSwitch.h
@@ -21,6 +21,8 @@
 #include "SkinSupport.h"
 #include "WidgetBaseMixin.h"
 
+class SurgeImage;
+
 namespace Surge
 {
 namespace Widgets
@@ -71,10 +73,10 @@ struct MultiSwitch : public juce::Component, public WidgetBaseMixin<MultiSwitch>
     bool isHovered{false};
     int hoverSelection{0};
 
-    juce::Drawable *switchD{nullptr}, *hoverSwitchD{nullptr}, *hoverOnSwitchD{nullptr};
-    void setSwitchDrawable(juce::Drawable *d) { switchD = d; }
-    void setHoverSwitchDrawable(juce::Drawable *d) { hoverSwitchD = d; }
-    void setHoverOnSwitchDrawable(juce::Drawable *d) { hoverOnSwitchD = d; }
+    SurgeImage *switchD{nullptr}, *hoverSwitchD{nullptr}, *hoverOnSwitchD{nullptr};
+    void setSwitchDrawable(SurgeImage *d) { switchD = d; }
+    void setHoverSwitchDrawable(SurgeImage *d) { hoverSwitchD = d; }
+    void setHoverOnSwitchDrawable(SurgeImage *d) { hoverOnSwitchD = d; }
 };
 } // namespace Widgets
 } // namespace Surge

--- a/src/gui/widgets/NumberField.h
+++ b/src/gui/widgets/NumberField.h
@@ -20,6 +20,7 @@
 #include "SkinModel.h"
 #include "WidgetBaseMixin.h"
 #include "SurgeJUCEHelpers.h"
+#include "SurgeImage.h"
 
 class SurgeStorage;
 
@@ -73,9 +74,9 @@ struct NumberField : public juce::Component, public WidgetBaseMixin<NumberField>
         DRAG
     } mouseMode{NONE};
 
-    juce::Drawable *bg{nullptr}, *bgHover{nullptr};
-    void setBackgroundDrawable(juce::Drawable *b) { bg = b; };
-    void setHoverBackgroundDrawable(juce::Drawable *bgh) { bgHover = bgh; }
+    SurgeImage *bg{nullptr}, *bgHover{nullptr};
+    void setBackgroundDrawable(SurgeImage *b) { bg = b; };
+    void setHoverBackgroundDrawable(SurgeImage *bgh) { bgHover = bgh; }
 
     juce::Point<float> mouseDownOrigin;
     float lastDistanceChecked{0};

--- a/src/gui/widgets/Switch.cpp
+++ b/src/gui/widgets/Switch.cpp
@@ -14,6 +14,7 @@
 */
 
 #include "Switch.h"
+#include "SurgeImage.h"
 
 namespace Surge
 {

--- a/src/gui/widgets/Switch.h
+++ b/src/gui/widgets/Switch.h
@@ -21,6 +21,8 @@
 #include "WidgetBaseMixin.h"
 #include "SurgeJUCEHelpers.h"
 
+class SurgeImage;
+
 namespace Surge
 {
 namespace Widgets
@@ -73,9 +75,9 @@ struct Switch : public juce::Component, public WidgetBaseMixin<Switch>
 
     bool isHovered{false};
 
-    juce::Drawable *switchD{nullptr}, *hoverSwitchD{nullptr};
-    void setSwitchDrawable(juce::Drawable *d) { switchD = d; }
-    void setHoverSwitchDrawable(juce::Drawable *d) { hoverSwitchD = d; }
+    SurgeImage *switchD{nullptr}, *hoverSwitchD{nullptr};
+    void setSwitchDrawable(SurgeImage *d) { switchD = d; }
+    void setHoverSwitchDrawable(SurgeImage *d) { hoverSwitchD = d; }
 };
 } // namespace Widgets
 } // namespace Surge

--- a/src/gui/widgets/VuMeter.cpp
+++ b/src/gui/widgets/VuMeter.cpp
@@ -109,7 +109,7 @@ void VuMeter::paint(juce::Graphics &g)
 
 void VuMeter::onSkinChanged()
 {
-    hVuBars = associatedBitmapStore->getDrawable(IDB_VUMETER_BARS);
+    hVuBars = associatedBitmapStore->getImage(IDB_VUMETER_BARS);
     jassert(hVuBars);
 }
 } // namespace Widgets

--- a/src/gui/widgets/VuMeter.h
+++ b/src/gui/widgets/VuMeter.h
@@ -19,6 +19,8 @@
 #include <JuceHeader.h>
 #include "WidgetBaseMixin.h"
 
+class SurgeImage;
+
 namespace Surge
 {
 namespace Widgets
@@ -41,7 +43,7 @@ struct VuMeter : public juce::Component, public WidgetBaseMixin<VuMeter>
     void paint(juce::Graphics &g) override;
 
     void onSkinChanged() override;
-    juce::Drawable *hVuBars;
+    SurgeImage *hVuBars;
 };
 } // namespace Widgets
 } // namespace Surge

--- a/src/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/gui/widgets/XMLConfiguredMenus.cpp
@@ -18,6 +18,7 @@
 #include "SurgeGUIEditor.h"
 #include "SurgeGUIUtils.h"
 #include "RuntimeFont.h"
+#include "SurgeImage.h"
 
 namespace Surge
 {

--- a/src/gui/widgets/XMLConfiguredMenus.h
+++ b/src/gui/widgets/XMLConfiguredMenus.h
@@ -25,6 +25,7 @@
 
 class SurgeStorage;
 class SurgeGUIEditor;
+class SurgeImage;
 class OscillatorStorage;
 class FxStorage;
 
@@ -114,9 +115,9 @@ struct OscillatorMenu : public juce::Component,
     OscillatorStorage *osc{nullptr};
     void setOscillatorStorage(OscillatorStorage *o) { osc = o; }
 
-    juce::Drawable *bg{}, *bgHover{};
-    void setBackgroundDrawable(juce::Drawable *b) { bg = b; };
-    void setHoverBackgroundDrawable(juce::Drawable *bgh) { bgHover = bgh; }
+    SurgeImage *bg{}, *bgHover{};
+    void setBackgroundDrawable(SurgeImage *b) { bg = b; };
+    void setHoverBackgroundDrawable(SurgeImage *bgh) { bgHover = bgh; }
 
     void paint(juce::Graphics &g) override;
 
@@ -171,9 +172,9 @@ struct FxMenu : public juce::Component, public XMLMenuPopulator, public WidgetBa
 
     void loadUserPreset(const Surge::FxUserPreset::Preset &p);
 
-    juce::Drawable *bg{}, *bgHover{};
-    void setBackgroundDrawable(juce::Drawable *b) { bg = b; };
-    void setHoverBackgroundDrawable(juce::Drawable *bgh) { bgHover = bgh; }
+    SurgeImage *bg{}, *bgHover{};
+    void setBackgroundDrawable(SurgeImage *b) { bg = b; };
+    void setHoverBackgroundDrawable(SurgeImage *bgh) { bgHover = bgh; }
 };
 } // namespace Widgets
 } // namespace Surge


### PR DESCRIPTION
The image API is now all SurgeImage which is basically a wrapper
upon multiple drawables and the load mechanism. Restore PNG zoom
as a result