### PR TITLE
Greatly improve unmapped note handling in Surge

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1855,7 +1855,7 @@ float glide_log(float x)
 
 bool SurgeStorage::resetToCurrentScaleAndMapping()
 {
-    currentTuning = Tunings::Tuning(currentScale, currentMapping);
+    currentTuning = Tunings::Tuning(currentScale, currentMapping).withSkippedNotesInterpolated();
 
     auto t = currentTuning;
 

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -344,6 +344,14 @@ void SurgeSynthesizer::playNote(char channel, char key, char velocity, char detu
         }
     }
 
+    if (!storage.isStandardTuning)
+    {
+        if (!storage.currentTuning.isMidiNoteMapped(key))
+        {
+            return;
+        }
+    }
+
     // For split/dual
     // MIDI Channel 1 plays the split/dual
     // MIDI Channel 2 plays A


### PR DESCRIPTION
1. Unmapped notes with native tunings now don't sound as opposed
   to sounding a constant frequency
2. Pitch bends across unmapped notes now do something reasonable

This brings our native mode in line with oddsound-mts for skipped note
handling

Address #4046