### PR TITLE
Minor MSEG editor GUI tweaks, NONE mode for numfield shows "-"

### DIFF
--- a/src/gui/widgets/NumberField.cpp
+++ b/src/gui/widgets/NumberField.cpp
@@ -30,6 +30,9 @@ std::string NumberField::valueToDisplay() const
     std::ostringstream oss;
     switch (controlMode)
     {
+    case Skin::Parameters::NONE:
+        oss << "-";
+        break;
     case Skin::Parameters::MIDICHANNEL_FROM_127:
     {
         int mc = iValue / 8 + 1;


### PR DESCRIPTION
This is all in order to match how 1.9 looked, with the exception of MSEG editor vertical tick markers, which now don't shift position of the bottommost marker when toggling Unipolar.
Also fixes incorrectly drawn gradient fill in unipolar mode.