### PR TITLE
Add an endHover explicit method and call it

### DIFF
--- a/src/gui/SurgeGUICallbackInterfaces.h
+++ b/src/gui/SurgeGUICallbackInterfaces.h
@@ -26,6 +26,8 @@ struct IComponentTagValue
     virtual float getValue() const = 0;
     virtual void setValue(float) = 0;
 
+    virtual void endHover() {}
+
     juce::Component *asJuceComponent()
     {
         auto r = dynamic_cast<juce::Component *>(this);

--- a/src/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -195,7 +195,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             }
 
             juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
-            contextMenu.showMenuAsync(optionsForPosition(cwhere));
+            contextMenu.showMenuAsync(optionsForPosition(cwhere),
+                                      [control](int i) { control->endHover(); });
 
             return 1;
         }
@@ -245,7 +246,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                 });
 
             juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
-            contextMenu.showMenuAsync(optionsForPosition(cwhere));
+            contextMenu.showMenuAsync(optionsForPosition(cwhere),
+                                      [control](int i) { control->endHover(); });
 
             return 1;
         }
@@ -775,7 +777,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             // FIXME: This one shouldn't be async yet since the macro can get swept underneath us
             contextMenu.showMenu(juce::PopupMenu::Options());
-
+            control->endHover();
             return 1;
         }
 
@@ -1952,7 +1954,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 }
             }
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options());
+            contextMenu.showMenuAsync(juce::PopupMenu::Options(),
+                                      [control](int i) { control->endHover(); });
 
             return 1;
         }

--- a/src/gui/widgets/EffectChooser.h
+++ b/src/gui/widgets/EffectChooser.h
@@ -68,6 +68,11 @@ struct EffectChooser : public juce::Component, public WidgetBaseMixin<EffectChoo
         mouseMove(event);
     }
     void mouseExit(const juce::MouseEvent &event) override { isHovered = false; }
+    void endHover() override
+    {
+        isHovered = false;
+        repaint();
+    }
     // State for mouse events
     bool isHovered{false}, hasDragged{false};
     int currentHover{-1}, currentClicked{-1};

--- a/src/gui/widgets/MenuForDiscreteParams.h
+++ b/src/gui/widgets/MenuForDiscreteParams.h
@@ -101,6 +101,11 @@ struct MenuForDiscreteParams : public juce::Component,
         isHovered = false;
         repaint();
     }
+    void endHover() override
+    {
+        isHovered = false;
+        repaint();
+    }
     juce::Point<int> mouseDownOrigin;
     bool isDraggingGlyph{false};
     float lastDragDistance{0};

--- a/src/gui/widgets/ModulatableSlider.cpp
+++ b/src/gui/widgets/ModulatableSlider.cpp
@@ -297,7 +297,9 @@ void ModulatableSlider::mouseEnter(const juce::MouseEvent &event)
     }
 }
 
-void ModulatableSlider::mouseExit(const juce::MouseEvent &event)
+void ModulatableSlider::mouseExit(const juce::MouseEvent &event) { endHover(); }
+
+void ModulatableSlider::endHover()
 {
     isHovered = false;
     auto sge = firstListenerOfType<SurgeGUIEditor>();
@@ -305,6 +307,7 @@ void ModulatableSlider::mouseExit(const juce::MouseEvent &event)
     {
         sge->sliderHoverEnd(getTag());
     }
+    repaint();
 }
 
 void ModulatableSlider::mouseDrag(const juce::MouseEvent &event)

--- a/src/gui/widgets/ModulatableSlider.h
+++ b/src/gui/widgets/ModulatableSlider.h
@@ -77,6 +77,7 @@ struct ModulatableSlider : public juce::Component,
     void mouseDoubleClick(const juce::MouseEvent &event) override;
     void mouseWheelMove(const juce::MouseEvent &event,
                         const juce::MouseWheelDetails &wheel) override;
+    void endHover() override;
 
     SurgeStorage *storage{nullptr};
     void setStorage(SurgeStorage *s) { storage = s; }

--- a/src/gui/widgets/ModulationSourceButton.cpp
+++ b/src/gui/widgets/ModulationSourceButton.cpp
@@ -305,7 +305,9 @@ void ModulationSourceButton::mouseEnter(const juce::MouseEvent &event)
     repaint();
 }
 
-void ModulationSourceButton::mouseExit(const juce::MouseEvent &event)
+void ModulationSourceButton::mouseExit(const juce::MouseEvent &event) { endHover(); }
+
+void ModulationSourceButton::endHover()
 {
     isHovered = false;
     repaint();

--- a/src/gui/widgets/ModulationSourceButton.h
+++ b/src/gui/widgets/ModulationSourceButton.h
@@ -93,6 +93,7 @@ struct ModulationSourceButton : public juce::Component,
 
     void mouseEnter(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override;
+    void endHover() override;
 
     void onSkinChanged() override;
 

--- a/src/gui/widgets/MultiSwitch.cpp
+++ b/src/gui/widgets/MultiSwitch.cpp
@@ -77,8 +77,6 @@ void MultiSwitch::mouseDown(const juce::MouseEvent &event)
 {
     if (event.mods.isPopupMenu())
     {
-        isHovered = false;
-        repaint();
         notifyControlModifierClicked(event.mods);
         return;
     }
@@ -114,7 +112,12 @@ void MultiSwitch::mouseEnter(const juce::MouseEvent &event)
     hoverSelection = coordinateToSelection(event.x, event.y);
     isHovered = true;
 }
-void MultiSwitch::mouseExit(const juce::MouseEvent &event) { isHovered = false; }
+void MultiSwitch::mouseExit(const juce::MouseEvent &event) { endHover(); }
+void MultiSwitch::endHover()
+{
+    isHovered = false;
+    repaint();
+}
 void MultiSwitch::mouseWheelMove(const juce::MouseEvent &event,
                                  const juce::MouseWheelDetails &wheel)
 {

--- a/src/gui/widgets/MultiSwitch.h
+++ b/src/gui/widgets/MultiSwitch.h
@@ -66,6 +66,8 @@ struct MultiSwitch : public juce::Component, public WidgetBaseMixin<MultiSwitch>
     void mouseMove(const juce::MouseEvent &event) override;
     void mouseDrag(const juce::MouseEvent &event) override;
 
+    void endHover() override;
+
     Surge::GUI::WheelAccumulationHelper wheelHelper;
     void mouseWheelMove(const juce::MouseEvent &event,
                         const juce::MouseWheelDetails &wheel) override;

--- a/src/gui/widgets/NumberField.h
+++ b/src/gui/widgets/NumberField.h
@@ -102,6 +102,11 @@ struct NumberField : public juce::Component, public WidgetBaseMixin<NumberField>
         setMouseCursor(juce::MouseCursor::NormalCursor);
         repaint();
     }
+    void endHover() override
+    {
+        isHover = false;
+        repaint();
+    }
 
     juce::Colour textColour, textHoverColour;
     void setTextColour(juce::Colour c)

--- a/src/gui/widgets/Switch.h
+++ b/src/gui/widgets/Switch.h
@@ -68,6 +68,11 @@ struct Switch : public juce::Component, public WidgetBaseMixin<Switch>
     void mouseDown(const juce::MouseEvent &event) override;
     void mouseEnter(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override;
+    void endHover() override
+    {
+        isHovered = false;
+        repaint();
+    }
 
     Surge::GUI::WheelAccumulationHelper wheelHelper;
     void mouseWheelMove(const juce::MouseEvent &event,


### PR DESCRIPTION
This results in popup menus calling endHover at selection and
thus making the menu-at-hover go away if we implement endHover
on all our components prolerly which I think I have

Closes #4487