### PR TITLE
Support parameter rename -> VST3 param name update

### DIFF
--- a/src/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -729,6 +729,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                 synth->storage.getPatch()
                                     .CustomControllerLabel[ccid][CUSTOM_CONTROLLER_LABEL_SIZE - 1] =
                                     0; // to be sure
+                                parameterNameUpdated = true;
 
                                 auto msb =
                                     dynamic_cast<Surge::Widgets::ModulationSourceButton *>(control);

--- a/src/surge_synth_juce/SurgeSynthProcessor.cpp
+++ b/src/surge_synth_juce/SurgeSynthProcessor.cpp
@@ -322,6 +322,15 @@ void SurgeSynthProcessor::processBlock(AudioBuffer<float> &buffer, MidiBuffer &m
 
         blockPos = (blockPos + 1) & (BLOCK_SIZE - 1);
     }
+
+    if (checkNamesEvery++ > 10)
+    {
+        checkNamesEvery = 0;
+        if (std::atomic_exchange(&parameterNameUpdated, false))
+        {
+            updateHostDisplay();
+        }
+    }
 }
 
 //==============================================================================

--- a/src/surge_synth_juce/SurgeSynthProcessor.h
+++ b/src/surge_synth_juce/SurgeSynthProcessor.h
@@ -35,6 +35,12 @@ struct SurgeParamToJuceInfo
         s->getParameterName(s->idForParameter(p), txt);
         return juce::String(txt);
     }
+
+    static juce::String getMacroName(SurgeSynthesizer *s, int macro)
+    {
+        juce::String res = s->storage.getPatch().CustomControllerLabel[macro];
+        return res;
+    }
 };
 
 /*
@@ -51,6 +57,12 @@ struct SurgeParamToJuceParamAdapter : juce::RangedAudioParameter
     }
 
     // Oh this is all incorrect of course
+    juce::String getName(int i) const override
+    {
+        juce::String res = SurgeParamToJuceInfo::getParameterName(s, p);
+        res = res.substring(0, i);
+        return res;
+    }
     float getValue() const override { return s->getParameter01(s->idForParameter(p)); }
     float getDefaultValue() const override { return 0.0; /* FIXME */ }
     void setValue(float f) override
@@ -104,6 +116,14 @@ struct SurgeMacroToJuceParamAdapter : public juce::RangedAudioParameter
     }
 
     // Oh this is all incorrect of course
+    juce::String getName(int i) const override
+    {
+        juce::String res = "C" + std::to_string(macroNum) + ": ";
+        res += SurgeParamToJuceInfo::getMacroName(s, macroNum);
+
+        res = res.substring(0, i);
+        return res;
+    }
     float getValue() const override { return s->getMacroParameter01(macroNum); }
     float getValueForText(const juce::String &text) const override
     {
@@ -193,6 +213,8 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
 
     std::vector<int> presetOrderToPatchList;
     int blockPos = 0;
+
+    int checkNamesEvery = 0;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SurgeSynthProcessor)
 };


### PR DESCRIPTION
using the existing mechanism trigger the juce call when appropirate
tested in mac/reaper/vst3

Closes #4714