### PR TITLE
Make LFO Shuffle extendable into bipolar

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -267,6 +267,7 @@ bool Parameter::can_extend_range()
     case ct_osc_feedback:
     case ct_osc_feedback_negative:
     case ct_lfoamplitude:
+    case ct_lfophaseshuffle:
     case ct_fmratio:
     case ct_reson_res_extendable:
     case ct_freq_audible_with_tunability:
@@ -371,6 +372,7 @@ bool Parameter::is_bipolar()
         res = true;
         break;
     case ct_lfoamplitude:
+    case ct_lfophaseshuffle:
         if (extend_range)
             res = true;
         break;
@@ -933,6 +935,12 @@ void Parameter::set_type(int ctrltype)
         valtype = vt_float;
         val_default.f = 1;
         break;
+    case ct_lfophaseshuffle:
+        val_min.f = 0;
+        val_max.f = 1;
+        valtype = vt_float;
+        val_default.f = 0;
+        break;
     case ct_modern_trimix:
     case ct_percent_bipolar:
     case ct_percent_bipolar_stereo:
@@ -1216,6 +1224,7 @@ void Parameter::set_type(int ctrltype)
     case ct_countedset_percent:
     case ct_countedset_percent_extendable:
     case ct_lfoamplitude:
+    case ct_lfophaseshuffle:
     case ct_reson_res_extendable:
     case ct_modern_trimix:
     case ct_alias_mask:
@@ -1501,6 +1510,7 @@ void Parameter::bound_value(bool force_integer)
         case ct_osc_feedback_negative:
         case ct_detuning:
         case ct_lfoamplitude:
+        case ct_lfophaseshuffle:
         case ct_airwindows_param:
         case ct_airwindows_param_bipolar:
         case ct_lfodeform:
@@ -1739,6 +1749,8 @@ bool Parameter::supportsDynamicName()
     switch (ctrltype)
     {
     case ct_modern_trimix:
+    case ct_lfoamplitude:
+    case ct_lfophaseshuffle:
     case ct_percent:
     case ct_percent_bipolar:
     case ct_percent_bipolar_w_dynamic_unipolar_formatting:
@@ -1845,6 +1857,11 @@ float Parameter::get_extended(float f)
             val_min.f = 21.23265f; // 1500 Hz
             return f;
         }
+        case ct_lfophaseshuffle:
+        {
+            val_default.f = 0.f;
+            return f;
+        }
         default:
         {
             return f;
@@ -1882,6 +1899,11 @@ float Parameter::get_extended(float f)
         return 4.f * f;
     case ct_lfoamplitude:
         return (2.f * f) - 1.f;
+    case ct_lfophaseshuffle:
+    {
+        val_default.f = 0.5f;
+        return (2.f * f) - 1.f;
+    }
     case ct_fmratio:
     {
         if (f > 16)
@@ -3693,6 +3715,7 @@ bool Parameter::can_setvalue_from_string()
     case ct_lforate:
     case ct_lforate_deactivatable:
     case ct_lfoamplitude:
+    case ct_lfophaseshuffle:
     case ct_lfodeform:
     case ct_detuning:
     case ct_oscspread:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -177,6 +177,7 @@ enum ctrltypes
     ct_alias_bits,
     ct_tape_microns,
     ct_tape_speed,
+    ct_lfophaseshuffle,
     num_ctrltypes,
 };
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -400,10 +400,11 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
                 p_id.next(), id_s++, label, "Rate", ct_lforate_deactivatable,
                 Surge::Skin::LFO::rate, sc_id, cg_LFO, ms_lfo1 + l, true, sceasy, false));
             snprintf(label, LABEL_SIZE, "lfo%i_phase", l);
-            a->push_back(scene[sc].lfo[l].start_phase.assign(
-                p_id.next(), id_s++, label, "Phase / Shuffle", ct_percent, Surge::Skin::LFO::phase,
-                // Surge::Skin::LfoSection::phase,
-                sc_id, cg_LFO, ms_lfo1 + l, true));
+            a->push_back(scene[sc].lfo[l].start_phase.assign(p_id.next(), id_s++, label,
+                                                             "Phase / Shuffle", ct_lfophaseshuffle,
+                                                             Surge::Skin::LFO::phase,
+                                                             // Surge::Skin::LfoSection::phase,
+                                                             sc_id, cg_LFO, ms_lfo1 + l, true));
             snprintf(label, LABEL_SIZE, "lfo%i_magnitude", l);
             a->push_back(scene[sc].lfo[l].magnitude.assign(
                 p_id.next(), id_s++, label, "Amplitude", ct_lfoamplitude,

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -446,7 +446,7 @@ bailOnPortable:
         if (!SHGetKnownFolderPath(FOLDERID_Documents, 0, nullptr, &documentsFolder))
         {
             fs::path path(documentsFolder);
-            path /= L"Surge";
+            path /= L"Surge XT";
             userDataPath = path_to_string(path);
         }
     }
@@ -465,9 +465,9 @@ bailOnPortable:
     // append separator if not present
     datapath = Surge::Storage::appendDirectory(datapath, std::string());
 
-    userFXPath = Surge::Storage::appendDirectory(userDataPath, "FXSettings");
+    userFXPath = Surge::Storage::appendDirectory(userDataPath, "FX Presets");
 
-    userMidiMappingsPath = Surge::Storage::appendDirectory(userDataPath, "MIDIMappings");
+    userMidiMappingsPath = Surge::Storage::appendDirectory(userDataPath, "MIDI Mappings");
 
     /*
     const auto snapshotmenupath{string_to_path(datapath + "configuration.xml")};
@@ -508,7 +508,7 @@ bailOnPortable:
     getPatch().scene[0].osc[0].wt.dt = 1.0f / 512.f;
     load_wt(0, &getPatch().scene[0].osc[0].wt, &getPatch().scene[0].osc[0]);
 
-    // WindowWT is a WaveTable which now has a constructor so don't do this
+    // WindowWT is a Wavetable which now has a constructor so don't do this
     // memset(&WindowWT, 0, sizeof(WindowWT));
     if (loadWtAndPatch &&
         !load_wt_wt_mem(SurgeCoreBinary::windows_wt, SurgeCoreBinary::windows_wtSize, &WindowWT))
@@ -677,7 +677,7 @@ void SurgeStorage::refresh_patchlist()
 
     refreshPatchlistAddDir(false, "patches_3rdparty");
     firstUserCategory = patch_category.size();
-    refreshPatchlistAddDir(true, "");
+    refreshPatchlistAddDir(true, "Patches");
 
     patchOrdering = std::vector<int>(patch_list.size());
     std::iota(patchOrdering.begin(), patchOrdering.end(), 0);
@@ -907,7 +907,7 @@ void SurgeStorage::refresh_wtlist()
     firstThirdPartyWTCategory = wt_category.size();
     refresh_wtlistAddDir(false, "wavetables_3rdparty");
     firstUserWTCategory = wt_category.size();
-    refresh_wtlistAddDir(true, "");
+    refresh_wtlistAddDir(true, "Wavetables");
 
     wtCategoryOrdering = std::vector<int>(wt_category.size());
     std::iota(wtCategoryOrdering.begin(), wtCategoryOrdering.end(), 0);

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -489,7 +489,8 @@ void SurgeSynthesizer::savePatch()
     if (storage.getPatch().category.empty())
         storage.getPatch().category = "Default";
 
-    fs::path savepath = string_to_path(getUserPatchDirectory());
+    fs::path savepath =
+        string_to_path(getUserPatchDirectory() + PATH_SEPARATOR + "Patches" + PATH_SEPARATOR);
 
     try
     {

--- a/src/common/WAVFileSupport.cpp
+++ b/src/common/WAVFileSupport.cpp
@@ -469,7 +469,7 @@ bool SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
 std::string SurgeStorage::export_wt_wav_portable(std::string fbase, Wavetable *wt)
 {
     std::string path;
-    path = Surge::Storage::appendDirectory(userDataPath, "Exported Wavetables");
+    path = Surge::Storage::appendDirectory(userDataPath, "Wavetables", "Exported");
     fs::create_directories(string_to_path(path));
 
     auto fnamePre = fbase + ".wav";

--- a/src/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -339,13 +339,7 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
                                               message);
         }
     };
-    contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Save Wavetable to File..."), exportAction);
-
-    contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Open Exported Wavetables Folder..."),
-                        [this]() {
-                            Surge::GUI::openFileOrFolder(Surge::Storage::appendDirectory(
-                                this->storage->userDataPath, "Exported Wavetables"));
-                        });
+    contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Export Wavetable to File..."), exportAction);
 
     if (sge)
     {

--- a/src/gui/widgets/PatchSelector.cpp
+++ b/src/gui/widgets/PatchSelector.cpp
@@ -88,9 +88,7 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
     // if RMB is down, only show the current category
     bool single_category =
         e.mods.isRightButtonDown() || e.mods.isCtrlDown() || e.mods.isCommandDown();
-    bool has_3rdparty = false;
     int last_category = current_category;
-    int root_count = 0, usercat_pos = 0, col_breakpoint = 0;
     auto patch_cat_size = storage->patch_category.size();
 
     if (single_category)
@@ -147,43 +145,27 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
 
         for (int i = 0; i < patch_cat_size; i++)
         {
-            if ((!single_category) || (i == last_category))
+            if (i == storage->firstThirdPartyCategory || i == storage->firstUserCategory)
             {
-                if (!single_category &&
-                    (i == storage->firstThirdPartyCategory || i == storage->firstUserCategory))
+                std::string txt;
+
+                if (i == storage->firstThirdPartyCategory && storage->firstUserCategory != i)
                 {
-                    std::string txt;
-
-                    if (i == storage->firstThirdPartyCategory && storage->firstUserCategory != i)
-                    {
-                        has_3rdparty = true;
-                        txt = "THIRD PARTY PATCHES";
-                    }
-                    else
-                    {
-                        txt = "USER PATCHES";
-                    }
-
-                    contextMenu.addColumnBreak();
-                    contextMenu.addSectionHeader(txt);
+                    txt = "THIRD PARTY PATCHES";
+                }
+                else
+                {
+                    txt = "USER PATCHES";
                 }
 
-                // Remap index to the corresponding category in alphabetical order.
-                int c = storage->patchCategoryOrdering[i];
-
-                // find at which position the first user category root folder shows up
-                if (storage->patch_category[i].isRoot)
-                {
-                    root_count++;
-
-                    if (i == storage->firstUserCategory)
-                    {
-                        usercat_pos = root_count;
-                    }
-                }
-
-                populatePatchMenuForCategory(c, contextMenu, single_category, main_e, true);
+                contextMenu.addColumnBreak();
+                contextMenu.addSectionHeader(txt);
             }
+
+            // remap index to the corresponding category in alphabetical order.
+            int c = storage->patchCategoryOrdering[i];
+
+            populatePatchMenuForCategory(c, contextMenu, single_category, main_e, true);
         }
     }
 
@@ -226,6 +208,8 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
             sge->showPatchBrowserDialog();
         }
     });
+
+    contextMenu.addSeparator();
 
     contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Refresh Patch List"),
                         [this]() { this->storage->refresh_patchlist(); });


### PR DESCRIPTION
TODO: Hide Extend range option for other LFO modes and disable it upon changing the LFO mode.
Q for @baconpaul: Can we remember that we had Extend enabled for step seq and reenable it upon switching back to step seq?