### PR TITLE
Mouse shift handling correction

### DIFF
--- a/src/gui/widgets/ModulatableSlider.cpp
+++ b/src/gui/widgets/ModulatableSlider.cpp
@@ -319,6 +319,9 @@ void ModulatableSlider::mouseDrag(const juce::MouseEvent &event)
     if (distance == 0 && editTypeWas == NOEDIT)
         return;
 
+    float dDistance = distance - lastDistance;
+    lastDistance = distance;
+
     if (editTypeWas == NOEDIT)
     {
         notifyBeginEdit();
@@ -348,11 +351,13 @@ void ModulatableSlider::mouseDrag(const juce::MouseEvent &event)
 
     if (isEditingModulation)
     {
-        modValue = limitpm1(modValueOnMouseDown + dMouse * distance);
+        modValue = modValue + dMouse * dDistance;
+        modValue = limitpm1(modValue);
     }
     else
     {
-        value = limit01(valueOnMouseDown + dMouse * distance);
+        value = value + dMouse * dDistance;
+        value = limit01(value);
     }
 
     notifyValueChanged();
@@ -376,6 +381,7 @@ void ModulatableSlider::mouseDown(const juce::MouseEvent &event)
 
     valueOnMouseDown = value;
     modValueOnMouseDown = modValue;
+    lastDistance = 0.f;
     editTypeWas = NOEDIT;
     showInfowindow(isEditingModulation);
 }

--- a/src/gui/widgets/ModulatableSlider.h
+++ b/src/gui/widgets/ModulatableSlider.h
@@ -68,7 +68,7 @@ struct ModulatableSlider : public juce::Component,
     void paint(juce::Graphics &g) override;
 
     bool isHovered{false};
-    float valueOnMouseDown{0.f}, modValueOnMouseDown{0.f};
+    float valueOnMouseDown{0.f}, modValueOnMouseDown{0.f}, lastDistance{0.f};
     void mouseEnter(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override;
     void mouseDrag(const juce::MouseEvent &event) override;


### PR DESCRIPTION
The mouse distance restated values based on base + total motion
but this broke with shift which kncoked you out of whack so
keep an incremental distance and += the value or modvalue
based on that

Closes #4738