### PR TITLE
Finally rewrite the OSC and FX menu data structures

### DIFF
--- a/src/common/FxPresetAndClipboardManager.cpp
+++ b/src/common/FxPresetAndClipboardManager.cpp
@@ -75,6 +75,7 @@ void forcePresetRescan(SurgeStorage *storage)
         {
             Preset preset;
             preset.file = path_to_string(f);
+
             TiXmlDocument d;
             int t;
 
@@ -100,6 +101,20 @@ void forcePresetRescan(SurgeStorage *storage)
                 goto badPreset;
 
             preset.type = t;
+
+            auto rpath = f.lexically_relative(string_to_path(storage->userFXPath)).parent_path();
+
+            auto startCatPath = rpath.begin();
+            if (*(startCatPath) == fx_type_names[t])
+            {
+                startCatPath++;
+            }
+
+            while (startCatPath != rpath.end())
+            {
+                preset.subPath /= *startCatPath;
+                startCatPath++;
+            }
 
             for (int i = 0; i < n_fx_params; ++i)
             {

--- a/src/common/FxPresetAndClipboardManager.h
+++ b/src/common/FxPresetAndClipboardManager.h
@@ -30,7 +30,8 @@ struct Preset
 {
     std::string file;
     std::string name;
-    int type;
+    fs::path subPath{};
+    int type{-1};
     float p[n_fx_params];
     bool ts[n_fx_params], er[n_fx_params], da[n_fx_params];
 

--- a/src/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2363,28 +2363,17 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     {
         if (fxMenu)
         {
-            auto jog = [this](int byThis) {
-                this->selectedFX[this->current_fx] =
-                    std::max(this->selectedFX[this->current_fx] + byThis, -1);
-                if (!fxMenu->loadSnapshotByIndex(this->selectedFX[this->current_fx]))
-                {
-                    // Try and go back to 0. This is the wrong behavior for negative jog
-                    this->selectedFX[this->current_fx] = 0;
-                    fxMenu->loadSnapshotByIndex(0);
-                }
-            };
-
-            if (fxMenu->selectedIdx >= 0 && fxMenu->selectedIdx != selectedFX[current_fx])
-                selectedFX[current_fx] = fxMenu->selectedIdx;
-
             if (control->getValue() > 0.5f)
             {
-                jog(+1);
+                fxMenu->jogBy(1);
             }
             else
             {
-                jog(-1);
+                fxMenu->jogBy(-1);
             }
+
+            if (fxMenu->selectedIdx >= 0 && fxMenu->selectedIdx != selectedFX[current_fx])
+                selectedFX[current_fx] = fxMenu->selectedIdx;
 
             if (fxPresetLabel)
             {


### PR DESCRIPTION
OSC and FX Menu finaly have a reasonable internal interleaved
data structure. This results in

1. The code being less nutso but also
2. Jog button not skipping user presets in FX
3. Wheel restored in FX
4. Wheel not skipping user presets in FX
5. etc...

Closes #2077

Also allows reading of but not writing of user FX presets
in subdirectories, so mostly addresses #3570