### PR TITLE
Correct built in preset index error

### DIFF
--- a/src/surge_synth_juce/SurgeSynthProcessor.cpp
+++ b/src/surge_synth_juce/SurgeSynthProcessor.cpp
@@ -114,22 +114,35 @@ bool SurgeSynthProcessor::isMidiEffect() const { return false; }
 
 double SurgeSynthProcessor::getTailLengthSeconds() const { return 2.0; }
 
-int SurgeSynthProcessor::getNumPrograms() { return surge->storage.patch_list.size() + 1; }
+#undef SURGE_JUCE_PRESETS
+
+int SurgeSynthProcessor::getNumPrograms()
+{
+#ifdef SURGE_JUCE_PRESETS
+    return surge->storage.patch_list.size() + 1;
+#else
+    return 1;
+#endif
+}
 
 int SurgeSynthProcessor::getCurrentProgram()
 {
-    if (surge->patchid < 0 || surge->patchid > surge->storage.patch_list.size())
-        return 0;
-
-    return surge->patchid + 1;
+#ifdef SURGE_JUCE_PRESETS
+    return juceSidePresetId;
+#else
+    return 0;
+#endif
 }
 
 void SurgeSynthProcessor::setCurrentProgram(int index)
 {
+#ifdef SURGE_JUCE_PRESETS
     if (index > 0 && index <= presetOrderToPatchList.size())
     {
+        juceSidePresetId = index;
         surge->patchid_queue = presetOrderToPatchList[index - 1];
     }
+#endif
 }
 
 const String SurgeSynthProcessor::getProgramName(int index)

--- a/src/surge_synth_juce/SurgeSynthProcessor.h
+++ b/src/surge_synth_juce/SurgeSynthProcessor.h
@@ -212,6 +212,8 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     std::vector<SurgeParamToJuceParamAdapter *> paramAdapters;
 
     std::vector<int> presetOrderToPatchList;
+    int juceSidePresetId{0};
+
     int blockPos = 0;
 
     int checkNamesEvery = 0;


### PR DESCRIPTION
There was a built in preset index error which forced
Reaper (and perhaps other hosts) to force-override the song
state in some cases.

Addresses #4759