### PR TITLE
Use only a 3 part version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,9 @@ if(NOT BUILD_TESTING)
   set(BUILD_TESTING "False" CACHE STRING "" FORCE)
 endif()
 
-project(Surge-XT VERSION 1.0.0.0 LANGUAGES C CXX ASM)
+project(Surge-XT VERSION 0.9.0 LANGUAGES C CXX ASM)
+
+message( STATUS "Its Surge-XT Folks! Version is ${PROJECT_VERSION}" )
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 if(APPLE)


### PR DESCRIPTION
Per #4739 with juce 6, a 4 part CMake version breaks version
in the AU. So adjust this to be (first) a 3 part version and
(second) 0.9 led.

Closes #4739