### PR TITLE
More waveshaper shapes and infrastructure

### DIFF
--- a/src/common/FilterConfiguration.h
+++ b/src/common/FilterConfiguration.h
@@ -465,6 +465,7 @@ enum ws_type
     wst_fwrectify,
     wst_poswav,
     wst_negwav,
+    wst_softrect,
 
     wst_singlefold,
     wst_dualfold,
@@ -487,41 +488,21 @@ enum ws_type
     n_ws_types,
 };
 
-const char wst_names[n_ws_types][16] = {"Off",
-                                        "Soft",
-                                        "Hard",
-                                        "Asymmetric",
-                                        "Sine",
-                                        "Digital",
-                                        "Soft Harm 2",
-                                        "Soft Harm 3",
-                                        "Soft Harm 4",
-                                        "Soft Harm 5",
-                                        "Abs Full Wave",
-                                        "Positive Wave",
-                                        "Negative Wave",
-                                        "Single Fold",
-                                        "Double Fold",
-                                        "WestCoast Fold",
-                                        "Additive 1+2",
-                                        "Additive 1+3",
-                                        "Additive 1+4",
-                                        "Additive 1+5",
-                                        "Additive 1234",
-                                        "Additive Saw 3",
-                                        "Additive Sqr 3",
+const char wst_names[n_ws_types][16] = {
+    "Off",           "Soft",           "Hard",           "Asymmetric",     "Sine",
+    "Digital",       "Soft Harm 2",    "Soft Harm 3",    "Soft Harm 4",    "Soft Harm 5",
+    "Abs Full Wave", "Positive Wave",  "Negative Wave",  "Soft Rectified", "Single Fold",
+    "Double Fold",   "WestCoast Fold", "Additive 1+2",   "Additive 1+3",   "Additive 1+4",
+    "Additive 1+5",  "Additive 1234",  "Additive Saw 3", "Additive Sqr 3",
 
-                                        "Fuzz",
-                                        "Fuzz SoftClip",
-                                        "Heavy Fuzz",
-                                        "Fuzz Center"
+    "Fuzz",          "Fuzz SoftClip",  "Heavy Fuzz",     "Fuzz Center"
 
 };
 
 const char wst_ui_names[n_ws_types][16] = {
-    "Off",    "Soft", "Hard",   "Asym",  "Sine",  "Digi",  "Harm 2",  "Harm 3", "Harm 4",
-    "Harm 5", "Abs",  "Pos",    "Neg",   "1Fold", "2Fold", "WstFold", "+12",    "+13",
-    "+14",    "+15",  "+12345", "+Saw3", "+Sqr3", "Fuzz",  "FzSft",   "FzHvy",  "FzCtr"};
+    "Off", "Soft",   "Hard",  "Asym",  "Sine",  "Digi",  "Harm 2",  "Harm 3", "Harm 4", "Harm 5",
+    "Abs", "Pos",    "Neg",   "SRect", "1Fold", "2Fold", "WstFold", "+12",    "+13",    "+14",
+    "+15", "+12345", "+Saw3", "+Sqr3", "Fuzz",  "FzSft", "FzHvy",   "FzCtr"};
 
 struct WaveShaperSelectorMapper : public ParameterDiscreteIndexRemapper
 {
@@ -556,6 +537,7 @@ struct WaveShaperSelectorMapper : public ParameterDiscreteIndexRemapper
         p(wst_fwrectify, "Rectify");
         p(wst_poswav, "Rectify");
         p(wst_negwav, "Rectify");
+        p(wst_softrect, "Rectify");
 
         p(wst_singlefold, "Folders");
         p(wst_dualfold, "Folders");


### PR DESCRIPTION
1. Fix a register bug in dcBlocker which only came into effect
   if you use R1/R2 != 0,1
2. Add a 'soft rectified' which is SOFT(2|x|-1) using ADAA,
   TANH and dcBlock in combination

Addresses #1964