### PR TITLE
Further infrastructural PatchBrowser work

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -4515,8 +4515,17 @@ void SurgeGUIEditor::toggleMSEGEditor()
 void SurgeGUIEditor::showPatchBrowserDialog()
 {
     auto pt = std::make_unique<Surge::Overlays::PatchDBViewer>(this, &(this->synth->storage));
+
+    auto npc = Surge::Skin::Connector::NonParameterConnection::PATCH_BROWSER;
+    auto conn = Surge::Skin::Connector::connectorByNonParameterConnection(npc);
+    auto skinCtrl = currentSkin->getOrCreateControlForConnector(conn);
+    auto yPos = skinCtrl->y + skinCtrl->h - 1;
+    auto xBuf = 25;
+    auto w = getWindowSizeX() - xBuf * 2;
+    auto h = getWindowSizeY() - yPos - xBuf;
+
     addJuceEditorOverlay(std::move(pt), "Patch Browser", PATCH_BROWSER,
-                         juce::Rectangle<int>(50, 50, 750, 450));
+                         juce::Rectangle<int>(xBuf, yPos, w, h));
 }
 
 void SurgeGUIEditor::closePatchBrowserDialog()
@@ -4524,6 +4533,18 @@ void SurgeGUIEditor::closePatchBrowserDialog()
     if (isAnyOverlayPresent(PATCH_BROWSER))
     {
         dismissEditorOfType(PATCH_BROWSER);
+    }
+}
+
+void SurgeGUIEditor::togglePatchBrowserDialog()
+{
+    if (isAnyOverlayPresent(PATCH_BROWSER))
+    {
+        closePatchBrowserDialog();
+    }
+    else
+    {
+        showPatchBrowserDialog();
     }
 }
 

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -367,6 +367,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     void closePatchBrowserDialog();
     void showPatchBrowserDialog();
+    void togglePatchBrowserDialog();
 
     void closeModulationEditorDialog();
     void showModulationEditorDialog();

--- a/src/gui/overlays/PatchDBViewer.cpp
+++ b/src/gui/overlays/PatchDBViewer.cpp
@@ -22,6 +22,184 @@ namespace Surge
 {
 namespace Overlays
 {
+struct SharedTreeViewItem : public juce::TreeViewItem
+{
+    SharedTreeViewItem(SurgeGUIEditor *ed, SurgeStorage *s) : editor(ed), storage(s) {}
+    int getItemHeight() const override { return 13; }
+
+    SurgeStorage *storage;
+    SurgeGUIEditor *editor;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SharedTreeViewItem)
+};
+struct PatchDBSQLTreeViewItem : public SharedTreeViewItem
+{
+    struct TextSubItem : public SharedTreeViewItem
+    {
+        TextSubItem(SurgeGUIEditor *ed, SurgeStorage *s, const std::string &ts)
+            : SharedTreeViewItem(ed, s), text(ts)
+        {
+        }
+        bool mightContainSubItems() override { return false; }
+
+        void paintItem(juce::Graphics &g, int width, int height) override
+        {
+            juce::TreeViewItem::paintItem(g, width, height);
+            g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
+            g.drawText(juce::CharPointer_UTF8(text.c_str()), 2, 0, width - 2, height,
+                       juce::Justification::centredLeft);
+        }
+
+        std::string text;
+    };
+
+    struct DBCatSubItem : public SharedTreeViewItem
+    {
+        DBCatSubItem(SurgeGUIEditor *ed, SurgeStorage *s,
+                     const Surge::PatchStorage::PatchDB::catRecord ts)
+            : SharedTreeViewItem(ed, s), cat(std::move(ts))
+        {
+        }
+        bool mightContainSubItems() override { return !cat.isleaf; }
+
+        void paintItem(juce::Graphics &g, int width, int height) override
+        {
+            juce::TreeViewItem::paintItem(g, width, height);
+            g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
+            g.drawText(juce::CharPointer_UTF8(cat.leaf_name.c_str()), 2, 0, width - 2, height,
+                       juce::Justification::centredLeft);
+        }
+
+        void itemOpennessChanged(bool isOpenNow) override
+        {
+            if (!isOpenNow)
+            {
+                while (getNumSubItems() > 0)
+                    removeSubItem(0);
+            }
+            else
+            {
+                auto res = storage->patchDB->childCategoriesOf(cat.id);
+                for (auto r : res)
+                {
+                    addSubItem(new DBCatSubItem(editor, storage, r));
+                }
+            }
+        }
+
+        Surge::PatchStorage::PatchDB::catRecord cat;
+    };
+    struct CategoryItem : public SharedTreeViewItem
+    {
+        CategoryItem(SurgeGUIEditor *ed, SurgeStorage *s, Surge::PatchStorage::PatchDB::CatType t)
+            : SharedTreeViewItem(ed, s), type(t)
+        {
+        }
+        bool mightContainSubItems() override { return true; }
+        void paintItem(juce::Graphics &g, int width, int height) override
+        {
+            juce::TreeViewItem::paintItem(g, width, height);
+            g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
+            std::string text = "Factory";
+            g.setColour(juce::Colours::black);
+            if (type == PatchStorage::PatchDB::THIRD_PARTY)
+                text = "Third Party";
+            if (type == PatchStorage::PatchDB::USER)
+                text = "User";
+            g.drawText(text.c_str(), 2, 0, width - 2, height, juce::Justification::centredLeft);
+        }
+
+        void itemOpennessChanged(bool isOpenNow) override
+        {
+            if (!isOpenNow)
+            {
+                while (getNumSubItems() > 0)
+                    removeSubItem(0);
+            }
+            else
+            {
+                auto res = storage->patchDB->rootCategoriesForType(type);
+                for (auto r : res)
+                {
+                    addSubItem(new DBCatSubItem(editor, storage, r));
+                }
+            }
+        }
+
+        Surge::PatchStorage::PatchDB::CatType type;
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(CategoryItem);
+    };
+
+    struct SpecialQueryItem : public SharedTreeViewItem
+    {
+        enum SpecialType
+        {
+            AUTHOR,
+            TAG,
+            FEATURE,
+            FAVORITE
+        } type;
+
+        SpecialQueryItem(SurgeGUIEditor *ed, SurgeStorage *s, SpecialType st)
+            : SharedTreeViewItem(ed, s), type(st)
+        {
+        }
+        bool mightContainSubItems() override { return true; }
+        void paintItem(juce::Graphics &g, int width, int height) override
+        {
+            juce::TreeViewItem::paintItem(g, width, height);
+            g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
+            std::string text = "";
+            switch (type)
+            {
+            case AUTHOR:
+                text = "By Author";
+                break;
+            case TAG:
+                text = "By Tag";
+                break;
+            case FEATURE:
+                text = "By Feature";
+                break;
+            case FAVORITE:
+                text = "Favorites";
+                break;
+            }
+            g.setColour(juce::Colours::black);
+            g.drawText(text.c_str(), 2, 0, width - 2, height, juce::Justification::centredLeft);
+        }
+
+        void itemOpennessChanged(bool isOpenNow) override
+        {
+            std::cout << type << " " << isOpenNow << std::endl;
+        }
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SpecialQueryItem);
+    };
+
+    PatchDBSQLTreeViewItem(SurgeGUIEditor *ed, SurgeStorage *s) : SharedTreeViewItem(ed, s)
+    {
+        addSubItem(new CategoryItem(editor, storage, Surge::PatchStorage::PatchDB::FACTORY));
+        addSubItem(new CategoryItem(editor, storage, Surge::PatchStorage::PatchDB::THIRD_PARTY));
+        addSubItem(new CategoryItem(editor, storage, Surge::PatchStorage::PatchDB::USER));
+
+        addSubItem(new SpecialQueryItem(editor, storage, SpecialQueryItem::AUTHOR));
+        addSubItem(new SpecialQueryItem(editor, storage, SpecialQueryItem::TAG));
+        addSubItem(new SpecialQueryItem(editor, storage, SpecialQueryItem::FEATURE));
+        addSubItem(new SpecialQueryItem(editor, storage, SpecialQueryItem::FAVORITE));
+    }
+
+    bool mightContainSubItems() override { return true; }
+    void paintItem(juce::Graphics &g, int width, int height) override
+    {
+        // TODO surge logo
+        g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
+        g.setColour(juce::Colours::black);
+        g.drawText("Surge", 2, 0, width - 2, height, juce::Justification::centredLeft);
+    }
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PatchDBSQLTreeViewItem);
+};
+
 class PatchDBSQLTableModel : public juce::TableListBoxModel
 {
   public:
@@ -82,9 +260,11 @@ class PatchDBSQLTableModel : public juce::TableListBoxModel
 
     void executeQuery(const std::string &n) { data = storage->patchDB->rawQueryForNameLike(n); }
 
-    std::vector<Surge::PatchStorage::PatchDB::record> data;
+    std::vector<Surge::PatchStorage::PatchDB::patchRecord> data;
     SurgeStorage *storage;
     SurgeGUIEditor *editor;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PatchDBSQLTableModel);
 };
 
 PatchDBViewer::PatchDBViewer(SurgeGUIEditor *e, SurgeStorage *s)
@@ -92,7 +272,7 @@ PatchDBViewer::PatchDBViewer(SurgeGUIEditor *e, SurgeStorage *s)
 {
     createElements();
 }
-PatchDBViewer::~PatchDBViewer() = default;
+PatchDBViewer::~PatchDBViewer() { treeView->setRootItem(nullptr); };
 
 void PatchDBViewer::createElements()
 {
@@ -104,7 +284,7 @@ void PatchDBViewer::createElements()
     table->getHeader().addColumn("category", 3, 250);
     table->getHeader().addColumn("author", 4, 200);
 
-    table->setBounds(0, 50, getWidth(), getHeight() - 50);
+    table->setBounds(200, 50, getWidth() - 200, getHeight() - 50);
     table->setRowHeight(18);
     addAndMakeVisible(*table);
 
@@ -112,6 +292,18 @@ void PatchDBViewer::createElements()
     nameTypein->setBounds(10, 10, 400, 30);
     nameTypein->addListener(this);
     addAndMakeVisible(*nameTypein);
+
+    treeView = std::make_unique<juce::TreeView>("Tree View for Categories");
+    treeView->setColour(juce::TreeView::backgroundColourId, juce::Colours::white);
+    treeView->setColour(juce::TreeView::evenItemsColourId, juce::Colour(200, 200, 255));
+    treeView->setColour(juce::TreeView::oddItemsColourId, juce::Colour(240, 240, 255));
+    treeView->setRootItemVisible(false);
+
+    treeView->setBounds(0, 50, 200, getHeight() - 50);
+    treeRoot = std::make_unique<PatchDBSQLTreeViewItem>(editor, storage);
+    treeView->setRootItem(treeRoot.get());
+
+    addAndMakeVisible(*treeView);
 
     executeQuery();
 }
@@ -130,7 +322,10 @@ void PatchDBViewer::resized()
         nameTypein->setBounds(10, 10, 400, 30);
 
     if (table)
-        table->setBounds(2, 50, getWidth() - 4, getHeight() - 52);
+        table->setBounds(200, 50, getWidth() - 202, getHeight() - 52);
+
+    if (treeView)
+        treeView->setBounds(2, 50, 196, getHeight() - 52);
 }
 
 } // namespace Overlays

--- a/src/gui/overlays/PatchDBViewer.h
+++ b/src/gui/overlays/PatchDBViewer.h
@@ -26,6 +26,7 @@ namespace Surge
 namespace Overlays
 {
 class PatchDBSQLTableModel;
+class PatchDBSQLTreeViewItem;
 
 class PatchDBViewer : public juce::Component, public juce::TextEditor::Listener
 {
@@ -46,6 +47,9 @@ class PatchDBViewer : public juce::Component, public juce::TextEditor::Listener
 
     SurgeStorage *storage;
     SurgeGUIEditor *editor;
+
+    std::unique_ptr<juce::TreeView> treeView;
+    std::unique_ptr<PatchDBSQLTreeViewItem> treeRoot;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PatchDBViewer);
 };

--- a/src/gui/widgets/PatchSelector.cpp
+++ b/src/gui/widgets/PatchSelector.cpp
@@ -83,6 +83,17 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
         return;
     }
 
+    if (e.mods.isShiftDown())
+    {
+        auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+        if (sge)
+        {
+            sge->togglePatchBrowserDialog();
+        }
+        return;
+    }
+
     auto contextMenu = juce::PopupMenu();
     int main_e = 0;
     // if RMB is down, only show the current category


### PR DESCRIPTION
This commit hints at some of the features of the patch
browser, and undertakes a lot of infrastructural improvements
which will allow them. It includes

1. Using the JUCE treeview to show some navigation, even though
   it is not hooked up as a filter
2. Having categories in the database, although not normalized to
   patches by ID yet (soon)
3. Adding various convenience and encapsulation classes to the
   PatchDB internals, including small objects to make the
   sqlite3 API for sstatements cleaner and have better error
   checking
4. Modify my worker queue to be omre generic so we can load more
   than just patches

Still the patch browser isn't 'good' or 'complete' but I want
to do a checkpoint here and move onto my next steps.