### PR TITLE
WIP: Basic support for octave-per-channel mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ The Emu (J Riley Hill) <http://jrileyhill.com>
 Matthias von Faber <http://github.com/mvf>
 Jani Frilander <http://github.com/janifr>
 Amy Furniss <http://github.com/amyfurniss>
+Cale Gibbard <cgibbard@gmail.com>
 Brian Ginsburg <https://github.com/bgins>
 Nathan Kopp <nk.sg@nathankopp.com>
 Korridor <fabian.kempe@gmail.com>

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2095,6 +2095,12 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 }
             }
 
+            p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("mapChannelToOctave"));
+            if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
+            {
+                dawExtraState.mapChannelToOctave = (ival != 0);
+            }
+
             p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("midictrl_map"));
             if (p)
             {
@@ -2559,6 +2565,11 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         TiXmlElement mpn("mappingName");
         mpn.SetAttribute("v", dawExtraState.mappingName.c_str());
         dawExtraXML.InsertEndChild(mpn);
+
+        // Revision 17 adds mapChannelToOctave
+        TiXmlElement mcto("mapChannelToOctave");
+        mcto.SetAttribute("v", (int)(storage->mapChannelToOctave));
+        dawExtraXML.InsertEndChild(mcto);
 
         /*
         ** Add the midi controls

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -529,6 +529,7 @@ bailOnPortable:
     twelveToneStandardMapping =
         Tunings::Tuning(Tunings::evenTemperament12NoteScale(), Tunings::KeyboardMapping());
     isStandardTuning = true;
+    mapChannelToOctave = false;
     isToggledToCache = false;
     for (int q = 0; q < 3; ++q)
         togglePriorState[q] = false;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -739,6 +739,8 @@ struct DAWExtraStateStorage
     std::string mappingContents = "";
     std::string mappingName = "";
 
+    bool mapChannelToOctave = false;
+
     std::unordered_map<int, int> midictrl_map;      // param -> midictrl
     std::unordered_map<int, int> customcontrol_map; // custom controller number -> midicontrol
 
@@ -1066,6 +1068,8 @@ class alignas(16) SurgeStorage
     Tunings::Scale currentScale;
     Tunings::KeyboardMapping currentMapping;
     bool isStandardTuning = true, isStandardScale = true, isStandardMapping = true;
+
+    std::atomic<bool> mapChannelToOctave; // When other midi modes come along, clean this up.
 
     enum TuningApplicationMode
     {

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -322,7 +322,8 @@ int SurgeSynthesizer::calculateChannelMask(int channel, int key)
             break;
         }
     }
-    else if (storage.getPatch().scenemode.val.i == sm_single)
+    else if (storage.getPatch().scenemode.val.i == sm_single &&
+             !storage.getPatch().dawExtraState.mapChannelToOctave)
     {
         if (storage.getPatch().scene_active.val.i == 1)
             channelmask = 2;
@@ -3852,6 +3853,7 @@ void SurgeSynthesizer::populateDawExtraState()
         storage.getPatch().dawExtraState.mappingContents = "";
         storage.getPatch().dawExtraState.mappingName = "";
     }
+    storage.getPatch().dawExtraState.mapChannelToOctave = storage.mapChannelToOctave;
 
     int n = n_global_params + n_scene_params; // only store midictrl's for scene A (scene A -> scene
                                               // B will be duplicated on load)
@@ -3928,6 +3930,8 @@ void SurgeSynthesizer::loadFromDawExtraState()
     {
         storage.remapToConcertCKeyboard();
     }
+
+    storage.mapChannelToOctave = storage.getPatch().dawExtraState.mapChannelToOctave;
 
     int n = n_global_params + n_scene_params; // only store midictrl's for scene A (scene A -> scene
                                               // B will be duplicated on load)

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -58,7 +58,7 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
         }
         auto rkey = keyRetuning;
 
-        return res + rkey;
+        res = res + rkey;
     }
     else if (!storage->isStandardTuning &&
              storage->tuningApplicationMode == SurgeStorage::RETUNE_MIDI_ONLY)
@@ -68,12 +68,24 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
         float frac = res - idx; // frac is 0 means use idx; frac is 1 means use idx+1
         float b0 = storage->currentTuning.logScaledFrequencyForMidiNote(idx) * 12;
         float b1 = storage->currentTuning.logScaledFrequencyForMidiNote(idx + 1) * 12;
-        return (1.f - frac) * b0 + frac * b1;
+        res = (1.f - frac) * b0 + frac * b1;
     }
-    else
+
+    if (storage->mapChannelToOctave)
     {
-        return res;
+        float shift;
+        if (channel > 7)
+        {
+            shift = channel - 16;
+        }
+        else
+        {
+            shift = channel;
+        }
+        res += 12 * shift;
     }
+
+    return res;
 }
 
 SurgeVoice::SurgeVoice() {}

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -2396,6 +2396,12 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                               });
         });
 
+    tuningSubMenu.addItem(Surge::GUI::toOSCaseForMenu("Use MIDI Channel for Octave Shift"), true,
+                          (synth->storage.mapChannelToOctave), [this]() {
+                              this->synth->storage.mapChannelToOctave =
+                                  !(this->synth->storage.mapChannelToOctave);
+                          });
+
     tuningSubMenu.addSeparator();
 
     tuningSubMenu.addItem(


### PR DESCRIPTION
See "Use MIDI Channel for Octave Shift" on the Tuning menu.

Only works correctly so far when tuning is applied at MIDI input, and has no special treatment for scene masking yet.

Aims to resolve #4151