### PR TITLE
Windows/MSVC: Specify UTF-8 encoding (fixes build on CJK systems)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ if(MSVC)
 
     # Build with Multiple Processes (Clang-cl builds use Ninja instead)
     $<$<CXX_COMPILER_ID:MSVC>:/MP>
+    # Set source and executable charsets to UTF-8
+    $<$<CXX_COMPILER_ID:MSVC>:/utf-8>
   )
 endif()
 
@@ -633,6 +635,8 @@ if (DEFINED ENV{VST2SDK_DIR})
   juce_set_vst2_sdk_path(${JUCE_VST2_DIR})
   set(SURGE_JUCE_FORMATS AU VST3 VST Standalone)
   message(STATUS "JUCE VST2 SDK Path is $ENV{VST2SDK_DIR}")
+  # VST2 headers are invalid UTF-8
+  add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/wd4828>)
 else()
   set(SURGE_JUCE_FORMATS AU VST3 Standalone)
 endif()


### PR DESCRIPTION
Surge and 3rd-party sources are de facto UTF-8. However, MSVC defaults to the build machine's codepage, which is never UTF-8, unless the user opted into the Beta. Nobody does, because it breaks some apps.

On CJK systems, the encoding mismatch caused [warning C4819](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4819) in various places, breaking the build:

:cn: JUCE, Surge
:jp: JUCE
:kr: JUCE, MTS-ESP, Surge, stmlib

This change sets source and execution charset to UTF-8, fixing the build and avoiding possible runtime surprises due to encoding of literals. It also enables charset validation, i.e. MSVC will now warn on invalid UTF-8. This happens with VST2, which has ISO-8859-1 copyright © symbols in its headers. So we also silence C4828, but only when VST2 is present.
