### PR TITLE
*NIX: Fix install-resources-local with Ninja generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1332,7 +1332,7 @@ if( APPLE )
           POST_BUILD
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           COMMAND echo "Installing local resources"
-          COMMAND rsync -r --delete "resources/data/" "\${HOME}/Library/Application Support/Surge XT/"
+          COMMAND rsync -r --delete "resources/data/" "$ENV{HOME}/Library/Application Support/Surge XT/"
   )
 
   add_custom_target( install-resources-global )
@@ -1351,8 +1351,8 @@ elseif( UNIX AND NOT APPLE )
           POST_BUILD
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           COMMAND echo "Installing local resources into ~/.local/share/surge-xt"
-          COMMAND ${CMAKE_COMMAND} -E make_directory "\${HOME}/.local/share/surge-xt/"
-          COMMAND rsync -r --delete "resources/data/" "\${HOME}/.local/share/surge-xt/"
+          COMMAND ${CMAKE_COMMAND} -E make_directory "$ENV{HOME}/.local/share/surge-xt/"
+          COMMAND rsync -r --delete "resources/data/" "$ENV{HOME}/.local/share/surge-xt/"
   )
 
   add_custom_target( install-resources-global )


### PR DESCRIPTION
Looks like a CMake bug. Before:
```
$ ninja install-resources-local
[0/2] Re-checking globbed directories...
ninja: error: unknown target 'install-resources-local', did you mean 'install-resources-global'?
```
After:
```
$ ninja install-resources-local
[0/2] Re-checking globbed directories...
[1/1] Running utility command for install-resources-local
Installing local resources
```
