### PR TITLE
PatchSelector: Draw patch name as UTF-8

### DIFF
--- a/src/gui/widgets/PatchSelector.cpp
+++ b/src/gui/widgets/PatchSelector.cpp
@@ -65,7 +65,7 @@ void PatchSelector::paint(juce::Graphics &g)
 
     // patch name
     g.setFont(Surge::GUI::getFontManager()->patchNameFont);
-    g.drawText(pname.c_str(), pbrowser, juce::Justification::centred);
+    g.drawText(pname, pbrowser, juce::Justification::centred);
 
     // category/author name
     g.setFont(Surge::GUI::getFontManager()->displayFont);


### PR DESCRIPTION
`juce::Graphics::drawText()` takes a `juce::String`. Implicit conversion from `char*` assumes the data is ASCII, while the one from `std::string` assumes it's UTF-8. So use the latter to preserve the encoding.

Before:
![Screen Shot 2021-08-06 at 22 32 53](https://user-images.githubusercontent.com/304760/128568445-6555b359-b862-4e59-9c30-4919b91bfb0a.png)
After:
![Screen Shot 2021-08-06 at 22 34 16](https://user-images.githubusercontent.com/304760/128568456-21ab8af0-ba8a-4b30-a459-3b736620932c.png)

Related to #4385