### PR TITLE
Drop JuceHeader.h, include JUCE modules directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,7 +557,7 @@ target_include_directories(surge-shared
         ${SURGE_COMMON_INCLUDES}
         ${OS_INCLUDE_DIRECTORIES}
         )
-target_compile_definitions(surge-shared PRIVATE ${OS_COMPILE_DEFINITIONS} )
+target_compile_definitions(surge-shared PUBLIC ${OS_COMPILE_DEFINITIONS} )
 
 if( BUILD_HEADLESS )
   add_executable(surge-headless
@@ -585,7 +585,6 @@ if( BUILD_HEADLESS )
   target_compile_definitions(surge-headless
     PRIVATE
     ${OS_COMPILE_DEFINITIONS}
-    TARGET_HEADLESS=1
     $<IF:$<CONFIG:DEBUG>,BUILD_IS_DEBUG,BUILD_IS_RELEASE>=1
   )
 
@@ -745,8 +744,6 @@ if( BUILD_SURGE_EFFECTS_BANK )
           FORMATS ${SURGE_JUCE_FORMATS}
           )
 
-  juce_generate_juce_header( surge-fx )
-
   file(GLOB SURGE_FX_BANK_RESOURCES_GLOB
           resources/surge_effects_bank/*.svg
           resources/surge_effects_bank/icons/*.svg
@@ -780,9 +777,6 @@ if( BUILD_SURGE_EFFECTS_BANK )
 
           JUCE_WASAPI=1
           JUCE_DIRECTSOUND=1
-
-          TARGET_HEADLESS=1
-
           )
 
   if (JUCE_ASIO_SUPPORT)
@@ -891,8 +885,6 @@ if( BUILD_SURGE_XT )
           FORMATS ${SURGE_JUCE_FORMATS}
           )
 
-  juce_generate_juce_header( surge-xt )
-
   file(GLOB SURGE_SYNTH_JUCE_RESOURCES_GLOB
           resources/classic-skin-svgs/*.svg
           resources/fonts/Lato*ttf
@@ -953,10 +945,6 @@ if( BUILD_SURGE_XT )
           SURGE_JUCE_ACCESSIBLE=${SURGE_JUCE_ACCESSIBLE_DEFINE}
           SURGE_JUCE_HOST_CONTEXT=${SURGE_JUCE_HOST_CONTEXT_DEFINE}
           SURGE_JUCE_VST3_EXTENSIONS=${SURGE_JUCE_VST3_EXTENSIONS}
-
-          TARGET_JUCE_SYNTH=1
-          TARGET_HEADLESS=1
-          TARGET_JUCE_UI=1
 
           $<IF:$<CONFIG:DEBUG>,BUILD_IS_DEBUG,BUILD_IS_RELEASE>=1
           )
@@ -1037,15 +1025,6 @@ if( BUILD_SURGE_XT )
       ${ASIOSDK_DIR}/common
       )
   endif()
-
-  target_compile_definitions(surge-xt PUBLIC ${OS_COMPILE_DEFINITIONS} DONT_SET_USING_JUCE_NAMESPACE=1)
-
-  target_compile_definitions(surge-xt_Standalone PUBLIC
-          TARGET_JUCE_SYNTH=1
-          TARGET_HEADLESS=1
-          TARGET_JUCE_UI=1)
-
-  # add_dependencies(surge-juce-pipeline-targets surge-xt_Standalone)
 
   get_target_property( SURGE_XT_OUTPUT_DIR surge-xt RUNTIME_OUTPUT_DIRECTORY )
 
@@ -1282,7 +1261,6 @@ if( ${BUILD_SURGE_PYTHON_BINDINGS} )
   target_compile_definitions(surgepy
           PRIVATE
           ${OS_COMPILE_DEFINITIONS}
-          TARGET_HEADLESS=1
           $<IF:$<CONFIG:DEBUG>,BUILD_IS_DEBUG,BUILD_IS_RELEASE>=1
           )
 

--- a/src/common/dsp/effects/chowdsp/bbd_utils/BBDCompander.h
+++ b/src/common/dsp/effects/chowdsp/bbd_utils/BBDCompander.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include "juce_core/juce_core.h"
 
 /**
  * Signal averager used for BBD companding.

--- a/src/gui/AccessibleHelpers.h
+++ b/src/gui/AccessibleHelpers.h
@@ -16,11 +16,12 @@
 #ifndef SURGE_XT_ACCESSIBLEHELPERS_H
 #define SURGE_XT_ACCESSIBLEHELPERS_H
 
-#include <JuceHeader.h>
+#if SURGE_JUCE_ACCESSIBLE
 #include "Parameter.h"
 #include "SurgeGUIEditor.h"
 
-#if SURGE_JUCE_ACCESSIBLE
+#include "juce_gui_basics/juce_gui_basics.h"
+
 namespace Surge
 {
 namespace Widgets

--- a/src/gui/RuntimeFont.cpp
+++ b/src/gui/RuntimeFont.cpp
@@ -14,7 +14,8 @@
 */
 
 #include "RuntimeFont.h"
-#include <JuceHeader.h>
+#include "BinaryData.h"
+
 #include <iostream>
 
 namespace Surge

--- a/src/gui/RuntimeFont.h
+++ b/src/gui/RuntimeFont.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include "juce_graphics/juce_graphics.h"
 
 namespace Surge
 {

--- a/src/gui/SkinSupport.h
+++ b/src/gui/SkinSupport.h
@@ -14,7 +14,7 @@
 #include "DebugHelpers.h"
 #include "globals.h"
 
-#include <JuceHeader.h>
+#include "juce_graphics/juce_graphics.h"
 
 #include "SkinModel.h"
 #include "SkinColors.h"

--- a/src/gui/SurgeGUICallbackInterfaces.h
+++ b/src/gui/SurgeGUICallbackInterfaces.h
@@ -16,6 +16,8 @@
 #ifndef SURGE_XT_SURGEGUICALLBACKINTERFACES_H
 #define SURGE_XT_SURGEGUICALLBACKINTERFACES_H
 
+#include "juce_gui_basics/juce_gui_basics.h"
+
 namespace Surge
 {
 namespace GUI

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -17,8 +17,6 @@
 
 #include "globals.h"
 
-#include <JuceHeader.h>
-
 #include "SurgeGUICallbackInterfaces.h"
 
 #include "SurgeStorage.h"
@@ -32,6 +30,8 @@
 #include "overlays/MSEGEditor.h"
 #include "overlays/OverlayWrapper.h" // This needs to be concrete for inline functions for now
 #include "widgets/ModulatableControlInterface.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 #include <vector>
 #include <thread>

--- a/src/gui/SurgeGUIUtils.cpp
+++ b/src/gui/SurgeGUIUtils.cpp
@@ -1,7 +1,8 @@
 #include "SurgeGUIUtils.h"
 
+#include "juce_core/juce_core.h"
+
 #include <cctype>
-#include <JuceHeader.h>
 
 namespace Surge
 {

--- a/src/gui/SurgeImage.cpp
+++ b/src/gui/SurgeImage.cpp
@@ -13,8 +13,8 @@
 ** open source in September 2018.
 */
 
-#include <JuceHeader.h>
 #include "SurgeImage.h"
+#include "BinaryData.h"
 
 SurgeImage::SurgeImage(int rid)
 {

--- a/src/gui/SurgeImage.h
+++ b/src/gui/SurgeImage.h
@@ -4,7 +4,7 @@
  * A utility wrapper around loading and drawables and stuff
  */
 
-#include <JuceHeader.h>
+#include "juce_gui_basics/juce_gui_basics.h"
 
 #include <vector>
 #include <map>

--- a/src/gui/SurgeImageStore.h
+++ b/src/gui/SurgeImageStore.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include "resource.h"
-#include <JuceHeader.h>
+#include <string>
 #include <map>
 #include <atomic>
 #include <algorithm>
 #include <cctype>
+#include <vector>
 
 class SurgeImage;
 

--- a/src/gui/SurgeJUCEHelpers.h
+++ b/src/gui/SurgeJUCEHelpers.h
@@ -16,7 +16,7 @@
 #ifndef SURGE_XT_JUCEHELPERS_H
 #define SURGE_XT_JUCEHELPERS_H
 
-#include <JuceHeader.h>
+#include "juce_gui_basics/juce_gui_basics.h"
 
 namespace Surge
 {

--- a/src/gui/SurgeJUCELookAndFeel.h
+++ b/src/gui/SurgeJUCELookAndFeel.h
@@ -16,7 +16,7 @@
 #ifndef SURGE_XT_SURGEJUCELOOKANDFEEL_H
 #define SURGE_XT_SURGEJUCELOOKANDFEEL_H
 
-#include <JuceHeader.h>
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4
 {

--- a/src/gui/overlays/AboutScreen.h
+++ b/src/gui/overlays/AboutScreen.h
@@ -16,8 +16,9 @@
 #ifndef SURGE_XT_ABOUTSCREEN_H
 #define SURGE_XT_ABOUTSCREEN_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeGUIEditor;
 class SurgeStorage;

--- a/src/gui/overlays/LuaEditors.h
+++ b/src/gui/overlays/LuaEditors.h
@@ -20,9 +20,10 @@
 #ifndef SURGE_XT_LUAEDITORS_H
 #define SURGE_XT_LUAEDITORS_H
 
-#include <JuceHeader.h>
 #include "SurgeStorage.h"
 #include "SkinSupport.h"
+
+#include "juce_gui_extra/juce_gui_extra.h"
 
 class SurgeGUIEditor;
 

--- a/src/gui/overlays/MSEGEditor.h
+++ b/src/gui/overlays/MSEGEditor.h
@@ -14,10 +14,11 @@
 */
 
 #pragma once
-#include <JuceHeader.h>
 #include "SurgeStorage.h"
 #include "SkinSupport.h"
 #include "RefreshableOverlay.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 namespace Surge
 {

--- a/src/gui/overlays/MiniEdit.h
+++ b/src/gui/overlays/MiniEdit.h
@@ -16,8 +16,9 @@
 #ifndef SURGE_XT_MINIEDIT_H
 #define SURGE_XT_MINIEDIT_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 namespace Surge
 {

--- a/src/gui/overlays/ModulationEditor.h
+++ b/src/gui/overlays/ModulationEditor.h
@@ -16,7 +16,7 @@
 #ifndef SURGE_XT_MODULATIONEDITOR_H
 #define SURGE_XT_MODULATIONEDITOR_H
 
-#include <JuceHeader.h>
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeGUIEditor;
 class SurgeSynthesizer;

--- a/src/gui/overlays/OverlayWrapper.h
+++ b/src/gui/overlays/OverlayWrapper.h
@@ -16,8 +16,9 @@
 #ifndef SURGE_XT_OVERLAYWRAPPER_H
 #define SURGE_XT_OVERLAYWRAPPER_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeGUIEditor;
 class SurgeImage;

--- a/src/gui/overlays/PatchDBViewer.h
+++ b/src/gui/overlays/PatchDBViewer.h
@@ -16,8 +16,9 @@
 #ifndef SURGE_PATCHDBVIEWER_H
 #define SURGE_PATCHDBVIEWER_H
 
-#include <JuceHeader.h>
 #include "SurgeStorage.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeGUIEditor;
 

--- a/src/gui/overlays/PatchStoreDialog.h
+++ b/src/gui/overlays/PatchStoreDialog.h
@@ -16,8 +16,9 @@
 #ifndef SURGE_XT_PATCHSTOREDIALOG_H
 #define SURGE_XT_PATCHSTOREDIALOG_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeGUIEditor;
 

--- a/src/gui/overlays/TypeinParamEditor.h
+++ b/src/gui/overlays/TypeinParamEditor.h
@@ -16,11 +16,12 @@
 #ifndef SURGE_XT_TYPEINPARAMEDITOR_H
 #define SURGE_XT_TYPEINPARAMEDITOR_H
 
-#include <JuceHeader.h>
 #include "Parameter.h"
 #include "SurgeStorage.h"
 #include "ModulationSource.h"
 #include "SkinSupport.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeGUIEditor;
 

--- a/src/gui/widgets/EffectChooser.h
+++ b/src/gui/widgets/EffectChooser.h
@@ -16,12 +16,14 @@
 #ifndef SURGE_XT_EFFECTCHOOSER_H
 #define SURGE_XT_EFFECTCHOOSER_H
 
-#include <JuceHeader.h>
-#include <array>
 #include "SurgeStorage.h"
 #include "SkinSupport.h"
 #include "WidgetBaseMixin.h"
 #include "SurgeJUCEHelpers.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
+
+#include <array>
 
 namespace Surge
 {

--- a/src/gui/widgets/EffectLabel.h
+++ b/src/gui/widgets/EffectLabel.h
@@ -16,9 +16,11 @@
 #ifndef SURGE_XT_EFFECTLABEL_H
 #define SURGE_XT_EFFECTLABEL_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
 #include "RuntimeFont.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
+
 #include <string>
 
 namespace Surge

--- a/src/gui/widgets/LFOAndStepDisplay.h
+++ b/src/gui/widgets/LFOAndStepDisplay.h
@@ -16,9 +16,10 @@
 #ifndef SURGE_XT_LFOANDSTEPDISPLAY_H
 #define SURGE_XT_LFOANDSTEPDISPLAY_H
 
-#include <JuceHeader.h>
 #include "WidgetBaseMixin.h"
 #include "SurgeStorage.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 namespace Surge
 {

--- a/src/gui/widgets/MainFrame.h
+++ b/src/gui/widgets/MainFrame.h
@@ -16,9 +16,10 @@
 #ifndef SURGE_XT_MAINFRAME_H
 #define SURGE_XT_MAINFRAME_H
 
-#include <JuceHeader.h>
 #include "SurgeImage.h"
 #include "Parameter.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeGUIEditor;
 

--- a/src/gui/widgets/MenuForDiscreteParams.h
+++ b/src/gui/widgets/MenuForDiscreteParams.h
@@ -16,11 +16,13 @@
 #ifndef SURGE_XT_MENUASMODULATABLEINTERFACE_H
 #define SURGE_XT_MENUASMODULATABLEINTERFACE_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
 #include "WidgetBaseMixin.h"
 #include "ModulatableControlInterface.h"
 #include "SurgeJUCEHelpers.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
+
 #include <vector>
 
 class SurgeImage;

--- a/src/gui/widgets/ModulatableControlInterface.h
+++ b/src/gui/widgets/ModulatableControlInterface.h
@@ -16,7 +16,7 @@
 #ifndef SURGE_XT_MODULATABLECONTROLINTERFACE_H
 #define SURGE_XT_MODULATABLECONTROLINTERFACE_H
 
-#include <JuceHeader.h>
+#include "juce_gui_basics/juce_gui_basics.h"
 
 namespace Surge
 {

--- a/src/gui/widgets/ModulatableSlider.h
+++ b/src/gui/widgets/ModulatableSlider.h
@@ -16,11 +16,12 @@
 #ifndef SURGE_XT_MODULATABLESLIDER_H
 #define SURGE_XT_MODULATABLESLIDER_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
 #include "WidgetBaseMixin.h"
 #include "ModulatableControlInterface.h"
 #include "SurgeJUCEHelpers.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeStorage;
 

--- a/src/gui/widgets/ModulationSourceButton.h
+++ b/src/gui/widgets/ModulationSourceButton.h
@@ -16,9 +16,11 @@
 #ifndef SURGE_XT_MODULATIONSOURCEBUTTON_H
 #define SURGE_XT_MODULATIONSOURCEBUTTON_H
 
-#include <JuceHeader.h>
 #include "WidgetBaseMixin.h"
 #include "ModulationSource.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
+
 #include <string>
 
 class SurgeStorage;

--- a/src/gui/widgets/MultiSwitch.h
+++ b/src/gui/widgets/MultiSwitch.h
@@ -16,10 +16,10 @@
 #ifndef SURGE_XT_MULTISWITCH_H
 #define SURGE_XT_MULTISWITCH_H
 
-#include <JuceHeader.h>
-#include <SurgeJUCEHelpers.h>
-#include "SkinSupport.h"
+#include "SurgeJUCEHelpers.h"
 #include "WidgetBaseMixin.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeImage;
 

--- a/src/gui/widgets/NumberField.h
+++ b/src/gui/widgets/NumberField.h
@@ -16,11 +16,12 @@
 #ifndef SURGE_XT_NUMBERFIELD_H
 #define SURGE_XT_NUMBERFIELD_H
 
-#include <JuceHeader.h>
 #include "SkinModel.h"
 #include "WidgetBaseMixin.h"
 #include "SurgeJUCEHelpers.h"
 #include "SurgeImage.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeStorage;
 

--- a/src/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/gui/widgets/OscillatorWaveformDisplay.h
@@ -16,10 +16,11 @@
 #ifndef SURGE_XT_OSCILLATORWAVEFORMDISPLAY_H
 #define SURGE_XT_OSCILLATORWAVEFORMDISPLAY_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
 #include "Parameter.h"
 #include "SurgeStorage.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeStorage;
 class SurgeGUIEditor;

--- a/src/gui/widgets/ParameterInfowindow.h
+++ b/src/gui/widgets/ParameterInfowindow.h
@@ -16,9 +16,10 @@
 #ifndef SURGE_XT_PARAMETERINFOWINDOW_H
 #define SURGE_XT_PARAMETERINFOWINDOW_H
 
-#include <JuceHeader.h>
 #include "Parameter.h"
 #include "SkinSupport.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 namespace Surge
 {

--- a/src/gui/widgets/PatchSelector.h
+++ b/src/gui/widgets/PatchSelector.h
@@ -16,10 +16,10 @@
 #ifndef SURGE_XT_PATCHSELECTOR_H
 #define SURGE_XT_PATCHSELECTOR_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
 #include "WidgetBaseMixin.h"
-#include "SurgeJUCEHelpers.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeStorage;
 

--- a/src/gui/widgets/Switch.h
+++ b/src/gui/widgets/Switch.h
@@ -16,10 +16,11 @@
 #ifndef SURGE_XT_SWITCH_H
 #define SURGE_XT_SWITCH_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
 #include "WidgetBaseMixin.h"
 #include "SurgeJUCEHelpers.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeImage;
 

--- a/src/gui/widgets/VerticalLabel.h
+++ b/src/gui/widgets/VerticalLabel.h
@@ -16,7 +16,8 @@
 #ifndef SURGE_XT_VERTICAL_LABEL_H
 #define SURGE_XT_VERTICAL_LABEL_H
 
-#include <JuceHeader.h>
+#include "juce_gui_basics/juce_gui_basics.h"
+
 #include <string>
 
 namespace Surge

--- a/src/gui/widgets/VuMeter.h
+++ b/src/gui/widgets/VuMeter.h
@@ -16,8 +16,9 @@
 #ifndef SURGE_XT_VUMETER_H
 #define SURGE_XT_VUMETER_H
 
-#include <JuceHeader.h>
 #include "WidgetBaseMixin.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeImage;
 

--- a/src/gui/widgets/WaveShaperSelector.h
+++ b/src/gui/widgets/WaveShaperSelector.h
@@ -5,11 +5,12 @@
 #ifndef SURGE_XT_WAVESHAPERSELECTOR_H
 #define SURGE_XT_WAVESHAPERSELECTOR_H
 
-#include <JuceHeader.h>
 #include "WidgetBaseMixin.h"
 #include "Parameter.h"
 #include "SurgeStorage.h"
 #include "SurgeJUCEHelpers.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 namespace Surge
 {

--- a/src/gui/widgets/WidgetBaseMixin.h
+++ b/src/gui/widgets/WidgetBaseMixin.h
@@ -16,10 +16,12 @@
 #ifndef SURGE_XT_WIDGETBASEMIXIN_H
 #define SURGE_XT_WIDGETBASEMIXIN_H
 
-#include <JuceHeader.h>
 #include "SkinSupport.h"
-#include <unordered_set>
 #include "SurgeGUICallbackInterfaces.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
+
+#include <unordered_set>
 
 class SurgeGUIEditor;
 

--- a/src/gui/widgets/XMLConfiguredMenus.h
+++ b/src/gui/widgets/XMLConfiguredMenus.h
@@ -16,12 +16,13 @@
 #ifndef SURGE_XT_XMLCONFIGUREDMENUS_H
 #define SURGE_XT_XMLCONFIGUREDMENUS_H
 
-#include <JuceHeader.h>
-
-#include <utility>
 #include "WidgetBaseMixin.h"
 #include "SurgeJUCEHelpers.h"
 #include "FxPresetAndClipboardManager.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
+
+#include <utility>
 
 class SurgeStorage;
 class SurgeGUIEditor;

--- a/src/surge_effects_bank/SurgeFXEditor.cpp
+++ b/src/surge_effects_bank/SurgeFXEditor.cpp
@@ -58,9 +58,10 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
     {
         fxParamSliders[i].setRange(0.0, 1.0, 0.0001);
         fxParamSliders[i].setValue(processor.getFXStorageValue01(i),
-                                   NotificationType::dontSendNotification);
-        fxParamSliders[i].setSliderStyle(Slider::SliderStyle::RotaryHorizontalVerticalDrag);
-        fxParamSliders[i].setTextBoxStyle(Slider::TextEntryBoxPosition::NoTextBox, true, 0, 0);
+                                   juce::NotificationType::dontSendNotification);
+        fxParamSliders[i].setSliderStyle(juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag);
+        fxParamSliders[i].setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, true, 0,
+                                          0);
         juce::Rectangle<int> position{(i / 6) * getWidth() / 2 + 5, (i % 6) * 60 + ypos0, 55, 55};
         fxParamSliders[i].setBounds(position);
         fxParamSliders[i].setChangeNotificationOnlyOnRelease(false);
@@ -88,7 +89,7 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
         fxTempoSync[i].setBounds(tsPos);
         fxTempoSync[i].setEnabled(processor.canTempoSync(i));
         fxTempoSync[i].setToggleState(processor.getFXStorageTempoSync(i),
-                                      NotificationType::dontSendNotification);
+                                      juce::NotificationType::dontSendNotification);
         fxTempoSync[i].onClick = [i, this]() {
             this->processor.setUserEditingParamFeature(i, true);
             this->processor.setFXParamTempoSync(i, this->fxTempoSync[i].getToggleState());
@@ -107,7 +108,7 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
         fxDeactivated[i].setBounds(daPos);
         fxDeactivated[i].setEnabled(processor.canDeactitvate(i));
         fxDeactivated[i].setToggleState(processor.getFXStorageDeactivated(i),
-                                        NotificationType::dontSendNotification);
+                                        juce::NotificationType::dontSendNotification);
         fxDeactivated[i].onClick = [i, this]() {
             this->processor.setUserEditingParamFeature(i, true);
             this->processor.setFXParamDeactivated(i, this->fxDeactivated[i].getToggleState());
@@ -127,7 +128,7 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
         fxExtended[i].setBounds(exPos);
         fxExtended[i].setEnabled(processor.canExtend(i));
         fxExtended[i].setToggleState(processor.getFXStorageExtended(i),
-                                     NotificationType::dontSendNotification);
+                                     juce::NotificationType::dontSendNotification);
         fxExtended[i].onClick = [i, this]() {
             this->processor.setUserEditingParamFeature(i, true);
             this->processor.setFXParamExtended(i, this->fxExtended[i].getToggleState());
@@ -147,7 +148,7 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
         fxAbsoluted[i].setBounds(abPos);
         fxAbsoluted[i].setEnabled(processor.canAbsolute(i));
         fxAbsoluted[i].setToggleState(processor.getFXParamAbsolute(i),
-                                      NotificationType::dontSendNotification);
+                                      juce::NotificationType::dontSendNotification);
         fxAbsoluted[i].onClick = [i, this]() {
             this->processor.setUserEditingParamFeature(i, true);
             this->processor.setFXParamAbsolute(i, this->fxAbsoluted[i].getToggleState());
@@ -251,11 +252,11 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
 
             if (ty == en)
             {
-                selectType[i].setToggleState(true, NotificationType::dontSendNotification);
+                selectType[i].setToggleState(true, juce::NotificationType::dontSendNotification);
             }
             else
             {
-                selectType[i].setToggleState(false, NotificationType::dontSendNotification);
+                selectType[i].setToggleState(false, juce::NotificationType::dontSendNotification);
             }
 
             addAndMakeVisible(selectType[i]);
@@ -278,7 +279,7 @@ void SurgefxAudioProcessorEditor::resetLabels()
     for (int i = 0; i < n_fx_params; ++i)
     {
         fxParamSliders[i].setValue(processor.getFXStorageValue01(i),
-                                   NotificationType::dontSendNotification);
+                                   juce::NotificationType::dontSendNotification);
         fxParamDisplay[i].setDisplay(processor.getParamValue(i).c_str());
         fxParamDisplay[i].setGroup(processor.getParamGroup(i).c_str());
         fxParamDisplay[i].setName(processor.getParamName(i).c_str());
@@ -288,18 +289,18 @@ void SurgefxAudioProcessorEditor::resetLabels()
                                      !processor.getFXStorageAppearsDeactivated(i));
         fxTempoSync[i].setEnabled(processor.canTempoSync(i));
         fxTempoSync[i].setToggleState(processor.getFXStorageTempoSync(i),
-                                      NotificationType::dontSendNotification);
+                                      juce::NotificationType::dontSendNotification);
 
         fxDeactivated[i].setEnabled(false);
         fxExtended[i].setEnabled(processor.canExtend(i));
         fxExtended[i].setToggleState(processor.getFXStorageExtended(i),
-                                     NotificationType::dontSendNotification);
+                                     juce::NotificationType::dontSendNotification);
         fxAbsoluted[i].setEnabled(processor.canAbsolute(i));
         fxAbsoluted[i].setToggleState(processor.getFXStorageAbsolute(i),
-                                      NotificationType::dontSendNotification);
+                                      juce::NotificationType::dontSendNotification);
         fxDeactivated[i].setEnabled(processor.canDeactitvate(i));
         fxDeactivated[i].setToggleState(processor.getFXStorageDeactivated(i),
-                                        NotificationType::dontSendNotification);
+                                        juce::NotificationType::dontSendNotification);
     }
 
     int row = 0, col = 0;
@@ -341,7 +342,7 @@ void SurgefxAudioProcessorEditor::paramsChangedCallback()
         {
             if (i < n_fx_params)
             {
-                fxParamSliders[i].setValue(fv[i], NotificationType::dontSendNotification);
+                fxParamSliders[i].setValue(fv[i], juce::NotificationType::dontSendNotification);
                 fxParamDisplay[i].setDisplay(processor.getParamValue(i));
             }
             else
@@ -358,12 +359,12 @@ void SurgefxAudioProcessorEditor::blastToggleState(int w)
     for (auto i = 0; i < n_fx_types; ++i)
     {
         selectType[i].setToggleState(typeByButtonIndex[i] == w + 1,
-                                     NotificationType::dontSendNotification);
+                                     juce::NotificationType::dontSendNotification);
     }
 }
 
 //==============================================================================
-void SurgefxAudioProcessorEditor::paint(Graphics &g)
+void SurgefxAudioProcessorEditor::paint(juce::Graphics &g)
 {
     surgeLookFeel->paintComponentBackground(g, getWidth(), getHeight());
 }

--- a/src/surge_effects_bank/SurgeFXEditor.h
+++ b/src/surge_effects_bank/SurgeFXEditor.h
@@ -10,21 +10,22 @@
 
 #pragma once
 
-#include "../JuceLibraryCode/JuceHeader.h"
 #include "SurgeFXProcessor.h"
 #include "SurgeLookAndFeel.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
 
 //==============================================================================
 /**
  */
-class SurgefxAudioProcessorEditor : public AudioProcessorEditor, AsyncUpdater
+class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor, juce::AsyncUpdater
 {
   public:
     SurgefxAudioProcessorEditor(SurgefxAudioProcessor &);
     ~SurgefxAudioProcessorEditor();
 
     //==============================================================================
-    void paint(Graphics &) override;
+    void paint(juce::Graphics &) override;
     void resized() override;
 
     void paramsChangedCallback();
@@ -42,14 +43,14 @@ class SurgefxAudioProcessorEditor : public AudioProcessorEditor, AsyncUpdater
     // access the processor object that created it.
     SurgefxAudioProcessor &processor;
 
-    Slider fxParamSliders[n_fx_params];
+    juce::Slider fxParamSliders[n_fx_params];
     SurgeFXParamDisplay fxParamDisplay[n_fx_params];
     SurgeTempoSyncSwitch fxTempoSync[n_fx_params];
     SurgeTempoSyncSwitch fxDeactivated[n_fx_params];
     SurgeTempoSyncSwitch fxExtended[n_fx_params];
     SurgeTempoSyncSwitch fxAbsoluted[n_fx_params];
 
-    TextButton
+    juce::TextButton
         selectType[n_fx_types]; // this had better match the list of fxnames in the constructor
     int typeByButtonIndex[n_fx_types];
 

--- a/src/surge_effects_bank/SurgeFXProcessor.h
+++ b/src/surge_effects_bank/SurgeFXProcessor.h
@@ -10,10 +10,10 @@
 
 #pragma once
 
-#include "../JuceLibraryCode/JuceHeader.h"
 #include "SurgeStorage.h"
-#include <functional>
 #include "Effect.h"
+
+#include "juce_audio_processors/juce_audio_processors.h"
 
 #if MAC
 #include <execinfo.h>
@@ -22,9 +22,9 @@
 //==============================================================================
 /**
  */
-class SurgefxAudioProcessor : public AudioProcessor,
-                              public AudioProcessorParameter::Listener,
-                              public AsyncUpdater
+class SurgefxAudioProcessor : public juce::AudioProcessor,
+                              public juce::AudioProcessorParameter::Listener,
+                              public juce::AsyncUpdater
 {
   public:
     //==============================================================================
@@ -37,14 +37,14 @@ class SurgefxAudioProcessor : public AudioProcessor,
 
     bool isBusesLayoutSupported(const BusesLayout &layouts) const override;
 
-    void processBlock(AudioBuffer<float> &, MidiBuffer &) override;
+    void processBlock(juce::AudioBuffer<float> &, juce::MidiBuffer &) override;
 
     //==============================================================================
-    AudioProcessorEditor *createEditor() override;
+    juce::AudioProcessorEditor *createEditor() override;
     bool hasEditor() const override;
 
     //==============================================================================
-    const String getName() const override;
+    const juce::String getName() const override;
 
     bool acceptsMidi() const override;
     bool producesMidi() const override;
@@ -55,11 +55,11 @@ class SurgefxAudioProcessor : public AudioProcessor,
     int getNumPrograms() override;
     int getCurrentProgram() override;
     void setCurrentProgram(int index) override;
-    const String getProgramName(int index) override;
-    void changeProgramName(int index, const String &newName) override;
+    const juce::String getProgramName(int index) override;
+    void changeProgramName(int index, const juce::String &newName) override;
 
     //==============================================================================
-    void getStateInformation(MemoryBlock &destData) override;
+    void getStateInformation(juce::MemoryBlock &destData) override;
     void setStateInformation(const void *data, int sizeInBytes) override;
 
     int getEffectType() { return effectNum; }
@@ -247,12 +247,12 @@ class SurgefxAudioProcessor : public AudioProcessor,
 
   private:
     //==============================================================================
-    AudioProcessorParameter *fxBaseParams[2 * n_fx_params + 1];
+    juce::AudioProcessorParameter *fxBaseParams[2 * n_fx_params + 1];
 
     // These are just copyes of the pointer from above with the cast done to make the code look
     // nicer
-    AudioParameterFloat *fxParams[n_fx_params];
-    AudioParameterInt *fxType;
+    juce::AudioParameterFloat *fxParams[n_fx_params];
+    juce::AudioParameterInt *fxType;
 
     enum ParamFeatureFlags
     {
@@ -261,7 +261,7 @@ class SurgefxAudioProcessor : public AudioProcessor,
         kAbsolute = 1U << 2U,
         kDeactivated = 1U << 3U
     };
-    AudioParameterInt *fxParamFeatures[n_fx_params];
+    juce::AudioParameterInt *fxParamFeatures[n_fx_params];
 
     std::atomic<bool> changedParams[2 * n_fx_params + 1];
     std::atomic<float> changedParamsValue[2 * n_fx_params + 1];

--- a/src/surge_effects_bank/SurgeLookAndFeel.h
+++ b/src/surge_effects_bank/SurgeLookAndFeel.h
@@ -1,12 +1,14 @@
 // -*- mode: c++-mode -*-
 
-#include "../JuceLibraryCode/JuceHeader.h"
 #include "version.h"
 
-class SurgeLookAndFeel : public LookAndFeel_V4
+#include "juce_gui_basics/juce_gui_basics.h"
+#include "BinaryData.h"
+
+class SurgeLookAndFeel : public juce::LookAndFeel_V4
 {
   private:
-    std::unique_ptr<Drawable> surgeLogo;
+    std::unique_ptr<juce::Drawable> surgeLogo;
 
   public:
     enum SurgeColourIds
@@ -47,13 +49,13 @@ class SurgeLookAndFeel : public LookAndFeel_V4
 
     SurgeLookAndFeel()
     {
-        Colour surgeGrayBg = Colour(205, 206, 212);
-        Colour surgeOrange = Colour(255, 144, 0);
-        Colour surgeBlue = Colour(18, 52, 99);
-        Colour white = Colour(255, 255, 255);
-        Colour black = Colour(0, 0, 0);
-        Colour surgeOrangeDark = Colour(101, 50, 3);
-        Colour surgeOrangeMedium = Colour(227, 112, 8);
+        juce::Colour surgeGrayBg = juce::Colour(205, 206, 212);
+        juce::Colour surgeOrange = juce::Colour(255, 144, 0);
+        juce::Colour surgeBlue = juce::Colour(18, 52, 99);
+        juce::Colour white = juce::Colour(255, 255, 255);
+        juce::Colour black = juce::Colour(0, 0, 0);
+        juce::Colour surgeOrangeDark = juce::Colour(101, 50, 3);
+        juce::Colour surgeOrangeMedium = juce::Colour(227, 112, 8);
 
         setColour(SurgeColourIds::componentBgStart,
                   surgeGrayBg.interpolatedWith(surgeOrangeMedium, 0.1));
@@ -86,13 +88,13 @@ class SurgeLookAndFeel : public LookAndFeel_V4
         setColour(SurgeColourIds::paramDisabledEdge, juce::Colour(150, 150, 150));
         setColour(SurgeColourIds::paramDisplay, white);
 
-        surgeLogo = Drawable::createFromImageData(BinaryData::SurgeLogoOnlyBlue_svg,
-                                                  BinaryData::SurgeLogoOnlyBlue_svgSize);
+        surgeLogo = juce::Drawable::createFromImageData(BinaryData::SurgeLogoOnlyBlue_svg,
+                                                        BinaryData::SurgeLogoOnlyBlue_svgSize);
     }
 
-    virtual void drawRotarySlider(Graphics &g, int x, int y, int width, int height, float sliderPos,
-                                  float rotaryStartAngle, float rotaryEndAngle,
-                                  Slider &slider) override
+    virtual void drawRotarySlider(juce::Graphics &g, int x, int y, int width, int height,
+                                  float sliderPos, float rotaryStartAngle, float rotaryEndAngle,
+                                  juce::Slider &slider) override
     {
         auto fill = findColour(SurgeColourIds::knobBg);
         auto edge = findColour(SurgeColourIds::knobEdge);
@@ -111,14 +113,16 @@ class SurgeLookAndFeel : public LookAndFeel_V4
         g.setColour(edge);
         g.drawEllipse(bounds, 1.0);
 
-        auto radius = jmin(bounds.getWidth(), bounds.getHeight()) / 2.0f;
+        auto radius = juce::jmin(bounds.getWidth(), bounds.getHeight()) / 2.0f;
         auto arcRadius = radius;
         auto toAngle = rotaryStartAngle + sliderPos * (rotaryEndAngle - rotaryStartAngle);
         auto thumbWidth = 5;
 
         juce::Point<float> thumbPoint(
-            bounds.getCentreX() + arcRadius * std::cos(toAngle - MathConstants<float>::halfPi),
-            bounds.getCentreY() + arcRadius * std::sin(toAngle - MathConstants<float>::halfPi));
+            bounds.getCentreX() +
+                arcRadius * std::cos(toAngle - juce::MathConstants<float>::halfPi),
+            bounds.getCentreY() +
+                arcRadius * std::sin(toAngle - juce::MathConstants<float>::halfPi));
 
         g.setColour(tick);
         g.fillEllipse(juce::Rectangle<float>(thumbWidth, thumbWidth).withCentre(thumbPoint));
@@ -128,11 +132,12 @@ class SurgeLookAndFeel : public LookAndFeel_V4
         g.fillEllipse(
             juce::Rectangle<float>(thumbWidth, thumbWidth).withCentre(bounds.getCentre()));
 
-        auto l = Line<float>(thumbPoint, bounds.getCentre());
+        auto l = juce::Line<float>(thumbPoint, bounds.getCentre());
         g.drawLine(l, thumbWidth);
     }
 
-    virtual void drawButtonBackground(Graphics &g, Button &button, const Colour &backgroundColour,
+    virtual void drawButtonBackground(juce::Graphics &g, juce::Button &button,
+                                      const juce::Colour &backgroundColour,
                                       bool shouldDrawButtonAsHighlighted,
                                       bool shouldDrawButtonAsDown) override
     {
@@ -175,27 +180,29 @@ class SurgeLookAndFeel : public LookAndFeel_V4
         g.drawRoundedRectangle(bounds, 3, edgeThickness);
     }
 
-    virtual void drawButtonText(Graphics &g, TextButton &button, bool shouldDrawButtonAsHighlighted,
+    virtual void drawButtonText(juce::Graphics &g, juce::TextButton &button,
+                                bool shouldDrawButtonAsHighlighted,
                                 bool shouldDrawButtonAsDown) override
     {
-        button.setColour(TextButton::ColourIds::textColourOffId,
+        button.setColour(juce::TextButton::ColourIds::textColourOffId,
                          findColour(SurgeColourIds::fxButtonTextUnselected));
 
-        button.setColour(TextButton::ColourIds::textColourOnId,
+        button.setColour(juce::TextButton::ColourIds::textColourOnId,
                          findColour(SurgeColourIds::fxButtonTextSelected));
 
         LookAndFeel_V4::drawButtonText(g, button, shouldDrawButtonAsHighlighted,
                                        shouldDrawButtonAsDown);
     }
 
-    void paintComponentBackground(Graphics &g, int w, int h)
+    void paintComponentBackground(juce::Graphics &g, int w, int h)
     {
         int orangeHeight = 40;
 
         g.fillAll(findColour(SurgeColourIds::componentBgStart));
 
-        ColourGradient cg(findColour(SurgeColourIds::componentBgStart), 0, 0,
-                          findColour(SurgeColourIds::componentBgEnd), 0, h - orangeHeight, false);
+        juce::ColourGradient cg(findColour(SurgeColourIds::componentBgStart), 0, 0,
+                                findColour(SurgeColourIds::componentBgEnd), 0, h - orangeHeight,
+                                false);
         g.setGradientFill(cg);
         g.fillRect(0, 0, w, h - orangeHeight);
 
@@ -221,7 +228,7 @@ class SurgeLookAndFeel : public LookAndFeel_V4
     }
 };
 
-class SurgeFXParamDisplay : public Component
+class SurgeFXParamDisplay : public juce::Component
 {
   public:
     virtual void setGroup(std::string grp)
@@ -246,7 +253,7 @@ class SurgeFXParamDisplay : public Component
         repaint();
     }
 
-    virtual void paint(Graphics &g)
+    virtual void paint(juce::Graphics &g)
     {
         auto bounds = getLocalBounds().toFloat().reduced(2.f, 2.f);
         auto edge = findColour(SurgeLookAndFeel::SurgeColourIds::paramEnabledEdge);
@@ -284,19 +291,19 @@ class SurgeFXParamDisplay : public Component
     bool appearsDeactivated = false;
 };
 
-class SurgeTempoSyncSwitch : public ToggleButton
+class SurgeTempoSyncSwitch : public juce::ToggleButton
 {
   public:
     void setOnOffImage(const char *onimgData, size_t onimgSize, const char *offimgData,
                        size_t offimgSize)
     {
-        onImg = Drawable::createFromImageData(onimgData, onimgSize);
-        offImg = Drawable::createFromImageData(offimgData, offimgSize);
+        onImg = juce::Drawable::createFromImageData(onimgData, onimgSize);
+        offImg = juce::Drawable::createFromImageData(offimgData, offimgSize);
     }
     std::unique_ptr<juce::Drawable> onImg, offImg;
 
   protected:
-    virtual void paintButton(Graphics &g, bool shouldDrawButtonAsHighlighted,
+    virtual void paintButton(juce::Graphics &g, bool shouldDrawButtonAsHighlighted,
                              bool shouldDrawButtonAsDown) override
     {
         if (isEnabled() && onImg && offImg)

--- a/src/surge_synth_juce/LockFreeStack.h
+++ b/src/surge_synth_juce/LockFreeStack.h
@@ -16,7 +16,8 @@
 #ifndef SURGE_XT_LOCKFREESTACK_H
 #define SURGE_XT_LOCKFREESTACK_H
 
-#include <JuceHeader.h>
+#include "juce_core/juce_core.h"
+
 #include <array>
 
 template <typename T, int qSize = 4096> class LockFreeStack

--- a/src/surge_synth_juce/SurgeSynthEditor.h
+++ b/src/surge_synth_juce/SurgeSynthEditor.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include <JuceHeader.h>
-
 #include "SurgeSynthProcessor.h"
+
+#include "juce_audio_utils/juce_audio_utils.h"
 
 class SurgeGUIEditor;
 class SurgeJUCELookAndFeel;

--- a/src/surge_synth_juce/SurgeSynthProcessor.h
+++ b/src/surge_synth_juce/SurgeSynthProcessor.h
@@ -10,13 +10,12 @@
 
 #pragma once
 
-#include <JuceHeader.h>
-
 #include "SurgeSynthesizer.h"
 #include "SurgeStorage.h"
 #include "LockFreeStack.h"
 
-#include <functional>
+#include "juce_audio_processors/juce_audio_processors.h"
+
 #include <unordered_map>
 
 #if MAC

--- a/src/surge_synth_juce/SurgeSynthVST3Extensions.cpp
+++ b/src/surge_synth_juce/SurgeSynthVST3Extensions.cpp
@@ -13,7 +13,6 @@
 ** open source in September 2018.
 */
 
-#include <JuceHeader.h>
 #include <iostream>
 
 #include "SurgeSynthProcessor.h"


### PR DESCRIPTION
JuceHeader.h is a generated header that includes all enabled JUCE
modules. This was bloating the preprocessed sources of many Surge TUs by
hundreds of KBytes each (on Linux), slowing down the build somewhat.

Also, JuceHeader.h is generated at build time, impairing IDE navigation
and completion until halfway through an initial build.

This change includes only the required JUCE modules directly, which
is supported in CMake projects as per the documentation.