### PR TITLE
Change a few patch db things

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -691,6 +691,9 @@ void SurgeStorage::createUserDirectory()
 
 void SurgeStorage::initializePatchDb()
 {
+    if (patchDB)
+        return;
+
     patchDB = std::make_unique<Surge::PatchStorage::PatchDB>(this);
 
     auto catToType = [this](int q) {

--- a/src/gui/overlays/PatchDBViewer.cpp
+++ b/src/gui/overlays/PatchDBViewer.cpp
@@ -270,6 +270,7 @@ class PatchDBSQLTableModel : public juce::TableListBoxModel
 PatchDBViewer::PatchDBViewer(SurgeGUIEditor *e, SurgeStorage *s)
     : editor(e), storage(s), juce::Component("PatchDB Viewer")
 {
+    storage->initializePatchDb();
     createElements();
 }
 PatchDBViewer::~PatchDBViewer() { treeView->setRootItem(nullptr); };

--- a/src/surge_synth_juce/SurgeSynthProcessor.cpp
+++ b/src/surge_synth_juce/SurgeSynthProcessor.cpp
@@ -41,7 +41,6 @@ SurgeSynthProcessor::SurgeSynthProcessor()
               << "  - CPU          : " << Surge::CPUFeatures::cpuBrand() << std::endl;
 
     surge = std::make_unique<SurgeSynthesizer>(this);
-    surge->storage.initializePatchDb(); // In the UI branch we want the patch DB running
 
     auto parent = std::make_unique<AudioProcessorParameterGroup>("Root", "Root", "|");
     auto macroG = std::make_unique<AudioProcessorParameterGroup>("macros", "Macros", "|");
@@ -147,6 +146,7 @@ void SurgeSynthProcessor::setCurrentProgram(int index)
 
 const String SurgeSynthProcessor::getProgramName(int index)
 {
+#ifdef SURGE_JUCE_PRESETS
     if (index == 0)
         return "INIT OR DROPPED";
     index--;
@@ -157,6 +157,9 @@ const String SurgeSynthProcessor::getProgramName(int index)
     auto patch = surge->storage.patch_list[presetOrderToPatchList[index]];
     auto res = surge->storage.patch_category[patch.category].name + " / " + patch.name;
     return res;
+#else
+    return "";
+#endif
 }
 
 void SurgeSynthProcessor::changeProgramName(int index, const String &newName) {}


### PR DESCRIPTION
1. Don't initialize the DB on startup; rather init it when
   you first open the patch browser
2. End my 'throw in destructor' bad habit since that worked
   horribly. Catch everything properly etc...

This closes #4822 but there's still lots to do in #2359 including
a nasty locked handler fail when you start two surges against a fresh
db