### PR TITLE
Reduce allocation on audio thread

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -766,7 +766,9 @@ void SurgePatch::update_controls(
             for (int i = 0; i < n_osc_params; i++)
                 sc.osc[osc].p[i].set_type(ct_none);
 
-            Oscillator *t_osc = spawn_osc(sc.osc[osc].type.val.i, nullptr, &sc.osc[osc], nullptr);
+            unsigned char mbuf alignas(16)[oscillator_buffer_size];
+            Oscillator *t_osc =
+                spawn_osc(sc.osc[osc].type.val.i, nullptr, &sc.osc[osc], nullptr, mbuf);
             if (t_osc)
             {
                 t_osc->init_ctrltypes(sn, osc);
@@ -778,7 +780,8 @@ void SurgePatch::update_controls(
                     t_osc->init_default_values();
                     t_osc->init_extra_config();
                 }
-                delete t_osc;
+                // delete t_osc;
+                t_osc->~Oscillator();
             }
         }
         sn++;

--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -30,47 +30,89 @@
 #include "TwistOscillator.h"
 #include "WavetableOscillator.h"
 #include "WindowOscillator.h"
+#include <utility>
 
 using namespace std;
 
 Oscillator *spawn_osc(int osctype, SurgeStorage *storage, OscillatorStorage *oscdata,
-                      pdata *localcopy)
+                      pdata *localcopy, unsigned char *onto)
 {
+    static bool checkSizes = true;
+    if (checkSizes)
+    {
+        size_t mx = 0;
+// #define S(x) std::cout << "sizeof(" << #x << ")=" << sizeof(x) << std::endl; mx = std::max(mx,
+// sizeof(x));
+#define S(x) mx = std::max(mx, sizeof(x));
+        S(ClassicOscillator);
+        S(WavetableOscillator);
+        S(WindowOscillator);
+        S(SineOscillator);
+        S(SampleAndHoldOscillator);
+        S(AudioInputOscillator);
+        S(FM2Oscillator);
+        S(FM3Oscillator);
+        S(ModernOscillator);
+        S(StringOscillator);
+        S(TwistOscillator);
+        S(AliasOscillator);
+
+        checkSizes = false;
+
+        if (mx > oscillator_buffer_size)
+        {
+            /*
+             * If you hit this you have added members to an oscillator type which are bigger than
+             * the static buffer into which we allocate oscillators. Basically at this point you
+             * either want to make your class smaller, make the buffer size bigger, or grab one of
+             * the other devs and ask for help.
+             *
+             * Surge will be so horribly broken in this case and it is a compile time condition that
+             * I decided to just throw an error out of here and crash everything. No way you can
+             * trigger this without changing source so it is safe!
+             */
+            std::cout
+                << "PANIC: Oscillator Buffer Size smaller than max sizeof one oscillator class"
+                << std::endl;
+            throw std::runtime_error("Software Error - Resize class or buffer");
+        }
+    }
+
     Oscillator *osc = 0;
     switch (osctype)
     {
     case ot_classic:
-        return new ClassicOscillator(storage, oscdata, localcopy);
+        return new (onto) ClassicOscillator(storage, oscdata, localcopy);
     case ot_wavetable:
-        return new WavetableOscillator(storage, oscdata, localcopy);
+        return new (onto) WavetableOscillator(storage, oscdata, localcopy);
     case ot_window:
     {
         // In the event we are misconfigured, window oscillator will segfault. If you still play
         // after clicking through 100 warnings, let's just give you a sine
         if (storage && storage->WindowWT.size == 0)
-            return new SineOscillator(storage, oscdata, localcopy);
+            return new (onto) SineOscillator(storage, oscdata, localcopy);
 
-        return new WindowOscillator(storage, oscdata, localcopy);
+        return new (onto) WindowOscillator(storage, oscdata, localcopy);
     }
     case ot_shnoise:
-        return new SampleAndHoldOscillator(storage, oscdata, localcopy);
+        return new (onto) SampleAndHoldOscillator(storage, oscdata, localcopy);
     case ot_audioinput:
-        return new AudioInputOscillator(storage, oscdata, localcopy);
+        return new (onto) AudioInputOscillator(storage, oscdata, localcopy);
     case ot_FM3:
-        return new FM3Oscillator(storage, oscdata, localcopy);
+        return new (onto) FM3Oscillator(storage, oscdata, localcopy);
     case ot_FM2:
-        return new FM2Oscillator(storage, oscdata, localcopy);
+        return new (onto) FM2Oscillator(storage, oscdata, localcopy);
     case ot_modern:
-        return new ModernOscillator(storage, oscdata, localcopy);
+        return new (onto) ModernOscillator(storage, oscdata, localcopy);
     case ot_string:
-        return new StringOscillator(storage, oscdata, localcopy);
+        return new (onto) StringOscillator(storage, oscdata, localcopy);
     case ot_twist:
-        return new TwistOscillator(storage, oscdata, localcopy);
+        return new (onto) TwistOscillator(storage, oscdata, localcopy);
     case ot_alias:
-        return new AliasOscillator(storage, oscdata, localcopy);
+        return new (onto) AliasOscillator(storage, oscdata, localcopy);
     case ot_sine:
     default:
-        return new SineOscillator(storage, oscdata, localcopy);
+        return new (onto) SineOscillator(storage, oscdata, localcopy);
     }
     return osc;
 }

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -7,5 +7,8 @@
 
 #include "OscillatorBase.h"
 
+static constexpr size_t oscillator_buffer_size = 16 * 1024;
+
 Oscillator *spawn_osc(int osctype, SurgeStorage *storage, OscillatorStorage *oscdata,
-                      pdata *localcopy);
+                      pdata *localcopy,
+                      unsigned char *onto); // This buffer should be at least oscillator_buffer_size

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -362,7 +362,8 @@ void SurgeVoice::switch_toggled()
         if (osctype[i] != scene->osc[i].type.val.i)
         {
             bool nzid = scene->drift.extend_range;
-            osc[i].reset(spawn_osc(scene->osc[i].type.val.i, storage, &scene->osc[i], localcopy));
+            osc[i] = spawn_osc(scene->osc[i].type.val.i, storage, &scene->osc[i], localcopy,
+                               oscbuffer[i]);
             if (osc[i])
             {
                 osc[i]->init(state.pitch, false, nzid);
@@ -1220,7 +1221,8 @@ void SurgeVoice::freeAllocatedElements()
 {
     for (int i = 0; i < 3; ++i)
     {
-        osc[i].reset(nullptr);
+        osc[i]->~Oscillator();
+        osc[i] = nullptr;
         osctype[i] = -1;
     }
     for (int i = 0; i < n_lfos_voice; ++i)

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -177,7 +177,8 @@ class alignas(16) SurgeVoice
     int FMmode;
     float noisegenL[2], noisegenR[2];
 
-    std::unique_ptr<Oscillator> osc[3];
+    Oscillator *osc[n_oscs];
+    unsigned char oscbuffer alignas(16)[n_oscs][oscillator_buffer_size];
 
   public: // this is public, but only for the regtests
     std::array<ModulationSource *, n_modsources> modsources;

--- a/src/common/dsp/oscillators/StringOscillator.cpp
+++ b/src/common/dsp/oscillators/StringOscillator.cpp
@@ -80,6 +80,8 @@ std::string stringosc_excitation_name(int i)
     return "Unknown";
 }
 
+StringOscillator::~StringOscillator() = default;
+
 void StringOscillator::init(float pitch, bool is_display, bool nzi)
 {
     memset((void *)dustBuffer, 0, 2 * (BLOCK_SIZE_OS) * sizeof(float));
@@ -141,7 +143,7 @@ void StringOscillator::init(float pitch, bool is_display, bool nzi)
 
     for (int i = 0; i < 2; ++i)
     {
-        delayLine[i].clear();
+        delayLine[i]->clear();
         driftLFO[i].init(nzi);
     }
 
@@ -319,7 +321,7 @@ void StringOscillator::init(float pitch, bool is_display, bool nzi)
 
         for (int t = 0; t < 2; ++t)
         {
-            delayLine[t].write(tone.v < 0 ? lpt[t] : hpt[t]);
+            delayLine[t]->write(tone.v < 0 ? lpt[t] : hpt[t]);
         }
     }
     lp.flush_sample_denormal();
@@ -327,7 +329,7 @@ void StringOscillator::init(float pitch, bool is_display, bool nzi)
 
     for (int t = 0; t < 2; ++t)
     {
-        priorSample[t] = delayLine[t].buffer[(delayLine[t].wp - 1) & delayLine[t].comb_size];
+        priorSample[t] = delayLine[t]->buffer[(delayLine[t]->wp - 1) & delayLine[t]->comb_size];
     }
 
     charFilt.init(storage->getPatch().character.val.i);
@@ -448,8 +450,8 @@ void StringOscillator::process_block_internal(float pitch, float drift, bool ste
         dp2 = pitch_to_dphase(pitch2_t);
     }
 
-    pitchmult_inv = std::min(pitchmult_inv, (delayLine[0].comb_size - 100) * 1.0);
-    pitchmult2_inv = std::min(pitchmult2_inv, (delayLine[0].comb_size - 100) * 1.0);
+    pitchmult_inv = std::min(pitchmult_inv, (delayLine[0]->comb_size - 100) * 1.0);
+    pitchmult2_inv = std::min(pitchmult2_inv, (delayLine[0]->comb_size - 100) * 1.0);
 
     tap[0].newValue(pitchmult_inv);
     tap[1].newValue(pitchmult2_inv);
@@ -507,7 +509,7 @@ void StringOscillator::process_block_internal(float pitch, float drift, bool ste
                 v *= Surge::DSP::fastexp(limit_range(fmdepth.v * master_osc[i] * 3, -6.f, 4.f));
             }
 
-            val[t] = delayLine[t].read(v);
+            val[t] = delayLine[t]->read(v);
             fbNoOutVal[t] = 0.f;
 
             // Add continuous excitation
@@ -599,7 +601,7 @@ void StringOscillator::process_block_internal(float pitch, float drift, bool ste
 
             if (fabs(filtv) < 1e-16)
                 filtv = 0;
-            delayLine[t].write(filtv * feedback[t].v);
+            delayLine[t]->write(filtv * feedback[t].v);
         }
 
         float out = val[0] + t2level.v * (val[1] - val[0]);

--- a/src/common/dsp/oscillators/StringOscillator.h
+++ b/src/common/dsp/oscillators/StringOscillator.h
@@ -60,7 +60,11 @@ class StringOscillator : public Oscillator
     StringOscillator(SurgeStorage *s, OscillatorStorage *o, pdata *p)
         : Oscillator(s, o, p), lp(s), hp(s), noiseLp(s)
     {
+        delayLine[0] = std::make_unique<SSESincDelayLine<16384>>();
+        delayLine[1] = std::make_unique<SSESincDelayLine<16384>>();
     }
+
+    ~StringOscillator();
 
     virtual void init(float pitch, bool is_display = false, bool nonzero_drift = true);
     virtual void init_ctrltypes(int scene, int oscnum) { init_ctrltypes(); };
@@ -78,7 +82,7 @@ class StringOscillator : public Oscillator
 
     lag<float, true> examp, tap[2], t2level, feedback[2], tone, fmdepth;
 
-    SSESincDelayLine<16384> delayLine[2];
+    std::array<std::unique_ptr<SSESincDelayLine<16384>>, 2> delayLine;
     float priorSample[2] = {0, 0};
     Surge::Oscillator::DriftLFO driftLFO[2];
     Surge::Oscillator::CharacterFilter<float> charFilt;

--- a/src/common/dsp/oscillators/TwistOscillator.h
+++ b/src/common/dsp/oscillators/TwistOscillator.h
@@ -83,7 +83,7 @@ class TwistOscillator : public Oscillator
     std::unique_ptr<plaits::Patch> patch;
     std::unique_ptr<plaits::Modulations> mod;
     std::unique_ptr<stmlib::BufferAllocator> alloc;
-    char shared_buffer[16834];
+    char *shared_buffer{nullptr};
 
     // Keep this here for now even if using lanczos since I'm using SRC for FM still
     SRC_STATE_tag *srcstate, *fmdownsamplestate;
@@ -91,7 +91,7 @@ class TwistOscillator : public Oscillator
     int fmwp, fmrp;
 
 #if SAMPLERATE_LANCZOS
-    LanczosResampler lancRes;
+    std::unique_ptr<LanczosResampler> lancRes;
 #endif
 
     float carryover[BLOCK_SIZE_OS][2];

--- a/src/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -115,6 +115,9 @@ void OscillatorWaveformDisplay::paint(juce::Graphics &g)
         }
     }
 
+    osc->~Oscillator();
+    osc = nullptr;
+
     auto yMargin = 2 * usesWT;
     auto h = getHeight() - usesWT * wtbheight - 2 * yMargin;
     auto xMargin = 2;
@@ -254,12 +257,12 @@ void OscillatorWaveformDisplay::repaintIfIdIsInRange(int id)
     }
 }
 
-std::unique_ptr<::Oscillator> OscillatorWaveformDisplay::setupOscillator()
+::Oscillator *OscillatorWaveformDisplay::setupOscillator()
 {
     tp[oscdata->pitch.param_id_in_scene].f = 0;
     for (int i = 0; i < n_osc_params; i++)
         tp[oscdata->p[i].param_id_in_scene].i = oscdata->p[i].val.i;
-    return std::unique_ptr<::Oscillator>(spawn_osc(oscdata->type.val.i, storage, oscdata, tp));
+    return spawn_osc(oscdata->type.val.i, storage, oscdata, tp, oscbuffer);
 }
 
 void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int selectedItem)

--- a/src/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/gui/widgets/OscillatorWaveformDisplay.h
@@ -21,6 +21,7 @@
 #include "SurgeStorage.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
+#include "Oscillator.h"
 
 class SurgeStorage;
 class SurgeGUIEditor;
@@ -58,7 +59,8 @@ struct OscillatorWaveformDisplay : public juce::Component, public Surge::GUI::Sk
 
     void repaintIfIdIsInRange(int id);
 
-    std::unique_ptr<::Oscillator> setupOscillator();
+    ::Oscillator *setupOscillator();
+    unsigned char oscbuffer alignas(16)[oscillator_buffer_size];
 
     void paint(juce::Graphics &g) override;
 


### PR DESCRIPTION
1. Make string and twist "small" with alloc in ctor/dtor for now
2. Once they are small, move spawn_osc to take an external buffer
   and new onto that
3. And then manage those buffers as a member of voice or as memory
   handed in from some other mechanism

Addresses #805

To be done with #805 I need to deal with those String and Twsti allocations
although I may open that as two separate issues.