### PR TITLE
Workaround build failure with glibc >= 2.34

### DIFF
--- a/libs/catch2/include/catch2/catch2.hpp
+++ b/libs/catch2/include/catch2/catch2.hpp
@@ -10452,7 +10452,7 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    static constexpr std::size_t sigStackSize = 32768;
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },


### PR DESCRIPTION
Seems glibc changed definition of MINSIGSTKSZ to

| # define MINSIGSTKSZ SIGSTKSZ
and
| # define SIGSTKSZ sysconf (_SC_SIGSTKSZ)

which is not constexpr. So build fails with:
| In file included from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/recipe-sysroot/usr/include/signal.h:328,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/git/libs/catch2/include/catch2/catch2.hpp:7641,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/git/src/headless/UnitTests.cpp:3:
| /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/git/libs/catch2/include/catch2/catch2.hpp:10455:58: error: call to non-'constexpr' function 'long int sysconf(int)'
| 10455 |     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
|       |                                                          ^~~~~~~~~~~
| In file included from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/recipe-sysroot/usr/include/bits/sigstksz.h:24,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/recipe-sysroot/usr/include/signal.h:328,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/git/libs/catch2/include/catch2/catch2.hpp:7641,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/git/src/headless/UnitTests.cpp:3:
| /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/recipe-sysroot/usr/include/unistd.h:641:17: note: 'long int sysconf(int)' declared here
|   641 | extern long int sysconf (int __name) __THROW;
|       |                 ^~~~~~~
| In file included from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/git/src/headless/UnitTests.cpp:3:
| /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/surge/1.9.0-r0/git/libs/catch2/include/catch2/catch2.hpp:10514:45: error: size of array 'altStackMem' is not an integral constant-expression
| 10514 |     char FatalConditionHandler::altStackMem[sigStackSize] = {};
|       |                                             ^~~~~~~~~~~~

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>