### PR TITLE
Audio Engine Unavailable Report Improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,7 @@ set(SURGE_GUI_SOURCES
   src/gui/UIInstrumentation.cpp
 
   src/gui/overlays/AboutScreen.cpp
+  src/gui/overlays/CoveringMessageOverlay.cpp
   src/gui/overlays/LuaEditors.cpp
   src/gui/overlays/MiniEdit.cpp
   src/gui/overlays/ModulationEditor.cpp

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3296,6 +3296,7 @@ void SurgeSynthesizer::process()
 #if DEBUG_RNG_THREADING
     storage.audioThreadID = pthread_self();
 #endif
+    processRunning = 0;
 
     float mfade = 1.f;
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -137,6 +137,8 @@ class alignas(16) SurgeSynthesizer
                                                // // TODO: FIX SCENE ASSUMPTION!
     int64_t voiceCounter = 1L;
 
+    std::atomic<unsigned int> processRunning{0};
+
   public:
     /*
      * For more on this IFDEF see the comment in SurgeSynthesizerIDManagement.cpp

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -33,6 +33,7 @@
 #include "SurgeGUIEditorTags.h"
 
 #include "overlays/AboutScreen.h"
+#include "overlays/CoveringMessageOverlay.h"
 #include "overlays/LuaEditors.h"
 #include "overlays/MiniEdit.h"
 #include "overlays/MSEGEditor.h"
@@ -202,6 +203,31 @@ void SurgeGUIEditor::idle()
 {
     if (!synth)
         return;
+
+    if (noProcessingOverlay)
+    {
+        if (synth->processRunning == 0)
+        {
+            frame->removeChildComponent(noProcessingOverlay.get());
+            noProcessingOverlay.reset(nullptr);
+        }
+    }
+    else
+    {
+        if (processRunningCheckEvery++ > 3 || processRunningCheckEvery < 0)
+        {
+            synth->processRunning++;
+            if (synth->processRunning > 20)
+            {
+                noProcessingOverlay =
+                    std::make_unique<Surge::Overlays::AudioEngineNotRunningOverlay>();
+                noProcessingOverlay->setBounds(frame->getBounds());
+                frame->addAndMakeVisible(*noProcessingOverlay);
+                synth->processRunning = 1;
+            }
+            processRunningCheckEvery = 0;
+        }
+    }
 
     if (pause_idle_updates)
         return;

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -441,6 +441,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     int selectedFX[8];
     std::string fxPresetName[8];
 
+    int processRunningCheckEvery{0};
+    std::unique_ptr<juce::Component> noProcessingOverlay{nullptr};
+
   public:
     std::shared_ptr<SurgeImageStore> bitmapStore = nullptr;
 

--- a/src/gui/overlays/CoveringMessageOverlay.cpp
+++ b/src/gui/overlays/CoveringMessageOverlay.cpp
@@ -1,0 +1,38 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "CoveringMessageOverlay.h"
+#include "RuntimeFont.h"
+
+namespace Surge
+{
+namespace Overlays
+{
+void CoveringMessageOverlay::paint(juce::Graphics &g)
+{
+    g.fillAll(juce::Colours::black.withAlpha(0.7f));
+    auto rT = getLocalBounds().withHeight(40).translated(0, 10);
+    auto rM = getLocalBounds().withTrimmedTop(75);
+
+    g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(30));
+    g.setColour(juce::Colours::white);
+    g.drawText(pt, rT, juce::Justification::centred);
+
+    g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(12));
+    g.setColour(juce::Colours::white);
+    g.drawMultiLineText(et, 20, rM.getY(), getWidth() - 40, juce::Justification::centred);
+}
+} // namespace Overlays
+} // namespace Surge

--- a/src/gui/overlays/CoveringMessageOverlay.h
+++ b/src/gui/overlays/CoveringMessageOverlay.h
@@ -1,0 +1,73 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#ifndef SURGE_XT_COVERINGMESSAGEOVERLAY_H
+#define SURGE_XT_COVERINGMESSAGEOVERLAY_H
+
+#include "juce_gui_basics/juce_gui_basics.h"
+namespace Surge
+{
+namespace Overlays
+{
+struct CoveringMessageOverlay : public juce::Component
+{
+    CoveringMessageOverlay() : juce::Component("CoveringMessage") {}
+    std::string pt, et;
+    void setPrimaryTitle(const std::string &msg)
+    {
+        pt = msg;
+        repaint();
+    }
+    void setExplanatoryText(const std::string &txt)
+    {
+        et = txt;
+        repaint();
+    }
+
+    void paint(juce::Graphics &g) override;
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(CoveringMessageOverlay);
+};
+
+struct AudioEngineNotRunningOverlay : public CoveringMessageOverlay
+{
+    AudioEngineNotRunningOverlay() : CoveringMessageOverlay()
+    {
+        setPrimaryTitle("Audio Engine Not Running");
+        setExplanatoryText(
+            R"MSG(The Surge UI requires the audio engine to be running in order for the UI to
+interact with the synth. A running audio engine is required to provide several
+core features, including modifying oscillator and FX types and loading patches.
+
+This instance of Surge does not have a running audio engine. Either the audio engine
+in your DAW is suspended, your instance of Surge is suspended, or in the standalone
+Surge application, you have not connected your output to at least a stereo output bus.
+
+To dismiss this message, start your audio engine, unsuspend this instance of Surge,
+or set up your standalone output routing appropriately.
+)MSG");
+
+#if SURGE_JUCE_ACCESSIBLE
+        setTitle(pt);
+        setDescription(pt);
+        setAccessible(true);
+#endif
+    }
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioEngineNotRunningOverlay);
+};
+
+} // namespace Overlays
+} // namespace Surge
+
+#endif // SURGE_XT_COVERINGMESSAGEOVERLAY_H


### PR DESCRIPTION
1. Have the synth and the GUI editor have a lock free communication
   that processing is happening
2. Have the GUI editor use that in ::idle to detect changes in
   the processing state
3. Implement the UI feedback to cover the UI and show a message

Closes #3503