### PR TITLE
Remove prior skin components on skin swap

### DIFF
--- a/src/gui/SkinSupport.cpp
+++ b/src/gui/SkinSupport.cpp
@@ -985,6 +985,7 @@ bool Skin::recursiveGroupParse(ControlGroup::ptr_t parent, TiXmlElement *control
             }
 
             controls.push_back(control);
+            sessionIds.insert(control->sessionid);
             parent->childControls.push_back(control);
         }
         else

--- a/src/gui/SkinSupport.h
+++ b/src/gui/SkinSupport.h
@@ -234,6 +234,12 @@ class Skin
 
     bool hasColor(const Surge::Skin::Color &col) const { return hasColor(col.name); }
 
+    std::unordered_set<Control::sessionid_t> sessionIds;
+    bool containsControlWithSessionId(const Control::sessionid_t &sid)
+    {
+        return (sessionIds.find(sid) != sessionIds.end());
+    }
+
     Skin::Control::ptr_t controlForUIID(const std::string &ui_id) const
     {
         // FIXME don't be stupid like this of course
@@ -261,6 +267,7 @@ class Skin
             res->copyFromConnector(c, getVersion());
             // resolveBaseParentOffsets( res );
             controls.push_back(res);
+            sessionIds.insert(res->sessionid);
         }
         return res;
     }

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -690,6 +690,23 @@ void SurgeGUIEditor::idle()
           */
     }
 #endif
+
+    if (scanJuceSkinComponents)
+    {
+        std::vector<Surge::GUI::Skin::Control::sessionid_t> toRemove;
+        for (const auto &c : juceSkinComponents)
+        {
+            if (!currentSkin->containsControlWithSessionId(c.first))
+            {
+                toRemove.push_back(c.first);
+            }
+        }
+        for (const auto &sid : toRemove)
+        {
+            juceSkinComponents.erase(sid);
+        }
+        scanJuceSkinComponents = false;
+    }
 }
 
 void SurgeGUIEditor::toggle_mod_editing()
@@ -3283,6 +3300,9 @@ void SurgeGUIEditor::reloadFromSkin()
     setJUCEColour(juce::ComboBox::backgroundColourId, juce::Colour(32, 32, 32));
     setJUCEColour(juce::PopupMenu::backgroundColourId, juce::Colour(48, 48, 48));
     setJUCEColour(juce::PopupMenu::highlightedBackgroundColourId, juce::Colour(96, 96, 96));
+
+    synth->refresh_editor = true;
+    scanJuceSkinComponents = true;
 }
 
 juce::PopupMenu SurgeGUIEditor::makeDevMenu(const juce::Point<int> &where)

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -505,6 +505,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
      */
     std::array<std::unique_ptr<Surge::Widgets::EffectLabel>, 15> effectLabels;
 
+    bool scanJuceSkinComponents{false};
     std::unordered_map<Surge::GUI::Skin::Control::sessionid_t, std::unique_ptr<juce::Component>>
         juceSkinComponents;
     template <typename T>


### PR DESCRIPTION
Prior skin components were removed from frame but
a refernece to their pointer was still around. When
we swap skins, clean them up. (They didn't leak per
se since they went away at shutdown but they were unused
and unallocated at runtime before this)

Closes #4588