### PR TITLE
Fix LFO Display Hover Bug

### DIFF
--- a/src/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/gui/widgets/LFOAndStepDisplay.cpp
@@ -1207,6 +1207,13 @@ void LFOAndStepDisplay::mouseDown(const juce::MouseEvent &event)
         }
     }
 }
+
+void LFOAndStepDisplay::mouseExit(const juce::MouseEvent &event)
+{
+    lfoTypeHover = -1;
+    repaint();
+}
+
 void LFOAndStepDisplay::mouseMove(const juce::MouseEvent &event)
 {
     int nextHover = -1;

--- a/src/gui/widgets/LFOAndStepDisplay.h
+++ b/src/gui/widgets/LFOAndStepDisplay.h
@@ -90,6 +90,7 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
     void mouseDoubleClick(const juce::MouseEvent &event) override;
     void mouseWheelMove(const juce::MouseEvent &event,
                         const juce::MouseWheelDetails &wheel) override;
+    void mouseExit(const juce::MouseEvent &event) override;
 
     enum DragMode
     {


### PR DESCRIPTION
The LFO Display would not unhover in an overall mouse exit
resulting in a lingering hover on left side exit.