### PR TITLE
Correct Const in get_extended

### DIFF
--- a/src/common/FxPresetAndClipboardManager.cpp
+++ b/src/common/FxPresetAndClipboardManager.cpp
@@ -321,7 +321,7 @@ void loadPresetOnto(const Preset &p, SurgeStorage *storage, FxStorage *fxbuffer)
             break;
         }
         fxbuffer->p[i].temposync = (int)p.ts[i];
-        fxbuffer->p[i].extend_range = (int)p.er[i];
+        fxbuffer->p[i].set_extend_range((int)p.er[i]);
         fxbuffer->p[i].deactivated = (int)p.da[i];
 
         if (p.dt[i] >= 0) // only set deform type if it could be read from the xml
@@ -411,7 +411,7 @@ void pasteFx(SurgeStorage *storage, FxStorage *fxbuffer, Clipboard &cb)
             break;
         }
         fxbuffer->p[i].temposync = (int)cb.fxCopyPaste[tp];
-        fxbuffer->p[i].extend_range = (int)cb.fxCopyPaste[xp];
+        fxbuffer->p[i].set_extend_range((int)cb.fxCopyPaste[xp]);
         fxbuffer->p[i].deactivated = (int)cb.fxCopyPaste[dp];
 
         if (fxbuffer->p[i].has_deformoptions())

--- a/src/common/ModulatorPresetManager.cpp
+++ b/src/common/ModulatorPresetManager.cpp
@@ -190,9 +190,9 @@ void loadPresetFrom(const fs::path &location, SurgeStorage *s, int scene, int lf
             else
                 curr->deform_type = 0;
             if (valNode->QueryIntAttribute("extend_range", &q) == TIXML_SUCCESS)
-                curr->extend_range = q;
+                curr->set_extend_range(q);
             else
-                curr->extend_range = false;
+                curr->set_extend_range(false);
             if (valNode->QueryIntAttribute("deactivated", &q) == TIXML_SUCCESS &&
                 curr->can_deactivate())
                 curr->deactivated = q;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -396,7 +396,7 @@ class Parameter
     const char *get_internal_name() const;
     const char *get_storage_name() const;
     const wchar_t *getUnit() const;
-    void get_display(char *txt, bool external = false, float ef = 0.f);
+    void get_display(char *txt, bool external = false, float ef = 0.f) const;
     enum ModulationDisplayMode
     {
         TypeIn,
@@ -406,12 +406,12 @@ class Parameter
 
     void get_display_of_modulation_depth(char *txt, float modulationDepth, bool isBipolar,
                                          ModulationDisplayMode mode,
-                                         ModulationDisplayInfoWindowStrings *iw = nullptr);
+                                         ModulationDisplayInfoWindowStrings *iw = nullptr) const;
     void get_display_alt(char *txt, bool external = false, float ef = 0.f) const;
     char *get_storage_value(char *) const;
     void set_storage_value(int i);
     void set_storage_value(float f);
-    float get_extended(float f);
+    float get_extended(float f) const;
     float get_value_f01() const;
     float normalized_to_value(float value) const;
     float value_to_normalized(float value) const;
@@ -419,6 +419,7 @@ class Parameter
     void set_value_f01(float v, bool force_integer = false);
     bool set_value_from_string(const std::string &s);
     bool set_value_from_string_onto(const std::string &s, pdata &ontoThis);
+    void set_extend_range(bool er);
 
     /*
      * These two functions convert the modulation depth to a -1,1 range appropriate
@@ -458,7 +459,16 @@ class Parameter
     bool affect_other_parameters{};
     float moverate{};
     bool per_voice_processing{};
-    bool temposync{}, extend_range{}, absolute{}, deactivated{};
+    bool temposync{}, absolute{}, deactivated{};
+
+#define DEBUG_WRITABLE_EXTEND_RANGE 0
+#if DEBUG_WRITABLE_EXTEND_RANGE
+    bool extend_range_internal{};
+    const bool &extend_range = extend_range_internal;
+#else
+    bool extend_range{};
+#endif
+
     bool porta_constrate{}, porta_gliss{}, porta_retrigger{};
     int porta_curve{};
     int deform_type{};

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1293,15 +1293,15 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             if (p->QueryIntAttribute("extend_range", &j) == TIXML_SUCCESS)
             {
                 if (j == 1)
-                    param_ptr[i]->extend_range = true;
+                    param_ptr[i]->set_extend_range(true);
                 else
-                    param_ptr[i]->extend_range = false;
+                    param_ptr[i]->set_extend_range(false);
             }
             else
             {
-                param_ptr[i]->extend_range = false;
+                param_ptr[i]->set_extend_range(false);
                 if (revision >= 16 && param_ptr[i]->ctrltype == ct_percent_oscdrift)
-                    param_ptr[i]->extend_range = true;
+                    param_ptr[i]->set_extend_range(true);
             }
 
             if ((p->QueryIntAttribute("absolute", &j) == TIXML_SUCCESS) && (j == 1))

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -624,7 +624,7 @@ bailOnPortable:
 
     for (int s = 0; s < n_scenes; ++s)
     {
-        getPatch().scene[s].drift.extend_range = true;
+        getPatch().scene[s].drift.set_extend_range(true);
     }
 
     bool mtsMode = Surge::Storage::getUserDefaultValue(this, Surge::Storage::UseODDMTS, false);
@@ -1476,7 +1476,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry)
             int pid = p.id + id;
             getPatch().param_ptr[pid]->val.i = p.val.i;
             getPatch().param_ptr[pid]->temposync = p.temposync;
-            getPatch().param_ptr[pid]->extend_range = p.extend_range;
+            getPatch().param_ptr[pid]->set_extend_range(p.extend_range);
             getPatch().param_ptr[pid]->deactivated = p.deactivated;
             getPatch().param_ptr[pid]->porta_constrate = p.porta_constrate;
             getPatch().param_ptr[pid]->porta_gliss = p.porta_gliss;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2381,7 +2381,7 @@ bool SurgeSynthesizer::loadOscalgos()
 
                     if (e->QueryIntAttribute(lbl, &j) == TIXML_SUCCESS)
                     {
-                        storage.getPatch().scene[s].osc[i].p[k].extend_range = j;
+                        storage.getPatch().scene[s].osc[i].p[k].set_extend_range(j);
                     }
                 }
 
@@ -3986,7 +3986,7 @@ void SurgeSynthesizer::reorderFx(int source, int target, FXReorderMode m)
     auto cp = [](Parameter &to, const Parameter &from) {
         to.val = from.val;
         to.temposync = from.temposync;
-        to.extend_range = from.extend_range;
+        to.set_extend_range(from.extend_range);
         to.deactivated = from.deactivated;
         to.absolute = from.absolute;
     };

--- a/src/common/dsp/effects/DistortionEffect.cpp
+++ b/src/common/dsp/effects/DistortionEffect.cpp
@@ -268,8 +268,8 @@ void DistortionEffect::handleStreamingMismatches(int streamingRevision,
     if (streamingRevision <= 11)
     {
         fxdata->p[dist_model].val.i = 0;
-        fxdata->p[dist_preeq_gain].extend_range = false;
-        fxdata->p[dist_posteq_gain].extend_range = false;
+        fxdata->p[dist_preeq_gain].set_extend_range(false);
+        fxdata->p[dist_posteq_gain].set_extend_range(false);
     }
 
     if (streamingRevision <= 15)

--- a/src/common/dsp/oscillators/StringOscillator.cpp
+++ b/src/common/dsp/oscillators/StringOscillator.cpp
@@ -674,7 +674,7 @@ void StringOscillator::init_default_values()
     oscdata->p[str_str2_decay].val.f = 0.95f;
 
     oscdata->p[str_str2_detune].val.f = 0.1f;
-    oscdata->p[str_str2_detune].extend_range = false;
+    oscdata->p[str_str2_detune].set_extend_range(false);
     oscdata->p[str_str_balance].val.f = 0.f;
 
     oscdata->p[str_stiffness].val.f = 0.f;

--- a/src/common/dsp/oscillators/TwistOscillator.cpp
+++ b/src/common/dsp/oscillators/TwistOscillator.cpp
@@ -636,7 +636,7 @@ void TwistOscillator::init_default_values()
     oscdata->p[twist_timbre].val.f = 0.f;
     oscdata->p[twist_morph].val.f = 0.f;
     oscdata->p[twist_aux_mix].val.f = -1.f;
-    oscdata->p[twist_aux_mix].extend_range = false;
+    oscdata->p[twist_aux_mix].set_extend_range(false);
     oscdata->p[twist_lpg_response].val.f = 0.f;
     oscdata->p[twist_lpg_response].deactivated = true;
     oscdata->p[twist_lpg_decay].val.f = 0.f;

--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -134,7 +134,7 @@ void WavetableOscillator::init_ctrltypes()
 void WavetableOscillator::init_default_values()
 {
     oscdata->p[wt_morph].val.f = 0.0f;
-    oscdata->p[wt_morph].extend_range = true;
+    oscdata->p[wt_morph].set_extend_range(true);
     oscdata->p[wt_skewv].val.f = 0.0f;
     oscdata->p[wt_saturate].val.f = 0.f;
     oscdata->p[wt_formant].val.f = 0.f;
@@ -539,6 +539,6 @@ void WavetableOscillator::handleStreamingMismatches(int streamingRevision,
 {
     if (streamingRevision <= 16)
     {
-        oscdata->p[wt_morph].extend_range = true;
+        oscdata->p[wt_morph].set_extend_range(true);
     }
 }

--- a/src/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1510,7 +1510,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                             contextMenu.addItem(Surge::GUI::toOSCaseForMenu(txt), enable, isChecked,
                                                 [this, p]() {
-                                                    p->extend_range = !p->extend_range;
+                                                    p->set_extend_range(!p->extend_range);
                                                     this->synth->refresh_editor = true;
                                                 });
                         }

--- a/src/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/gui/widgets/XMLConfiguredMenus.cpp
@@ -486,8 +486,8 @@ void FxMenu::loadSnapshot(int type, TiXmlElement *e, int idx)
             fxbuffer->p[i].temposync =
                 ((e->QueryIntAttribute(sublbl, &j) == TIXML_SUCCESS) && (j == 1));
             snprintf(sublbl, TXT_SIZE, "p%i_extend_range", i);
-            fxbuffer->p[i].extend_range =
-                ((e->QueryIntAttribute(sublbl, &j) == TIXML_SUCCESS) && (j == 1));
+            fxbuffer->p[i].set_extend_range(
+                ((e->QueryIntAttribute(sublbl, &j) == TIXML_SUCCESS) && (j == 1)));
             snprintf(sublbl, TXT_SIZE, "p%i_deactivated", i);
             fxbuffer->p[i].deactivated =
                 ((e->QueryIntAttribute(sublbl, &j) == TIXML_SUCCESS) && (j == 1));

--- a/src/headless/UnitTestsDSP.cpp
+++ b/src/headless/UnitTestsDSP.cpp
@@ -84,7 +84,7 @@ TEST_CASE("Unison Absolute and Relative", "[osc]")
         REQUIRE(f72_1 / f60_1 == Approx(2).margin(0.01));
 
         // test extended mode
-        surge->storage.getPatch().scene[0].osc[0].p[5].extend_range = true;
+        surge->storage.getPatch().scene[0].osc[0].p[5].set_extend_range(true);
         auto f60_0e = frequencyForNote(surge, 60, 5, 0);
         auto f60_1e = frequencyForNote(surge, 60, 5, 1);
         REQUIRE(f60_0e / f60_avg == Approx(pow(f60_0 / f60_avg, 12.f)).margin(0.05));


### PR DESCRIPTION
get_extended was mutating the state of Parameter; rather than
do that add a set_extend_range and call it consistently. Add
but don't activate a mode where you can force a write to extend
into a compiler error also

Closes #4861
Addresses #3808