### PR TITLE
Add a Normal distribution to each Random

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2770,12 +2770,17 @@ bool SurgeSynthesizer::supportsIndexedModulator(int scene, modsources modsource)
         auto lf = &(storage.getPatch().scene[scene].lfo[modsource - ms_lfo1]);
         return lf->shape.val.i == lt_formula;
     }
+
+    if (modsource == ms_random_bipolar || modsource == ms_random_unipolar)
+    {
+        return true;
+    }
     return false;
 }
 
 int SurgeSynthesizer::getMaxModulationIndex(int scene, modsources modsource) const
 {
-    if (modsource >= ms_lfo1 && modsource <= ms_lfo6)
+    if (modsource >= ms_lfo1 && modsource <= ms_slfo6)
     {
         auto lf = &(storage.getPatch().scene[scene].lfo[modsource - ms_lfo1]);
         if (lf->shape.val.i == lt_formula)
@@ -2783,6 +2788,10 @@ int SurgeSynthesizer::getMaxModulationIndex(int scene, modsources modsource) con
             return Surge::Formula::max_formula_outputs;
         }
     }
+    if (modsource == ms_random_bipolar)
+        return 2;
+    if (modsource == ms_random_unipolar)
+        return 2;
     return 1;
 }
 

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -223,10 +223,16 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
     /*
     ** We want to snap the rnd and alt
     */
-    rndUni.set_output(0, oscene->modsources[ms_random_unipolar]->get_output(0));
+    int ao = oscene->modsources[ms_random_unipolar]->get_active_outputs();
+    rndUni.set_active_outputs(ao);
+    for (int w = 0; w < ao; ++w)
+        rndUni.set_output(w, oscene->modsources[ms_random_unipolar]->get_output(w));
     modsources[ms_random_unipolar] = &rndUni;
 
-    rndBi.set_output(0, oscene->modsources[ms_random_bipolar]->get_output(0));
+    ao = oscene->modsources[ms_random_bipolar]->get_active_outputs();
+    rndBi.set_active_outputs(ao);
+    for (int w = 0; w < ao; ++w)
+        rndBi.set_output(w, oscene->modsources[ms_random_bipolar]->get_output(w));
     modsources[ms_random_bipolar] = &rndBi;
 
     altUni.set_output(0, oscene->modsources[ms_alternate_unipolar]->get_output(0));

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -4946,6 +4946,20 @@ std::string SurgeGUIEditor::modulatorIndexExtension(int scene, int ms, int index
 {
     if (synth->supportsIndexedModulator(scene, (modsources)ms))
     {
+        if (ms == ms_random_bipolar)
+        {
+            if (index == 0)
+                return " (Uniform)";
+            if (index == 1)
+                return " (Normal)";
+        }
+        if (ms == ms_random_unipolar)
+        {
+            if (index == 0)
+                return " (Uniform)";
+            if (index == 1)
+                return " (Half Normal)";
+        }
         return std::string(" Out ") + std::to_string(index + 1);
     }
     return "";

--- a/src/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1776,74 +1776,47 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             char tmptxt[512];
                             sprintf(tmptxt, "%s", modulatorName(ms, false).c_str());
 
+                            auto *popMenu = &addMIDISub;
+
                             // TODO FIXME: Try not to be gross!
                             if (ms >= ms_ctrl1 && ms <= ms_ctrl1 + n_customcontrollers - 1)
                             {
-                                addMacroSub.addItem(tmptxt, [this, p, bvf, ms]() {
-                                    this->promptForUserValueEntry(p, bvf, ms, 0);
-                                });
+                                popMenu = &addMacroSub;
                             }
                             else if (ms >= ms_lfo1 && ms <= ms_lfo1 + n_lfos_voice - 1)
                             {
-                                if (isIndexed)
-                                {
-                                    int maxidx = synth->getMaxModulationIndex(current_scene, ms);
-                                    auto subm = juce::PopupMenu();
-                                    for (int i = 0; i < maxidx; ++i)
-                                    {
-                                        auto subn = modulatorName(ms, false) +
-                                                    modulatorIndexExtension(current_scene, ms, i);
-                                        subm.addItem(subn, [this, p, bvf, ms, i]() {
-                                            this->promptForUserValueEntry(p, bvf, ms, i);
-                                        });
-                                    }
-                                    addVLFOSub.addSubMenu(tmptxt, subm);
-                                }
-                                else
-                                {
-                                    addVLFOSub.addItem(tmptxt, [this, p, bvf, ms]() {
-                                        this->promptForUserValueEntry(p, bvf, ms, 0);
-                                    });
-                                }
+                                popMenu = &addVLFOSub;
                             }
                             else if (ms >= ms_slfo1 && ms <= ms_slfo1 + n_lfos_scene - 1)
                             {
-                                if (isIndexed)
-                                {
-                                    int maxidx = synth->getMaxModulationIndex(current_scene, ms);
-                                    auto subm = juce::PopupMenu();
-                                    for (int i = 0; i < maxidx; ++i)
-                                    {
-                                        auto subn = modulatorName(ms, false) +
-                                                    modulatorIndexExtension(current_scene, ms, i);
-                                        subm.addItem(subn, [this, p, bvf, ms, i]() {
-                                            this->promptForUserValueEntry(p, bvf, ms, i);
-                                        });
-                                    }
-                                    addSLFOSub.addSubMenu(tmptxt, subm);
-                                }
-                                else
-                                {
-                                    addSLFOSub.addItem(tmptxt, [this, p, bvf, ms]() {
-                                        this->promptForUserValueEntry(p, bvf, ms, 0);
-                                    });
-                                }
+                                popMenu = &addSLFOSub;
                             }
                             else if (ms >= ms_ampeg && ms <= ms_filtereg)
                             {
-                                addEGSub.addItem(tmptxt, [this, p, bvf, ms]() {
-                                    this->promptForUserValueEntry(p, bvf, ms, 0);
-                                });
+                                popMenu = &addEGSub;
                             }
                             else if (ms >= ms_random_bipolar && ms <= ms_alternate_unipolar)
                             {
-                                addMiscSub.addItem(tmptxt, [this, p, bvf, ms]() {
-                                    this->promptForUserValueEntry(p, bvf, ms, 0);
-                                });
+                                popMenu = &addMiscSub;
+                            }
+
+                            if (isIndexed)
+                            {
+                                int maxidx = synth->getMaxModulationIndex(current_scene, ms);
+                                auto subm = juce::PopupMenu();
+                                for (int i = 0; i < maxidx; ++i)
+                                {
+                                    auto subn = modulatorName(ms, false) +
+                                                modulatorIndexExtension(current_scene, ms, i);
+                                    subm.addItem(subn, [this, p, bvf, ms, i]() {
+                                        this->promptForUserValueEntry(p, bvf, ms, i);
+                                    });
+                                }
+                                popMenu->addSubMenu(tmptxt, subm);
                             }
                             else
                             {
-                                addMIDISub.addItem(tmptxt, [this, p, bvf, ms]() {
+                                popMenu->addItem(tmptxt, [this, p, bvf, ms]() {
                                     this->promptForUserValueEntry(p, bvf, ms, 0);
                                 });
                             }


### PR DESCRIPTION
The Random Bi and Uni polar have a normally distributed output
as well as a uniform one, implemented as modulator indices.
This is useful, but also serves as a 'second implementation'
test of my modulator index code and as such has a couple of
tiny tweaks and fixes from adding a second, addresseing #4868