### PR TITLE
Fix alignment of some arrays that are loaded by SSE

### DIFF
--- a/src/common/dsp/effects/chowdsp/bbd_utils/BBDNonlin.h
+++ b/src/common/dsp/effects/chowdsp/bbd_utils/BBDNonlin.h
@@ -35,7 +35,7 @@ class FastDiode : public chowdsp::WDF_SSE::WDFNode
         logVal = vMul(nextR_Is, oneOverVt);
         // array must be aligned to 16-byte boundary for SSE load
         float f alignas(16)[4];
-        _mm_storeu_ps(f, logVal);
+        _mm_store_ps(f, logVal);
         f[0] = std::log(f[0]);
         f[1] = std::log(f[1]);
         f[2] = std::log(f[2]);
@@ -55,7 +55,7 @@ class FastDiode : public chowdsp::WDF_SSE::WDFNode
         b = vAdd(logVal, vMul(vAdd(a, nextR_Is), oneOverVt));
         // array must be aligned to 16-byte boundary for SSE load
         float f alignas(16)[4];
-        _mm_storeu_ps(f, b);
+        _mm_store_ps(f, b);
         f[0] = chowdsp::Omega::omega2(f[0]);
         f[1] = chowdsp::Omega::omega2(f[1]);
         f[2] = chowdsp::Omega::omega2(f[2]);
@@ -164,7 +164,7 @@ class BBDNonlin
 
         // array must be aligned to 16-byte boundary for SSE load
         float f alignas(16)[4];
-        _mm_storeu_ps(f, input);
+        _mm_store_ps(f, input);
         f[0] = bbdNonlinLUT(f[0]);
         f[1] = bbdNonlinLUT(f[1]);
         f[2] = bbdNonlinLUT(f[2]);

--- a/src/common/dsp/effects/chowdsp/bbd_utils/BBDNonlin.h
+++ b/src/common/dsp/effects/chowdsp/bbd_utils/BBDNonlin.h
@@ -33,7 +33,8 @@ class FastDiode : public chowdsp::WDF_SSE::WDFNode
         nextR_Is = vMul(next->R, Is);
 
         logVal = vMul(nextR_Is, oneOverVt);
-        float f[4];
+        // array must be aligned to 16-byte boundary for SSE load
+        float f alignas(16)[4];
         _mm_storeu_ps(f, logVal);
         f[0] = std::log(f[0]);
         f[1] = std::log(f[1]);
@@ -52,7 +53,8 @@ class FastDiode : public chowdsp::WDF_SSE::WDFNode
     {
         // See eqn (10) from reference paper
         b = vAdd(logVal, vMul(vAdd(a, nextR_Is), oneOverVt));
-        float f[4];
+        // array must be aligned to 16-byte boundary for SSE load
+        float f alignas(16)[4];
         _mm_storeu_ps(f, b);
         f[0] = chowdsp::Omega::omega2(f[0]);
         f[1] = chowdsp::Omega::omega2(f[1]);
@@ -160,7 +162,8 @@ class BBDNonlin
     {
         auto input = vSub(vMul(vLoad1(0.1f), _Vg), vMul(vLoad1(0.001f), _Vp));
 
-        float f[4];
+        // array must be aligned to 16-byte boundary for SSE load
+        float f alignas(16)[4];
         _mm_storeu_ps(f, input);
         f[0] = bbdNonlinLUT(f[0]);
         f[1] = bbdNonlinLUT(f[1]);

--- a/src/common/dsp/filters/OBXDFilter.cpp
+++ b/src/common/dsp/filters/OBXDFilter.cpp
@@ -258,7 +258,8 @@ __m128 process_4_pole(QuadFilterUnitState *__restrict f, __m128 sample)
     // f->R[s1] =atan(s1*rcor24)*rcor24inv;
     __m128 s1_rcor24 = _mm_mul_ps(f->R[s1], f->C[rcor24]);
 
-    float s1_rcor24_arr[ssew];
+    // this array must be aligned to a 16-byte boundary for SSE store/load
+    float s1_rcor24_arr alignas(16)[ssew];
     _mm_store_ps(s1_rcor24_arr, s1_rcor24);
 
     for (int i = 0; i < ssew; i++)


### PR DESCRIPTION
Some arrays that were passed to `_mm_load_ps` could potentially be unaligned.

I found four - but because spotting these is somewhat difficult (as the definition of each array passed to a potentially-unaligned SSE function must be looked up) there may be more in there. I also only checked `_mm_load_ps` calls.