### PR TITLE
Branch around Juce Path Space bug

### DIFF
--- a/src/gui/SurgeGUIUtils.cpp
+++ b/src/gui/SurgeGUIUtils.cpp
@@ -2,7 +2,11 @@
 
 #include "juce_core/juce_core.h"
 
-#include <cctype>
+#if LINUX
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 
 namespace Surge
 {
@@ -67,7 +71,19 @@ void openFileOrFolder(const std::string &f)
 
     if (path.isDirectory())
     {
+        // See this for why we branch out linux here
+        // https://forum.juce.com/t/linux-spaces-in-path-startasprocess-and-process-opendocument/47296
+#if LINUX
+        if (vfork() == 0)
+        {
+            if (execlp("xdg-open", "xdg-open", f.c_str(), (char *)nullptr) < 0)
+            {
+                _exit(0);
+            }
+        }
+#else
         path.startAsProcess();
+#endif
     }
     else
     {


### PR DESCRIPTION
Juce path process open has a bug where they double protect
spaces in path names. Branch around this and also report it
on juce forums.

Closes #4820