### PR TITLE
VST3 Popup Menu on Macros restored

### DIFF
--- a/src/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -779,6 +779,20 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                 synth->refresh_editor = true;
                             });
                     });
+
+                auto jpm = juceEditor->hostMenuForMacro(ccid);
+
+                if (jpm.getNumItems() > 0)
+                {
+                    contextMenu.addSeparator();
+
+                    juce::PopupMenu::MenuItemIterator iterator(jpm);
+
+                    while (iterator.next())
+                    {
+                        contextMenu.addItem(iterator.getItem());
+                    }
+                }
             }
 
             int lfo_id = isLFO(modsource) ? modsource - ms_lfo1 : -1;

--- a/src/surge_synth_juce/SurgeSynthEditor.cpp
+++ b/src/surge_synth_juce/SurgeSynthEditor.cpp
@@ -205,3 +205,15 @@ juce::PopupMenu SurgeSynthEditor::hostMenuFor(Parameter *p)
 
     return juce::PopupMenu();
 }
+
+juce::PopupMenu SurgeSynthEditor::hostMenuForMacro(int macro)
+{
+    auto par = processor.macrosById[macro];
+#if SURGE_JUCE_HOST_CONTEXT
+    if (auto *c = getHostContext())
+        if (auto menuInfo = c->getContextMenuForParameterIndex(par))
+            return menuInfo->getEquivalentPopupMenu();
+#endif
+
+    return juce::PopupMenu();
+}

--- a/src/surge_synth_juce/SurgeSynthEditor.h
+++ b/src/surge_synth_juce/SurgeSynthEditor.h
@@ -69,6 +69,7 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     void filesDropped(const juce::StringArray &files, int, int) override;
 
     juce::PopupMenu hostMenuFor(Parameter *p);
+    juce::PopupMenu hostMenuForMacro(int macro);
 
     friend class SurgeGUIEditor;
 


### PR DESCRIPTION
We had it on params but that was before we exposed the
macros as params. Now fully back to 1.9 state

Closes #4880