### PR TITLE
Fixup some unhover on menu edge cases

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -1636,7 +1636,7 @@ void SurgeGUIEditor::setParameter(long index, float value)
     }
 }
 
-void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene)
+void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene, Surge::Widgets::EffectChooser *c)
 {
     auto fxGridMenu = juce::PopupMenu();
 
@@ -1671,7 +1671,7 @@ void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene)
             this->synth->storage.sceneHardclipMode[whichScene] = SurgeStorage::HARDCLIP_TO_18DBFS;
         });
 
-    fxGridMenu.showMenuAsync(juce::PopupMenu::Options());
+    fxGridMenu.showMenuAsync(juce::PopupMenu::Options(), [c](int i) { c->endHover(); });
 }
 
 void SurgeGUIEditor::controlBeginEdit(Surge::GUI::IComponentTagValue *control)

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -138,7 +138,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void refresh_mod();
     void broadcastPluginAutomationChangeFor(Parameter *p);
 
-    void effectSettingsBackgroundClick(int whichScene);
+    void effectSettingsBackgroundClick(int whichScene, Surge::Widgets::EffectChooser *c);
 
     void setDisabledForParameter(Parameter *p, Surge::Widgets::ModulatableControlInterface *s);
     void showSettingsMenu(const juce::Point<int> &where,

--- a/src/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -92,6 +92,20 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                   << "Is your JUCE-only inheritance hierarchy missing the tag class?" << std::endl;
     }
 
+    /*
+     * Alright why is this here? Well when we show the macro menu we use the modal version to
+     * stop changes happening underneath us. It's the only non-async menu we have and probably
+     * should get fixed. But juce has a thing where RMB / RMB means the modal menus release both
+     * after the second RMB. So the end hover on rmb rmb doesn't work leading to the bug in
+     * 4874. A fix to this is to use an async menu. But I'm hnot sure why i didn't and there's an
+     * incomplete comment that it was for good reason so instead...
+     */
+    for (const auto &g : gui_modsrc)
+    {
+        if (g && g.get() != control)
+            g->endHover();
+    }
+
     long tag = control->getTag();
 
     if (button.isCtrlDown() && (tag == tag_mp_patch || tag == tag_mp_category))

--- a/src/gui/widgets/EffectChooser.cpp
+++ b/src/gui/widgets/EffectChooser.cpp
@@ -213,7 +213,7 @@ void EffectChooser::mouseDown(const juce::MouseEvent &event)
             auto sge = firstListenerOfType<SurgeGUIEditor>();
             if (sge)
             {
-                sge->effectSettingsBackgroundClick(i);
+                sge->effectSettingsBackgroundClick(i, this);
             }
         }
     }

--- a/src/gui/widgets/ModulationSourceButton.cpp
+++ b/src/gui/widgets/ModulationSourceButton.cpp
@@ -342,8 +342,10 @@ void ModulationSourceButton::mouseExit(const juce::MouseEvent &event) { endHover
 
 void ModulationSourceButton::endHover()
 {
+    bool oh = isHovered;
     isHovered = false;
-    repaint();
+    if (oh != isHovered)
+        repaint();
 }
 
 void ModulationSourceButton::onSkinChanged()


### PR DESCRIPTION
1. EffectChooser didn't lambda to endhover in menu
2. Controls use sync menu so are more tricky but see comment and
   fix in SGEVC

Closes #4874