### PR TITLE
Two infowindow cleanups

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2906,7 +2906,10 @@ void SurgeSynthesizer::getParameterDisplay(long index, char *text)
     {
         storage.getPatch().param_ptr[index]->get_display(text);
     }
-    snprintf(text, TXT_SIZE, "-");
+    else
+    {
+        snprintf(text, TXT_SIZE, "-");
+    }
 }
 
 void SurgeSynthesizer::getParameterDisplayAlt(long index, char *text)

--- a/src/gui/SurgeGUIEditorInfowindow.cpp
+++ b/src/gui/SurgeGUIEditorInfowindow.cpp
@@ -77,7 +77,11 @@ void SurgeGUIEditor::updateInfowindowContents(int ptag, bool isModulated)
         SurgeSynthesizer::ID ptagid;
         if (synth->fromSynthSideId(pid, ptagid))
             synth->getParameterName(ptagid, txt);
-        sprintf(pname, "%s -> %s", modulatorName(modsource, true).c_str(), txt);
+        auto mn = modulatorName(modsource, true);
+        if (synth->supportsIndexedModulator(current_scene, modsource))
+            mn += modulatorIndexExtension(current_scene, modsource, modsource_index, true);
+
+        sprintf(pname, "%s -> %s", mn.c_str(), txt);
         ModulationDisplayInfoWindowStrings mss;
         p->get_display_of_modulation_depth(
             pdisp, synth->getModDepth(pid, modsource, modsource_index),


### PR DESCRIPTION
1. I forgot an 'else' in surge synth so all param displays were '-'
2. Show the index modulator source in the infowindow when modulating
   by an indexed modulator