### PR TITLE
Choose user directory; misc cleanups

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -2374,6 +2374,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
 
         auto kbm_path = Surge::Storage::appendDirectory(this->synth->storage.datapath,
                                                         "tuning-library", "KBM Concert Pitch");
+
         juce::FileChooser c("Select KBM Mapping", juce::File(kbm_path), "*.kbm");
 
         auto r = c.browseForFileToOpen();
@@ -3066,19 +3067,23 @@ juce::PopupMenu SurgeGUIEditor::makeDataMenu(const juce::Point<int> &where)
     });
 
     dataSubMenu.addItem(Surge::GUI::toOSCaseForMenu("Set Custom User Data Folder..."), [this]() {
-        auto cb = [this](std::string f) {
-            // FIXME - check if f is a path
-            this->synth->storage.userDataPath = f;
+        juce::FileChooser f("Set Custom User Data Folder", juce::File(synth->storage.userDataPath));
+        if (f.browseForDirectory())
+        {
+            auto r = f.getResult();
+            if (!r.isDirectory())
+                return;
+            auto s = f.getResult().getFullPathName().toStdString();
+
             Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
-                                                   Surge::Storage::UserDataPath, f);
+                                                   Surge::Storage::UserDataPath, s);
+
+            this->synth->storage.userDataPath = s;
+            synth->storage.createUserDirectory();
+
             this->synth->storage.refresh_wtlist();
             this->synth->storage.refresh_patchlist();
-        };
-        /*
-         * TODO: Implement JUCE directory picker
-        Surge::UserInteractions::promptFileOpenDialog(this->synth->storage.userDataPath,
-        "", "", cb, true, true);
-                                                      */
+        }
     });
 
     dataSubMenu.addSeparator();

--- a/src/surge_synth_juce/SurgeSynthAUExtensions.cpp
+++ b/src/surge_synth_juce/SurgeSynthAUExtensions.cpp
@@ -19,11 +19,5 @@
 #include "SurgeSynthEditor.h"
 #include "SurgeSynthFlavorExtensions.h"
 
-void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s)
-{
-    std::cout << "SynthProcessor: " << __FILE__ << std::endl;
-}
-void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed)
-{
-    std::cout << "SynthEditor: " << __FILE__ << std::endl;
-}
+void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s) {}
+void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed) {}

--- a/src/surge_synth_juce/SurgeSynthAUv3Extensions.cpp
+++ b/src/surge_synth_juce/SurgeSynthAUv3Extensions.cpp
@@ -19,11 +19,5 @@
 #include "SurgeSynthEditor.h"
 #include "SurgeSynthFlavorExtensions.h"
 
-void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s)
-{
-    std::cout << "SynthProcessor: " << __FILE__ << std::endl;
-}
-void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed)
-{
-    std::cout << "SynthEditor: " << __FILE__ << std::endl;
-}
+void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s) {}
+void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed) {}

--- a/src/surge_synth_juce/SurgeSynthLV2Extensions.cpp
+++ b/src/surge_synth_juce/SurgeSynthLV2Extensions.cpp
@@ -21,14 +21,10 @@
 
 void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s)
 {
-    std::cout << "LV2SynthProcessor: " << __FILE__ << std::endl;
     p->surge->activateExtraOutputs = false;
     p->canRemoveBusValue = true;
     p->removeBus(false);
     p->removeBus(false);
     p->canRemoveBusValue = false;
 }
-void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed)
-{
-    std::cout << "LV2SynthEditor: " << __FILE__ << std::endl;
-}
+void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed) {}

--- a/src/surge_synth_juce/SurgeSynthProcessor.cpp
+++ b/src/surge_synth_juce/SurgeSynthProcessor.cpp
@@ -25,22 +25,15 @@ SurgeSynthProcessor::SurgeSynthProcessor()
                          .withOutput("Scene A", AudioChannelSet::stereo(), false)
                          .withOutput("Scene B", AudioChannelSet::stereo(), false))
 {
-    std::cout << "SurgeXT Startup\n"
-              << "  - Version      : " << Surge::Build::FullVersionStr << "\n"
-              << "  - Build Info   : " << Surge::Build::BuildArch << " "
-              << Surge::Build::BuildCompiler << "\n"
-              << "  - Build Time   : " << Surge::Build::BuildDate << " " << Surge::Build::BuildTime
-              << "\n"
-              << "  - JUCE Version : " << std::hex << JUCE_VERSION << std::dec << "\n"
-#if SURGE_JUCE_ACCESSIBLE
-              << "  - Accessiblity : Enabled\n"
-#endif
-#if SURGE_JUCE_HOST_CONTEXT
-              << "  - JUCE Host Context Support Enabled\n"
-#endif
-              << "  - CPU          : " << Surge::CPUFeatures::cpuBrand() << std::endl;
+    std::cout << "SurgeXT " << getWrapperTypeDescription(wrapperType) << "\n"
+              << "  - Version      : " << Surge::Build::FullVersionStr << " with JUCE " << std::hex
+              << JUCE_VERSION << std::dec << "\n"
+              << "  - Build Info   : " << Surge::Build::BuildDate << " " << Surge::Build::BuildTime
+              << " using " << Surge::Build::BuildCompiler << "\n";
 
     surge = std::make_unique<SurgeSynthesizer>(this);
+    std::cout << "  - Data         : " << surge->storage.datapath << "\n"
+              << "  - User Data    : " << surge->storage.userDataPath << std::endl;
 
     auto parent = std::make_unique<AudioProcessorParameterGroup>("Root", "Root", "|");
     auto macroG = std::make_unique<AudioProcessorParameterGroup>("macros", "Macros", "|");

--- a/src/surge_synth_juce/SurgeSynthStandaloneExtensions.cpp
+++ b/src/surge_synth_juce/SurgeSynthStandaloneExtensions.cpp
@@ -19,11 +19,5 @@
 #include "SurgeSynthEditor.h"
 #include "SurgeSynthFlavorExtensions.h"
 
-void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s)
-{
-    std::cout << "SynthProcessor: " << __FILE__ << std::endl;
-}
-void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed)
-{
-    std::cout << "SynthEditor: " << __FILE__ << std::endl;
-}
+void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s) {}
+void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed) {}

--- a/src/surge_synth_juce/SurgeSynthVST2Extensions.cpp
+++ b/src/surge_synth_juce/SurgeSynthVST2Extensions.cpp
@@ -19,11 +19,5 @@
 #include "SurgeSynthEditor.h"
 #include "SurgeSynthFlavorExtensions.h"
 
-void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s)
-{
-    std::cout << "SynthProcessor: " << __FILE__ << std::endl;
-}
-void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed)
-{
-    std::cout << "SynthEditor: " << __FILE__ << std::endl;
-}
+void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s) {}
+void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed) {}

--- a/src/surge_synth_juce/SurgeSynthVST3Extensions.cpp
+++ b/src/surge_synth_juce/SurgeSynthVST3Extensions.cpp
@@ -19,11 +19,5 @@
 #include "SurgeSynthEditor.h"
 #include "SurgeSynthFlavorExtensions.h"
 
-void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s)
-{
-    std::cout << "SynthProcessor: " << __FILE__ << std::endl;
-}
-void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed)
-{
-    std::cout << "SynthEditor: " << __FILE__ << std::endl;
-}
+void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s) {}
+void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed) {}


### PR DESCRIPTION
1. Choose a file directory reinstated. Closes #4378
2. Cleanup some of the prints on startup, especially the
   flavor specific ones, and generaly make the startup debugging
   blast shorter and more useful