### PR TITLE
Remember directory used in open operations

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -129,6 +129,18 @@ void initMaps()
             case InitialPatchCategory:
                 r = "initialPatchCategory";
                 break;
+            case LastSCLPath:
+                r = "lastSCLPath";
+                break;
+            case LastKBMPath:
+                r = "lastKBMPath";
+                break;
+            case LastPatchPath:
+                r = "lastPatchPath";
+                break;
+            case LastWavetablePath:
+                r = "lastWavetablePath";
+                break;
             case nKeys:
                 break;
             }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -51,6 +51,11 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     InitialPatchName,
     InitialPatchCategory,
 
+    LastSCLPath,
+    LastKBMPath,
+    LastWavetablePath,
+    LastPatchPath,
+
     nKeys
 };
 /**

--- a/src/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -438,13 +438,22 @@ void OscillatorWaveformDisplay::loadWavetable(int id)
 
 void OscillatorWaveformDisplay::loadWavetableFromFile()
 {
-    juce::FileChooser c("Select Wavetable to Load");
+    auto wtPath = storage->userWavetablesPath;
+    wtPath =
+        Surge::Storage::getUserDefaultValue(storage, Surge::Storage::LastWavetablePath, wtPath);
+
+    juce::FileChooser c("Select Wavetable to Load", juce::File(wtPath));
     auto r = c.browseForFileToOpen();
     if (r)
     {
         auto res = c.getResult();
         auto rString = res.getFullPathName().toStdString();
         strncpy(this->oscdata->wt.queue_filename, rString.c_str(), 255);
+        auto dir = res.getParentDirectory().getFullPathName().toStdString();
+        if (dir != wtPath)
+        {
+            Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::LastWavetablePath, dir);
+        }
     }
 }
 void OscillatorWaveformDisplay::showWavetableMenu()

--- a/src/gui/widgets/PatchSelector.cpp
+++ b/src/gui/widgets/PatchSelector.cpp
@@ -240,7 +240,10 @@ void PatchSelector::showClassicMenu(bool single_category)
                         [this]() { this->storage->refresh_patchlist(); });
 
     contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Load Patch From File..."), [this]() {
-        juce::FileChooser c("Select Patch to Load", juce::File(storage->userDataPath), "*.fxp");
+        auto patchPath = storage->userPatchesPath;
+        patchPath =
+            Surge::Storage::getUserDefaultValue(storage, Surge::Storage::LastPatchPath, patchPath);
+        juce::FileChooser c("Select Patch to Load", juce::File(patchPath), "*.fxp");
         auto r = c.browseForFileToOpen();
 
         if (r)
@@ -252,6 +255,11 @@ void PatchSelector::showClassicMenu(bool single_category)
             if (sge)
             {
                 sge->queuePatchFileLoad(rString);
+            }
+            auto dir = res.getParentDirectory().getFullPathName().toStdString();
+            if (dir != patchPath)
+            {
+                Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::LastPatchPath, dir);
             }
         }
     });


### PR DESCRIPTION
The directory in open operations isn't sticky. There's
no real JUCE X-Platform way to do this other than the way I did which
is remember and update the last directory in those operations as a user pref.
So I did it that way.

Closes #1864