### PR TITLE
Restore Drag and Drop after Accessibility changes

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -3740,16 +3740,36 @@ void SurgeGUIEditor::modSourceButtonDroppedAt(Surge::Widgets::ModulationSourceBu
     // We need to do this search vs componentAt because componentAt will return self since I am
     // there being dropped
     juce::Component *target = nullptr;
-    for (auto kid : frame->getChildren())
-    {
-        if (kid && kid->isVisible() && kid != msb && kid->getBounds().contains(pt))
+
+    auto isDroppable = [msb](juce::Component *c) {
+        auto tMSB = dynamic_cast<Surge::Widgets::ModulationSourceButton *>(c);
+        auto tMCI = dynamic_cast<Surge::Widgets::ModulatableControlInterface *>(c);
+        if (tMSB && msb->isMeta && tMSB && tMSB->isMeta)
+            return true;
+        if (tMCI)
+            return true;
+        return false;
+    };
+    auto recC = [isDroppable, msb, pt](juce::Component *p, auto rec) -> juce::Component * {
+        for (auto kid : p->getChildren())
         {
-            target = kid;
-            // break;
+            if (kid && kid->isVisible() && kid != msb && kid->getBounds().contains(pt))
+            {
+                if (isDroppable(kid))
+                    return kid;
+
+                auto q = rec(kid, rec);
+                if (q)
+                    return q;
+            }
         }
-    }
+        return nullptr;
+    };
+    target = recC(frame.get(), recC);
+
     if (!target)
         return;
+
     auto tMSB = dynamic_cast<Surge::Widgets::ModulationSourceButton *>(target);
     auto tMCI = dynamic_cast<Surge::Widgets::ModulatableControlInterface *>(target);
     if (msb->isMeta && tMSB && tMSB->isMeta)

--- a/src/gui/widgets/ModulationSourceButton.cpp
+++ b/src/gui/widgets/ModulationSourceButton.cpp
@@ -410,6 +410,7 @@ void ModulationSourceButton::mouseDrag(const juce::MouseEvent &event)
         return;
     }
 
+    getParentComponent()->toFront(false);
     toFront(false);
     mouseMode = DRAG_COMPONENT_HAPPEN;
     componentDragger.dragComponent(this, event, nullptr);


### PR DESCRIPTION
To make accessibility more reasonable I group components in overlays
but those overlays messed up z order a bit and also made the component
heirarchy deeper. So handle both of those and allow dnd to work with
a deeper heirarchy

Closes #4858