### PR TITLE
Restore 1.9 scrolling behavior on Int and Bool sliders

### DIFF
--- a/src/gui/widgets/ModulatableControlInterface.h
+++ b/src/gui/widgets/ModulatableControlInterface.h
@@ -161,8 +161,13 @@ struct ModulatableControlInterface
      * It is used to do things like step unison count but value quantization does
      * that just fine.
      */
-    virtual void setIsStepped(bool s) {}
-    virtual void setIntStepRange(int i) {}
+    // virtual void setIsStepped(bool s) {}
+    // virtual void setIntStepRange(int i) {}
+
+    bool isStepped{false};
+    virtual void setIsStepped(bool s) { isStepped = s; }
+    int intRange{0};
+    virtual void setIntStepRange(int i) { intRange = i; }
 
     /*
      * Font handling. FIXME - implement this

--- a/src/gui/widgets/ModulatableControlInterface.h
+++ b/src/gui/widgets/ModulatableControlInterface.h
@@ -156,14 +156,7 @@ struct ModulatableControlInterface
     virtual void setQuantitizedDisplayValue(float f) { quantizedDisplayValue = f; }
     float quantizedDisplayValue{0.f};
 
-    /*
-     * This API is present but doesn't seem to be needed. FIXME - remove it if so.
-     * It is used to do things like step unison count but value quantization does
-     * that just fine.
-     */
-    // virtual void setIsStepped(bool s) {}
-    // virtual void setIntStepRange(int i) {}
-
+    // Needed for scroll wheel behavior on stepped sliders
     bool isStepped{false};
     virtual void setIsStepped(bool s) { isStepped = s; }
     int intRange{0};

--- a/src/gui/widgets/ModulatableSlider.cpp
+++ b/src/gui/widgets/ModulatableSlider.cpp
@@ -464,18 +464,28 @@ void ModulatableSlider::mouseWheelMove(const juce::MouseEvent &event,
 
     showInfowindowSelfDismiss(isEditingModulation);
 
-#if MAC
-    float speed = 1.2;
-#else
-    float speed = 0.42666;
-#endif
-
-    if (event.mods.isShiftDown())
+    // Revert to classic scrolling behavior if Ctrl is pressed down
+    if (intRange && isStepped && !event.mods.isCtrlDown())
     {
-        speed /= 10.f;
+        delta = 1.f / intRange * (delta > 0 ? 1 : -1);
     }
 
-    delta *= speed;
+    else
+    {
+
+#if MAC
+        float speed = 1.2;
+#else
+        float speed = 0.42666;
+#endif
+
+        if (event.mods.isShiftDown())
+        {
+            speed /= 10.f;
+        }
+
+        delta *= speed;
+    }
 
     editTypeWas = WHEEL;
     notifyBeginEdit();


### PR DESCRIPTION
This restores the scrolling behavior on Int and Bool sliders so that one scroll step on a mouse = one discrete value, as opposed to 10% no matter how many discrete values there are. Like in 1.9, pressing Ctrl will ignore this tweak and attempt to scroll by 10% anyways.