### PR TITLE
Fix a number of step seq UI/UX regressions

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -889,7 +889,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
     ** There are a collection of member states we need to reset
     */
     polydisp = nullptr;
-    msegEditSwitch = nullptr;
+    lfoEditSwitch = nullptr;
     lfoNameLabel = nullptr;
     midiLearnOverlay = nullptr;
 
@@ -1124,14 +1124,14 @@ void SurgeGUIEditor::openOrRecreateEditor()
         }
         case Surge::Skin::Connector::NonParameterConnection::MSEG_EDITOR_OPEN:
         {
-            msegEditSwitch = layoutComponentForSkin(skinCtrl, tag_mseg_edit);
-            setAccessibilityInformationByTitleAndAction(msegEditSwitch->asJuceComponent(),
+            lfoEditSwitch = layoutComponentForSkin(skinCtrl, tag_mseg_edit);
+            setAccessibilityInformationByTitleAndAction(lfoEditSwitch->asJuceComponent(),
                                                         "Show MSEG Editor", "Show");
-            auto msejc = dynamic_cast<juce::Component *>(msegEditSwitch);
+            auto msejc = dynamic_cast<juce::Component *>(lfoEditSwitch);
             jassert(msejc);
             msejc->setVisible(false);
-            msegEditSwitch->setValue(isAnyOverlayPresent(MSEG_EDITOR) ||
-                                     isAnyOverlayPresent(FORMULA_EDITOR));
+            lfoEditSwitch->setValue(isAnyOverlayPresent(MSEG_EDITOR) ||
+                                    isAnyOverlayPresent(FORMULA_EDITOR));
             auto q = modsource_editor[current_scene];
             if ((q >= ms_lfo1 && q <= ms_lfo6) || (q >= ms_slfo1 && q <= ms_slfo6))
             {
@@ -4575,9 +4575,9 @@ void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)
     if (prior != curr || prior == lt_mseg || curr == lt_mseg || prior == lt_formula ||
         curr == lt_formula)
     {
-        if (msegEditSwitch)
+        if (lfoEditSwitch)
         {
-            auto msejc = dynamic_cast<juce::Component *>(msegEditSwitch);
+            auto msejc = dynamic_cast<juce::Component *>(lfoEditSwitch);
             msejc->setVisible(curr == lt_mseg || curr == lt_formula);
         }
     }
@@ -4626,6 +4626,12 @@ void SurgeGUIEditor::closeMSEGEditor()
     {
         broadcastMSEGState();
         dismissEditorOfType(MSEG_EDITOR);
+
+        if (lfoEditSwitch)
+        {
+            lfoEditSwitch->setValue(0.0);
+            lfoEditSwitch->asJuceComponent()->repaint();
+        }
     }
 }
 void SurgeGUIEditor::toggleMSEGEditor()
@@ -4707,6 +4713,12 @@ void SurgeGUIEditor::showFormulaEditorDialog()
 
     addJuceEditorOverlay(std::move(pt), "Formula Editor", FORMULA_EDITOR, skinCtrl->getRect(), true,
                          []() {});
+
+    if (lfoEditSwitch)
+    {
+        lfoEditSwitch->setValue(1.0);
+        lfoEditSwitch->asJuceComponent()->repaint();
+    }
 }
 
 void SurgeGUIEditor::closeFormulaEditorDialog()
@@ -4714,6 +4726,12 @@ void SurgeGUIEditor::closeFormulaEditorDialog()
     if (isAnyOverlayPresent(FORMULA_EDITOR))
     {
         dismissEditorOfType(FORMULA_EDITOR);
+
+        if (lfoEditSwitch)
+        {
+            lfoEditSwitch->setValue(0.0);
+            lfoEditSwitch->asJuceComponent()->repaint();
+        }
     }
 }
 
@@ -4797,17 +4815,17 @@ void SurgeGUIEditor::showMSEGEditor()
     auto skinCtrl = currentSkin->getOrCreateControlForConnector(conn);
 
     addJuceEditorOverlay(std::move(mse), title, MSEG_EDITOR, skinCtrl->getRect(), true, [this]() {
-        if (msegEditSwitch)
+        if (lfoEditSwitch)
         {
-            msegEditSwitch->setValue(0.0);
-            msegEditSwitch->asJuceComponent()->repaint();
+            lfoEditSwitch->setValue(0.0);
+            lfoEditSwitch->asJuceComponent()->repaint();
         }
     });
 
-    if (msegEditSwitch)
+    if (lfoEditSwitch)
     {
-        msegEditSwitch->setValue(1.0);
-        msegEditSwitch->asJuceComponent()->repaint();
+        lfoEditSwitch->setValue(1.0);
+        lfoEditSwitch->asJuceComponent()->repaint();
     }
 }
 

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -505,7 +505,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     friend struct Surge::Overlays::PatchStoreDialog;
     friend struct Surge::Widgets::MainFrame;
 
-    Surge::GUI::IComponentTagValue *msegEditSwitch = nullptr;
+    Surge::GUI::IComponentTagValue *lfoEditSwitch = nullptr;
     int typeinResetCounter = -1;
     std::string typeinResetLabel = "";
 

--- a/src/gui/widgets/LFOAndStepDisplay.h
+++ b/src/gui/widgets/LFOAndStepDisplay.h
@@ -29,9 +29,10 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
 {
     LFOAndStepDisplay();
     void paint(juce::Graphics &g) override;
-    void paintWaveform(juce::Graphics &g, const juce::Rectangle<int> &within);
-    void paintStepSeq(juce::Graphics &g, const juce::Rectangle<int> &within);
-    void paintTypeSelector(juce::Graphics &g, const juce::Rectangle<int> &within);
+    void paintWaveform(juce::Graphics &g);
+    void paintStepSeq(juce::Graphics &g);
+    void paintTypeSelector(juce::Graphics &g);
+    void resized() override;
 
     float value;
     float getValue() const override { return value; }
@@ -41,6 +42,7 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
     bool isMSEG() { return lfodata->shape.val.i == lt_mseg; }
     bool isFormula() { return lfodata->shape.val.i == lt_formula; }
     bool isUnipolar() { return lfodata->unipolar.val.b; }
+
     void invalidateIfIdIsInRange(int j) {}
     void invalidateIfAnythingIsTemposynced()
     {
@@ -60,6 +62,9 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
         }
         return drawBeats;
     }
+
+    void setStepToDefault(const juce::MouseEvent &event);
+    void setStepValue(const juce::MouseEvent &event);
 
     int tsNum{4}, tsDen{4};
     void setTimeSignature(int num, int den)
@@ -102,9 +107,11 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
         ARROW,
         LOOP_START,
         LOOP_END,
+        RESET_VALUE,
         TRIGGERS,
-        VALUES
+        VALUES,
     } dragMode{NONE};
+
     int draggedStep{-1};
     int keyModMult;
     uint64_t dragTrigger0;
@@ -127,10 +134,13 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
 
     std::array<juce::Rectangle<int>, n_lfo_types> shaperect;
     std::array<juce::Rectangle<float>, n_stepseqsteps> steprect, gaterect;
+
+    juce::Rectangle<int> outer, left_panel, main_panel, waveform_display;
     juce::Rectangle<float> loopStartRect, loopEndRect, rect_steps, rect_steps_retrig;
-    juce::Rectangle<float> ss_shift_left, ss_shift_right;
+    juce::Rectangle<float> ss_shift_bg, ss_shift_left, ss_shift_right;
+
     int lfoTypeHover{-1};
-    int ss_shift_hover{-1};
+    int stepSeqShiftHover{-1};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LFOAndStepDisplay);
 };


### PR DESCRIPTION
Addresses #4877

Also:
- properly update state of Pencil button when toggling MSEG/formula overlays by clicking on the display
- rename msegEditSwitch SGE member to something more universal
- make elementary rects of LFO widget member variables, remove &within argument from pain functions as a consequence
- step seq value is added directly on mouse down, not just on mouse move