### PR TITLE
Remove sticky vertical line when LFO in bipolar envelope mode

### DIFF
--- a/src/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/gui/widgets/LFOAndStepDisplay.cpp
@@ -286,7 +286,7 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
             path.startNewSubPath(xc, val);
             eupath.startNewSubPath(xc, euval);
 
-            if (!isUnipolar() && (lfodata->shape.val.i != lt_envelope))
+            if (!isUnipolar())
             {
                 edpath.startNewSubPath(xc, edval);
             }


### PR DESCRIPTION
Remove sticky vertical line when LFO in bipolar envelope mode:
![image](https://user-images.githubusercontent.com/50145178/131191949-7028ffa0-e516-4e9c-9914-7399034ee6dd.png)