### PR TITLE
Tab Key Changes

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -141,6 +141,9 @@ void initMaps()
             case LastWavetablePath:
                 r = "lastWavetablePath";
                 break;
+            case TabKeyArmsModulators:
+                r = "tabKeyArmsModulators";
+                break;
             case nKeys:
                 break;
             }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -56,6 +56,8 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     LastWavetablePath,
     LastPatchPath,
 
+    TabKeyArmsModulators,
+
     nKeys
 };
 /**

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -370,6 +370,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
         return false;
     }
+    bool isAnyOverlayOpenAtAll() { return !juceOverlays.empty(); }
 
     std::string getDisplayForTag(long tag, bool external = false, float value = 0);
     float getF01FromString(long tag, const std::string &s);


### PR DESCRIPTION
1. Tab key modulation arming is off by default with a workflow menu
2. Even when its on it doesn't screw up the patch store any more

Closes #4911