### PR TITLE
Move Presets to Objects

### DIFF
--- a/src/common/FxPresetAndClipboardManager.cpp
+++ b/src/common/FxPresetAndClipboardManager.cpp
@@ -20,15 +20,15 @@
 
 namespace Surge
 {
-namespace FxUserPreset
+namespace Storage
 {
 
-static std::unordered_map<int, std::vector<Preset>> scannedPresets;
-static bool haveScannedPresets = false;
+std::unordered_map<int, std::vector<FxUserPreset::Preset>> FxUserPreset::getPresetsByType()
+{
+    return scannedPresets;
+}
 
-std::unordered_map<int, std::vector<Preset>> getPresetsByType() { return scannedPresets; }
-
-void doPresetRescan(SurgeStorage *storage, bool forceRescan)
+void FxUserPreset::doPresetRescan(SurgeStorage *storage, bool forceRescan)
 {
     if (haveScannedPresets && !forceRescan)
         return;
@@ -199,7 +199,7 @@ void doPresetRescan(SurgeStorage *storage, bool forceRescan)
     }
 }
 
-std::vector<Preset> getPresetsForSingleType(int id)
+std::vector<FxUserPreset::Preset> FxUserPreset::getPresetsForSingleType(int id)
 {
     if (scannedPresets.find(id) == scannedPresets.end())
     {
@@ -208,9 +208,12 @@ std::vector<Preset> getPresetsForSingleType(int id)
     return scannedPresets[id];
 }
 
-bool hasPresetsForSingleType(int id) { return scannedPresets.find(id) != scannedPresets.end(); }
+bool FxUserPreset::hasPresetsForSingleType(int id)
+{
+    return scannedPresets.find(id) != scannedPresets.end();
+}
 
-void saveFxIn(SurgeStorage *storage, FxStorage *fx, const std::string &s)
+void FxUserPreset::saveFxIn(SurgeStorage *storage, FxStorage *fx, const std::string &s)
 {
     char fxName[TXT_SIZE];
     fxName[0] = 0;
@@ -308,10 +311,10 @@ void saveFxIn(SurgeStorage *storage, FxStorage *fx, const std::string &s)
     pfile << "</single-fx>\n";
     pfile.close();
 
-    Surge::FxUserPreset::doPresetRescan(storage, true);
+    doPresetRescan(storage, true);
 }
 
-void loadPresetOnto(const Preset &p, SurgeStorage *storage, FxStorage *fxbuffer)
+void FxUserPreset::loadPresetOnto(const Preset &p, SurgeStorage *storage, FxStorage *fxbuffer)
 {
     fxbuffer->type.val.i = p.type;
 
@@ -347,7 +350,7 @@ void loadPresetOnto(const Preset &p, SurgeStorage *storage, FxStorage *fxbuffer)
             fxbuffer->p[i].deform_type = p.dt[i];
     }
 }
-} // namespace FxUserPreset
+} // namespace Storage
 
 namespace FxClipboard
 {

--- a/src/common/FxPresetAndClipboardManager.h
+++ b/src/common/FxPresetAndClipboardManager.h
@@ -24,44 +24,50 @@
 
 namespace Surge
 {
-namespace FxUserPreset
+namespace Storage
 {
-struct Preset
+struct FxUserPreset
 {
-    std::string file;
-    std::string name;
-    fs::path subPath{};
-    bool isFactory{false};
-    int type{-1};
-    float p[n_fx_params];
-    bool ts[n_fx_params], er[n_fx_params], da[n_fx_params];
-    int dt[n_fx_params];
-
-    Preset()
+    struct Preset
     {
-        type = 0;
-        isFactory = false;
+        std::string file;
+        std::string name;
+        fs::path subPath{};
+        bool isFactory{false};
+        int type{-1};
+        float p[n_fx_params];
+        bool ts[n_fx_params], er[n_fx_params], da[n_fx_params];
+        int dt[n_fx_params];
 
-        for (int i = 0; i < n_fx_params; ++i)
+        Preset()
         {
-            p[i] = 0.0;
-            ts[i] = false;
-            er[i] = false;
-            da[i] = false;
-            dt[i] = -1;
+            type = 0;
+            isFactory = false;
+
+            for (int i = 0; i < n_fx_params; ++i)
+            {
+                p[i] = 0.0;
+                ts[i] = false;
+                er[i] = false;
+                da[i] = false;
+                dt[i] = -1;
+            }
         }
-    }
+    };
+
+    std::unordered_map<int, std::vector<Preset>> scannedPresets;
+    bool haveScannedPresets{false};
+
+    void doPresetRescan(SurgeStorage *storage, bool forceRescan = false);
+    std::unordered_map<int, std::vector<Preset>> getPresetsByType();
+    std::vector<Preset> getPresetsForSingleType(int type_id);
+    bool hasPresetsForSingleType(int type_id);
+
+    void saveFxIn(SurgeStorage *s, FxStorage *fxdata, const std::string &fn);
+
+    void loadPresetOnto(const Preset &p, SurgeStorage *s, FxStorage *fxbuffer);
 };
-
-void doPresetRescan(SurgeStorage *storage, bool forceRescan = false);
-std::unordered_map<int, std::vector<Preset>> getPresetsByType();
-std::vector<Preset> getPresetsForSingleType(int type_id);
-bool hasPresetsForSingleType(int type_id);
-
-void saveFxIn(SurgeStorage *s, FxStorage *fxdata, const std::string &fn);
-
-void loadPresetOnto(const Preset &p, SurgeStorage *s, FxStorage *fxbuffer);
-} // namespace FxUserPreset
+} // namespace Storage
 
 namespace FxClipboard
 {

--- a/src/common/ModulatorPresetManager.cpp
+++ b/src/common/ModulatorPresetManager.cpp
@@ -23,13 +23,14 @@
 
 namespace Surge
 {
-namespace ModulatorPreset
+namespace Storage
 {
 
 const static std::string PresetDir = "Modulator Presets";
 const static std::string PresetXtn = ".modpreset";
 
-void savePresetToUser(const fs::path &location, SurgeStorage *s, int scene, int lfoid)
+void ModulatorPreset::savePresetToUser(const fs::path &location, SurgeStorage *s, int scene,
+                                       int lfoid)
 {
     auto lfo = &(s->getPatch().scene[scene].lfo[lfoid]);
     int lfotype = lfo->shape.val.i;
@@ -121,7 +122,8 @@ void savePresetToUser(const fs::path &location, SurgeStorage *s, int scene, int 
 /*
  * Given a completed path, load the preset into our storage
  */
-void loadPresetFrom(const fs::path &location, SurgeStorage *s, int scene, int lfoid)
+void ModulatorPreset::loadPresetFrom(const fs::path &location, SurgeStorage *s, int scene,
+                                     int lfoid)
 {
     auto lfo = &(s->getPatch().scene[scene].lfo[lfoid]);
     // ToDo: Inverse of above
@@ -221,13 +223,10 @@ void loadPresetFrom(const fs::path &location, SurgeStorage *s, int scene, int lf
     }
 }
 
-static std::vector<Category> scanedPresets;
-static bool haveScanedPresets = false;
-
 /*
  * Note: Clients rely on this being sorted by category path if you change it
  */
-std::vector<Category> getPresets(SurgeStorage *s)
+std::vector<ModulatorPreset::Category> ModulatorPreset::getPresets(SurgeStorage *s)
 {
     if (haveScanedPresets)
         return scanedPresets;
@@ -331,10 +330,10 @@ std::vector<Category> getPresets(SurgeStorage *s)
     return res;
 }
 
-void forcePresetRescan()
+void ModulatorPreset::forcePresetRescan()
 {
     haveScanedPresets = false;
     scanedPresets.clear();
 }
-} // namespace ModulatorPreset
+} // namespace Storage
 } // namespace Surge

--- a/src/common/ModulatorPresetManager.h
+++ b/src/common/ModulatorPresetManager.h
@@ -21,37 +21,43 @@ class SurgeStorage;
 
 namespace Surge
 {
-namespace ModulatorPreset
+namespace Storage
 {
-/*
- * Given a storage, scene, and LFO, stream stream it to a file relative to the location
- * in the user directory LFO presets area
- */
-void savePresetToUser(const fs::path &location, SurgeStorage *s, int scene, int lfo);
-
-/*
- * Given a compelted path, load the preset into our storage
- */
-void loadPresetFrom(const fs::path &location, SurgeStorage *s, int scene, int lfo);
-
-/*
- * What are the presets we have? In some form of category order
- */
-struct Preset
+struct ModulatorPreset
 {
-    std::string name;
-    fs::path path;
+    /*
+     * Given a storage, scene, and LFO, stream stream it to a file relative to the location
+     * in the user directory LFO presets area
+     */
+    void savePresetToUser(const fs::path &location, SurgeStorage *s, int scene, int lfo);
+
+    /*
+     * Given a compelted path, load the preset into our storage
+     */
+    void loadPresetFrom(const fs::path &location, SurgeStorage *s, int scene, int lfo);
+
+    /*
+     * What are the presets we have? In some form of category order
+     */
+    struct Preset
+    {
+        std::string name;
+        fs::path path;
+    };
+
+    struct Category
+    {
+        std::string name;
+        std::string path;
+        std::string parentPath;
+        std::vector<Preset> presets;
+    };
+
+    std::vector<Category> getPresets(SurgeStorage *s);
+    void forcePresetRescan();
+
+    std::vector<Category> scanedPresets;
+    bool haveScanedPresets{false};
 };
-
-struct Category
-{
-    std::string name;
-    std::string path;
-    std::string parentPath;
-    std::vector<Preset> presets;
-};
-
-std::vector<Category> getPresets(SurgeStorage *s);
-void forcePresetRescan();
-} // namespace ModulatorPreset
+} // namespace Storage
 } // namespace Surge

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -48,6 +48,8 @@
 
 #include "strnatcmp.h"
 #include "libMTSClient.h"
+#include "FxPresetAndClipboardManager.h"
+#include "ModulatorPresetManager.h"
 
 // FIXME probably remove this when we remove the hardcoded hack below
 #include "MSEGModulationHelper.h"
@@ -642,6 +644,12 @@ bailOnPortable:
         Surge::Storage::getUserDefaultValue(this, Surge::Storage::InitialPatchName, "Init Saw");
     initPatchCategory = Surge::Storage::getUserDefaultValue(
         this, Surge::Storage::InitialPatchCategory, "Templates");
+
+    fxUserPreset = std::make_unique<Surge::Storage::FxUserPreset>();
+    fxUserPreset->doPresetRescan(this);
+
+    modulatorPreset = std::make_unique<Surge::Storage::ModulatorPreset>();
+    modulatorPreset->forcePresetRescan();
 }
 
 void SurgeStorage::createUserDirectory()

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -880,6 +880,15 @@ class MTSClient;
 
 /* storage layer */
 
+namespace Surge
+{
+namespace Storage
+{
+struct FxUserPreset;
+struct ModulatorPreset;
+} // namespace Storage
+} // namespace Surge
+
 class alignas(16) SurgeStorage
 {
   public:
@@ -1010,6 +1019,9 @@ class alignas(16) SurgeStorage
     int firstUserWTCategory;
     std::vector<int> wtOrdering;
     std::vector<int> wtCategoryOrdering;
+
+    std::unique_ptr<Surge::Storage::FxUserPreset> fxUserPreset;
+    std::unique_ptr<Surge::Storage::ModulatorPreset> modulatorPreset;
 
     std::string wtpath;
     std::string datapath;

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -1969,33 +1969,33 @@ juce::PopupMenu SurgeGUIEditor::makeLfoMenu(const juce::Point<int> &where)
     lfoSubMenu.addItem("[?] LFO Presets", [hurl]() { juce::URL(hurl).launchInDefaultBrowser(); });
     lfoSubMenu.addSeparator();
 
-    lfoSubMenu.addItem(Surge::GUI::toOSCaseForMenu("Save " + what + " As..."), [this, currentLfoId,
-                                                                                what]() {
-        // Prompt for a name
-        promptForMiniEdit(
-            "preset", "Enter the name for " + what + " preset:", what + " Preset Name",
-            juce::Point<int>{}, [this, currentLfoId](const std::string &s) {
-                Surge::ModulatorPreset::savePresetToUser(string_to_path(s), &(this->synth->storage),
-                                                         current_scene, currentLfoId);
-            });
-        // and save
-    });
+    lfoSubMenu.addItem(
+        Surge::GUI::toOSCaseForMenu("Save " + what + " As..."), [this, currentLfoId, what]() {
+            // Prompt for a name
+            promptForMiniEdit(
+                "preset", "Enter the name for " + what + " preset:", what + " Preset Name",
+                juce::Point<int>{}, [this, currentLfoId](const std::string &s) {
+                    this->synth->storage.modulatorPreset->savePresetToUser(
+                        string_to_path(s), &(this->synth->storage), current_scene, currentLfoId);
+                });
+            // and save
+        });
 
-    auto presetCategories = Surge::ModulatorPreset::getPresets(&(synth->storage));
+    auto presetCategories = this->synth->storage.modulatorPreset->getPresets(&(synth->storage));
     if (!presetCategories.empty())
     {
         lfoSubMenu.addSeparator();
     }
 
-    std::function<void(juce::PopupMenu & m, const Surge::ModulatorPreset::Category &cat)>
+    std::function<void(juce::PopupMenu & m, const Surge::Storage::ModulatorPreset::Category &cat)>
         recurseCat;
-    recurseCat = [this, currentLfoId, presetCategories,
-                  &recurseCat](juce::PopupMenu &m, const Surge::ModulatorPreset::Category &cat) {
+    recurseCat = [this, currentLfoId, presetCategories, &recurseCat](
+                     juce::PopupMenu &m, const Surge::Storage::ModulatorPreset::Category &cat) {
         for (const auto &p : cat.presets)
         {
             auto action = [this, p, currentLfoId]() {
-                Surge::ModulatorPreset::loadPresetFrom(p.path, &(this->synth->storage),
-                                                       current_scene, currentLfoId);
+                this->synth->storage.modulatorPreset->loadPresetFrom(
+                    p.path, &(this->synth->storage), current_scene, currentLfoId);
 
                 auto newshape = this->synth->storage.getPatch()
                                     .scene[current_scene]
@@ -2043,7 +2043,7 @@ juce::PopupMenu SurgeGUIEditor::makeLfoMenu(const juce::Point<int> &where)
 
     lfoSubMenu.addSeparator();
     lfoSubMenu.addItem(Surge::GUI::toOSCaseForMenu("Rescan Presets"),
-                       []() { Surge::ModulatorPreset::forcePresetRescan(); });
+                       [this]() { this->synth->storage.modulatorPreset->forcePresetRescan(); });
 
     return lfoSubMenu;
 }
@@ -3044,8 +3044,8 @@ juce::PopupMenu SurgeGUIEditor::makeDataMenu(const juce::Point<int> &where)
         this->synth->storage.refresh_patchlist();
         this->scannedForMidiPresets = false;
 
-        Surge::FxUserPreset::doPresetRescan(&(this->synth->storage));
-        Surge::ModulatorPreset::forcePresetRescan();
+        this->synth->storage.fxUserPreset->doPresetRescan(&(this->synth->storage), true);
+        this->synth->storage.modulatorPreset->forcePresetRescan();
 
         // Rescan for skins
         auto r = this->currentSkin->root;

--- a/src/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/gui/widgets/XMLConfiguredMenus.cpp
@@ -500,7 +500,7 @@ void FxMenu::populate()
     /*
     ** Are there user presets
     */
-    Surge::FxUserPreset::doPresetRescan(storage);
+    storage->fxUserPreset->doPresetRescan(storage);
 
     XMLMenuPopulator::populate();
 
@@ -520,7 +520,7 @@ void FxMenu::populate()
     }
 
     auto rsA = [this]() {
-        Surge::FxUserPreset::doPresetRescan(this->storage, true);
+        this->storage->fxUserPreset->doPresetRescan(this->storage, true);
         auto *sge = firstListenerOfType<SurgeGUIEditor>();
         if (sge)
             sge->queueRebuildUI();
@@ -552,7 +552,7 @@ void FxMenu::saveFX()
     {
         sge->promptForMiniEdit("", "Enter a name for the FX preset:", "Save FX Preset",
                                juce::Point<int>{}, [this](const std::string &s) {
-                                   Surge::FxUserPreset::saveFxIn(this->storage, fx, s);
+                                   this->storage->fxUserPreset->saveFxIn(this->storage, fx, s);
                                    auto *sge = firstListenerOfType<SurgeGUIEditor>();
                                    if (sge)
                                        sge->queueRebuildUI();
@@ -560,9 +560,9 @@ void FxMenu::saveFX()
     }
 }
 
-void FxMenu::loadUserPreset(const Surge::FxUserPreset::Preset &p)
+void FxMenu::loadUserPreset(const Surge::Storage::FxUserPreset::Preset &p)
 {
-    Surge::FxUserPreset::loadPresetOnto(p, storage, fxbuffer);
+    this->storage->fxUserPreset->loadPresetOnto(p, storage, fxbuffer);
 
     selectedIdx = -1;
     selectedName = p.name;
@@ -572,8 +572,8 @@ void FxMenu::loadUserPreset(const Surge::FxUserPreset::Preset &p)
 
 void FxMenu::scanExtraPresets()
 {
-    Surge::FxUserPreset::doPresetRescan(storage);
-    for (const auto &tp : Surge::FxUserPreset::getPresetsByType())
+    storage->fxUserPreset->doPresetRescan(storage);
+    for (const auto &tp : storage->fxUserPreset->getPresetsByType())
     {
         // So lets run all presets until we find the first item with type tp.first
         auto alit = allPresets.begin();

--- a/src/gui/widgets/XMLConfiguredMenus.h
+++ b/src/gui/widgets/XMLConfiguredMenus.h
@@ -73,7 +73,7 @@ struct XMLMenuPopulator
          * I knwo this isn't very generalized and I could template it and subclass
          * and use this for N other controls. But I wont
          */
-        Surge::FxUserPreset::Preset fxPreset;
+        Surge::Storage::FxUserPreset::Preset fxPreset;
         bool hasFxUserPreset{false};
     };
     virtual void scanExtraPresets() {}
@@ -203,7 +203,7 @@ struct FxMenu : public juce::Component, public XMLMenuPopulator, public WidgetBa
     void saveFX();
 
     void loadByIndex(int index) override;
-    void loadUserPreset(const Surge::FxUserPreset::Preset &p);
+    void loadUserPreset(const Surge::Storage::FxUserPreset::Preset &p);
 
     SurgeImage *bg{}, *bgHover{};
     void setBackgroundDrawable(SurgeImage *b) { bg = b; };


### PR DESCRIPTION
FxUserPreset and ModulatorPreset had static banks which was fine
but made me squeamish so undo that. Closes #4921