### PR TITLE
Show InfoWindow on Mouse Hover

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -144,6 +144,9 @@ void initMaps()
             case TabKeyArmsModulators:
                 r = "tabKeyArmsModulators";
                 break;
+            case InfoWindowPopupOnIdle:
+                r = "infoWindowPopupOnIdle";
+                break;
             case nKeys:
                 break;
             }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -58,6 +58,8 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
 
     TabKeyArmsModulators,
 
+    InfoWindowPopupOnIdle,
+
     nKeys
 };
 /**

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -2727,6 +2727,17 @@ juce::PopupMenu SurgeGUIEditor::makeValueDisplaysMenu(const juce::Point<int> &wh
                             this->frame->repaint();
                         });
 
+    bool infowi = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
+                                                      Surge::Storage::InfoWindowPopupOnIdle, true);
+
+    dispDefMenu.addItem(Surge::GUI::toOSCaseForMenu("Show Value Popup On Slider Mouseover"), true,
+                        infowi, [this, infowi]() {
+                            Surge::Storage::updateUserDefaultValue(
+                                &(this->synth->storage), Surge::Storage::InfoWindowPopupOnIdle,
+                                !infowi);
+                            this->frame->repaint();
+                        });
+
     // Middle C submenu
     auto middleCSubMenu = juce::PopupMenu();
 

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -483,6 +483,23 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void hideInfowindowNow();
     void hideInfowindowSoon();
     void idleInfowindow();
+    enum InfoQAction
+    {
+        START,
+        CANCEL,
+        LEAVE
+    };
+    void enqueueFutureInfowindow(int ptag, const juce::Rectangle<int> &around, InfoQAction action);
+    enum InfoQState
+    {
+        NONE,
+        COUNTDOWN,
+        SHOWING,
+        DISMISSED_BEFORE
+    } infoQState{NONE};
+    int infoQCountdown{-1};
+    int infoQTag{-1};
+    juce::Rectangle<int> infoQBounds;
 
   private:
     std::unique_ptr<Surge::Widgets::EffectChooser> effectChooser;

--- a/src/gui/widgets/ModulatableSlider.cpp
+++ b/src/gui/widgets/ModulatableSlider.cpp
@@ -288,6 +288,7 @@ void ModulatableSlider::onSkinChanged()
 
 void ModulatableSlider::mouseEnter(const juce::MouseEvent &event)
 {
+    enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::START);
     isHovered = true;
     auto sge = firstListenerOfType<SurgeGUIEditor>();
     if (sge)
@@ -300,6 +301,7 @@ void ModulatableSlider::mouseExit(const juce::MouseEvent &event) { endHover(); }
 
 void ModulatableSlider::endHover()
 {
+    enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::LEAVE);
     isHovered = false;
     auto sge = firstListenerOfType<SurgeGUIEditor>();
     if (sge)
@@ -367,6 +369,8 @@ void ModulatableSlider::mouseDrag(const juce::MouseEvent &event)
 
 void ModulatableSlider::mouseDown(const juce::MouseEvent &event)
 {
+    enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::CANCEL);
+
     if (forwardedMainFrameMouseDowns(event))
     {
         return;
@@ -389,6 +393,11 @@ void ModulatableSlider::mouseDown(const juce::MouseEvent &event)
     lastDistance = 0.f;
     editTypeWas = NOEDIT;
     showInfowindow(isEditingModulation);
+}
+
+void ModulatableSlider::mouseMove(const juce::MouseEvent &event)
+{
+    enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::START);
 }
 
 void ModulatableSlider::mouseUp(const juce::MouseEvent &event)

--- a/src/gui/widgets/ModulatableSlider.h
+++ b/src/gui/widgets/ModulatableSlider.h
@@ -73,6 +73,7 @@ struct ModulatableSlider : public juce::Component,
     void mouseEnter(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override;
     void mouseDrag(const juce::MouseEvent &event) override;
+    void mouseMove(const juce::MouseEvent &event) override;
     void mouseDown(const juce::MouseEvent &event) override;
     void mouseUp(const juce::MouseEvent &event) override;
     void mouseDoubleClick(const juce::MouseEvent &event) override;

--- a/src/gui/widgets/WidgetBaseMixin.h
+++ b/src/gui/widgets/WidgetBaseMixin.h
@@ -76,6 +76,14 @@ struct WidgetBaseMixin : public Surge::GUI::SkinConsumingComponent,
             t->controlEndEdit(this);
     }
 
+    void enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction place)
+    {
+        auto t = getTag();
+        auto sge = firstListenerOfType<SurgeGUIEditor>();
+        if (sge)
+            sge->enqueueFutureInfowindow(t, asT()->getBounds(), place);
+    }
+
     void showInfowindow(bool isEditingModulation)
     {
         auto l = asT()->getBounds();


### PR DESCRIPTION
This diff optionally (value menu controlled) shows the value
info window when you hover over a slider. Has correct state for
dismiss stays dismissed etc...

Closes #377. A 2.5 year old issue!