### PR TITLE
Restore Graphical MSEG State

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Esa Juhani Ruoho <esaruoho@gmail.com>
 Mikko Saarinki <https://github.com/kingston1>
 Jarkko Sakkinen <jarkko.sakkinen@iki.fi>
 Jeremy Sagan <info@sagantech.biz>
+Sebastian Schwarzhuber <https://github.com/cannero>
 Jeff Smith <whydoubt@gmail.com>
 Jon Spruyt <http://jonspru.yt>
 Markku Tavasti <tavasti@iki.fi>

--- a/src/gui/overlays/MSEGEditor.cpp
+++ b/src/gui/overlays/MSEGEditor.cpp
@@ -2895,8 +2895,15 @@ void MSEGControlRegion::rebuild()
         movementMode->setHoverSwitchDrawable(std::get<1>(dbl));
         movementMode->setHoverOnSwitchDrawable(std::get<2>(dbl));
 
+        // canvas is nullptr in rebuild call in constructor, use state in this case
         if (canvas)
+        {
             movementMode->setValue(canvas->timeEditMode / 2.f);
+        }
+        else
+        {
+            movementMode->setValue(eds->timeEditMode / 2.f);
+        }
         addAndMakeVisible(*movementMode);
         // this value centers the loop mode and snap sections against the MSEG editor width
         // if more controls are to be added to that center section, reduce this value
@@ -2978,7 +2985,7 @@ void MSEGControlRegion::rebuild()
         loopMode->setHoverSwitchDrawable(std::get<1>(dbl));
         loopMode->setHoverOnSwitchDrawable(std::get<2>(dbl));
 
-        loopMode->setValue((ms->loopMode - 1) / 2);
+        loopMode->setValue((ms->loopMode - 1) / 2.f);
         addAndMakeVisible(*loopMode);
 
         xpos += segWidth;


### PR DESCRIPTION
First the canvas and the controls are created, the reference to each other is set later.
canvas = make; controls = make; canvas->controls = controls; controls->canvas = canvas
So in the first rebuild in controls the canvas member is a nullptr and the time edit mode value is taken from the state.

The loop mode 'On' was not set as integer division was used.

Closes #4835