### PR TITLE
Double-click on macro name opens rename miniedit

### DIFF
--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -381,6 +381,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         synth->has_patchid_file = true;
     }
 
+    void openMacroRenameDialog(const int ccid, const juce::Point<int> where,
+                               Surge::Widgets::ModulationSourceButton *msb);
+
     void closeStorePatchDialog();
     void showStorePatchDialog();
 
@@ -597,7 +600,6 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::array<std::unique_ptr<Surge::Widgets::ModulationSourceButton>, n_modsources> gui_modsrc;
     std::unique_ptr<Surge::Widgets::LFOAndStepDisplay> lfoDisplay;
 
-    // VSTGUI::CControl *lfodisplay = nullptr;
     Surge::Widgets::Switch *filtersubtype[2] = {};
 
   public:

--- a/src/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -754,47 +754,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                 contextMenu.addItem(
                     Surge::GUI::toOSCaseForMenu("Rename Macro..."), [this, control, ccid]() {
-                        std::string pval = synth->storage.getPatch().CustomControllerLabel[ccid];
+                        auto msb = dynamic_cast<Surge::Widgets::ModulationSourceButton *>(control);
+                        auto pos = control->asJuceComponent()->getBounds().getTopLeft();
 
-                        if (pval == "-")
-                        {
-                            pval = "";
-                        }
-
-                        promptForMiniEdit(
-                            pval, "Enter a new name for the macro:", "Rename Macro",
-                            control->asJuceComponent()->getBounds().getTopLeft(),
-                            [this, control, ccid](const std::string &s) {
-                                auto useS = s;
-
-                                if (useS == "")
-                                {
-                                    useS = "-";
-                                }
-
-                                strxcpy(synth->storage.getPatch().CustomControllerLabel[ccid],
-                                        useS.c_str(), CUSTOM_CONTROLLER_LABEL_SIZE - 1);
-                                synth->storage.getPatch()
-                                    .CustomControllerLabel[ccid][CUSTOM_CONTROLLER_LABEL_SIZE - 1] =
-                                    0; // to be sure
-                                parameterNameUpdated = true;
-
-                                auto msb =
-                                    dynamic_cast<Surge::Widgets::ModulationSourceButton *>(control);
-
-                                if (msb)
-                                {
-                                    msb->setCurrentModLabel(
-                                        synth->storage.getPatch().CustomControllerLabel[ccid]);
-                                }
-
-                                if (control && control->asJuceComponent())
-                                {
-                                    control->asJuceComponent()->repaint();
-                                }
-
-                                synth->refresh_editor = true;
-                            });
+                        openMacroRenameDialog(ccid, pos, msb);
                     });
 
                 auto jpm = juceEditor->hostMenuForMacro(ccid);

--- a/src/gui/widgets/ModulationSourceButton.cpp
+++ b/src/gui/widgets/ModulationSourceButton.cpp
@@ -296,7 +296,6 @@ void ModulationSourceButton::buildHamburgerMenu(juce::PopupMenu &menu,
         }
 
         menu.addItem(modName, [this, idx]() {
-            printf("%d\n", idx);
             this->modlistIndex = idx;
             mouseMode = HAMBURGER;
             notifyValueChanged();

--- a/src/gui/widgets/ModulationSourceButton.cpp
+++ b/src/gui/widgets/ModulationSourceButton.cpp
@@ -296,6 +296,7 @@ void ModulationSourceButton::buildHamburgerMenu(juce::PopupMenu &menu,
         }
 
         menu.addItem(modName, [this, idx]() {
+            printf("%d\n", idx);
             this->modlistIndex = idx;
             mouseMode = HAMBURGER;
             notifyValueChanged();
@@ -371,11 +372,16 @@ void ModulationSourceButton::mouseDoubleClick(const juce::MouseEvent &event)
     {
         auto topRect = getLocalBounds().withHeight(splitHeight);
 
-        // TODO: double-click to rename macro?
-        // if (topRect.contains(event.position.toInt()))
-        //{
-        //    return;
-        //}
+        // rename macro on double-click
+        if (topRect.contains(event.position.toInt()))
+        {
+            auto ccid = (int)getCurrentModSource() - ms_ctrl1;
+            auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+            sge->openMacroRenameDialog(ccid, topRect.getTopLeft(), this);
+
+            return;
+        }
 
         // match the mouseable area to the painted macro slider area (including slider frame)
         auto frameRect = getLocalBounds();


### PR DESCRIPTION
Also abstracts promptForMiniEdit from SurgeGUIEditorValueCallbacks
into a method that can be reused (and is used in ModulationSourceButton then)