### PR TITLE
Allow scene modulators onto globals correctly

### DIFF
--- a/src/common/ModulationSource.h
+++ b/src/common/ModulationSource.h
@@ -253,6 +253,12 @@ struct ModulationRouting
     float depth;
     bool muted = false;
     int source_index{0};
+    /*
+     * In the case of routing LFO -> Global, the target parameter doesnt have
+     * a scene so we need to disambiguate the source scene. This is only used
+     * for global routings. See #2285
+     */
+    int source_scene{-1};
 };
 
 class ModulationSource

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1391,6 +1391,22 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                     t.depth = (float)depth;
                     t.source_id = modsource;
 
+                    if (sceneId != 0)
+                        t.source_scene = sceneId - 1;
+                    else
+                    {
+                        int sourcescene = 0;
+                        if (mr->QueryIntAttribute("source_scene", &sourcescene) == TIXML_SUCCESS)
+                        {
+                            t.source_scene = sourcescene;
+                        }
+                        else
+                        {
+                            // Explicity set scene to A. See #2285
+                            t.source_scene = 0;
+                        }
+                    }
+
                     int muted = 0;
                     if (mr->QueryIntAttribute("muted", &muted) == TIXML_SUCCESS)
                         t.muted = muted;
@@ -2260,6 +2276,8 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
                     {
                         if (r->at(b).destination_id == p_id)
                         {
+                            // if you add something here make sure to replicated it in the global
+                            // below
                             TiXmlElement mr("modrouting");
                             mr.SetAttribute("source", r->at(b).source_id);
                             mr.SetAttribute("depth", float_to_str(r->at(b).depth, tempstr));
@@ -2281,6 +2299,9 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
                         TiXmlElement mr("modrouting");
                         mr.SetAttribute("source", r->at(b).source_id);
                         mr.SetAttribute("depth", float_to_str(r->at(b).depth, tempstr));
+                        mr.SetAttribute("muted", r->at(b).muted);
+                        mr.SetAttribute("source_index", r->at(b).source_index);
+                        mr.SetAttribute("source_scene", r->at(b).source_scene);
                         p.InsertEndChild(mr);
                     }
                 }

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -260,23 +260,31 @@ class alignas(16) SurgeSynthesizer
   public:
     void updateDisplay();
     bool isValidModulation(long ptag, modsources modsource) const;
-    bool isActiveModulation(long ptag, modsources modsource, int index) const;
-    bool isAnyActiveModulation(long ptag, modsources modsource) const; // independent of index
+    bool isActiveModulation(long ptag, modsources modsource, int modsourceScene, int index) const;
+    bool isAnyActiveModulation(long ptag, modsources modsource,
+                               int modsourceScene) const; // independent of index
     bool isBipolarModulation(modsources modsources) const;
     bool isModsourceUsed(modsources modsource); // FIXME - this should be const
     bool isModDestUsed(long moddest) const;
 
     bool supportsIndexedModulator(int scene, modsources modsource) const;
     int getMaxModulationIndex(int scene, modsources modsource) const;
-    std::vector<int> getModulationIndicesBetween(long ptag, modsources modsource) const;
-    ModulationRouting *getModRouting(long ptag, modsources modsource, int index) const;
+    std::vector<int> getModulationIndicesBetween(long ptag, modsources modsource,
+                                                 int modsourceScene) const;
+    ModulationRouting *getModRouting(long ptag, modsources modsource, int modsourceScene,
+                                     int index) const;
 
-    bool setModulation(long ptag, modsources modsource, int index, float value);
-    float getModulation(long ptag, modsources modsource, int index) const;
-    void muteModulation(long ptag, modsources modsource, int index, bool mute);
-    bool isModulationMuted(long ptag, modsources modsource, int index) const;
-    float getModDepth(long ptag, modsources modsource, int index) const;
-    void clearModulation(long ptag, modsources modsource, int index,
+    /*
+     * setModulation etc take a modsource scene. This is only needed for global modulations
+     * since for in-scene modulations the paramter implicit in ptag has a scene. But for
+     * LFOs modulating FX, we need to knwo which scene they originate from. See #2285
+     */
+    bool setModulation(long ptag, modsources modsource, int modsourceScene, int index, float value);
+    float getModulation(long ptag, modsources modsource, int modsourceScene, int index) const;
+    void muteModulation(long ptag, modsources modsource, int modsourceScene, int index, bool mute);
+    bool isModulationMuted(long ptag, modsources modsource, int modsourceScene, int index) const;
+    float getModDepth(long ptag, modsources modsource, int modsourceScene, int index) const;
+    void clearModulation(long ptag, modsources modsource, int modsourceScene, int index,
                          bool clearEvenIfInvalid = false);
     void clear_osc_modulation(
         int scene, int entry); // clear the modulation routings on the algorithm-specific sliders
@@ -349,7 +357,7 @@ class alignas(16) SurgeSynthesizer
     bool fx_reload[n_fx_slots];   // if true, reload new effect parameters from fxsync
     FxStorage fxsync[n_fx_slots]; // used for synchronisation of parameter init
     bool fx_reload_mod[n_fx_slots];
-    std::array<std::vector<std::tuple<int, int, int, float>>, n_fx_slots> fxmodsync;
+    std::array<std::vector<std::tuple<int, int, int, int, float>>, n_fx_slots> fxmodsync;
     int32_t fx_suspend_bitmask;
 
     // hold pedal stuff

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -522,8 +522,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     std::unique_ptr<Surge::Overlays::TypeinParamEditor> typeinParamEditor;
     bool setParameterFromString(Parameter *p, const std::string &s);
-    bool setParameterModulationFromString(Parameter *p, modsources ms, int modidx,
-                                          const std::string &s);
+    bool setParameterModulationFromString(Parameter *p, modsources ms, int modsourceScene,
+                                          int modidx, const std::string &s);
     bool setControlFromString(modsources ms, const std::string &s);
     friend struct Surge::Overlays::TypeinParamEditor;
     friend struct Surge::Overlays::PatchStoreDialog;
@@ -583,7 +583,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::unique_ptr<juce::Label> fxPresetLabel;
 
   public:
-    std::string modulatorName(int ms, bool forButton);
+    std::string modulatorName(int ms, bool forButton, int forScene = -1);
     std::string modulatorIndexExtension(int scene, int ms, int index, bool shortV = false);
 
   private:
@@ -652,9 +652,10 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
   private:
     void promptForUserValueEntry(Parameter *p, juce::Component *c)
     {
-        promptForUserValueEntry(p, c, -1, -1);
+        promptForUserValueEntry(p, c, -1, -1, -1);
     }
-    void promptForUserValueEntry(Parameter *p, juce::Component *c, int modsource, int modindex);
+    void promptForUserValueEntry(Parameter *p, juce::Component *c, int modsource, int modScene,
+                                 int modindex);
 
     /*
     ** Skin support

--- a/src/gui/SurgeGUIEditorInfowindow.cpp
+++ b/src/gui/SurgeGUIEditorInfowindow.cpp
@@ -98,7 +98,7 @@ void SurgeGUIEditor::updateInfowindowContents(int ptag, bool isModulated)
         sprintf(pname, "%s -> %s", mn.c_str(), txt);
         ModulationDisplayInfoWindowStrings mss;
         p->get_display_of_modulation_depth(
-            pdisp, synth->getModDepth(pid, modsource, modsource_index),
+            pdisp, synth->getModDepth(pid, modsource, current_scene, modsource_index),
             synth->isBipolarModulation(modsource), Parameter::InfoWindow, &mss);
         if (mss.val != "")
         {

--- a/src/gui/overlays/TypeinParamEditor.cpp
+++ b/src/gui/overlays/TypeinParamEditor.cpp
@@ -116,8 +116,8 @@ void TypeinParamEditor::textEditorReturnKeyPressed(juce::TextEditor &te)
     {
         if (p && ms > 0)
         {
-            res =
-                editor->setParameterModulationFromString(p, ms, modidx, te.getText().toStdString());
+            res = editor->setParameterModulationFromString(p, ms, modScene, modidx,
+                                                           te.getText().toStdString());
         }
         else
         {

--- a/src/gui/overlays/TypeinParamEditor.h
+++ b/src/gui/overlays/TypeinParamEditor.h
@@ -46,11 +46,12 @@ struct TypeinParamEditor : public juce::Component,
     void setEditedParam(Parameter *pin) { p = pin; };
     bool isMod{false};
     modsources ms{ms_original};
-    int modidx{0};
-    void setModulation(bool isMod, modsources ms, int modidx)
+    int modScene{-1}, modidx{0};
+    void setModulation(bool isMod, modsources ms, int modScene, int modidx)
     {
         this->isMod = isMod;
         this->ms = ms;
+        this->modScene = modScene;
         this->modidx = modidx;
     }
 

--- a/src/headless/UnitTestsMOD.cpp
+++ b/src/headless/UnitTestsMOD.cpp
@@ -989,10 +989,10 @@ TEST_CASE("High Low Latest Note Modulator in All Modes", "[mod]")
         // Assign highest note keytrack to any parameter. Lets do this with highest latest and
         // lowest
         surge->setModulation(surge->storage.getPatch().scene[0].osc[0].pitch.id, ms_highest_key, 0,
+                             0, 0.2);
+        surge->setModulation(surge->storage.getPatch().scene[0].osc[0].p[0].id, ms_latest_key, 0, 0,
                              0.2);
-        surge->setModulation(surge->storage.getPatch().scene[0].osc[0].p[0].id, ms_latest_key, 0,
-                             0.2);
-        surge->setModulation(surge->storage.getPatch().scene[0].osc[0].p[1].id, ms_lowest_key, 0,
+        surge->setModulation(surge->storage.getPatch().scene[0].osc[0].p[1].id, ms_lowest_key, 0, 0,
                              0.2);
         return surge;
     };
@@ -1171,17 +1171,17 @@ TEST_CASE("High Low Latest with splits", "[mod]")
         // Assign highest note keytrack to any parameter. Lets do this with highest latest and
         // lowest
         surge->setModulation(surge->storage.getPatch().scene[0].osc[0].pitch.id, ms_highest_key, 0,
+                             0, 0.2);
+        surge->setModulation(surge->storage.getPatch().scene[0].osc[0].p[0].id, ms_latest_key, 0, 0,
                              0.2);
-        surge->setModulation(surge->storage.getPatch().scene[0].osc[0].p[0].id, ms_latest_key, 0,
-                             0.2);
-        surge->setModulation(surge->storage.getPatch().scene[0].osc[0].p[1].id, ms_lowest_key, 0,
+        surge->setModulation(surge->storage.getPatch().scene[0].osc[0].p[1].id, ms_lowest_key, 0, 0,
                              0.2);
 
         surge->setModulation(surge->storage.getPatch().scene[1].osc[0].pitch.id, ms_highest_key, 0,
+                             0, 0.2);
+        surge->setModulation(surge->storage.getPatch().scene[1].osc[0].p[0].id, ms_latest_key, 0, 0,
                              0.2);
-        surge->setModulation(surge->storage.getPatch().scene[1].osc[0].p[0].id, ms_latest_key, 0,
-                             0.2);
-        surge->setModulation(surge->storage.getPatch().scene[1].osc[0].p[1].id, ms_lowest_key, 0,
+        surge->setModulation(surge->storage.getPatch().scene[1].osc[0].p[1].id, ms_lowest_key, 0, 0,
                              0.2);
 
         return surge;

--- a/src/python_bindings/surgepy.cpp
+++ b/src/python_bindings/surgepy.cpp
@@ -595,12 +595,12 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
     void setModulationPy(const SurgePyNamedParam &to, SurgePyModSource const &from, float amt)
     {
         // FIXME - 4871
-        setModulation(to.getID().getSynthSideId(), (modsources)from.getModSource(), amt, 0);
+        setModulation(to.getID().getSynthSideId(), (modsources)from.getModSource(), amt, 0, 0);
     }
     float getModulationPy(const SurgePyNamedParam &to, const SurgePyModSource &from)
     {
         // FIXME - 4871
-        return getModulation(to.getID().getSynthSideId(), (modsources)from.getModSource(), 0);
+        return getModulation(to.getID().getSynthSideId(), (modsources)from.getModSource(), 0, 0);
     }
     bool isValidModulationPy(const SurgePyNamedParam &to, const SurgePyModSource &from)
     {
@@ -609,7 +609,8 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
     bool isActiveModulationPy(const SurgePyNamedParam &to, const SurgePyModSource &from)
     {
         // FIXME - 4871
-        return isActiveModulation(to.getID().getSynthSideId(), (modsources)from.getModSource(), 0);
+        return isActiveModulation(to.getID().getSynthSideId(), (modsources)from.getModSource(), 0,
+                                  0);
     }
     bool isBipolarModulationPy(const SurgePyModSource &from)
     {
@@ -733,7 +734,7 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
             r.dest = surgePyNamedParamById(gm.destination_id);
             r.depth = gm.depth;
             // FIXME 4871
-            r.normalizedDepth = getModulation(gm.destination_id, (modsources)gm.source_id, 0);
+            r.normalizedDepth = getModulation(gm.destination_id, (modsources)gm.source_id, 0, 0);
             gmr.append(r);
         }
 
@@ -755,7 +756,7 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
                 // FIXME 4871
                 r.normalizedDepth =
                     getModulation(gm.destination_id + storage.getPatch().scene_start[sc],
-                                  (modsources)gm.source_id, 0);
+                                  (modsources)gm.source_id, 0, 0);
                 sms.append(r);
             }
             ts["scene"] = sms;
@@ -772,7 +773,7 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
                 // FIXME 4871
                 r.normalizedDepth =
                     getModulation(gm.destination_id + storage.getPatch().scene_start[sc],
-                                  (modsources)gm.source_id, 0);
+                                  (modsources)gm.source_id, 0, 0);
                 smv.append(r);
             }
             ts["voice"] = smv;


### PR DESCRIPTION
As detained in #2285, scene b modulators onto global properties
(basically FX) didn't work but kinda looked like it kinda worked
so add a scene_source which is (1) only used for global targets and
(2) always set to 0 for everything which isn't an LFO

Closes #2285