### PR TITLE
Fix two annoying mac slider problems

### DIFF
--- a/src/gui/widgets/ModulatableSlider.cpp
+++ b/src/gui/widgets/ModulatableSlider.cpp
@@ -313,7 +313,7 @@ void ModulatableSlider::endHover()
 
 void ModulatableSlider::mouseDrag(const juce::MouseEvent &event)
 {
-    auto p = event.getMouseDownPosition();
+    auto p = mouseDownFloatPosition;
     float distance = event.position.getX() - p.getX();
     if (orientation == ParamConfig::kVertical)
         distance = -(event.position.getY() - p.getY());
@@ -326,6 +326,11 @@ void ModulatableSlider::mouseDrag(const juce::MouseEvent &event)
 
     if (editTypeWas == NOEDIT)
     {
+        if (!Surge::GUI::showCursor(storage))
+        {
+            juce::Desktop::getInstance().getMainMouseSource().enableUnboundedMouseMovement(true);
+        }
+
         notifyBeginEdit();
     }
     editTypeWas = DRAG;
@@ -370,6 +375,7 @@ void ModulatableSlider::mouseDrag(const juce::MouseEvent &event)
 void ModulatableSlider::mouseDown(const juce::MouseEvent &event)
 {
     enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::CANCEL);
+    mouseDownFloatPosition = event.position;
 
     if (forwardedMainFrameMouseDowns(event))
     {
@@ -381,11 +387,6 @@ void ModulatableSlider::mouseDown(const juce::MouseEvent &event)
         editTypeWas = NOEDIT;
         notifyControlModifierClicked(event.mods);
         return;
-    }
-
-    if (!Surge::GUI::showCursor(storage))
-    {
-        juce::Desktop::getInstance().getMainMouseSource().enableUnboundedMouseMovement(true);
     }
 
     valueOnMouseDown = value;

--- a/src/gui/widgets/ModulatableSlider.h
+++ b/src/gui/widgets/ModulatableSlider.h
@@ -129,6 +129,8 @@ struct ModulatableSlider : public juce::Component,
     // How far do we move in the image to make the handle image be the mod
     float modHandleX{0};
 
+    juce::Point<float> mouseDownFloatPosition;
+
     // Should we draw the label, and where?
     bool drawLabel{false};
     juce::Rectangle<int> labelRect;


### PR DESCRIPTION
1. The hide happens on mouseDown. In 1.9 it happened on mouse
   drag and that is much more natural, especially with a double
   click gesture, so revert to 1.9 behavior
2. The 'distance' calculation was from mouseDownPosition which was
   an int but on high res mac displays at > 200% that int to float
   rounding meant you failed a drag at the outset, so keep your
   own mouseFloatPosition