### PR TITLE
Some index modulator button fixes

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -3816,7 +3816,8 @@ void SurgeGUIEditor::modSourceButtonDroppedAt(Surge::Widgets::ModulationSourceBu
     }
     else if (tMCI)
     {
-        openModTypeinOnDrop(msb->getTag(), tMCI, tMCI->asControlValueInterface()->getTag());
+        openModTypeinOnDrop(msb->getTag(), tMCI, tMCI->asControlValueInterface()->getTag(),
+                            msb->modlistIndex);
     }
 }
 void SurgeGUIEditor::swapControllers(int t1, int t2)
@@ -3825,15 +3826,14 @@ void SurgeGUIEditor::swapControllers(int t1, int t2)
 }
 
 void SurgeGUIEditor::openModTypeinOnDrop(int modt, Surge::Widgets::ModulatableControlInterface *sl,
-                                         int slidertag)
+                                         int slidertag, int modidx)
 {
     auto p = synth->storage.getPatch().param_ptr[slidertag - start_paramtags];
     int ms = modt - tag_mod_source0;
 
-    jassert(false); // the index below needs fixing
     if (synth->isValidModulation(p->id, (modsources)ms))
         promptForUserValueEntry(p, sl->asControlValueInterface()->asJuceComponent(), ms,
-                                current_scene, 0);
+                                current_scene, modidx);
 }
 
 void SurgeGUIEditor::openMacroRenameDialog(const int ccid, const juce::Point<int> where,

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -299,7 +299,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void modSourceButtonDroppedAt(Surge::Widgets::ModulationSourceButton *msb,
                                   const juce::Point<int> &);
     void swapControllers(int t1, int t2);
-    void openModTypeinOnDrop(int ms, Surge::Widgets::ModulatableControlInterface *sl, int tgt);
+    void openModTypeinOnDrop(int ms, Surge::Widgets::ModulatableControlInterface *sl, int tgt,
+                             int modidx);
 
     void queueRebuildUI()
     {

--- a/src/gui/widgets/ModulationSourceButton.cpp
+++ b/src/gui/widgets/ModulationSourceButton.cpp
@@ -285,25 +285,24 @@ void ModulationSourceButton::buildHamburgerMenu(juce::PopupMenu &menu,
 
         menu.addSeparator();
     }
-    else
+    if (modlist.size() > 1)
     {
-        if (modlist.size() > 1)
+        for (auto e : modlist)
         {
-            for (auto e : modlist)
-            {
-                auto modName = std::get<3>(e);
+            auto modName = std::get<3>(e);
+
+            if (addedToModbuttonContextMenu)
                 modName = "Switch to " + modName;
 
-                menu.addItem(modName, [this, idx]() {
-                    this->modlistIndex = idx;
-                    mouseMode = HAMBURGER;
-                    notifyValueChanged();
-                    mouseMode = NONE;
-                    repaint();
-                });
+            menu.addItem(modName, [this, idx]() {
+                this->modlistIndex = idx;
+                mouseMode = HAMBURGER;
+                notifyValueChanged();
+                mouseMode = NONE;
+                repaint();
+            });
 
-                idx++;
-            }
+            idx++;
         }
     }
 }


### PR DESCRIPTION
1. Drag and Drop carries the index. Closes #4970
2. The hamburger menu left you wondering "where's the beef" so
   put entires back in it