### PR TITLE
Add dark skin waveshaper SVG

### DIFF
--- a/resources/classic-skin-svgs/bmp00183.svg
+++ b/resources/classic-skin-svgs/bmp00183.svg
@@ -2,7 +2,7 @@
 <svg viewBox="0 0 34 47" xmlns="http://www.w3.org/2000/svg">
   <rect x="0.5" y="0.5" width="33" height="46" rx="4" ry="4" style="stroke: #eeeeee; fill: rgb(21, 21, 21);"/>
   <rect x="0.5" y="0.5" width="33" height="12" rx="4" ry="4" style="fill: rgb(255, 144, 0);"/>
-  <line style="stroke: #eeeeee;" x1="0" y1="13" x2="34" y2="13"/>
   <rect x="0.5" y="3" width="33" height="10" rx="0" ry="0" style="fill: rgb(255, 144, 0);"/>
+  <line style="stroke: #eeeeee;" x1="0" y1="13" x2="34" y2="13"/>
   <rect x="0.5" y="0.5" width="33" height="46" rx="4" ry="4" style="stroke: #eeeeee; fill: none;"/>
 </svg>

--- a/resources/data/skins/dark-mode.surge-skin/SVG/bmp00183.svg
+++ b/resources/data/skins/dark-mode.surge-skin/SVG/bmp00183.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 34 47" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0.5" y="0.5" width="33" height="46" rx="4" ry="4" style="stroke: #000000; fill: #242424;"/>
+  <rect x="0.5" y="0.5" width="33" height="12" rx="4" ry="4" style="fill: #3D3D3D;"/>
+  <rect x="0.5" y="3" width="33" height="10" rx="0" ry="0" style="fill: #3D3D3D;"/>
+  <line style="stroke: #000000;" x1="0" y1="13" x2="34" y2="13"/>
+  <rect x="0.5" y="0.5" width="33" height="46" rx="4" ry="4" style="stroke: #000000; fill: none;"/>
+</svg>

--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -76,6 +76,10 @@
     <color id="osc.wavename.frame.hover" value="white"/>
     <color id="osc.wavename.text.hover" value="black"/>
 
+    <color id="waveshaper.text" value="lightgray"/>
+    <color id="waveshaper.text.hover" value="white"/>
+    <color id="waveshaper.waveform.dots" value="black"/>
+
     <color id="msegeditor.background" value="#202020"/>
     <color id="msegeditor.curve" value="modblue"/>
     <color id="msegeditor.curve.deformed" value="#2E86FE80"/>

--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -349,11 +349,16 @@ const Surge::Skin::Color Text("osc.type.text", 255, 158, 0),
 } // namespace Type
 } // namespace Osc
 
-namespace WaveShaper
+namespace Waveshaper
 {
-const Surge::Skin::Color Label("waveshaper.label", 15, 15, 15),
-    LabelHover("waveshaper.label.hover", 255, 255, 255);
+const Surge::Skin::Color Text("waveshaper.text", 15, 15, 15),
+    TextHover("waveshaper.text.hover", 255, 255, 255);
+namespace Display
+{
+const Surge::Skin::Color Dots("waveshaper.waveform.dots", 64, 64, 64),
+    Wave("waveshaper.waveform", 255, 144, 0);
 }
+} // namespace Waveshaper
 
 namespace Overlay
 {

--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -253,10 +253,14 @@ extern const Surge::Skin::Color Text, TextHover;
 }
 } // namespace Osc
 
-namespace WaveShaper
+namespace Waveshaper
 {
-extern const Surge::Skin::Color Label, LabelHover;
+extern const Surge::Skin::Color Text, TextHover;
+namespace Display
+{
+extern const Surge::Skin::Color Dots, Wave;
 }
+} // namespace Waveshaper
 
 namespace Overlay
 {

--- a/src/gui/widgets/WaveShaperSelector.cpp
+++ b/src/gui/widgets/WaveShaperSelector.cpp
@@ -337,12 +337,19 @@ void WaveShaperSelector::paint(juce::Graphics &g)
     }
 
     if (bg)
+    {
         bg->draw(g, 1.0);
+    }
 
     if (isLabelHovered)
-        g.setColour(skin->getColor(Colors::WaveShaper::LabelHover));
+    {
+        g.setColour(skin->getColor(Colors::Waveshaper::TextHover));
+    }
     else
-        g.setColour(skin->getColor(Colors::WaveShaper::Label));
+    {
+        g.setColour(skin->getColor(Colors::Waveshaper::Text));
+    }
+
     g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(7));
     g.drawText(wst_ui_names[iValue], getLocalBounds().withHeight(labelHeight),
                juce::Justification::centred);
@@ -373,16 +380,19 @@ void WaveShaperSelector::paint(juce::Graphics &g)
                   .translated(waveArea.getX(), waveArea.getY());
     {
         juce::Graphics::ScopedSaveState gs(g);
-        g.setColour(skin->getColor(Colors::Osc::Display::Dots));
+        g.setColour(skin->getColor(Colors::Waveshaper::Display::Dots));
+
         int nxd = 7, nyd = 7;
+
         for (int xd = 1; xd < nxd - 1; ++xd)
         {
             float normx = 4.f * xd / (nxd - 1) - 2;
+
             for (int yd = 0; yd < nyd; ++yd)
             {
                 float normy = 2.f * yd / (nyd - 1) - 1;
-
                 auto p = juce::Point<float>(normx, normy).transformedBy(xf);
+
                 g.fillEllipse(p.x - 0.5, p.y - 0.5, 1, 1);
             }
         }
@@ -391,7 +401,7 @@ void WaveShaperSelector::paint(juce::Graphics &g)
         juce::Graphics::ScopedSaveState gs(g);
 
         g.reduceClipRegion(waveArea);
-        g.setColour(skin->getColor(Colors::Osc::Display::Wave));
+        g.setColour(skin->getColor(Colors::Waveshaper::Display::Wave));
         g.strokePath(curvePath, juce::PathStrokeType{iValue == wst_none ? 0.6f : 1.f}, xf);
     }
 }


### PR DESCRIPTION
Make waveshaper color names more consistent with the rest
Add waveshaper dots and waveform skin colors
(sharing with osc waveform display is ok but ultimately less flexible)