### PR TITLE
Disallow opposite orientation mouse drag on MultiButton

### DIFF
--- a/src/gui/widgets/MultiSwitch.cpp
+++ b/src/gui/widgets/MultiSwitch.cpp
@@ -57,13 +57,17 @@ int MultiSwitch::coordinateToSelection(int x, int y)
     double coefX = (double)getWidth() / (double)columns;
     double coefY = (double)getHeight() / (double)rows;
 
-    int my = (int)(y / coefY);
-    int mx = (int)(x / coefX);
+    bool doX = (columns > 1 && rows < 2);
+    bool doY = (rows > 1 && columns < 2);
+
+    int mx = (int)((x * doX) / coefX);
+    int my = (int)((y * doY) / coefY);
 
     if (columns * rows > 1)
     {
         return (mx + my * columns);
     }
+
     return 0;
 }
 


### PR DESCRIPTION
Previously, if we had a 1 row x column MultiButton,
dragging in any direction would change the value of the parameter,
which felt weird.

Now, if we have a horizontally oriented MultiButton,
only horizontal drag will change value, and if we have
vertically oriented MultiButton, only vertical drag will
change value. Behavior for MultiButtons that have more than
one row and column simultaneously doesn't change.