### PR TITLE
Virtual Keyboard always gets Key events

### DIFF
--- a/src/gui/overlays/MiniEdit.cpp
+++ b/src/gui/overlays/MiniEdit.cpp
@@ -29,6 +29,7 @@ MiniEdit::MiniEdit()
     typein->setJustification(juce::Justification::centred);
     typein->setFont(Surge::GUI::getFontManager()->getLatoAtSize(10, juce::Font::bold));
     typein->setSelectAllWhenFocused(true);
+    typein->setWantsKeyboardFocus(true);
     typein->addListener(this);
     addAndMakeVisible(*typein);
 

--- a/src/surge_synth_juce/SurgeSynthEditor.cpp
+++ b/src/surge_synth_juce/SurgeSynthEditor.cpp
@@ -23,6 +23,9 @@ SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p) : AudioProcessorEdito
 {
     surgeLF = std::make_unique<SurgeJUCELookAndFeel>();
     juce::LookAndFeel::setDefaultLookAndFeel(surgeLF.get());
+
+    addKeyListener(this);
+
     adapter = std::make_unique<SurgeGUIEditor>(this, processor.surge.get());
 
     int yExtra = 0;
@@ -226,4 +229,24 @@ juce::PopupMenu SurgeSynthEditor::hostMenuForMacro(int macro)
 #endif
 
     return juce::PopupMenu();
+}
+
+bool SurgeSynthEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig)
+{
+    if (adapter->getShowVirtualKeyboard() && orig != keyboard.get())
+    {
+        return keyboard->keyPressed(key);
+    }
+
+    return false;
+}
+
+bool SurgeSynthEditor::keyStateChanged(bool isKeyDown, juce::Component *originatingComponent)
+{
+    if (adapter->getShowVirtualKeyboard() && originatingComponent != keyboard.get())
+    {
+        return keyboard->keyStateChanged(isKeyDown);
+    }
+
+    return false;
 }

--- a/src/surge_synth_juce/SurgeSynthEditor.h
+++ b/src/surge_synth_juce/SurgeSynthEditor.h
@@ -22,7 +22,8 @@ class SurgeJUCELookAndFeel;
  */
 class SurgeSynthEditor : public juce::AudioProcessorEditor,
                          public juce::AsyncUpdater,
-                         public juce::FileDragAndDropTarget
+                         public juce::FileDragAndDropTarget,
+                         public juce::KeyListener
 {
   public:
     SurgeSynthEditor(SurgeSynthProcessor &);
@@ -48,6 +49,9 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
 
     void beginMacroEdit(long macroNum);
     void endMacroEdit(long macroNum);
+
+    bool keyPressed(const juce::KeyPress &key, juce::Component *originatingComponent) override;
+    bool keyStateChanged(bool isKeyDown, juce::Component *originatingComponent) override;
 
     struct IdleTimer : juce::Timer
     {


### PR DESCRIPTION
If surge doesn't eat em, give the keyboard a try. Also
take focus in the MiniEdit.

Closes #4930