### PR TITLE
On windows, use OS Lato if available

### DIFF
--- a/scripts/installer_win/surge-x86.iss
+++ b/scripts/installer_win/surge-x86.iss
@@ -55,7 +55,7 @@ Name: Data; Description: Data Files; Types: full compact custom; Flags: fixed
 
 [Files]
 Source: {#SURGE_SRC}\resources\data\*; DestDir: {commonappdata}\Surge XT\; Components: Data; Flags: recursesubdirs; Excludes: "*.git,windows.wt,configuration.xml,paramdocumentation.xml";
-
+Source: {#SURGE_SRC}\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 ;; these lines are used by Azure pipelines - if you want to build the installer locally, comment them out!
 Source: {#SURGE_BIN}\surge_xt_products\Surge XT (32-bit).vst3\*; DestDir: {commoncf32}\VST3\Surge Synth Team\; Components: VST3; Flags: ignoreversion recursesubdirs
 Source: {#SURGE_BIN}\surge_xt_products\Surge XT Effects (32-bit).vst3\*; DestDir: {commoncf32}\VST3\Surge Synth Team\; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist recursesubdirs

--- a/scripts/installer_win/surge.iss
+++ b/scripts/installer_win/surge.iss
@@ -57,6 +57,7 @@ Name: Data; Description: Data Files; Types: full compact custom; Flags: fixed
 
 [Files]
 Source: {#SURGE_SRC}\resources\data\*; DestDir: {commonappdata}\Surge XT\; Components: Data; Flags: recursesubdirs; Excludes: "*.git,windows.wt,configuration.xml,paramdocumentation.xml";
+Source: {#SURGE_SRC}\resources\fonts\Lato-Regular.ttf; DestDir: "{fonts}"; Components: Data; FontInstall: "Lato"; Flags: onlyifdoesntexist uninsneveruninstall
 Source: {#SURGE_BIN}\surge_xt_products\Surge XT.vst3\*; DestDir: {commoncf64}\VST3\Surge Synth Team\; Components: VST3; Flags: ignoreversion recursesubdirs
 Source: {#SURGE_BIN}\surge_xt_products\Surge XT Effects.vst3\*; DestDir: {commoncf64}\VST3\Surge Synth Team\; Components: EffectsVST3; Flags: ignoreversion skipifsourcedoesntexist recursesubdirs
 Source: {#SURGE_BIN}\surge_xt_products\Surge XT.exe; DestDir: {commonpf64}\Surge Synth Team\; Components: SA; Flags: ignoreversion

--- a/src/gui/RuntimeFont.cpp
+++ b/src/gui/RuntimeFont.cpp
@@ -25,6 +25,17 @@ namespace GUI
 
 DefaultFonts::DefaultFonts()
 {
+#if WINDOWS
+    /* On windows in memory fonts use GDI and OS fonts use D2D so if we have
+     * LATO in the OS use that
+     */
+    auto ft = juce::Font::findAllTypefaceNames();
+    for (const auto &q : ft)
+        if (q == "Lato")
+            useOSLato = true;
+
+#endif
+
 #define TEST_WITH_INDIE_FLOWER 0
 #if TEST_WITH_INDIE_FLOWER
     latoRegularTypeface = juce::Typeface::createSystemTypefaceFor(
@@ -46,7 +57,14 @@ DefaultFonts::~DefaultFonts(){};
 
 juce::Font DefaultFonts::getLatoAtSize(float size, juce::Font::FontStyleFlags style) const
 {
-    return juce::Font(latoRegularTypeface).withPointHeight(size).withStyle(style);
+    if (useOSLato)
+    {
+        return juce::Font("Lato", 10, 0).withPointHeight(size).withStyle(style);
+    }
+    else
+    {
+        return juce::Font(latoRegularTypeface).withPointHeight(size).withStyle(style);
+    }
 }
 
 juce::Font DefaultFonts::getFiraMonoAtSize(float size) const

--- a/src/gui/RuntimeFont.h
+++ b/src/gui/RuntimeFont.h
@@ -16,6 +16,8 @@ struct DefaultFonts : public juce::DeletedAtShutdown
                   juce::Font::FontStyleFlags style = juce::Font::FontStyleFlags::plain) const;
     juce::Font getFiraMonoAtSize(float size) const;
 
+    bool useOSLato{false};
+
     juce::Font displayFont;
     juce::Font patchNameFont;
     juce::Font lfoTypeFont;

--- a/src/gui/widgets/ModulatableSlider.cpp
+++ b/src/gui/widgets/ModulatableSlider.cpp
@@ -117,7 +117,7 @@ void ModulatableSlider::updateLocationState()
         // This calculation is a little dicey but is correct
         labelRect = juce::Rectangle<int>()
                         .withX(handleX0)
-                        .withY(trayh / 2)
+                        .withY(trayh / 2 + 1)
                         .withHeight(trayh)
                         .withWidth(range)
                         .withTrimmedRight(1)


### PR DESCRIPTION
JUCE uses GDI for memory fonts and D2D for OS fonts
so install Lato and detect if it is there and use that
rather than memory font on Win to improve font rendering
of Lato labels on Win. Noop on mac/lin.

Closes #4856