### PR TITLE
Add skin colors for virtual keyboard and tempo panel

### DIFF
--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -39,7 +39,8 @@ namespace Entry
 {
 const Surge::Skin::Color Background("dialog.textfield.background", 255, 255, 255),
     Border("dialog.textfield.border", 160, 160, 160),
-    Focus("dialog.textfield.focus", 170, 170, 230), Text("dialog.textfield.text", 0, 0, 0);
+    Caret("dialog.textfield.caret", 160, 160, 160), Focus("dialog.textfield.focus", 224, 224, 224),
+    Text("dialog.textfield.text", 0, 0, 0);
 }
 namespace Label
 {
@@ -409,4 +410,22 @@ const Surge::Skin::Color Background("vumeter.background", 21, 21, 21),
     Border("vumeter.border", 205, 206, 212);
 
 }
+
+namespace VirtualKeyboard
+{
+const Surge::Skin::Color Text("vkb.text", 0, 0, 0), Shadow("vkb.shadow", 0, 0, 0, 64);
+
+namespace Key
+{
+const Surge::Skin::Color Black("vkb.key.black", 0, 0, 0), White("vkb.key.white", 255, 255, 255),
+    Separator("vkb.key.separator", 0, 0, 0, 96), MouseOver("vkb.key.mouse_over", 255, 144, 0, 128),
+    Pressed("vkb.key.pressed", 255, 144, 0);
+}
+
+namespace OctaveJog
+{
+const Surge::Skin::Color Background("vkb.octave.background", 151, 151, 151),
+    Arrow("vkb.octave.arrow", 255, 0, 0);
+}
+} // namespace VirtualKeyboard
 } // namespace Colors

--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -425,7 +425,7 @@ const Surge::Skin::Color Black("vkb.key.black", 0, 0, 0), White("vkb.key.white",
 namespace OctaveJog
 {
 const Surge::Skin::Color Background("vkb.octave.background", 151, 151, 151),
-    Arrow("vkb.octave.arrow", 255, 0, 0);
+    Arrow("vkb.octave.arrow", 0, 0, 0);
 }
 } // namespace VirtualKeyboard
 } // namespace Colors

--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -54,7 +54,7 @@ extern const Surge::Skin::Color Background, Border, Tick;
 }
 namespace Entry
 {
-extern const Surge::Skin::Color Background, Border, Focus, Text;
+extern const Surge::Skin::Color Background, Border, Caret, Focus, Text;
 }
 namespace Label
 {
@@ -304,4 +304,18 @@ namespace VuMeter
 {
 extern const Surge::Skin::Color Border, Background;
 }
+
+namespace VirtualKeyboard
+{
+extern const Surge::Skin::Color Text, Shadow;
+
+namespace Key
+{
+extern const Surge::Skin::Color Black, White, Separator, MouseOver, Pressed;
+}
+namespace OctaveJog
+{
+extern const Surge::Skin::Color Background, Arrow;
+} // namespace OctaveJog
+} // namespace VirtualKeyboard
 } // namespace Colors

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -29,6 +29,7 @@
 #include "ModulatorPresetManager.h"
 
 #include "SurgeSynthEditor.h"
+#include "SurgeJUCELookAndFeel.h"
 
 #include "SurgeGUIEditorTags.h"
 #include "fmt/core.h"
@@ -3318,6 +3319,8 @@ void SurgeGUIEditor::reloadFromSkin()
 
     setJUCEColour(juce::DocumentWindow::backgroundColourId, juce::Colour(48, 48, 48));
     setJUCEColour(juce::TextButton::buttonColourId, juce::Colour(32, 32, 32));
+    setJUCEColour(juce::CaretComponent::caretColourId,
+                  currentSkin->getColor(Colors::Dialog::Entry::Caret));
     setJUCEColour(juce::TextEditor::backgroundColourId, juce::Colour(32, 32, 32));
     setJUCEColour(juce::ListBox::backgroundColourId, juce::Colour(32, 32, 32));
     setJUCEColour(juce::ListBox::backgroundColourId, juce::Colour(32, 32, 32));
@@ -3330,8 +3333,41 @@ void SurgeGUIEditor::reloadFromSkin()
     setJUCEColour(juce::PopupMenu::backgroundColourId, juce::Colour(48, 48, 48));
     setJUCEColour(juce::PopupMenu::highlightedBackgroundColourId, juce::Colour(96, 96, 96));
 
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::tempoBackgroundId,
+                  currentSkin->getColor(Colors::Dialog::Background));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::tempoLabelId,
+                  currentSkin->getColor(Colors::Dialog::Label::Text));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::tempoTypeinBackgroundId,
+                  currentSkin->getColor(Colors::Dialog::Entry::Background));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::tempoTypeinBorderId,
+                  currentSkin->getColor(Colors::Dialog::Entry::Border));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::tempoTypeinHighlightId,
+                  currentSkin->getColor(Colors::Dialog::Entry::Focus));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::tempoTypeinTextId,
+                  currentSkin->getColor(Colors::Dialog::Entry::Text));
+
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::vkbTextLabelId,
+                  currentSkin->getColor(Colors::VirtualKeyboard::Text));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::vkbShadowId,
+                  currentSkin->getColor(Colors::VirtualKeyboard::Shadow));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::vkbBlackKeyId,
+                  currentSkin->getColor(Colors::VirtualKeyboard::Key::Black));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::vkbWhiteKeyId,
+                  currentSkin->getColor(Colors::VirtualKeyboard::Key::White));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::vkbKeySeparatorId,
+                  currentSkin->getColor(Colors::VirtualKeyboard::Key::Separator));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::vkbMouseOverKeyOverlayId,
+                  currentSkin->getColor(Colors::VirtualKeyboard::Key::MouseOver));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::vkbKeyDownOverlayId,
+                  currentSkin->getColor(Colors::VirtualKeyboard::Key::Pressed));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::vkbOctaveJogBackgroundId,
+                  currentSkin->getColor(Colors::VirtualKeyboard::OctaveJog::Background));
+    setJUCEColour(SurgeJUCELookAndFeel::SurgeColourIds::vkbOctaveJogArrowId,
+                  currentSkin->getColor(Colors::VirtualKeyboard::OctaveJog::Arrow));
+
     synth->refresh_editor = true;
     scanJuceSkinComponents = true;
+    juceEditor->repaint();
 }
 
 juce::PopupMenu SurgeGUIEditor::makeDevMenu(const juce::Point<int> &where)

--- a/src/gui/SurgeJUCELookAndFeel.h
+++ b/src/gui/SurgeJUCELookAndFeel.h
@@ -24,6 +24,29 @@ class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4
     void drawLabel(juce::Graphics &graphics, juce::Label &label) override;
     void drawTextEditorOutline(juce::Graphics &graphics, int width, int height,
                                juce::TextEditor &editor) override;
-};
 
+    enum SurgeColourIds
+    {
+        componentBgStart = 0x3700001,
+        componentBgEnd,
+
+        vkbTextLabelId,
+        vkbShadowId,
+        vkbBlackKeyId,
+        vkbWhiteKeyId,
+        vkbKeySeparatorId,
+        vkbMouseOverKeyOverlayId,
+        vkbKeyDownOverlayId,
+        vkbOctaveJogBackgroundId,
+        vkbOctaveJogArrowId,
+
+        tempoBackgroundId,
+        tempoLabelId,
+
+        tempoTypeinBackgroundId,
+        tempoTypeinBorderId,
+        tempoTypeinHighlightId,
+        tempoTypeinTextId,
+    };
+};
 #endif // SURGE_XT_SURGEJUCELOOKANDFEEL_H

--- a/src/gui/overlays/MiniEdit.cpp
+++ b/src/gui/overlays/MiniEdit.cpp
@@ -101,6 +101,8 @@ void MiniEdit::onSkinChanged()
     typein->setColour(juce::TextEditor::backgroundColourId,
                       skin->getColor(Colors::Dialog::Entry::Background));
     typein->setColour(juce::TextEditor::textColourId, skin->getColor(Colors::Dialog::Entry::Text));
+    typein->setColour(juce::TextEditor::highlightedTextColourId,
+                      skin->getColor(Colors::Dialog::Entry::Text));
     typein->setColour(juce::TextEditor::highlightColourId,
                       skin->getColor(Colors::Dialog::Entry::Focus));
     typein->setColour(juce::TextEditor::outlineColourId,

--- a/src/gui/overlays/PatchStoreDialog.cpp
+++ b/src/gui/overlays/PatchStoreDialog.cpp
@@ -79,6 +79,8 @@ void PatchStoreDialog::onSkinChanged()
                           skin->getColor(Colors::Dialog::Entry::Background));
         typein->setColour(juce::TextEditor::textColourId,
                           skin->getColor(Colors::Dialog::Entry::Text));
+        typein->setColour(juce::TextEditor::highlightedTextColourId,
+                          skin->getColor(Colors::Dialog::Entry::Text));
         typein->setColour(juce::TextEditor::highlightColourId,
                           skin->getColor(Colors::Dialog::Entry::Focus));
         typein->setColour(juce::TextEditor::outlineColourId,

--- a/src/gui/overlays/TypeinParamEditor.cpp
+++ b/src/gui/overlays/TypeinParamEditor.cpp
@@ -97,6 +97,8 @@ void TypeinParamEditor::onSkinChanged()
     textEd->setColour(juce::TextEditor::backgroundColourId,
                       skin->getColor(Colors::Dialog::Entry::Background));
     textEd->setColour(juce::TextEditor::textColourId, skin->getColor(Colors::Dialog::Entry::Text));
+    textEd->setColour(juce::TextEditor::highlightedTextColourId,
+                      skin->getColor(Colors::Dialog::Entry::Text));
     textEd->setColour(juce::TextEditor::highlightColourId,
                       skin->getColor(Colors::Dialog::Entry::Focus));
     textEd->setColour(juce::TextEditor::outlineColourId,

--- a/src/surge_synth_juce/SurgeSynthEditor.cpp
+++ b/src/surge_synth_juce/SurgeSynthEditor.cpp
@@ -49,7 +49,9 @@ SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p) : AudioProcessorEdito
         float newT = std::atof(tempoTypein->getText().toRawUTF8());
 
         processor.standaloneTempo = newT;
+#if SURGE_JUCE_ACCESSIBLE
         tempoTypein->giveAwayKeyboardFocus();
+#endif
     };
 
     tempoLabel = std::make_unique<juce::Label>("Tempo", "Tempo");

--- a/src/surge_synth_juce/SurgeSynthEditor.h
+++ b/src/surge_synth_juce/SurgeSynthEditor.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "SurgeSynthProcessor.h"
+#include "SkinSupport.h"
 
 #include "juce_audio_utils/juce_audio_utils.h"
 
@@ -86,6 +87,7 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     std::unique_ptr<juce::Drawable> logo;
 
     std::unique_ptr<SurgeJUCELookAndFeel> surgeLF;
+
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SurgeSynthEditor)
 };

--- a/src/surge_synth_juce/SurgeSynthEditor.h
+++ b/src/surge_synth_juce/SurgeSynthEditor.h
@@ -88,6 +88,5 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
 
     std::unique_ptr<SurgeJUCELookAndFeel> surgeLF;
 
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SurgeSynthEditor)
 };


### PR DESCRIPTION
Also add skin color for text editor caret across the board.
Make highlighted text match normal text across the board.
Allow only up to 3 characters and only numbers in tempo typein.
Reduce width of Tempo panel.
Select all text upon clicking Tempo typein and release focus on pressing Enter.