### PR TITLE
Fix behavior of SurgeSynthProcessor::isBusesLayoutSupported

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Luna Langton <https://github.com/selenologist>
 Jacky Ligon <http://jackyligon.com>
 Erik-Jan Maalderink <fonkle@gmx.com>
 Kjetil Matheussen <k.s.matheussen@notam02.no>
+Sean McGoff <https://github.com/SeanMcGoff>
 Dave Palmer <itsmedavep@gmail.com>
 Adam Raisbeck <sense@i2pi.com>
 Esa Juhani Ruoho <esaruoho@gmail.com>

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -3845,10 +3845,15 @@ bool SurgeGUIEditor::modSourceButtonDraggedOver(Surge::Widgets::ModulationSource
 {
     juce::Component *target = nullptr;
 
-    auto isDroppable = [msb](juce::Component *c) {
-        auto tMCI = dynamic_cast<Surge::Widgets::ModulatableControlInterface *>(c);
+    auto msrc = msb->getCurrentModSource();
+    auto isDroppable = [this, msrc](juce::Component *c) {
+        auto tMCI = dynamic_cast<Surge::Widgets::ModulatableSlider *>(c);
         if (tMCI)
-            return true;
+        {
+            auto ptag = tMCI->getTag() - start_paramtags;
+            if (this->synth->isValidModulation(ptag, msrc))
+                return true;
+        }
         return false;
     };
     auto recC = [isDroppable, msb, pt](juce::Component *p, auto rec) -> juce::Component * {

--- a/src/surge_synth_juce/SurgeSynthProcessor.cpp
+++ b/src/surge_synth_juce/SurgeSynthProcessor.cpp
@@ -175,7 +175,7 @@ bool SurgeSynthProcessor::isBusesLayoutSupported(const BusesLayout &layouts) con
     auto mocs = layouts.getMainOutputChannelSet();
     auto mics = layouts.getMainInputChannelSet();
 
-    auto outputValid = (mocs == AudioChannelSet::stereo()) || mocs.isDisabled();
+    auto outputValid = (mocs == AudioChannelSet::stereo()) || (mocs == AudioChannelSet::mono()) || mocs.isDisabled();
     auto inputValid = (mics == AudioChannelSet::stereo()) || (mics == AudioChannelSet::mono()) ||
                       (mics.isDisabled());
 

--- a/src/surge_synth_juce/SurgeSynthProcessor.cpp
+++ b/src/surge_synth_juce/SurgeSynthProcessor.cpp
@@ -175,7 +175,8 @@ bool SurgeSynthProcessor::isBusesLayoutSupported(const BusesLayout &layouts) con
     auto mocs = layouts.getMainOutputChannelSet();
     auto mics = layouts.getMainInputChannelSet();
 
-    auto outputValid = (mocs == AudioChannelSet::stereo()) || (mocs == AudioChannelSet::mono()) || mocs.isDisabled();
+    auto outputValid = (mocs == AudioChannelSet::stereo()) || (mocs == AudioChannelSet::mono()) ||
+                       (mocs.isDisabled());
     auto inputValid = (mics == AudioChannelSet::stereo()) || (mics == AudioChannelSet::mono()) ||
                       (mics.isDisabled());
 


### PR DESCRIPTION
Allow AudioChannelSet::mono() to be a valid MainOutputChannelSet value. This means that an incompatible audio mixbus now only disables the audio engine rather than crashing the standalone version.