### PR TITLE
Handle Midi at the sample where it is realized

### DIFF
--- a/src/surge_synth_juce/SurgeSynthProcessor.h
+++ b/src/surge_synth_juce/SurgeSynthProcessor.h
@@ -163,6 +163,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     bool canRemoveBusValue = false;
     bool canRemoveBus(bool isInput) const override { return canRemoveBusValue; }
     void processBlock(juce::AudioBuffer<float> &, juce::MidiBuffer &) override;
+    void applyMidi(const juce::MidiMessageMetadata &);
 
     //==============================================================================
     juce::AudioProcessorEditor *createEditor() override;


### PR DESCRIPTION
My original rough draft handled midi all up front. This now
interlaves the midi iteration with the sample iteration so
midi should arrive at the right block.

Closes #4983