### PR TITLE
Another MSEG Performance Tweak

### DIFF
--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -274,6 +274,15 @@ void SurgeGUIEditor::idle()
             hideMidiLearnOverlay();
         }
 
+        if (lfoDisplayRepaintCountdown > 0)
+        {
+            lfoDisplayRepaintCountdown--;
+            if (lfoDisplayRepaintCountdown == 0)
+            {
+                lfoDisplay->repaint();
+            }
+        }
+
         {
             bool expected = true;
             if (synth->rawLoadNeedsUIDawExtraState.compare_exchange_weak(expected, true) &&
@@ -5197,6 +5206,12 @@ void SurgeGUIEditor::showMSEGEditor()
     auto mse = std::make_unique<Surge::Overlays::MSEGEditor>(&(synth->storage), lfodata, ms,
                                                              &msegEditState[current_scene][lfo_id],
                                                              currentSkin, bitmapStore);
+    mse->onModelChanged = [this]() {
+        if (lfoDisplayRepaintCountdown == 0)
+        {
+            lfoDisplayRepaintCountdown = 2;
+        }
+    };
 
     std::string title = modsource_names[modsource_editor[current_scene]];
     title += " Editor";

--- a/src/gui/SurgeGUIEditor.h
+++ b/src/gui/SurgeGUIEditor.h
@@ -621,6 +621,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     Surge::GUI::IComponentTagValue *nonmod_param[n_paramslots] = {};
     std::array<std::unique_ptr<Surge::Widgets::ModulationSourceButton>, n_modsources> gui_modsrc;
     std::unique_ptr<Surge::Widgets::LFOAndStepDisplay> lfoDisplay;
+    int lfoDisplayRepaintCountdown{0};
 
     Surge::Widgets::Switch *filtersubtype[2] = {};
 

--- a/src/gui/overlays/MSEGEditor.cpp
+++ b/src/gui/overlays/MSEGEditor.cpp
@@ -166,6 +166,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         std::function<void(float, float, const juce::Point<float> &)> onDrag;
     };
 
+    std::function<void()> onModelChanged = []() {};
     std::vector<hotzone> hotzones;
 
     static constexpr int drawInsertX = 10, drawInsertY = 10, axisSpaceX = 18, axisSpaceY = 8;
@@ -2582,12 +2583,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         applyZoomPanConstraints(activeSegment, specialEndpoint);
         if (rchz)
             recalcHotZones(mouseDownOrigin); // FIXME
-        // Do this more heavy handed version
-        auto c = getParentComponent();
-        while (c && c->getParentComponent())
-            c = c->getParentComponent();
-        if (c)
-            c->repaint();
+
+        onModelChanged();
     }
 
     static constexpr int longestMSEG = 128;
@@ -3163,6 +3160,8 @@ MSEGEditor::MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *
 
     canvas->controlregion = controls.get();
     controls->canvas = canvas.get();
+
+    canvas->onModelChanged = [this]() { this->onModelChanged(); };
 
     addAndMakeVisible(*controls);
     addAndMakeVisible(*canvas);

--- a/src/gui/overlays/MSEGEditor.h
+++ b/src/gui/overlays/MSEGEditor.h
@@ -52,6 +52,8 @@ struct MSEGEditor : public juce::Component,
     std::unique_ptr<MSEGControlRegion> controls;
     std::unique_ptr<MSEGCanvas> canvas;
 
+    std::function<void()> onModelChanged = []() {};
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MSEGEditor);
 };
 } // namespace Overlays


### PR DESCRIPTION
Be more parsimonious with repaints when model changes. Rather than
force paint the entire UI, speed-gated repaint just the lfo display

Closes #4929