### PR TITLE
Fix a bug with Async Prompts

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -928,14 +928,14 @@ class alignas(16) SurgeStorage
         CANCEL
     };
 
-    std::function<OkCancel(const std::string &msg, const std::string &title, OkCancel def)>
-        okCancelProvider =
-            [](const std::string &, const std::string &, OkCancel def) { return def; };
+    std::function<void(const std::string &msg, const std::string &title, OkCancel def,
+                       std::function<void(OkCancel)>)>
+        okCancelProvider = [](const std::string &, const std::string &, OkCancel def,
+                              std::function<void(OkCancel)> callback) { callback(def); };
     void clearOkCancelProvider()
     {
-        okCancelProvider = [](const std::string &, const std::string &, OkCancel def) {
-            return def;
-        };
+        okCancelProvider = [](const std::string &, const std::string &, OkCancel def,
+                              std::function<void(OkCancel)> callback) { callback(def); };
     }
 
     std::string initPatchName{"Init Saw"}, initPatchCategory{"Templates"};

--- a/src/gui/SurgeGUIEditor.cpp
+++ b/src/gui/SurgeGUIEditor.cpp
@@ -93,14 +93,15 @@ SurgeGUIEditor::SurgeGUIEditor(SurgeSynthEditor *jEd, SurgeSynthesizer *synth)
     assert(n_paramslots >= n_total_params);
     synth->storage.addErrorListener(this);
     synth->storage.okCancelProvider = [](const std::string &msg, const std::string &title,
-                                         SurgeStorage::OkCancel def) {
+                                         SurgeStorage::OkCancel def,
+                                         std::function<void(SurgeStorage::OkCancel)> callback) {
         // think about threading one day probably
+        auto cb = juce::ModalCallbackFunction::create([callback](int isOk) {
+            auto r = isOk ? SurgeStorage::OK : SurgeStorage::CANCEL;
+            callback(r);
+        });
         auto res = juce::AlertWindow::showOkCancelBox(juce::AlertWindow::InfoIcon, title, msg, "OK",
-                                                      "Cancel", nullptr, nullptr);
-
-        if (res)
-            return SurgeStorage::OK;
-        return SurgeStorage::CANCEL;
+                                                      "Cancel", nullptr, cb);
     };
 #ifdef INSTRUMENT_UI
     Surge::Debug::record("SurgeGUIEditor::SurgeGUIEditor");


### PR DESCRIPTION
the Async Prompt stuff earlier htis week to get MODAL_LOOPS
on broke the non-modal Storage OkCancel. Defacto this meant
that you could never replace a patch because the OK Cancel asked you
but had already canceled.

Closes #5045, where we had thought this was a global volume saving
problem, but it was really an anything saving problem