### PR TITLE
Copy instead of move borrowed path (fixes double-free SIGSEGV)

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -864,7 +864,9 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir, string subdir,
                 {
                     Patch e;
                     e.category = category;
-                    e.path = f.path();
+                    // do placement new to call copy constructor, not move constructor
+                    // (prevents crash from the lifetime of f.path() expiring)
+                    new (&e.path) fs::path(f.path());
                     e.name = path_to_string(f.path().filename());
                     e.name = e.name.substr(0, e.name.size() - xtn.length());
                     items.push_back(e);


### PR DESCRIPTION
Fixes an invalid borrowing of memory beyond the lifetime of `fs::directory_entry f`. Attached is a Valgrind log of Surge being loaded in Ardour where the double-free was observed that led to this fix.

Though I'd appreciate another set of eyeballs on this fix, the placement-new is a little ugly so there might be a better way to do this.

[valgrind.txt](https://github.com/surge-synthesizer/surge/files/7147565/valgrind.txt)
