### PR TITLE
Improve static lifecycle

### DIFF
--- a/src/gui/ModulationGridConfiguration.h
+++ b/src/gui/ModulationGridConfiguration.h
@@ -65,6 +65,9 @@ struct ModulationGrid : juce::DeletedAtShutdown
         add(ms_latest_key, 9, 7);
     }
 
+    // This is only called at dll shutdown basically
+    ~ModulationGrid() { grid = nullptr; }
+
     void add(modsources ms, int x, int y) { data[ms] = Entry{x, y, ms}; }
     void add(modsources ms, int x, int y, const std::vector<modsources> &alternates)
     {

--- a/src/gui/RuntimeFont.cpp
+++ b/src/gui/RuntimeFont.cpp
@@ -53,7 +53,7 @@ DefaultFonts::DefaultFonts()
     aboutFont = getLatoAtSize(10);
 }
 
-DefaultFonts::~DefaultFonts(){};
+DefaultFonts::~DefaultFonts() { fmi = nullptr; };
 
 juce::Font DefaultFonts::getLatoAtSize(float size, juce::Font::FontStyleFlags style) const
 {
@@ -72,12 +72,13 @@ juce::Font DefaultFonts::getFiraMonoAtSize(float size) const
     return juce::Font(firaMonoRegularTypeface).withPointHeight(size);
 }
 
+DefaultFonts *DefaultFonts::fmi{nullptr};
+
 DefaultFonts *getFontManager()
 {
-    static DefaultFonts *fmi{nullptr};
-    if (!fmi)
-        fmi = new DefaultFonts();
-    return fmi;
+    if (!DefaultFonts::fmi)
+        DefaultFonts::fmi = new DefaultFonts();
+    return DefaultFonts::fmi;
 }
 
 } // namespace GUI

--- a/src/gui/RuntimeFont.h
+++ b/src/gui/RuntimeFont.h
@@ -25,6 +25,8 @@ struct DefaultFonts : public juce::DeletedAtShutdown
 
     juce::ReferenceCountedObjectPtr<juce::Typeface> latoRegularTypeface;
     juce::ReferenceCountedObjectPtr<juce::Typeface> firaMonoRegularTypeface;
+
+    static DefaultFonts *fmi;
 };
 
 DefaultFonts *getFontManager();

--- a/src/gui/SkinSupport.cpp
+++ b/src/gui/SkinSupport.cpp
@@ -26,9 +26,10 @@ const std::string NoneClassName = "none";
 const std::string Skin::defaultImageIDPrefix = "DEFAULT/";
 std::ostringstream SkinDB::errorStream;
 
+SkinDB *SkinDB::instance{nullptr};
+
 SkinDB *Surge::GUI::SkinDB::get()
 {
-    static SkinDB *instance{nullptr};
     if (!instance)
         instance = new SkinDB();
 
@@ -51,6 +52,7 @@ SkinDB::~SkinDB()
     skins.clear(); // Not really necessary but means the skins are destroyed before the rest of the
                    // dtor runs
                    // std::cout << "Destroying SkinDB" << std::endl;
+    instance = nullptr;
 }
 
 std::shared_ptr<Skin> SkinDB::defaultSkin(SurgeStorage *storage)

--- a/src/gui/SkinSupport.h
+++ b/src/gui/SkinSupport.h
@@ -414,6 +414,7 @@ class Skin
 class SkinDB : public juce::DeletedAtShutdown
 {
   public:
+    static SkinDB *instance;
     static SkinDB *get();
 
     struct Entry
@@ -481,7 +482,6 @@ class SkinDB : public juce::DeletedAtShutdown
     Entry defaultSkinEntry;
     bool foundDefaultSkinEntry = false;
 
-    static std::shared_ptr<SkinDB> instance;
     static std::ostringstream errorStream;
 
     friend class Skin;


### PR DESCRIPTION
Reset our system wide statics for delete at shutdown types to
null. We think this may solve a reload problem in Ardour.