### PR TITLE
don't merge but leave open to remind us to fix Force use of GHC filesystem on Linux 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1160,6 +1160,8 @@ if( UNIX AND NOT APPLE )
           COMMAND ${CMAKE_COMMAND} -E echo ${CMAKE_SOURCE_DIR}/installer_linux/make_rpm.sh "${SURGE_PRODUCT_DIR}" "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/${SURGE_XT_DIST_OUTPUT_DIR}" "${SXTVER}"
           COMMAND ${CMAKE_SOURCE_DIR}/scripts/installer_linux/make_rpm.sh "${SURGE_PRODUCT_DIR}" "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/${SURGE_XT_DIST_OUTPUT_DIR}" "${SXTVER}"
           )
+
+  set(SURGE_FILESYSTEM_FORCE_GHC TRUE)
 endif()
 
 if( WIN32 )


### PR DESCRIPTION
Resolves path lifetime issue like #5051, but without the ugly code change.

Does raise some interesting questions about the behaviour of GNU/Linux libc++ vs others though.