### PR TITLE
The FXSpawn mutex locked too late

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2174,6 +2174,8 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
         {
             fx_reload[s] = false;
 
+            std::lock_guard<std::mutex> g(fxSpawnMutex);
+
             fx[s].reset();
             /*if (!force_reload_all)*/ storage.getPatch().fx[s].type.val.i = fxsync[s].type.val.i;
             // else fxsync[s].type.val.i = storage.getPatch().fx[s].type.val.i;
@@ -2191,10 +2193,6 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
             if (/*!force_reload_all && */ storage.getPatch().fx[s].type.val.i)
                 memcpy((void *)&storage.getPatch().fx[s].p, (void *)&fxsync[s].p,
                        sizeof(Parameter) * n_fx_params);
-
-            // std::cout << "About to call reset with " << _D(initp) << " at " << s << " to " <<
-            // fxsync[s].type.val.i << std::endl;
-            std::lock_guard<std::mutex> g(fxSpawnMutex);
 
             fx[s].reset(spawn_effect(storage.getPatch().fx[s].type.val.i, &storage,
                                      &storage.getPatch().fx[s], storage.getPatch().globaldata));


### PR DESCRIPTION
Leading to occasional crashes when automating FX type
This fixes it and also Closes #4038