### PR TITLE
Add User/Factory flag to default patch

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -645,6 +645,8 @@ bailOnPortable:
         Surge::Storage::getUserDefaultValue(this, Surge::Storage::InitialPatchName, "Init Saw");
     initPatchCategory = Surge::Storage::getUserDefaultValue(
         this, Surge::Storage::InitialPatchCategory, "Templates");
+    initPatchCategoryType = Surge::Storage::getUserDefaultValue(
+        this, Surge::Storage::InitialPatchCategoryType, "Factory");
 
     fxUserPreset = std::make_unique<Surge::Storage::FxUserPreset>();
     fxUserPreset->doPresetRescan(this);
@@ -855,6 +857,7 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir, string subdir,
             PatchCategory c;
             c.name = path_to_string(p).substr(patchpathSubstrLength);
             c.internalid = category;
+            c.isFactory = !userDir;
 
             c.numberOfPatchesInCatgory = 0;
             for (auto &f : fs::directory_iterator(p))

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -858,6 +858,7 @@ struct PatchCategory
     int order;
     std::vector<PatchCategory> children;
     bool isRoot;
+    bool isFactory;
 
     int internalid;
     int numberOfPatchesInCatgory;
@@ -937,7 +938,8 @@ class alignas(16) SurgeStorage
                               std::function<void(OkCancel)> callback) { callback(def); };
     }
 
-    std::string initPatchName{"Init Saw"}, initPatchCategory{"Templates"};
+    std::string initPatchName{"Init Saw"}, initPatchCategory{"Templates"},
+        initPatchCategoryType{"Factory"};
 
     static constexpr int tuning_table_size = 512;
     float table_pitch alignas(16)[tuning_table_size];
@@ -1269,14 +1271,14 @@ class alignas(16) SurgeStorage
     // whether to skip loading, desired while exporting manifests. Only used by LV2 currently.
     static bool skipLoadWtAndPatch;
 
-    /*
-     * An RNG which is decoupled from the non-Surge global state and is threadsafe.
-     * This RNG has the semantic that it is seeded when the first Surge in your session
-     * uses it on a given thread, and then retains its independent state. It is designed
-     * to have the same API as std::rand, so 'std::rand -> storage::rand' is a good change.
-     *
-     * Reseeding it impacts the global state on that thread.
-     */
+/*
+ * An RNG which is decoupled from the non-Surge global state and is threadsafe.
+ * This RNG has the semantic that it is seeded when the first Surge in your session
+ * uses it on a given thread, and then retains its independent state. It is designed
+ * to have the same API as std::rand, so 'std::rand -> storage::rand' is a good change.
+ *
+ * Reseeding it impacts the global state on that thread.
+ */
 #define STORAGE_USES_INDEPENDENT_RNG 1
 #if STORAGE_USES_INDEPENDENT_RNG
     /*
@@ -1334,7 +1336,7 @@ class alignas(16) SurgeStorage
         runningOnAudioThread();
         return rngGen.z1(rngGen.g);
     }
-    // void seed_rand(int s) { rngGen.g.seed(s); }
+// void seed_rand(int s) { rngGen.g.seed(s); }
 #else
     inline int rand() { return std::rand(); }
     inline uint32_t rand_u32() { return (uint32_t)(rand_01() * (float)(0xFFFFFFFF)); }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -228,10 +228,12 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, const std::string &suppl
     mpeGlobalPitchBendRange = 0;
 
     int pid = 0;
+    bool lookingForFactory = (storage.initPatchCategoryType == "Factory");
     for (auto p : storage.patch_list)
     {
         if (p.name == storage.initPatchName &&
-            storage.patch_category[p.category].name == storage.initPatchCategory)
+            storage.patch_category[p.category].name == storage.initPatchCategory &&
+            storage.patch_category[p.category].isFactory == lookingForFactory)
         {
             patchid_queue = pid;
             break;

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -129,6 +129,9 @@ void initMaps()
             case InitialPatchCategory:
                 r = "initialPatchCategory";
                 break;
+            case InitialPatchCategoryType:
+                r = "initialPatchCategoryType";
+                break;
             case LastSCLPath:
                 r = "lastSCLPath";
                 break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -51,6 +51,7 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
 
     InitialPatchName,
     InitialPatchCategory,
+    InitialPatchCategoryType,
 
     LastSCLPath,
     LastKBMPath,

--- a/src/gui/widgets/PatchSelector.cpp
+++ b/src/gui/widgets/PatchSelector.cpp
@@ -201,10 +201,12 @@ void PatchSelector::showClassicMenu(bool single_category)
     auto initAction = [this]() {
         int i = 0;
 
+        bool lookingForFactory = (storage->initPatchCategoryType == "Factory");
         for (auto p : storage->patch_list)
         {
             if (p.name == storage->initPatchName &&
-                storage->patch_category[p.category].name == storage->initPatchCategory)
+                storage->patch_category[p.category].name == storage->initPatchCategory &&
+                storage->patch_category[p.category].isFactory == lookingForFactory)
             {
                 loadPatch(i);
                 break;
@@ -222,6 +224,10 @@ void PatchSelector::showClassicMenu(bool single_category)
 
         Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::InitialPatchCategory,
                                                storage->patch_category[current_category].name);
+
+        Surge::Storage::updateUserDefaultValue(
+            storage, Surge::Storage::InitialPatchCategoryType,
+            storage->patch_category[current_category].isFactory ? "Factory" : "User");
     });
 
     contextMenu.addSeparator();


### PR DESCRIPTION
Add User/Factory flag to default patch. Unfortunately it is rather
hard to set this to Factory if you ahve a duped category and patch
name but in that case it basically picks user, for the same reason
as all the other same-cat-same-name ambiguities.

So not perfect but closes #5058 in the same way we closed the other
collision problem.