### PR TITLE
CMake Dependencies for surge-xt should be Private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1022,7 +1022,7 @@ if (BUILD_SURGE_XT)
         endif ()
     endif ()
 
-    target_link_libraries(surge-xt PUBLIC
+    target_link_libraries(surge-xt PRIVATE
             surge::airwindows
             surge::filesystem
             surge::tinyxml


### PR DESCRIPTION
This speeds up builds by reducing an uneeded rebuild of some
juce sub-libs