### PR TITLE
Some small PatchDb Improvements

### DIFF
--- a/src/common/PatchDB.h
+++ b/src/common/PatchDB.h
@@ -30,7 +30,7 @@ namespace PatchStorage
 {
 struct PatchDB
 {
-    struct workerS;
+    struct WriterWorker;
     struct patchRecord
     {
         patchRecord(int i, const std::string &f, const std::string &c, const std::string &n,
@@ -70,13 +70,15 @@ struct PatchDB
 
     SurgeStorage *storage;
 
-    std::unique_ptr<workerS> worker;
+    std::unique_ptr<WriterWorker> worker;
 
     void considerFXPForLoad(const fs::path &fxp, const std::string &name,
                             const std::string &catName, const CatType type) const;
 
     void addRootCategory(const std::string &name, CatType type);
     void addSubCategory(const std::string &name, const std::string &parent, CatType type);
+
+    void addDebugMessage(const std::string &debug);
 
     // This is a temporary API point
     std::vector<patchRecord> rawQueryForNameLike(const std::string &nameLikeThis);

--- a/src/gui/overlays/PatchDBViewer.cpp
+++ b/src/gui/overlays/PatchDBViewer.cpp
@@ -303,8 +303,13 @@ void PatchDBViewer::createElements()
     treeView->setBounds(0, 50, 200, getHeight() - 50);
     treeRoot = std::make_unique<PatchDBSQLTreeViewItem>(editor, storage);
     treeView->setRootItem(treeRoot.get());
-
     addAndMakeVisible(*treeView);
+
+    auto tb = std::make_unique<juce::TextButton>();
+    tb->setButtonText("Debug");
+    doDebug = std::move(tb);
+    doDebug->addListener(this);
+    addAndMakeVisible(*doDebug);
 
     executeQuery();
 }
@@ -322,11 +327,21 @@ void PatchDBViewer::resized()
     if (nameTypein)
         nameTypein->setBounds(10, 10, 400, 30);
 
+    if (doDebug)
+        doDebug->setBounds(420, 10, 100, 30);
+
     if (table)
         table->setBounds(200, 50, getWidth() - 202, getHeight() - 52);
 
     if (treeView)
         treeView->setBounds(2, 50, 196, getHeight() - 52);
+}
+void PatchDBViewer::buttonClicked(juce::Button *button)
+{
+    if (button == doDebug.get())
+    {
+        storage->patchDB->addDebugMessage(std::string("Debugging with ") + std::to_string(rand()));
+    }
 }
 
 } // namespace Overlays

--- a/src/gui/overlays/PatchDBViewer.h
+++ b/src/gui/overlays/PatchDBViewer.h
@@ -30,7 +30,9 @@ namespace Overlays
 class PatchDBSQLTableModel;
 class PatchDBSQLTreeViewItem;
 
-class PatchDBViewer : public OverlayComponent, public juce::TextEditor::Listener
+class PatchDBViewer : public OverlayComponent,
+                      public juce::TextEditor::Listener,
+                      public juce::Button::Listener
 {
   public:
     PatchDBViewer(SurgeGUIEditor *ed, SurgeStorage *s);
@@ -52,6 +54,9 @@ class PatchDBViewer : public OverlayComponent, public juce::TextEditor::Listener
 
     std::unique_ptr<juce::TreeView> treeView;
     std::unique_ptr<PatchDBSQLTreeViewItem> treeRoot;
+
+    std::unique_ptr<juce::Button> doDebug;
+    void buttonClicked(juce::Button *button) override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PatchDBViewer);
 };


### PR DESCRIPTION
1. Improve concurrency both in and cross process
   a. open one connection per thread
   b. close the readwrite connection when not in use
   c. since (a) we can do nomutex and therefore
   d. since (c) and (b) not lock across processes
2. Add a 'debug junk' table and a 'debug' button to write into it
   to test for now

Addresses byt does not yet fully resolve #4825