### PR TITLE
Add option to copy to products for individual targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,8 @@ option(SURGE_BUILD_TESTRUNNER "Build Surge unit test runner" ON)
 option(SURGE_BUILD_FX "Build Surge FX bank" ON)
 option(SURGE_BUILD_XT "Build Surge XT synth" ON)
 option(SURGE_BUILD_PYTHON_BINDINGS "Build Surge Python bindings with pybind11" OFF)
-option(SURGE_COPY_AFTER_BUILD "Copy JUCE plugins after build" OFF)
+option(SURGE_COPY_TO_PRODUCTS "Copy built plugins to the products directory" ON)
+option(SURGE_COPY_AFTER_BUILD "Copy JUCE plugins to System Plugin area after build" OFF)
 
 set(SURGE_JUCE_PATH "${CMAKE_SOURCE_DIR}/libs/JUCE" CACHE STRING "Path to JUCE library source tree")
 

--- a/src/cmake/lib.cmake
+++ b/src/cmake/lib.cmake
@@ -17,14 +17,28 @@ function(surge_juce_package target product_name)
     add_dependencies(${pkg_target} ${target}_${format})
   endforeach()
   foreach(format AU Standalone VST3)
-    if(TARGET ${target}_${format})
-      add_custom_command(
-        TARGET ${pkg_target}
-        POST_BUILD
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND echo "${target}: Re-locating ${format} components"
-        COMMAND ${CMAKE_COMMAND} -E copy_directory ${output_dir}/${format} ${SURGE_PRODUCT_DIR}/
-      )
+    if(NOT SURGE_COPY_TO_PRODUCTS)
+      # Add the copy rule to the pkg_target
+      if(TARGET ${target}_${format})
+        add_custom_command(
+          TARGET ${pkg_target}
+          POST_BUILD
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+          COMMAND echo "${target}: Re-locating ${format} components"
+          COMMAND ${CMAKE_COMMAND} -E copy_directory ${output_dir}/${format} ${SURGE_PRODUCT_DIR}/
+        )
+      endif()
+    else()
+      # Add the copy rule to the target itself
+      if(TARGET ${target}_${format})
+        add_custom_command(
+          TARGET ${target}_${format}
+          POST_BUILD
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+          COMMAND echo "${target}: Re-locating ${format} components"
+          COMMAND ${CMAKE_COMMAND} -E copy_directory ${output_dir}/${format} ${SURGE_PRODUCT_DIR}/
+        )
+      endif()
     endif()
   endforeach()
 


### PR DESCRIPTION
as rewritten surge-xt_Packaged would copy vst3, au, etc... to
the surge_xt_products directory but sometimes we wnat to point our
DAWs there and have stuff appear, so at a target, on by default,
which copies the VST3 to that location and so on when built.