### PR TITLE
Add more keyboard shortcuts, some code refactoring

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -111,9 +111,6 @@ void initMaps()
             case ModWindowShowsValues:
                 r = "modWindowShowsValues";
                 break;
-            case SkinReloadViaF5:
-                r = "skinReloadViaF5";
-                break;
             case LayoutGridResolution:
                 r = "layoutGridResolution";
                 break;
@@ -146,6 +143,12 @@ void initMaps()
                 break;
             case TabKeyArmsModulators:
                 r = "tabKeyArmsModulators";
+                break;
+            case UseKeyboardShortcuts_Plugin:
+                r = "useKeyboardShortcutsPlugin";
+                break;
+            case UseKeyboardShortcuts_Standalone:
+                r = "useKeyboardShortcutsStandalone";
                 break;
             case InfoWindowPopupOnIdle:
                 r = "infoWindowPopupOnIdle";
@@ -188,7 +191,7 @@ void readDefaultsFile(std::string fn, bool forceRead, SurgeStorage *storage)
                 std::ostringstream oss;
                 oss << "This version of Surge only reads version 1 defaults. You user defaults "
                        "version is "
-                    << version << ". Defaults ignored";
+                    << version << ". Defaults will be ignored!";
                 storage->reportError(oss.str(), "File Version Error");
                 return;
             }
@@ -203,13 +206,8 @@ void readDefaultsFile(std::string fn, bool forceRead, SurgeStorage *storage)
                 def->Attribute("type", &vt);
                 v.type = (UserDefaultValue::ValueType)vt;
 
-                if (stringsToKeys.find(v.keystring) == stringsToKeys.end())
-                {
-                    storage->reportError(std::string("Unknown key '") + v.keystring +
-                                             "' when loading UserDefaults.",
-                                         "User Defaults Error");
-                }
-                else
+                // silently disregard default keys we don't recognize
+                if (stringsToKeys.find(v.keystring) != stringsToKeys.end())
                 {
                     v.key = stringsToKeys[v.keystring];
                     defaultsFileContents[v.key] = v;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -43,7 +43,6 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     DefaultPatchAuthor,
     DefaultPatchComment,
     ModWindowShowsValues,
-    SkinReloadViaF5,
     LayoutGridResolution,
 
     ShowVirtualKeyboard_Plugin,
@@ -61,6 +60,9 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     TabKeyArmsModulators,
 
     InfoWindowPopupOnIdle,
+
+    UseKeyboardShortcuts_Plugin,
+    UseKeyboardShortcuts_Standalone,
 
     nKeys
 };

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -120,16 +120,6 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         }
     }
 
-  protected:
-#if PORTED_TO_JUCE
-    int32_t onKeyDown(const VstKeyCode &code,
-                      VSTGUI::CFrame *frame) override; ///< should return 1 if no further key down
-                                                       ///< processing should apply, otherwise -1
-    int32_t onKeyUp(const VstKeyCode &code,
-                    VSTGUI::CFrame *frame) override; ///< should return 1 if no further key up
-                                                     ///< processing should apply, otherwise -1
-#endif
-
   public:
     bool keyPressed(const juce::KeyPress &key, juce::Component *originatingComponent) override;
 
@@ -146,6 +136,11 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     void createMIDILearnMenuEntries(juce::PopupMenu &parentMenu, bool isForMacro, int ccid,
                                     Surge::GUI::IComponentTagValue *control);
+
+    void changeSelectedOsc(int value);
+    void changeSelectedScene(int value);
+
+    void refreshSkin();
 
   public:
     // to make file chooser async it has to stick around
@@ -656,6 +651,10 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool getShowVirtualKeyboard();
     void setShowVirtualKeyboard(bool b);
     void toggleVirtualKeyboard();
+
+    bool getUseKeyboardShortcuts();
+    void setUseKeyboardShortcuts(bool b);
+    void toggleUseKeyboardShortcuts();
 
   private:
     bool scannedForMidiPresets = false;


### PR DESCRIPTION
Tagging @VincyZed here because documentation.

Alt+1/2/3 - select oscillator
Alt+S - switch scenes
Alt+M - toggle Modulation List
Alt+T - toggle Tuning Editor
Alt+E - toggle whichever editor is viable to toggle (for now MSEG and Formula only)
Alt+P - toggle Patch Browser (well it's called Database currently)
Ctrl+left/right - previous/next patch
Shift+left/right - previous/next category
Ctrl+S - store patch but currently not working (needs investigation)

This PR also refactors some code into methods (`changeSelectedOsc()`, `changeSelectedScene()`, `refreshSkin()`).
Keyboard shortcuts are separately togglable for standalone (default enabled) and plugin (defualt disabled).
Removed the last remnants of `PORTED_TO_JUCE` from VSTGUI times.
Updated the Workflow menu layout, added some separators.
Removed `SkinReloadViaF5` user default.
If a default is not recognized, instead of popping up an error dialog for each one, silently disregard them.