### PR TITLE
Add options to initialize individual FX chains, or all FX

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3163,6 +3163,15 @@ void SurgeSynthesizer::resetStateFromTimeData()
         storage.temposyncratio_inv = 1.f;
     }
 }
+
+void SurgeSynthesizer::enqueueFXOff(int whichFX)
+{
+    // this can come from the UI thread. I don't think we need the spawn mutex but we might
+    std::lock_guard<std::mutex> lg(fxSpawnMutex);
+    fxsync[whichFX].type.val.i = fxt_off;
+    load_fx_needed = true;
+}
+
 void SurgeSynthesizer::processControl()
 {
     processEnqueuedPatchIfNeeded();

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -101,6 +101,7 @@ class alignas(16) SurgeSynthesizer
      */
     void processThreadunsafeOperations(bool doItEvenIfAudioIsRunningDANGER = false);
     bool loadFx(bool initp, bool force_reload_all);
+    void enqueueFXOff(int whichFX);
     bool loadOscalgos();
     bool load_fx_needed;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1664,10 +1664,7 @@ void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene, Surge::Widget
         {
             if (fxchain == -1 || (fxchain >= 0 && (i >= (fxchain * 4) && i < ((fxchain + 1) * 4))))
             {
-                fxMenu->setFxStorage(&synth->storage.getPatch().fx[fxSlotOrder[i]]);
-                fxMenu->setFxBuffer(&synth->fxsync[fxSlotOrder[i]]);
-                fxMenu->setCurrentFx(fxSlotOrder[i]);
-                fxMenu->loadByIndex(0);
+                synth->enqueueFXOff(fxSlotOrder[i]);
             }
         }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1652,6 +1652,45 @@ void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene, Surge::Widget
 
     fxGridMenu.addSeparator();
 
+    int fxSlotOrder[n_fx_slots] = {fxslot_ains1,   fxslot_ains2,   fxslot_ains3,   fxslot_ains4,
+                                   fxslot_bins1,   fxslot_bins2,   fxslot_bins3,   fxslot_bins4,
+                                   fxslot_send1,   fxslot_send2,   fxslot_send3,   fxslot_send4,
+                                   fxslot_global1, fxslot_global2, fxslot_global3, fxslot_global4};
+
+    auto clearSlots = [this, fxSlotOrder](int fxchain) {
+        auto selfx = current_fx;
+
+        for (int i = 0; i < n_fx_slots; i++)
+        {
+            if (fxchain == -1 || (fxchain >= 0 && (i >= (fxchain * 4) && i < ((fxchain + 1) * 4))))
+            {
+                fxMenu->setFxStorage(&synth->storage.getPatch().fx[fxSlotOrder[i]]);
+                fxMenu->setFxBuffer(&synth->fxsync[fxSlotOrder[i]]);
+                fxMenu->setCurrentFx(fxSlotOrder[i]);
+                fxMenu->loadByIndex(0);
+            }
+        }
+
+        fxMenu->setCurrentFx(selfx);
+    };
+
+    fxGridMenu.addItem(Surge::GUI::toOSCaseForMenu("Initialize Scene A Insert FX"), true, false,
+                       [this, clearSlots]() { clearSlots(0); });
+
+    fxGridMenu.addItem(Surge::GUI::toOSCaseForMenu("Initialize Scene B Insert FX"), true, false,
+                       [this, clearSlots]() { clearSlots(1); });
+
+    fxGridMenu.addItem(Surge::GUI::toOSCaseForMenu("Initialize Send FX"), true, false,
+                       [this, clearSlots]() { clearSlots(2); });
+
+    fxGridMenu.addItem(Surge::GUI::toOSCaseForMenu("Initialize Global FX"), true, false,
+                       [this, clearSlots]() { clearSlots(3); });
+
+    fxGridMenu.addItem(Surge::GUI::toOSCaseForMenu("Initialize All FX"), true, false,
+                       [this, clearSlots]() { clearSlots(-1); });
+
+    fxGridMenu.addSeparator();
+
     std::string sc = std::string("Scene ") + (char)('A' + whichScene);
 
     fxGridMenu.addItem(


### PR DESCRIPTION
This is available by clicking the A/B boxes in the FX grid. Useful stuff!

Tagging @baconpaul for improvements in implementation.