### PR TITLE
A Rudimentary Patch Tagging System

### DIFF
--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -921,7 +921,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
             auto flag = SQLITE_OPEN_NOMUTEX; // basically lock
             flag |= SQLITE_OPEN_READONLY;
 
-            std::cout << ">>>RO> Opening r/o DB" << std::endl;
+            // std::cout << ">>>RO> Opening r/o DB" << std::endl;
             auto ec = sqlite3_open_v2(dbname.c_str(), &rodbh, flag, nullptr);
 
             if (ec != SQLITE_OK)

--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -566,7 +566,7 @@ Connector vu_meter =
 Connector mseg_editor = Connector("msegeditor.window", 0, 57, 750, 365, Components::Custom,
                                   Connector::MSEG_EDITOR_WINDOW);
 
-Connector store_patch_dialog = Connector("controls.patch.store.window", 157, 57, 390, 143,
+Connector store_patch_dialog = Connector("controls.patch.store.window", 157, 57, 390, 220,
                                          Components::Custom, Connector::STORE_PATCH_DIALOG);
 
 // modulation panel is special, so it shows up as 'CUSTOM' with no connector and is special-cased in

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1155,6 +1155,19 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
         s = meta->Attribute("author");
         if (s)
             author = s;
+
+        auto *tagsX = TINYXML_SAFE_TO_ELEMENT(meta->FirstChild("tags"));
+        tags.clear();
+        if (tagsX)
+        {
+            auto tag = TINYXML_SAFE_TO_ELEMENT(tagsX->FirstChildElement("tag"));
+            while (tag)
+            {
+                std::string tagName = tag->Attribute("tag");
+                tags.emplace_back(tagName);
+                tag = TINYXML_SAFE_TO_ELEMENT(tag->NextSiblingElement("tag"));
+            }
+        }
     }
 
     TiXmlElement *parameters = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("parameters"));
@@ -2244,6 +2257,15 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
     meta.SetAttribute("category", this->category);
     meta.SetAttribute("comment", comment);
     meta.SetAttribute("author", author);
+
+    TiXmlElement tagsX("tags");
+    for (auto t : tags)
+    {
+        TiXmlElement tx("tag");
+        tx.SetAttribute("tag", t.tag);
+        tagsX.InsertEndChild(tx);
+    }
+    meta.InsertEndChild(tagsX);
     patch.InsertEndChild(meta);
 
     TiXmlElement parameters("parameters");

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -241,6 +241,7 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
     std::string buildOverrideDataPath;
     if (getOverrideDataHome(buildOverrideDataPath))
     {
+        datapathOverriden = true;
         hasSuppliedDataPath = true;
         suppliedDataPath = buildOverrideDataPath;
     }
@@ -319,6 +320,7 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
         std::string buildOverrideDataPath;
         if (getOverrideDataHome(buildOverrideDataPath))
         {
+            datapathOverriden = true;
             datapath = buildOverrideDataPath;
             std::cout << "WARNING: Surge overriding data path to " << datapath << std::endl;
             std::cout << "         Only use this in build pipelines please!" << std::endl;
@@ -432,6 +434,7 @@ bailOnPortable:
     std::string orPath;
     if (getOverrideDataHome(orPath))
     {
+        datapathOverriden = true;
         datapath = orPath;
     }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -822,6 +822,15 @@ class SurgePatch
 
     // metadata
     std::string name, category, author, comment;
+
+    struct Tag
+    {
+        Tag() : tag("no-tag") {}
+        Tag(const std::string &s) : tag(s) {}
+        std::string tag;
+    };
+    std::vector<Tag> tags;
+
     // macro controllers
 #define CUSTOM_CONTROLLER_LABEL_SIZE 20
     char CustomControllerLabel[n_customcontrollers][CUSTOM_CONTROLLER_LABEL_SIZE];
@@ -1026,6 +1035,7 @@ class alignas(16) SurgeStorage
     std::unique_ptr<Surge::Storage::FxUserPreset> fxUserPreset;
     std::unique_ptr<Surge::Storage::ModulatorPreset> modulatorPreset;
 
+    bool datapathOverriden{false};
     fs::path datapath;
     fs::path userDefaultFilePath;
     fs::path userDataPath;

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -309,7 +309,7 @@ class alignas(16) SurgeSynthesizer
     void swapMetaControllers(int ct1, int ct2);
 
     void savePatchToPath(fs::path p);
-    void savePatch();
+    void savePatch(bool factoryInPlace = false);
     void updateUsedState();
     void prepareModsourceDoProcess(int scenemask);
     unsigned int saveRaw(void **data);

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -484,12 +484,19 @@ void SurgeSynthesizer::loadRaw(const void *data, int size, bool preset)
 #include <sys/stat.h>
 #endif
 
-void SurgeSynthesizer::savePatch()
+void SurgeSynthesizer::savePatch(bool factoryInPlace)
 {
     if (storage.getPatch().category.empty())
         storage.getPatch().category = "Default";
 
     fs::path savepath = storage.userPatchesPath;
+
+    if (factoryInPlace && patchid >= 0 && patchid < storage.patch_list.size())
+    {
+        auto fpath = storage.patch_list[patchid].path;
+        savePatchToPath(fpath);
+        return;
+    }
 
     try
     {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -405,6 +405,7 @@ void SurgeGUIEditor::idle()
                 patchSelector->setCategory(synth->storage.getPatch().category);
                 patchSelector->setAuthor(synth->storage.getPatch().author);
                 patchSelector->setIsFavorite(isPatchFavorite());
+                patchSelector->setTags(synth->storage.getPatch().tags);
                 patchSelector->repaint();
             }
         }
@@ -1260,6 +1261,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             patchSelector->setCategory(synth->storage.getPatch().category);
             patchSelector->setIDs(synth->current_category_id, synth->patchid);
             patchSelector->setAuthor(synth->storage.getPatch().author);
+            patchSelector->setTags(synth->storage.getPatch().tags);
             patchSelector->setBounds(skinCtrl->getRect());
 
             setAccessibilityInformationByTitleAndAction(patchSelector.get(), "Patch Selector",

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -84,6 +84,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::makeStorePatc
     pb->setAuthor(author);
     pb->setCategory(category);
     pb->setComment(comments);
+    pb->setTags(synth->storage.getPatch().tags);
     pb->setSurgeGUIEditor(this);
 
     pb->setEnclosingParentTitle("Store Patch");

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.h
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.h
@@ -17,6 +17,7 @@
 #define SURGE_XT_PATCHSTOREDIALOG_H
 
 #include "SkinSupport.h"
+#include "SurgeStorage.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "OverlayComponent.h"
@@ -36,18 +37,19 @@ struct PatchStoreDialog : public OverlayComponent,
     void resized() override;
 
     SurgeGUIEditor *editor{nullptr};
-    void setSurgeGUIEditor(SurgeGUIEditor *e) { editor = e; }
+    void setSurgeGUIEditor(SurgeGUIEditor *e);
 
     void setName(const std::string &n) { nameEd->setText(n, juce::dontSendNotification); }
     void setAuthor(const std::string &a) { authorEd->setText(a, juce::dontSendNotification); }
     void setCategory(const std::string &c) { catEd->setText(c, juce::dontSendNotification); }
     void setComment(const std::string &c) { commentEd->setText(c, juce::dontSendNotification); }
+    void setTags(const std::vector<SurgePatch::Tag> &t);
 
     void onSkinChanged() override;
     void buttonClicked(juce::Button *button) override;
-    std::unique_ptr<juce::TextEditor> nameEd, authorEd, catEd, commentEd;
-    std::unique_ptr<juce::Label> nameEdL, authorEdL, catEdL, commentEdL;
-    std::unique_ptr<juce::TextButton> okButton, cancelButton;
+    std::unique_ptr<juce::TextEditor> nameEd, authorEd, catEd, tagEd, commentEd;
+    std::unique_ptr<juce::Label> nameEdL, authorEdL, catEdL, tagEdL, commentEdL;
+    std::unique_ptr<juce::TextButton> okButton, okOverButton, cancelButton;
     std::unique_ptr<juce::ToggleButton> storeTuningButton;
     std::unique_ptr<juce::Label> storeTuningLabel;
 

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -79,6 +79,8 @@ struct PatchSelector : public juce::Component, public WidgetBaseMixin<PatchSelec
         repaint();
     }
 
+    void setTags(const std::vector<SurgePatch::Tag> &itag) { tags = itag; }
+
     void resized() override;
     void mouseDown(const juce::MouseEvent &event) override;
     bool favoritesHover{false};
@@ -109,6 +111,7 @@ struct PatchSelector : public juce::Component, public WidgetBaseMixin<PatchSelec
     std::string pname;
     std::string category;
     std::string author;
+    std::vector<SurgePatch::Tag> tags;
     int current_category = 0, current_patch = 0;
 
     /**


### PR DESCRIPTION
1. Add a vector of tags on SurgePatch
2. Have a UI which can set them and also do a factory override
3. Store the tags in the FXP; read from the FXP for edit