### PR TITLE
Resolve some patch database issues

### DIFF
--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -332,6 +332,11 @@ CREATE TABLE IF NOT EXISTS Favorites (
             oss << "An error occured opening sqlite file '" << dbname << "'. The error was '"
                 << sqlite3_errmsg(dbh) << "'.";
             storage->reportError(oss.str(), "Surge Patch Database Error");
+            if (dbh)
+            {
+                // even if opening fails we still need to close the database
+                sqlite3_close(dbh);
+            }
             dbh = nullptr;
             return;
         }
@@ -941,7 +946,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
 
   private:
     sqlite3 *rodbh{nullptr};
-    sqlite3 *dbh;
+    sqlite3 *dbh = nullptr;
     SurgeStorage *storage;
 };
 PatchDB::PatchDB(SurgeStorage *s) : storage(s) { initialize(); }


### PR DESCRIPTION
According to https://sqlite.org/c3ref/open.html we're supposed to `sqlite3_close()` a database handle even if the open fails, unless the pointer was `NULL` due to allocation failure.

It was also possible for `PatchDB::WriterWorker`'s `dbh` variable to be uninitialised which could result in invalid handles being passed to sqlite3. Now it's defaulted to `nullptr`.

These fixes should hopefully resolve @mkruselj 's crash.