### PR TITLE
A number of minor UI tweaks

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -465,16 +465,17 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             contextMenu.addSeparator();
 
-            contextMenu.addItem(
-                "Copy", [this, a]() { synth->storage.clipboard_copy(cp_osc, current_scene, a); });
-
-            contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Copy With Modulation"), [this, a]() {
-                synth->storage.clipboard_copy(cp_oscmod, current_scene, a);
+            contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Copy Oscillator"), [this, a]() {
+                synth->storage.clipboard_copy(cp_osc, current_scene, a);
             });
+
+            contextMenu.addItem(
+                Surge::GUI::toOSCaseForMenu("Copy Oscillator with Modulation"),
+                [this, a]() { synth->storage.clipboard_copy(cp_oscmod, current_scene, a); });
 
             if (synth->storage.get_clipboard_type() == cp_osc)
             {
-                contextMenu.addItem("Paste", [this, a]() {
+                contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Paste Oscillator"), [this, a]() {
                     synth->clear_osc_modulation(current_scene, a);
                     synth->storage.clipboard_paste(cp_osc, current_scene, a);
                     queue_refresh = true;
@@ -517,9 +518,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             contextMenu.addSeparator();
 
-            contextMenu.addItem("Copy",
+            contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Copy Scene"),
                                 [this, a]() { synth->storage.clipboard_copy(cp_scene, a, -1); });
-            contextMenu.addItem("Paste",
+            contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Paste Scene"),
                                 synth->storage.get_clipboard_type() == cp_scene, // enabled
                                 false, [this, a]() {
                                     synth->storage.clipboard_paste(cp_scene, a, -1);
@@ -923,17 +924,18 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             {
                 contextMenu.addSeparator();
 
-                contextMenu.addItem("Copy", [this, sc, lfo_id]() {
-                    if (lfo_id >= 0)
-                    {
-                        synth->storage.clipboard_copy(cp_lfo, sc, lfo_id);
-                        mostRecentCopiedMSEGState = msegEditState[sc][lfo_id];
-                    }
-                });
+                contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Copy Modulator"),
+                                    [this, sc, lfo_id]() {
+                                        if (lfo_id >= 0)
+                                        {
+                                            synth->storage.clipboard_copy(cp_lfo, sc, lfo_id);
+                                            mostRecentCopiedMSEGState = msegEditState[sc][lfo_id];
+                                        }
+                                    });
 
                 if (synth->storage.get_clipboard_type() == cp_lfo)
                 {
-                    contextMenu.addItem("Paste", [this, sc, lfo_id]() {
+                    contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Paste"), [this, sc, lfo_id]() {
                         if (lfo_id >= 0)
                         {
                             synth->storage.clipboard_paste(cp_lfo, sc, lfo_id);

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -149,6 +149,7 @@ struct ModulationListBoxModel : public juce::ListBoxModel
                     mod->rows[row].source_scene, mod->rows[row].source_index);
                 mod->updateRows();
                 mod->moded->listBox->updateContent();
+                mod->moded->ed->queue_refresh = true;
             }
             if (button == muteButton.get())
             {

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -16,6 +16,7 @@
 #include "PatchStoreDialog.h"
 #include "RuntimeFont.h"
 #include "SurgeGUIEditor.h"
+#include "SurgeGUIUtils.h"
 
 namespace Surge
 {
@@ -70,7 +71,7 @@ PatchStoreDialog::PatchStoreDialog()
     storeTuningButton->setButtonText("");
     addAndMakeVisible(*storeTuningButton);
 
-    storeTuningLabel = makeL("Store tuning in patch");
+    storeTuningLabel = makeL(Surge::GUI::toOSCaseForMenu("Store Tuning in Patch"));
 }
 
 void PatchStoreDialog::paint(juce::Graphics &g)

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -538,8 +538,8 @@ void FxMenu::populate()
 
     menu.addSeparator();
 
-    menu.addItem("Copy", [this]() { this->copyFX(); });
-    menu.addItem("Paste", [this]() { this->pasteFX(); });
+    menu.addItem(Surge::GUI::toOSCaseForMenu("Copy FX Preset"), [this]() { this->copyFX(); });
+    menu.addItem(Surge::GUI::toOSCaseForMenu("Paste FX Preset"), [this]() { this->pasteFX(); });
 
     if (fx->type.val.i != fxt_off)
     {


### PR DESCRIPTION
- Instead of just Copy/Paste, mention exactly what is being copied or pasted
- Use toOSCaseForMenu on "Store tuning in patch" label in patch store dialog
- Queue refresh of SGE on clearing a modulator from modulation list