### PR TITLE
Spress VKB Forwarding with Typeins Open

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -302,24 +302,28 @@ juce::PopupMenu SurgeSynthEditor::hostMenuForMacro(int macro)
 
 bool SurgeSynthEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig)
 {
-#if MAC
-    // See #5123
-    if (adapter->getShowVirtualKeyboard() && orig != keyboard.get())
+    /*
+     * So sigh. On Lin/Win the keyStateChanged event of the parent isn't supressed
+     * when the ksystatechange is false. But the midi keyboard rescans on state change.
+     * So what we need to do is: forward all keystate trues (which will come before a
+     * keypress but only if the keybress is not in a text edit) but only forward keystate
+     * false if i have sent at least one key through this fallthrough mechanism. So:
+     */
+    if (adapter->getShowVirtualKeyboard() && adapter->shouldForwardKeysToVKB() &&
+        orig != keyboard.get())
     {
         return keyboard->keyPressed(key);
     }
-#endif
     return false;
 }
 
 bool SurgeSynthEditor::keyStateChanged(bool isKeyDown, juce::Component *originatingComponent)
 {
-#if MAC
-    if (adapter->getShowVirtualKeyboard() && originatingComponent != keyboard.get())
+    if (adapter->getShowVirtualKeyboard() && adapter->shouldForwardKeysToVKB() &&
+        originatingComponent != keyboard.get())
     {
         return keyboard->keyStateChanged(isKeyDown);
     }
-#endif
 
     return false;
 }

--- a/src/surge-xt/SurgeSynthEditor.h
+++ b/src/surge-xt/SurgeSynthEditor.h
@@ -52,6 +52,8 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     void beginMacroEdit(long macroNum);
     void endMacroEdit(long macroNum);
 
+    int forwardedKeypressCount{0};
+    std::array<bool, 256> forwardedKeypresses;
     bool keyPressed(const juce::KeyPress &key, juce::Component *originatingComponent) override;
     bool keyStateChanged(bool isKeyDown, juce::Component *originatingComponent) override;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3859,22 +3859,6 @@ void SurgeGUIEditor::sliderHoverEnd(int tag)
     }
 }
 
-void SurgeGUIEditor::dismissEditorOfType(OverlayTags ofType)
-{
-    if (juceOverlays.empty())
-        return;
-
-    if (juceOverlays.find(ofType) != juceOverlays.end())
-    {
-        if (juceOverlays[ofType])
-        {
-            frame->removeChildComponent(juceOverlays[ofType].get());
-            juceDeleteOnIdle.push_back(std::move(juceOverlays[ofType]));
-        }
-        juceOverlays.erase(ofType);
-    }
-}
-
 std::string SurgeGUIEditor::getDisplayForTag(long tag, bool external, float f)
 {
     if (tag < start_paramtags)
@@ -3920,6 +3904,7 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
                                        std::function<void(const std::string &)> onOK)
 {
     miniEdit->setSkin(currentSkin, bitmapStore);
+    miniEdit->setEditor(this);
     if (frame->getIndexOfChildComponent(miniEdit.get()) < 0)
     {
         frame->addChildComponent(*miniEdit);

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -380,7 +380,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
             showOverlay(t);
         }
     }
-
+    bool overlayConsumesKeyboard(OverlayTags);
     // I will be handed a pointer I need to keep around you know.
     void addJuceEditorOverlay(
         std::unique_ptr<juce::Component> c,
@@ -657,6 +657,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool getShowVirtualKeyboard();
     void setShowVirtualKeyboard(bool b);
     void toggleVirtualKeyboard();
+
+    int vkbForward{0};
+    bool shouldForwardKeysToVKB() { return vkbForward == 0; }
 
     bool getUseKeyboardShortcuts();
     void setUseKeyboardShortcuts(bool b);

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -364,6 +364,41 @@ void SurgeGUIEditor::addJuceEditorOverlay(
     ol->addAndTakeOwnership(std::move(c));
     frame->addAndMakeVisible(*ol);
     juceOverlays[editorTag] = std::move(ol);
+    if (overlayConsumesKeyboard(editorTag))
+        vkbForward++;
+}
+
+void SurgeGUIEditor::dismissEditorOfType(OverlayTags ofType)
+{
+    if (juceOverlays.empty())
+        return;
+
+    if (overlayConsumesKeyboard(ofType))
+        vkbForward--;
+
+    if (juceOverlays.find(ofType) != juceOverlays.end())
+    {
+        if (juceOverlays[ofType])
+        {
+            frame->removeChildComponent(juceOverlays[ofType].get());
+            juceDeleteOnIdle.push_back(std::move(juceOverlays[ofType]));
+        }
+        juceOverlays.erase(ofType);
+    }
+}
+
+bool SurgeGUIEditor::overlayConsumesKeyboard(OverlayTags ofType)
+{
+    switch (ofType)
+    {
+    case PATCH_BROWSER:
+    case STORE_PATCH:
+    case FORMULA_EDITOR:
+        return true;
+    default:
+        break;
+    }
+    return false;
 }
 
 juce::Component *SurgeGUIEditor::getOverlayIfOpen(OverlayTags tag)

--- a/src/surge-xt/gui/overlays/MiniEdit.cpp
+++ b/src/surge-xt/gui/overlays/MiniEdit.cpp
@@ -18,6 +18,7 @@
 #include "SurgeImageStore.h"
 #include "RuntimeFont.h"
 #include "SurgeImage.h"
+#include "SurgeGUIEditor.h"
 
 namespace Surge
 {
@@ -151,6 +152,13 @@ void MiniEdit::visibilityChanged()
 {
     if (isVisible())
         grabFocus();
+    if (editor)
+    {
+        if (isVisible())
+            editor->vkbForward++;
+        else
+            editor->vkbForward--;
+    }
 }
 
 void MiniEdit::textEditorReturnKeyPressed(juce::TextEditor &editor)

--- a/src/surge-xt/gui/overlays/MiniEdit.h
+++ b/src/surge-xt/gui/overlays/MiniEdit.h
@@ -20,6 +20,8 @@
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
+class SurgeGUIEditor;
+
 namespace Surge
 {
 namespace Overlays
@@ -31,6 +33,7 @@ struct MiniEdit : public juce::Component,
 {
     MiniEdit();
     ~MiniEdit();
+    void setEditor(SurgeGUIEditor *ed) { editor = ed; }
     void paint(juce::Graphics &g) override;
     void onSkinChanged() override;
     void visibilityChanged() override;
@@ -50,6 +53,7 @@ struct MiniEdit : public juce::Component,
     void textEditorEscapeKeyPressed(juce::TextEditor &editor) override;
     void textEditorReturnKeyPressed(juce::TextEditor &editor) override;
     void grabFocus() { typein->grabKeyboardFocus(); }
+    SurgeGUIEditor *editor{nullptr};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MiniEdit);
 };

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
@@ -100,6 +100,19 @@ void TypeinParamEditor::resized()
     textEd->setBounds(ter);
 }
 
+void TypeinParamEditor::visibilityChanged()
+{
+    if (isVisible())
+        textEd->setWantsKeyboardFocus(true);
+    if (editor)
+    {
+        if (isVisible())
+            editor->vkbForward++;
+        else
+            editor->vkbForward--;
+    }
+}
+
 void TypeinParamEditor::onSkinChanged()
 {
     textEd->setColour(juce::TextEditor::backgroundColourId,

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.h
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.h
@@ -43,11 +43,8 @@ struct TypeinParamEditor : public juce::Component,
     void setBoundsToAccompany(const juce::Rectangle<int> &controlRect,
                               const juce::Rectangle<int> &parentRect);
     void resized() override;
-    void visibilityChanged() override
-    {
-        if (isVisible())
-            textEd->setWantsKeyboardFocus(true);
-    }
+
+    void visibilityChanged() override;
 
     Parameter *p{nullptr};
     void setEditedParam(Parameter *pin) { p = pin; };


### PR DESCRIPTION
If a typein is open supress VKB forwarding to work
around inconsistent cross platform even tsupression from
typein fields

Closes #5123