### PR TITLE
platform: Add initial Paths interface

### DIFF
--- a/libs/oddsound-mts/CMakeLists.txt
+++ b/libs/oddsound-mts/CMakeLists.txt
@@ -4,5 +4,6 @@ add_library(${PROJECT_NAME}
       MTS-ESP/Client/libMTSClient.cpp
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_NAME} MTS-ESP/Client/)
+target_include_directories(${PROJECT_NAME} PUBLIC MTS-ESP/Client)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
 add_library(surge::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -254,13 +254,12 @@ if(APPLE)
     )
 elseif(UNIX)
   target_compile_definitions(${PROJECT_NAME} PUBLIC LINUX=1)
-  target_link_libraries(${PROJECT_NAME} PUBLIC
+  target_link_libraries(${PROJECT_NAME} PRIVATE
     pthread
-    dl
     -Wl,--no-undefined
     )
   if(CMAKE_SYSTEM_NAME MATCHES "BSD")
-    target_link_libraries(${PROJECT_NAME} PUBLIC execinfo)
+    target_link_libraries(${PROJECT_NAME} PRIVATE execinfo)
   endif()
   if(LINUX_ON_ARM)
     target_compile_definitions(${PROJECT_NAME} PUBLIC ARM_NEON=1)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1047,8 +1047,6 @@ class alignas(16) SurgeStorage
     fs::path userSkinsPath;
     fs::path userMidiMappingsPath;
 
-    fs::path installedPath;
-
     std::map<std::string, TiXmlDocument> userMidiMappingsXMLByName;
     void rescanUserMidiMappings();
     void loadMidiMappingByName(std::string name);

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -1,10 +1,20 @@
 # vi:set sw=2 et:
 project(surge-platform)
 
+add_library(${PROJECT_NAME}
+  include/platform/Paths.h
+  src/Paths.cpp
+  )
 if(APPLE)
-  add_library(${PROJECT_NAME})
-  target_sources(${PROJECT_NAME} PRIVATE macos/cpp17-aligned-new.cpp)
-else()
-  # no sources yet on other platforms
-  add_library(${PROJECT_NAME} INTERFACE)
+  target_sources(${PROJECT_NAME} PRIVATE
+    macos/cpp17-aligned-new.cpp
+    unix/Paths.cpp
+    )
+elseif(WIN32)
+  target_sources(${PROJECT_NAME} PRIVATE windows/Paths.cpp)
+elseif(UNIX)
+  target_sources(${PROJECT_NAME} PRIVATE unix/Paths.cpp)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
 endif()
+target_link_libraries(${PROJECT_NAME} PUBLIC surge::filesystem)
+target_include_directories(${PROJECT_NAME} PUBLIC include)

--- a/src/platform/include/platform/Paths.h
+++ b/src/platform/include/platform/Paths.h
@@ -1,0 +1,33 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#pragma once
+
+#include "filesystem/import.h"
+
+namespace Surge::Paths
+{
+
+/// @return The path of the running Surge application / plugin itself. Equivalent to binaryPath(),
+/// except on macOS, where it returns the bundle directory (.app, .component, ...)
+fs::path appPath();
+
+/// @return The path of the running Surge binary file itself (.exe, .dll, .so, ...)
+fs::path binaryPath();
+
+/// @return The directory where the running Surge application / plugin is installed
+inline fs::path installPath() { return appPath().parent_path(); }
+
+} // namespace Surge::Paths

--- a/src/platform/src/Paths.cpp
+++ b/src/platform/src/Paths.cpp
@@ -1,0 +1,31 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "platform/Paths.h"
+
+namespace Surge::Paths
+{
+
+fs::path appPath()
+{
+#ifdef __APPLE__
+    // FIXME: This is what the old code did. We can probably do better...
+    return binaryPath().parent_path().parent_path().parent_path();
+#else
+    return binaryPath();
+#endif
+}
+
+} // namespace Surge::Paths

--- a/src/platform/unix/Paths.cpp
+++ b/src/platform/unix/Paths.cpp
@@ -1,0 +1,34 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "platform/Paths.h"
+#include <stdexcept>
+#include <dlfcn.h>
+
+namespace Surge::Paths
+{
+
+fs::path binaryPath()
+{
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<const void *>(&binaryPath), &info) || !info.dli_fname[0])
+    {
+        // If dladdr(3) returns zero, dlerror(3) won't know why either
+        throw std::runtime_error{"Failed to retrieve shared object file name"};
+    }
+    return fs::path{info.dli_fname};
+}
+
+} // namespace Surge::Paths

--- a/src/platform/windows/Paths.cpp
+++ b/src/platform/windows/Paths.cpp
@@ -1,0 +1,45 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "platform/Paths.h"
+#include <system_error>
+#include <windows.h>
+
+namespace Surge::Paths
+{
+
+fs::path binaryPath()
+{
+    HMODULE hmodule;
+    if (!::GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                  GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                              reinterpret_cast<LPCWSTR>(&binaryPath), &hmodule))
+    {
+        throw std::system_error{int(::GetLastError()), std::system_category(),
+                                "Failed to retrieve module handle"};
+    }
+
+    for (std::vector<WCHAR> buf{MAX_PATH};; buf.resize(buf.size() * 2))
+    {
+        const auto len = ::GetModuleFileNameW(hmodule, &buf[0], buf.size());
+        if (!len)
+            throw std::system_error{int(::GetLastError()), std::system_category(),
+                                    "Failed to retrieve module file name"};
+        if (len < buf.size())
+            return fs::path{&buf[0]};
+    }
+}
+
+} // namespace Surge::Paths

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -185,19 +185,20 @@ foreach(format ${SURGE_JUCE_FORMATS})
 endforeach()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  surge::surge-common
+  surge-common
+  surge-platform
   surge-juce
   juce::juce_graphics
   juce::juce_audio_utils
   juce::juce_audio_processors
   juce::juce_audio_plugin_client
-  PUBLIC surge-xt-binary # FIXME
+  surge-xt-binary
   )
 
-# FIXME: surge-gui and surge-xt depend on each other :(
 target_include_directories(${PROJECT_NAME}
-  PUBLIC
+  PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/gui
-  ${CMAKE_CURRENT_SOURCE_DIR})
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 
 surge_juce_package(${PROJECT_NAME} "Surge XT")

--- a/src/surge-xt/gui/overlays/AboutScreen.cpp
+++ b/src/surge-xt/gui/overlays/AboutScreen.cpp
@@ -20,6 +20,7 @@
 #include "version.h"
 #include "RuntimeFont.h"
 #include "SurgeImage.h"
+#include "platform/Paths.h"
 
 namespace Surge
 {
@@ -113,7 +114,7 @@ void AboutScreen::populateData()
                            storage->datapath.u8string());
     lowerLeft.emplace_back("User Data", storage->userDataPath.u8string(),
                            storage->userDataPath.u8string());
-    lowerLeft.emplace_back("Plugin", storage->installedPath.u8string(), "");
+    lowerLeft.emplace_back("Plugin", Paths::appPath().u8string(), "");
     lowerLeft.emplace_back("Current Skin", skin->displayName, skin->root + skin->name);
     lowerLeft.emplace_back("Skin Author", skin->author, skin->authorURL);
 


### PR DESCRIPTION
This will become the one-stop shop for portably querying well-known file
system paths like Surge install directory, home directory, etc.

#4823