### PR TITLE
Patch Comments are Multiline; Tooltip Sketchout

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -404,6 +404,7 @@ void SurgeGUIEditor::idle()
                 patchSelector->setLabel(synth->storage.getPatch().name);
                 patchSelector->setCategory(synth->storage.getPatch().category);
                 patchSelector->setAuthor(synth->storage.getPatch().author);
+                patchSelector->setComment(synth->storage.getPatch().comment);
                 patchSelector->setIsFavorite(isPatchFavorite());
                 patchSelector->setTags(synth->storage.getPatch().tags);
                 patchSelector->repaint();
@@ -1267,6 +1268,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             patchSelector->setCategory(synth->storage.getPatch().category);
             patchSelector->setIDs(synth->current_category_id, synth->patchid);
             patchSelector->setAuthor(synth->storage.getPatch().author);
+            patchSelector->setComment(synth->storage.getPatch().comment);
             patchSelector->setTags(synth->storage.getPatch().tags);
             patchSelector->setBounds(skinCtrl->getRect());
 

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -36,6 +36,9 @@ PatchStoreDialog::PatchStoreDialog()
     nameEd = makeEd("patch name");
     authorEd = makeEd("patch author");
     commentEd = makeEd("patch comment");
+    commentEd->setMultiLine(true, true);
+    commentEd->setReturnKeyStartsNewLine(true);
+    commentEd->setJustification(juce::Justification::topLeft);
     tagEd = makeEd("patch tags");
     catEd = makeEd("patch category");
 
@@ -161,7 +164,6 @@ void PatchStoreDialog::resized()
     ce = ce.translated(0, h);
     auto q = ce.withHeight(commH - margin);
     commentEd->setBounds(q);
-    commentEd->setIndents(4, (commentEd->getHeight() - commentEd->getTextHeight()) / 2);
     ce = ce.translated(0, commH);
 
     auto be = ce.withWidth(buttonWidth).withRightX(ce.getRight());

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -95,8 +95,20 @@ void PatchSelector::resized()
                         .translated(-2, 1);
 }
 
+void PatchSelector::mouseEnter(const juce::MouseEvent &)
+{
+    if (tooltipCountdown < 0)
+    {
+        tooltipCountdown = 5;
+        juce::Timer::callAfterDelay(200, [this]() { shouldTooltip(); });
+    }
+}
+
 void PatchSelector::mouseMove(const juce::MouseEvent &e)
 {
+    if (tooltipCountdown >= 0)
+        tooltipCountdown = 5;
+    toggleCommentTooltip(false);
     auto pfh = favoritesHover;
     favoritesHover = false;
     if (favoritesRect.contains(e.position.toInt()))
@@ -154,6 +166,28 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
     bool single_category =
         e.mods.isRightButtonDown() || e.mods.isCtrlDown() || e.mods.isCommandDown();
     showClassicMenu(single_category);
+}
+
+void PatchSelector::shouldTooltip()
+{
+    if (tooltipCountdown < 0)
+        return;
+    tooltipCountdown--;
+    if (tooltipCountdown == 0)
+    {
+        tooltipCountdown = -1;
+        toggleCommentTooltip(true);
+    }
+    else
+    {
+        juce::Timer::callAfterDelay(200, [this]() { shouldTooltip(); });
+    }
+}
+
+void PatchSelector::toggleCommentTooltip(bool b)
+{
+    if (b && !comment.empty())
+        std::cout << "-------------\n" << comment << "---------------\n" << std::endl;
 }
 
 void PatchSelector::openPatchBrowser()

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -78,6 +78,7 @@ struct PatchSelector : public juce::Component, public WidgetBaseMixin<PatchSelec
 
         repaint();
     }
+    void setComment(const std::string &c) { comment = c; }
 
     void setTags(const std::vector<SurgePatch::Tag> &itag) { tags = itag; }
 
@@ -85,10 +86,13 @@ struct PatchSelector : public juce::Component, public WidgetBaseMixin<PatchSelec
     void mouseDown(const juce::MouseEvent &event) override;
     bool favoritesHover{false};
     void mouseMove(const juce::MouseEvent &event) override;
+    void mouseEnter(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override { endHover(); }
     void endHover() override
     {
         favoritesHover = false;
+        tooltipCountdown = -1;
+        toggleCommentTooltip(false);
         repaint();
     }
     void showClassicMenu(bool singleCategory = false);
@@ -112,8 +116,13 @@ struct PatchSelector : public juce::Component, public WidgetBaseMixin<PatchSelec
     std::string pname;
     std::string category;
     std::string author;
+    std::string comment;
     std::vector<SurgePatch::Tag> tags;
     int current_category = 0, current_patch = 0;
+
+    int tooltipCountdown{-1};
+    void toggleCommentTooltip(bool b);
+    void shouldTooltip();
 
     /**
      * populatePatchMenuForCategory


### PR DESCRIPTION
Patch comments are multiline and persiste OK and the like
There's code here which would show a tooltip if we wanted on
hover but right now just prints the comment out to stdout
if it woudl do so. Need to ponder whether we want that.