### PR TITLE
Less steps for vkb vel adjustment, setWantsKeyboardFocus to false

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.h
+++ b/src/surge-xt/SurgeSynthEditor.h
@@ -70,7 +70,7 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     std::unique_ptr<IdleTimer> idleTimer;
 
     bool drawExtendedControls{false};
-    float midiKeyboardVelocity{90.f / 127.f};
+    float midiKeyboardVelocity{0.7f};
     std::unique_ptr<juce::MidiKeyboardComponent> keyboard;
     std::unique_ptr<juce::Label> tempoLabel;
     std::unique_ptr<juce::TextEditor> tempoTypein;


### PR DESCRIPTION
This makes the virtual keyboard always receive keypresses (when we allow it of course - so when typeins are focused, VKB is not doing anything). Doing this makes using QWERTY for virtual keyboard atually sane, since you don't have to refocus VKB every time you tweak a slider with mouse etc.