### PR TITLE
Disable dragging with middle mouse button

### DIFF
--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -273,6 +273,11 @@ void EffectChooser::mouseUp(const juce::MouseEvent &event)
 
 void EffectChooser::mouseDrag(const juce::MouseEvent &event)
 {
+    if (supressMainFrameMouseEvent(event))
+    {
+        return;
+    }
+
     if (event.getDistanceFromDragStart() > 2)
     {
         if (!hasDragged)

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1518,6 +1518,11 @@ void LFOAndStepDisplay::mouseMove(const juce::MouseEvent &event)
 
 void LFOAndStepDisplay::mouseDrag(const juce::MouseEvent &event)
 {
+    if (supressMainFrameMouseEvent(event))
+    {
+        return;
+    }
+
     auto sge = firstListenerOfType<SurgeGUIEditor>();
 
     if (!isStepSequencer() || dragMode == NONE)

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -167,6 +167,11 @@ void MenuForDiscreteParams::mouseDown(const juce::MouseEvent &event)
 
 void MenuForDiscreteParams::mouseDrag(const juce::MouseEvent &e)
 {
+    if (supressMainFrameMouseEvent(e))
+    {
+        return;
+    }
+
     auto d = e.getDistanceFromDragStartX() - e.getDistanceFromDragStartY();
     if (fabs(d - lastDragDistance) > 10)
     {

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -313,6 +313,11 @@ void ModulatableSlider::endHover()
 
 void ModulatableSlider::mouseDrag(const juce::MouseEvent &event)
 {
+    if (supressMainFrameMouseEvent(event))
+    {
+        return;
+    }
+
     auto p = mouseDownFloatPosition;
     float distance = event.position.getX() - p.getX();
     if (orientation == ParamConfig::kVertical)
@@ -452,6 +457,11 @@ void ModulatableSlider::mouseUp(const juce::MouseEvent &event)
 
 void ModulatableSlider::mouseDoubleClick(const juce::MouseEvent &event)
 {
+    if (supressMainFrameMouseEvent(event))
+    {
+        return;
+    }
+
     editTypeWas = DOUBLECLICK;
 
     notifyBeginEdit();

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -141,6 +141,11 @@ void MultiSwitch::setCursorToArrow()
 
 void MultiSwitch::mouseDrag(const juce::MouseEvent &event)
 {
+    if (supressMainFrameMouseEvent(event))
+    {
+        return;
+    }
+
     if (draggable)
     {
         if (!everDragged)

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -148,6 +148,11 @@ void NumberField::mouseDown(const juce::MouseEvent &event)
 
 void NumberField::mouseDrag(const juce::MouseEvent &event)
 {
+    if (supressMainFrameMouseEvent(event))
+    {
+        return;
+    }
+
     float d = -event.getDistanceFromDragStartY();
     float dD = d - lastDistanceChecked;
     float thresh = 10;
@@ -177,6 +182,11 @@ void NumberField::mouseUp(const juce::MouseEvent &event)
 }
 void NumberField::mouseDoubleClick(const juce::MouseEvent &event)
 {
+    if (supressMainFrameMouseEvent(event))
+    {
+        return;
+    }
+
     notifyControlModifierDoubleClicked(event.mods);
     repaint();
 }

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -781,6 +781,11 @@ struct AliasAdditiveEditor : public juce::Component, Surge::GUI::SkinConsumingCo
 
     void mouseDoubleClick(const juce::MouseEvent &event) override
     {
+        if (event.mods.isMiddleButtonDown())
+        {
+            return;
+        }
+
         int clickedSlider = -1;
 
         for (int i = 0; i < AliasOscillator::n_additive_partials; ++i)
@@ -801,6 +806,10 @@ struct AliasAdditiveEditor : public juce::Component, Surge::GUI::SkinConsumingCo
 
     void mouseDrag(const juce::MouseEvent &event) override
     {
+        if (event.mods.isMiddleButtonDown())
+        {
+            return;
+        }
 
         int draggedSlider = -1;
 

--- a/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
@@ -191,6 +191,11 @@ void WaveShaperSelector::mouseDown(const juce::MouseEvent &event)
 
 void WaveShaperSelector::mouseDrag(const juce::MouseEvent &e)
 {
+    if (supressMainFrameMouseEvent(e))
+    {
+        return;
+    }
+
     auto d = e.getDistanceFromDragStartX() - e.getDistanceFromDragStartY();
     if (fabs(d - lastDragDistance) > 0)
     {

--- a/src/surge-xt/gui/widgets/WidgetBaseMixin.h
+++ b/src/surge-xt/gui/widgets/WidgetBaseMixin.h
@@ -145,6 +145,11 @@ struct WidgetBaseMixin : public Surge::GUI::SkinConsumingComponent,
         }
         return false;
     }
+
+    bool supressMainFrameMouseEvent(const juce::MouseEvent &e)
+    {
+        return firstListenerOfType<SurgeGUIEditor>() && e.mods.isMiddleButtonDown();
+    }
 };
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -343,6 +343,11 @@ void OscillatorMenu::loadSnapshot(int type, TiXmlElement *e, int idx)
 
 void OscillatorMenu::mouseDown(const juce::MouseEvent &event)
 {
+    if (forwardedMainFrameMouseDowns(event))
+    {
+        return;
+    }
+
     menu.showMenuAsync(juce::PopupMenu::Options(), [this](int) {
         isHovered = false;
         repaint();
@@ -447,6 +452,11 @@ void FxMenu::paint(juce::Graphics &g)
 
 void FxMenu::mouseDown(const juce::MouseEvent &event)
 {
+    if (forwardedMainFrameMouseDowns(event))
+    {
+        return;
+    }
+
     menu.showMenuAsync(juce::PopupMenu::Options(), [this](int i) {
         isHovered = false;
         repaint();


### PR DESCRIPTION
Middle mouse button click in widgets should only enable mod editing.
Disabled all other actions where dragging or double click was possible.
Closes #5108