### PR TITLE
Handle voice stealing problem with 64 poly

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -446,10 +446,10 @@ void SurgeSynthesizer::enforcePolyphonyLimit(int s, int margin)
 {
     list<SurgeVoice *>::iterator iter;
 
-    if (voices[s].size() > (storage.getPatch().polylimit.val.i + margin))
+    int paddedPoly = std::min((storage.getPatch().polylimit.val.i + margin), MAX_VOICES - 1);
+    if (voices[s].size() > paddedPoly)
     {
-        int excess_voices =
-            max(0, (int)voices[s].size() - (storage.getPatch().polylimit.val.i + margin));
+        int excess_voices = max(0, (int)voices[s].size() - paddedPoly);
         iter = voices[s].begin();
 
         while (iter != voices[s].end())

--- a/src/surge-testrunner/UnitTestsMOD.cpp
+++ b/src/surge-testrunner/UnitTestsMOD.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <iostream>
 #include <iomanip>
 #include <sstream>
 #include <algorithm>


### PR DESCRIPTION
When polyphony was near MAX_VOICES the voice stealing algorithm
mis-stole voices and left things unplayable. So fix that by
having the margin not push us past max voices and also
add an assertive regtest that fails before the fix and works after

Addresses #5165