### PR TITLE
First pass at Filter Deactivation

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -340,6 +340,8 @@ bool Parameter::can_deactivate() const
     case ct_envtime_deactivatable:
     case ct_tape_drive:
     case ct_tape_speed:
+    case ct_wstype:
+    case ct_filtertype:
         return true;
     }
     return false;

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1317,11 +1317,14 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             {
                 if (param_ptr[i]->can_deactivate())
                 {
-                    if ((param_ptr[i]->ctrlgroup ==
-                         cg_LFO) || // this is the LFO rate and env special case
-                        (param_ptr[i]->ctrlgroup == cg_GLOBAL &&
-                         param_ptr[i]->ctrltype ==
-                             ct_freq_hpf)) // this is the global highpass special case
+                    auto cg = param_ptr[i]->ctrlgroup;
+                    auto ct = param_ptr[i]->ctrltype;
+                    // Do we want to taggle to default deactivated on or off?
+                    if ((cg == cg_LFO) || // this is the LFO rate and env special case
+                        (ct == cg_GLOBAL &&
+                         ct == ct_freq_hpf) || // this is the global highpass special case
+                        (ct == ct_filtertype || ct == ct_wstype) // filter bypass
+                    )
                         param_ptr[i]->deactivated = false;
                     else
                         param_ptr[i]->deactivated = true;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3529,11 +3529,33 @@ void SurgeSynthesizer::process()
         storage.modRoutingMutex.unlock();
 
         fbq_global g;
-        g.FU1ptr = GetQFPtrFilterUnit(storage.getPatch().scene[s].filterunit[0].type.val.i,
-                                      storage.getPatch().scene[s].filterunit[0].subtype.val.i);
-        g.FU2ptr = GetQFPtrFilterUnit(storage.getPatch().scene[s].filterunit[1].type.val.i,
-                                      storage.getPatch().scene[s].filterunit[1].subtype.val.i);
-        g.WSptr = GetQFPtrWaveshaper(storage.getPatch().scene[s].wsunit.type.val.i);
+        if (storage.getPatch().scene[s].filterunit[0].type.deactivated)
+        {
+            g.FU1ptr = nullptr;
+        }
+        else
+        {
+            g.FU1ptr = GetQFPtrFilterUnit(storage.getPatch().scene[s].filterunit[0].type.val.i,
+                                          storage.getPatch().scene[s].filterunit[0].subtype.val.i);
+        }
+        if (storage.getPatch().scene[s].filterunit[1].type.deactivated)
+        {
+            g.FU2ptr = nullptr;
+        }
+        else
+        {
+            g.FU2ptr = GetQFPtrFilterUnit(storage.getPatch().scene[s].filterunit[1].type.val.i,
+                                          storage.getPatch().scene[s].filterunit[1].subtype.val.i);
+        }
+
+        if (storage.getPatch().scene[s].wsunit.type.deactivated)
+        {
+            g.WSptr = nullptr;
+        }
+        else
+        {
+            g.WSptr = GetQFPtrWaveshaper(storage.getPatch().scene[s].wsunit.type.val.i);
+        }
 
         FBQFPtr ProcessQuadFB =
             GetFBQPointer(storage.getPatch().scene[s].filterblock_configuration.val.i,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4157,6 +4157,8 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
             auto dbls = currentSkin->standardHoverAndHoverOnForIDB(IDB_MENU_AS_SLIDER, bitmapStore);
             hs->setBackgroundDrawable(dbls[0]);
             hs->setHoverBackgroundDrawable(dbls[1]);
+            hs->setDeactivatedFn([p]() { return p->appears_deactivated(); });
+
             setAccessibilityInformationByParameter(hs.get(), p, "Adjust");
             param[p->id] = hs.get();
             frame->getControlGroupLayer(p->ctrlgroup)->addAndMakeVisible(*hs);
@@ -4694,6 +4696,7 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
         hsw->setStorage(&(synth->storage));
         hsw->setBounds(rect);
         hsw->setValue(p->get_value_f01());
+        hsw->setDeactivated(p->appears_deactivated());
         p->ctrlstyle = p->ctrlstyle | kNoPopup;
 
         setAccessibilityInformationByParameter(hsw.get(), p, "Select");
@@ -4704,7 +4707,6 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
 
         hsw->setMinMax(0, n_fu_types - 1);
         hsw->setLabel(p->get_name());
-        hsw->setDeactivated(false);
 
         auto pv = currentSkin->propertyValue(skinCtrl, Surge::Skin::Component::BACKGROUND);
         if (pv.has_value())
@@ -4796,6 +4798,8 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
         waveshaperSelector->setTag(p->id + start_paramtags);
         waveshaperSelector->setBounds(rect);
         waveshaperSelector->setValue(p->get_value_f01());
+
+        waveshaperSelector->setDeactivated(p->appears_deactivated());
 
         auto *parm = dynamic_cast<ParameterDiscreteIndexRemapper *>(p->user_data);
         if (parm && parm->supportsTotalIndexOrdering())

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1354,6 +1354,20 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                 makeMonoModeOptionsMenu(menuRect, false));
                         }
                     }
+
+                    if (p->can_deactivate())
+                    {
+                        contextMenu.addSeparator();
+                        std::string txt = "Deactivate";
+                        if (p->deactivated)
+                        {
+                            txt = "Activate";
+                        }
+                        contextMenu.addItem(txt, [this, p]() {
+                            p->deactivated = !p->deactivated;
+                            this->synth->refresh_editor = true;
+                        });
+                    }
                 }
             }
 

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -89,11 +89,16 @@ void MenuForDiscreteParams::paint(juce::Graphics &g)
             g.reduceClipRegion(glyphBox);
             if (dragGlyph)
             {
-                dragGlyph->draw(g, 1.0, gt);
+                auto opacity = 1.0;
+                if ((hasDeactivatedFn && isDeactivatedFn()) || isDeactivated)
+                {
+                    opacity = 0.5;
+                }
+                dragGlyph->draw(g, opacity, gt);
 
                 if (isHovered && dragGlyphHover)
                 {
-                    dragGlyphHover->draw(g, 1.0, gt);
+                    dragGlyphHover->draw(g, opacity, gt);
                 }
             }
             else
@@ -110,6 +115,10 @@ void MenuForDiscreteParams::paint(juce::Graphics &g)
         if (isHovered)
         {
             valcol = skin->getColor(Colors::Menu::FilterValueHover);
+        }
+        if ((hasDeactivatedFn && isDeactivatedFn()) || isDeactivated)
+        {
+            valcol = valcol.withAlpha(0.5f);
         }
         g.setColour(valcol);
         g.drawText(dt, r, juce::Justification::centredLeft);
@@ -130,7 +139,7 @@ void MenuForDiscreteParams::paint(juce::Graphics &g)
             labcol = skin->getColor(Colors::Menu::NameHover);
             valcol = skin->getColor(Colors::Menu::ValueHover);
         }
-        if (isDeactivated)
+        if ((hasDeactivatedFn && isDeactivatedFn()) || isDeactivated)
         {
             labcol = skin->getColor(Colors::Menu::NameDeactivated);
             valcol = skin->getColor(Colors::Menu::ValueDeactivated);

--- a/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
@@ -23,6 +23,7 @@ WaveShaperSelector::~WaveShaperSelector() {}
 
 void WaveShaperSelector::paint(juce::Graphics &g)
 {
+    float dOpacity = (isDeactivated ? 0.5 : 1.0);
     if (wsCurves[iValue].empty())
     {
         /*
@@ -88,11 +89,11 @@ void WaveShaperSelector::paint(juce::Graphics &g)
 
     if (isLabelHovered)
     {
-        g.setColour(skin->getColor(Colors::Waveshaper::TextHover));
+        g.setColour(skin->getColor(Colors::Waveshaper::TextHover).withAlpha(dOpacity));
     }
     else
     {
-        g.setColour(skin->getColor(Colors::Waveshaper::Text));
+        g.setColour(skin->getColor(Colors::Waveshaper::Text).withAlpha(dOpacity));
     }
 
     g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(7));
@@ -147,9 +148,9 @@ void WaveShaperSelector::paint(juce::Graphics &g)
 
         g.reduceClipRegion(waveArea);
         if (isWaveHovered)
-            g.setColour(skin->getColor(Colors::Waveshaper::Display::WaveHover));
+            g.setColour(skin->getColor(Colors::Waveshaper::Display::WaveHover).withAlpha(dOpacity));
         else
-            g.setColour(skin->getColor(Colors::Waveshaper::Display::Wave));
+            g.setColour(skin->getColor(Colors::Waveshaper::Display::Wave).withAlpha(dOpacity));
         g.strokePath(curvePath, juce::PathStrokeType{iValue == wst_none ? 0.6f : 1.f}, xf);
     }
 }

--- a/src/surge-xt/gui/widgets/WaveShaperSelector.h
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.h
@@ -101,7 +101,8 @@ struct WaveShaperSelector : public juce::Component, public WidgetBaseMixin<WaveS
 
     SurgeImage *bg{nullptr}, *bgHover{nullptr};
     void onSkinChanged() override;
-    bool isLabelHovered{false}, isWaveHovered{false};
+    bool isLabelHovered{false}, isWaveHovered{false}, isDeactivated{false};
+    void setDeactivated(bool b) { isDeactivated = b; }
 
 #if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;


### PR DESCRIPTION
Filters and Waveshapers can be deactivated. I used
the consistent UI gesture of RMB/Deactivate RMB/Activate
and opacity .5 the associated widgets when deactivated.

Addresses #5134. Probably good enough to call it done too
but i bet we will do some UI tweaks like explicit colors and
stuff.