### PR TITLE
FX Menu Tweaks

### DIFF
--- a/resources/surge-shared/configuration.xml
+++ b/resources/surge-shared/configuration.xml
@@ -38,7 +38,6 @@
 </type>
 </osc>
 <fx>
-<type i="0" name="Off"/>
 <sectionheader label="FILTERING"/>
 <type i="6" name="EQ">
     <snapshot name="Init" p0="0.000000" p1="-27.251785" p2="2.000000" p3="0.000000" p4="6.000000" p5="2.000000"
@@ -95,9 +94,7 @@
     <snapshot name="Init" p0="0" p1="-96" p2="0" p3="0" p5="20" p6="-15.4741" p7="49.0958" p8="0" p9="0" p10="0"
               p11="1"/>
 </type>
-<sectionheader label="" columnbreak="1"/>
-<type i="-1" name=""/>
-<sectionheader label="MODULATION"/>
+<sectionheader label="MODULATION" columnbreak="1"/>
 <type i="9" name="Chorus">
     <snapshot name="Init (Dry)" p0="-7.885717" p1="-2.850000" p2="0.669643" p3="0.000000" p4="-23.625008" p5="65.662498"
               p6="0.500000"/>

--- a/src/common/FxPresetAndClipboardManager.cpp
+++ b/src/common/FxPresetAndClipboardManager.cpp
@@ -385,6 +385,7 @@ void copyFx(SurgeStorage *storage, FxStorage *fx, Clipboard &cb)
     }
 }
 
+bool isPasteAvailable(const Clipboard &cb) { return !cb.fxCopyPaste.empty(); }
 void pasteFx(SurgeStorage *storage, FxStorage *fxbuffer, Clipboard &cb)
 {
     if (cb.fxCopyPaste.empty())

--- a/src/common/FxPresetAndClipboardManager.h
+++ b/src/common/FxPresetAndClipboardManager.h
@@ -77,6 +77,7 @@ struct Clipboard
     std::vector<float> fxCopyPaste;
 };
 void copyFx(SurgeStorage *, FxStorage *from, Clipboard &cb);
+bool isPasteAvailable(const Clipboard &cb);
 void pasteFx(SurgeStorage *, FxStorage *onto, Clipboard &cb);
 } // namespace FxClipboard
 } // namespace Surge


### PR DESCRIPTION
1. Move 'Off' to 'Initialize'
2. Don't show Paste if theirs nothin to be pastin
3. Add a help to the end of the menu, like in
   patch selector and wavetable and stuff