### PR TITLE
Add MS Tool Effect

### DIFF
--- a/doc/Adding An FX.md
+++ b/doc/Adding An FX.md
@@ -1,4 +1,4 @@
-# How to add a effect
+# How to add an effect
 
 This tutorial will demonstrate how to add an example effect called `MyEffect`.
 
@@ -8,7 +8,7 @@ This tutorial will demonstrate how to add an example effect called `MyEffect`.
      and `init_default_values()` to set the default parameter values.
    * The guts of your signal processing should go in the `process()` function.
 
-2. In `Effect.cpp` add the newly created header file to the list of includes at the top.
+2. In `src/common/dsp/Effect.cpp` add the newly created header file to the list of includes at the top.
    Then in `spawn_effect()` add a case to spawn your new effect:
 
 ```cpp
@@ -25,15 +25,14 @@ Note that we have chosen the effect ID `fxt_myeffect` for our example effect.
   Verify if this fits properly in the FX grid boxes on the GUI!
 
 4. In `resources/surge-shared/configuration.xml` add your effect to the `fx` XML group.
-   Later, you may also add snapshots for presets of your effect.
+   Later, you may also add snapshots for presets of your effect. 
+   `"init"` goes here, create any further factory presets in `resources/data/fx_presets`   
 
-5. In `src/common/CMakeLists.txt`, add path to your .cpp under `SURGE_SHARED_SOURCES`,
+5. In `src/common/CMakeLists.txt`, add the path to your .cpp and .h under `add_library`,
    search the file for `Chorus` for example, to see where it goes.
    Please place your effect in alphabetical order here.
 
-Note that the configuration file DOES NOT automatically reload when you compile and run the plugin!
-Whenever you make changes to this file, you must copy it to the correct "installed" location where
-the plugin is expecting to find it. You can find this file by opening the factory data folder
-(`Menu > Data Folders > Open Factory Data Folder...`).
+Note that the configuration file DOES NOW automatically reload when you compile and run the plugin!
+(A full build may be required though)
 
-Then you can finish coding up your effect!
+Now you can finish coding up your effect!

--- a/resources/data/fx_presets/MS Tool/MS Decode(-6dB).srgfx
+++ b/resources/data/fx_presets/MS Tool/MS Decode(-6dB).srgfx
@@ -1,0 +1,23 @@
+<single-fx streaming_version="17">
+  <snapshot name="MS Decode(-6dB)" 
+     type="26"
+     p0="2"
+     p1="-60"
+     p1_deactivated="1"
+     p2="0"
+     p2_deactivated="1"
+     p3="-6.63049"
+     p4="70"
+     p4_deactivated="1"
+     p5="-60"
+     p5_deactivated="1"
+     p6="0"
+     p6_deactivated="1"
+     p7="50.2131"
+     p8="70"
+     p8_deactivated="1"
+     p9="-6"
+     p10="-6"
+     p11="0"
+  />
+</single-fx>

--- a/resources/data/fx_presets/MS Tool/MS Decode.srgfx
+++ b/resources/data/fx_presets/MS Tool/MS Decode.srgfx
@@ -1,0 +1,23 @@
+<single-fx streaming_version="17">
+  <snapshot name="MS Decode" 
+     type="26"
+     p0="2"
+     p1="-60"
+     p1_deactivated="1"
+     p2="0"
+     p2_deactivated="1"
+     p3="-6.63049"
+     p4="70"
+     p4_deactivated="1"
+     p5="-60"
+     p5_deactivated="1"
+     p6="0"
+     p6_deactivated="1"
+     p7="50.2131"
+     p8="70"
+     p8_deactivated="1"
+     p9="0"
+     p10="0"
+     p11="0"
+  />
+</single-fx>

--- a/resources/data/fx_presets/MS Tool/MS EQ.srgfx
+++ b/resources/data/fx_presets/MS Tool/MS EQ.srgfx
@@ -1,0 +1,17 @@
+<single-fx streaming_version="17">
+  <snapshot name="MS EQ" 
+     type="26"
+     p0="0"
+     p1="-60"
+     p2="0"
+     p3="-6.63049"
+     p4="70"
+     p5="-60"
+     p6="0"
+     p7="50.2131"
+     p8="70"
+     p9="0"
+     p10="0"
+     p11="0"
+  />
+</single-fx>

--- a/resources/data/fx_presets/MS Tool/MS Encode.srgfx
+++ b/resources/data/fx_presets/MS Tool/MS Encode.srgfx
@@ -1,0 +1,23 @@
+<single-fx streaming_version="17">
+  <snapshot name="MS Encode" 
+     type="26"
+     p0="1"
+     p1="-60"
+     p1_deactivated="1"
+     p2="0"
+     p2_deactivated="1"
+     p3="-6.63049"
+     p4="70"
+     p4_deactivated="1"
+     p5="-60"
+     p5_deactivated="1"
+     p6="0"
+     p6_deactivated="1"
+     p7="50.2131"
+     p8="70"
+     p8_deactivated="1"
+     p9="0"
+     p10="0"
+     p11="0"
+  />
+</single-fx>

--- a/resources/data/fx_presets/MS Tool/Tight Bass.srgfx
+++ b/resources/data/fx_presets/MS Tool/Tight Bass.srgfx
@@ -1,0 +1,22 @@
+<single-fx streaming_version="17">
+  <snapshot name="Tight Bass" 
+     type="26"
+     p0="0"
+     p1="-60"
+     p1_deactivated="1"
+     p2="0"
+     p2_deactivated="1"
+     p3="-6.63049"
+     p4="70"
+     p4_deactivated="1"
+     p5="-31.8249"
+     p6="0"
+     p6_deactivated="1"
+     p7="50.2131"
+     p8="70"
+     p8_deactivated="1"
+     p9="0"
+     p10="0"
+     p11="0"
+  />
+</single-fx>

--- a/resources/surge-shared/configuration.xml
+++ b/resources/surge-shared/configuration.xml
@@ -49,6 +49,11 @@
 <type i="16" name="Graphic EQ">
     <snapshot name="Init" p0="0" p1="0" p2="0" p3="0" p4="0" p5="0" p6="0" p7="0" p8="0" p9="0" p10="0" p11="0"/>
 </type>
+<type i="26" name="MS Tool">
+    <snapshot name="Init" p0="0" p1="-60" p1_deactivated="1" p2="0" p2_deactivated="1" p3="-6.63049" p4="70"  
+              p4_deactivated="1" p5="-60" p5_deactivated="1" p6="0" p6_deactivated="1" p7="50.2131" p8="70" 
+              p8_deactivated="1" p9="0" p10="0" p11="0"/>
+</type>
 <type i="17" name="Resonator">
     <snapshot name="Init" p0="-18.6305" p1="0.75" p2="0.793701" p3="8.03822" p4="0.75" p5="0.793701" p6="35.9013"
               p7="0.75" p8="0.793701" p9="1" p10="0" p11="1"/>

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -98,6 +98,8 @@ add_library(${PROJECT_NAME}
   dsp/effects/GraphicEQ11BandEffect.cpp
   dsp/effects/GraphicEQ11BandEffect.h
   dsp/effects/ModControl.h
+  dsp/effects/MSToolEffect.cpp
+  dsp/effects/MSToolEffect.h
   dsp/effects/NimbusEffect.cpp
   dsp/effects/NimbusEffect.h
   dsp/effects/ParametricEQ3BandEffect.cpp

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -4,7 +4,7 @@
 ** Surge is made available under the Gnu General Public License, v3.0
 ** https://www.gnu.org/licenses/gpl-3.0.en.html
 **
-** Copyright 2004-2020 by various individuals as described by the Git transaction log
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
 **
 ** All source at: https://github.com/surge-synthesizer/surge.git
 **
@@ -443,6 +443,7 @@ bool Parameter::is_discrete_selection() const
     case ct_ensemble_stages:
     case ct_alias_wave:
     case ct_wstype:
+    case ct_mscodec:
         return true;
     default:
         break;
@@ -458,6 +459,7 @@ bool Parameter::is_nonlocal_on_change() const
     case ct_twist_engine:
     case ct_phaser_stages:
     case ct_nimbusmode:
+    case ct_mscodec:
         return true;
     default:
         break;
@@ -689,6 +691,12 @@ void Parameter::set_type(int ctrltype)
         valtype = vt_float;
         val_min.f = -96;
         val_max.f = 0;
+        val_default.f = 0;
+        break;
+    case ct_decibel_attenuation_plus12:
+        valtype = vt_float;
+        val_min.f = -48;
+        val_max.f = 12;
         val_default.f = 0;
         break;
     case ct_decibel_fmdepth:
@@ -1037,6 +1045,12 @@ void Parameter::set_type(int ctrltype)
     case ct_distortion_waveshape:
         val_min.i = 0;
         val_max.i = n_fxws - 1;
+        valtype = vt_int;
+        val_default.i = 0;
+        break;
+    case ct_mscodec:
+        val_min.i = 0;
+        val_max.i = 2;
         valtype = vt_int;
         val_default.i = 0;
         break;
@@ -1407,6 +1421,7 @@ void Parameter::set_type(int ctrltype)
     case ct_decibel_attenuation:
     case ct_decibel_attenuation_clipper:
     case ct_decibel_attenuation_large:
+    case ct_decibel_attenuation_plus12:
     case ct_decibel_fmdepth:
     case ct_decibel_narrow:
     case ct_decibel_extra_narrow:
@@ -1662,6 +1677,7 @@ void Parameter::bound_value(bool force_integer)
         case ct_decibel_attenuation:
         case ct_decibel_attenuation_clipper:
         case ct_decibel_attenuation_large:
+        case ct_decibel_attenuation_plus12:
         case ct_decibel_fmdepth:
         case ct_decibel_extendable:
         case ct_decibel_deactivatable:
@@ -3399,6 +3415,20 @@ void Parameter::get_display(char *txt, bool external, float ef) const
         case ct_distortion_waveshape:
             snprintf(txt, TXT_SIZE, "%s", wst_names[FXWaveShapers[i]]);
             break;
+        case ct_mscodec:
+            switch (i)
+            {
+            case 0:
+                snprintf(txt, TXT_SIZE, "LR -> MS -> LR");
+                break;
+            case 1:
+                snprintf(txt, TXT_SIZE, "LR -> MS");
+                break;
+            case 2:
+                snprintf(txt, TXT_SIZE, "MS -> LR");
+                break;
+            }
+            break;
         case ct_oscroute:
             switch (i)
             {
@@ -3802,6 +3832,7 @@ bool Parameter::can_setvalue_from_string() const
     case ct_decibel_attenuation:
     case ct_decibel_attenuation_clipper:
     case ct_decibel_attenuation_large:
+    case ct_decibel_attenuation_plus12:
     case ct_decibel_fmdepth:
     case ct_decibel_extendable:
     case ct_decibel_deactivatable:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -4,7 +4,7 @@
 ** Surge is made available under the Gnu General Public License, v3.0
 ** https://www.gnu.org/licenses/gpl-3.0.en.html
 **
-** Copyright 2004-2020 by various individuals as described by the Git transaction log
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
 **
 ** All source at: https://github.com/surge-synthesizer/surge.git
 **
@@ -64,6 +64,7 @@ enum ctrltypes
     ct_decibel_attenuation,
     ct_decibel_attenuation_clipper,
     ct_decibel_attenuation_large,
+    ct_decibel_attenuation_plus12,
     ct_decibel_fmdepth,
     ct_decibel_extendable,
     ct_decibel_deactivatable,
@@ -180,6 +181,7 @@ enum ctrltypes
     ct_tape_microns,
     ct_tape_speed,
     ct_lfophaseshuffle,
+    ct_mscodec,
     num_ctrltypes,
 };
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -298,19 +298,22 @@ enum fx_type
     fxt_tape,
     fxt_treemonster,
     fxt_waveshaper,
+    fxt_mstool,
 
     n_fx_types,
 };
 
 const char fx_type_names[n_fx_types][16] = {
-    "Off",        "Delay",       "Reverb 1",   "Phaser",      "Rotary",    "Distortion", "EQ",
-    "Freq Shift", "Conditioner", "Chorus",     "Vocoder",     "Reverb 2",  "Flanger",    "Ring Mod",
-    "Airwindows", "Neuron",      "Graphic EQ", "Resonator",   "CHOW",      "Exciter",    "Ensemble",
-    "Combulator", "Nimbus",      "Tape",       "Treemonster", "Waveshaper"};
+    "Off",         "Delay",      "Reverb 1",    "Phaser",     "Rotary",     "Distortion",
+    "EQ",          "Freq Shift", "Conditioner", "Chorus",     "Vocoder",    "Reverb 2",
+    "Flanger",     "Ring Mod",   "Airwindows",  "Neuron",     "Graphic EQ", "Resonator",
+    "CHOW",        "Exciter",    "Ensemble",    "Combulator", "Nimbus",     "Tape",
+    "Treemonster", "Waveshaper", "MS Tool"};
 
-const char fx_type_shortnames[n_fx_types][8] = {
-    "OFF", "DLY", "RV1", "PH",  "ROT", "DIST", "EQ",  "FRQ", "DYN", "CH",  "VOC",  "RV2", "FL",
-    "RM",  "AW",  "NEU", "GEQ", "RES", "CHW",  "XCT", "ENS", "CMB", "NIM", "TAPE", "TM",  "WS"};
+const char fx_type_shortnames[n_fx_types][8] = {"OFF", "DLY", "RV1",  "PH",  "ROT", "DIST", "EQ",
+                                                "FRQ", "DYN", "CH",   "VOC", "RV2", "FL",   "RM",
+                                                "AW",  "NEU", "GEQ",  "RES", "CHW", "XCT",  "ENS",
+                                                "CMB", "NIM", "TAPE", "TM",  "WS",  "MS"};
 
 enum fx_bypass
 {

--- a/src/common/dsp/Effect.cpp
+++ b/src/common/dsp/Effect.cpp
@@ -7,6 +7,7 @@
 #include "FlangerEffect.h"
 #include "FrequencyShifterEffect.h"
 #include "GraphicEQ11BandEffect.h"
+#include "MSToolEffect.h"
 #include "NimbusEffect.h"
 #include "ParametricEQ3BandEffect.h"
 #include "PhaserEffect.h"
@@ -83,6 +84,8 @@ Effect *spawn_effect(int id, SurgeStorage *storage, FxStorage *fxdata, pdata *pd
         return new TreemonsterEffect(storage, fxdata, pd);
     case fxt_waveshaper:
         return new WaveShaperEffect(storage, fxdata, pd);
+    case fxt_mstool:
+        return new MSToolEffect(storage, fxdata, pd);
     default:
         return 0;
     };

--- a/src/common/dsp/effects/MSToolEffect.cpp
+++ b/src/common/dsp/effects/MSToolEffect.cpp
@@ -1,0 +1,298 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "MSToolEffect.h"
+#include "Parameter.h"
+#include "SurgeStorage.h"
+#include <vembertech/basic_dsp.h>
+
+MSToolEffect::MSToolEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd)
+    : Effect(storage, fxdata, pd), hpm(storage), hps(storage), lpm(storage), lps(storage),
+      bandm(storage), bands(storage)
+{
+    ampM.set_blocksize(BLOCK_SIZE);
+    ampS.set_blocksize(BLOCK_SIZE);
+    postampL.set_blocksize(BLOCK_SIZE);
+    postampR.set_blocksize(BLOCK_SIZE);
+
+    hpm.setBlockSize(BLOCK_SIZE * slowrate);
+    bandm.setBlockSize(BLOCK_SIZE * slowrate);
+    lpm.setBlockSize(BLOCK_SIZE * slowrate);
+    hps.setBlockSize(BLOCK_SIZE * slowrate);
+    bands.setBlockSize(BLOCK_SIZE * slowrate);
+    lps.setBlockSize(BLOCK_SIZE * slowrate);
+}
+
+MSToolEffect::~MSToolEffect() {}
+
+void MSToolEffect::init()
+{
+    setvars(true);
+    hpm.suspend();
+    bandm.suspend();
+    lpm.suspend();
+    hps.suspend();
+    bands.suspend();
+    lps.suspend();
+}
+
+void MSToolEffect::setvars(bool init)
+{
+
+    if (init)
+    {
+        bandm.coeff_peakEQ(bandm.calc_omega(*f[mstl_freqm] * (1.f / 12.f)), 1, 1.f);
+        bands.coeff_peakEQ(bands.calc_omega(*f[mstl_freqs] * (1.f / 12.f)), 1, 1.f);
+
+        hpm.coeff_instantize();
+        bandm.coeff_instantize();
+        lpm.coeff_instantize();
+        hps.coeff_instantize();
+        bands.coeff_instantize();
+        lps.coeff_instantize();
+
+        ampM.set_target(1.f);
+        ampS.set_target(1.f);
+        postampL.set_target(-1.f);
+        postampR.set_target(1.f);
+
+        ampM.instantize();
+        ampS.instantize();
+        postampL.instantize();
+        postampR.instantize();
+    }
+    else
+    {
+        hpm.coeff_HP(hpm.calc_omega(*f[mstl_hpm] / 12.0), 0.4);
+        bandm.coeff_peakEQ(bandm.calc_omega(*f[mstl_freqm] * (1.f / 12.f)), 1, *f[mstl_pqm]);
+        lpm.coeff_LP(lpm.calc_omega(*f[mstl_lpm] / 12.0), 0.4);
+        hps.coeff_HP(hps.calc_omega(*f[mstl_hps] / 12.0), 0.4);
+        bands.coeff_peakEQ(bands.calc_omega(*f[mstl_freqs] * (1.f / 12.f)), 1, *f[mstl_pqs]);
+        lps.coeff_LP(lps.calc_omega(*f[mstl_lps] / 12.0), 0.4);
+    }
+}
+
+void MSToolEffect::process(float *dataL, float *dataR)
+{
+    setvars(false);
+
+    ampM.set_target_smoothed(db_to_linear(*f[mstl_mgain]));
+    ampS.set_target_smoothed(db_to_linear(*f[mstl_sgain]));
+    postampL.set_target_smoothed(clamp1bp(1 - *f[mstl_outgain]));
+    postampR.set_target_smoothed(clamp1bp(1 + *f[mstl_outgain]));
+
+    float M alignas(16)[BLOCK_SIZE], S alignas(16)[BLOCK_SIZE];
+
+    int io = (fxdata->p[mstl_matrix].val.i);
+    switch (io)
+    {
+    case 0:
+        encodeMS(dataL, dataR, M, S, BLOCK_SIZE_QUAD);
+        break;
+    case 1:
+        encodeMS(dataL, dataR, M, S, BLOCK_SIZE_QUAD);
+        break;
+    case 2:
+        copy_block(dataL, M, BLOCK_SIZE_QUAD);
+        copy_block(dataR, S, BLOCK_SIZE_QUAD);
+        break;
+    }
+
+    if (!fxdata->p[mstl_hpm].deactivated)
+        hpm.process_block(M);
+    if (!fxdata->p[mstl_pqm].deactivated)
+        bandm.process_block(M);
+    if (!fxdata->p[mstl_lpm].deactivated)
+        lpm.process_block(M);
+
+    if (!fxdata->p[mstl_hps].deactivated)
+        hps.process_block(S);
+    if (!fxdata->p[mstl_pqs].deactivated)
+        bands.process_block(S);
+    if (!fxdata->p[mstl_lps].deactivated)
+        lps.process_block(S);
+
+    ampM.multiply_block(M, BLOCK_SIZE_QUAD);
+    ampS.multiply_block(S, BLOCK_SIZE_QUAD);
+
+    switch (io)
+    {
+    case 0:
+        decodeMS(M, S, dataL, dataR, BLOCK_SIZE_QUAD);
+        break;
+    case 1:
+        copy_block(M, dataL, BLOCK_SIZE_QUAD);
+        copy_block(S, dataR, BLOCK_SIZE_QUAD);
+        break;
+    case 2:
+        decodeMS(M, S, dataL, dataR, BLOCK_SIZE_QUAD);
+        break;
+    }
+
+    postampL.multiply_block(dataL, BLOCK_SIZE_QUAD);
+    postampR.multiply_block(dataR, BLOCK_SIZE_QUAD);
+}
+
+const char *MSToolEffect::group_label(int id)
+{
+    switch (id)
+    {
+    case 0:
+        return "MS Options";
+    case 1:
+        return "Filter M";
+    case 2:
+        return "Filter S";
+    case 3:
+        return "Output";
+    }
+    return 0;
+}
+
+int MSToolEffect::group_label_ypos(int id)
+{
+    switch (id)
+    {
+    case 0:
+        return 1;
+    case 1:
+        return 5;
+    case 2:
+        return 15;
+    case 3:
+        return 25;
+    }
+    return 0;
+}
+
+void MSToolEffect::suspend() { init(); }
+
+void MSToolEffect::init_ctrltypes()
+{
+    // using deactivation function from EQ3
+    static struct EQD : public ParameterDynamicDeactivationFunction
+    {
+        const bool getValue(const Parameter *p) const override
+        {
+            auto fx = &(p->storage->getPatch().fx[p->ctrlgroup_entry]);
+            auto idx = p - fx->p;
+
+            switch (idx)
+            {
+            case mstl_freqm:
+                return fx->p[mstl_pqm].deactivated;
+            case mstl_freqs:
+                return fx->p[mstl_pqs].deactivated;
+            }
+
+            return false;
+        }
+        Parameter *getPrimaryDeactivationDriver(const Parameter *p) const override
+        {
+            auto fx = &(p->storage->getPatch().fx[p->ctrlgroup_entry]);
+            auto idx = p - fx->p;
+
+            switch (idx)
+            {
+            case mstl_freqm:
+                return &(fx->p[mstl_pqm]);
+            case mstl_freqs:
+                return &(fx->p[mstl_pqs]);
+            }
+            return nullptr;
+        }
+    } eqGroupDeact;
+
+    Effect::init_ctrltypes();
+
+    fxdata->p[mstl_matrix].set_name("Matrix");
+    fxdata->p[mstl_matrix].set_type(ct_mscodec);
+
+    fxdata->p[mstl_hpm].set_name("HP M");
+    fxdata->p[mstl_hpm].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[mstl_pqm].set_name("Peak M");
+    fxdata->p[mstl_pqm].set_type(ct_decibel_narrow_deactivatable);
+    fxdata->p[mstl_freqm].set_name("Freq M");
+    fxdata->p[mstl_freqm].set_type(ct_freq_audible);
+    fxdata->p[mstl_freqm].dynamicDeactivation = &eqGroupDeact;
+    fxdata->p[mstl_lpm].set_name("LP M");
+    fxdata->p[mstl_lpm].set_type(ct_freq_audible_deactivatable);
+
+    fxdata->p[mstl_hps].set_name("HP S");
+    fxdata->p[mstl_hps].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[mstl_pqs].set_name("Peak S");
+    fxdata->p[mstl_pqs].set_type(ct_decibel_narrow_deactivatable);
+    fxdata->p[mstl_freqs].set_name("Freq S");
+    fxdata->p[mstl_freqs].set_type(ct_freq_audible);
+    fxdata->p[mstl_freqs].dynamicDeactivation = &eqGroupDeact;
+    fxdata->p[mstl_lps].set_name("LP S");
+    fxdata->p[mstl_lps].set_type(ct_freq_audible_deactivatable);
+
+    fxdata->p[mstl_mgain].set_name("Gain M");
+    fxdata->p[mstl_mgain].set_type(ct_decibel_attenuation_plus12);
+    fxdata->p[mstl_sgain].set_name("Gain S");
+    fxdata->p[mstl_sgain].set_type(ct_decibel_attenuation_plus12);
+    fxdata->p[mstl_outgain].set_name("Balance L/R");
+    fxdata->p[mstl_outgain].set_type(ct_percent_bipolar);
+
+    fxdata->p[mstl_matrix].posy_offset = 1;
+
+    fxdata->p[mstl_hpm].posy_offset = 3;
+    fxdata->p[mstl_pqm].posy_offset = 3;
+    fxdata->p[mstl_freqm].posy_offset = 3;
+    fxdata->p[mstl_lpm].posy_offset = 3;
+
+    fxdata->p[mstl_hps].posy_offset = 5;
+    fxdata->p[mstl_pqs].posy_offset = 5;
+    fxdata->p[mstl_freqs].posy_offset = 5;
+    fxdata->p[mstl_lps].posy_offset = 5;
+
+    fxdata->p[mstl_mgain].posy_offset = 7;
+    fxdata->p[mstl_sgain].posy_offset = 7;
+    fxdata->p[mstl_outgain].posy_offset = 7;
+}
+
+void MSToolEffect::init_default_values()
+{
+    fxdata->p[mstl_matrix].val.i = 0;
+
+    fxdata->p[mstl_hpm].val.f = -60;
+    fxdata->p[mstl_hpm].deactivated = true;
+    fxdata->p[mstl_pqm].val.f = 0;
+    fxdata->p[mstl_pqm].deactivated = true;
+    fxdata->p[mstl_freqm].val.f = -6.63049;
+    fxdata->p[mstl_lpm].val.f = 70;
+    fxdata->p[mstl_lpm].deactivated = true;
+
+    fxdata->p[mstl_hps].val.f = -60;
+    fxdata->p[mstl_hps].deactivated = true;
+    fxdata->p[mstl_pqs].val.f = 0;
+    fxdata->p[mstl_pqs].deactivated = true;
+    fxdata->p[mstl_freqs].val.f = 50.2131;
+    fxdata->p[mstl_lps].val.f = 70;
+    fxdata->p[mstl_lps].deactivated = true;
+
+    fxdata->p[mstl_mgain].val.f = 0;
+    fxdata->p[mstl_sgain].val.f = 0;
+    fxdata->p[mstl_outgain].val.f = 0;
+}
+
+void MSToolEffect::handleStreamingMismatches(int streamingRevision,
+                                             int currentSynthStreamingRevision)
+{
+    if (streamingRevision <= 17)
+    {
+    }
+}

--- a/src/common/dsp/effects/MSToolEffect.h
+++ b/src/common/dsp/effects/MSToolEffect.h
@@ -1,0 +1,60 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#pragma once
+#include "Effect.h"
+#include "BiquadFilter.h"
+#include "DSPUtils.h"
+#include <vembertech/lipol.h>
+
+class MSToolEffect : public Effect
+{
+    lipol_ps ampM alignas(16), ampS alignas(16), width alignas(16), postampL alignas(16),
+        postampR alignas(16);
+
+  public:
+    MSToolEffect(SurgeStorage *storage, FxStorage *fxdata, pdata *pd);
+    virtual ~MSToolEffect();
+    virtual const char *get_effectname() override { return "MS Tool"; }
+    virtual void init() override;
+    virtual void process(float *dataL, float *dataR) override;
+    virtual void suspend() override;
+    void setvars(bool init);
+    virtual void init_ctrltypes() override;
+    virtual void init_default_values() override;
+    virtual const char *group_label(int id) override;
+    virtual int group_label_ypos(int id) override;
+
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
+    enum mstl_params
+    {
+        mstl_matrix = 0,
+        mstl_hpm,
+        mstl_pqm,
+        mstl_freqm,
+        mstl_lpm,
+        mstl_hps,
+        mstl_pqs,
+        mstl_freqs,
+        mstl_lps,
+        mstl_mgain,
+        mstl_sgain,
+        mstl_outgain,
+    };
+
+  private:
+    BiquadFilter hpm, hps, lpm, lps, bandm, bands;
+};


### PR DESCRIPTION
This attempts to solve issue #3596 and expands the idea a little.
- It has switchable I/O (LR->MS->LR, LR->MS, MS->LR)
- HP, LP and a semi parametric band per M and S channel
  (each activatable)
- separate gain for M/S
- L/R balance

possible use cases:
- sandwich fx between en- and decoder
- decode sources defined as m/s (2 oscillators or scenes)
  (incl. the option to mono low frequencies that was requested in the issue)
- eq/filter mid and side channels of l/r-stereo content
- etc.

It is currently in  a state where I'd like to hear opinions
and ask for a review

Adresses #3596