### PR TITLE
A bunch of UI/UX fixes

### DIFF
--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -566,7 +566,7 @@ Connector vu_meter =
 Connector mseg_editor = Connector("msegeditor.window", 0, 57, 750, 365, Components::Custom,
                                   Connector::MSEG_EDITOR_WINDOW);
 
-Connector store_patch_dialog = Connector("controls.patch.store.window", 157, 57, 390, 220,
+Connector store_patch_dialog = Connector("controls.patch.store.window", 157, 57, 390, 270,
                                          Components::Custom, Connector::STORE_PATCH_DIALOG);
 
 // modulation panel is special, so it shows up as 'CUSTOM' with no connector and is special-cased in

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2751,7 +2751,7 @@ juce::PopupMenu SurgeGUIEditor::makePatchDefaultsMenu(const juce::Point<int> &wh
         txt[0] = 0;
         if (Surge::Storage::isValidUTF8(s))
             strxcpy(txt, s.c_str(), 256);
-        promptForMiniEdit(txt, "Enter default patch author name:", "Set Default Patch Author",
+        promptForMiniEdit(txt, "Enter a default patch author name:", "Set Default Patch Author",
                           where, [this](const std::string &s) {
                               Surge::Storage::updateUserDefaultValue(
                                   &(this->synth->storage), Surge::Storage::DefaultPatchAuthor, s);
@@ -2766,8 +2766,8 @@ juce::PopupMenu SurgeGUIEditor::makePatchDefaultsMenu(const juce::Point<int> &wh
         txt[0] = 0;
         if (Surge::Storage::isValidUTF8(s))
             strxcpy(txt, s.c_str(), 256);
-        promptForMiniEdit(txt, "Enter default patch comment text:", "Set Default Patch Comment",
-                          where, [this](const std::string &s) {
+        promptForMiniEdit(txt, "Enter a default patch comment:", "Set Default Patch Comment", where,
+                          [this](const std::string &s) {
                               Surge::Storage::updateUserDefaultValue(
                                   &(this->synth->storage), Surge::Storage::DefaultPatchComment, s);
                           });
@@ -3274,7 +3274,7 @@ juce::PopupMenu SurgeGUIEditor::makeMidiMenu(const juce::Point<int> &where)
         char msn[256];
         msn[0] = 0;
         promptForMiniEdit(
-            msn, "MIDI Mapping Name", "Save MIDI Mapping", where,
+            msn, "Enter a name for the MIDI mapping:", "Save MIDI Mapping", where,
             [this](const std::string &s) { this->synth->storage.storeMidiMappingToName(s); });
     });
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -352,11 +352,13 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
     if (button.isMiddleButtonDown())
     {
         toggle_mod_editing();
+
         return 1;
     }
 
     juce::Rectangle<int> viewSize;
     auto bvf = control->asJuceComponent();
+
     if (bvf)
     {
         viewSize = bvf->getBounds();
@@ -369,22 +371,24 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
     }
 
     /*
-     * Alright why is this here? Well when we show the macro menu we use the modal version to
+     * Alright why is this here? Well, when we show the macro menu we use the modal version to
      * stop changes happening underneath us. It's the only non-async menu we have and probably
-     * should get fixed. But juce has a thing where RMB / RMB means the modal menus release both
-     * after the second RMB. So the end hover on rmb rmb doesn't work leading to the bug in
-     * 4874. A fix to this is to use an async menu. But I'm hnot sure why i didn't and there's an
-     * incomplete comment that it was for good reason so instead...
+     * should get fixed. But JUCE has a thing where RMB RMB means the modal menus release both
+     * after the second RMB. So the end hover on RMB RMB doesn't work, leading to the bug in
+     * #4874. A fix to this is to use an async menu. But I'm not sure why I didn't and there's an
+     * incomplete comment that it was for good reason, so instead...
      */
     for (const auto &g : gui_modsrc)
     {
         if (g && g.get() != control)
+        {
             g->endHover();
+        }
     }
 
     long tag = control->getTag();
 
-    if (button.isCtrlDown() && (tag == tag_mp_patch || tag == tag_mp_category))
+    if (button.isCommandDown() && (tag == tag_mp_patch || tag == tag_mp_category))
     {
         synth->selectRandomPatch();
         return 1;
@@ -1014,7 +1018,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         }
     }
 
-    if (!(button.isRightButtonDown() || button.isCtrlDown() || isDoubleClickEvent))
+    if (!(button.isRightButtonDown() || isDoubleClickEvent))
     {
         return 0;
     }
@@ -2276,7 +2280,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             }
         }
         // exclusive mute/solo in the mixer
-        else if (button.isCtrlDown())
+        else if (button.isCommandDown())
         {
             if (p->ctrltype == ct_bool_mute)
             {
@@ -2317,7 +2321,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 synth->refresh_editor = true;
             }
             else
+            {
                 p->bound_value();
+            }
         }
     }
     return 0;
@@ -2337,6 +2343,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
 
     juce::Rectangle<int> viewSize;
     auto bvf = control->asJuceComponent();
+
     if (bvf)
     {
         viewSize = bvf->getBounds();
@@ -2762,7 +2769,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                         thisms = cms->getAlternate();
 #endif
                 }
-                bool quantize_mod = juce::ModifierKeys::currentModifiers.isCtrlDown();
+                bool quantize_mod = juce::ModifierKeys::currentModifiers.isCommandDown();
                 float mv = mci->getModValue();
                 if (quantize_mod)
                 {
@@ -2857,7 +2864,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                     }
                 }
 
-                bool force_integer = juce::ModifierKeys::currentModifiers.isCtrlDown();
+                bool force_integer = juce::ModifierKeys::currentModifiers.isCommandDown();
                 SurgeSynthesizer::ID ptagid;
                 synth->fromSynthSideId(ptag, ptagid);
                 if (synth->setParameter01(ptagid, val, false, force_integer))

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1018,12 +1018,14 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         }
     }
 
-    /* ED: unsure why this is here, it prevents keyboard modifiers from reaching the following
+    /* ED: unsure why this is here, it prevents key modifiers from reaching the following
        section of code? */
-    // if (!(button.isRightButtonDown() || isDoubleClickEvent))
-    //{
-    //    return 0;
-    //}
+    /*
+    if (!(button.isRightButtonDown() || isDoubleClickEvent))
+    {
+        return 0;
+    }
+    */
 
     int ptag = tag - start_paramtags;
 
@@ -2217,11 +2219,15 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 synth->clearModulation(ptag, thisms, current_scene, modsource_index);
                 auto ctrms = dynamic_cast<Surge::Widgets::ModulatableControlInterface *>(control);
                 jassert(ctrms);
+
                 if (ctrms)
                 {
                     auto use_scene = 0;
+
                     if (this->synth->isModulatorDistinctPerScene(thisms))
+                    {
                         use_scene = current_scene;
+                    }
 
                     ctrms->setModValue(
                         synth->getModulation(p->id, thisms, use_scene, modsource_index));
@@ -2230,6 +2236,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         synth->isActiveModulation(p->id, thisms, use_scene, modsource_index));
                     ctrms->setIsModulationBipolar(synth->isBipolarModulation(thisms));
                 }
+
                 oscWaveform->repaint();
 
                 return 0;
@@ -2240,10 +2247,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 {
                 case ct_lfotype:
                     /*
-                    ** This code resets you to default if you double click on control
-                    ** but on the lfoshape UI this is undesirable; it means if you accidentally
-                    ** control click on step sequencer, say, you go back to sin and lose your
-                    ** edits. So supress
+                    ** This code resets you to default if you double-click on control,
+                    ** but on the LFO type widget this is undesirable; it means if you accidentally
+                    ** Control-click on step sequencer, say, you go back to Sine and lose your
+                    ** edits. So supress it!
                     */
                     break;
                 case ct_freq_audible_with_tunability:
@@ -2270,12 +2277,22 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 {
                     p->set_value_f01(p->get_default_value_f01());
                     control->setValue(p->get_value_f01());
+
                     if (oscWaveform && (p->ctrlgroup == cg_OSC))
+                    {
                         oscWaveform->repaint();
+                    }
+
                     if (lfoDisplay && (p->ctrlgroup == cg_LFO))
+                    {
                         lfoDisplay->repaint();
+                    }
+
                     if (bvf)
+                    {
                         bvf->repaint();
+                    }
+
                     return 0;
                 }
                 }
@@ -2328,6 +2345,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             }
         }
     }
+
     return 0;
 }
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1018,10 +1018,12 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         }
     }
 
-    if (!(button.isRightButtonDown() || isDoubleClickEvent))
-    {
-        return 0;
-    }
+    /* ED: unsure why this is here, it prevents keyboard modifiers from reaching the following
+       section of code? */
+    // if (!(button.isRightButtonDown() || isDoubleClickEvent))
+    //{
+    //    return 0;
+    //}
 
     int ptag = tag - start_paramtags;
 

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -110,8 +110,7 @@ void CodeEditorContainerWithApply::codeDocumentTextDeleted(int startIndex, int e
 }
 bool CodeEditorContainerWithApply::keyPressed(const juce::KeyPress &key, juce::Component *o)
 {
-    if (key.getKeyCode() == juce::KeyPress::returnKey &&
-        (key.getModifiers().isCommandDown() || key.getModifiers().isCtrlDown()))
+    if (key.getKeyCode() == juce::KeyPress::returnKey && key.getModifiers().isCommandDown())
     {
         applyCode();
         return true;

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -1651,19 +1651,21 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                  * Activate temporary snap. Note this is also handled similarly in
                  * onMouseMoved so if you change ctrl/alt here change it there too
                  */
-                bool c = e.mods.isCtrlDown();
-#if MAC
-                c = e.mods.isCommandDown();
-#endif
-
+                bool c = e.mods.isCommandDown();
                 bool a = e.mods.isAltDown();
+
                 if (c || a)
                 {
                     snapGuard = std::make_shared<SnapGuard>(this);
+
                     if (c)
+                    {
                         ms->hSnap = ms->hSnapDefault;
+                    }
                     if (a)
+                    {
                         ms->vSnap = ms->vSnapDefault;
+                    }
                 }
                 break;
             }
@@ -2149,15 +2151,13 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
          * Activate temporary snap. Note this is also checked in onMouseDown
          * so if you change ctrl/alt here change it there too
          */
-        bool c = event.mods.isCtrlDown();
-#if MAC
-        c = event.mods.isCommandDown();
-#endif
-
+        bool c = event.mods.isCommandDown();
         bool a = event.mods.isAltDown();
+
         if ((c || a))
         {
             bool wasSnapGuard = true;
+
             if (!snapGuard)
             {
                 wasSnapGuard = false;

--- a/src/surge-xt/gui/overlays/MiniEdit.cpp
+++ b/src/surge-xt/gui/overlays/MiniEdit.cpp
@@ -28,7 +28,7 @@ MiniEdit::MiniEdit()
 {
     typein = std::make_unique<juce::TextEditor>("minieditTypein");
     typein->setJustification(juce::Justification::centred);
-    typein->setFont(Surge::GUI::getFontManager()->getLatoAtSize(10, juce::Font::bold));
+    typein->setFont(Surge::GUI::getFontManager()->getLatoAtSize(11));
     typein->setSelectAllWhenFocused(true);
     typein->setWantsKeyboardFocus(true);
     typein->addListener(this);
@@ -49,7 +49,7 @@ MiniEdit::~MiniEdit() {}
 
 juce::Rectangle<int> MiniEdit::getDisplayRegion()
 {
-    auto fullRect = juce::Rectangle<int>(0, 0, 160, 80).withCentre(getBounds().getCentre());
+    auto fullRect = juce::Rectangle<int>(0, 0, 180, 80).withCentre(getBounds().getCentre());
     return fullRect;
 }
 
@@ -108,27 +108,32 @@ void MiniEdit::onSkinChanged()
                       skin->getColor(Colors::Dialog::Entry::Focus));
     typein->setColour(juce::TextEditor::outlineColourId,
                       skin->getColor(Colors::Dialog::Entry::Border));
+    typein->setColour(juce::TextEditor::focusedOutlineColourId,
+                      skin->getColor(Colors::Dialog::Entry::Border));
+
     repaint();
 }
 
 void MiniEdit::resized()
 {
-    auto eh = 18, mg = 2, bw = 40;
-    auto fullRect = getDisplayRegion();
+    auto typeinHeight = 18, margin = 2, btnWidth = 40;
 
-    auto typeinBox = fullRect.translated(0, 2 * eh + mg * 2)
-                         .withHeight(eh)
-                         .withTrimmedLeft(2 * mg)
-                         .withTrimmedRight(2 * mg);
+    auto fullRect = getDisplayRegion();
+    auto dialogCenter = fullRect.getWidth() / 2;
+    auto typeinBox = fullRect.translated(0, 2 * typeinHeight + margin * 2)
+                         .withHeight(typeinHeight)
+                         .withTrimmedLeft(2 * margin)
+                         .withTrimmedRight(2 * margin);
+
     typein->setBounds(typeinBox);
     typein->setIndents(4, (typein->getHeight() - typein->getTextHeight()) / 2);
 
-    auto buttonRow = fullRect.translated(0, (3 * eh) + (mg * 3) + 2)
-                         .withHeight(eh - 4)
-                         .withTrimmedLeft(mg)
-                         .withTrimmedRight(mg);
-    auto okRect = buttonRow.withTrimmedLeft(40).withWidth(40);
-    auto canRect = buttonRow.withTrimmedLeft(80).withWidth(40);
+    auto buttonRow = fullRect.translated(0, (3 * typeinHeight) + (margin * 3) + 2)
+                         .withHeight(typeinHeight - 4)
+                         .withTrimmedLeft(margin)
+                         .withTrimmedRight(margin);
+    auto okRect = buttonRow.withTrimmedLeft(dialogCenter - btnWidth - margin).withWidth(btnWidth);
+    auto canRect = buttonRow.withTrimmedLeft(dialogCenter + margin).withWidth(btnWidth);
 
     okButton->setBounds(okRect);
     cancelButton->setBounds(canRect);
@@ -145,19 +150,27 @@ void MiniEdit::buttonClicked(juce::Button *button)
     {
         callback(typein->getText().toStdString());
     }
+
     setVisible(false);
 }
 
 void MiniEdit::visibilityChanged()
 {
     if (isVisible())
+    {
         grabFocus();
+    }
+
     if (editor)
     {
         if (isVisible())
+        {
             editor->vkbForward++;
+        }
         else
+        {
             editor->vkbForward--;
+        }
     }
 }
 

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -107,6 +107,7 @@ void PatchStoreDialog::onSkinChanged()
         typein->setColour(juce::TextEditor::outlineColourId,
                           skin->getColor(Colors::Dialog::Entry::Border));
     };
+
     resetColors(nameEd);
     resetColors(authorEd);
     resetColors(catEd);
@@ -117,6 +118,7 @@ void PatchStoreDialog::onSkinChanged()
         label->setFont(skin->getFont(Fonts::PatchStore::Label));
         label->setColour(juce::Label::textColourId, skin->getColor(Colors::Dialog::Label::Text));
     };
+
     resetLabel(nameEdL);
     resetLabel(authorEdL);
     resetLabel(tagEdL);
@@ -134,6 +136,7 @@ void PatchStoreDialog::onSkinChanged()
         button->setColour(juce::TextButton::textColourOnId,
                           skin->getColor(Colors::Dialog::Button::TextPressed));
     };
+
     resetButton(okButton);
     resetButton(cancelButton);
     resetButton(okOverButton);
@@ -142,12 +145,15 @@ void PatchStoreDialog::onSkinChanged()
 void PatchStoreDialog::resized()
 {
     auto h = 25;
-    auto commH = getHeight() - 5 * h;
+    auto commH = getHeight() - 6 * h + 8;
     auto xSplit = 70;
     auto buttonWidth = 60;
     auto margin = 2;
     auto r = getLocalBounds().withHeight(h);
-    auto ce = r.withTrimmedLeft(xSplit).reduced(margin);
+    auto ce = r.withTrimmedLeft(xSplit)
+                  .withTrimmedRight(margin * 3)
+                  .reduced(margin)
+                  .translated(0, margin * 3);
 
     nameEd->setBounds(ce);
     nameEd->setIndents(4, (nameEd->getHeight() - nameEd->getTextHeight()) / 2);
@@ -166,7 +172,7 @@ void PatchStoreDialog::resized()
     commentEd->setBounds(q);
     ce = ce.translated(0, commH);
 
-    auto be = ce.withWidth(buttonWidth).withRightX(ce.getRight());
+    auto be = ce.withWidth(buttonWidth).withRightX(ce.getRight()).translated(0, margin * 3);
     cancelButton->setBounds(be);
     be = be.translated(-buttonWidth - margin, 0);
     okButton->setBounds(be);
@@ -177,7 +183,7 @@ void PatchStoreDialog::resized()
         okOverButton->setBounds(be);
     }
 
-    auto cl = r.withRight(xSplit).reduced(2);
+    auto cl = r.withRight(xSplit).reduced(2).translated(0, margin * 3);
     nameEdL->setBounds(cl);
     cl = cl.translated(0, h);
     catEdL->setBounds(cl);
@@ -196,10 +202,12 @@ void PatchStoreDialog::resized()
     }
     else
     {
-        cl = cl.withWidth(getWidth() - 6 * margin - 3 * buttonWidth);
+        cl = cl.withWidth(getWidth() - 6 * margin - 3 * buttonWidth).translated(0, margin * 3);
+
         auto fb = cl.withWidth(h);
+        auto lb = cl.withX(fb.getRight());
+
         storeTuningButton->setBounds(fb);
-        auto lb = cl.withX(fb.getRight() + margin);
         storeTuningLabel->setBounds(lb);
     }
 }

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
@@ -40,7 +40,7 @@ void TypeinParamEditor::paint(juce::Graphics &g)
     g.drawRect(getLocalBounds());
 
     g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(10));
-    g.setColour(skin->getColor(Colors::Slider::Label::Dark));
+    g.setColour(skin->getColor(Colors::Dialog::Label::Text));
 
     auto r = getLocalBounds().translated(0, 2).withHeight(14);
     g.drawText(mainLabel, r, juce::Justification::centred);
@@ -57,7 +57,7 @@ void TypeinParamEditor::paint(juce::Graphics &g)
 
     if (wasInputInvalid)
     {
-        g.setColour(juce::Colours::red);
+        g.setColour(skin->getColor(Colors::Dialog::Label::Error));
         g.drawText("Input out of range!", r, juce::Justification::centred);
     }
     else
@@ -65,7 +65,7 @@ void TypeinParamEditor::paint(juce::Graphics &g)
         g.drawText(primaryVal, r, juce::Justification::centred);
     }
 
-    g.setColour(skin->getColor(Colors::Slider::Label::Dark));
+    g.setColour(skin->getColor(Colors::Dialog::Label::Text));
 
     if (isMod)
     {
@@ -103,13 +103,20 @@ void TypeinParamEditor::resized()
 void TypeinParamEditor::visibilityChanged()
 {
     if (isVisible())
+    {
         textEd->setWantsKeyboardFocus(true);
+    }
+
     if (editor)
     {
         if (isVisible())
+        {
             editor->vkbForward++;
+        }
         else
+        {
             editor->vkbForward--;
+        }
     }
 }
 

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -245,18 +245,23 @@ void EffectChooser::mouseUp(const juce::MouseEvent &event)
         for (int i = 0; i < n_fx_slots; ++i)
         {
             auto r = getEffectRectangle(i);
+
             if (r.contains(event.getPosition()))
             {
                 auto m = SurgeSynthesizer::FXReorderMode::SWAP;
-                if (event.mods.isCtrlDown())
+
+                if (event.mods.isCommandDown())
                 {
                     m = SurgeSynthesizer::FXReorderMode::COPY;
                 }
+
                 if (event.mods.isShiftDown())
                 {
                     m = SurgeSynthesizer::FXReorderMode::MOVE;
                 }
+
                 auto sge = firstListenerOfType<SurgeGUIEditor>();
+
                 if (sge)
                 {
                     sge->swapFX(currentClicked, i, m);

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1284,7 +1284,7 @@ void LFOAndStepDisplay::mouseDown(const juce::MouseEvent &event)
     {
         dragMode = NONE;
 
-        if (event.mods.isCtrlDown())
+        if (event.mods.isCommandDown())
         {
             setStepToDefault(event);
             dragMode = RESET_VALUE;
@@ -1616,7 +1616,7 @@ void LFOAndStepDisplay::mouseDrag(const juce::MouseEvent &event)
     }
     case RESET_VALUE:
     {
-        if (event.mods.isCtrlDown())
+        if (event.mods.isCommandDown())
         {
             setStepToDefault(event);
             return;

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -490,7 +490,7 @@ void ModulatableSlider::mouseWheelMove(const juce::MouseEvent &event,
     showInfowindowSelfDismiss(isEditingModulation);
 
     // Revert to classic scrolling behavior if Ctrl is pressed down
-    if (intRange && isStepped && !event.mods.isCtrlDown())
+    if (intRange && isStepped && !event.mods.isCommandDown())
     {
         delta = 1.f / intRange * (delta > 0 ? 1 : -1);
     }

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -91,10 +91,10 @@ void MultiSwitch::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
-    notifyControlModifierClicked(event.mods);
 
-    if (event.mods.isPopupMenu())
+    if (event.mods.isPopupMenu() || event.mods.isCommandDown())
     {
+        notifyControlModifierClicked(event.mods);
         return;
     }
 

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -91,7 +91,6 @@ void MultiSwitch::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
-
     if (event.mods.isPopupMenu() || event.mods.isCommandDown())
     {
         notifyControlModifierClicked(event.mods);

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -91,9 +91,10 @@ void MultiSwitch::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
+    notifyControlModifierClicked(event.mods);
+
     if (event.mods.isPopupMenu())
     {
-        notifyControlModifierClicked(event.mods);
         return;
     }
 

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -133,9 +133,15 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
         if (e.mods.isPopupMenu())
         {
             juce::PopupMenu menu;
+
             menu.addSectionHeader("FAVORITES");
-            optionallyAddFavorites(menu, false, false);
-            menu.showMenuAsync(juce::PopupMenu::Options(), [this](int) { this->endHover(); });
+            auto haveFavs = optionallyAddFavorites(menu, false, false);
+
+            if (haveFavs)
+            {
+                menu.showMenuAsync(juce::PopupMenu::Options(), [this](int) { this->endHover(); });
+            }
+
             return;
         }
         else
@@ -162,17 +168,21 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
         }
         return;
     }
+
     // if RMB is down, only show the current category
-    bool single_category =
-        e.mods.isRightButtonDown() || e.mods.isCtrlDown() || e.mods.isCommandDown();
+    bool single_category = e.mods.isRightButtonDown() || e.mods.isCommandDown();
     showClassicMenu(single_category);
 }
 
 void PatchSelector::shouldTooltip()
 {
     if (tooltipCountdown < 0)
+    {
         return;
+    }
+
     tooltipCountdown--;
+
     if (tooltipCountdown == 0)
     {
         tooltipCountdown = -1;
@@ -446,12 +456,15 @@ bool PatchSelector::optionallyAddFavorites(juce::PopupMenu &p, bool addColumnBre
     if (addToSubMenu)
     {
         auto subMenu = juce::PopupMenu();
+
         subMenu.addSectionHeader("FAVORITES");
+
         for (auto f : favs)
         {
             subMenu.addItem(juce::CharPointer_UTF8(f.second.name.c_str()),
                             [this, f]() { this->loadPatch(f.first); });
         }
+
         p.addSubMenu("Favorites", subMenu);
     }
     else

--- a/src/surge-xt/gui/widgets/Switch.cpp
+++ b/src/surge-xt/gui/widgets/Switch.cpp
@@ -59,9 +59,10 @@ void Switch::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
+    notifyControlModifierClicked(event.mods);
+
     if (event.mods.isPopupMenu())
     {
-        notifyControlModifierClicked(event.mods);
         return;
     }
 

--- a/src/surge-xt/gui/widgets/Switch.cpp
+++ b/src/surge-xt/gui/widgets/Switch.cpp
@@ -59,10 +59,9 @@ void Switch::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
-    notifyControlModifierClicked(event.mods);
-
-    if (event.mods.isPopupMenu())
+    if (event.mods.isPopupMenu() || event.mods.isCommandDown())
     {
+        notifyControlModifierClicked(event.mods);
         return;
     }
 


### PR DESCRIPTION
* Adjusted margins and size of Patch Store dialog
* Param typein now uses correct skin color for its text labels
* Miniedit now has same font as param typein, is wider, has better
  spacing and positioning of OK/Cancel buttons, and has
  focused outline color assigned to match the look of param typein
* Swapped all uses of isCtrlDown() with isCommandDown()
* Switch and MultiSwitch didn't pass key modifiers to controlModifierClicked()