### PR TITLE
Initial version of category typeahead

### DIFF
--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -140,6 +140,7 @@ target_sources(${PROJECT_NAME} PRIVATE
   gui/widgets/PatchSelector.h
   gui/widgets/Switch.cpp
   gui/widgets/Switch.h
+  gui/widgets/TypeAheadTextEditor.cpp
   gui/widgets/VerticalLabel.cpp
   gui/widgets/VerticalLabel.h
   gui/widgets/VuMeter.cpp

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -86,6 +86,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::makeStorePatc
     pb->setComment(comments);
     pb->setTags(synth->storage.getPatch().tags);
     pb->setSurgeGUIEditor(this);
+    pb->setStorage(&(this->synth->storage));
 
     // since it is now modal center in the window
     auto posRect = skinCtrl->getRect().withCentre(frame->getBounds().getCentre());

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.h
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.h
@@ -23,21 +23,28 @@
 #include "OverlayComponent.h"
 
 class SurgeGUIEditor;
+class SurgeStorage;
 
 namespace Surge
 {
 namespace Overlays
 {
+struct PatchStoreDialogCategoryProvider;
+
 struct PatchStoreDialog : public OverlayComponent,
                           public Surge::GUI::SkinConsumingComponent,
                           public juce::Button::Listener
 {
     PatchStoreDialog();
+    ~PatchStoreDialog();
     void paint(juce::Graphics &g) override;
     void resized() override;
 
     SurgeGUIEditor *editor{nullptr};
     void setSurgeGUIEditor(SurgeGUIEditor *e);
+
+    SurgeStorage *storage{nullptr};
+    void setStorage(SurgeStorage *s);
 
     void setName(const std::string &n) { nameEd->setText(n, juce::dontSendNotification); }
     void setAuthor(const std::string &a) { authorEd->setText(a, juce::dontSendNotification); }
@@ -52,6 +59,8 @@ struct PatchStoreDialog : public OverlayComponent,
     std::unique_ptr<juce::TextButton> okButton, okOverButton, cancelButton;
     std::unique_ptr<juce::ToggleButton> storeTuningButton;
     std::unique_ptr<juce::Label> storeTuningLabel;
+
+    std::unique_ptr<PatchStoreDialogCategoryProvider> categoryProvider;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PatchStoreDialog);
 };

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -1,0 +1,150 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "TypeAheadTextEditor.h"
+
+namespace Surge
+{
+namespace Widgets
+{
+
+struct TypeAheadListBoxModel : public juce::ListBoxModel
+{
+    TypeAheadDataProvider *provider;
+    std::vector<std::string> search;
+    TypeAhead *ta{nullptr};
+    TypeAheadListBoxModel(TypeAhead *t, TypeAheadDataProvider *p) : ta(t), provider(p) {}
+
+    void setSearch(const std::string &t) { search = provider->searchFor(t); }
+    int getNumRows() override { return search.size(); }
+
+    void paintListBoxItem(int rowNumber, juce::Graphics &g, int width, int height,
+                          bool rowIsSelected) override
+    {
+        if (rowIsSelected)
+        {
+            g.fillAll(juce::Colours::wheat);
+            g.setColour(juce::Colours::darkblue);
+        }
+        else
+        {
+            g.fillAll(juce::Colours::white);
+            g.setColour(juce::Colours::black);
+        }
+        g.drawText(search[rowNumber], 0, 0, width, height, juce::Justification::centredLeft);
+    }
+
+    void returnKeyPressed(int lastRowSelected) override
+    {
+        ta->dismissWithValue(search[lastRowSelected]);
+    }
+    void escapeKeyPressed() { ta->dismissWithoutValue(); }
+};
+
+struct TypeAheadListBox : public juce::ListBox
+{
+    TypeAheadListBox(const juce::String &s, juce::ListBoxModel *m) : juce::ListBox(s, m)
+    {
+        setColour(outlineColourId, juce::Colours::black);
+        setOutlineThickness(1);
+        setColour(backgroundColourId, juce::Colours::white);
+    }
+
+    bool keyPressed(const juce::KeyPress &press) override
+    {
+        if (press.isKeyCode(juce::KeyPress::escapeKey))
+        {
+            if (auto m = dynamic_cast<TypeAheadListBoxModel *>(getModel()))
+            {
+                m->escapeKeyPressed();
+                return true;
+            }
+        }
+        return ListBox::keyPressed(press);
+    }
+};
+
+TypeAhead::TypeAhead(const std::string &l, TypeAheadDataProvider *p)
+    : juce::TextEditor(l), lboxmodel(std::make_unique<TypeAheadListBoxModel>(this, p))
+{
+    addListener(this);
+    lbox = std::make_unique<TypeAheadListBox>("TypeAhead", lboxmodel.get());
+    lbox->setMultipleSelectionEnabled(false);
+    lbox->setVisible(false);
+}
+
+TypeAhead::~TypeAhead() = default;
+
+void TypeAhead::dismissWithValue(const std::string &s)
+{
+    setText(s, juce::NotificationType::dontSendNotification);
+    lbox->setVisible(false);
+    grabKeyboardFocus();
+}
+
+void TypeAhead::dismissWithoutValue()
+{
+    lbox->setVisible(false);
+    grabKeyboardFocus();
+}
+
+void TypeAhead::parentHierarchyChanged()
+{
+    TextEditor::parentHierarchyChanged();
+    getParentComponent()->addChildComponent(*lbox);
+}
+
+void TypeAhead::showLbox()
+{
+    auto b = getBounds().translated(0, getHeight()).withHeight(140);
+    lbox->setBounds(b);
+    lbox->setVisible(true);
+    lbox->toFront(false);
+}
+
+void TypeAhead::textEditorTextChanged(TextEditor &editor)
+{
+    lboxmodel->setSearch(editor.getText().toStdString());
+
+    if (!lbox->isVisible())
+    {
+        showLbox();
+    }
+    lbox->updateContent();
+    lbox->repaint();
+}
+
+bool TypeAhead::keyPressed(const juce::KeyPress &press)
+{
+    if (press.isKeyCode(juce::KeyPress::downKey))
+    {
+        if (!lbox->isVisible())
+        {
+            lboxmodel->setSearch("");
+            showLbox();
+
+            lbox->updateContent();
+            lbox->repaint();
+        }
+        juce::SparseSet<int> r;
+        r.addRange({0, 1});
+        lbox->setSelectedRows(r);
+        lbox->grabKeyboardFocus();
+        return true;
+    }
+    return TextEditor::keyPressed(press);
+}
+} // namespace Widgets
+} // namespace Surge

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -1,0 +1,58 @@
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2021 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#ifndef SURGE_TYPEAHEADTEXTEDITOR_H
+#define SURGE_TYPEAHEADTEXTEDITOR_H
+
+#include <string>
+#include "juce_gui_basics/juce_gui_basics.h"
+
+namespace Surge
+{
+namespace Widgets
+{
+struct TypeAheadListBoxModel;
+
+struct TypeAheadDataProvider
+{
+    virtual ~TypeAheadDataProvider() = default;
+    virtual std::vector<std::string> searchFor(const std::string &s) = 0;
+};
+
+struct TypeAhead : public juce::TextEditor, juce::TextEditor::Listener
+{
+
+    TypeAhead(const std::string &l, TypeAheadDataProvider *p); // does not take ownership
+    ~TypeAhead();
+
+    void dismissWithValue(const std::string &s);
+    void dismissWithoutValue();
+
+    std::unique_ptr<juce::ListBox> lbox;
+    std::unique_ptr<TypeAheadListBoxModel> lboxmodel;
+
+    void showLbox();
+    void parentHierarchyChanged() override;
+    void textEditorTextChanged(juce::TextEditor &editor) override;
+    void textEditorReturnKeyPressed(juce::TextEditor &editor) override { lbox->setVisible(false); }
+    void textEditorEscapeKeyPressed(juce::TextEditor &editor) override { lbox->setVisible(false); }
+
+    bool keyPressed(const juce::KeyPress &press) override;
+};
+
+} // namespace Widgets
+} // namespace Surge
+
+#endif // SURGE_TYPEAHEADTEXTEDITOR_H


### PR DESCRIPTION
The primary thing this accomplishes is give us a typeahead
widget, which still needs work for skinning, font, etc...
but which takes a data provider and does reductive typeahead
with mouse gestures to select.

I used it in the user category list in the Patch Selector for now

Addresses #1840