### PR TITLE
All Notes Off support

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -365,6 +365,15 @@ void SurgeSynthProcessor::applyMidi(const juce::MidiMessageMetadata &it)
         // for whatever reason!
         surge->programChange(ch, m.getProgramChangeNumber());
     }
+    else if (m.isAllNotesOff() || m.isAllSoundOff())
+    {
+        /*
+         * Surge currently doesn't distinguish allNouts and allSounds off. It should
+         * in the future but for now push both APIs through here so XT and 1.9 behave
+         * the same
+         */
+        surge->allNotesOff();
+    }
     else
     {
         // std::cout << "Ignoring message " << std::endl;


### PR DESCRIPTION
AllNotes/AllSounds off message was ignored in the JUCE port. Ooops!
Clearly surge should separate these messages, but Surge 1.9 didn't and
Surge XT1 won't either. But this commit removes the regression that
the message was ignored.