### PR TITLE
Add new control types for high and lowpass

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -330,6 +330,8 @@ bool Parameter::can_deactivate() const
     case ct_percent_deactivatable:
     case ct_freq_hpf:
     case ct_freq_audible_deactivatable:
+    case ct_freq_audible_deactivatable_hp:
+    case ct_freq_audible_deactivatable_lp:
     case ct_lforate_deactivatable:
     case ct_rotarydrive:
     case ct_airwindows_fx:
@@ -605,6 +607,18 @@ void Parameter::set_type(int ctrltype)
         val_min.f = -60;
         val_max.f = 70;
         val_default.f = 3;
+        break;
+    case ct_freq_audible_deactivatable_hp:
+        valtype = vt_float;
+        val_min.f = -60;
+        val_max.f = 70;
+        val_default.f = -60;
+        break;
+    case ct_freq_audible_deactivatable_lp:
+        valtype = vt_float;
+        val_min.f = -60;
+        val_max.f = 70;
+        val_default.f = 70;
         break;
     case ct_freq_audible_with_very_low_lowerbound:
         valtype = vt_float;
@@ -1360,6 +1374,8 @@ void Parameter::set_type(int ctrltype)
     case ct_freq_hpf:
     case ct_freq_audible:
     case ct_freq_audible_deactivatable:
+    case ct_freq_audible_deactivatable_hp:
+    case ct_freq_audible_deactivatable_lp:
     case ct_freq_audible_with_tunability:
     case ct_freq_audible_with_very_low_lowerbound:
     case ct_freq_reson_band1:
@@ -2777,6 +2793,8 @@ float Parameter::quantize_modulation(float inputval) const
         case ct_freq_hpf:
         case ct_freq_audible:
         case ct_freq_audible_deactivatable:
+        case ct_freq_audible_deactivatable_hp:
+        case ct_freq_audible_deactivatable_lp:
         case ct_freq_audible_with_tunability:
         case ct_freq_audible_with_very_low_lowerbound:
         case ct_freq_reson_band1:
@@ -2863,6 +2881,8 @@ void Parameter::get_display_alt(char *txt, bool external, float ef) const
     case ct_freq_hpf:
     case ct_freq_audible:
     case ct_freq_audible_deactivatable:
+    case ct_freq_audible_deactivatable_hp:
+    case ct_freq_audible_deactivatable_lp:
     case ct_freq_audible_with_tunability:
     case ct_freq_audible_with_very_low_lowerbound:
     case ct_freq_reson_band1:
@@ -3434,13 +3454,13 @@ void Parameter::get_display(char *txt, bool external, float ef) const
             switch (i)
             {
             case 0:
-                snprintf(txt, TXT_SIZE, "L-R > M-S > L-R");
+                snprintf(txt, TXT_SIZE, "LR -> MS -> LR");
                 break;
             case 1:
-                snprintf(txt, TXT_SIZE, "L-R > M-S");
+                snprintf(txt, TXT_SIZE, "LR -> MS");
                 break;
             case 2:
-                snprintf(txt, TXT_SIZE, "M-S > L-R");
+                snprintf(txt, TXT_SIZE, "MS -> LR");
                 break;
             }
             break;
@@ -3855,6 +3875,8 @@ bool Parameter::can_setvalue_from_string() const
     case ct_envtime_linkable_delay:
     case ct_freq_audible:
     case ct_freq_audible_deactivatable:
+    case ct_freq_audible_deactivatable_hp:
+    case ct_freq_audible_deactivatable_lp:
     case ct_freq_audible_with_tunability:
     case ct_freq_audible_with_very_low_lowerbound:
     case ct_freq_reson_band1:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -70,6 +70,8 @@ enum ctrltypes
     ct_decibel_deactivatable,
     ct_freq_audible,
     ct_freq_audible_deactivatable,
+    ct_freq_audible_deactivatable_hp,
+    ct_freq_audible_deactivatable_lp,
     ct_freq_audible_with_tunability, // we abuse 'extended' to mean 'use SCL tunign'
     ct_freq_audible_with_very_low_lowerbound,
     ct_freq_mod,

--- a/src/common/dsp/effects/ChorusEffectImpl.h
+++ b/src/common/dsp/effects/ChorusEffectImpl.h
@@ -178,9 +178,9 @@ template <int v> void ChorusEffect<v>::init_ctrltypes()
     fxdata->p[ch_feedback].set_type(ct_percent);
 
     fxdata->p[ch_lowcut].set_name("Low Cut");
-    fxdata->p[ch_lowcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[ch_lowcut].set_type(ct_freq_audible_deactivatable_hp);
     fxdata->p[ch_highcut].set_name("High Cut");
-    fxdata->p[ch_highcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[ch_highcut].set_type(ct_freq_audible_deactivatable_lp);
 
     fxdata->p[ch_mix].set_name("Mix");
     fxdata->p[ch_mix].set_type(ct_percent);
@@ -237,11 +237,9 @@ template <int v> void ChorusEffect<v>::init_default_values()
     fxdata->p[ch_depth].val.f = 0.3f;
     fxdata->p[ch_feedback].val.f = 0.5f;
 
-    fxdata->p[ch_lowcut].val_default.f = fxdata->p[ch_lowcut].val_min.f;
     fxdata->p[ch_lowcut].val.f = -3.f * 12.f;
     fxdata->p[ch_lowcut].deactivated = false;
 
-    fxdata->p[ch_highcut].val_default.f = fxdata->p[ch_lowcut].val_max.f;
     fxdata->p[ch_highcut].val.f = 3.f * 12.f;
     fxdata->p[ch_highcut].deactivated = false;
 

--- a/src/common/dsp/effects/DelayEffect.cpp
+++ b/src/common/dsp/effects/DelayEffect.cpp
@@ -270,9 +270,9 @@ void DelayEffect::init_ctrltypes()
     fxdata->p[dly_crossfeed].set_name("Crossfeed");
     fxdata->p[dly_crossfeed].set_type(ct_percent);
     fxdata->p[dly_lowcut].set_name("Low Cut");
-    fxdata->p[dly_lowcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[dly_lowcut].set_type(ct_freq_audible_deactivatable_hp);
     fxdata->p[dly_highcut].set_name("High Cut");
-    fxdata->p[dly_highcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[dly_highcut].set_type(ct_freq_audible_deactivatable_lp);
     fxdata->p[dly_mod_rate].set_name("Rate");
     fxdata->p[dly_mod_rate].set_type(ct_lforate);
     fxdata->p[dly_mod_depth].set_name("Depth");
@@ -309,11 +309,9 @@ void DelayEffect::init_default_values()
     fxdata->p[dly_feedback].val.f = 0.0f;
     fxdata->p[dly_crossfeed].val.f = 0.0f;
 
-    fxdata->p[dly_lowcut].val_default.f = fxdata->p[dly_lowcut].val_min.f;
     fxdata->p[dly_lowcut].val.f = -24.f;
     fxdata->p[dly_lowcut].deactivated = false;
 
-    fxdata->p[dly_highcut].val_default.f = fxdata->p[dly_highcut].val_max.f;
     fxdata->p[dly_highcut].val.f = 30.f;
     fxdata->p[dly_highcut].deactivated = false;
 

--- a/src/common/dsp/effects/DistortionEffect.cpp
+++ b/src/common/dsp/effects/DistortionEffect.cpp
@@ -208,7 +208,7 @@ void DistortionEffect::init_ctrltypes()
     fxdata->p[dist_preeq_bw].set_name("Bandwidth");
     fxdata->p[dist_preeq_bw].set_type(ct_bandwidth);
     fxdata->p[dist_preeq_highcut].set_name("High Cut");
-    fxdata->p[dist_preeq_highcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[dist_preeq_highcut].set_type(ct_freq_audible_deactivatable_lp);
 
     fxdata->p[dist_drive].set_name("Drive");
     fxdata->p[dist_drive].set_type(ct_decibel_narrow_extendable);
@@ -225,7 +225,7 @@ void DistortionEffect::init_ctrltypes()
     fxdata->p[dist_posteq_bw].set_name("Bandwidth");
     fxdata->p[dist_posteq_bw].set_type(ct_bandwidth);
     fxdata->p[dist_posteq_highcut].set_name("High Cut");
-    fxdata->p[dist_posteq_highcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[dist_posteq_highcut].set_type(ct_freq_audible_deactivatable_lp);
 
     fxdata->p[dist_gain].set_name("Gain");
     fxdata->p[dist_gain].set_type(ct_decibel_narrow);

--- a/src/common/dsp/effects/MSToolEffect.cpp
+++ b/src/common/dsp/effects/MSToolEffect.cpp
@@ -150,7 +150,7 @@ const char *MSToolEffect::group_label(int id)
     switch (id)
     {
     case 0:
-        return " Options";
+        return "Options";
     case 1:
         return "Mid Filter";
     case 2:
@@ -221,24 +221,24 @@ void MSToolEffect::init_ctrltypes()
     fxdata->p[mstl_matrix].set_type(ct_mscodec);
 
     fxdata->p[mstl_hpm].set_name("Low Cut");
-    fxdata->p[mstl_hpm].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[mstl_hpm].set_type(ct_freq_audible_deactivatable_hp);
     fxdata->p[mstl_pqm].set_name("Gain");
     fxdata->p[mstl_pqm].set_type(ct_decibel_narrow_deactivatable);
     fxdata->p[mstl_freqm].set_name("Frequency");
     fxdata->p[mstl_freqm].set_type(ct_freq_audible);
     fxdata->p[mstl_freqm].dynamicDeactivation = &eqGroupDeact;
     fxdata->p[mstl_lpm].set_name("High Cut");
-    fxdata->p[mstl_lpm].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[mstl_lpm].set_type(ct_freq_audible_deactivatable_lp);
 
     fxdata->p[mstl_hps].set_name("Low Cut");
-    fxdata->p[mstl_hps].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[mstl_hps].set_type(ct_freq_audible_deactivatable_hp);
     fxdata->p[mstl_pqs].set_name("Gain");
     fxdata->p[mstl_pqs].set_type(ct_decibel_narrow_deactivatable);
     fxdata->p[mstl_freqs].set_name("Frequency");
     fxdata->p[mstl_freqs].set_type(ct_freq_audible);
     fxdata->p[mstl_freqs].dynamicDeactivation = &eqGroupDeact;
     fxdata->p[mstl_lps].set_name("High Cut");
-    fxdata->p[mstl_lps].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[mstl_lps].set_type(ct_freq_audible_deactivatable_lp);
 
     fxdata->p[mstl_mgain].set_name("Mid Gain");
     fxdata->p[mstl_mgain].set_type(ct_decibel_attenuation_plus12);

--- a/src/common/dsp/effects/Reverb1Effect.cpp
+++ b/src/common/dsp/effects/Reverb1Effect.cpp
@@ -346,13 +346,13 @@ void Reverb1Effect::init_ctrltypes()
     fxdata->p[rev1_damping].set_type(ct_percent);
 
     fxdata->p[rev1_lowcut].set_name("Low Cut");
-    fxdata->p[rev1_lowcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[rev1_lowcut].set_type(ct_freq_audible_deactivatable_hp);
     fxdata->p[rev1_freq1].set_name("Peak Freq");
     fxdata->p[rev1_freq1].set_type(ct_freq_audible);
     fxdata->p[rev1_gain1].set_name("Peak Gain");
     fxdata->p[rev1_gain1].set_type(ct_decibel);
     fxdata->p[rev1_highcut].set_name("High Cut");
-    fxdata->p[rev1_highcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[rev1_highcut].set_type(ct_freq_audible_deactivatable_lp);
 
     fxdata->p[rev1_mix].set_name("Mix");
     fxdata->p[rev1_mix].set_type(ct_percent);
@@ -388,11 +388,9 @@ void Reverb1Effect::init_default_values()
     fxdata->p[rev1_freq1].val.f = 0.0f;
     fxdata->p[rev1_gain1].val.f = 0.0f;
 
-    fxdata->p[rev1_lowcut].val_default.f = fxdata->p[rev1_lowcut].val_min.f;
     fxdata->p[rev1_lowcut].val.f = -24.0f;
     fxdata->p[rev1_lowcut].deactivated = false;
 
-    fxdata->p[rev1_highcut].val_default.f = fxdata->p[rev1_highcut].val_max.f;
     fxdata->p[rev1_highcut].val.f = 72.0f;
     fxdata->p[rev1_highcut].deactivated = false;
 

--- a/src/common/dsp/effects/RingModulatorEffect.cpp
+++ b/src/common/dsp/effects/RingModulatorEffect.cpp
@@ -232,9 +232,9 @@ void RingModulatorEffect::init_ctrltypes()
     fxdata->p[rm_diode_linregion].set_type(ct_percent);
 
     fxdata->p[rm_lowcut].set_name("Low Cut");
-    fxdata->p[rm_lowcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[rm_lowcut].set_type(ct_freq_audible_deactivatable_hp);
     fxdata->p[rm_highcut].set_name("High Cut");
-    fxdata->p[rm_highcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[rm_highcut].set_type(ct_freq_audible_deactivatable_lp);
 
     fxdata->p[rm_mix].set_name("Mix");
     fxdata->p[rm_mix].set_type(ct_percent);
@@ -261,11 +261,9 @@ void RingModulatorEffect::init_default_values()
     fxdata->p[rm_unison_detune].val.f = 0.2;
     fxdata->p[rm_unison_voices].val.i = 1;
 
-    fxdata->p[rm_lowcut].val_default.f = fxdata->p[rm_lowcut].val_min.f;
     fxdata->p[rm_lowcut].val.f = fxdata->p[rm_lowcut].val_min.f;
     fxdata->p[rm_lowcut].deactivated = false;
 
-    fxdata->p[rm_highcut].val_default.f = fxdata->p[rm_highcut].val_max.f;
     fxdata->p[rm_highcut].val.f = fxdata->p[rm_highcut].val_max.f;
     fxdata->p[rm_highcut].deactivated = false;
     fxdata->p[rm_mix].val.f = 1.0;

--- a/src/common/dsp/effects/TreemonsterEffect.cpp
+++ b/src/common/dsp/effects/TreemonsterEffect.cpp
@@ -258,10 +258,10 @@ void TreemonsterEffect::init_ctrltypes()
     fxdata->p[tm_speed].val_default.f = 0.5f;
     fxdata->p[tm_speed].posy_offset = 1;
     fxdata->p[tm_hp].set_name("Low Cut");
-    fxdata->p[tm_hp].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[tm_hp].set_type(ct_freq_audible_deactivatable_hp);
     fxdata->p[tm_hp].posy_offset = 1;
     fxdata->p[tm_lp].set_name("High Cut");
-    fxdata->p[tm_lp].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[tm_lp].set_type(ct_freq_audible_deactivatable_lp);
     fxdata->p[tm_lp].posy_offset = 1;
 
     fxdata->p[tm_pitch].set_name("Pitch");
@@ -286,11 +286,9 @@ void TreemonsterEffect::init_default_values()
     fxdata->p[tm_threshold].val.f = -24.f;
     fxdata->p[tm_speed].val.f = 0.5f;
 
-    fxdata->p[tm_hp].val_default.f = fxdata->p[tm_hp].val_min.f;
     fxdata->p[tm_hp].val.f = fxdata->p[tm_hp].val_min.f;
     fxdata->p[tm_hp].deactivated = false;
 
-    fxdata->p[tm_lp].val_default.f = fxdata->p[tm_lp].val_max.f;
     fxdata->p[tm_lp].val.f = fxdata->p[tm_lp].val_max.f;
     fxdata->p[tm_lp].deactivated = false;
 

--- a/src/common/dsp/effects/WaveShaperEffect.cpp
+++ b/src/common/dsp/effects/WaveShaperEffect.cpp
@@ -204,9 +204,9 @@ void WaveShaperEffect::init_ctrltypes()
     Effect::init_ctrltypes();
 
     fxdata->p[ws_prelowcut].set_name("Low Cut");
-    fxdata->p[ws_prelowcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[ws_prelowcut].set_type(ct_freq_audible_deactivatable_hp);
     fxdata->p[ws_prehighcut].set_name("High Cut");
-    fxdata->p[ws_prehighcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[ws_prehighcut].set_type(ct_freq_audible_deactivatable_lp);
 
     fxdata->p[ws_shaper].set_name("Shape");
     fxdata->p[ws_shaper].set_type(ct_wstype);
@@ -218,9 +218,9 @@ void WaveShaperEffect::init_ctrltypes()
     fxdata->p[ws_drive].set_type(ct_decibel_narrow_short_extendable);
 
     fxdata->p[ws_postlowcut].set_name("Low Cut");
-    fxdata->p[ws_postlowcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[ws_postlowcut].set_type(ct_freq_audible_deactivatable_hp);
     fxdata->p[ws_posthighcut].set_name("High Cut");
-    fxdata->p[ws_posthighcut].set_type(ct_freq_audible_deactivatable);
+    fxdata->p[ws_posthighcut].set_type(ct_freq_audible_deactivatable_lp);
 
     fxdata->p[ws_postboost].set_name("Gain");
     fxdata->p[ws_postboost].set_type(ct_decibel_narrow_short_extendable);

--- a/src/common/dsp/oscillators/AudioInputOscillator.cpp
+++ b/src/common/dsp/oscillators/AudioInputOscillator.cpp
@@ -69,10 +69,10 @@ void AudioInputOscillator::init_ctrltypes(int scene, int osc)
         oscdata->p[audioin_sceneAmix].set_type(ct_percent);
     }
     oscdata->p[audioin_lowcut].set_name("Low Cut");
-    oscdata->p[audioin_lowcut].set_type(ct_freq_audible_deactivatable);
+    oscdata->p[audioin_lowcut].set_type(ct_freq_audible_deactivatable_hp);
 
     oscdata->p[audioin_highcut].set_name("High Cut");
-    oscdata->p[audioin_highcut].set_type(ct_freq_audible_deactivatable);
+    oscdata->p[audioin_highcut].set_type(ct_freq_audible_deactivatable_lp);
 }
 
 void AudioInputOscillator::init_default_values()
@@ -87,13 +87,11 @@ void AudioInputOscillator::init_default_values()
         oscdata->p[audioin_sceneAmix].val.f = 0.0f;
     }
 
-    // high cut at the bottom
-    oscdata->p[audioin_lowcut].val_default.f = oscdata->p[audioin_lowcut].val_min.f;
+    // low cut at the bottom
     oscdata->p[audioin_lowcut].val.f = oscdata->p[audioin_lowcut].val_min.f;
     oscdata->p[audioin_lowcut].deactivated = true;
 
-    // low cut at the top
-    oscdata->p[audioin_highcut].val_default.f = oscdata->p[audioin_highcut].val_max.f;
+    // high cut at the top
     oscdata->p[audioin_highcut].val.f = oscdata->p[audioin_highcut].val_max.f;
     oscdata->p[audioin_highcut].deactivated = true;
 }
@@ -193,10 +191,10 @@ void AudioInputOscillator::handleStreamingMismatches(int streamingRevision,
     if (streamingRevision <= 12)
     {
         oscdata->p[audioin_lowcut].val.f =
-            oscdata->p[audioin_lowcut].val_min.f; // high cut at the bottom
+            oscdata->p[audioin_lowcut].val_min.f; // low cut at the bottom
         oscdata->p[audioin_lowcut].deactivated = true;
         oscdata->p[audioin_highcut].val.f =
-            oscdata->p[audioin_highcut].val_max.f; // low cut at the top
+            oscdata->p[audioin_highcut].val_max.f; // high cut at the top
         oscdata->p[audioin_highcut].deactivated = true;
     }
 }

--- a/src/common/dsp/oscillators/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/oscillators/SampleAndHoldOscillator.cpp
@@ -131,9 +131,9 @@ void SampleAndHoldOscillator::init_ctrltypes()
     oscdata->p[shn_width].set_type(ct_percent);
     oscdata->p[shn_width].val_default.f = 0.5f;
     oscdata->p[shn_lowcut].set_name("Low Cut");
-    oscdata->p[shn_lowcut].set_type(ct_freq_audible_deactivatable);
+    oscdata->p[shn_lowcut].set_type(ct_freq_audible_deactivatable_hp);
     oscdata->p[shn_highcut].set_name("High Cut");
-    oscdata->p[shn_highcut].set_type(ct_freq_audible_deactivatable);
+    oscdata->p[shn_highcut].set_type(ct_freq_audible_deactivatable_lp);
     oscdata->p[shn_sync].set_name("Sync");
     oscdata->p[shn_sync].set_type(ct_syncpitch);
     oscdata->p[shn_unison_detune].set_name("Unison Detune");
@@ -147,13 +147,11 @@ void SampleAndHoldOscillator::init_default_values()
 
     oscdata->p[shn_width].val.f = 0.5f;
 
-    // high cut at the bottom
-    oscdata->p[shn_lowcut].val_default.f = oscdata->p[shn_lowcut].val_min.f;
+    // low cut at the bottom
     oscdata->p[shn_lowcut].val.f = oscdata->p[shn_lowcut].val_min.f;
     oscdata->p[shn_lowcut].deactivated = true;
 
-    // low cut at the top
-    oscdata->p[shn_highcut].val_default.f = oscdata->p[shn_highcut].val_max.f;
+    // high cut at the top
     oscdata->p[shn_highcut].val.f = oscdata->p[shn_highcut].val_max.f;
     oscdata->p[shn_highcut].deactivated = true;
 
@@ -492,9 +490,9 @@ void SampleAndHoldOscillator::handleStreamingMismatches(int streamingRevision,
 {
     if (streamingRevision <= 12)
     {
-        oscdata->p[shn_lowcut].val.f = oscdata->p[shn_lowcut].val_min.f; // high cut at the bottom
+        oscdata->p[shn_lowcut].val.f = oscdata->p[shn_lowcut].val_min.f; // low cut at the bottom
         oscdata->p[shn_lowcut].deactivated = true;
-        oscdata->p[shn_highcut].val.f = oscdata->p[shn_highcut].val_max.f; // low cut at the top
+        oscdata->p[shn_highcut].val.f = oscdata->p[shn_highcut].val_max.f; // high cut at the top
         oscdata->p[shn_sync].deactivated = true;
     }
 }

--- a/src/common/dsp/oscillators/SineOscillator.cpp
+++ b/src/common/dsp/oscillators/SineOscillator.cpp
@@ -998,10 +998,10 @@ void SineOscillator::init_ctrltypes()
     oscdata->p[sine_FMmode].set_type(ct_sinefmlegacy);
 
     oscdata->p[sine_lowcut].set_name("Low Cut");
-    oscdata->p[sine_lowcut].set_type(ct_freq_audible_deactivatable);
+    oscdata->p[sine_lowcut].set_type(ct_freq_audible_deactivatable_hp);
 
     oscdata->p[sine_highcut].set_name("High Cut");
-    oscdata->p[sine_highcut].set_type(ct_freq_audible_deactivatable);
+    oscdata->p[sine_highcut].set_type(ct_freq_audible_deactivatable_lp);
 
     oscdata->p[sine_unison_detune].set_name("Unison Detune");
     oscdata->p[sine_unison_detune].set_type(ct_oscspread);
@@ -1016,13 +1016,11 @@ void SineOscillator::init_default_values()
     oscdata->p[sine_feedback].val.f = 0;
     oscdata->p[sine_FMmode].val.i = 1;
 
-    // high cut at the bottom
-    oscdata->p[sine_lowcut].val_default.f = oscdata->p[sine_lowcut].val_min.f;
+    // low cut at the bottom
     oscdata->p[sine_lowcut].val.f = oscdata->p[sine_lowcut].val_min.f;
     oscdata->p[sine_lowcut].deactivated = true;
 
-    // low cut at the top
-    oscdata->p[sine_highcut].val_default.f = oscdata->p[sine_highcut].val_max.f;
+    // high cut at the top
     oscdata->p[sine_highcut].val.f = oscdata->p[sine_highcut].val_max.f;
     oscdata->p[sine_highcut].deactivated = true;
 
@@ -1046,11 +1044,11 @@ void SineOscillator::handleStreamingMismatches(int streamingRevision,
 
     if (streamingRevision <= 12)
     {
-        // high cut at the bottom
+        // low cut at the bottom
         oscdata->p[sine_lowcut].val.f = oscdata->p[sine_lowcut].val_min.f;
         oscdata->p[sine_lowcut].deactivated = true;
 
-        // low cut at the top
+        // high cut at the top
         oscdata->p[sine_highcut].val.f = oscdata->p[sine_highcut].val_max.f;
         oscdata->p[sine_highcut].deactivated = true;
 

--- a/src/common/dsp/oscillators/WindowOscillator.cpp
+++ b/src/common/dsp/oscillators/WindowOscillator.cpp
@@ -150,9 +150,9 @@ void WindowOscillator::init_ctrltypes()
     oscdata->p[win_window].set_type(ct_wt2window);
 
     oscdata->p[win_lowcut].set_name("Low Cut");
-    oscdata->p[win_lowcut].set_type(ct_freq_audible_deactivatable);
+    oscdata->p[win_lowcut].set_type(ct_freq_audible_deactivatable_hp);
     oscdata->p[win_highcut].set_name("High Cut");
-    oscdata->p[win_highcut].set_type(ct_freq_audible_deactivatable);
+    oscdata->p[win_highcut].set_type(ct_freq_audible_deactivatable_lp);
 
     oscdata->p[win_unison_detune].set_name("Unison Detune");
     oscdata->p[win_unison_detune].set_type(ct_oscspread);
@@ -166,13 +166,11 @@ void WindowOscillator::init_default_values()
     oscdata->p[win_formant].val.f = 0.0f;
     oscdata->p[win_window].val.i = 0;
 
-    // high cut at the bottom
-    oscdata->p[win_lowcut].val_default.f = oscdata->p[win_lowcut].val_min.f;
+    // low cut at the bottom
     oscdata->p[win_lowcut].val.f = oscdata->p[win_lowcut].val_min.f;
     oscdata->p[win_lowcut].deactivated = true;
 
-    // low cut at the top
-    oscdata->p[win_highcut].val_default.f = oscdata->p[win_highcut].val_max.f;
+    // high cut at the top
     oscdata->p[win_highcut].val.f = oscdata->p[win_highcut].val_max.f;
     oscdata->p[win_highcut].deactivated = true;
 


### PR DESCRIPTION
with different defaults that don't reset to center on doubleclick
- changed in fx and oscs where used
  also replacing the val_default conversion used in some places
- change MSTool "options" display back to not appear as math operations
  (where L - R  would have a different meaning in this context)