### PR TITLE
Extended PB range

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -3179,7 +3179,7 @@ void Parameter::get_display(char *txt, bool external, float ef) const
         case ct_pbdepth:
         {
             if (extend_range)
-                snprintf(txt, TXT_SIZE, "%i Cents", i);
+                snprintf(txt, TXT_SIZE, "%0.2f Keys", i * 1.f / 100);
             else
                 snprintf(txt, TXT_SIZE, "%i Keys", i);
         }
@@ -4051,6 +4051,21 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
                     ni = 200;
                 }
             }
+            else if (extend_range)
+            {
+                try
+                {
+                    ni = std::round(std::stof(s) * 100);
+                }
+                catch (const std::invalid_argument &)
+                {
+                    ni = val_min.i - 1; // set value of ni out of range on invalid input
+                }
+                catch (const std::out_of_range &)
+                {
+                    ni = val_min.i - 1; // same for out of range input
+                }
+            }
         }
         break;
         }
@@ -4432,7 +4447,7 @@ float Parameter::calculate_modulation_value_from_string(const std::string &s, bo
         {
             /*
              * OK so what's happening here? Well we need to give a number that
-             * when handed in asfter going through get_extended gives us what
+             * when handed in after going through get_extended gives us what
              * we typed in through the formatting.
              *
              * That is p->get_extended(mf) = v / 31 / 2. So lets get to work

--- a/src/surge-fx/SurgeFXProcessor.h
+++ b/src/surge-fx/SurgeFXProcessor.h
@@ -97,7 +97,10 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
         fxParamFeatures[i]->setValueNotifyingHost((float)v / 0xFF);
     }
     bool getFXParamExtended(int i) { return *(fxParamFeatures[i]) & kExtended; }
-    void setFXStorageExtended(int i, bool b) { fxstorage->p[fx_param_remap[i]].extend_range = b; }
+    void setFXStorageExtended(int i, bool b)
+    {
+        fxstorage->p[fx_param_remap[i]].set_extend_range(b);
+    }
     bool getFXStorageExtended(int i) { return fxstorage->p[fx_param_remap[i]].extend_range; }
     bool canExtend(int i) { return fxstorage->p[fx_param_remap[i]].can_extend_range(); }
 
@@ -207,7 +210,7 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
     void paramFeatureOntoParam(Parameter *p, int32_t features)
     {
         p->temposync = features & kTempoSync;
-        p->extend_range = features & kExtended;
+        p->set_extend_range(features & kExtended);
     }
 
     // Information about parameter strings

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -158,12 +158,12 @@ void NumberField::mouseDrag(const juce::MouseEvent &event)
     float thresh = 10;
     if (dD > thresh)
     {
-        changeBy(1);
+        changeBy(getChangeMultiplier(event));
         lastDistanceChecked = d;
     }
     if (dD < -thresh)
     {
-        changeBy(-1);
+        changeBy(-getChangeMultiplier(event));
         lastDistanceChecked = d;
     }
 }
@@ -197,18 +197,35 @@ void NumberField::mouseWheelMove(const juce::MouseEvent &event,
 
     if (dir != 0)
     {
-        changeBy(dir);
+        changeBy(dir * getChangeMultiplier(event));
     }
 }
 
-void NumberField::changeBy(int inc)
+void NumberField::changeBy(float inc)
 {
     float dv = 1.f / (iMax - iMin);
     value = limit01(value + dv * inc);
     bounceToInt();
+    if (iValue == iMin)
+    {
+        value = 0.005f;
+    }
+    else if (iValue == iMax)
+    {
+        value = 0.995f;
+    }
 
     notifyValueChanged();
     repaint();
+}
+
+float NumberField::getChangeMultiplier(const juce::MouseEvent &event)
+{
+    if (controlMode == Skin::Parameters::PB_DEPTH && extended && !event.mods.isShiftDown())
+    {
+        return 99.f + 0.005f;
+    }
+    return 1.f;
 }
 
 #if SURGE_JUCE_ACCESSIBLE

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -201,31 +201,25 @@ void NumberField::mouseWheelMove(const juce::MouseEvent &event,
     }
 }
 
-void NumberField::changeBy(float inc)
+void NumberField::changeBy(int inc)
 {
-    float dv = 1.f / (iMax - iMin);
-    value = limit01(value + dv * inc);
     bounceToInt();
-    if (iValue == iMin)
-    {
-        value = 0.005f;
-    }
-    else if (iValue == iMax)
-    {
-        value = 0.995f;
-    }
+    iValue = limit_range(iValue + inc, iMin, iMax);
+    value = limit01(Parameter::intScaledToFloat(iValue, iMax, iMin));
+
+    bounceToInt();
 
     notifyValueChanged();
     repaint();
 }
 
-float NumberField::getChangeMultiplier(const juce::MouseEvent &event)
+int NumberField::getChangeMultiplier(const juce::MouseEvent &event)
 {
     if (controlMode == Skin::Parameters::PB_DEPTH && extended && !event.mods.isShiftDown())
     {
-        return 99.f + 0.005f;
+        return 100;
     }
-    return 1.f;
+    return 1;
 }
 
 #if SURGE_JUCE_ACCESSIBLE

--- a/src/surge-xt/gui/widgets/NumberField.h
+++ b/src/surge-xt/gui/widgets/NumberField.h
@@ -65,7 +65,9 @@ struct NumberField : public juce::Component, public WidgetBaseMixin<NumberField>
 
     void paint(juce::Graphics &g) override;
 
-    void changeBy(int inc);
+    void changeBy(float inc);
+
+    float getChangeMultiplier(const juce::MouseEvent &event);
 
     Surge::Skin::Parameters::NumberfieldControlModes controlMode{Surge::Skin::Parameters::NONE};
     void setControlMode(Surge::Skin::Parameters::NumberfieldControlModes n,

--- a/src/surge-xt/gui/widgets/NumberField.h
+++ b/src/surge-xt/gui/widgets/NumberField.h
@@ -65,9 +65,9 @@ struct NumberField : public juce::Component, public WidgetBaseMixin<NumberField>
 
     void paint(juce::Graphics &g) override;
 
-    void changeBy(float inc);
+    void changeBy(int inc);
 
-    float getChangeMultiplier(const juce::MouseEvent &event);
+    int getChangeMultiplier(const juce::MouseEvent &event);
 
     Surge::Skin::Parameters::NumberfieldControlModes controlMode{Surge::Skin::Parameters::NONE};
     void setControlMode(Surge::Skin::Parameters::NumberfieldControlModes n,


### PR DESCRIPTION
- changed pitch bend parameter formatting for input field
- scale by 100 for pb when extended range is activated in `NumberField` and shift is not pressed
- use setter function for extended property in fx processor