### PR TITLE
Skin PatchDB typeahead, among other thigns

### DIFF
--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -1219,19 +1219,19 @@ std::string PatchDB::sqlWhereClauseFor(const std::unique_ptr<PatchDBQueryParser:
         oss << "( p.name LIKE '%" << t->content << "%' )";
         break;
     case PatchDBQueryParser::AND:
-        oss << "( ";
-        oss << sqlWhereClauseFor(t->children[0]);
-        oss << " AND ";
-        oss << sqlWhereClauseFor(t->children[1]);
-        oss << " )";
-        break;
     case PatchDBQueryParser::OR:
+    {
         oss << "( ";
-        oss << sqlWhereClauseFor(t->children[0]);
-        oss << " OR ";
-        oss << sqlWhereClauseFor(t->children[1]);
+        std::string inter = "";
+        for (auto &c : t->children)
+        {
+            oss << inter;
+            oss << sqlWhereClauseFor(c);
+            inter = t->type == PatchDBQueryParser::AND ? " AND " : " OR ";
+        }
         oss << " )";
         break;
+    }
     }
 
     return oss.str();

--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -39,7 +39,7 @@ namespace Entry
 {
 const Surge::Skin::Color Background("dialog.textfield.background", 255, 255, 255),
     Border("dialog.textfield.border", 160, 160, 160),
-    Caret("dialog.textfield.caret", 160, 160, 160), Focus("dialog.textfield.focus", 224, 224, 224),
+    Caret("dialog.textfield.caret", 160, 160, 160), Focus("dialog.textfield.focus", 214, 214, 255),
     Text("dialog.textfield.text", 0, 0, 0);
 }
 namespace Label
@@ -375,7 +375,20 @@ const Surge::Skin::Color Background("editor.overlay.background", 0, 0, 0, 204);
 namespace PatchBrowser
 {
 const Surge::Skin::Color Text("patchbrowser.text", 0, 0, 0);
+
+namespace TypeAheadList
+{
+const Surge::Skin::Color Border("patchbrowser.typeahead.border", 100, 100, 130),
+    Background("patchbrowser.typeahead.background", 255, 255, 255),
+    Text("patchbrowser.typeahead.text", 0, 0, 0),
+    HighlightBackground("patchbrowser.typeahead.background.highlight", 210, 210, 255),
+    HighlightText("patchbrowser.typeahead.text.highlight", 0, 0, 100),
+    SubText("patchbrowser.typeahead.subtext", 0, 0, 50),
+    HighlightSubText("patchbrowser.typeahead.subtext.highlight", 40, 40, 140),
+    Divider("patchbrowser.typeahead.divider", 140, 140, 140);
 }
+
+} // namespace PatchBrowser
 
 namespace Scene
 {

--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -274,7 +274,13 @@ extern const Surge::Skin::Color Background;
 namespace PatchBrowser
 {
 extern const Surge::Skin::Color Text;
+
+namespace TypeAheadList
+{
+extern const Surge::Skin::Color Border, Background, Text, HighlightBackground, HighlightText,
+    SubText, HighlightSubText, Divider;
 }
+} // namespace PatchBrowser
 
 namespace Scene
 {

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -72,7 +72,7 @@ struct PatchStoreDialogCategoryProvider : public Surge::Widgets::TypeAheadDataPr
             g.setColour(txt);
         }
         g.setFont(font);
-        g.drawText(textBoxValueForIndex(searchIndex), 0, 0, width, height,
+        g.drawText(textBoxValueForIndex(searchIndex), 4, 0, width - 4, height,
                    juce::Justification::centredLeft);
     }
 
@@ -105,8 +105,11 @@ PatchStoreDialog::PatchStoreDialog()
 #endif
 
     categoryProvider = std::make_unique<PatchStoreDialogCategoryProvider>();
-    catEd = std::make_unique<Surge::Widgets::TypeAhead>("patch category", categoryProvider.get());
-    catEd->setJustification(juce::Justification::centredLeft);
+    auto ta = std::make_unique<Surge::Widgets::TypeAhead>("patch category", categoryProvider.get());
+    ta->setJustification(juce::Justification::centredLeft);
+    ta->setToElementZeroOnReturn = true;
+
+    catEd = std::move(ta);
     addAndMakeVisible(*catEd);
 
     auto makeL = [this](const std::string &n) {

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -126,6 +126,8 @@ struct PatchSelector : public juce::Component,
 
     std::string getPatchNameAccessibleValue() { return pname + " by " + author; }
 
+    void onSkinChanged() override;
+
   protected:
     juce::Rectangle<int> favoritesRect, searchRect;
 

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -131,9 +131,9 @@ void TypeAhead::textEditorReturnKeyPressed(juce::TextEditor &editor)
 {
     lbox->setVisible(false);
 
-    if (setToElementZeroOnReturn && lboxmodel->getNumRows() > 1)
+    if (setToElementZeroOnReturn && lboxmodel->getNumRows() > 0)
     {
-        auto r = lboxmodel->provider->textBoxValueForIndex(0);
+        auto r = lboxmodel->provider->textBoxValueForIndex(lboxmodel->search[0]);
         setText(r, juce::NotificationType::dontSendNotification);
         for (auto l : taList)
         {
@@ -162,7 +162,11 @@ void TypeAhead::showLbox()
         p = p->getParentComponent();
     }
 
-    auto b = getLocalBounds().translated(0, getHeight()).withHeight(140);
+    auto b =
+        getLocalBounds()
+            .translated(0, getHeight())
+            .withHeight(
+                lboxmodel->provider->getRowHeight() * lboxmodel->provider->getDisplayedRows() + 4);
     if (p)
     {
         b = p->getLocalArea(this, b);

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -33,6 +33,7 @@ struct TypeAheadDataProvider
     virtual std::vector<int> searchFor(const std::string &s) = 0;
     virtual std::string textBoxValueForIndex(int idx) = 0;
     virtual int getRowHeight() { return 15; }
+    virtual int getDisplayedRows() { return 9; }
     virtual void paintDataItem(int searchIndex, juce::Graphics &g, int width, int height,
                                bool rowIsSelected);
 };


### PR DESCRIPTION
Fix some gestures and some index bugs, make the patchdb
typeahead look nice and show information, handle sizing of
typeaheads. Generally 'have it be more or less usable'. Still
work to do though