### PR TITLE
Avoid a crash in a bad skin edge case

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1502,8 +1502,11 @@ void SurgeGUIEditor::openOrRecreateEditor()
                 {
                     auto r = l->getRect();
                     auto db = bmp->getDrawableButUseWithCaution();
-                    db->setBounds(r);
-                    frame->addAndMakeVisible(db);
+                    if (db)
+                    {
+                        db->setBounds(r);
+                        frame->addAndMakeVisible(db);
+                    }
                 }
             }
         }

--- a/src/surge-xt/gui/SurgeImage.h
+++ b/src/surge-xt/gui/SurgeImage.h
@@ -31,25 +31,34 @@ class SurgeImage
     {
         juce::Graphics::ScopedSaveState gs(g);
         g.addTransform(scaleAdjustmentTransform());
-        internalDrawableResolved()->draw(g, opacity, transform);
+        auto idr = internalDrawableResolved();
+        if (idr)
+            idr->draw(g, opacity, transform);
     }
     void drawAt(juce::Graphics &g, float x, float y, float opacity) const
     {
         juce::Graphics::ScopedSaveState gs(g);
         g.addTransform(scaleAdjustmentTransform());
-        internalDrawableResolved()->drawAt(g, x, y, opacity);
+        auto idr = internalDrawableResolved();
+        if (idr)
+            idr->drawAt(g, x, y, opacity);
     }
     void drawWithin(juce::Graphics &g, juce::Rectangle<float> destArea,
                     juce::RectanglePlacement placement, float opacity) const
     {
         juce::Graphics::ScopedSaveState gs(g);
         g.addTransform(scaleAdjustmentTransform());
-        internalDrawableResolved()->drawWithin(g, destArea, placement, opacity);
+        auto idr = internalDrawableResolved();
+        if (idr)
+            idr->drawWithin(g, destArea, placement, opacity);
     }
 
     std::unique_ptr<juce::Drawable> createCopy()
     {
-        return internalDrawableResolved()->createCopy();
+        auto idr = internalDrawableResolved();
+        if (idr)
+            return idr->createCopy();
+        return nullptr;
     }
 
     /*


### PR DESCRIPTION
In a case where a skin had an invalid but existant SVG of a particular
form we would not detect a failure to parse and would deref nullptr

Check for nullptr in those spots and do nothing accordingly.