### PR TITLE
Fix a collection of scene mod small problems

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2660,8 +2660,9 @@ void SurgeSynthesizer::updateUsedState()
         for (int i = 0; i < n; i++)
         {
             int id = modlist->at(i).source_id;
-            assert((id > 0) && (id < n_modsources));
-            modsourceused[id] = true;
+            if (!isModulatorDistinctPerScene((modsources)id) ||
+                modlist->at(i).source_scene == scene)
+                modsourceused[id] = true;
         }
     }
 }
@@ -2864,6 +2865,7 @@ void SurgeSynthesizer::clearModulation(long ptag, modsources modsource, int mods
 bool SurgeSynthesizer::setModulation(long ptag, modsources modsource, int modsourceScene, int index,
                                      float val)
 {
+
     if (!isValidModulation(ptag, modsource))
         return false;
     float value = storage.getPatch().param_ptr[ptag]->set_modulation_f01(val);


### PR DESCRIPTION
There were a collection of problems in the new UI along with
the cross-scene stuff mostly involving mistakes around whether
a modulator was cross-scene or not. So

1. Make sure to always assigne macros and other non-split sources
   from an artificial scene 0
2. When iterating to show menus and clear, make sure you show
   all the targets for non-split sources
3. Read appropriate scene split state when activating items,
   which means an SLFO -> global in scene A didn't stay 'lit' in
   scene b

Closes #5180
Closes #5191