### PR TITLE
SGE knows if key press events occur

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -347,6 +347,8 @@ void SurgeSynthesizer::playNote(char channel, char key, char velocity, char detu
         }
     }
 
+    midiNoteEvents++;
+
     if (!storage.isStandardTuning)
     {
         if (!storage.currentTuning.isMidiNoteMapped(key))
@@ -817,6 +819,7 @@ void SurgeSynthesizer::releaseScene(int s)
 
 void SurgeSynthesizer::releaseNote(char channel, char key, char velocity)
 {
+    midiNoteEvents++;
     bool foundVoice[n_scenes];
     for (int sc = 0; sc < n_scenes; ++sc)
     {

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -348,6 +348,7 @@ class alignas(16) SurgeSynthesizer
 
     std::array<uint64_t, 128> midiKeyPressedForScene[n_scenes];
     uint64_t orderedMidiKey = 0;
+    std::atomic<uint64_t> midiNoteEvents{0};
 
     int current_category_id = 0;
     bool modsourceused[n_modsources];

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -246,6 +246,11 @@ void SurgeGUIEditor::idle()
 
     if (editor_open && frame && !synth->halt_engine)
     {
+        if (lastObservedMidiNoteEventCount != synth->midiNoteEvents)
+        {
+            lastObservedMidiNoteEventCount = synth->midiNoteEvents;
+            // If there are things subscribed to keys update them here
+        }
         idleInfowindow();
         juceDeleteOnIdle.clear();
         /*

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -169,6 +169,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::string nameOfStandardReturnToChangeTo(int pid);
     void activateFromCurrentFx();
 
+    uint64_t lastObservedMidiNoteEventCount{0};
+
   private:
     void openOrRecreateEditor();
     std::unique_ptr<Surge::Overlays::OverlayComponent> makeStorePatchDialog();


### PR DESCRIPTION
This is a change which lays a groundwork for something i need
later this week and just want to get committed. SGE idle gets
a way to know if midi key press events have occured since the last
idle.