### PR TITLE
TearOut Overlays

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2757,7 +2757,12 @@ void SurgeSynthesizer::muteModulation(long ptag, modsources modsource, int modso
 
     ModulationRouting *r = getModRouting(ptag, modsource, modsourceScene, index);
     if (r)
+    {
         r->muted = mute;
+
+        for (auto l : modListeners)
+            l->modMuted(ptag, modsource, modsourceScene, index, mute);
+    }
 }
 
 void SurgeSynthesizer::clear_osc_modulation(int scene, int entry)
@@ -2857,6 +2862,10 @@ void SurgeSynthesizer::clearModulation(long ptag, modsources modsource, int mods
             storage.modRoutingMutex.lock();
             modlist->erase(modlist->begin() + i);
             storage.modRoutingMutex.unlock();
+
+            for (auto l : modListeners)
+                l->modCleared(ptag, modsource, modsourceScene, index);
+
             return;
         }
     }
@@ -2865,7 +2874,6 @@ void SurgeSynthesizer::clearModulation(long ptag, modsources modsource, int mods
 bool SurgeSynthesizer::setModulation(long ptag, modsources modsource, int modsourceScene, int index,
                                      float val)
 {
-
     if (!isValidModulation(ptag, modsource))
         return false;
     float value = storage.getPatch().param_ptr[ptag]->set_modulation_f01(val);
@@ -2930,6 +2938,8 @@ bool SurgeSynthesizer::setModulation(long ptag, modsources modsource, int modsou
     }
     storage.modRoutingMutex.unlock();
 
+    for (auto l : modListeners)
+        l->modSet(ptag, modsource, modsourceScene, index, val);
     return true;
 }
 

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -113,6 +113,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         auto h = getWindowSizeY() - yPos - xBuf;
         pt->setEnclosingParentPosition(juce::Rectangle<int>(xBuf, yPos, w, h));
         pt->setEnclosingParentTitle("Patch Database");
+        pt->setCanTearOut(true);
         return pt;
     }
     break;
@@ -187,6 +188,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         // pt->addScaleTextEditedListener(this);
         pt->setEnclosingParentPosition(juce::Rectangle<int>(px, py, w, h));
         pt->setEnclosingParentTitle("Tuning Editor");
+        pt->setCanTearOut(true);
         return pt;
     }
     break;
@@ -234,6 +236,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         auto pt = std::make_unique<Surge::Overlays::ModulationEditor>(this, this->synth);
         pt->setEnclosingParentTitle("Modulation List");
         pt->setEnclosingParentPosition(juce::Rectangle<int>(50, 50, 750, 450));
+        pt->setCanTearOut(true);
         return pt;
     }
     break;
@@ -333,7 +336,7 @@ void SurgeGUIEditor::closeOverlay(OverlayTags olt)
     }
 }
 
-void SurgeGUIEditor::addJuceEditorOverlay(
+Surge::Overlays::OverlayWrapper *SurgeGUIEditor::addJuceEditorOverlay(
     std::unique_ptr<juce::Component> c,
     std::string editorTitle, // A window display title - whatever you want
     OverlayTags editorTag,   // A tag by editor class. Please unique, no spaces.
@@ -362,11 +365,18 @@ void SurgeGUIEditor::addJuceEditorOverlay(
         onClose();
     });
 
+    auto olc = dynamic_cast<Surge::Overlays::OverlayComponent *>(c.get());
+    if (olc)
+    {
+        ol->setCanTearOut(olc->getCanTearOut());
+    }
+
     ol->addAndTakeOwnership(std::move(c));
     frame->addAndMakeVisible(*ol);
     juceOverlays[editorTag] = std::move(ol);
     if (overlayConsumesKeyboard(editorTag))
         vkbForward++;
+    return juceOverlays[editorTag].get();
 }
 
 void SurgeGUIEditor::dismissEditorOfType(OverlayTags ofType)

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -349,6 +349,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         return 0;
     }
 
+    SelfModulationGuard modGuard(this);
+
     if (button.isMiddleButtonDown())
     {
         toggle_mod_editing();
@@ -2384,6 +2386,8 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     juce::Rectangle<int> viewSize;
     auto bvf = control->asJuceComponent();
 
+    SelfModulationGuard modGuard(this);
+
     if (bvf)
     {
         viewSize = bvf->getBounds();
@@ -3094,4 +3098,22 @@ bool SurgeGUIEditor::setControlFromString(modsources ms, const std::string &s)
         return true;
     }
     return false;
+}
+
+void SurgeGUIEditor::modSet(long ptag, modsources modsource, int modsourceScene, int index,
+                            float value)
+{
+    if (!selfModulation)
+        needsModUpdate = true;
+}
+void SurgeGUIEditor::modMuted(long ptag, modsources modsource, int modsourceScene, int index,
+                              bool mute)
+{
+    if (!selfModulation)
+        needsModUpdate = true;
+}
+void SurgeGUIEditor::modCleared(long ptag, modsources modsource, int modsourceScene, int index)
+{
+    if (!selfModulation)
+        needsModUpdate = true;
 }

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -112,10 +112,19 @@ void SurgeJUCELookAndFeel::drawDocumentWindowTitleBar(juce::DocumentWindow &wind
 
     g.setColour(juce::Colours::white);
 
+    auto wt = window.getName();
+
     juce::String surgeLabel = "Surge XT";
     auto surgeVersion = Surge::Build::FullVersionStr;
     auto fontSurge = Surge::GUI::getFontManager()->getLatoAtSize(14);
     auto fontVersion = Surge::GUI::getFontManager()->getFiraMonoAtSize(14);
+
+    if (wt != "Surge XT")
+    {
+        surgeLabel = wt;
+        surgeVersion = "Surge XT";
+        fontVersion = fontSurge;
+    }
 
     auto sw = fontSurge.getStringWidth(surgeLabel);
     auto vw = fontVersion.getStringWidth(surgeVersion);

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -37,6 +37,10 @@ struct OverlayComponent : juce::Component
     bool hasIndependentClose{true};
     void setHasIndependentClose(bool b) { hasIndependentClose = b; }
     bool getHasIndependentClose() { return hasIndependentClose; }
+
+    bool canTearOut{false};
+    void setCanTearOut(bool b) { canTearOut = b; }
+    bool getCanTearOut() { return canTearOut; }
 };
 } // namespace Overlays
 } // namespace Surge

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -46,20 +46,36 @@ struct OverlayWrapper : public juce::Component,
 
     std::unique_ptr<juce::Component> primaryChild;
     void addAndTakeOwnership(std::unique_ptr<juce::Component> c);
-    std::unique_ptr<juce::TextButton> closeButton;
+    std::unique_ptr<juce::TextButton> closeButton, tearOutButton;
     void buttonClicked(juce::Button *button) override;
 
     SurgeImage *icon{nullptr};
     void setIcon(SurgeImage *d) { icon = d; }
 
+    bool canTearOut{false};
+    void setCanTearOut(bool b) { canTearOut = b; }
+    void doTearOut();
+    bool isTornOut();
+
+    bool hasInteriorDec{true};
+    void supressInteriorDecoration();
+
     bool showCloseButton{true};
     void setShowCloseButton(bool b) { showCloseButton = b; }
 
+    void onClose()
+    {
+        closeOverlay();
+        if (isTornOut())
+            tearOutParent.reset(nullptr);
+    }
     std::function<void()> closeOverlay = []() {};
     void setCloseOverlay(std::function<void()> f) { closeOverlay = std::move(f); }
 
     juce::Rectangle<int> componentBounds;
     bool isModal{false};
+
+    std::unique_ptr<juce::DocumentWindow> tearOutParent;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OverlayWrapper);
 };

--- a/src/surge-xt/gui/overlays/TuningOverlays.cpp
+++ b/src/surge-xt/gui/overlays/TuningOverlays.cpp
@@ -597,8 +597,12 @@ TuningOverlay::~TuningOverlay() = default;
 
 void TuningOverlay::resized()
 {
+    auto t = getTransform().inverted();
     auto h = getHeight();
     auto w = getWidth();
+
+    t.transformPoint(w, h);
+
     tuningKeyboardTable->setBounds(0, 0, 120, h);
 
     tabArea->setBounds(120, 0, w - 120, h);


### PR DESCRIPTION
This commit makes the Tuning and ModulationList overlay 'tear out'
overlays which can be separated from the main screen and run as
an independent window.