### PR TITLE
DOubleClick resets WSAnalysis Slider to zero

### DIFF
--- a/src/surge-xt/gui/overlays/WaveShaperAnalysis.cpp
+++ b/src/surge-xt/gui/overlays/WaveShaperAnalysis.cpp
@@ -130,6 +130,18 @@ void WaveShaperAnalysis::valueChanged(Surge::GUI::IComponentTagValue *p)
     repaint();
 }
 
+int32_t WaveShaperAnalysis::controlModifierClicked(Surge::GUI::IComponentTagValue *p,
+                                                   const juce::ModifierKeys &mods,
+                                                   bool isDoubleClickEvent)
+{
+    if (isDoubleClickEvent)
+    {
+        tryitSlider->setValue(0.5f);
+        valueChanged(tryitSlider.get());
+    }
+    return 0;
+}
+
 void WaveShaperAnalysis::recalcFromSlider()
 {
     sliderDrivenCurve.clear();

--- a/src/surge-xt/gui/overlays/WaveShaperAnalysis.h
+++ b/src/surge-xt/gui/overlays/WaveShaperAnalysis.h
@@ -38,6 +38,10 @@ struct WaveShaperAnalysis : public OverlayComponent,
     void resized() override;
 
     void valueChanged(Surge::GUI::IComponentTagValue *p) override;
+    int32_t controlModifierClicked(Surge::GUI::IComponentTagValue *p,
+                                   const juce::ModifierKeys &mods,
+                                   bool isDoubleClickEvent) override;
+
     void recalcFromSlider();
 
     void setWSType(int wst);


### PR DESCRIPTION
Because all the other sliders do that

Closes #5218