### PR TITLE
Waveshaper analysis UI nitpicks

### DIFF
--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -363,7 +363,7 @@ namespace Analysis
 {
 const Surge::Skin::Color Border("waveshaper.analysis.border", 255, 255, 255),
     Background("waveshaper.analysis.background", 10, 10, 20),
-    Title("waveshaper.analysis.title", 255, 255, 255);
+    Text("waveshaper.analysis.text", 255, 255, 255);
 }
 } // namespace Waveshaper
 

--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -262,7 +262,7 @@ extern const Surge::Skin::Color Dots, Wave, WaveHover;
 }
 namespace Analysis
 {
-extern const Surge::Skin::Color Border, Background, Title;
+extern const Surge::Skin::Color Border, Background, Text;
 }
 } // namespace Waveshaper
 

--- a/src/common/SkinFonts.cpp
+++ b/src/common/SkinFonts.cpp
@@ -15,34 +15,36 @@
 
 #include "SkinFonts.h"
 
+using namespace Surge::Skin;
+
 namespace Fonts
 {
 namespace System
 {
-const Surge::Skin::FontDesc Display("fonts.system.display", 9);
+const FontDesc Display("fonts.system.display", 9);
 }
 
 namespace Widgets
 {
-const Surge::Skin::FontDesc NumberField("fonts.widgets.numberfield", System::Display),
+const FontDesc NumberField("fonts.widgets.numberfield", System::Display),
     EffectLabel("fonts.widgets.effectlabel", System::Display);
-const Surge::Skin::FontDesc TabButtonFont("fonts.widgets.tabbutton", System::Display);
+const FontDesc TabButtonFont("fonts.widgets.tabbutton", System::Display);
 
 } // namespace Widgets
 namespace PatchStore
 {
-const Surge::Skin::FontDesc Label("fonts.patchstore.label", 11),
-    TextEntry("fonts.patchstore.textentry", 11);
+const FontDesc Label("fonts.patchstore.label", 11), TextEntry("fonts.patchstore.textentry", 11);
 }
 namespace LuaEditor
 {
-const Surge::Skin::FontDesc Code("fonts.luaeditor.code", Surge::Skin::FontDesc::MONO, 9);
+const FontDesc Code("fonts.luaeditor.code", FontDesc::MONO, 9);
 }
 
-namespace WaveShaperAnalysis
+namespace WaveshaperAnalysis
 {
-const Surge::Skin::FontDesc Title("fonts.waveshaperanalysis.title", 12),
-    DBAmount("fonts.waveshaperanalysis.dbamout", 9), DBLabel("fonts.waveshaperanalysis.dblabel", 7);
+const FontDesc Title("fonts.waveshaper.analysis.title", 9, FontDesc::FontStyleFlags::bold),
+    DriveAmount("fonts.waveshaper.analysis.drive_amount", 9),
+    DriveLabel("fonts.waveshaper.analysis.drive_label", 7);
 }
 
 } // namespace Fonts

--- a/src/common/SkinFonts.h
+++ b/src/common/SkinFonts.h
@@ -28,10 +28,10 @@ namespace Surge
 namespace Skin
 {
 struct FontDesc // this isn't actually a font; it is a description of a desire to get a font
-                // also avoid name clashes with all the other thigns called "Font"
+                // also avoid name clashes with all the other things called "Font"
 {
-    // I don't want to couple to juce this early so let me do this here
-    // and then assert they are equal in Skin::getFont in case Juce changes
+    // I don't want to couple to JUCE this early so let me do this here
+    // and then assert they are equal in Skin::getFont in case JUCE changes
     enum FontStyleFlags
     {
         plain = 0,
@@ -95,9 +95,9 @@ namespace LuaEditor
 {
 extern const Surge::Skin::FontDesc Code;
 }
-namespace WaveShaperAnalysis
+namespace WaveshaperAnalysis
 {
-extern const Surge::Skin::FontDesc Title, DBAmount, DBLabel;
+extern const Surge::Skin::FontDesc Title, DriveAmount, DriveLabel;
 }
 
 } // namespace Fonts

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3596,11 +3596,31 @@ void SurgeGUIEditor::reloadFromSkin()
 
     setZoomFactor(getZoomFactor(), true);
 
-    // update MSEG editor if opened
+    // update overlays, if opened
     if (isAnyOverlayPresent(MSEG_EDITOR))
     {
         showOverlay(SurgeGUIEditor::MSEG_EDITOR);
     }
+
+    // update waveshaper analyzer if opened
+    if (isAnyOverlayPresent(WAVESHAPER_ANALYZER))
+    {
+        showOverlay(SurgeGUIEditor::WAVESHAPER_ANALYZER);
+    }
+
+    /* TODO note for @baconpaul: make everything SkinConsumingComponent and fix the API
+    // update colors of any active overlays
+    for (int i = NO_EDITOR; i < n_overlay_tags; i++)
+    {
+        auto component =
+            dynamic_cast<Surge::GUI::SkinConsumingComponent *>(getOverlayIfOpen((OverlayTags)i));
+
+        if (component)
+        {
+            component->setSkin(currentSkin, bitmapStore);
+        }
+    }
+    */
 
     // adjust JUCE look and feel colors
     auto setJUCEColour = [this](int id, juce::Colour x) {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -359,7 +359,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         FORMULA_EDITOR,
         WAVETABLESCRIPTING_EDITOR, // This code is here but incomplete, and off in XT 1.0
         TUNING_EDITOR,
-        WAVESHAPER_ANALYZER
+        WAVESHAPER_ANALYZER,
+
+        n_overlay_tags,
     };
 
   private:


### PR DESCRIPTION
* Adjusted the border size so that it doesn't overlap with waveforms
* Adjusted text color and skin color name for WS analysis text
* Adjusted internal font names for WS analysis
* Update WS analysis overlay on skin change
* Add a more generic way of updating overlays on skin change (commented out, needs work)