### PR TITLE
Focus "Name" in PatchStore Dialog when opened

### DIFF
--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -90,7 +90,6 @@ PatchStoreDialog::PatchStoreDialog()
         auto ed = std::make_unique<juce::TextEditor>(n);
         ed->setJustification(juce::Justification::centredLeft);
         ed->setWantsKeyboardFocus(true);
-        ed->grabKeyboardFocus();
 
         addAndMakeVisible(*ed);
         return std::move(ed);
@@ -176,6 +175,12 @@ void PatchStoreDialog::setSurgeGUIEditor(SurgeGUIEditor *e)
         okOverButton->setVisible(false);
         resized();
     }
+}
+
+void PatchStoreDialog::parentHierarchyChanged()
+{
+    if (nameEd->isShowing() && isVisible())
+        nameEd->grabKeyboardFocus();
 }
 
 void PatchStoreDialog::onSkinChanged()

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.h
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.h
@@ -39,6 +39,7 @@ struct PatchStoreDialog : public OverlayComponent,
     ~PatchStoreDialog();
     void paint(juce::Graphics &g) override;
     void resized() override;
+    void parentHierarchyChanged() override;
 
     SurgeGUIEditor *editor{nullptr};
     void setSurgeGUIEditor(SurgeGUIEditor *e);


### PR DESCRIPTION
You have to do this on the event *after* the name editor is showing
so in the parent heirarchy changed callbacks.