### PR TITLE
Moveable Overlays

### DIFF
--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -64,6 +64,11 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     UseKeyboardShortcuts_Plugin,
     UseKeyboardShortcuts_Standalone,
 
+    TuningOverlayLocation,
+    ModlistOverlayLocation,
+    MSEGFormulaOverlayLocation,
+    WSAnalysisOverlayLocation,
+
     nKeys
 };
 /**
@@ -76,6 +81,8 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
 std::string getUserDefaultValue(SurgeStorage *storage, const DefaultKey &key,
                                 const std::string &valueIfMissing);
 int getUserDefaultValue(SurgeStorage *storage, const DefaultKey &key, int valueIfMissing);
+std::pair<int, int> getUserDefaultValue(SurgeStorage *storage, const DefaultKey &key,
+                                        const std::pair<int, int> &valueIfMissing);
 inline fs::path getUserDefaultPath(SurgeStorage *storage, const DefaultKey &key,
                                    const fs::path &valueIfMissing)
 {
@@ -94,6 +101,8 @@ inline bool updateUserDefaultPath(SurgeStorage *storage, const DefaultKey &key,
 {
     return updateUserDefaultValue(storage, key, path_to_string(path));
 }
+bool updateUserDefaultValue(SurgeStorage *stoarge, const DefaultKey &key,
+                            const std::pair<int, int> &value);
 
 } // namespace Storage
 } // namespace Surge

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -17,6 +17,7 @@
 #define SURGE_XT_OVERLAYCOMPONENT_H
 
 #include "juce_gui_basics/juce_gui_basics.h"
+#include "UserDefaults.h"
 
 namespace Surge
 {
@@ -41,6 +42,12 @@ struct OverlayComponent : juce::Component
     bool canTearOut{false};
     void setCanTearOut(bool b) { canTearOut = b; }
     bool getCanTearOut() { return canTearOut; }
+
+    std::pair<bool, Surge::Storage::DefaultKey> canMoveAround{false, Surge::Storage::nKeys};
+    void setCanMoveAround(std::pair<bool, Surge::Storage::DefaultKey> b) { canMoveAround = b; }
+    bool getCanMoveAround() { return canMoveAround.first; }
+    juce::Point<int> defaultLocation;
+    Surge::Storage::DefaultKey getMoveAroundKey() { return canMoveAround.second; }
 };
 } // namespace Overlays
 } // namespace Surge

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -22,11 +22,14 @@
 
 class SurgeGUIEditor;
 class SurgeImage;
+class SurgeStorage;
 
 namespace Surge
 {
 namespace Overlays
 {
+
+class OverlayComponent;
 struct OverlayWrapper : public juce::Component,
                         public Surge::GUI::SkinConsumingComponent,
                         public juce::Button::Listener
@@ -44,10 +47,21 @@ struct OverlayWrapper : public juce::Component,
     SurgeGUIEditor *editor{nullptr};
     void setSurgeGUIEditor(SurgeGUIEditor *e) { editor = e; }
 
+    SurgeStorage *storage{nullptr};
+    void setStorage(SurgeStorage *s) { storage = s; }
+
     std::unique_ptr<juce::Component> primaryChild;
     void addAndTakeOwnership(std::unique_ptr<juce::Component> c);
     std::unique_ptr<juce::TextButton> closeButton, tearOutButton;
     void buttonClicked(juce::Button *button) override;
+
+    juce::Point<float> distanceFromCornerToMouseDown;
+    bool isDragging{false};
+    bool allowDrag{true};
+    void mouseDown(const juce::MouseEvent &) override;
+    void mouseUp(const juce::MouseEvent &) override;
+    void mouseDrag(const juce::MouseEvent &) override;
+    void mouseDoubleClick(const juce::MouseEvent &e) override;
 
     SurgeImage *icon{nullptr};
     void setIcon(SurgeImage *d) { icon = d; }
@@ -79,6 +93,8 @@ struct OverlayWrapper : public juce::Component,
     bool isModal{false};
 
     std::unique_ptr<juce::DocumentWindow> tearOutParent;
+
+    OverlayComponent *getPrimaryChildAsOverlayComponent();
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OverlayWrapper);
 };


### PR DESCRIPTION
Some overlays are movable. Following the spec in #2824 they save
their last moved state into prefs when dragged. Also double click
returns them to default location when done in header. It's pretty
nifty actually! Tuning, ModList, MSEG/Form and WS Analysis all
got the treatment

Closes #2824