### PR TITLE
Rename/Delete Menu Items (Function not there yet)

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -624,6 +624,7 @@ void SurgeGUIEditor::idle()
                 patchSelector->setAuthor(synth->storage.getPatch().author);
                 patchSelector->setComment(synth->storage.getPatch().comment);
                 patchSelector->setIsFavorite(isPatchFavorite());
+                patchSelector->setIsUser(isPatchUser());
                 patchSelector->setTags(synth->storage.getPatch().tags);
                 patchSelector->repaint();
             }
@@ -1483,6 +1484,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             patchSelector->setSkin(currentSkin, bitmapStore);
             patchSelector->setLabel(synth->storage.getPatch().name);
             patchSelector->setIsFavorite(isPatchFavorite());
+            patchSelector->setIsUser(isPatchUser());
             patchSelector->setCategory(synth->storage.getPatch().category);
             patchSelector->setIDs(synth->current_category_id, synth->patchid);
             patchSelector->setAuthor(synth->storage.getPatch().author);
@@ -5732,6 +5734,16 @@ bool SurgeGUIEditor::isPatchFavorite()
     if (synth->patchid >= 0 && synth->patchid < synth->storage.patch_list.size())
     {
         return synth->storage.patch_list[synth->patchid].isFavorite;
+    }
+    return false;
+}
+
+bool SurgeGUIEditor::isPatchUser()
+{
+    if (synth->patchid >= 0 && synth->patchid < synth->storage.patch_list.size())
+    {
+        auto p = synth->storage.patch_list[synth->patchid];
+        return !synth->storage.patch_category[p.category].isFactory;
     }
     return false;
 }

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -532,6 +532,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
      */
     void setPatchAsFavorite(bool b);
     bool isPatchFavorite();
+    bool isPatchUser();
 
     /*
      * Modulation Client API

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -442,6 +442,16 @@ void PatchSelector::showClassicMenu(bool single_category)
             storage->patch_category[current_category].isFactory ? "Factory" : "User");
     });
 
+    if (isUser)
+    {
+        contextMenu.addItem("Rename Patch", [this]() {
+            storage->reportError("Coming Soon", "Function Not Implemented Yet");
+        });
+        contextMenu.addItem("Delete Patch", [this]() {
+            storage->reportError("Coming Soon", "Function Not Implemented Yet");
+        });
+    }
+
 #if HIDE_PATCH_BROWSER == false
     contextMenu.addSeparator();
 

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -56,6 +56,14 @@ struct PatchSelector : public juce::Component,
         isFavorite = b;
         repaint();
     }
+
+    bool isUser{false};
+    void setIsUser(bool b)
+    {
+        isUser = b;
+        repaint();
+    }
+
     void setLabel(const std::string &l) { pname = l; }
     void setCategory(std::string l)
     {


### PR DESCRIPTION
So I started doing rename delete (#4391) and then realized
I can't do it until I sort out the patch db add-remove stuff
properly. But that patch db add remove stuff is more hairy
but I didn't want to lose this bit of ground work I did
so just a checkpoint merge.