### PR TITLE
TearOut Enhancements

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -736,6 +736,14 @@ struct DAWExtraStateStorage
         {
             bool hasCustomEditor = false;
         } oscExtraEditState[n_scenes][n_lfos];
+
+        struct OverlayState
+        {
+            int whichOverlay{-1};
+            bool isTornOut{false};
+            std::pair<int, int> tearOutPosition{-1, -1};
+        };
+        std::vector<OverlayState> activeOverlays;
     } editor;
 
     bool mpeEnabled = false;

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2554,6 +2554,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
 
                     bool hadExtendedOverlay = false;
                     bool wasTornOut = false;
+                    auto wasTornOutTag = MSEG_EDITOR;
                     juce::Point<int> tearOutLoc;
                     for (auto otag : {MSEG_EDITOR, FORMULA_EDITOR})
                     {
@@ -2564,8 +2565,12 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                             {
                                 wasTornOut = c->isTornOut();
                                 tearOutLoc = c->currentTearOutLocation();
+                                wasTornOutTag = otag;
                             }
-                            closeOverlay(otag);
+                            if (!wasTornOut)
+                            {
+                                closeOverlay(otag);
+                            }
                             hadExtendedOverlay = true;
                         }
                     }
@@ -2587,6 +2592,10 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                         }
                         if (go)
                         {
+                            if (wasTornOut)
+                            {
+                                closeOverlay(wasTornOutTag);
+                            }
                             showOverlay(tag);
                             if (wasTornOut)
                             {


### PR DESCRIPTION
Closes #5233

- TearOuts rezoom when the main UI rezooms
- MSEG/Formula stay open if torn out and you select a non-MSEG
- All overlays including tearout go into DAW Extra State