### PR TITLE
PatchDB Improvements : Faster Startup, Deletes, etc...

### DIFF
--- a/src/common/PatchDB.h
+++ b/src/common/PatchDB.h
@@ -18,6 +18,7 @@
 #include <thread>
 #include <vector>
 #include <deque>
+#include <unordered_map>
 #include <condition_variable>
 #include "filesystem/import.h"
 #include <iostream>
@@ -108,6 +109,7 @@ struct PatchDB
     void addSubCategory(const std::string &name, const std::string &parent, CatType type);
     void addDebugMessage(const std::string &debug);
     void setUserFavorite(const std::string &path, bool isIt);
+    void erasePatchByID(int id);
 
     int numberOfJobsOutstanding();
 
@@ -116,6 +118,8 @@ struct PatchDB
     std::vector<std::string> readAllFeatureValueString(const std::string &feature);
     std::vector<int> readAllFeatureValueInt(const std::string &feature);
     std::vector<std::string> readUserFavorites();
+
+    std::unordered_map<std::string, std::pair<int, int64_t>> readAllPatchPathsWithIdAndModTime();
 
     // How the query string works
     static std::string sqlWhereClauseFor(const std::unique_ptr<PatchDBQueryParser::Token> &t);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -868,6 +868,7 @@ struct Patch
 {
     std::string name;
     fs::path path;
+    uint64_t lastModTime;
     int category;
     int order;
     bool isFavorite;

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -786,14 +786,28 @@ void PatchSelector::toggleTypeAheadSearch(bool b)
     if (isTypeaheadSearchOn)
     {
         storage->initializePatchDb();
+        bool enable = true;
+        auto txt = pname;
+        if (storage->patchDB->numberOfJobsOutstanding() > 0)
+        {
+            enable = false;
+            txt = "Updating Patch DB: " +
+                  std::to_string(storage->patchDB->numberOfJobsOutstanding()) + " jobs";
+        }
         typeAhead->setJustification(juce::Justification::centred);
-        typeAhead->setText(pname, juce::NotificationType::dontSendNotification);
+        typeAhead->setText(txt, juce::NotificationType::dontSendNotification);
         typeAhead->setIndents(4, (typeAhead->getHeight() - typeAhead->getTextHeight()) / 2);
 
         typeAhead->setVisible(true);
+        typeAhead->setEnabled(enable);
 
         typeAhead->grabKeyboardFocus();
         typeAhead->selectAll();
+
+        if (!enable)
+        {
+            juce::Timer::callAfterDelay(1000 / 30, [this]() { this->enableTypeAheadIfReady(); });
+        }
     }
     else
     {
@@ -801,6 +815,33 @@ void PatchSelector::toggleTypeAheadSearch(bool b)
     }
     repaint();
     return;
+}
+
+void PatchSelector::enableTypeAheadIfReady()
+{
+    if (!isTypeaheadSearchOn)
+        return;
+
+    bool enable = true;
+    auto txt = pname;
+    if (storage->patchDB->numberOfJobsOutstanding() > 0)
+    {
+        enable = false;
+        txt = "Updating Patch DB: " + std::to_string(storage->patchDB->numberOfJobsOutstanding()) +
+              " jobs";
+    }
+    typeAhead->setText(txt, juce::NotificationType::dontSendNotification);
+    typeAhead->setEnabled(enable);
+
+    if (enable)
+    {
+        typeAhead->grabKeyboardFocus();
+        typeAhead->selectAll();
+    }
+    else
+    {
+        juce::Timer::callAfterDelay(1000 / 30, [this]() { this->enableTypeAheadIfReady(); });
+    }
 }
 
 #if SURGE_JUCE_ACCESSIBLE

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -129,6 +129,7 @@ struct PatchSelector : public juce::Component,
 
     bool isTypeaheadSearchOn{false};
     void toggleTypeAheadSearch(bool);
+    void enableTypeAheadIfReady();
     std::unique_ptr<Surge::Widgets::TypeAhead> typeAhead;
     std::unique_ptr<PatchDBTypeAheadProvider> patchDbProvider;
 


### PR DESCRIPTION
Variety of patch db improvements

- Much faster startup if your db is already built
- THe patch typeahead shows jobs outstanding and disables
  if the database is under construction
- Few other code cleanups and improvements