### PR TITLE
PatchDB Progress

### DIFF
--- a/src/common/PatchDBQueryParser.cpp
+++ b/src/common/PatchDBQueryParser.cpp
@@ -158,7 +158,6 @@ std::unique_ptr<PatchDBQueryParser::Token> PatchDBQueryParser::parseQuery(const 
     //  pegtl::parse<grammar::combo_op, pegtl::nothing, pegtl::tracer>(tin);
 
     pegtl::string_input<> in(q, "Provided Expression");
-    std::cout << "\nINPUT '" << q << "'" << std::endl;
 
     try
     {
@@ -169,7 +168,7 @@ std::unique_ptr<PatchDBQueryParser::Token> PatchDBQueryParser::parseQuery(const 
             if (root->children.size() == 1)
             {
                 auto t = treeToToken(*(root->children[0]));
-                printParseTree(std::cout, t);
+                // printParseTree(std::cout, t);
                 return t;
             }
 
@@ -177,7 +176,6 @@ std::unique_ptr<PatchDBQueryParser::Token> PatchDBQueryParser::parseQuery(const 
         }
         else
         {
-            std::cout << "PARSE FAILED" << std::endl;
             return std::make_unique<Token>();
         }
     }

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -617,10 +617,13 @@ void SurgeStorage::createUserDirectory()
     }
 }
 
-void SurgeStorage::initializePatchDb()
+void SurgeStorage::initializePatchDb(bool force)
 {
-    if (patchDBInitialized)
+    if (patchDBInitialized && !force)
         return;
+
+    if (force)
+        std::cout << "FORCING PATCH RESCAN" << std::endl;
 
     patchDBInitialized = true;
 
@@ -681,6 +684,7 @@ void SurgeStorage::initializePatchDb()
 
     for (auto p : addThese)
     {
+        std::cout << "Adding " << p.name << " " << std::this_thread::get_id() << std::endl;
         auto t = catToType(p.category);
         patchDB->considerFXPForLoad(p.path, p.name, patch_category[p.category].name, t);
     }

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -978,7 +978,7 @@ class alignas(16) SurgeStorage
 
     std::unique_ptr<Surge::PatchStorage::PatchDB> patchDB;
     bool patchDBInitialized{false};
-    void initializePatchDb();
+    void initializePatchDb(bool forcePatchRescan = false);
 
     std::unique_ptr<SurgePatch> _patch;
 

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -586,6 +586,7 @@ void SurgeSynthesizer::savePatchToPath(fs::path filename)
 
     // refresh list
     storage.refresh_patchlist();
+    storage.initializePatchDb(true);
     refresh_editor = true;
     midiprogramshavechanged = true;
 }

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -22,8 +22,7 @@
 #include "UserDefaults.h"
 #include "widgets/MenuCustomComponents.h"
 #include "PatchDB.h"
-
-#define HIDE_PATCH_BROWSER false
+#include "fmt/core.h"
 
 namespace Surge
 {
@@ -88,6 +87,15 @@ struct PatchDBTypeAheadProvider : public TypeAheadDataProvider
         }
         g.setColour(divider);
         g.drawLine(4, height, width - 4, height, 1);
+    }
+
+    void paintOverChildren(juce::Graphics &g, const juce::Rectangle<int> &bounds) override
+    {
+        auto q = bounds.reduced(2, 2);
+        g.setColour(rowText.withAlpha(0.5f));
+        auto txt = fmt::format("{:d}", lastSearchResult.size());
+        g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(8));
+        g.drawText(txt, q, juce::Justification::topLeft);
     }
 };
 
@@ -452,7 +460,7 @@ void PatchSelector::showClassicMenu(bool single_category)
         });
     }
 
-#if HIDE_PATCH_BROWSER == false
+#if INCLUDE_PATCH_BROWSER
     contextMenu.addSeparator();
 
     contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Open Patch Database..."), [this]() {

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -66,6 +66,11 @@ struct TypeAheadListBoxModel : public juce::ListBoxModel
                              provider->textBoxValueForIndex(search[lastRowSelected]));
     }
     void escapeKeyPressed() { ta->dismissWithoutValue(); }
+
+    void listBoxItemClicked(int row, const juce::MouseEvent &event) override
+    {
+        returnKeyPressed(row);
+    }
 };
 
 struct TypeAheadListBox : public juce::ListBox
@@ -75,6 +80,13 @@ struct TypeAheadListBox : public juce::ListBox
         setOutlineThickness(1);
     }
 
+    void paintOverChildren(juce::Graphics &graphics) override
+    {
+        if (auto m = dynamic_cast<TypeAheadListBoxModel *>(getModel()))
+        {
+            m->provider->paintOverChildren(graphics, getLocalBounds());
+        }
+    }
     bool keyPressed(const juce::KeyPress &press) override
     {
         if (press.isKeyCode(juce::KeyPress::escapeKey))
@@ -115,7 +127,8 @@ void TypeAhead::dismissWithValue(int providerIdx, const std::string &s)
 {
     setText(s, juce::NotificationType::dontSendNotification);
     lbox->setVisible(false);
-    grabKeyboardFocus();
+    if (isVisible())
+        grabKeyboardFocus();
     for (auto l : taList)
         l->itemSelected(providerIdx);
 }

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -36,6 +36,7 @@ struct TypeAheadDataProvider
     virtual int getDisplayedRows() { return 9; }
     virtual void paintDataItem(int searchIndex, juce::Graphics &g, int width, int height,
                                bool rowIsSelected);
+    virtual void paintOverChildren(juce::Graphics &g, const juce::Rectangle<int> &bounds) {}
 };
 
 struct TypeAhead : public juce::TextEditor, juce::TextEditor::Listener


### PR DESCRIPTION
1. Disable Patch Browser
2. Update the patchdb when you store a patch, but at the cost
   of the schema upgrade mechanism being broken.
3. Show total patch count in UI
4. Cleanup cout
5. Make click to select work

Addresses #5253