### PR TITLE
wip: Fix portamento in channel-per-octave mode

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -73,18 +73,8 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
 
     if (storage->mapChannelToOctave)
     {
-        float shift;
-        if (channel > 7)
-        {
-            shift = channel - 16;
-        }
-        else
-        {
-            shift = channel;
-        }
-        res += 12 * shift;
+        res += 12 * (float) SurgeVoice::channelToOctaveShift(channel);
     }
-
     return res;
 }
 
@@ -285,8 +275,9 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
 
 SurgeVoice::~SurgeVoice() {}
 
-void SurgeVoice::legato(int key, int velocity, char detune)
+void SurgeVoice::legato(char channel, int key, int velocity, char detune)
 {
+    if (storage->mapChannelToOctave) state.channel = channel;
     if (state.portaphase > 1)
         state.portasrc_key = state.getPitch(storage);
     else
@@ -305,8 +296,9 @@ void SurgeVoice::legato(int key, int velocity, char detune)
             phase = glide_exp(state.portaphase);
             break;
         }
-
+        cout << "legato portasrc_key before: " << state.portasrc_key << "\n";
         state.portasrc_key = ((1 - phase) * state.portasrc_key + phase * state.getPitch(storage));
+        cout << "legato portasrc_key after: " << state.portasrc_key << "\n";
 
         if (scene->portamento.porta_gliss) // quantize portamento to keys
             state.pkey = floor(state.pkey + 0.5);

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -48,12 +48,34 @@ class alignas(16) SurgeVoice
 
     bool process_block(QuadFilterChainState &, int);
     void GetQFB(); // Get the updated registers from the QuadFB
-    void legato(int key, int velocity, char detune);
+    void legato(char channel, int key, int velocity, char detune);
     void switch_toggled();
     void freeAllocatedElements();
     int osctype[n_oscs];
     SurgeVoiceState state;
     int age, age_release;
+
+    inline static int channelToOctaveShift(char channel) {
+        if (channel > 7)
+        {
+            return (channel - 16);
+        }
+        else
+        {
+            return channel;
+        }
+    }
+
+    inline static char octaveShiftToChannel(int shift) {
+        if (shift < 0)
+        {
+            return (16 - shift);
+        }
+        else
+        {
+            return shift;
+        }
+    }
 
     /*
     ** Given a note0 and an oscilator this returns the appropriate note.


### PR DESCRIPTION
This change almost works right, I think... but portamento up and down by octaves (i.e. different channels, same note number) is not smooth in cases where it ought to be, so there's still something missing to find.