### PR TITLE
Fix Mono Modes in Octave Per Channel

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -721,6 +721,26 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
                     }
                 }
             }
+            else if (storage.mapChannelToOctave)
+            {
+                auto keyadj = SurgeVoice::channelKeyEquvialent(key, channel, &storage);
+
+                for (int k = lowkey; k < hikey; ++k)
+                {
+                    for (int ch = 0; ch < 16; ++ch)
+                    {
+                        if (channelState[ch].keyState[k].keystate)
+                        {
+                            auto kadj = SurgeVoice::channelKeyEquvialent(k, ch, &storage);
+
+                            if (primode == ALWAYS_HIGHEST && kadj > keyadj)
+                                createVoice = false;
+                            if (primode == ALWAYS_LOWEST && kadj < keyadj)
+                                createVoice = false;
+                        }
+                    }
+                }
+            }
             else
             {
                 for (int k = lowkey; k < hikey; ++k)
@@ -746,14 +766,14 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
                 {
                     v->legato(key, velocity, detune);
                     found_one = true;
-                    if (mpeEnabled)
+                    if (mpeEnabled || storage.mapChannelToOctave)
                     {
                         /*
                         ** This voice was created on a channel but is being legato held to another
                         *channel
                         ** so it needs to borrow the channel and channelState. Obviously this can
                         *only
-                        ** happen in MPE mode.
+                        ** happen in MPE mode or channel to octave mode
                         */
                         v->state.channel = channel;
                         v->state.voiceChannelState = &channelState[channel];

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -71,6 +71,14 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
         res = (1.f - frac) * b0 + frac * b1;
     }
 
+    res = SurgeVoice::channelKeyEquvialent(res, channel, storage);
+
+    return res;
+}
+
+float SurgeVoice::channelKeyEquvialent(float key, int channel, SurgeStorage *storage)
+{
+    float res = key;
     if (storage->mapChannelToOctave)
     {
         float shift;
@@ -90,7 +98,6 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
             res += ct / 100 * shift;
         }
     }
-
     return res;
 }
 

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -133,6 +133,8 @@ class alignas(16) SurgeVoice
         }
     }
 
+    static float channelKeyEquvialent(float key, int channel, SurgeStorage *storage);
+
   private:
     template <bool first> void calc_ctrldata(QuadFilterChainState *, int);
     void update_portamento();

--- a/src/surge-testrunner/UnitTestsTUN.cpp
+++ b/src/surge-testrunner/UnitTestsTUN.cpp
@@ -1339,13 +1339,7 @@ TEST_CASE("Octave Per Channel and Porta", "[tun]")
 {
     namespace hs = Surge::Headless;
 
-    SECTION("BaseLine Different Note Same Channel")
-    {
-        auto surge = surgeOnSine();
-        surge->storage.getPatch().scene[0].polymode.val.i = pm_mono_st;
-        surge->storage.mapChannelToOctave = true;
-        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
-
+    auto noteTwoFreq = [](auto surge, int key, int channel) {
         auto events = hs::playerEvents_t();
 
         int len = 20000;
@@ -1357,13 +1351,9 @@ TEST_CASE("Octave Per Channel and Porta", "[tun]")
         on.atSample = 0;
         events.push_back(on);
 
-        on.data1 = 72;
+        on.data1 = key;
+        on.channel = channel;
         on.atSample = len;
-        events.push_back(on);
-
-        on.data1 = 60;
-        on.type = hs::Event::NOTE_OFF;
-        on.atSample = len * 2;
         events.push_back(on);
 
         on.type = hs::Event::NO_EVENT;
@@ -1374,21 +1364,7 @@ TEST_CASE("Octave Per Channel and Porta", "[tun]")
         hs::playAsConfigured(surge, events, &buffer, &nS, &nC);
         delete[] buffer;
 
-        for (int sc = 0; sc < n_scenes; ++sc)
-        {
-            for (int k = 0; k < 128; ++k)
-            {
-                if (surge->midiKeyPressedForScene[sc][k] > 0)
-                {
-                    std::cout << "KEYON is " << k << std::endl;
-                }
-            }
-        }
-
         events.clear();
-        on.data1 = 72;
-        on.atSample = len * 4;
-        on.type = hs::Event::NOTE_OFF;
         events.push_back(on);
         hs::playAsConfigured(surge, events, &buffer, &nS, &nC);
 
@@ -1398,116 +1374,83 @@ TEST_CASE("Octave Per Channel and Porta", "[tun]")
 
         delete[] buffer;
 
+        return freq;
+    };
+
+    SECTION("BaseLine - Different Note Same Channel")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.getPatch().scene[0].polymode.val.i = pm_mono_st;
+        surge->storage.getPatch().scene[0].monoVoicePriorityMode = ALWAYS_HIGHEST;
+        surge->storage.mapChannelToOctave = true;
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
+
+        auto freq = noteTwoFreq(surge, 72, 0);
         REQUIRE(freq == Approx(Tunings::MIDI_0_FREQ * 64).margin(1));
     }
 
-#if RESOLVED_5259
-    SECTION("BaseLine Different Note Different Channel")
+    SECTION("Different Note Different Channel")
     {
         auto surge = surgeOnSine();
         surge->storage.mapChannelToOctave = true;
+        surge->storage.getPatch().scene[0].monoVoicePriorityMode = ALWAYS_HIGHEST;
         surge->storage.getPatch().scene[0].polymode.val.i = pm_mono_st;
         surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
 
-        auto events = hs::playerEvents_t();
-
-        int len = 20000;
-        auto on = hs::Event();
-        on.type = hs::Event::NOTE_ON;
-        on.channel = 0;
-        on.data1 = 60;
-        on.data2 = 100;
-        on.atSample = 0;
-        events.push_back(on);
-
-        on.data1 = 72;
-        on.atSample = len;
-        on.channel = 1;
-        events.push_back(on);
-
-        on.data1 = 60;
-        on.type = hs::Event::NOTE_OFF;
-        on.channel = 0;
-        on.atSample = len * 2;
-        events.push_back(on);
-
-        on.type = hs::Event::NO_EVENT;
-        on.atSample = len * 3;
-
-        float *buffer;
-        int nS, nC;
-        hs::playAsConfigured(surge, events, &buffer, &nS, &nC);
-        delete[] buffer;
-
-        events.clear();
-        on.data1 = 72;
-        on.atSample = len * 4;
-        on.channel = 1;
-        on.type = hs::Event::NOTE_OFF;
-        events.push_back(on);
-        hs::playAsConfigured(surge, events, &buffer, &nS, &nC);
-
-        int nSTrim = (int)(nS / 2 * 0.8);
-        int start = (int)(nS / 2 * 0.05);
-        auto freq = frequencyFromData(buffer, nS, nC, 0, start, nSTrim);
-
-        delete[] buffer;
+        auto freq = noteTwoFreq(surge, 72, 1);
 
         REQUIRE(freq == Approx(Tunings::MIDI_0_FREQ * 32 * 4).margin(1));
     }
 
-    SECTION("BaseLine Same Note Different Channel")
+    SECTION("Same Note Different Channel")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.mapChannelToOctave = true;
+        surge->storage.getPatch().scene[0].monoVoicePriorityMode = ALWAYS_HIGHEST;
+        surge->storage.getPatch().scene[0].polymode.val.i = pm_mono_st;
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
+
+        auto freq = noteTwoFreq(surge, 60, 1);
+
+        REQUIRE(freq == Approx(Tunings::MIDI_0_FREQ * 32 * 2).margin(1));
+    }
+
+    SECTION("Same Key Lower Note Different Channel")
     {
         auto surge = surgeOnSine();
         surge->storage.mapChannelToOctave = true;
         surge->storage.getPatch().scene[0].polymode.val.i = pm_mono_st;
+        surge->storage.getPatch().scene[0].monoVoicePriorityMode = ALWAYS_HIGHEST;
         surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
 
-        auto events = hs::playerEvents_t();
+        auto freq = noteTwoFreq(surge, 60, 15);
 
-        int len = 20000;
-        auto on = hs::Event();
-        on.type = hs::Event::NOTE_ON;
-        on.channel = 0;
-        on.data1 = 60;
-        on.data2 = 100;
-        on.atSample = 0;
-        events.push_back(on);
-
-        on.data1 = 60;
-        on.atSample = len;
-        on.channel = 1;
-        events.push_back(on);
-
-        on.data1 = 60;
-        on.type = hs::Event::NOTE_OFF;
-        on.channel = 0;
-        on.atSample = len * 2;
-        events.push_back(on);
-
-        on.type = hs::Event::NO_EVENT;
-        on.atSample = len * 3;
-
-        float *buffer;
-        int nS, nC;
-        hs::playAsConfigured(surge, events, &buffer, &nS, &nC);
-        delete[] buffer;
-
-        events.clear();
-        on.data1 = 60;
-        on.atSample = len * 4;
-        on.channel = 1;
-        on.type = hs::Event::NOTE_OFF;
-        events.push_back(on);
-        hs::playAsConfigured(surge, events, &buffer, &nS, &nC);
-
-        int nSTrim = (int)(nS / 2 * 0.8);
-        int start = (int)(nS / 2 * 0.05);
-        auto freq = frequencyFromData(buffer, nS, nC, 0, start, nSTrim);
-
-        delete[] buffer;
-
-        REQUIRE(freq == Approx(Tunings::MIDI_0_FREQ * 32 * 2).margin(1));
+        REQUIRE(freq == Approx(Tunings::MIDI_0_FREQ * 32).margin(1));
     }
-#endif
+
+    SECTION("Higher Key Lower Note Different Channel")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.mapChannelToOctave = true;
+        surge->storage.getPatch().scene[0].polymode.val.i = pm_mono_st;
+        surge->storage.getPatch().scene[0].monoVoicePriorityMode = ALWAYS_HIGHEST;
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
+
+        auto freq = noteTwoFreq(surge, 62, 15);
+
+        REQUIRE(freq == Approx(Tunings::MIDI_0_FREQ * 32).margin(1));
+    }
+
+    SECTION("Lower Key Higher Note Different Channel")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.mapChannelToOctave = true;
+        surge->storage.getPatch().scene[0].polymode.val.i = pm_mono_st;
+        surge->storage.getPatch().scene[0].monoVoicePriorityMode = ALWAYS_HIGHEST;
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
+
+        auto freq = noteTwoFreq(surge, 69 - 12, 1);
+
+        REQUIRE(freq == Approx(440.0).margin(1));
+    }
 }


### PR DESCRIPTION
Mono ST modes reuse voices; in octave per channel
this makes us a bit like MPE, but not quite, so add
the branch

Addresses #5259