### PR TITLE
MONO and MONO_FP modes pass tests in OctavePerChannel mode

### DIFF
--- a/src/surge-testrunner/UnitTestsTUN.cpp
+++ b/src/surge-testrunner/UnitTestsTUN.cpp
@@ -1430,7 +1430,7 @@ TEST_CASE("Octave Per Channel and Porta", "[tun]")
         return surge;
     };
 
-    for (auto mode : {/*pm_mono, pm_mono_fp, pm_mono_st, pm_mono_st_fp*/ pm_mono_st, pm_mono_st_fp})
+    for (auto mode : {pm_mono, pm_mono_fp, pm_mono_st, pm_mono_st_fp})
     {
         DYNAMIC_SECTION("Mode " << mode << ": "
                                 << "BaseLine - Different Note Same Channel")


### PR DESCRIPTION
This I think addresses all the issues in #5259