### PR TITLE
Fix TearOut objections

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -168,6 +168,15 @@ void initMaps()
             case WSAnalysisOverlayLocation:
                 r = "wsAnalysisOverlayLocation";
                 break;
+            case TuningOverlayLocationTearOut:
+                r = "tuningOverlayLocationTearOut";
+                break;
+            case ModlistOverlayLocationTearOut:
+                r = "modlistOverlayLocationTearOut";
+                break;
+            case MSEGFormulaOverlayLocationTearOut:
+                r = "msegFormulaOverlayLocationTearOut";
+                break;
             case nKeys:
                 break;
             }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -69,6 +69,10 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     MSEGFormulaOverlayLocation,
     WSAnalysisOverlayLocation,
 
+    TuningOverlayLocationTearOut,
+    ModlistOverlayLocationTearOut,
+    MSEGFormulaOverlayLocationTearOut,
+
     nKeys
 };
 /**

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3649,7 +3649,21 @@ void SurgeGUIEditor::reloadFromSkin()
     // update overlays, if opened
     if (isAnyOverlayPresent(MSEG_EDITOR))
     {
+        bool tornOut = false;
+        juce::Point<int> tearOutPos;
+        auto olw = getOverlayWrapperIfOpen(MSEG_EDITOR);
+        if (olw && olw->isTornOut())
+        {
+            tornOut = true;
+            tearOutPos = olw->currentTearOutLocation();
+        }
         showOverlay(SurgeGUIEditor::MSEG_EDITOR);
+        if (tornOut)
+        {
+            auto olw = getOverlayWrapperIfOpen(MSEG_EDITOR);
+            if (olw)
+                olw->doTearOut(tearOutPos);
+        }
     }
 
     // update waveshaper analyzer if opened
@@ -5243,13 +5257,27 @@ void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)
     }
 
     bool hadExtendedEditor = false;
+    bool isTornOut = false;
+    juce::Point<int> tearOutPos;
     if (isAnyOverlayPresent(MSEG_EDITOR))
     {
+        auto olw = getOverlayWrapperIfOpen(MSEG_EDITOR);
+        if (olw && olw->isTornOut())
+        {
+            isTornOut = true;
+            tearOutPos = olw->currentTearOutLocation();
+        }
         closeOverlay(SurgeGUIEditor::MSEG_EDITOR);
         hadExtendedEditor = true;
     }
     if (isAnyOverlayPresent(FORMULA_EDITOR))
     {
+        auto olw = getOverlayWrapperIfOpen(FORMULA_EDITOR);
+        if (olw && olw->isTornOut())
+        {
+            isTornOut = true;
+            tearOutPos = olw->currentTearOutLocation();
+        }
         closeOverlay(FORMULA_EDITOR);
         hadExtendedEditor = true;
     }
@@ -5259,10 +5287,22 @@ void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)
         if (curr == lt_mseg)
         {
             showOverlay(SurgeGUIEditor::MSEG_EDITOR);
+            if (isTornOut)
+            {
+                auto olw = getOverlayWrapperIfOpen(MSEG_EDITOR);
+                if (olw)
+                    olw->doTearOut(tearOutPos);
+            }
         }
         if (curr == lt_formula)
         {
             showOverlay(FORMULA_EDITOR);
+            if (isTornOut)
+            {
+                auto olw = getOverlayWrapperIfOpen(FORMULA_EDITOR);
+                if (olw)
+                    olw->doTearOut(tearOutPos);
+            }
         }
     }
 

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -24,6 +24,7 @@
 #include "overlays/OverlayWrapper.h"
 #include "widgets/MainFrame.h"
 #include "widgets/WaveShaperSelector.h"
+#include "UserDefaults.h"
 
 std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::makeStorePatchDialog()
 {
@@ -138,7 +139,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         auto h = getWindowSizeY() - yPos - xBuf;
         pt->setEnclosingParentPosition(juce::Rectangle<int>(xBuf, yPos, w, h));
         pt->setEnclosingParentTitle("Patch Database");
-        pt->setCanTearOut(true);
+        jassert(false); // Make a key for me please!
+        pt->setCanTearOut({true, Surge::Storage::nKeys});
         return pt;
     }
     break;
@@ -187,7 +189,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         Surge::Storage::findReplaceSubstring(title, std::string("LFO"), std::string("MSEG"));
 
         mse->setEnclosingParentTitle(title);
-        mse->setCanTearOut(true);
+        mse->setCanTearOut({true, Surge::Storage::MSEGFormulaOverlayLocationTearOut});
         locationForMSFR(mse.get());
         return mse;
     }
@@ -230,7 +232,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         Surge::Storage::findReplaceSubstring(title, std::string("LFO"), std::string("Formula"));
 
         pt->setEnclosingParentTitle(title);
-        pt->setCanTearOut(true);
+        pt->setCanTearOut({true, Surge::Storage::MSEGFormulaOverlayLocationTearOut});
         locationForMSFR(pt.get());
         return pt;
     }
@@ -263,7 +265,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         pt->setTuning(synth->storage.currentTuning);
         pt->setEnclosingParentPosition(juce::Rectangle<int>(px, py, w, h));
         pt->setEnclosingParentTitle("Tuning Editor");
-        pt->setCanTearOut(true);
+        pt->setCanTearOut({true, Surge::Storage::TuningOverlayLocationTearOut});
         pt->defaultLocation = dl;
         pt->setCanMoveAround(std::make_pair(true, Surge::Storage::TuningOverlayLocation));
         return pt;
@@ -346,7 +348,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         pt->setEnclosingParentTitle("Modulation List");
         pt->setEnclosingParentPosition(r);
         pt->setCanMoveAround(std::make_pair(true, Surge::Storage::ModlistOverlayLocation));
-        pt->setCanTearOut(true);
+        pt->setCanTearOut({true, Surge::Storage::ModlistOverlayLocationTearOut});
         pt->defaultLocation = dl;
         return pt;
     }

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -3259,7 +3259,7 @@ void MSEGEditor::forceRefresh()
     }
 }
 
-void MSEGEditor::paint(juce::Graphics &g) { g.fillAll(juce::Colours::orchid); }
+void MSEGEditor::paint(juce::Graphics &g) { g.fillAll(juce::Colours::black); }
 
 void MSEGEditor::resized()
 {

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -39,9 +39,9 @@ struct OverlayComponent : juce::Component
     void setHasIndependentClose(bool b) { hasIndependentClose = b; }
     bool getHasIndependentClose() { return hasIndependentClose; }
 
-    bool canTearOut{false};
-    void setCanTearOut(bool b) { canTearOut = b; }
-    bool getCanTearOut() { return canTearOut; }
+    std::pair<bool, Surge::Storage::DefaultKey> canTearOut{false, Surge::Storage::nKeys};
+    void setCanTearOut(std::pair<bool, Surge::Storage::DefaultKey> b) { canTearOut = b; }
+    std::pair<bool, Surge::Storage::DefaultKey> getCanTearOut() { return canTearOut; }
     virtual void onTearOutChanged(bool isTornOut) {}
 
     std::pair<bool, Surge::Storage::DefaultKey> canMoveAround{false, Surge::Storage::nKeys};

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -17,6 +17,7 @@
 #define SURGE_XT_OVERLAYWRAPPER_H
 
 #include "SkinSupport.h"
+#include "UserDefaults.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -55,7 +56,8 @@ struct OverlayWrapper : public juce::Component,
     std::unique_ptr<juce::TextButton> closeButton, tearOutButton;
     void buttonClicked(juce::Button *button) override;
 
-    juce::Point<float> distanceFromCornerToMouseDown;
+    juce::Point<int> mouseDownWithinTarget;
+
     bool isDragging{false};
     bool allowDrag{true};
     void mouseDown(const juce::MouseEvent &) override;
@@ -66,8 +68,13 @@ struct OverlayWrapper : public juce::Component,
     SurgeImage *icon{nullptr};
     void setIcon(SurgeImage *d) { icon = d; }
 
-    bool canTearOut{false};
-    void setCanTearOut(bool b) { canTearOut = b; }
+    std::pair<bool, Surge::Storage::DefaultKey> canTearOutPair{false, Surge::Storage::nKeys};
+    bool canTearOut;
+    void setCanTearOut(std::pair<bool, Surge::Storage::DefaultKey> b)
+    {
+        canTearOutPair = b;
+        canTearOut = b.first;
+    }
     void doTearOut(const juce::Point<int> &showAt = juce::Point<int>(-1, -1));
     void doTearIn();
     bool isTornOut();


### PR DESCRIPTION
Closes #5247

- Center initial position
- Handle close and reskin and swap type closes
- Pink line in mseg gone
- Mouse drag at correct speed
- Positions remember as defaults keys