### PR TITLE
An init edge case

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -813,9 +813,13 @@ void SurgePatch::update_controls(
             if (fx[i].type.val.i != fxt_off)
             {
                 Effect *t_fx = spawn_effect(fx[i].type.val.i, nullptr, &(fx[i]), nullptr);
-                t_fx->init_ctrltypes();
-                t_fx->handleStreamingMismatches(streamingRevision, currentSynthStreamingRevision);
-                delete t_fx;
+                if (t_fx)
+                {
+                    t_fx->init_ctrltypes();
+                    t_fx->handleStreamingMismatches(streamingRevision,
+                                                    currentSynthStreamingRevision);
+                    delete t_fx;
+                }
             }
         }
     }


### PR DESCRIPTION
Lets say you start standalone against a branch, load a new effect,
rebuild against main, and hten start standalone again. Your patch now
has an invalid fx id in it. It would crash horribly. This must makes
it sort of go a bit garbled instead in the ui.