### PR TITLE
Tuning Overlay Infinite Knob Double Click

### DIFF
--- a/src/surge-xt/gui/overlays/TuningOverlays.h
+++ b/src/surge-xt/gui/overlays/TuningOverlays.h
@@ -74,6 +74,7 @@ struct TuningOverlay : public OverlayComponent,
     void onToneChanged(int tone, double newCentsValue);
     void onToneStringChanged(int tone, const std::string &newCentsValue);
     void onScaleRescaled(double scaledBy);
+    void onScaleRescaledAbsolute(double setRITo);
     void recalculateScaleText();
     void setTuning(const Tunings::Tuning &t);
     void resized() override;


### PR DESCRIPTION
resets to ET for the scale length and RI in effect.
On the 0 knob, resets to 1200 RI