### PR TITLE
A major rework of the Modulation List screen (Incomplete)

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2428,8 +2428,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
     case Decibel:
     {
         float v = amp_to_db(val.f);
-        float mp = amp_to_db(val.f + modulationDepth);
-        float mn = amp_to_db(val.f - modulationDepth);
+        float mp = amp_to_db(std::max(val.f + modulationDepth, 1.e-7f));
+        float mn = amp_to_db(std::max(val.f - modulationDepth, 1.e-7f));
 
         char posval[TXT_SIZE];
         char negval[TXT_SIZE];

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2599,7 +2599,7 @@ bool SurgeSynthesizer::loadOscalgos()
     return true;
 }
 
-bool SurgeSynthesizer::isModulatorDistinctPerScene(modsources modsource)
+bool SurgeSynthesizer::isModulatorDistinctPerScene(modsources modsource) const
 {
     if (modsource >= ms_lfo1 && modsource <= ms_slfo6)
         return true;
@@ -3127,7 +3127,7 @@ bool SurgeSynthesizer::setModulation(long ptag, modsources modsource, int modsou
     storage.modRoutingMutex.unlock();
 
     for (auto l : modListeners)
-        l->modSet(ptag, modsource, modsourceScene, index, val);
+        l->modSet(ptag, modsource, modsourceScene, index, val, found_id < 0);
     return true;
 }
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -268,7 +268,7 @@ class alignas(16) SurgeSynthesizer
     bool isBipolarModulation(modsources modsources) const;
     bool isModsourceUsed(modsources modsource); // FIXME - this should be const
     bool isModDestUsed(long moddest) const;
-    bool isModulatorDistinctPerScene(modsources modsource); // ModWheel no; SLFO2 yes. etc...
+    bool isModulatorDistinctPerScene(modsources modsource) const; // ModWheel no; SLFO2 yes. etc...
 
     bool supportsIndexedModulator(int scene, modsources modsource) const;
     int getMaxModulationIndex(int scene, modsources modsource) const;
@@ -306,7 +306,7 @@ class alignas(16) SurgeSynthesizer
     {
         virtual ~ModulationAPIListener() = default;
         virtual void modSet(long ptag, modsources modsource, int modsourceScene, int index,
-                            float value) = 0;
+                            float value, bool isNewModulation) = 0;
         virtual void modMuted(long ptag, modsources modsource, int modsourceScene, int index,
                               bool mute) = 0;
         virtual void modCleared(long ptag, modsources modsource, int modsourceScene, int index) = 0;

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -504,8 +504,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         SurgeGUIEditor *moded;
     };
     std::atomic<bool> selfModulation{false}, needsModUpdate{false};
-    void modSet(long ptag, modsources modsource, int modsourceScene, int index,
-                float value) override;
+    void modSet(long ptag, modsources modsource, int modsourceScene, int index, float value,
+                bool isNew) override;
     void modMuted(long ptag, modsources modsource, int modsourceScene, int index,
                   bool mute) override;
     void modCleared(long ptag, modsources modsource, int modsourceScene, int index) override;

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -329,7 +329,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
     case MODULATION_EDITOR:
     {
         auto pt = std::make_unique<Surge::Overlays::ModulationEditor>(this, this->synth);
-        int w = 750, h = 500;
+        int w = 650, h = 500;
         auto px = (getWindowSizeX() - w) / 2;
         auto py = (getWindowSizeY() - h) / 2;
 
@@ -350,6 +350,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         pt->setCanMoveAround(std::make_pair(true, Surge::Storage::ModlistOverlayLocation));
         pt->setCanTearOut({true, Surge::Storage::ModlistOverlayLocationTearOut});
         pt->defaultLocation = dl;
+        pt->setSkin(currentSkin, bitmapStore);
+
         return pt;
     }
     break;

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -39,6 +39,7 @@
 
 #include "overlays/TypeinParamEditor.h"
 #include "widgets/WaveShaperSelector.h"
+#include "overlays/ModulationEditor.h"
 
 std::string decodeControllerID(int id)
 {
@@ -2964,6 +2965,13 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                     // The green line might change so...
                     refresh_mod();
                 }
+
+                // Finally we may have to update the modulation editor
+                auto me = getOverlayIfOpenAs<Surge::Overlays::ModulationEditor>(MODULATION_EDITOR);
+                if (me)
+                {
+                    me->updateParameterById(ptagid);
+                }
             }
             if (!queue_refresh)
             {
@@ -3132,7 +3140,7 @@ bool SurgeGUIEditor::setControlFromString(modsources ms, const std::string &s)
 }
 
 void SurgeGUIEditor::modSet(long ptag, modsources modsource, int modsourceScene, int index,
-                            float value)
+                            float value, bool isNew)
 {
     if (!selfModulation)
         needsModUpdate = true;

--- a/src/surge-xt/gui/overlays/ModulationEditor.h
+++ b/src/surge-xt/gui/overlays/ModulationEditor.h
@@ -19,6 +19,7 @@
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "OverlayComponent.h"
 #include "SurgeSynthesizer.h"
+#include "SkinSupport.h"
 
 class SurgeGUIEditor;
 
@@ -26,17 +27,18 @@ namespace Surge
 {
 namespace Overlays
 {
-class ModulationListBoxModel;
+// class ModulationListBoxModel;
+struct ModulationSideControls;
+struct ModulationListContents;
 
-class ModulationEditor : public OverlayComponent, public SurgeSynthesizer::ModulationAPIListener
+class ModulationEditor : public OverlayComponent,
+                         public Surge::GUI::SkinConsumingComponent,
+                         public SurgeSynthesizer::ModulationAPIListener
 {
   public:
     ModulationEditor(SurgeGUIEditor *ed, SurgeSynthesizer *s);
     ~ModulationEditor();
 
-    std::unique_ptr<juce::ListBox> listBox;
-    std::unique_ptr<ModulationListBoxModel> listBoxModel;
-    std::unique_ptr<juce::TextEditor> textBox;
     SurgeGUIEditor *ed;
     SurgeSynthesizer *synth;
 
@@ -52,12 +54,20 @@ class ModulationEditor : public OverlayComponent, public SurgeSynthesizer::Modul
         ~SelfModulationGuard() { moded->selfModulation = false; }
         ModulationEditor *moded;
     };
-    std::atomic<bool> selfModulation{false}, needsModUpdate{false};
-    void modSet(long ptag, modsources modsource, int modsourceScene, int index,
-                float value) override;
+    std::atomic<bool> selfModulation{false}, needsModUpdate{false}, needsModValueOnlyUpdate{false};
+    void modSet(long ptag, modsources modsource, int modsourceScene, int index, float value,
+                bool isNew) override;
     void modMuted(long ptag, modsources modsource, int modsourceScene, int index,
                   bool mute) override;
     void modCleared(long ptag, modsources modsource, int modsourceScene, int index) override;
+
+    std::unique_ptr<ModulationSideControls> sideControls;
+    std::unique_ptr<ModulationListContents> modContents;
+    std::unique_ptr<juce::Viewport> viewport;
+
+    void onSkinChanged() override;
+
+    void updateParameterById(const SurgeSynthesizer::ID &pid);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModulationEditor);
 };

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -24,46 +24,18 @@ namespace Widgets
 int mg = 1;
 int xp = 16;
 
-struct TinyLittleIconButton : public juce::Component
+void TinyLittleIconButton::paint(juce::Graphics &g)
 {
-    TinyLittleIconButton(int off, std::function<void()> cb) : offset(off), callback(std::move(cb))
-    {
-    }
-
-    void setIcon(SurgeImage *img)
-    {
-        icons = img;
-        repaint();
-    }
-
-    void paint(juce::Graphics &g) override
-    {
-        auto yp = offset * 20;
-        auto xp = isHovered ? 20 : 0;
-        g.reduceClipRegion(getLocalBounds());
-        auto t = juce::AffineTransform().translated(-xp, -yp);
-        if (icons)
-            icons->draw(g, 1.0, t);
-    }
-    void mouseUp(const juce::MouseEvent &e) override { callback(); }
-    void mouseEnter(const juce::MouseEvent &e) override
-    {
-        isHovered = true;
-        repaint();
-    }
-    void mouseExit(const juce::MouseEvent &e) override
-    {
-        isHovered = false;
-        repaint();
-    }
-
-    bool isHovered{false};
-    std::function<void()> callback;
-    SurgeImage *icons{nullptr};
-    int offset{0};
-
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TinyLittleIconButton);
-};
+    auto yp = offset * 20;
+    auto xp = isHovered ? 20 : 0;
+    g.reduceClipRegion(getLocalBounds());
+    auto t = juce::AffineTransform();
+    t = t.translated(-xp, -yp);
+    if (getWidth() < 20 || getHeight() < 20)
+        t = t.scaled(getWidth() / 20.f);
+    if (icons)
+        icons->draw(g, 1.0, t);
+}
 
 void MenuTitleHelpComponent::getIdealSize(int &idealWidth, int &idealHeight)
 {

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -24,6 +24,39 @@ namespace Surge
 namespace Widgets
 {
 
+struct TinyLittleIconButton : public juce::Component
+{
+    TinyLittleIconButton(int off, std::function<void()> cb) : offset(off), callback(std::move(cb))
+    {
+    }
+
+    void setIcon(SurgeImage *img)
+    {
+        icons = img;
+        repaint();
+    }
+
+    void paint(juce::Graphics &g) override;
+    void mouseUp(const juce::MouseEvent &e) override { callback(); }
+    void mouseEnter(const juce::MouseEvent &e) override
+    {
+        isHovered = true;
+        repaint();
+    }
+    void mouseExit(const juce::MouseEvent &e) override
+    {
+        isHovered = false;
+        repaint();
+    }
+
+    bool isHovered{false};
+    std::function<void()> callback;
+    SurgeImage *icons{nullptr};
+    int offset{0};
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TinyLittleIconButton);
+};
+
 struct MenuTitleHelpComponent : juce::PopupMenu::CustomComponent, Surge::GUI::SkinConsumingComponent
 {
     MenuTitleHelpComponent(const std::string &l, const std::string &u)

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -134,9 +134,15 @@ void ModulatableSlider::updateLocationState()
 
 void ModulatableSlider::paint(juce::Graphics &g)
 {
+    jassert(skin);
     jassert(pTray);
     if (!pTray)
         return;
+    if (!skin)
+    {
+        std::cout << "No skin on " << this << std::endl;
+        return;
+    }
 
     float activationOpacity = 1.0;
     if ((hasDeactivatedFn && isDeactivatedFn()) || isDeactivated)

--- a/src/surge-xt/gui/widgets/MultiSwitch.h
+++ b/src/surge-xt/gui/widgets/MultiSwitch.h
@@ -103,7 +103,11 @@ struct MultiSwitchSelfDraw : public MultiSwitch
     void paint(juce::Graphics &g);
 
     std::vector<std::string> labels;
-    void setLabels(const std::vector<std::string> &l) { labels = l; }
+    void setLabels(const std::vector<std::string> &l)
+    {
+        labels = l;
+        repaint();
+    }
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MultiSwitchSelfDraw);
 };


### PR DESCRIPTION
This commit is a major rework of the look, feel, and action
of the modulation list screen. It is incomplete in several ways
including features being missing and drawing and layout sitll
being a placeholder requiring design, but critically it uses
surge components and skins, uses the design language of the other
overlays, coordinates wiht the synth properly, adds filter, sort, and
other capabilities, and fixes innumerable little bugs which were in
the prior version.

Still to do includes some efficiencies, the add, skinning and designing
the row, and more.