### PR TITLE
Tweaks to spring reverb parameterization

### DIFF
--- a/src/common/dsp/effects/chowdsp/spring_reverb/ReflectionNetwork.h
+++ b/src/common/dsp/effects/chowdsp/spring_reverb/ReflectionNetwork.h
@@ -51,7 +51,7 @@ class ReflectionNetwork
             auto delaySamples = baseDelaysSec[i] * reverbSize * fs;
             delays[i].setDelay(delaySamples);
             feedbackArr[i] = std::pow(0.001f, delaySamples / (t60 * fs));
-            feedbackArr[i] *= mix * (0.5f * (0.33f + 1.67f * reverbSize));
+            feedbackArr[i] *= 0.23f * mix * (0.735f + 0.235f * reverbSize);
         }
 
         feedback = _mm_load_ps(feedbackArr);

--- a/src/common/dsp/effects/chowdsp/spring_reverb/SpringReverbProc.cpp
+++ b/src/common/dsp/effects/chowdsp/spring_reverb/SpringReverbProc.cpp
@@ -40,9 +40,8 @@ void SpringReverbProc::setParams(const Params &params, int numSamples)
 
     constexpr float lowT60 = 0.5f;
     constexpr float highT60 = 4.5f;
-    float t60Seconds =
-        lowT60 *
-        std::pow(highT60 / lowT60, params.decay - 0.7f * (1.0f - std::pow(params.size, 2.0f)));
+    const auto decayCorr = 0.7f * (1.0f - params.size * params.size);
+    float t60Seconds = lowT60 * std::pow(highT60 / lowT60, 0.95f * params.decay - decayCorr);
 
     float delaySamples = 1000.0f + std::pow(params.size * 0.099f, 1.0f) * fs;
     chaosSmooth.setTargetValue(urng01() * delaySamples * 0.07f);
@@ -61,7 +60,8 @@ void SpringReverbProc::setParams(const Params &params, int numSamples)
     auto dampFreq = dampFreqLow * std::pow(dampFreqHigh / dampFreqLow, 1.0f - params.damping);
     lpf.setCutoffFrequency(dampFreq);
 
-    reflectionNetwork.setParams(params.size, t60Seconds, params.reflections * 0.5f, params.damping);
+    auto reflSkew = 0.95f * params.reflections * params.reflections;
+    reflectionNetwork.setParams(params.size, t60Seconds, reflSkew, params.damping);
 }
 
 void SpringReverbProc::processBlock(float *left, float *right, const int numSamples)


### PR DESCRIPTION
Minor tweaks to the internal parameterization for the Spring Reverb effect. The main idea is to make it so the effect cannot go unstable, and to make the "Reflections" parameter a bit more noticeable.