### PR TITLE
Add a Formula Modulator Test Probe for UnitTests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ jobs:
         linux-clang-juce-lv2:
           imageName: 'ubuntu-18.04'
           isLinux: True
-          aptGetExtras: "clang"
+          aptGetExtras: "clang-10"
           needsLV2: True
           cmakeArguments: "-GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DJUCE_SUPPORTS_LV2=True -DSURGE_JUCE_PATH=$PWD/libs/JUCE-lv2"
           cmakeTarget: "surge-xt_LV2"

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -19,6 +19,7 @@
 #include "SurgeStorage.h"
 #include "StringOps.h"
 #include "LuaSupport.h"
+#include <variant>
 
 namespace Surge
 {
@@ -63,6 +64,13 @@ void valueAt(int phaseIntPart, float phaseFracPart, FormulaModulatorStorage *fs,
              EvaluatorState *state, float output[max_formula_outputs]);
 
 std::string createDebugViewOfModState(const EvaluatorState &s);
+
+/*
+ * Our test harness wants to send bits of lua to the modstate to get results out for
+ * regtests. Send a function query(modstate) which returns somethign leaf like
+ */
+std::variant<float, std::string, bool> runOverModStateForTesting(const std::string &query,
+                                                                 const EvaluatorState &s);
 
 void createInitFormula(FormulaModulatorStorage *fs);
 

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -569,3 +569,49 @@ end
         }
     }
 }
+
+TEST_CASE("Simple Used Formula Modulator", "[formula]")
+{
+    SECTION("Run Formula on Voice and Scene")
+    {
+        auto surge = Surge::Test::surgeOnSine();
+        surge->storage.getPatch().scene[0].lfo[0].shape.val.i = lt_formula;
+        auto pitchId = surge->storage.getPatch().scene[0].osc[0].pitch.id;
+        surge->setModulation(pitchId, ms_lfo1, 0, 0, 0.1);
+
+        surge->storage.getPatch().formulamods[0][0].setFormula(R"FN(
+function init(modstate)
+   modstate["depth"] = 0.2
+   modstate["count"] = -1   -- There is an initial attack which will also run process once
+   return modstate
+end
+
+function process(modstate)
+    modstate["output"] = (modstate["phase"] * 2 - 1) * modstate["depth" ]
+    modstate["count"] = modstate["count"] + 1
+    return modstate
+end)FN");
+        for (int i = 0; i < 10; ++i)
+            surge->process();
+
+        surge->playNote(0, 60, 100, 0);
+        for (int i = 0; i < 10; ++i)
+            surge->process();
+
+        REQUIRE(!surge->voices[0].empty());
+        auto ms = surge->voices[0].front()->modsources[ms_lfo1];
+        REQUIRE(ms);
+        auto lms = dynamic_cast<LFOModulationSource *>(ms);
+        REQUIRE(lms);
+
+        auto c = Surge::Formula::runOverModStateForTesting(R"FN(
+function query(modstate)
+   return modstate["count"];
+end
+)FN",
+                                                           lms->formulastate);
+        auto ival = std::get_if<float>(&c);
+        REQUIRE(ival);
+        REQUIRE(*ival == 10);
+    }
+}


### PR DESCRIPTION
The unit tests couldn't really poke inside the modstate in running
surges. That's about to get important as I add the various
midi and velocity and other-modulator cases and I would prefer
to tackle that with unit tests. So add the plumbing I need
and a rudimentary regtest.