### PR TITLE
Formula and MSEG setup in SurgePatch ctor

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -579,6 +579,25 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
         }
     }
 
+    // Set up the storages just in case
+    for (int s = 0; s < n_scenes; ++s)
+        for (int m = 0; m < n_lfos; ++m)
+        {
+            auto *ms = &(msegs[s][m]);
+            if (ms_lfo1 + m >= ms_slfo1 && ms_lfo1 + m <= ms_slfo6)
+            {
+                Surge::MSEG::createInitSceneMSEG(ms);
+            }
+            else
+            {
+                Surge::MSEG::createInitVoiceMSEG(ms);
+            }
+            Surge::MSEG::rebuildCache(ms);
+
+            auto *fs = &(formulamods[s][m]);
+            Surge::Formula::createInitFormula(fs);
+        }
+
 #if 0
    // DEBUG CODE WHICH WILL DIE
    std::map<std::string, int> idToParam;


### PR DESCRIPTION
FOrmula and MSEG states weren't set in SurgePatch ctor.
This is fine in almost all cases *except* when running
without a data dir. In that case we don't find init saw so
dont' stream xml so don't do the setup in the load xml path.

Do it here just to be safe for that edge case