### PR TITLE
Handle the "No Tutorials" case better

### DIFF
--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -573,7 +573,7 @@ void PatchSelector::showClassicMenu(bool single_category)
 
     contextMenu.addSeparator();
 
-    if (tutorialCat)
+    if (tutorialCat >= 0)
     {
         populatePatchMenuForCategory(tutorialCat, contextMenu, single_category, main_e, true);
     }


### PR DESCRIPTION
in the case of "No Tutorials" we would get a segmentation error
in the patch selector. Fix the bound to be correct to avoid this.

Closes #5337