### PR TITLE
Remove an unneeded 'toFront'

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2697,7 +2697,6 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     {
         if (this->waveshaperSelector)
         {
-            control->asJuceComponent()->getParentComponent()->toFront(false);
             if (control->getValue() > 0.5f)
                 showOverlay(WAVESHAPER_ANALYZER);
             else


### PR DESCRIPTION
before the WS Analyzer was a proper overlay it needed to front its
parent. Now it doesn't any more.

Closes #5313