### PR TITLE
Notify FX on sample rate changes

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2011,6 +2011,14 @@ void SurgeSynthesizer::setSamplerate(float sr)
 {
     storage.setSamplerate(sr);
     sinus.set_rate(1000.0 * dsamplerate_inv);
+
+    for (const auto &f : fx)
+    {
+        if (f)
+        {
+            f->sampleRateReset();
+        }
+    }
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/src/common/dsp/Effect.h
+++ b/src/common/dsp/Effect.h
@@ -63,6 +63,10 @@ class alignas(16) Effect
     virtual void suspend() { return; }
     float vu[KNumVuSlots]; // stereo pairs, just use every other when mono
 
+    // Most of the fx read the sample rate at sample time but airwindows
+    // keeps a cache so give loaded fx a notice when the sample rate cahnges
+    virtual void sampleRateReset() {}
+
     virtual void handleStreamingMismatches(int streamingRevision, int currentSynthStreamingRevision)
     {
         // No-op here.

--- a/src/common/dsp/effects/airwindows/AirWindowsEffect.h
+++ b/src/common/dsp/effects/airwindows/AirWindowsEffect.h
@@ -51,6 +51,14 @@ class alignas(16) AirWindowsEffect : public Effect
     std::unique_ptr<AirWinBaseClass> airwin;
     int lastSelected = -1;
 
+    void sampleRateReset() override
+    {
+        if (airwin)
+        {
+            airwin->sr = samplerate;
+        }
+    }
+
     static std::vector<AirWinBaseClass::Registration> fxreg;
     static std::vector<int> fxregOrdering;
 


### PR DESCRIPTION
This allows FX which cache the sample rate for various
reasons (notably Airwindows to avoid a link cycle) to
get updated correctly. This is especially important in
the standalone startup path.

Closes #5353