### PR TITLE
Initialize LFOs to poast-end-of-envelope

### DIFF
--- a/src/common/dsp/modulators/LFOModulationSource.cpp
+++ b/src/common/dsp/modulators/LFOModulationSource.cpp
@@ -28,7 +28,7 @@ void LFOModulationSource::assign(SurgeStorage *storage, LFOStorage *lfo, pdata *
     iout = 0;
     output = 0;
     step = 0;
-    env_state = lfoeg_delay;
+    env_state = lfoeg_stuck; // in the case we process this without an attack, we want to be 'done'
     env_val = 0.f;
     env_phase = 0;
     shuffle_id = 0;


### PR DESCRIPTION
LFOModulationSource::assign for some wierd reason initialized
the envelope state to 'half way through'. This didn't matter if
you sent attacks, but for keytrigger SLFO it meant that on patch
load the first time the LFOs were ringing until you pressed a key
to run the instance through the envelope. So start at the end
and then it all works

Closes #5359