### PR TITLE
FXSelector Ditches the Buttons

### DIFF
--- a/src/surge-fx/SurgeFXEditor.h
+++ b/src/surge-fx/SurgeFXEditor.h
@@ -24,6 +24,22 @@ class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor, juce::Asy
     SurgefxAudioProcessorEditor(SurgefxAudioProcessor &);
     ~SurgefxAudioProcessorEditor();
 
+    struct FxMenu
+    {
+        enum Type
+        {
+            SECTION,
+            FX
+        } type;
+        bool isBreak{false};
+        std::string name;
+        int fxtype{-1};
+    };
+    std::vector<FxMenu> menu;
+    std::unique_ptr<juce::Component> picker;
+    void makeMenu();
+    void showMenu();
+
     //==============================================================================
     void paint(juce::Graphics &) override;
     void resized() override;
@@ -38,21 +54,17 @@ class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor, juce::Asy
         FxTypeGroup = 1776
     };
 
-  private:
     // This reference is provided as a quick way for your editor to
     // access the processor object that created it.
     SurgefxAudioProcessor &processor;
 
+  private:
     juce::Slider fxParamSliders[n_fx_params];
     SurgeFXParamDisplay fxParamDisplay[n_fx_params];
     SurgeTempoSyncSwitch fxTempoSync[n_fx_params];
     SurgeTempoSyncSwitch fxDeactivated[n_fx_params];
     SurgeTempoSyncSwitch fxExtended[n_fx_params];
     SurgeTempoSyncSwitch fxAbsoluted[n_fx_params];
-
-    juce::TextButton
-        selectType[n_fx_types]; // this had better match the list of fxnames in the constructor
-    int typeByButtonIndex[n_fx_types];
 
     void blastToggleState(int i);
     void resetLabels();

--- a/src/surge-fx/SurgeFXProcessor.h
+++ b/src/surge-fx/SurgeFXProcessor.h
@@ -255,6 +255,9 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
     void resetFxType(int t, bool updateJuceParams = true);
     void resetFxParams(bool updateJuceParams = true);
 
+    // Members for the FX. If this looks a lot like surge-rack/SurgeFX.hpp that's not a coincidence
+    std::unique_ptr<SurgeStorage> storage;
+
   private:
     //==============================================================================
     juce::AudioProcessorParameter *fxBaseParams[2 * n_fx_params + 1];
@@ -290,9 +293,6 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
         }
         ~SupressGuard() { *s = false; }
     };
-
-    // Members for the FX. If this looks a lot like surge-rack/SurgeFX.hpp that's not a coincidence
-    std::unique_ptr<SurgeStorage> storage;
 
     std::shared_ptr<Effect> surge_effect;
     std::shared_ptr<Effect> audio_thread_surge_effect;


### PR DESCRIPTION
uses the same structural (absent preset) menu that the
plugin uses form config.xml

Closes #5301