### PR TITLE
A large collection of Accessibility improvements

### DIFF
--- a/scripts/pyauto-tests/basics-show-tree.py
+++ b/scripts/pyauto-tests/basics-show-tree.py
@@ -1,0 +1,12 @@
+# The simplest use of the accessibility API. Grab a surge xt running instance
+# and dump the accesibility heirarchy
+
+
+import atomacos
+import sxttest
+
+sxt = sxttest.getSXT()
+mf = sxttest.getMainFrame(sxt)
+mf.activate()
+
+sxttest.recursiveDump(mf, "")

--- a/scripts/pyauto-tests/dump-tree.py
+++ b/scripts/pyauto-tests/dump-tree.py
@@ -1,8 +1,0 @@
-# /usr/bin/python3
-
-import atomacos
-import sxttest
-
-sxt = sxttest.getSXT()
-mf = sxttest.getMainFrame(sxt)
-sxttest.recursiveDump(mf, "")

--- a/scripts/pyauto-tests/fx-setup.py
+++ b/scripts/pyauto-tests/fx-setup.py
@@ -1,0 +1,43 @@
+# Load init sine and then set up a couple of effects using the menus
+# and so on
+
+import sxttest
+import time
+
+sxt = sxttest.getSXT()
+mf = sxttest.getMainFrame(sxt)
+mf.activate()
+
+sxttest.loadPatchByPath(sxt, ["Templates", "Init Sine"])
+time.sleep(0.2)
+
+fxr = sxttest.firstChildByTitle(mf, "FX Controls")
+sxttest.recursiveDump(fxr, "FX>> ")
+
+slt = sxttest.firstChildByTitle(fxr, "FX Slots")
+print("SLOT VALUE : ", slt.AXValue)
+sxttest.recursiveDump(slt, "SLOT>")
+
+f1 = sxttest.firstChildByTitle(slt, "Send FX 1")
+f1.Press()
+print("SLOT VALUE : ", slt.AXValue)
+time.sleep(0.2)
+
+fxtype = sxttest.firstChildByTitle(fxr, "FX Type")
+fxtype.ShowMenu()
+path = ["Chorus", "Fat"]
+for p in path:
+    patchMenu = sxttest.findAllMenus(sxt)[0]
+    temp = sxttest.firstChildByTitle(patchMenu, p)
+    temp.Press()
+
+a1 = sxttest.firstChildByTitle(slt, "A Insert FX 1")
+a1.Press()
+print("SLOT VALUE : ", slt.AXValue)
+time.sleep(0.2)
+fxtype.ShowMenu()
+path = ["Flanger", "Fast"]
+for p in path:
+    patchMenu = sxttest.findAllMenus(sxt)[0]
+    temp = sxttest.firstChildByTitle(patchMenu, p)
+    temp.Press()

--- a/scripts/pyauto-tests/mod-create.py
+++ b/scripts/pyauto-tests/mod-create.py
@@ -1,0 +1,13 @@
+# INCOMPLETE
+
+import sxttest
+import time
+
+sxt = sxttest.getSXT()
+mf = sxttest.getMainFrame(sxt)
+mf.activate()
+
+sxttest.loadPatchByPath(sxt, ["Templates", "Init Sine"])
+time.sleep(1)
+
+sxttest.recursiveDump(mf, "")

--- a/scripts/pyauto-tests/mod-lfotypeswap.py
+++ b/scripts/pyauto-tests/mod-lfotypeswap.py
@@ -1,0 +1,32 @@
+import sxttest
+import time
+
+sxt = sxttest.getSXT()
+mf = sxttest.getMainFrame(sxt)
+mf.activate()
+
+sxttest.loadPatchByPath(sxt, ["Templates", "Init Sine"])
+time.sleep(0.2)
+
+lct = sxttest.firstChildByTitle(mf, "LFO Controls")
+sxttest.recursiveDump(lct, "LFO>")
+
+tad = sxttest.firstChildByTitle(lct, "LFO Type And Display")
+tri = sxttest.firstChildByTitle(tad, "Triangle")
+noise = sxttest.firstChildByTitle(tad, "Noise")
+mseg = sxttest.firstChildByTitle(tad, "MSEG")
+
+tri.Press()
+time.sleep(0.1)
+print(tad.AXValue)
+time.sleep(0.5)
+
+noise.Press()
+time.sleep(0.1)
+print(tad.AXValue)
+time.sleep(0.5)
+
+mseg.Press()
+time.sleep(0.1)
+print(tad.AXValue)
+time.sleep(0.5)

--- a/scripts/pyauto-tests/mod-use-menu-buttons.py
+++ b/scripts/pyauto-tests/mod-use-menu-buttons.py
@@ -1,3 +1,6 @@
+# Show that that the modulation menu properly exposes to accesibility
+# by dumping the menu, muting it, then dumping it again and unmuting it
+
 import sxttest
 import time
 
@@ -6,29 +9,20 @@ mf = sxttest.getMainFrame(sxt)
 mf.activate()
 
 # Load DXEP
-ps = sxttest.firstChildByTitle(mf, "Patch Selector")
-ps.ShowMenu()
-patchMenu = sxttest.findAllMenus(sxt)[0]
-temp = sxttest.firstChildByTitle(patchMenu, "Keys")
-temp.Press()
-subMen = sxttest.findAllMenus(sxt)[0]
-loadPatch = sxttest.firstChildByTitle(subMen, "DX EP")
-loadPatch.Press()
-time.sleep(1)
+sxttest.loadPatchByPath(sxt, ["Keys", "DX EP"])
+time.sleep(0.5)
 
 pfg = sxttest.firstChildByTitle(mf, "Scene A Pre-Filter Gain")
 pfg.ShowMenu()
 pfgMenu = sxttest.findAllMenus(sxt)[0]
 sxttest.recursiveDump(pfgMenu, "MENU>> ")
-
-# moded = sxttest.firstChildByTitle(pfgMenu, "ENV 3 by 4.63 dB");
-# moded.Press()
-
 moded = sxttest.firstChildByTitle(pfgMenu, "Mute ENV 3");
 moded.Press()
 
-time.sleep(1)
+time.sleep(0.5)
 
 pfg.ShowMenu()
 pfgMenu = sxttest.findAllMenus(sxt)[0]
 sxttest.recursiveDump(pfgMenu, "MENU>> ")
+moded = sxttest.firstChildByTitle(pfgMenu, "UnMute ENV 3");
+moded.Press()

--- a/scripts/pyauto-tests/osc-manip.py
+++ b/scripts/pyauto-tests/osc-manip.py
@@ -1,0 +1,49 @@
+import sxttest
+import time
+import math
+
+sxt = sxttest.getSXT()
+mf = sxttest.getMainFrame(sxt)
+mf.activate()
+
+sxttest.loadPatchByPath(sxt, ["Templates", "Init Sine"])
+time.sleep(0.2)
+
+scns = sxttest.firstChildByTitle(mf, "Active Scene")
+sca = sxttest.firstChildByTitle(scns, "Scene A")
+sca.Press()
+
+osc = sxttest.firstChildByTitle(mf, "Oscillator Controls")
+on = sxttest.firstChildByTitle(osc, "Oscillator Number")
+o1 = sxttest.firstChildByTitle(on, "Osc 1")
+o1.Press()
+time.sleep(0.1)
+
+for i in range(4):
+    o3 = sxttest.firstChildByTitle(on, "Osc 3")
+    o3.Press()
+    time.sleep(0.1)
+    o1 = sxttest.firstChildByTitle(on, "Osc 1")
+    o1.Press()
+    time.sleep(0.1)
+
+# it is a bummer that the rebuild requires us to do this
+mf = sxttest.getMainFrame(sxt)
+osc = sxttest.firstChildByTitle(mf, "Oscillator Controls")
+sxttest.recursiveDump(osc, "OSC>")
+opitch = sxttest.firstChildByTitle(osc, "Scene A Osc 1 Pitch")
+
+for i in range(1000):
+    x = i * 0.004
+    v = 4.4 * math.sin(x)
+    opitch.AXValue = str(v)
+    time.sleep(0.002)
+
+ot = sxttest.firstChildByTitle(osc, "Oscillator Type")
+ot.ShowMenu()
+oscMenu = sxttest.findAllMenus(sxt)[0]
+wt = sxttest.firstChildByTitle(oscMenu, "Wavetable")
+wt.Press()
+
+osc = sxttest.firstChildByTitle(mf, "Oscillator Controls")
+sxttest.recursiveDump(osc, "OSC Post>")

--- a/scripts/pyauto-tests/patch-load-patches.py
+++ b/scripts/pyauto-tests/patch-load-patches.py
@@ -1,3 +1,6 @@
+# Load patches by a path. The function that is explicitly tested here
+# is also available in sxttest as a helper function
+
 import sxttest
 import time
 
@@ -5,7 +8,6 @@ sxt = sxttest.getSXT()
 mf = sxttest.getMainFrame(sxt)
 mf.activate()
 
-# test the 'depth 1' patch menus
 patches = [["Leads", "Sharpish"],
            ["Sequences", "Gate Chord"],
            ["Keys", "DX EP"],
@@ -24,4 +26,4 @@ for patchPair in patches:
     subMen = sxttest.findAllMenus(sxt)[0]
     loadPatch = sxttest.firstChildByTitle(subMen, patchPair[1])
     loadPatch.Press()
-    time.sleep(2)
+    time.sleep(0.5)

--- a/scripts/pyauto-tests/patch-open-factory-folder.py
+++ b/scripts/pyauto-tests/patch-open-factory-folder.py
@@ -1,3 +1,5 @@
+# Using the patch selector menu, find and press the 'open factory patches' folder
+
 import sxttest
 
 sxt = sxttest.getSXT()
@@ -7,9 +9,7 @@ mf.activate()
 ps = sxttest.firstChildByTitle(mf, "Patch Selector")
 ps.ShowMenu()
 
-menus = sxttest.findAllMenus(sxt)
-patchMenu = menus[0]
-
+patchMenu = sxttest.findAllMenus(sxt)[0]
 sxttest.recursiveDump(patchMenu, "MENU:--")
 
 temp = sxttest.firstChildByTitle(patchMenu, "Open Factory Patches Folder...")

--- a/scripts/pyauto-tests/sxttest.py
+++ b/scripts/pyauto-tests/sxttest.py
@@ -14,6 +14,11 @@ def getMainFrame(sxt):
 
 def recursiveDump(w, pf):
     l = "{0} '{1}' ({2} actions={3})".format(pf, w.AXTitle, w.AXRole, w.getActions())
+    try:
+        r = " value=" + w.AXValue
+        l += r
+    except:
+        pass
     print(l)
     kids = w.AXChildrenInNavigationOrder
     for k in kids:
@@ -46,3 +51,13 @@ def findAllMenus(sxt):
         except:
             pass
     return res
+
+
+def loadPatchByPath(sxt, path):
+    mf = getMainFrame(sxt)
+    ps = firstChildByTitle(mf, "Patch Selector")
+    ps.ShowMenu()
+    for p in path:
+        patchMenu = findAllMenus(sxt)[0]
+        temp = firstChildByTitle(patchMenu, p)
+        temp.Press()

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -52,6 +52,7 @@ struct EffectLabel;
 struct LFOAndStepDisplay;
 struct ModulationSourceButton;
 struct ModulatableControlInterface;
+struct ModulationOverviewLaunchButton;
 struct NumberField;
 struct OscillatorWaveformDisplay;
 struct ParameterInfowindow;
@@ -403,7 +404,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
   private:
     juce::Rectangle<int> positionForModulationGrid(modsources entry);
     juce::Rectangle<int> positionForModOverview();
-    std::unique_ptr<juce::Component> modOverviewLauncher;
+    std::unique_ptr<Surge::Widgets::ModulationOverviewLaunchButton> modOverviewLauncher;
 
     int wsx = BASE_WINDOW_SIZE_X;
     int wsy = BASE_WINDOW_SIZE_Y;
@@ -690,6 +691,18 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     static std::string fullyResolvedHelpURL(const std::string &helpurl);
 
   private:
+    /*
+     * the add remove handlers
+     */
+    friend class Surge::Widgets::MainFrame;
+    std::unordered_map<juce::Component *, juce::Component *> containedComponents;
+    void addComponentWithTracking(juce::Component *target, juce::Component &source);
+    void addAndMakeVisibleWithTracking(juce::Component *target, juce::Component &source);
+    void addAndMakeVisibleWithTrackingInCG(ControlGroup cg, juce::Component &source);
+
+    void resetComponentTracking();
+    void removeUnusedTrackedComponents();
+
     void promptForUserValueEntry(Parameter *p, juce::Component *c)
     {
         promptForUserValueEntry(p, c, -1, -1, -1);

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -493,7 +493,8 @@ Surge::Overlays::OverlayWrapper *SurgeGUIEditor::addJuceEditorOverlay(
     }
 
     ol->addAndTakeOwnership(std::move(c));
-    frame->addAndMakeVisible(*ol);
+    addAndMakeVisibleWithTracking(frame.get(), *ol);
+
     juceOverlays[editorTag] = std::move(ol);
     if (overlayConsumesKeyboard(editorTag))
         vkbForward++;

--- a/src/surge-xt/gui/widgets/EffectChooser.h
+++ b/src/surge-xt/gui/widgets/EffectChooser.h
@@ -119,6 +119,7 @@ struct EffectChooser : public juce::Component, public WidgetBaseMixin<EffectChoo
                           juce::Colour &txtcol);
 
 #if SURGE_JUCE_ACCESSIBLE
+    std::array<std::unique_ptr<juce::Component>, n_fx_slots> slotAccOverlays;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
 #endif
 

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -151,6 +151,12 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
     int stepSeqShiftHover{-1};
     bool overWaveform{false};
     void enterExitWaveform(bool isInWF);
+    void updateShapeTo(int i);
+
+#if SURGE_JUCE_ACCESSIBLE
+    std::array<std::unique_ptr<juce::Component>, n_lfo_types> typeAccOverlays;
+    std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
+#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LFOAndStepDisplay);
 };

--- a/src/surge-xt/gui/widgets/MainFrame.cpp
+++ b/src/surge-xt/gui/widgets/MainFrame.cpp
@@ -48,23 +48,6 @@ void MainFrame::mouseDown(const juce::MouseEvent &event)
         editor->showSettingsMenu(juce::Point<int>{}, nullptr);
     }
 }
-
-struct OverlayComponent : public juce::Component
-{
-#if SURGE_JUCE_ACCESSIBLE
-    OverlayComponent()
-    {
-        setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
-        setAccessible(true);
-    }
-
-    std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override
-    {
-        return std::make_unique<juce::AccessibilityHandler>(*this, juce::AccessibilityRole::group);
-    }
-#endif
-};
-
 juce::Component *MainFrame::getSynthControlsLayer()
 {
     if (!synthControls)
@@ -81,7 +64,7 @@ juce::Component *MainFrame::getSynthControlsLayer()
 
     if (getIndexOfChildComponent(synthControls.get()) < 0)
     {
-        addAndMakeVisible(*synthControls);
+        editor->addAndMakeVisibleWithTracking(this, *synthControls);
     }
 
     return synthControls.get();
@@ -102,7 +85,7 @@ juce::Component *MainFrame::getModButtonLayer()
 
     if (getIndexOfChildComponent(modGroup.get()) < 0)
     {
-        addAndMakeVisible(*modGroup.get());
+        editor->addAndMakeVisibleWithTracking(this, *modGroup);
     }
 
     return modGroup.get();
@@ -152,10 +135,15 @@ juce::Component *MainFrame::getControlGroupLayer(ControlGroup cg)
 
     if (getIndexOfChildComponent(cgOverlays[cg].get()) < 0)
     {
-        addAndMakeVisible(*cgOverlays[cg]);
+        editor->addAndMakeVisibleWithTracking(this, *cgOverlays[cg]);
     }
 
     return cgOverlays[cg].get();
+}
+
+void MainFrame::addChildComponentThroughEditor(juce::Component &c)
+{
+    editor->addComponentWithTracking(this, c);
 }
 
 #if SURGE_JUCE_ACCESSIBLE

--- a/src/surge-xt/gui/widgets/MainFrame.h
+++ b/src/surge-xt/gui/widgets/MainFrame.h
@@ -70,6 +70,24 @@ struct MainFrame : public juce::Component
 
     void mouseDown(const juce::MouseEvent &event) override;
 
+    struct OverlayComponent : public juce::Component
+    {
+#if SURGE_JUCE_ACCESSIBLE
+        OverlayComponent()
+        {
+            setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
+            setAccessible(true);
+        }
+
+        std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override
+        {
+            return std::make_unique<juce::AccessibilityHandler>(*this,
+                                                                juce::AccessibilityRole::group);
+        }
+#endif
+    };
+
+    void addChildComponentThroughEditor(juce::Component &comp);
     std::array<std::unique_ptr<juce::Component>, endCG> cgOverlays;
     std::unique_ptr<juce::Component> modGroup, synthControls;
 

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.h
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.h
@@ -189,7 +189,8 @@ struct ModulationOverviewLaunchButton : public juce::Button,
                                         juce::Button::Listener,
                                         Surge::GUI::SkinConsumingComponent
 {
-    ModulationOverviewLaunchButton(SurgeGUIEditor *ed) : juce::Button("modov"), editor(ed)
+    ModulationOverviewLaunchButton(SurgeGUIEditor *ed)
+        : juce::Button("Open Modulation Overview"), editor(ed)
     {
         addListener(this);
     }

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -117,6 +117,10 @@ TypeAhead::TypeAhead(const std::string &l, TypeAheadDataProvider *p)
     lbox->setMultipleSelectionEnabled(false);
     lbox->setVisible(false);
     lbox->setRowHeight(p->getRowHeight());
+#if SURGE_JUCE_ACCESSIBLE
+    setTitle(l);
+    lbox->setTitle(l);
+#endif
     setColour(ColourIds::borderid, juce::Colours::black);
     setColour(ColourIds::emptyBackgroundId, juce::Colours::white);
 }
@@ -172,7 +176,13 @@ void TypeAhead::parentHierarchyChanged()
         p = p->getParentComponent();
     }
     if (p)
-        p->addChildComponent(*lbox);
+    {
+        auto mf = dynamic_cast<Surge::Widgets::MainFrame *>(p);
+        if (mf)
+        {
+            mf->addChildComponentThroughEditor(*lbox);
+        }
+    }
 }
 
 void TypeAhead::showLbox()

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -25,6 +25,7 @@ namespace Surge
 {
 namespace Widgets
 {
+struct TypeAheadListBox;
 struct TypeAheadListBoxModel;
 
 struct TypeAheadDataProvider


### PR DESCRIPTION
This commit addresses many issues in #4616 with several changes

1. Rather than removing and adding all components on all rebuilds,
   track components which are changed between states of the UI.
   This results in much less parent hierarchy and accessibility churn
   and also means something like switching an oscillator type doesn't
   invalidate your acc tree

2. Make accessible hooks for LFO Shape and for the Effect Chooser

3. Clean up many mis-labeled or unlabeled components

4. Add a chunk of tests which exercise the accesibility api
   using atomacos to drive surge