### PR TITLE
AudioProcessing Message softer; more works

### DIFF
--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -50,12 +50,13 @@ class alignas(16) SurgeSynthesizer
 
     float input alignas(16)[N_INPUTS][BLOCK_SIZE];
     timedata time_data;
-    bool audio_processing_active;
 
     // aligned stuff
     SurgeStorage storage alignas(16);
     lipol_ps FX alignas(16)[n_send_slots], amp alignas(16), amp_mute alignas(16),
         send alignas(16)[n_send_slots][n_scenes];
+
+    std::atomic<bool> audio_processing_active;
 
     // methods
   public:

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -191,6 +191,7 @@ bool SurgeSynthProcessor::isBusesLayoutSupported(const BusesLayout &layouts) con
 void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
                                        juce::MidiBuffer &midiMessages)
 {
+    surge->audio_processing_active = true;
     auto fpuguard = Surge::CPUFeatures::FPUStateGuard();
 
     auto playhead = getPlayHead();

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -424,10 +424,14 @@ void SurgeGUIEditor::idle()
         if (processRunningCheckEvery++ > 3 || processRunningCheckEvery < 0)
         {
             synth->processRunning++;
-            if (synth->processRunning > 20)
+            if (synth->processRunning > 10)
+            {
+                synth->audio_processing_active = false;
+            }
+            if (synth->processRunning > 10 && showNoProcessingOverlay)
             {
                 noProcessingOverlay =
-                    std::make_unique<Surge::Overlays::AudioEngineNotRunningOverlay>();
+                    std::make_unique<Surge::Overlays::AudioEngineNotRunningOverlay>(this);
                 noProcessingOverlay->setBounds(frame->getBounds());
                 addAndMakeVisibleWithTracking(frame.get(), *noProcessingOverlay);
                 synth->processRunning = 1;
@@ -5898,6 +5902,16 @@ void SurgeGUIEditor::populateDawExtraState(SurgeSynthesizer *synth)
             }
             des->editor.activeOverlays.push_back(os);
         }
+    }
+}
+
+void SurgeGUIEditor::clearNoProcessingOverlay()
+{
+    if (noProcessingOverlay)
+    {
+        showNoProcessingOverlay = false;
+        frame->removeChildComponent(noProcessingOverlay.get());
+        noProcessingOverlay.reset(nullptr);
     }
 }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -145,6 +145,11 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     void refreshSkin();
 
+    bool showNoProcessingOverlay{true};
+
+  public:
+    void clearNoProcessingOverlay();
+
   public:
     // to make file chooser async it has to stick around
     std::unique_ptr<juce::FileChooser> fileChooser;

--- a/src/surge-xt/gui/overlays/CoveringMessageOverlay.h
+++ b/src/surge-xt/gui/overlays/CoveringMessageOverlay.h
@@ -17,6 +17,8 @@
 #define SURGE_XT_COVERINGMESSAGEOVERLAY_H
 
 #include "juce_gui_basics/juce_gui_basics.h"
+#include "SurgeGUIEditor.h"
+
 namespace Surge
 {
 namespace Overlays
@@ -42,20 +44,16 @@ struct CoveringMessageOverlay : public juce::Component
 
 struct AudioEngineNotRunningOverlay : public CoveringMessageOverlay
 {
-    AudioEngineNotRunningOverlay() : CoveringMessageOverlay()
+    AudioEngineNotRunningOverlay(SurgeGUIEditor *e) : CoveringMessageOverlay(), editor(e)
     {
         setPrimaryTitle("AUDIO ENGINE NOT RUNNING");
         setExplanatoryText(
-            R"MSG(Surge XT requires the audio engine to be running in order for the GUI to
-interact with the synth. A running audio engine is required to provide several
-core features, including selecting oscillator or FX types and loading patches.
-
-This instance of Surge does not have a running audio engine. Either the audio engine
+            R"MSG(This instance of Surge does not have a running audio engine. Either the audio engine
 in your DAW is suspended, your instance of Surge is suspended, or in the standalone
 application you haven't connected your output to at least one stereo output bus.
 
-To dismiss this message, start your audio engine, unsuspend this instance of Surge,
-or set up output routing in standalone application appropriately.
+You can click to dismiss this message and the Surge UI will continue to operate, but
+no sound will be produced under MIDI input unless you activate your audio system.
 )MSG");
 
 #if SURGE_JUCE_ACCESSIBLE
@@ -64,6 +62,9 @@ or set up output routing in standalone application appropriately.
         setAccessible(true);
 #endif
     }
+
+    void mouseUp(const juce::MouseEvent &e) override { editor->clearNoProcessingOverlay(); }
+    SurgeGUIEditor *editor;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioEngineNotRunningOverlay);
 };
 


### PR DESCRIPTION
1. AudioProcessing Inactive message is click dismssable
2. If processing is inactive set up internal state properly
   so i can *actually* do those threadunsafe things i try
   to do