### PR TITLE
Fix a TypeIn Bug; add Frequency Modulation Typein Notation

### DIFF
--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -499,6 +499,7 @@ class Parameter
         kUnitsAreSemitonesOrKeys = 1U << 5U,
         kScaleBasedOnIsBiPolar = 1U << 6U,
         kAllowsTuningFractionTypein = 1U << 7U,
+        kAllowsModulationsInNotesAndCents = 1U << 8U
     };
 
 #define DISPLAYINFO_TXT_SIZE 128

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6020,6 +6020,8 @@ void SurgeGUIEditor::resetComponentTracking()
 
         if (dynamic_cast<Surge::GUI::IComponentTagValue *>(comp))
             recurse = false;
+        if (dynamic_cast<Surge::Overlays::TypeinParamEditor *>(comp))
+            recurse = false;
         if (dynamic_cast<Surge::Overlays::OverlayWrapper *>(comp))
             recurse = false;
         if (dynamic_cast<juce::ListBox *>(comp)) // special case of the typeahead


### PR DESCRIPTION
1. Fix a bug where typeins broke second time
2. Add "N" "C" and "T" notation for frequency typeins where you
   can type notes, cents, or tuning fractions.

Closes #5369