### PR TITLE
AudioProcessing Turn On flag

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -191,7 +191,6 @@ bool SurgeSynthProcessor::isBusesLayoutSupported(const BusesLayout &layouts) con
 void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
                                        juce::MidiBuffer &midiMessages)
 {
-    surge->audio_processing_active = true;
     auto fpuguard = Surge::CPUFeatures::FPUStateGuard();
 
     auto playhead = getPlayHead();
@@ -232,6 +231,7 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         // We have to have a stereo output
         return;
     }
+    surge->audio_processing_active = true;
     auto mainOutput = getBusBuffer(buffer, false, 0);
 
     auto mainInput = getBusBuffer(buffer, true, 0);


### PR DESCRIPTION
The AUdioProcessing Active flag would be set true if
we had input and no output, but we wouldn't then process

Closes #5387 and the associated blinking