### PR TITLE
Modulator Menu and Name Changes

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -53,6 +53,7 @@ const int n_oscs = 3;
 const int n_lfos_voice = 6;
 const int n_lfos_scene = 6;
 const int n_lfos = n_lfos_voice + n_lfos_scene;
+const int max_lfo_indices = 8;
 const int n_osc_params = 7;
 const int n_egs = 2;
 const int n_fx_params = 12;
@@ -847,6 +848,8 @@ class SurgePatch
     // macro controllers
 #define CUSTOM_CONTROLLER_LABEL_SIZE 20
     char CustomControllerLabel[n_customcontrollers][CUSTOM_CONTROLLER_LABEL_SIZE];
+
+    char LFOBankLabel[n_lfos][max_lfo_indices][CUSTOM_CONTROLLER_LABEL_SIZE];
 
     int streamingRevision;
     int currentSynthStreamingRevision;

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -27,7 +27,7 @@ namespace Surge
 {
 namespace Formula
 {
-static constexpr int max_formula_outputs{8};
+static constexpr int max_formula_outputs{max_lfo_indices};
 
 struct EvaluatorState
 {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -622,6 +622,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
   public:
     std::string modulatorName(int ms, bool forButton, int forScene = -1);
     std::string modulatorIndexExtension(int scene, int ms, int index, bool shortV = false);
+    std::string modulatorNameWithIndex(int scene, int ms, int index, bool forButton, bool useScene);
 
   private:
     Parameter *typeinEditTarget = nullptr;

--- a/src/surge-xt/gui/SurgeGUIEditorInfowindow.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorInfowindow.cpp
@@ -93,9 +93,7 @@ void SurgeGUIEditor::updateInfowindowContents(int ptag, bool isModulated)
         SurgeSynthesizer::ID ptagid;
         if (synth->fromSynthSideId(pid, ptagid))
             synth->getParameterName(ptagid, txt);
-        auto mn = modulatorName(modsource, true);
-        if (synth->supportsIndexedModulator(current_scene, modsource))
-            mn += modulatorIndexExtension(current_scene, modsource, modsource_index, true);
+        auto mn = modulatorNameWithIndex(current_scene, modsource, modsource_index, true, false);
 
         sprintf(pname, "%s -> %s", mn.c_str(), txt);
         ModulationDisplayInfoWindowStrings mss;

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -479,11 +479,9 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
         SurgeSynthesizer::ID ptagid;
         if (synth->fromSynthSideId(d.destination_id + d.idBase, ptagid))
             synth->getParameterName(ptagid, nm);
-        std::string sname = editor->ed->modulatorName(d.source_id, false);
-        if (d.inScene < 0)
-            sname = editor->ed->modulatorName(d.source_id, false, d.source_scene);
-        if (d.inScene >= 0)
-            sname += editor->ed->modulatorIndexExtension(d.inScene, d.source_id, d.source_index);
+
+        std::string sname = editor->ed->modulatorNameWithIndex(
+            d.source_scene, d.source_id, d.source_index, false, d.inScene < 0);
 
         d.sname = sname + sceneMod;
         d.pname = nm;


### PR DESCRIPTION
1. For indexed modulators, the RMB menu shows
   jst the paths for that modulator.
2. LFO-class modulators can be renamed by index
   and then have short name of "N" and long name
   of "N (FORM 1.2)" or waht not. Closes #5391
3. Add a single api to get the name rather than
   having to add index extensions everywhere.