### PR TITLE
Handle Tuning Mode error when Toggling MTS

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2477,7 +2477,14 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
 
     // Revision 16 adds the TAM
     TiXmlElement tam("tuningApplicationMode");
-    tam.SetAttribute("v", (int)(storage->tuningApplicationMode));
+    if (storage->oddsound_mts_active)
+    {
+        tam.SetAttribute("v", (int)(storage->patchStoredTuningApplicationMode));
+    }
+    else
+    {
+        tam.SetAttribute("v", (int)(storage->tuningApplicationMode));
+    }
     nonparamconfig.InsertEndChild(tam);
 
     patch.InsertEndChild(nonparamconfig);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1139,7 +1139,9 @@ class alignas(16) SurgeStorage
     {
         RETUNE_ALL = 0, // These values are streamed so don't change them if you add
         RETUNE_MIDI_ONLY = 1
-    } tuningApplicationMode = RETUNE_MIDI_ONLY; // This is the default as of 1.9/sv16
+    } tuningApplicationMode = RETUNE_MIDI_ONLY,
+      patchStoredTuningApplicationMode =
+          tuningApplicationMode; // This is the default as of 1.9/sv16
 
     float tuningPitch = 32.0f, tuningPitchInv = 0.03125f;
 
@@ -1241,6 +1243,7 @@ class alignas(16) SurgeStorage
     void deinitialize_oddsound();
     MTSClient *oddsound_mts_client = nullptr;
     std::atomic<bool> oddsound_mts_active;
+    void setOddsoundMTSActiveTo(bool b);
     uint32_t oddsound_mts_on_check = 0;
     enum OddsoundRetuneMode
     {

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3611,7 +3611,8 @@ void SurgeSynthesizer::processControl()
         if (storage.oddsound_mts_on_check == 0)
         {
             bool prior = storage.oddsound_mts_active;
-            storage.oddsound_mts_active = MTS_HasMaster(storage.oddsound_mts_client);
+            storage.setOddsoundMTSActiveTo(MTS_HasMaster(storage.oddsound_mts_client));
+
             if (prior != storage.oddsound_mts_active)
             {
                 refresh_editor = true;


### PR DESCRIPTION
When toggling MTS from a non-RETUNE_MIDI patch the synth
ended up in a mixed state of half-MTS half-native tuning.
So

1. Set the state to RETUNE MIDI if MTS is active
2. Keep the 'patch' state around so we can keep it saved for
   non mts applications

Addresses #5386 but there's more to do there - can I make the
filter tuning work with MTS is the open question left.