### PR TITLE
Don't launch a popup if a popup is popped up

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1966,7 +1966,10 @@ void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene, Surge::Widget
             this->synth->storage.sceneHardclipMode[whichScene] = SurgeStorage::HARDCLIP_TO_18DBFS;
         });
 
-    fxGridMenu.showMenuAsync(juce::PopupMenu::Options(), [c](int i) { c->endHover(); });
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        fxGridMenu.showMenuAsync(juce::PopupMenu::Options(), [c](int i) { c->endHover(); });
+    }
 }
 
 void SurgeGUIEditor::controlBeginEdit(Surge::GUI::IComponentTagValue *control)
@@ -2039,36 +2042,45 @@ juce::PopupMenu::Options SurgeGUIEditor::optionsForPosition(const juce::Point<in
 void SurgeGUIEditor::showZoomMenu(const juce::Point<int> &where,
                                   Surge::GUI::IComponentTagValue *launchFrom)
 {
-    auto m = makeZoomMenu(where, true);
-    m.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
-        if (launchFrom)
-        {
-            launchFrom->endHover();
-        }
-    });
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        auto m = makeZoomMenu(where, true);
+        m.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
+            if (launchFrom)
+            {
+                launchFrom->endHover();
+            }
+        });
+    }
 }
 
 void SurgeGUIEditor::showMPEMenu(const juce::Point<int> &where,
                                  Surge::GUI::IComponentTagValue *launchFrom)
 {
-    auto m = makeMpeMenu(where, true);
-    m.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
-        if (launchFrom)
-        {
-            launchFrom->endHover();
-        }
-    });
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        auto m = makeMpeMenu(where, true);
+        m.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
+            if (launchFrom)
+            {
+                launchFrom->endHover();
+            }
+        });
+    }
 }
 void SurgeGUIEditor::showLfoMenu(const juce::Point<int> &where,
                                  Surge::GUI::IComponentTagValue *launchFrom)
 {
-    auto m = makeLfoMenu(where);
-    m.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
-        if (launchFrom)
-        {
-            launchFrom->endHover();
-        }
-    });
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        auto m = makeLfoMenu(where);
+        m.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
+            if (launchFrom)
+            {
+                launchFrom->endHover();
+            }
+        });
+    }
 }
 
 void SurgeGUIEditor::toggleTuning()
@@ -2086,14 +2098,17 @@ void SurgeGUIEditor::toggleTuning()
 void SurgeGUIEditor::showTuningMenu(const juce::Point<int> &where,
                                     Surge::GUI::IComponentTagValue *launchFrom)
 {
-    auto m = makeTuningMenu(where, true);
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        auto m = makeTuningMenu(where, true);
 
-    m.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
-        if (launchFrom)
-        {
-            launchFrom->endHover();
-        }
-    });
+        m.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
+            if (launchFrom)
+            {
+                launchFrom->endHover();
+            }
+        });
+    }
 }
 
 void SurgeGUIEditor::scaleFileDropped(const string &fn)
@@ -2320,12 +2335,15 @@ void SurgeGUIEditor::showSettingsMenu(const juce::Point<int> &where,
 
     settingsMenu.addItem("About Surge", [this]() { this->showAboutScreen(); });
 
-    settingsMenu.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
-        if (launchFrom != nullptr)
-        {
-            launchFrom->endHover();
-        }
-    });
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        settingsMenu.showMenuAsync(optionsForPosition(where), [launchFrom](int i) {
+            if (launchFrom != nullptr)
+            {
+                launchFrom->endHover();
+            }
+        });
+    }
 }
 
 juce::PopupMenu SurgeGUIEditor::makeLfoMenu(const juce::Point<int> &where)

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -487,9 +487,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             }
 
             juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
-            contextMenu.showMenuAsync(optionsForPosition(cwhere),
-                                      [control](int i) { control->endHover(); });
-
+            if (!juce::PopupMenu::dismissAllActiveMenus())
+            {
+                contextMenu.showMenuAsync(optionsForPosition(cwhere),
+                                          [control](int i) { control->endHover(); });
+            }
             return 1;
         }
 
@@ -532,9 +534,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                 });
 
             juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
-            contextMenu.showMenuAsync(optionsForPosition(cwhere),
-                                      [control](int i) { control->endHover(); });
-
+            if (!juce::PopupMenu::dismissAllActiveMenus())
+            {
+                contextMenu.showMenuAsync(optionsForPosition(cwhere),
+                                          [control](int i) { control->endHover(); });
+            }
             return 1;
         }
     }
@@ -1020,8 +1024,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 }
             }
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options(),
-                                      [control](int opt) { control->endHover(); });
+            if (!juce::PopupMenu::dismissAllActiveMenus())
+            {
+                contextMenu.showMenuAsync(juce::PopupMenu::Options(),
+                                          [control](int opt) { control->endHover(); });
+            }
             return 1;
         }
 
@@ -2223,9 +2230,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 }
             }
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options(),
-                                      [control](int i) { control->endHover(); });
-
+            if (!juce::PopupMenu::dismissAllActiveMenus())
+            {
+                contextMenu.showMenuAsync(juce::PopupMenu::Options(),
+                                          [control](int i) { control->endHover(); });
+            }
             return 1;
         }
         // reset to default value
@@ -2436,12 +2445,15 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
             auto m = makeTuningMenu(where, true);
 
             auto launchFrom = control;
-            m.showMenuAsync(juce::PopupMenu::Options(), [launchFrom](int i) {
-                if (launchFrom)
-                {
-                    launchFrom->endHover();
-                }
-            });
+            if (!juce::PopupMenu::dismissAllActiveMenus())
+            {
+                m.showMenuAsync(juce::PopupMenu::Options(), [launchFrom](int i) {
+                    if (launchFrom)
+                    {
+                        launchFrom->endHover();
+                    }
+                });
+            }
         }
 
         return;

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -2605,7 +2605,10 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             typeTo(Surge::GUI::toOSCaseForMenu("Brownian Bridge"),
                    MSEGStorage::segment::Type::BROWNIAN);
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options());
+            if (!juce::PopupMenu::dismissAllActiveMenus())
+            {
+                contextMenu.showMenuAsync(juce::PopupMenu::Options());
+            }
         }
     }
 
@@ -2995,7 +2998,11 @@ int32_t MSEGControlRegion::controlModifierClicked(Surge::GUI::IComponentTagValue
             };
             contextMenu.addItem("Edit Value", true, false, showTypein);
         }
-        contextMenu.showMenuAsync(juce::PopupMenu::Options());
+
+        if (!juce::PopupMenu::dismissAllActiveMenus())
+        {
+            contextMenu.showMenuAsync(juce::PopupMenu::Options());
+        }
     }
     return 1;
 }

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -695,7 +695,10 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
                 filterL->setText("Filter By Target", juce::NotificationType::dontSendNotification);
                 filterW->setLabels({t});
             });
-        men.showMenuAsync(juce::PopupMenu::Options(), [this](int) { filterW->endHover(); });
+        if (!juce::PopupMenu::dismissAllActiveMenus())
+        {
+            men.showMenuAsync(juce::PopupMenu::Options(), [this](int) { filterW->endHover(); });
+        }
     }
     break;
     case tag_add_source:
@@ -707,7 +710,10 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
         men.addCustomItem(-1, std::move(tcomp));
         men.addSeparator();
         men.addItem("Coming soon!", [this]() {});
-        men.showMenuAsync(juce::PopupMenu::Options(), [this](int) { addSourceW->endHover(); });
+        if (!juce::PopupMenu::dismissAllActiveMenus())
+        {
+            men.showMenuAsync(juce::PopupMenu::Options(), [this](int) { addSourceW->endHover(); });
+        }
     }
     break;
     }

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1905,7 +1905,10 @@ void LFOAndStepDisplay::showMSEGPopupMenu()
                             repaint();
                         });
 
-    contextMenu.showMenuAsync(juce::PopupMenu::Options());
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        contextMenu.showMenuAsync(juce::PopupMenu::Options());
+    }
 }
 
 void LFOAndStepDisplay::populateLFOMS(LFOModulationSource *s)

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -321,8 +321,10 @@ void ModulationSourceButton::mouseDown(const juce::MouseEvent &event)
 
         mouseMode = HAMBURGER;
 
-        menu.showMenuAsync(juce::PopupMenu::Options(), [this](int) { endHover(); });
-
+        if (!juce::PopupMenu::dismissAllActiveMenus())
+        {
+            menu.showMenuAsync(juce::PopupMenu::Options(), [this](int) { endHover(); });
+        }
         return;
     }
 

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -503,7 +503,10 @@ void OscillatorWaveformDisplay::showWavetableMenu()
         int id = oscdata->wt.current_id;
         juce::PopupMenu menu;
         populateMenu(menu, id);
-        menu.showMenuAsync(juce::PopupMenu::Options());
+        if (!juce::PopupMenu::dismissAllActiveMenus())
+        {
+            menu.showMenuAsync(juce::PopupMenu::Options());
+        }
     }
 }
 
@@ -537,9 +540,12 @@ void OscillatorWaveformDisplay::mouseUp(const juce::MouseEvent &event)
         }
         else if (waveTableName.contains(event.position))
         {
-            juce::PopupMenu menu;
-            populateMenu(menu, id);
-            menu.showMenuAsync(juce::PopupMenu::Options());
+            if (!juce::PopupMenu::dismissAllActiveMenus())
+            {
+                juce::PopupMenu menu;
+                populateMenu(menu, id);
+                menu.showMenuAsync(juce::PopupMenu::Options());
+            }
         }
     }
 
@@ -770,7 +776,10 @@ struct AliasAdditiveEditor : public juce::Component, Surge::GUI::SkinConsumingCo
                 contextMenu.addItem("Reverse", action);
             }
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options());
+            if (!juce::PopupMenu::dismissAllActiveMenus())
+            {
+                contextMenu.showMenuAsync(juce::PopupMenu::Options());
+            }
             return;
         }
 

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -263,7 +263,11 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
 
             if (haveFavs)
             {
-                menu.showMenuAsync(juce::PopupMenu::Options(), [this](int) { this->endHover(); });
+                if (!juce::PopupMenu::dismissAllActiveMenus())
+                {
+                    menu.showMenuAsync(juce::PopupMenu::Options(),
+                                       [this](int) { this->endHover(); });
+                }
             }
 
             return;
@@ -644,7 +648,10 @@ void PatchSelector::showClassicMenu(bool single_category)
     auto o = juce::PopupMenu::Options();
     if (sge)
         o = sge->optionsForPosition(getBounds().getBottomLeft());
-    contextMenu.showMenuAsync(o);
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        contextMenu.showMenuAsync(o);
+    }
 }
 
 bool PatchSelector::optionallyAddFavorites(juce::PopupMenu &p, bool addColumnBreak,

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -372,10 +372,13 @@ void OscillatorMenu::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
-    menu.showMenuAsync(juce::PopupMenu::Options(), [this](int) {
-        isHovered = false;
-        repaint();
-    });
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        menu.showMenuAsync(juce::PopupMenu::Options(), [this](int) {
+            isHovered = false;
+            repaint();
+        });
+    }
 }
 
 void OscillatorMenu::mouseWheelMove(const juce::MouseEvent &event,
@@ -481,10 +484,13 @@ void FxMenu::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
-    menu.showMenuAsync(juce::PopupMenu::Options(), [this](int i) {
-        isHovered = false;
-        repaint();
-    });
+    if (!juce::PopupMenu::dismissAllActiveMenus())
+    {
+        menu.showMenuAsync(juce::PopupMenu::Options(), [this](int i) {
+            isHovered = false;
+            repaint();
+        });
+    }
 }
 
 void FxMenu::mouseEnter(const juce::MouseEvent &event)


### PR DESCRIPTION
As described in #5395, 1.9 won't launch a popup with a click
if a popup is open and juce will. This change guards the popups
so this won't happen (namely if there is a meny to dismiss dont show
the new popup). This commit is isolated so if we dislike that
behavior we can revert it easily.

Closes #5395