### PR TITLE
Fix two name modulator bugs

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -849,7 +849,7 @@ class SurgePatch
 #define CUSTOM_CONTROLLER_LABEL_SIZE 20
     char CustomControllerLabel[n_customcontrollers][CUSTOM_CONTROLLER_LABEL_SIZE];
 
-    char LFOBankLabel[n_lfos][max_lfo_indices][CUSTOM_CONTROLLER_LABEL_SIZE];
+    char LFOBankLabel[n_scenes][n_lfos][max_lfo_indices][CUSTOM_CONTROLLER_LABEL_SIZE];
 
     int streamingRevision;
     int currentSynthStreamingRevision;

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -26,6 +26,7 @@
 #include "DebugHelpers.h"
 #include "StringOps.h"
 #include "ModulatorPresetManager.h"
+#include "ModulationSource.h"
 
 #include "SurgeSynthEditor.h"
 #include "SurgeJUCELookAndFeel.h"
@@ -5506,7 +5507,11 @@ std::string SurgeGUIEditor::modulatorIndexExtension(int scene, int ms, int index
 std::string SurgeGUIEditor::modulatorNameWithIndex(int scene, int ms, int index, bool forButton,
                                                    bool useScene)
 {
-    if (synth->storage.getPatch().LFOBankLabel[ms - ms_lfo1][index][0] == 0)
+    int lfo_id = ms - ms_lfo1;
+    bool hasOverride = isLFO((modsources)ms) &&
+                       synth->storage.getPatch().LFOBankLabel[scene][lfo_id][index][0] != 0;
+
+    if (!hasOverride)
     {
         auto base = modulatorName(ms, forButton, useScene ? scene : -1);
         if (synth->supportsIndexedModulator(scene, (modsources)ms))
@@ -5516,13 +5521,13 @@ std::string SurgeGUIEditor::modulatorNameWithIndex(int scene, int ms, int index,
     else
     {
         if (forButton)
-            return synth->storage.getPatch().LFOBankLabel[ms - ms_lfo1][index];
+            return synth->storage.getPatch().LFOBankLabel[scene][ms - ms_lfo1][index];
 
         // Long name is alias (button name)
         auto base = modulatorName(ms, true, useScene ? scene : -1);
         if (synth->supportsIndexedModulator(scene, (modsources)ms))
             base += modulatorIndexExtension(scene, ms, index, true);
-        std::string res = synth->storage.getPatch().LFOBankLabel[ms - ms_lfo1][index];
+        std::string res = synth->storage.getPatch().LFOBankLabel[scene][ms - ms_lfo1][index];
         res = res + " (" + base + ")";
         return res;
     }

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -934,17 +934,18 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             if (lfo_id >= 0)
             {
                 auto msi = modsource_index;
-                contextMenu.addItem(
-                    Surge::GUI::toOSCaseForMenu("Rename Modulator"), [this, lfo_id, msi, cms]() {
-                        auto mecb = [this, lfo_id, msi](const std::string &nv) {
-                            auto cp = synth->storage.getPatch().LFOBankLabel[lfo_id][msi];
-                            strxcpy(cp, nv.c_str(), CUSTOM_CONTROLLER_LABEL_SIZE);
-                            synth->refresh_editor = true;
-                        };
-                        promptForMiniEdit(synth->storage.getPatch().LFOBankLabel[lfo_id][msi],
-                                          "Set Modulator Name", "Rename Modulator",
-                                          juce::Point<int>(10, 10), mecb);
-                    });
+                contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Rename Modulator"), [this, lfo_id,
+                                                                                      msi, cms]() {
+                    auto mecb = [this, lfo_id, msi](const std::string &nv) {
+                        auto cp =
+                            synth->storage.getPatch().LFOBankLabel[current_scene][lfo_id][msi];
+                        strxcpy(cp, nv.c_str(), CUSTOM_CONTROLLER_LABEL_SIZE);
+                        synth->refresh_editor = true;
+                    };
+                    promptForMiniEdit(
+                        synth->storage.getPatch().LFOBankLabel[current_scene][lfo_id][msi],
+                        "Set Modulator Name", "Rename Modulator", juce::Point<int>(10, 10), mecb);
+                });
                 contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Copy Modulator"),
                                     [this, sc, lfo_id]() {
                                         synth->storage.clipboard_copy(cp_lfo, sc, lfo_id);


### PR DESCRIPTION
1. Differentiate by scene and
2. Only LFO s have names so don't check for non-LFOs