### PR TITLE
Minor modbutton renaming and switching tweaks

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4340,7 +4340,7 @@ void SurgeGUIEditor::openMacroRenameDialog(const int ccid, const juce::Point<int
     }
 
     promptForMiniEdit(
-        pval, "Enter a new name for the macro:", "Rename Macro", where,
+        pval, fmt::format("Enter a new name for Macro {:d}:", ccid + 1), "Rename Macro", where,
         [this, ccid, msb](const std::string &s) {
             auto useS = s;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -5499,28 +5499,50 @@ std::string SurgeGUIEditor::modulatorIndexExtension(int scene, int ms, int index
 }
 
 std::string SurgeGUIEditor::modulatorNameWithIndex(int scene, int ms, int index, bool forButton,
-                                                   bool useScene)
+                                                   bool useScene, bool baseNameOnly)
 {
     int lfo_id = ms - ms_lfo1;
     bool hasOverride = isLFO((modsources)ms) &&
                        synth->storage.getPatch().LFOBankLabel[scene][lfo_id][index][0] != 0;
 
+    if (baseNameOnly)
+    {
+        auto base = modulatorName(ms, true, useScene ? scene : -1);
+
+        if (synth->supportsIndexedModulator(scene, (modsources)ms))
+        {
+            base += modulatorIndexExtension(scene, ms, index, true);
+        }
+
+        return base;
+    }
+
     if (!hasOverride)
     {
         auto base = modulatorName(ms, forButton, useScene ? scene : -1);
+
         if (synth->supportsIndexedModulator(scene, (modsources)ms))
+        {
             base += modulatorIndexExtension(scene, ms, index, forButton);
+        }
+
         return base;
     }
     else
     {
         if (forButton)
+        {
             return synth->storage.getPatch().LFOBankLabel[scene][ms - ms_lfo1][index];
+        }
 
         // Long name is alias (button name)
         auto base = modulatorName(ms, true, useScene ? scene : -1);
+
         if (synth->supportsIndexedModulator(scene, (modsources)ms))
+        {
             base += modulatorIndexExtension(scene, ms, index, true);
+        }
+
         std::string res = synth->storage.getPatch().LFOBankLabel[scene][ms - ms_lfo1][index];
         res = res + " (" + base + ")";
         return res;

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -622,7 +622,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
   public:
     std::string modulatorName(int ms, bool forButton, int forScene = -1);
     std::string modulatorIndexExtension(int scene, int ms, int index, bool shortV = false);
-    std::string modulatorNameWithIndex(int scene, int ms, int index, bool forButton, bool useScene, bool baseNameOnly = false);
+    std::string modulatorNameWithIndex(int scene, int ms, int index, bool forButton, bool useScene,
+                                       bool baseNameOnly = false);
 
   private:
     Parameter *typeinEditTarget = nullptr;

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -622,7 +622,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
   public:
     std::string modulatorName(int ms, bool forButton, int forScene = -1);
     std::string modulatorIndexExtension(int scene, int ms, int index, bool shortV = false);
-    std::string modulatorNameWithIndex(int scene, int ms, int index, bool forButton, bool useScene);
+    std::string modulatorNameWithIndex(int scene, int ms, int index, bool forButton, bool useScene, bool baseNameOnly = false);
 
   private:
     Parameter *typeinEditTarget = nullptr;

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -938,18 +938,24 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             if (lfo_id >= 0)
             {
                 auto msi = modsource_index;
-                contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Rename Modulator"), [this, lfo_id,
-                                                                                      msi, cms]() {
-                    auto mecb = [this, lfo_id, msi](const std::string &nv) {
-                        auto cp =
-                            synth->storage.getPatch().LFOBankLabel[current_scene][lfo_id][msi];
-                        strxcpy(cp, nv.c_str(), CUSTOM_CONTROLLER_LABEL_SIZE);
-                        synth->refresh_editor = true;
-                    };
-                    promptForMiniEdit(
-                        synth->storage.getPatch().LFOBankLabel[current_scene][lfo_id][msi],
-                        "Set Modulator Name", "Rename Modulator", juce::Point<int>(10, 10), mecb);
-                });
+                contextMenu.addItem(
+                    Surge::GUI::toOSCaseForMenu("Rename Modulator..."),
+                    [this, lfo_id, modsource, msi, cms]() {
+                        auto mecb = [this, lfo_id, msi](const std::string &nv) {
+                            auto cp =
+                                synth->storage.getPatch().LFOBankLabel[current_scene][lfo_id][msi];
+                            strxcpy(cp, nv.c_str(), CUSTOM_CONTROLLER_LABEL_SIZE);
+                            synth->refresh_editor = true;
+                        };
+                        promptForMiniEdit(
+                            synth->storage.getPatch().LFOBankLabel[current_scene][lfo_id][msi],
+                            fmt::format("Enter a new name for {:s}:",
+                                        modulatorName(modsource, true)),
+                            "Rename Modulator", juce::Point<int>(10, 10), mecb);
+                    });
+
+                contextMenu.addSeparator();
+
                 contextMenu.addItem(Surge::GUI::toOSCaseForMenu("Copy Modulator"),
                                     [this, sc, lfo_id]() {
                                         synth->storage.clipboard_copy(cp_lfo, sc, lfo_id);

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -950,7 +950,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         promptForMiniEdit(
                             synth->storage.getPatch().LFOBankLabel[current_scene][lfo_id][msi],
                             fmt::format("Enter a new name for {:s}:",
-                                        modulatorName(modsource, true)),
+                                        modulatorNameWithIndex(current_scene, modsource, msi, false,
+                                                               false, true)),
                             "Rename Modulator", juce::Point<int>(10, 10), mecb);
                     });
 

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -286,22 +286,28 @@ void ModulationSourceButton::buildHamburgerMenu(juce::PopupMenu &menu,
 
         menu.addSeparator();
     }
+
     if (modlist.size() > 1)
     {
         for (auto e : modlist)
         {
             auto modName = std::get<3>(e);
 
-            if (addedToModbuttonContextMenu)
-                modName = "Switch to " + modName;
+            if (this->modlistIndex != idx)
+            {
+                if (addedToModbuttonContextMenu)
+                {
+                    modName = "Switch to " + modName;
+                }
 
-            menu.addItem(modName, [this, idx]() {
-                this->modlistIndex = idx;
-                mouseMode = HAMBURGER;
-                notifyValueChanged();
-                mouseMode = NONE;
-                repaint();
-            });
+                menu.addItem(modName, [this, idx]() {
+                    this->modlistIndex = idx;
+                    mouseMode = HAMBURGER;
+                    notifyValueChanged();
+                    mouseMode = NONE;
+                    repaint();
+                });
+            }
 
             idx++;
         }


### PR DESCRIPTION
Show all alternate modulators except currently selected one in Switch To menu.
Reword text in Rename macro/modulator dialogs
Add ellipsis to Rename Modulator menu option