### PR TITLE
Force MiniEdit to front always

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4203,6 +4203,7 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
     miniEdit->callback = std::move(onOK);
     miniEdit->setBounds(0, 0, getWindowSizeX(), getWindowSizeY());
     miniEdit->setVisible(true);
+    miniEdit->toFront(true);
     miniEdit->grabFocus();
 }
 


### PR DESCRIPTION
This is the fix to #5408, but I couldn't reproduce
for a retest with this in place.