### PR TITLE
Do better than 'close/open' for some refreshes

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -601,12 +601,50 @@ void SurgeGUIEditor::refreshOverlayWithOpenClose(OverlayTags tag)
         to = olw->isTornOut();
         tol = olw->currentTearOutLocation();
     }
-    closeOverlay(tag);
-    showOverlay(tag);
-    if (to)
+    /*
+     * Some editors can do better than a forced open-clsoe
+     */
+    bool couldRefresh = true;
+    switch (tag)
     {
-        olw = getOverlayWrapperIfOpen(tag);
-        if (olw)
-            olw->doTearOut(tol);
+    case TUNING_EDITOR:
+    {
+        auto tunol = dynamic_cast<Surge::Overlays::TuningOverlay *>(getOverlayIfOpen(tag));
+        if (tunol)
+        {
+            tunol->setTuning(synth->storage.currentTuning);
+        }
+        break;
+    }
+    case MODULATION_EDITOR:
+    {
+        auto modol = dynamic_cast<Surge::Overlays::ModulationEditor *>(getOverlayIfOpen(tag));
+
+        if (modol)
+        {
+            modol->rebuildContents();
+        }
+        break;
+    }
+    case WAVESHAPER_ANALYZER:
+    {
+        updateWaveshaperOverlay();
+        break;
+    }
+    default:
+        couldRefresh = false;
+        break;
+    }
+
+    if (!couldRefresh)
+    {
+        closeOverlay(tag);
+        showOverlay(tag);
+        if (to)
+        {
+            olw = getOverlayWrapperIfOpen(tag);
+            if (olw)
+                olw->doTearOut(tol);
+        }
     }
 }

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -1165,6 +1165,11 @@ ModulationEditor::~ModulationEditor()
     idleTimer->stopTimer();
 }
 
+void ModulationEditor::rebuildContents()
+{
+    if (synth && modContents)
+        modContents->rebuildFrom(synth);
+}
 /*
  * At a later date I can make this more efficient but for now if any modulation changes
  * in the main UI just rebuild the table.

--- a/src/surge-xt/gui/overlays/ModulationEditor.h
+++ b/src/surge-xt/gui/overlays/ModulationEditor.h
@@ -66,6 +66,7 @@ class ModulationEditor : public OverlayComponent,
     std::unique_ptr<juce::Viewport> viewport;
 
     void onSkinChanged() override;
+    void rebuildContents();
 
     void updateParameterById(const SurgeSynthesizer::ID &pid);
 


### PR DESCRIPTION
For some of our overlays we have a cleaner semantic than close/open
to reset state, so do that for tuning, modlist, wsanalysis, and
make it so others can be added to if we want and as we go.

Closes #5305