### PR TITLE
An assortment of minor GUI tweaks and fixes

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2347,7 +2347,7 @@ juce::PopupMenu SurgeGUIEditor::makeLfoMenu(const juce::Point<int> &where)
     lfoSubMenu.addItem(Surge::GUI::toOSCaseForMenu("Save " + what + " Preset As..."),
                        [this, currentLfoId, what]() {
                            promptForMiniEdit(
-                               "", "Enter the name for " + what + " preset:", what + " Preset Name",
+                               "", "Enter the preset name:", what + " Preset Name",
                                juce::Point<int>{}, [this, currentLfoId](const std::string &s) {
                                    this->synth->storage.modulatorPreset->savePresetToUser(
                                        string_to_path(s), &(this->synth->storage), current_scene,
@@ -2455,7 +2455,7 @@ juce::PopupMenu SurgeGUIEditor::makeMpeMenu(const juce::Point<int> &where, bool 
     mpeSubMenu.addItem(Surge::GUI::toOSCaseForMenu(oss.str().c_str()), [this, where]() {
         // FIXME! This won't work on Linux
         const auto c{std::to_string(int(synth->storage.mpePitchBendRange))};
-        promptForMiniEdit(c, "Enter new MPE pitch bend range:", "MPE Pitch Bend Range", where,
+        promptForMiniEdit(c, "Enter a new value:", "MPE Pitch Bend Range", where,
                           [this](const std::string &c) {
                               int newVal = ::atoi(c.c_str());
                               this->synth->storage.mpePitchBendRange = newVal;
@@ -2470,8 +2470,8 @@ juce::PopupMenu SurgeGUIEditor::makeMpeMenu(const juce::Point<int> &where, bool 
     mpeSubMenu.addItem(Surge::GUI::toOSCaseForMenu(oss2.str().c_str()), [this, where]() {
         // FIXME! This won't work on linux
         const auto c{std::to_string(int(synth->storage.mpePitchBendRange))};
-        promptForMiniEdit(c, "Enter default MPE pitch bend range:", "Default MPE Pitch Bend Range",
-                          where, [this](const std::string &s) {
+        promptForMiniEdit(c, "Enter a default value:", "Default MPE Pitch Bend Range", where,
+                          [this](const std::string &s) {
                               int newVal = ::atoi(s.c_str());
                               Surge::Storage::updateUserDefaultValue(
                                   &(this->synth->storage), Surge::Storage::MPEPitchBendRange,
@@ -2747,16 +2747,15 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
         tuningSubMenu.addItem(
             Surge::GUI::toOSCaseForMenu("Remap " + middle_A + " (MIDI Note 69) Directly to..."),
             [this, middle_A, where]() {
-                char ma[256];
-                sprintf(ma, "Remap %s Frequency", middle_A.c_str());
-
                 char c[256];
                 snprintf(c, 256, "440.0");
-                promptForMiniEdit(c, "Remap MIDI note 69 frequency to: ", ma, where,
+                promptForMiniEdit(c, fmt::format("Enter a new frequency for {:s}:", middle_A),
+                                  fmt::format("Remap {:s} Frequency", middle_A), where,
                                   [this](const std::string &s) {
                                       float freq = ::atof(s.c_str());
                                       auto kb = Tunings::tuneA69To(freq);
                                       kb.name = fmt::format("Note 69 Retuned 440 to {:.2f}", freq);
+
                                       if (!this->synth->storage.remapToKeyboard(kb))
                                       {
                                           synth->storage.reportError("This .kbm file is not valid!",
@@ -2886,8 +2885,9 @@ juce::PopupMenu SurgeGUIEditor::makeZoomMenu(const juce::Point<int> &where, bool
     for (auto s : zoomTos) // These are somewhat arbitrary reasonable defaults
     {
         std::string lab = "Zoom to " + std::to_string(s) + "%";
-
-        zoomSubMenu.addItem(lab, true, (s == zoomFactor), [this, s]() { resizeWindow(s); });
+        printf("%d | %.5f\n", s, zoomFactor);
+        zoomSubMenu.addItem(lab, true, (s == floor(zoomFactor + 0.5f)),
+                            [this, s]() { resizeWindow(s); });
     }
 
     zoomSubMenu.addSeparator();
@@ -2950,9 +2950,9 @@ juce::PopupMenu SurgeGUIEditor::makeZoomMenu(const juce::Point<int> &where, bool
         zoomSubMenu.addItem(
             Surge::GUI::toOSCaseForMenu("Set Default Zoom Level to..."), [this, where]() {
                 char c[256];
-                snprintf(c, 256, "%d", (int)zoomFactor);
-                promptForMiniEdit(c, "Enter a default zoom level value:", "Set Default Zoom Level",
-                                  where, [this](const std::string &s) {
+                snprintf(c, 256, "%d", (int)floor(zoomFactor + 0.5f));
+                promptForMiniEdit(c, "Enter a new value:", "Set Default Zoom Level", where,
+                                  [this](const std::string &s) {
                                       int newVal = ::atoi(s.c_str());
                                       Surge::Storage::updateUserDefaultValue(
                                           &(synth->storage), Surge::Storage::DefaultZoom, newVal);
@@ -3056,8 +3056,8 @@ juce::PopupMenu SurgeGUIEditor::makePatchDefaultsMenu(const juce::Point<int> &wh
         txt[0] = 0;
         if (Surge::Storage::isValidUTF8(s))
             strxcpy(txt, s.c_str(), 256);
-        promptForMiniEdit(txt, "Enter a default patch author name:", "Set Default Patch Author",
-                          where, [this](const std::string &s) {
+        promptForMiniEdit(txt, "Enter a default text:", "Set Default Patch Author", where,
+                          [this](const std::string &s) {
                               Surge::Storage::updateUserDefaultValue(
                                   &(this->synth->storage), Surge::Storage::DefaultPatchAuthor, s);
                           });
@@ -3071,7 +3071,7 @@ juce::PopupMenu SurgeGUIEditor::makePatchDefaultsMenu(const juce::Point<int> &wh
         txt[0] = 0;
         if (Surge::Storage::isValidUTF8(s))
             strxcpy(txt, s.c_str(), 256);
-        promptForMiniEdit(txt, "Enter a default patch comment:", "Set Default Patch Comment", where,
+        promptForMiniEdit(txt, "Enter a default text:", "Set Default Patch Comment", where,
                           [this](const std::string &s) {
                               Surge::Storage::updateUserDefaultValue(
                                   &(this->synth->storage), Surge::Storage::DefaultPatchComment, s);
@@ -3405,7 +3405,7 @@ juce::PopupMenu SurgeGUIEditor::makeSkinMenu(const juce::Point<int> &where)
         skinSubMenu.addItem(
             Surge::GUI::toOSCaseForMenu("Change Layout Grid Resolution..."), [this, pxres]() {
                 this->promptForMiniEdit(
-                    std::to_string(pxres), "Enter new resolution:", "Layout Grid Resolution",
+                    std::to_string(pxres), "Enter a new value:", "Layout Grid Resolution",
                     juce::Point<int>{400, 400}, [this](const std::string &s) {
                         Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
                                                                Surge::Storage::LayoutGridResolution,
@@ -3585,7 +3585,7 @@ juce::PopupMenu SurgeGUIEditor::makeMidiMenu(const juce::Point<int> &where)
         char msn[256];
         msn[0] = 0;
         promptForMiniEdit(
-            msn, "Enter a name for the MIDI mapping:", "Save MIDI Mapping", where,
+            msn, "Enter the preset name:", "Save MIDI Mapping", where,
             [this](const std::string &s) { this->synth->storage.storeMidiMappingToName(s); });
     });
 

--- a/src/surge-xt/gui/overlays/MiniEdit.cpp
+++ b/src/surge-xt/gui/overlays/MiniEdit.cpp
@@ -79,7 +79,7 @@ void MiniEdit::paint(juce::Graphics &g)
 
     if (d)
     {
-        d->drawAt(g, fullRect.getX(), fullRect.getY() + 2, 1.0);
+        d->drawAt(g, fullRect.getX() + 2, fullRect.getY() + 2, 1.0);
     }
 
     auto bodyRect = fullRect.withTrimmedTop(18);
@@ -90,7 +90,7 @@ void MiniEdit::paint(juce::Graphics &g)
     g.setColour(skin->getColor(Colors::Dialog::Label::Text));
     g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
 
-    auto labelRect = bodyRect.withHeight(20).reduced(4, 0);
+    auto labelRect = bodyRect.withHeight(20).reduced(6, 0);
 
     g.drawText(label, labelRect, juce::Justification::centredLeft);
 
@@ -126,8 +126,8 @@ void MiniEdit::resized()
     auto dialogCenter = fullRect.getWidth() / 2;
     auto typeinBox = fullRect.translated(0, 2 * typeinHeight + margin * 2)
                          .withHeight(typeinHeight)
-                         .withTrimmedLeft(2 * margin)
-                         .withTrimmedRight(2 * margin);
+                         .withTrimmedLeft(3 * margin)
+                         .withTrimmedRight(3 * margin);
 
     typein->setBounds(typeinBox);
     typein->setIndents(4, (typein->getHeight() - typein->getTextHeight()) / 2);

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -65,7 +65,7 @@ void OverlayWrapper::paint(juce::Graphics &g)
 
     if (icon)
     {
-        icon->drawAt(g, sp.getX() + 2, sp.getY() + 1, 1);
+        icon->drawAt(g, sp.getX() + 3, sp.getY() + 1, 1);
     }
 
     g.setColour(skin->getColor(Colors::Dialog::Border));

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
@@ -76,16 +76,17 @@ void TypeinParamEditor::paint(juce::Graphics &g)
 
 juce::Rectangle<int> TypeinParamEditor::getRequiredSize()
 {
-    int ht = 56 + (isMod ? 22 : 0);
+    int ht = 50 + (isMod ? 24 : 0);
     auto r = juce::Rectangle<int>(0, 0, 144, ht);
     return r;
 }
+
 void TypeinParamEditor::setBoundsToAccompany(const juce::Rectangle<int> &controlRect,
                                              const juce::Rectangle<int> &parentRect)
 {
     auto r = getRequiredSize();
     r = r.withX(controlRect.getX()).withY(controlRect.getY() - r.getHeight());
-    ;
+
     if (!parentRect.contains(r))
     {
         r = r.withY(controlRect.getBottom());
@@ -96,7 +97,7 @@ void TypeinParamEditor::setBoundsToAccompany(const juce::Rectangle<int> &control
 
 void TypeinParamEditor::resized()
 {
-    auto ter = juce::Rectangle<int>(0, getHeight() - 22, 144, 22).reduced(2);
+    auto ter = juce::Rectangle<int>(0, getHeight() - 24, 144, 22).reduced(4, 2);
     textEd->setBounds(ter);
 }
 

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -375,12 +375,12 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
 
         if (sge)
         {
-            sge->promptForMiniEdit(
-                c, "Enter a custom wavetable display name:", "Wavetable Display Name",
-                juce::Point<int>{}, [this](const std::string &s) {
-                    strncpy(this->oscdata->wavetable_display_name, s.c_str(), 256);
-                    this->repaint();
-                });
+            sge->promptForMiniEdit(c, "Enter a new name:", "Wavetable Display Name",
+                                   juce::Point<int>{}, [this](const std::string &s) {
+                                       strncpy(this->oscdata->wavetable_display_name, s.c_str(),
+                                               256);
+                                       this->repaint();
+                                   });
         }
     };
 

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -668,8 +668,8 @@ void FxMenu::saveFX()
     auto *sge = firstListenerOfType<SurgeGUIEditor>();
     if (sge)
     {
-        sge->promptForMiniEdit("", "Enter a name for the FX preset:", "Save FX Preset",
-                               juce::Point<int>{}, [this](const std::string &s) {
+        sge->promptForMiniEdit("", "Enter the preset name:", "Save FX Preset", juce::Point<int>{},
+                               [this](const std::string &s) {
                                    this->storage->fxUserPreset->saveFxIn(this->storage, fx, s);
                                    auto *sge = firstListenerOfType<SurgeGUIEditor>();
                                    if (sge)


### PR DESCRIPTION
* Better padding around miniedit and parameter typein text input fields
* Less redundant text in all the various miniedits
* Slightly more left margin for the Surge icon in overlays/miniedits
* Fix checkmark not always showing for fixed zoom levels
* Round the default value that shows in Default zoom level miniedit