### PR TITLE
Change top level window borders on skin changes

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -140,6 +140,20 @@ void SurgeSynthEditor::reapplySurgeComponentColours()
     tempoTypein->applyColourToAllText(
         findColour(SurgeJUCELookAndFeel::SurgeColourIds::tempoTypeinTextId), true);
 
+    for (auto *p = getParentComponent(); p != nullptr; p = p->getParentComponent())
+    {
+        if (auto dw = dynamic_cast<juce::DocumentWindow *>(p))
+        {
+            dw->setName("Surge XT");
+
+            if (processor.wrapperType == juce::AudioProcessor::wrapperType_Standalone)
+            {
+                dw->setColour(juce::DocumentWindow::backgroundColourId,
+                              findColour(SurgeJUCELookAndFeel::SurgeColourIds::topWindowBorderId));
+            }
+        }
+    }
+
     repaint();
 }
 
@@ -218,22 +232,7 @@ void SurgeSynthEditor::resized()
     }
 }
 
-void SurgeSynthEditor::parentHierarchyChanged()
-{
-    for (auto *p = getParentComponent(); p != nullptr; p = p->getParentComponent())
-    {
-        if (auto dw = dynamic_cast<juce::DocumentWindow *>(p))
-        {
-            dw->setName("Surge XT");
-
-            if (processor.wrapperType == juce::AudioProcessor::wrapperType_Standalone)
-            {
-                dw->setColour(juce::DocumentWindow::backgroundColourId,
-                              findColour(SurgeJUCELookAndFeel::SurgeColourIds::topWindowBorderId));
-            }
-        }
-    }
-}
+void SurgeSynthEditor::parentHierarchyChanged() { reapplySurgeComponentColours(); }
 
 void SurgeSynthEditor::IdleTimer::timerCallback() { ed->idle(); }
 

--- a/src/surge-xt/SurgeSynthEditor.h
+++ b/src/surge-xt/SurgeSynthEditor.h
@@ -43,6 +43,7 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
         SurgeSynthEditor *editor{nullptr};
     };
     void parentHierarchyChanged() override;
+    void resetWindowFromSkin();
 
     void paramsChangedCallback();
     void setEffectType(int i);

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3701,6 +3701,7 @@ void SurgeGUIEditor::reloadFromSkin()
         if (component)
         {
             component->setSkin(currentSkin, bitmapStore);
+            ol.second->repaint();
         }
     }
 

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -19,6 +19,7 @@
 #include "SurgeGUIEditor.h"
 #include "OverlayComponent.h"
 #include "widgets/MainFrame.h"
+#include "SurgeJUCELookAndFeel.h"
 
 namespace Surge
 {
@@ -237,6 +238,8 @@ void OverlayWrapper::doTearOut(const juce::Point<int> &showAt)
     dw->supressMoveUpdates = false;
     supressInteriorDecoration();
     tearOutParent = std::move(dw);
+    tearOutParent->setColour(juce::DocumentWindow::backgroundColourId,
+                             findColour(SurgeJUCELookAndFeel::SurgeColourIds::topWindowBorderId));
 }
 
 juce::Point<int> OverlayWrapper::currentTearOutLocation()
@@ -367,6 +370,14 @@ void OverlayWrapper::onSkinChanged()
         skc->setSkin(skin, associatedBitmapStore);
     }
     icon = associatedBitmapStore->getImage(IDB_SURGE_ICON);
+    if (tearOutParent)
+    {
+        tearOutParent->setColour(
+            juce::DocumentWindow::backgroundColourId,
+            findColour(SurgeJUCELookAndFeel::SurgeColourIds::topWindowBorderId));
+        tearOutParent->repaint();
+    }
+    repaint();
 }
 
 } // namespace Overlays


### PR DESCRIPTION
Basically just calling the right thing at the right time just
annoyingly correctly as opposed to lcose-to-correctly like
we were

Closes #5447