### PR TITLE
A collection of beta fixes

### DIFF
--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -27,14 +27,14 @@ namespace Overlays
 {
 OverlayWrapper::OverlayWrapper()
 {
-    closeButton = std::make_unique<juce::TextButton>("closeButton");
+    closeButton.reset(
+        getLookAndFeel().createDocumentWindowButton(juce::DocumentWindow::closeButton));
     closeButton->addListener(this);
-    closeButton->setButtonText("X");
     addChildComponent(*closeButton);
 
-    tearOutButton = std::make_unique<juce::TextButton>("tearOut");
+    tearOutButton.reset(
+        getLookAndFeel().createDocumentWindowButton(juce::DocumentWindow::maximiseButton));
     tearOutButton->addListener(this);
-    tearOutButton->setButtonText("^");
     addChildComponent(*tearOutButton);
 }
 
@@ -86,7 +86,7 @@ void OverlayWrapper::addAndTakeOwnership(std::unique_ptr<juce::Component> c)
     primaryChild = std::move(c);
     primaryChild->setBounds(q);
 
-    auto buttonSize = titlebarSize - 2;
+    auto buttonSize = titlebarSize;
     auto closeButtonBounds =
         getLocalBounds().withHeight(buttonSize).withLeft(getWidth() - buttonSize).translated(-2, 2);
     auto tearOutButtonBounds = closeButtonBounds.translated(-buttonSize - 2, 0);

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -53,7 +53,7 @@ struct OverlayWrapper : public juce::Component,
 
     std::unique_ptr<juce::Component> primaryChild;
     void addAndTakeOwnership(std::unique_ptr<juce::Component> c);
-    std::unique_ptr<juce::TextButton> closeButton, tearOutButton;
+    std::unique_ptr<juce::Button> closeButton, tearOutButton;
     void buttonClicked(juce::Button *button) override;
 
     juce::Point<int> mouseDownWithinTarget;

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1206,7 +1206,9 @@ void LFOAndStepDisplay::setStepValue(const juce::MouseEvent &event)
     {
         auto r = steprect[i];
 
-        if (r.contains(event.position))
+        float rx0 = r.getX();
+        float rx1 = r.getX() + r.getWidth();
+        if (event.position.x >= rx0 && event.position.x < rx1)
         {
             draggedStep = i;
 


### PR DESCRIPTION
1. Tune button blinks because it uses legacy state from toggle.
   Closes #5459
2. Allow drag outside of SS to reset values. Closes #5455
3. Use JUCE documetn buttons on overlay popout/close. Closes #5453