### PR TITLE
Use full display name for FX menu in Surge FX

### DIFF
--- a/doc/Adding An FX.md
+++ b/doc/Adding An FX.md
@@ -21,7 +21,9 @@ Note that we have chosen the effect ID `fxt_myeffect` for our example effect.
 3. In SurgeStorage.h:
 * Add an enum to `fx_type` with your effect ID.
 * Add the name of your effect to `fx_type_names`.
-* Add a 3 or 4 character shorthand name of your effect to `fx_type_shortnames`.
+* Add the shorter name of your effect to `fx_type_shortnames`. This is used in Surge XT effect type menu itself (right side),
+  so make sure it fits there!
+* Add a 3 or 4 character acronym of your effect to `fx_type_acronyms`.
   Verify if this fits properly in the FX grid boxes on the GUI!
 
 4. In `resources/surge-shared/configuration.xml` add your effect to the `fx` XML group.

--- a/src/common/FxPresetAndClipboardManager.cpp
+++ b/src/common/FxPresetAndClipboardManager.cpp
@@ -125,7 +125,7 @@ void FxUserPreset::doPresetRescan(SurgeStorage *storage, bool forceRescan)
                 rpath = f.first.lexically_relative(storage->userFXPath).parent_path();
 
             auto startCatPath = rpath.begin();
-            if (*(startCatPath) == fx_type_names[t])
+            if (*(startCatPath) == fx_type_shortnames[t])
             {
                 startCatPath++;
             }
@@ -244,7 +244,7 @@ void FxUserPreset::saveFxIn(SurgeStorage *storage, FxStorage *fx, const std::str
 
     int ti = fx->type.val.i;
 
-    auto storagePath = storage->userFXPath / fs::path(fx_type_names[ti]);
+    auto storagePath = storage->userFXPath / fs::path(fx_type_shortnames[ti]);
 
     if (!spp.empty())
         storagePath /= spp;

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -3255,7 +3255,8 @@ void Parameter::get_display(char *txt, bool external, float ef) const
             snprintf(txt, TXT_SIZE, "%d voice%s", i, (i > 1 ? "s" : ""));
             break;
         case ct_fxtype:
-            snprintf(txt, TXT_SIZE, "%s", fx_type_names[limit_range(i, 0, (int)n_fx_types - 1)]);
+            snprintf(txt, TXT_SIZE, "%s",
+                     fx_type_shortnames[limit_range(i, 0, (int)n_fx_types - 1)]);
             break;
         case ct_reverbshape:
             snprintf(txt, TXT_SIZE, "Type %d", i + 1);

--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -564,7 +564,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
                 {
                     if (sm != 0)
                     {
-                        res.emplace_back("FX", STRING, 0, fx_type_names[sm]);
+                        res.emplace_back("FX", STRING, 0, fx_type_shortnames[sm]);
                     }
                 }
             }

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -306,17 +306,46 @@ enum fx_type
     n_fx_types,
 };
 
-const char fx_type_names[n_fx_types][16] = {
+const char fx_type_names[n_fx_types][32] = {"Off",
+                                            "Delay",
+                                            "Reverb 1",
+                                            "Phaser",
+                                            "Rotary Speaker",
+                                            "Distortion",
+                                            "EQ",
+                                            "Frequency Shifter",
+                                            "Conditioner",
+                                            "Chorus",
+                                            "Vocoder",
+                                            "Reverb 2",
+                                            "Flanger",
+                                            "Ring Modulator",
+                                            "Airwindows",
+                                            "Neuron",
+                                            "Graphic EQ",
+                                            "Resonator",
+                                            "CHOW",
+                                            "Exciter",
+                                            "Ensemble",
+                                            "Combulator",
+                                            "Nimbus",
+                                            "Tape",
+                                            "Treemonster",
+                                            "Waveshaper",
+                                            "Mid-Side Tool",
+                                            "Spring Reverb"};
+
+const char fx_type_shortnames[n_fx_types][16] = {
     "Off",         "Delay",      "Reverb 1",      "Phaser",       "Rotary",     "Distortion",
     "EQ",          "Freq Shift", "Conditioner",   "Chorus",       "Vocoder",    "Reverb 2",
     "Flanger",     "Ring Mod",   "Airwindows",    "Neuron",       "Graphic EQ", "Resonator",
     "CHOW",        "Exciter",    "Ensemble",      "Combulator",   "Nimbus",     "Tape",
     "Treemonster", "Waveshaper", "Mid-Side Tool", "Spring Reverb"};
 
-const char fx_type_shortnames[n_fx_types][8] = {"OFF", "DLY", "RV1",  "PH",  "ROT", "DIST", "EQ",
-                                                "FRQ", "DYN", "CH",   "VOC", "RV2", "FL",   "RM",
-                                                "AW",  "NEU", "GEQ",  "RES", "CHW", "XCT",  "ENS",
-                                                "CMB", "NIM", "TAPE", "TM",  "WS",  "M-S",  "SRV"};
+const char fx_type_acronyms[n_fx_types][8] = {"OFF", "DLY", "RV1",  "PH",  "ROT", "DIST", "EQ",
+                                              "FRQ", "DYN", "CH",   "VOC", "RV2", "FL",   "RM",
+                                              "AW",  "NEU", "GEQ",  "RES", "CHW", "XCT",  "ENS",
+                                              "CMB", "NIM", "TAPE", "TM",  "WS",  "M-S",  "SRV"};
 
 enum fx_bypass
 {

--- a/src/surge-fx/SurgeFXEditor.cpp
+++ b/src/surge-fx/SurgeFXEditor.cpp
@@ -58,7 +58,7 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
     setSize(600, 55 * 6 + 80 + topSection);
     setResizable(false, false); // For now
 
-    fxNameLabel = std::make_unique<juce::Label>("fxlabel", "Surge FX Bank");
+    fxNameLabel = std::make_unique<juce::Label>("fxlabel", "Surge XT Effects");
     fxNameLabel->setFont(28);
     fxNameLabel->setColour(juce::Label::textColourId,
                            surgeLookFeel->findColour(SurgeLookAndFeel::blue));

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -134,7 +134,7 @@ void EffectChooser::paint(juce::Graphics &g)
 void EffectChooser::drawSlotText(juce::Graphics &g, const juce::Rectangle<int> &r,
                                  const juce::Colour &txtcol, int fxid)
 {
-    auto fxname = fx_type_shortnames[fxid];
+    auto fxname = fx_type_acronyms[fxid];
 
     g.setColour(txtcol);
 
@@ -147,7 +147,7 @@ void EffectChooser::drawSlotText(juce::Graphics &g, const juce::Rectangle<int> &
     }
     else
     {
-        g.drawText(fx_type_shortnames[fxid], r, juce::Justification::centred);
+        g.drawText(fx_type_acronyms[fxid], r, juce::Justification::centred);
     }
 }
 

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -474,7 +474,7 @@ void FxMenu::paint(juce::Graphics &g)
     g.setColour(fgc);
     auto r = getLocalBounds().reduced(2).withTrimmedLeft(4).withTrimmedRight(12);
     g.drawText(fxslot_names[current_fx], r, juce::Justification::centredLeft);
-    g.drawText(fx_type_names[fx->type.val.i], r, juce::Justification::centredRight);
+    g.drawText(fx_type_shortnames[fx->type.val.i], r, juce::Justification::centredRight);
 }
 
 void FxMenu::mouseDown(const juce::MouseEvent &event)
@@ -658,7 +658,7 @@ void FxMenu::pasteFX()
 {
     Surge::FxClipboard::pasteFx(storage, fxbuffer, fxClipboard);
 
-    selectedName = std::string("Copied ") + fx_type_names[fxbuffer->type.val.i];
+    selectedName = std::string("Copied ") + fx_type_shortnames[fxbuffer->type.val.i];
 
     notifyValueChanged();
 }
@@ -759,7 +759,7 @@ template <> struct XMLValue<FxMenu>
 {
     static std::string value(FxMenu *comp)
     {
-        std::string r = fx_type_names[comp->fx->type.val.i];
+        std::string r = fx_type_shortnames[comp->fx->type.val.i];
         r += " in ";
         r += fxslot_names[comp->current_fx];
         return r;


### PR DESCRIPTION
Also rename `fx_type_shortnames` to `fx_type_acronyms`.
Previously `fx_type_names` are now `fx_type_shortnames`, and `fx_type_names`
contain full display names (as in preset XML).

Also the SXTFX GUI now also properly says Surge XT Effects (no more Surge FX Bank)..

Also updated Adding an FX documentation with the new array names.