### PR TITLE
Fix another octave-per-channel mode thing

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -71,16 +71,27 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
         res = (1.f - frac) * b0 + frac * b1;
     }
 
-    res = SurgeVoice::channelKeyEquvialent(res, channel, storage);
+    res = SurgeVoice::channelKeyEquvialent(res, channel, storage, false);
 
     return res;
 }
 
-float SurgeVoice::channelKeyEquvialent(float key, int channel, SurgeStorage *storage)
+float SurgeVoice::channelKeyEquvialent(float key, int channel, SurgeStorage *storage,
+                                       bool remapKeyForTuning)
 {
     float res = key;
     if (storage->mapChannelToOctave)
     {
+        if (remapKeyForTuning && !storage->isStandardTuning &&
+            storage->tuningApplicationMode == SurgeStorage::RETUNE_MIDI_ONLY)
+        {
+            auto idx = (int)floor(res);
+            float frac = res - idx; // frac is 0 means use idx; frac is 1 means use idx+1
+            float b0 = storage->currentTuning.logScaledFrequencyForMidiNote(idx) * 12;
+            float b1 = storage->currentTuning.logScaledFrequencyForMidiNote(idx + 1) * 12;
+            res = (1.f - frac) * b0 + frac * b1;
+        }
+
         float shift;
         if (channel > 7)
         {

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -133,7 +133,8 @@ class alignas(16) SurgeVoice
         }
     }
 
-    static float channelKeyEquvialent(float key, int channel, SurgeStorage *storage);
+    static float channelKeyEquvialent(float key, int channel, SurgeStorage *storage,
+                                      bool remapKeyForTuning = true);
 
   private:
     template <bool first> void calc_ctrldata(QuadFilterChainState *, int);


### PR DESCRIPTION
In the case where e RETUNE_AT_MIDI with a long scale the
voice stealing compairson used different indices than the voice
souding algorithm, so we compared in untuned space accidentally.

Closes #5469