### PR TITLE
Fix for building with clang-cl on Windows

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -280,10 +280,8 @@ elseif(UNIX)
 elseif(WIN32)
   target_compile_definitions(${PROJECT_NAME} PUBLIC
     WINDOWS=1
-    NOMINMAX=1
     WIN32
     _USE_MATH_DEFINES
-    _WIN32_WINNT=0x0601
     _USRDLL
     VA_SUBTRACTIVE_EXPORTS
     USE_LIBPNG

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -13,6 +13,8 @@
 ** open source in September 2018.
 */
 
+#define NOMINMAX
+
 #include "SurgeSynthesizer.h"
 #include "DSPUtils.h"
 #include <ctime>


### PR DESCRIPTION
This fixes clang-cl errors about NOMINMAX and WIN32_WINNT already being defined by juce_BasicNativeHeaders.h when building.

```
D:\GitHub\build\surge\libs\JUCE\modules\juce_core/native/juce_BasicNativeHeaders.h(129,10): error: 'NOMINMAX' macro redefined [-Werror,-Wmacro-redefined]
 #define NOMINMAX
         ^
<command line>(26,9): note: previous definition is here
#define NOMINMAX 1
        ^
```

```
D:\GitHub\build\surge\libs\JUCE\modules\juce_core/native/juce_BasicNativeHeaders.h(137,11): error: '_WIN32_WINNT' macro redefined [-Werror,-Wmacro-redefined]
  #define _WIN32_WINNT 0x0602
          ^
<command line>(38,9): note: previous definition is here
#define _WIN32_WINNT 0x0601
        ^
```