### PR TITLE
Repeated Portamento in OPC mode

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -168,7 +168,10 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
         }
         else
         {
-            state.portasrc_key = storage->remapKeyInMidiOnlyMode(lk);
+            if (storage->mapChannelToOctave)
+                state.portasrc_key = channelKeyEquvialent(lk, state.channel, storage, true);
+            else
+                state.portasrc_key = storage->remapKeyInMidiOnlyMode(lk);
         }
     }
     state.priorpkey = state.portasrc_key;


### PR DESCRIPTION
In OPC mode the same repeated portamento starting point
as with MTS was in play. Fix it in the same spot and add
a test.

Closes #5503