### PR TITLE
Bounds Cmoparison Wrong in MenuForDiscreteParams

### DIFF
--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -239,7 +239,7 @@ void MenuForDiscreteParams::mouseWheelMove(const juce::MouseEvent &e,
 float MenuForDiscreteParams::nextValueInOrder(float v, int inc)
 {
     int iv = Parameter::intUnscaledFromFloat(v, iMax, iMin);
-    if (!intOrdering.empty() && iMax == intOrdering.size() - 1)
+    if (!intOrdering.empty() && iMax == intOrdering.size())
     {
         int pidx = 0;
 


### PR DESCRIPTION
Only used in AirWindows right now, but it woudl have borken others
too.

Closes #5507