### PR TITLE
Correct front overlays

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1808,7 +1808,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
     for (const auto &el : juceOverlays)
     {
         if (!el.second->isTornOut())
+        {
             addAndMakeVisibleWithTracking(frame.get(), *(el.second));
+        }
     }
 
     if (showMSEGEditorOnNextIdleOrOpen)
@@ -1845,6 +1847,22 @@ void SurgeGUIEditor::openOrRecreateEditor()
     if (synth->storage.oddsound_mts_active)
     {
         closeOverlay(TUNING_EDITOR);
+    }
+
+    /*
+     * Finally make sure the Z-Order fronting for our overlays is still OK
+     */
+    std::vector<juce::Component *> frontthese;
+    for (auto c : frame->getChildren())
+    {
+        if (auto ol = dynamic_cast<Surge::Overlays::OverlayWrapper *>(c))
+        {
+            frontthese.push_back(c);
+        }
+    }
+    for (auto c : frontthese)
+    {
+        c->toFront(true);
     }
 
     tuningChanged(); // a patch load could change tuning

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -311,6 +311,7 @@ void OverlayWrapper::mouseUp(const juce::MouseEvent &e)
     if (isTornOut())
         return;
 
+    toFront(true);
     auto c = getPrimaryChildAsOverlayComponent();
     if (c && c->getCanMoveAround() && editor)
     {


### PR DESCRIPTION
1. Keep them fronted on rebuilds and skin changes
2. Allow click-menu-bar to bring-to-front for two overlay case

Closes #5445