### PR TITLE
Add "Knock" parameter to spring reverb

### DIFF
--- a/src/common/dsp/effects/chowdsp/SpringReverbEffect.cpp
+++ b/src/common/dsp/effects/chowdsp/SpringReverbEffect.cpp
@@ -40,7 +40,7 @@ void SpringReverbEffect::process(float *dataL, float *dataR)
             clamp01(*f[spring_reverb_spin]),
             clamp01(*f[spring_reverb_damping]),
             clamp01(*f[spring_reverb_chaos]),
-            fxdata->p[spring_reverb_shake].val.b,
+            *f[spring_reverb_knock] > 0.5f,
         },
         BLOCK_SIZE);
 
@@ -89,10 +89,10 @@ void SpringReverbEffect::init_ctrltypes()
     fxdata->p[spring_reverb_chaos].val_default.f = 0.0f;
     fxdata->p[spring_reverb_chaos].posy_offset = 3;
 
-    fxdata->p[spring_reverb_shake].set_name("Shake");
-    fxdata->p[spring_reverb_shake].set_type(ct_bool);
-    fxdata->p[spring_reverb_shake].val_default.b = false;
-    fxdata->p[spring_reverb_shake].posy_offset = 3;
+    fxdata->p[spring_reverb_knock].set_name("Knock");
+    fxdata->p[spring_reverb_knock].set_type(ct_float_toggle);
+    fxdata->p[spring_reverb_knock].val_default.f = 0.0f;
+    fxdata->p[spring_reverb_knock].posy_offset = 3;
 
     fxdata->p[spring_reverb_mix].set_name("Mix");
     fxdata->p[spring_reverb_mix].set_type(ct_percent);
@@ -108,7 +108,7 @@ void SpringReverbEffect::init_default_values()
     fxdata->p[spring_reverb_damping].val.f = 0.5f;
     fxdata->p[spring_reverb_spin].val.f = 0.5f;
     fxdata->p[spring_reverb_chaos].val.f = 0.0f;
-    fxdata->p[spring_reverb_shake].val.b = false;
+    fxdata->p[spring_reverb_knock].val.f = 0.0f;
     fxdata->p[spring_reverb_mix].val.f = 0.5f;
 }
 

--- a/src/common/dsp/effects/chowdsp/SpringReverbEffect.cpp
+++ b/src/common/dsp/effects/chowdsp/SpringReverbEffect.cpp
@@ -40,6 +40,7 @@ void SpringReverbEffect::process(float *dataL, float *dataR)
             clamp01(*f[spring_reverb_spin]),
             clamp01(*f[spring_reverb_damping]),
             clamp01(*f[spring_reverb_chaos]),
+            fxdata->p[spring_reverb_shake].val.b,
         },
         BLOCK_SIZE);
 
@@ -88,6 +89,11 @@ void SpringReverbEffect::init_ctrltypes()
     fxdata->p[spring_reverb_chaos].val_default.f = 0.0f;
     fxdata->p[spring_reverb_chaos].posy_offset = 3;
 
+    fxdata->p[spring_reverb_shake].set_name("Shake");
+    fxdata->p[spring_reverb_shake].set_type(ct_bool);
+    fxdata->p[spring_reverb_shake].val_default.b = false;
+    fxdata->p[spring_reverb_shake].posy_offset = 3;
+
     fxdata->p[spring_reverb_mix].set_name("Mix");
     fxdata->p[spring_reverb_mix].set_type(ct_percent);
     fxdata->p[spring_reverb_mix].val_default.f = 0.5f;
@@ -102,6 +108,7 @@ void SpringReverbEffect::init_default_values()
     fxdata->p[spring_reverb_damping].val.f = 0.5f;
     fxdata->p[spring_reverb_spin].val.f = 0.5f;
     fxdata->p[spring_reverb_chaos].val.f = 0.0f;
+    fxdata->p[spring_reverb_shake].val.b = false;
     fxdata->p[spring_reverb_mix].val.f = 0.5f;
 }
 
@@ -128,7 +135,7 @@ int SpringReverbEffect::group_label_ypos(int id)
     case 1:
         return 11;
     case 2:
-        return 17;
+        return 19;
     }
     return 0;
 }

--- a/src/common/dsp/effects/chowdsp/SpringReverbEffect.h
+++ b/src/common/dsp/effects/chowdsp/SpringReverbEffect.h
@@ -46,7 +46,7 @@ class SpringReverbEffect : public Effect
 
         spring_reverb_spin,
         spring_reverb_chaos,
-        spring_reverb_shake,
+        spring_reverb_knock,
 
         spring_reverb_mix,
 

--- a/src/common/dsp/effects/chowdsp/SpringReverbEffect.h
+++ b/src/common/dsp/effects/chowdsp/SpringReverbEffect.h
@@ -46,6 +46,7 @@ class SpringReverbEffect : public Effect
 
         spring_reverb_spin,
         spring_reverb_chaos,
+        spring_reverb_shake,
 
         spring_reverb_mix,
 

--- a/src/common/dsp/effects/chowdsp/spring_reverb/SpringReverbProc.h
+++ b/src/common/dsp/effects/chowdsp/spring_reverb/SpringReverbProc.h
@@ -38,6 +38,7 @@ class SpringReverbProc
         float spin = 0.5f;
         float damping = 0.5f;
         float chaos = 0.0f;
+        bool shake = false;
     };
 
     void prepare(float sampleRate, int samplesPerBlock);
@@ -69,5 +70,10 @@ class SpringReverbProc
     StateVariableFilter<float> lpf;
 
     ReflectionNetwork reflectionNetwork; // early reflections
+
+    int shakeCounter = -1;
+    std::vector<float> shakeBuffer;
+    int shakeBufferSize = 0;
+    float shortShakeBuffer[BLOCK_SIZE];
 };
 } // namespace chowdsp


### PR DESCRIPTION
Added this parameter so that you can "shake" the spring reverb. Not sure that "shake" is the right name, since it's more like if you were to knock against a spring reverb unit, rather than actually pick it up and shake it.

i made the new parameter a boolean, since that seemed to make sense internally, but then I found that I wasn't able to modulate the parameter. Are boolean parameters not modulate-able,  or am I just not doing it right?