### PR TITLE
Modify Linux for pipeline LV2

### DIFF
--- a/scripts/installer_linux/build-lv2
+++ b/scripts/installer_linux/build-lv2
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+OUTDIR=$1
+TMPDIR=$2
+
+mkdir -p ${TMPDIR}
+pushd libs/
+
+git clone --depth 1 --branch lv2 https://github.com/lv2-porting-project/JUCE JUCE-lv2
+cd JUCE-lv2
+git checkout lv2
+popd
+
+BT=Release
+cmake -GNinja -B${TMPDIR}/build-lv2 -DCMAKE_BUILD_TYPE=${BT} -DJUCE_SUPPORTS_LV2=True -DSURGE_JUCE_PATH=$PWD/libs/JUCE-lv2
+#cmake --build ${TMPDIR}/build-lv2 --target surge-xt_LV2 surge-fx_LV2 --parallel
+
+rm -rf "${OUTDIR}/*.lv2"
+mv "${TMPDIR}/build-lv2/src/surge-xt/surge-xt_artefacts/${BT}/LV2/Surge XT.lv2" "${OUTDIR}/surge_xt_products"
+mv "${TMPDIR}/build-lv2/src/surge-fx/surge-fx_artefacts/${BT}/LV2/Surge XT Effects.lv2" "${OUTDIR}/surge_xt_products"
+

--- a/scripts/installer_linux/make_deb.sh
+++ b/scripts/installer_linux/make_deb.sh
@@ -30,6 +30,7 @@ PACKAGE_NAME="$SURGE_NAME"
 # Cleanup from failed prior runs
 rm -rf ${PACKAGE_NAME} product
 mkdir -p ${PACKAGE_NAME}/usr/lib/vst3
+mkdir -p ${PACKAGE_NAME}/usr/lib/lv2
 mkdir -p ${PACKAGE_NAME}/usr/bin
 mkdir -p ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc
 mkdir -p ${PACKAGE_NAME}/DEBIAN
@@ -52,7 +53,7 @@ Provides: vst-plugin
 Section: sound
 Priority: optional
 Description: Subtractive hybrid synthesizer virtual instrument
- Surge XT includes VST3 instrument formats for use in compatible hosts and a standalone executable
+ Surge XT includes VST3 and LV2 instrument formats for use in compatible hosts and a standalone executable
 EOT
 
 touch ${PACKAGE_NAME}/usr/share/${SURGE_NAME}/doc/changelog.Debian
@@ -79,12 +80,15 @@ cp -r "${INDIR}/Surge XT Effects.vst3" ${PACKAGE_NAME}/usr/lib/vst3/
 cp -r "${INDIR}/Surge XT" ${PACKAGE_NAME}/usr/bin/
 cp -r "${INDIR}/Surge XT Effects" ${PACKAGE_NAME}/usr/bin/
 
-# copy the lv2 bundle
-# cp -r ../build/surge_products/Surge.lv2 ${PACKAGE_NAME}/usr/lib/lv2/
-
 # set permissions on shared libraries
 find ${PACKAGE_NAME}/usr/lib/vst3/ -type f -iname "*.so" -exec chmod 0644 {} +
-# find ${PACKAGE_NAME}/usr/lib/lv2/ -type f -iname "*.so" -exec chmod 0644 {} +
+
+if [[ -d "${INDIR}/Surge XT.lv2" ]]; then
+  cp -r "${INDIR}/Surge XT.lv2" ${PACKAGE_NAME}/usr/lib/lv2/
+  cp -r "${INDIR}/Surge XT Effects.lv2" ${PACKAGE_NAME}/usr/lib/lv2/
+  find ${PACKAGE_NAME}/usr/lib/lv2/ -type f -iname "*.so" -exec chmod 0644 {} +
+fi
+
 
 echo "----- LIBRARY CONTENTS (except resource) -----"
 find ${PACKAGE_NAME}/usr/lib -print

--- a/scripts/installer_linux/make_rpm.sh
+++ b/scripts/installer_linux/make_rpm.sh
@@ -105,6 +105,7 @@ install -m 0755 -d %{buildroot}%{_bindir}/
 install -m 0755 -d %{buildroot}%{_datadir}/
 install -m 0755 -d %{buildroot}%{_defaultdocdir}/
 install -m 0755 -d %{buildroot}%{_libdir}/vst3/
+install -m 0755 -d %{buildroot}%{_libdir}/lv2/
 install -m 0755 -d %{buildroot}%{_datarootdir}
 install -m 0755 -d %{buildroot}%{_datarootdir}/surge-xt/
 install -m 0755 -d %{buildroot}%{_datarootdir}/surge-xt/doc
@@ -114,6 +115,8 @@ install -m 0644 $(pwd)/changelog.txt %{buildroot}%{_datarootdir}/surge-xt/doc/ch
 cp -r ${SOURCEDIR}/resources/data/* %{buildroot}%{_datarootdir}/surge-xt/
 cp -r "${INDIR}/Surge XT.vst3" %{buildroot}%{_libdir}/vst3/
 cp -r "${INDIR}/Surge XT Effects.vst3" %{buildroot}%{_libdir}/vst3/
+cp -r "${INDIR}/Surge XT.lv2" %{buildroot}%{_libdir}/lv2/
+cp -r "${INDIR}/Surge XT Effects.lv2" %{buildroot}%{_libdir}/lv2/
 
 # install executable files as executable
 install -m 0755 "${INDIR}/Surge XT" %{buildroot}/%{_bindir}
@@ -126,6 +129,7 @@ find %{buildroot}%{_libdir}/vst3/ -type f -iname "*.so" -exec chmod 0644 {} +
 %files
 %{_bindir}
 %{_libdir}/vst3/
+%{_libdir}/lv2/
 %{_datarootdir}/surge-xt/
 
 


### PR DESCRIPTION
This diff will allow the release pipeline to build nad package
the LV2 along with the Standalone and VST3, albeit with a different
JUCE

Addresses #5487