### PR TITLE
Handle first-time infowindow blink

### DIFF
--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -335,7 +335,7 @@ void ModulatableSlider::onSkinChanged()
 
 void ModulatableSlider::mouseEnter(const juce::MouseEvent &event)
 {
-    enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::START);
+    enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::START, event.position);
     isHovered = true;
     auto sge = firstListenerOfType<SurgeGUIEditor>();
     if (sge)
@@ -450,7 +450,7 @@ void ModulatableSlider::mouseDown(const juce::MouseEvent &event)
 
 void ModulatableSlider::mouseMove(const juce::MouseEvent &event)
 {
-    enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::START);
+    enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::START, event.position);
 }
 
 void ModulatableSlider::mouseUp(const juce::MouseEvent &event)

--- a/src/surge-xt/gui/widgets/WidgetBaseMixin.h
+++ b/src/surge-xt/gui/widgets/WidgetBaseMixin.h
@@ -76,8 +76,30 @@ struct WidgetBaseMixin : public Surge::GUI::SkinConsumingComponent,
             t->controlEndEdit(this);
     }
 
-    void enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction place)
+    juce::Point<float> enqueueStartPosition{-18.f, -18.f};
+    void enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction place,
+                                 const juce::Point<float> &fromPosition = juce::Point<float>{-17.f,
+                                                                                             -17.f})
     {
+        /*
+         * So what the heck is this you may ask? Well when juce shows the info window on the
+         * very first go round, since it is a hierarchy change, juce sends us a zero-distance
+         * mouse moved event. So we need ot make sure, in the case of a start and only a start,
+         * that if we get two in a row they are from different places. See #5487
+         */
+        if (place == SurgeGUIEditor::InfoQAction::START)
+        {
+            jassert(fromPosition.x != -17 && fromPosition.y != -17);
+            if (enqueueStartPosition == fromPosition)
+            {
+                return;
+            }
+            enqueueStartPosition = fromPosition;
+        }
+        else
+        {
+            enqueueStartPosition = juce::Point<float>{-18.f, -18.f};
+        }
         auto t = getTag();
         auto sge = firstListenerOfType<SurgeGUIEditor>();
         if (sge)


### PR DESCRIPTION
the first time after a rebuild we show the infowindow it generates
a zero move mouse event, because it is changing the hierarchy
it seems. This caused info window to blink. Supress by looking
for move distance on start.

Closes #5487