### PR TITLE
CMake Installs resources; Group name tweak

### DIFF
--- a/src/cmake/lib.cmake
+++ b/src/cmake/lib.cmake
@@ -56,6 +56,7 @@ function(surge_juce_package target product_name)
     if(TARGET ${target}_VST3)
       install(DIRECTORY "${output_dir}/VST3/${product_name}.vst3" DESTINATION lib/vst3)
     endif()
+    install(DIRECTORY "${CMAKE_SOURCE_DIR}/resources/data/" DESTINATION share/surge-xt)
   endif()
 endfunction()
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -432,7 +432,7 @@ std::string SurgeSynthProcessor::paramClumpName(int clumpid)
     case 1:
         return "Macro Parameters";
     case 2:
-        return "Global / FX";
+        return "Global and FX";
     case 3:
         return "Scene A Common";
     case 4:


### PR DESCRIPTION
1. CMake installs resources. Closes #5537
2. CHange the gropu name "Global / FX" to "Global And FX" to not
   confuse "/" with a group delimeter.