### PR TITLE
Correct the Threading for JUCE Patch Load

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3370,6 +3370,8 @@ void SurgeSynthesizer::processThreadunsafeOperations(bool dangerMode)
 {
     if (!audio_processing_active || dangerMode)
     {
+        processEnqueuedPatchIfNeeded();
+
         // if the audio processing is inactive, patchloading should occur anyway
         if (patchid_queue >= 0)
         {

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -319,10 +319,10 @@ class alignas(16) SurgeSynthesizer
   public:
     std::atomic<bool> rawLoadEnqueued{false}, rawLoadNeedsUIDawExtraState{false};
     std::mutex rawLoadQueueMutex;
-    void *enqueuedLoadData{nullptr}; // if this is set I need to free it
+    std::unique_ptr<char[]> enqueuedLoadData{nullptr}; // if this is set I need to free it
     int enqueuedLoadSize{0};
-    void enqueuePatchForLoad(void *data, int size); // safe from any thread
-    void processEnqueuedPatchIfNeeded();            // only safe from audio thread
+    void enqueuePatchForLoad(const void *data, int size); // safe from any thread
+    void processEnqueuedPatchIfNeeded();                  // only safe from audio thread
 
     void loadRaw(const void *data, int size, bool preset = false);
     void loadPatch(int id);

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -400,15 +400,8 @@ void SurgeSynthProcessor::getStateInformation(juce::MemoryBlock &destData)
 
 void SurgeSynthProcessor::setStateInformation(const void *data, int sizeInBytes)
 {
-    // FIXME - casting away constness is gross
-    surge->loadRaw(data, sizeInBytes, false);
-
-    surge->loadFromDawExtraState();
-    auto sse = dynamic_cast<SurgeSynthEditor *>(getActiveEditor());
-    if (sse)
-    {
-        sse->populateFromStreaming(surge.get());
-    }
+    surge->enqueuePatchForLoad(data, sizeInBytes);
+    surge->processThreadunsafeOperations();
 }
 
 void SurgeSynthProcessor::surgeParameterUpdated(const SurgeSynthesizer::ID &id, float f)


### PR DESCRIPTION
I actually had this API from the old VST3 and had just mis-ported
JUCE. So this makes sure the raw data load happens properly on teh
audio thread and then bounces back to the UI, with just a slight
mod on the VST3 code.

Closes #5544