### PR TITLE
Sort FX Presets in SubPaths

### DIFF
--- a/src/common/FxPresetAndClipboardManager.cpp
+++ b/src/common/FxPresetAndClipboardManager.cpp
@@ -195,6 +195,11 @@ void FxUserPreset::doPresetRescan(SurgeStorage *storage, bool forceRescan)
                     return a.isFactory;
                 }
 
+                if (a.subPath != b.subPath)
+                {
+                    return a.subPath < b.subPath;
+                }
+
                 return _stricmp(a.name.c_str(), b.name.c_str()) < 0;
             }
             else


### PR DESCRIPTION
This resolves an incorrect display order in AirWindows preset
menu.

Closes #5549