### PR TITLE
ZOrder Edge Case with Modal Overlays fixed

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1854,14 +1854,26 @@ void SurgeGUIEditor::openOrRecreateEditor()
      * Finally make sure the Z-Order fronting for our overlays is still OK
      */
     std::vector<juce::Component *> frontthese;
+    std::vector<juce::Component *> thenFrontThese;
     for (auto c : frame->getChildren())
     {
         if (auto ol = dynamic_cast<Surge::Overlays::OverlayWrapper *>(c))
         {
-            frontthese.push_back(c);
+            if (ol->getIsModal())
+            {
+                thenFrontThese.push_back(c);
+            }
+            else
+            {
+                frontthese.push_back(c);
+            }
         }
     }
     for (auto c : frontthese)
+    {
+        c->toFront(true);
+    }
+    for (auto c : thenFrontThese)
     {
         c->toFront(true);
     }

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -99,6 +99,7 @@ struct OverlayWrapper : public juce::Component,
 
     juce::Rectangle<int> componentBounds;
     bool isModal{false};
+    bool getIsModal() const { return isModal; }
 
     std::unique_ptr<juce::DocumentWindow> tearOutParent;
 


### PR DESCRIPTION
If you F5 skin refresh with a patch dialog over an mseg
the mseg would front. Now the mseg blinks momentarily but
thepatch store stays fronted

CLoses #5445