### PR TITLE
Improve Linux ARM detection

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -273,10 +273,7 @@ elseif(UNIX)
   if(CMAKE_SYSTEM_NAME MATCHES "BSD")
     target_link_libraries(${PROJECT_NAME} PRIVATE execinfo)
   endif()
-  if(LINUX_ON_ARM)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC ARM_NEON=1)
-    target_link_libraries(${PROJECT_NAME} PUBLIC surge::simde)
-  endif()
+  target_link_libraries(${PROJECT_NAME} PUBLIC surge::simde)
 elseif(WIN32)
   target_compile_definitions(${PROJECT_NAME} PUBLIC
     WINDOWS=1

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -29,6 +29,12 @@
 
 #endif
 
+#if LINUX
+#if defined(__aarch64__)
+#define ARM_NEON 1
+#endif
+#endif
+
 #if defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) ||                                   \
     (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
 #include <emmintrin.h>


### PR DESCRIPTION
No longer require LINUX_ON_ARM at CMake time if compiling
natively.