### PR TITLE
Improve the TearOut icon

### DIFF
--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -25,6 +25,28 @@ namespace Surge
 {
 namespace Overlays
 {
+
+// right now this is just the tearout
+struct OverlayWrapperToolbarButton : public juce::Button
+{
+    OverlayWrapperToolbarButton(const juce::String &name) : juce::Button(name) {}
+
+    void paintButton(juce::Graphics &g, bool shouldDrawButtonAsHighlighted,
+                     bool shouldDrawButtonAsDown) override
+    {
+        if (shouldDrawButtonAsHighlighted)
+        {
+            g.fillAll(juce::Colours::grey.withAlpha(0.6f));
+        }
+
+        g.setColour(juce::Colour(0xff0A830A));
+        auto r = getLocalBounds().reduced(2, 4);
+        g.drawRect(r);
+
+        g.drawLine(r.getX(), r.getY(), r.getRight(), r.getY(), 2);
+    }
+};
+
 OverlayWrapper::OverlayWrapper()
 {
     closeButton.reset(
@@ -32,8 +54,7 @@ OverlayWrapper::OverlayWrapper()
     closeButton->addListener(this);
     addChildComponent(*closeButton);
 
-    tearOutButton.reset(
-        getLookAndFeel().createDocumentWindowButton(juce::DocumentWindow::maximiseButton));
+    tearOutButton.reset(new OverlayWrapperToolbarButton("Tear Out"));
     tearOutButton->addListener(this);
     addChildComponent(*tearOutButton);
 }


### PR DESCRIPTION
This icon was nowhere near clear enough, as evidenced by watching
unfa look for it in the video he just posted, So make it look more
like a window icon.