### PR TITLE
Modulation Sliders and Arming via Screen Reader

### DIFF
--- a/scripts/pyauto-tests/mod-create.py
+++ b/scripts/pyauto-tests/mod-create.py
@@ -1,4 +1,4 @@
-# INCOMPLETE
+# Demonstrates creating modulations and so forth
 
 import sxttest
 import time
@@ -14,8 +14,38 @@ mods = sxttest.firstChildByTitle(mf, "Modulators")
 
 sxttest.recursiveDump(mods, "MOD>")
 l1 = sxttest.firstChildByTitle(mods, "LFO 1");
-arm = sxttest.firstChildByTitle(l1, "Select");
-arm.Press()
-arm.Press()
+select = sxttest.firstChildByTitle(l1, "Select");
+select.Press()
+time.sleep(1)
 
-sxttest.recursiveDump(mf, "TOP>");
+l1 = sxttest.firstChildByTitle(mods, "Keytrack");
+select = sxttest.firstChildByTitle(l1, "Select");
+select.Press()
+time.sleep(1)
+
+od = sxttest.firstChildByTitle(mf, "Scene A Osc Drift")
+od.AXValue = "32"
+time.sleep(0.5)
+
+co = sxttest.firstChildByTitle(mf, "Scene A Filter 1 Cutoff")
+co.AXValue = "440"
+time.sleep(0.5)
+
+sxttest.recursiveDump(l1, "Keytrack PRE>")
+arm = sxttest.firstChildByTitle(l1, "Arm");
+arm.Press()
+time.sleep(1)
+sxttest.recursiveDump(l1, "Keytrack POST>")
+
+l2 = sxttest.firstChildByTitle(mods, "LFO 3")
+tg = sxttest.firstChildByTitle(l2, "Target")
+tg.Press()
+time.sleep(0.5)
+
+od.AXValue = "23"
+time.sleep(0.5)
+
+co.AXValue = "880"
+time.sleep(2.5)
+
+arm.Press()

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -377,6 +377,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     std::string getDisplayForTag(long tag, bool external = false, float value = 0);
     float getF01FromString(long tag, const std::string &s);
+    float getModulationF01FromString(long tag, const std::string &s);
 
     void queuePatchFileLoad(const std::string &file)
     {

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2529,6 +2529,32 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                     break;
                 };
             }
+            else if (cms->getMouseMode() ==
+                     Surge::Widgets::ModulationSourceButton::CLICK_TOGGLE_ARM)
+            {
+                modsource = newsource;
+                modsource_index = newindex;
+                if ((state & 3) == 0)
+                {
+                    mod_editor = true;
+                    queue_refresh = true;
+                }
+                else
+                {
+                    mod_editor = !mod_editor;
+                }
+                refresh_mod();
+            }
+            else if (cms->getMouseMode() ==
+                     Surge::Widgets::ModulationSourceButton::CLICK_SELECT_ONLY)
+            {
+                modsource = newsource;
+                modsource_index = newindex;
+                mod_editor = false;
+                if ((state & 3) == 0)
+                    queue_refresh = true;
+                refresh_mod();
+            }
             else if (cms->getMouseMode() == Surge::Widgets::ModulationSourceButton::HAMBURGER)
             {
                 updated = true;

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -591,8 +591,15 @@ struct ModulatableSliderAH : public juce::AccessibilityHandler
         double getCurrentValue() const override { return slider->getValue(); }
         void setValue(double newValue) override
         {
-            slider->setValue(newValue);
-            slider->setQuantitizedDisplayValue(newValue);
+            if (slider->isEditingModulation)
+            {
+                slider->setModValue(newValue);
+            }
+            else
+            {
+                slider->setValue(newValue);
+                slider->setQuantitizedDisplayValue(newValue);
+            }
             slider->repaint();
             slider->notifyValueChanged();
         }
@@ -607,12 +614,23 @@ struct ModulatableSliderAH : public juce::AccessibilityHandler
         }
         virtual void setValueAsString(const juce::String &newValue) override
         {
+            // FIXME - deal with modulation
             auto sge = slider->firstListenerOfType<SurgeGUIEditor>();
             if (sge)
             {
-                float f = sge->getF01FromString(slider->getTag(), newValue.toStdString());
-                setValue(f);
-                return;
+                if (slider->isEditingModulation)
+                {
+                    float f =
+                        sge->getModulationF01FromString(slider->getTag(), newValue.toStdString());
+                    setValue(f);
+                    return;
+                }
+                else
+                {
+                    float f = sge->getF01FromString(slider->getTag(), newValue.toStdString());
+                    setValue(f);
+                    return;
+                }
             }
             setValue(newValue.getDoubleValue());
         }

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -38,11 +38,20 @@ ModulationSourceButton::ModulationSourceButton()
     auto ol = std::make_unique<OverlayAsAccessibleButton<ModulationSourceButton>>(
         this, "Select", juce::AccessibilityRole::button);
     ol->onPress = [this](auto *t) {
-        mouseMode = CLICK;
+        mouseMode = CLICK_SELECT_ONLY;
         notifyValueChanged();
     };
     addChildComponent(*ol);
     selectAccButton = std::move(ol);
+
+    ol = std::make_unique<OverlayAsAccessibleButton<ModulationSourceButton>>(
+        this, "Arm", juce::AccessibilityRole::button);
+    ol->onPress = [this](auto *t) {
+        mouseMode = CLICK_TOGGLE_ARM;
+        notifyValueChanged();
+    };
+    addChildComponent(*ol);
+    toggleArmAccButton = std::move(ol);
 
     ol = std::make_unique<OverlayAsAccessibleButton<ModulationSourceButton>>(
         this, "Target", juce::AccessibilityRole::button);
@@ -621,8 +630,10 @@ void ModulationSourceButton::resized()
     b = b.translated(getHeight(), 0);
     targetAccButton->setBounds(b);
     b = b.translated(getHeight(), 0);
+    toggleArmAccButton->setBounds(b);
 
     selectAccButton->setVisible(true);
+    toggleArmAccButton->setVisible(true);
     if (isLFO())
     {
         targetAccButton->setVisible(true);

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.h
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.h
@@ -120,7 +120,20 @@ struct ModulationSourceButton : public juce::Component,
 
     int state{0};
 
-    void setState(int s) { state = s; }
+    void setState(int s)
+    {
+        state = s;
+#if SURGE_JUCE_ACCESSIBLE
+        if ((state & 3) == 2)
+        {
+            toggleArmAccButton->setTitle("Disarm");
+        }
+        else
+        {
+            toggleArmAccButton->setTitle("Arm");
+        }
+#endif
+    }
     int getState() const { return state; }
     bool transientArmed{false}; // armed in drop state
 
@@ -163,6 +176,8 @@ struct ModulationSourceButton : public juce::Component,
     {
         NONE,
         CLICK,
+        CLICK_TOGGLE_ARM,
+        CLICK_SELECT_ONLY,
         CLICK_ARROW,
         PREDRAG_VALUE,
         DRAG_VALUE,
@@ -190,7 +205,7 @@ struct ModulationSourceButton : public juce::Component,
     void resized() override;
 
 #if SURGE_JUCE_ACCESSIBLE
-    std::unique_ptr<juce::Component> targetAccButton, selectAccButton;
+    std::unique_ptr<juce::Component> targetAccButton, selectAccButton, toggleArmAccButton;
 #endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModulationSourceButton);


### PR DESCRIPTION
This commit adds three 'synthetic' accesible buttons to the
modlists, select, arm, and target (taregt == orange arrow)
and makes the modulatable slider setvalue api aware of if
the slider is armed for modulation.

This defacto makes modulation setup with screen readers
possible in sruge xt.

Addresses #4616