### PR TITLE
Use correctly scaled modulation dept for display

### DIFF
--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -610,7 +610,7 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
         d.isBipolar = synth->isBipolarModulation(thisms);
         d.isMuted = synth->isModulationMuted(ptag, thisms, d.source_scene, d.source_index);
         p->get_display_of_modulation_depth(
-            pdisp, synth->getModulation(ptag, thisms, d.source_scene, d.source_index),
+            pdisp, synth->getModDepth(ptag, thisms, d.source_scene, d.source_index),
             synth->isBipolarModulation(thisms), Parameter::InfoWindow, &(d.mss));
         d.moddepth = pdisp;
     }


### PR DESCRIPTION
We were using getModulation not getModDepth which is the
difference between the scaled and 01 apis, so mod list was
inconsistent display with infowindow.

Closes #5562