### PR TITLE
Add option to append OG author to modified patches

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -110,6 +110,9 @@ void initMaps()
             case DefaultPatchComment:
                 r = "defaultPatchComment";
                 break;
+            case AppendOriginalPatchBy:
+                r = "appendOriginalPatchBy";
+                break;
             case ModWindowShowsValues:
                 r = "modWindowShowsValues";
                 break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -40,7 +40,7 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     SliderMoveRateState,
     RememberTabPositionsPerScene,
     PatchJogWraparound,
-    
+
     DefaultPatchAuthor,
     DefaultPatchComment,
     AppendOriginalPatchBy,

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -40,8 +40,11 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     SliderMoveRateState,
     RememberTabPositionsPerScene,
     PatchJogWraparound,
+    
     DefaultPatchAuthor,
     DefaultPatchComment,
+    AppendOriginalPatchBy,
+
     ModWindowShowsValues,
     LayoutGridResolution,
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3152,12 +3152,12 @@ juce::PopupMenu SurgeGUIEditor::makePatchDefaultsMenu(const juce::Point<int> &wh
                                   &(this->synth->storage), Surge::Storage::DefaultPatchComment, s);
                           });
     });
-
     patchDefMenu.addSeparator();
 
     auto pscid = patchSelector->getCurrentCategoryId();
     auto pspid = patchSelector->getCurrentPatchId();
     auto s = &(this->synth->storage);
+
     if (pscid >= 0 && pscid < s->patch_category.size() && pspid >= 0 &&
         pspid < s->patch_list.size())
     {
@@ -3176,6 +3176,19 @@ juce::PopupMenu SurgeGUIEditor::makePatchDefaultsMenu(const juce::Point<int> &wh
                     &(this->synth->storage), Surge::Storage::InitialPatchCategory, *catCurId);
             });
     }
+
+    patchDefMenu.addSeparator();
+
+    bool appendOGPatchBy = Surge::Storage::getUserDefaultValue(
+        &(synth->storage), Surge::Storage::AppendOriginalPatchBy, true);
+
+    patchDefMenu.addItem(Surge::GUI::toOSCaseForMenu("Append Original Author to Modified Patches"),
+                         true, appendOGPatchBy, [this, appendOGPatchBy]() {
+                             Surge::Storage::updateUserDefaultValue(
+                                 &(this->synth->storage), Surge::Storage::AppendOriginalPatchBy,
+                                 !appendOGPatchBy);
+                         });
+
     return patchDefMenu;
 }
 

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -41,6 +41,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::makeStorePatc
         &(this->synth->storage), Surge::Storage::DefaultPatchAuthor, "");
     auto defaultComment = Surge::Storage::getUserDefaultValue(
         &(this->synth->storage), Surge::Storage::DefaultPatchComment, "");
+    bool appendOGPatchBy = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::AppendOriginalPatchBy, true);
     auto oldAuthor = std::string("");
 
     if (!Surge::Storage::isValidUTF8(defaultAuthor))
@@ -71,7 +73,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::makeStorePatc
         comments = defaultComment;
     }
 
-    if (oldAuthor != "")
+    if (oldAuthor != "" && appendOGPatchBy)
     {
         if (comments == "")
             comments += "Original patch by " + oldAuthor;


### PR DESCRIPTION
By default it is on to retain existing behavior, but people who don't want this can now turn it off.