### PR TITLE
Handle NAN and INF from Formula

### DIFF
--- a/src/common/dsp/modulators/FormulaModulationHelper.cpp
+++ b/src/common/dsp/modulators/FormulaModulationHelper.cpp
@@ -525,12 +525,22 @@ void valueAt(int phaseIntPart, float phaseFracPart, FormulaModulatorStorage *fs,
     // stack is now just the result
     if (lres == LUA_OK)
     {
+        s->isFinite = true;
+        auto checkFinite = [s](float f) {
+            if (!std::isfinite(f))
+            {
+                s->isFinite = false;
+                return 0.f;
+            }
+            return f;
+        };
+
         if (lua_isnumber(s->L, -1))
         {
             // OK so you returned a value. Just use it
             auto r = lua_tonumber(s->L, -1);
             lua_pop(s->L, 1);
-            output[0] = r;
+            output[0] = checkFinite(r);
             return;
         }
         if (!lua_istable(s->L, -1))
@@ -552,7 +562,7 @@ void valueAt(int phaseIntPart, float phaseFracPart, FormulaModulatorStorage *fs,
         float res = 0.0;
         if (lua_isnumber(s->L, -1))
         {
-            output[0] = lua_tonumber(s->L, -1);
+            output[0] = checkFinite(lua_tonumber(s->L, -1));
         }
         else if (lua_istable(s->L, -1))
         {
@@ -574,7 +584,7 @@ void valueAt(int phaseIntPart, float phaseFracPart, FormulaModulatorStorage *fs,
                 }
 
                 // Remember - LUA is 0 based
-                output[idx - 1] = lua_tonumber(s->L, -1);
+                output[idx - 1] = checkFinite(lua_tonumber(s->L, -1));
                 lua_pop(s->L, 1);
                 len = std::max(len, idx - 1);
             }

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -38,6 +38,7 @@ struct EvaluatorState
 
     bool isvalid = false;
     bool useEnvelope = true;
+    bool isFinite = true;
 
     bool subVoice{false}, subLfoParams{true}, subLfoEnvelope{false}, subTiming{true};
     bool subMacros[n_customcontrollers], subAnyMacro{false};

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -244,6 +244,9 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
 
     float priorval = 0.f, priorwval = 0.f;
 
+    bool warnForInvalid{false};
+    std::string invalidMessage;
+
     for (int i = 0; i < totalSamples; i += averagingWindow)
     {
         float val = 0;
@@ -261,6 +264,16 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
             if (tFullWave)
             {
                 tFullWave->process_block();
+            }
+
+            if (lfodata->shape.val.i == lt_formula)
+            {
+                if (!tlfo->formulastate.isFinite ||
+                    (tFullWave && !tFullWave->formulastate.isFinite))
+                {
+                    warnForInvalid = true;
+                    invalidMessage = "Formula produced nan or inf";
+                }
             }
 
             if (susCountdown < 0 && tlfo->env_state == lfoeg_stuck)
@@ -605,6 +618,14 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
         dc->setFrameColor(juce::Colours::red);
         dc->drawLine(sp, ep);
 #endif
+    }
+
+    if (warnForInvalid)
+    {
+        g.setColour(skin->getColor(Colors::LFO::Waveform::Wave));
+        g.setFont(Surge::GUI::getFontManager()->getLatoAtSize(14, juce::Font::bold));
+        g.drawText(invalidMessage, waveform_display.withTrimmedBottom(30),
+                   juce::Justification::centred);
     }
 }
 


### PR DESCRIPTION
NaN and Inf from formula would rip through the engine and
blow through various checks and so on. So inside formula
do an explicit std::isfinite and set a flag if they return
these.

Closes #5566