### PR TITLE
Fix Window osc streaming handler

### DIFF
--- a/src/common/dsp/oscillators/WindowOscillator.cpp
+++ b/src/common/dsp/oscillators/WindowOscillator.cpp
@@ -467,7 +467,6 @@ void WindowOscillator::handleStreamingMismatches(int streamingRevision,
         oscdata->p[win_lowcut].deactivated = true;
         oscdata->p[win_highcut].val.f = oscdata->p[win_highcut].val_max.f; // low cut at the top
         oscdata->p[win_highcut].deactivated = true;
-        oscdata->p[win_formant].set_type(ct_osc_feedback);
     }
 
     if (streamingRevision <= 15)


### PR DESCRIPTION
So when @baconpaul added version streaming handlers, there was a miscopied line from Sine osc into Window osc that changed the type of Formant parameter to ct_osc_feedback, which messes up certain factory patches that are sv<=12.

This fixes that!