### PR TITLE
Use a 1x1 size for menu withTargetScreenArea

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2079,7 +2079,8 @@ juce::PopupMenu::Options SurgeGUIEditor::optionsForPosition(const juce::Point<in
     auto o = juce::PopupMenu::Options();
     if (where.x > 0 && where.y > 0)
     {
-        auto r = juce::Rectangle<int>().withPosition(frame->localPointToGlobal(where));
+        auto r = juce::Rectangle<int>().withWidth(1).withHeight(1).withPosition(
+            frame->localPointToGlobal(where));
         o = o.withTargetScreenArea(r);
     }
     return o;

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2445,11 +2445,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
         if (synth->storage.isStandardTuningAndHasNoToggle())
         {
             juce::Point<int> where = control->asJuceComponent()->getBounds().getBottomLeft();
-            auto m = makeTuningMenu(where, true);
-
-            auto launchFrom = control;
-            m.showMenuAsync(juce::PopupMenu::Options(),
-                            Surge::GUI::makeEndHoverCallback(launchFrom));
+            showTuningMenu(where, control);
         }
 
         return;


### PR DESCRIPTION
Otherwise the menu position is incorrect in some cases, choosing
the wrong side of the screen for the patch brwoser

Closes #5578