### PR TITLE
Store state for new overlays in DES

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -763,6 +763,12 @@ struct DAWExtraStateStorage
             int timeEditMode = 0;
         } msegEditState[n_scenes][n_lfos];
 
+        struct FormulaEditState
+        {
+            int codeOrPrelude{0};
+            bool debuggerOpen{false};
+        } formulaEditState[n_scenes][n_lfos];
+
         struct
         {
             bool hasCustomEditor = false;
@@ -775,6 +781,18 @@ struct DAWExtraStateStorage
             std::pair<int, int> tearOutPosition{-1, -1};
         };
         std::vector<OverlayState> activeOverlays;
+
+        struct ModulationEditorState
+        {
+            int sortOrder = 0;
+            int filterOn = 0;
+            std::string filterString{""};
+        } modulationEditorState;
+
+        struct TuningOverlayState
+        {
+            int editMode = 0;
+        } tuningOverlayState;
     } editor;
 
     bool mpeEnabled = false;

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -238,7 +238,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
 
         auto fme = std::make_unique<Surge::Overlays::FormulaModulatorEditor>(
             this, &(this->synth->storage),
-            &synth->storage.getPatch().scene[current_scene].lfo[lfo_id], fs, lfo_id, currentSkin);
+            &synth->storage.getPatch().scene[current_scene].lfo[lfo_id], fs, lfo_id, current_scene,
+            currentSkin);
 
         std::string title = modsource_names[modsource_editor[current_scene]];
         title += " Editor";

--- a/src/surge-xt/gui/overlays/LuaEditors.h
+++ b/src/surge-xt/gui/overlays/LuaEditors.h
@@ -76,7 +76,8 @@ struct FormulaControlArea;
 struct FormulaModulatorEditor : public CodeEditorContainerWithApply
 {
     FormulaModulatorEditor(SurgeGUIEditor *ed, SurgeStorage *s, LFOStorage *lfos,
-                           FormulaModulatorStorage *fs, int lfoid, Surge::GUI::Skin::ptr_t sk);
+                           FormulaModulatorStorage *fs, int lfoid, int scene,
+                           Surge::GUI::Skin::ptr_t sk);
     ~FormulaModulatorEditor();
 
     std::unique_ptr<ExpandingFormulaDebugger> debugPanel;
@@ -91,10 +92,12 @@ struct FormulaModulatorEditor : public CodeEditorContainerWithApply
 
     LFOStorage *lfos{nullptr};
     FormulaModulatorStorage *formulastorage{nullptr};
-    int lfo_id;
+    int lfo_id, scene;
 
     void onSkinChanged() override;
     void setApplyEnabled(bool b) override;
+
+    DAWExtraStateStorage::EditorState::FormulaEditState &getEditState();
 
     std::unique_ptr<juce::CodeDocument> preludeDocument;
     std::unique_ptr<juce::CodeEditorComponent> preludeDisplay;

--- a/src/surge-xt/gui/overlays/TuningOverlays.cpp
+++ b/src/surge-xt/gui/overlays/TuningOverlays.cpp
@@ -1765,6 +1765,9 @@ struct TuningControlArea : public juce::Component,
             selectS->setColumns(5);
             selectS->setDraggable(true);
             selectS->setSkin(skin, associatedBitmapStore);
+            selectS->setValue(
+                overlay->storage->getPatch().dawExtraState.editor.tuningOverlayState.editMode /
+                4.f);
             addAndMakeVisible(*selectS);
             xpos += btnWidth + 10;
         }
@@ -1962,6 +1965,8 @@ TuningOverlay::TuningOverlay()
     intervalMatrix->setVisible(false);
 }
 
+void TuningOverlay::setStorage(SurgeStorage *s) { storage = s; }
+
 TuningOverlay::~TuningOverlay() = default;
 
 void TuningOverlay::resized()
@@ -1991,6 +1996,8 @@ void TuningOverlay::resized()
     {
         auto mcoff = Surge::Storage::getUserDefaultValue(storage, Surge::Storage::MiddleC, 1);
         tuningKeyboardTableModel->setMiddleCOff(mcoff);
+
+        showEditor(storage->getPatch().dawExtraState.editor.tuningOverlayState.editMode);
     }
 }
 
@@ -2015,6 +2022,11 @@ void TuningOverlay::showEditor(int which)
     if (which == 4)
     {
         intervalMatrix->setRotationMode();
+    }
+
+    if (storage)
+    {
+        storage->getPatch().dawExtraState.editor.tuningOverlayState.editMode = which;
     }
 }
 

--- a/src/surge-xt/gui/overlays/TuningOverlays.h
+++ b/src/surge-xt/gui/overlays/TuningOverlays.h
@@ -65,7 +65,7 @@ struct TuningOverlay : public OverlayComponent,
     TuningOverlay();
     ~TuningOverlay();
 
-    void setStorage(SurgeStorage *s) { storage = s; }
+    void setStorage(SurgeStorage *s);
 
     SurgeGUIEditor *editor{nullptr};
     void setEditor(SurgeGUIEditor *ed) { editor = ed; }


### PR DESCRIPTION
DawExtraState gets state for control panels on modulator,
tuning, and formula editor

These items all stream into the DAW Extra State so it persists
across daw sessions.

Closes #5588