### PR TITLE
Update patchid and category state on save

### DIFF
--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -590,6 +590,17 @@ void SurgeSynthesizer::savePatchToPath(fs::path filename)
     // refresh list
     storage.refresh_patchlist();
     storage.initializePatchDb(true);
+
+    int idx = 0;
+    for (auto p : storage.patch_list)
+    {
+        if (p.path == filename)
+        {
+            patchid = idx;
+            current_category_id = p.category;
+        }
+        idx++;
+    }
     refresh_editor = true;
     midiprogramshavechanged = true;
 }


### PR DESCRIPTION
When saving a patch to a new file, the patch id and current
category isn't updated so you get, well, the old one mostly!
Fix that by rescanning after a save.

Closes #5570