### PR TITLE
Correct API for Overlays on Scene Change

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -286,7 +286,7 @@ void SurgeGUIEditor::changeSelectedScene(int value)
 
         if (ld->shape.val.i == lt_mseg)
         {
-            showOverlay(SurgeGUIEditor::MSEG_EDITOR);
+            refreshOverlayWithOpenClose(SurgeGUIEditor::MSEG_EDITOR);
         }
         else
         {
@@ -302,7 +302,7 @@ void SurgeGUIEditor::changeSelectedScene(int value)
 
         if (ld->shape.val.i == lt_formula)
         {
-            showOverlay(SurgeGUIEditor::FORMULA_EDITOR);
+            refreshOverlayWithOpenClose(SurgeGUIEditor::FORMULA_EDITOR);
         }
         else
         {

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -3039,7 +3039,6 @@ void MSEGControlRegion::rebuild()
         // button
         auto btnrect = juce::Rectangle<int>(marginPos, ypos - 1, btnWidth, buttonHeight);
 
-        jassert(!movementMode);
         movementMode = std::make_unique<Surge::Widgets::MultiSwitch>();
         movementMode->setBounds(btnrect);
         movementMode->setStorage(storage);
@@ -3091,7 +3090,6 @@ void MSEGControlRegion::rebuild()
         // button
         auto btnrect = juce::Rectangle<int>(xpos, ypos - 1, btnWidth, buttonHeight);
 
-        jassert(!editMode);
         editMode = std::make_unique<Surge::Widgets::MultiSwitch>();
         editMode->setBounds(btnrect);
         editMode->setStorage(storage);
@@ -3132,7 +3130,6 @@ void MSEGControlRegion::rebuild()
 
         // button
         auto btnrect = juce::Rectangle<int>(xpos, ypos - 1, btnWidth, buttonHeight);
-        jassert(!loopMode);
         loopMode = std::make_unique<Surge::Widgets::MultiSwitch>();
         loopMode->setBounds(btnrect);
         loopMode->setStorage(storage);


### PR DESCRIPTION
We were using 'show' as opposed to 'refresh' in one spot
still, so the overlay would pop in (mostly).

Closes #5590