### PR TITLE
Avoid a startup transient due to denorm noise

### DIFF
--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -366,6 +366,8 @@ class alignas(16) SurgeSynthesizer
     std::list<SurgeVoice *> voices[n_scenes];
     std::unique_ptr<Effect> fx[n_fx_slots];
     std::atomic<bool> halt_engine;
+    int blocks_since_unhalt{0};
+    static constexpr int blocks_until_first_denorm_noise{500};
     MidiChannelState channelState[16];
     bool mpeEnabled = false;
     int mpeVoices = 0;

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -389,6 +389,9 @@ void SurgeSynthesizer::processEnqueuedPatchIfNeeded()
 void SurgeSynthesizer::loadRaw(const void *data, int size, bool preset)
 {
     halt_engine = true;
+    // See other comments in SS.cpp
+    blocks_since_unhalt = 0;
+
     allNotesOff();
     for (int s = 0; s < n_scenes; s++)
         for (int i = 0; i < n_customcontrollers; i++)


### PR DESCRIPTION
Slight denormalization noise in the warmup phase of some
aurwindows (esp DeRez) would cause a pop. Avoid that by having
either the first 500 blocks (~1/3 second) or time until first note
whichever is smaller clear the output with zeros, then add the
noise after

Closes #4900