### PR TITLE
Few late stage UI tweaks

### DIFF
--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -553,7 +553,7 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
 
         for (auto &r : rows)
         {
-            r->isAfterTop = prior;
+            r->isAfterTop = prior && yPos < -4; // that's about scroll for first. #5602
             prior = r->isTop;
         }
 

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1698,7 +1698,14 @@ void LFOAndStepDisplay::mouseDrag(const juce::MouseEvent &event)
     }
     case VALUES:
     {
-        setStepValue(event);
+        if (event.mods.isCommandDown())
+        {
+            setStepToDefault(event);
+        }
+        else
+        {
+            setStepValue(event);
+        }
         break;
     }
     }


### PR DESCRIPTION
1. Command-while-moving resets in LFO. Closes #5603
2. Supress extra label for unscrolled modlist. Closes #5602