### PR TITLE
A Linux 150% zoom hack

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2211,6 +2211,11 @@ void SurgeGUIEditor::setZoomFactor(float zf) { setZoomFactor(zf, false); }
 void SurgeGUIEditor::setZoomFactor(float zf, bool resizeWindow)
 {
     zoomFactor = std::max(zf, 25.f);
+#if LINUX
+    if (zoomFactor == 150)
+        zoomFactor = 149;
+#endif
+
     float zff = zoomFactor * 0.01;
     if (currentSkin && resizeWindow)
     {
@@ -2956,7 +2961,12 @@ juce::PopupMenu SurgeGUIEditor::makeZoomMenu(const juce::Point<int> &where, bool
     for (auto s : zoomTos) // These are somewhat arbitrary reasonable defaults
     {
         lab = fmt::format("Zoom to {:d}%", s);
-        zoomSubMenu.addItem(lab, true, (s == zoomFactor), [this, s]() { resizeWindow(s); });
+        bool ticked = (s == zoomFactor);
+#if LINUX
+        if (s == 150 && zoomFactor == 149)
+            ticked = true;
+#endif
+        zoomSubMenu.addItem(lab, true, ticked, [this, s]() { resizeWindow(s); });
     }
 
     zoomSubMenu.addSeparator();


### PR DESCRIPTION
For some reason, fonts wiggle at 150 and only 150 zoom when you
drag a slider. We don't know why. But if you force 150 to 149, it's
all fine.

My theory is some rounding is hitting either side in a paint somewhere
but that's deep in juce land if true.

Addresses #5565