### PR TITLE
Imprve StepSequencer Accessibility

### DIFF
--- a/scripts/pyauto-tests/mod-stepseq.py
+++ b/scripts/pyauto-tests/mod-stepseq.py
@@ -11,6 +11,11 @@ sxttest.loadPatchByPath(sxt, ["Templates", "Init Sine"])
 # sxttest.loadPatchByPath(sxt, ["Test Cases", "StepAcc"])
 time.sleep(0.2)
 
+mods = sxttest.firstChildByTitle(mf, "Modulators")
+l1 = sxttest.firstChildByTitle(mods, "LFO 1");
+select = sxttest.firstChildByTitle(l1, "Select");
+select.Press()
+
 lct = sxttest.firstChildByTitle(mf, "LFO Controls")
 sxttest.recursiveDump(lct, "LFO>")
 
@@ -24,10 +29,20 @@ time.sleep(0.5)
 
 sxttest.recursiveDump(tad, "TAD>")
 
-for i in range(1000):
+for i in range(20):
     q = random.randint(1, 16)
     v = random.uniform(-1, 1)
     nm = "Step Value " + str(q)
     step = sxttest.firstChildByTitle(lct, nm)
     step.AXValue = str(v)
     time.sleep(0.2)
+
+mods = sxttest.firstChildByTitle(mf, "Modulators")
+l1 = sxttest.firstChildByTitle(mods, "S-LFO 1");
+select = sxttest.firstChildByTitle(l1, "Select");
+select.Press()
+time.sleep(0.2)
+stp = sxttest.firstChildByTitle(tad, "Step Sequencer")
+stp.Press()
+time.sleep(0.2)
+sxttest.recursiveDump(tad, "SLFO>")

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -232,6 +232,17 @@ template <typename T> struct OverlayAsAccessibleSlider : public juce::Component
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OverlayAsAccessibleSlider<T>);
 };
 
+struct OverlayAsAccessibleContainer : public juce::Component
+{
+    OverlayAsAccessibleContainer(const std::string &desc) : juce::Component()
+    {
+        setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
+        setAccessible(true);
+        setDescription(desc);
+        setTitle(desc);
+    }
+};
+
 } // namespace Widgets
 } // namespace Surge
 

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -155,6 +155,7 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
     void setupAccessibility();
 
 #if SURGE_JUCE_ACCESSIBLE
+    std::unique_ptr<juce::Component> typeLayer, stepLayer;
     std::array<std::unique_ptr<juce::Component>, n_lfo_types> typeAccOverlays;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
 


### PR DESCRIPTION
Use grouping at component level to make the displayed hierarchy
seem correct; show the trigger buttons.