### PR TITLE
Couple FX tweaks

### DIFF
--- a/resources/surge-shared/configuration.xml
+++ b/resources/surge-shared/configuration.xml
@@ -138,9 +138,9 @@
 </type>
 <type i="27" name="Spring Reverb">
     <snapshot name="Init (Dry)" p0="0.500000" p1="0.500000" p2="1.000000" p3="0.500000" p4="0.500000" p5="0.000000"
-              p6="0.500000"/>
+              p6="0.000000" p7="0.500000"/>
     <snapshot name="Init (Send)" p0="0.500000" p1="0.500000" p2="1.000000" p3="0.500000" p4="0.500000" p5="0.000000"
-              p6="1.000000"/>
+              p6="0.000000" p7="1.000000"/>
 </type>
 <sectionheader label="MULTIEFFECTS"/>
 <type i="14" name="Airwindows">
@@ -151,8 +151,8 @@
               p6="0.000000" p7="0.000000" p8="-60" p8_deactivated="1"/>
 </type>
 <type i="26" name="Mid-Side Tool">
-    <snapshot name="Init" p0="0" p1="-60" p1_deactivated="1" p2="0" p2_deactivated="1" p3="-6.63049" p4="70"  
-              p4_deactivated="1" p5="-60" p5_deactivated="1" p6="0" p6_deactivated="1" p7="50.2131" p8="70" 
+    <snapshot name="Init" p0="0" p1="-60" p1_deactivated="1" p2="0" p2_deactivated="1" p3="-6.63049" p4="70"
+              p4_deactivated="1" p5="-60" p5_deactivated="1" p6="0" p6_deactivated="1" p7="50.2131" p8="70"
               p8_deactivated="1" p9="0" p10="0" p11="0"/>
 </type>
 </fx>

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -209,6 +209,15 @@ juce::Rectangle<int> EffectChooser::getEffectRectangle(int i)
     return r;
 }
 
+void EffectChooser::mouseDoubleClick(const juce::MouseEvent &event)
+{
+    if (!hasDragged && currentClicked >= 0)
+    {
+        deactivatedBitmask ^= (1 << currentClicked);
+        notifyValueChanged();
+    }
+}
+
 void EffectChooser::mouseDown(const juce::MouseEvent &event)
 {
     if (forwardedMainFrameMouseDowns(event))

--- a/src/surge-xt/gui/widgets/EffectChooser.h
+++ b/src/surge-xt/gui/widgets/EffectChooser.h
@@ -52,6 +52,7 @@ struct EffectChooser : public juce::Component, public WidgetBaseMixin<EffectChoo
     void setEffectType(int index, int type) { fxTypes[index] = type; }
     std::array<int, n_fx_slots> fxTypes;
 
+    void mouseDoubleClick(const juce::MouseEvent &event) override;
     void mouseDown(const juce::MouseEvent &event) override;
     void mouseUp(const juce::MouseEvent &event) override;
     void mouseDrag(const juce::MouseEvent &event) override;


### PR DESCRIPTION
Add double click to toggle FX slot bypass. Addresses #5613.

Fix Spring Reverb default presets (Mix parameter wasn't loading correctly after Knock parameter was added)