### PR TITLE
Restore tab-key navigation

### DIFF
--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -136,6 +136,7 @@ template <typename T> struct OverlayAsAccessibleButton : public juce::Component
         setTitle(label);
         setInterceptsMouseClicks(false, false);
         setAccessible(true);
+        setWantsKeyboardFocus(true);
     }
 
     T *under;
@@ -177,6 +178,7 @@ template <typename T> struct OverlayAsAccessibleSlider : public juce::Component
         setTitle(label);
         setInterceptsMouseClicks(false, false);
         setAccessible(true);
+        setWantsKeyboardFocus(true);
     }
 
     T *under;

--- a/src/surge-xt/gui/widgets/MainFrame.cpp
+++ b/src/surge-xt/gui/widgets/MainFrame.cpp
@@ -24,7 +24,7 @@ namespace Widgets
 MainFrame::MainFrame()
 {
 #if SURGE_JUCE_ACCESSIBLE
-    setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
+    setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
     setAccessible(true);
     setDescription("Surge XT");
     setTitle("Main Frame");

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -120,6 +120,8 @@ PatchSelector::PatchSelector()
     typeAhead->addTypeAheadListener(this);
     typeAhead->setToElementZeroOnReturn = true;
     addChildComponent(*typeAhead);
+
+    setWantsKeyboardFocus(true);
 };
 PatchSelector::~PatchSelector() = default;
 

--- a/src/surge-xt/gui/widgets/WidgetBaseMixin.h
+++ b/src/surge-xt/gui/widgets/WidgetBaseMixin.h
@@ -34,6 +34,7 @@ template <typename T>
 struct WidgetBaseMixin : public Surge::GUI::SkinConsumingComponent,
                          public Surge::GUI::IComponentTagValue
 {
+    WidgetBaseMixin() { asT()->setWantsKeyboardFocus(true); }
     inline T *asT() { return static_cast<T *>(this); }
 
     uint32_t tag{0};


### PR DESCRIPTION
At least allow tab key navigation to work in accesible mode
even if no other key binding does, allowing some traversal
of the accessible hierarchy again.

Addresses #4616