### PR TITLE
Optional Arrow Keys for Slider/Button Editors

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -161,6 +161,12 @@ void initMaps()
             case UseKeyboardShortcuts_Standalone:
                 r = "useKeyboardShortcutsStandalone";
                 break;
+            case UseKeyboardAccEditors_Plugin:
+                r = "useKeyboardAccEditorsPlugin";
+                break;
+            case UseKeyboardAccEditors_Standalone:
+                r = "useKeyboardAccEditorsStandalone";
+                break;
             case InfoWindowPopupOnIdle:
                 r = "infoWindowPopupOnIdle";
                 break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -70,6 +70,10 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     UseKeyboardShortcuts_Plugin,
     UseKeyboardShortcuts_Standalone,
 
+    // These allow arrow keys to edit sliders, switches, etc...
+    UseKeyboardAccEditors_Plugin,
+    UseKeyboardAccEditors_Standalone,
+
     TuningOverlayLocation,
     ModlistOverlayLocation,
     MSEGOverlayLocation,

--- a/src/surge-xt/gui/SurgeGUICallbackInterfaces.h
+++ b/src/surge-xt/gui/SurgeGUICallbackInterfaces.h
@@ -28,6 +28,7 @@ struct IComponentTagValue
     virtual float getValue() const = 0;
     virtual void setValue(float) = 0;
 
+    virtual void startHover(const juce::Point<float> &) {}
     virtual void endHover() {}
 
     juce::Component *asJuceComponent()

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -693,6 +693,10 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void setUseKeyboardShortcuts(bool b);
     void toggleUseKeyboardShortcuts();
 
+    bool getUseKeyboardAccEditors();
+    void setUseKeyboardAccEditors(bool b);
+    void toggleUseKeyboardAccEditors();
+
   private:
     bool scannedForMidiPresets = false;
 

--- a/src/surge-xt/gui/SurgeGUIUtils.cpp
+++ b/src/surge-xt/gui/SurgeGUIUtils.cpp
@@ -1,6 +1,7 @@
 #include "SurgeGUIUtils.h"
 
 #include "juce_core/juce_core.h"
+#include "UserDefaults.h"
 
 #if LINUX
 #include <sys/types.h>
@@ -36,6 +37,34 @@ bool showCursor(SurgeStorage *storage)
 
     return sc || tm;
 };
+
+/*
+ * We kinda want to know if we are standalone here, but don't have reference to the processor
+ * but that's a constant for a process (you can't mix standalone and not) so make it a static
+ * and explicitly grab this symbol in the SGE startup path
+ */
+static bool isStandalone{false};
+void setIsStandalone(bool b) { isStandalone = b; }
+
+bool allowKeyboardEdits(SurgeStorage *storage)
+{
+    if (!storage)
+        return false;
+
+    bool res{false};
+    if (isStandalone)
+    {
+        res = Surge::Storage::getUserDefaultValue(
+            storage, Surge::Storage::UseKeyboardAccEditors_Standalone, true);
+    }
+    else
+    {
+        res = Surge::Storage::getUserDefaultValue(
+            storage, Surge::Storage::UseKeyboardAccEditors_Plugin, false);
+    }
+
+    return res;
+}
 
 // Returns 1 if the lines intersect, otherwise 0. In addition, if the lines
 // intersect, the intersection point may be stored in the floats i_x and i_y.

--- a/src/surge-xt/gui/SurgeGUIUtils.h
+++ b/src/surge-xt/gui/SurgeGUIUtils.h
@@ -11,6 +11,7 @@ namespace GUI
 std::string toOSCaseForMenu(const std::string &menuName);
 
 extern bool showCursor(SurgeStorage *storage);
+extern bool allowKeyboardEdits(SurgeStorage *storage);
 
 bool get_line_intersection(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
                            float p3_x, float p3_y, float *i_x, float *i_y);

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -342,5 +342,34 @@ std::unique_ptr<juce::AccessibilityHandler> MenuForDiscreteParams::createAccessi
     return std::make_unique<DiscreteAH<MenuForDiscreteParams>>(this);
 }
 #endif
+
+bool MenuForDiscreteParams::keyPressed(const juce::KeyPress &key)
+{
+    if (!Surge::GUI::allowKeyboardEdits(storage))
+        return false;
+
+    bool got{false};
+    int dir = -1;
+    if (key.getKeyCode() == juce::KeyPress::leftKey || key.getKeyCode() == juce::KeyPress::downKey)
+    {
+        got = true;
+    }
+    if (key.getKeyCode() == juce::KeyPress::rightKey || key.getKeyCode() == juce::KeyPress::upKey)
+    {
+        got = true;
+        dir = 1;
+    }
+
+    if (got)
+    {
+        notifyBeginEdit();
+        setValue(nextValueInOrder(value, -dir));
+        notifyValueChanged();
+        notifyEndEdit();
+        repaint();
+    }
+    return got;
+}
+
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
@@ -117,6 +117,11 @@ struct MenuForDiscreteParams : public juce::Component,
 
     void mouseExit(const juce::MouseEvent &event) override { endHover(); }
 
+    void startHover(const juce::Point<float> &p) override
+    {
+        isHovered = true;
+        repaint();
+    }
     void endHover() override
     {
         isHovered = false;
@@ -126,6 +131,18 @@ struct MenuForDiscreteParams : public juce::Component,
             setMouseCursor(juce::MouseCursor::NormalCursor);
         }
 
+        repaint();
+    }
+
+    bool keyPressed(const juce::KeyPress &key) override;
+    void focusGained(juce::Component::FocusChangeType cause) override
+    {
+        startHover(getBounds().getBottomLeft().toFloat());
+        repaint();
+    }
+    void focusLost(juce::Component::FocusChangeType cause) override
+    {
+        endHover();
         repaint();
     }
 

--- a/src/surge-xt/gui/widgets/ModulatableSlider.h
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.h
@@ -79,8 +79,19 @@ struct ModulatableSlider : public juce::Component,
     void mouseDoubleClick(const juce::MouseEvent &event) override;
     void mouseWheelMove(const juce::MouseEvent &event,
                         const juce::MouseWheelDetails &wheel) override;
+    void startHover(const juce::Point<float> &) override;
     void endHover() override;
-
+    bool keyPressed(const juce::KeyPress &key) override;
+    void focusGained(juce::Component::FocusChangeType cause) override
+    {
+        startHover(getBounds().getBottomLeft().toFloat());
+        repaint();
+    }
+    void focusLost(juce::Component::FocusChangeType cause) override
+    {
+        endHover();
+        repaint();
+    }
     SurgeStorage *storage{nullptr};
     void setStorage(SurgeStorage *s) { storage = s; }
 

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -179,9 +179,11 @@ void MultiSwitch::mouseUp(const juce::MouseEvent &event)
     }
 }
 
-void MultiSwitch::mouseEnter(const juce::MouseEvent &event)
+void MultiSwitch::mouseEnter(const juce::MouseEvent &event) { startHover(event.position); }
+
+void MultiSwitch::startHover(const juce::Point<float> &p)
 {
-    hoverSelection = coordinateToSelection(event.x, event.y);
+    hoverSelection = coordinateToSelection(p.x, p.y);
 
     isHovered = true;
 }

--- a/src/surge-xt/gui/widgets/MultiSwitch.h
+++ b/src/surge-xt/gui/widgets/MultiSwitch.h
@@ -74,8 +74,20 @@ struct MultiSwitch : public juce::Component, public WidgetBaseMixin<MultiSwitch>
     void mouseUp(const juce::MouseEvent &event) override;
     void setCursorToArrow();
 
+    void startHover(const juce::Point<float> &) override;
     void endHover() override;
 
+    void focusGained(juce::Component::FocusChangeType cause) override
+    {
+        // fixme - probably use the location of the current element
+        startHover(getBounds().getBottomLeft().toFloat());
+        repaint();
+    }
+    void focusLost(juce::Component::FocusChangeType cause) override
+    {
+        endHover();
+        repaint();
+    }
     Surge::GUI::WheelAccumulationHelper wheelHelper;
     void mouseWheelMove(const juce::MouseEvent &event,
                         const juce::MouseWheelDetails &wheel) override;

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -201,6 +201,39 @@ void NumberField::mouseWheelMove(const juce::MouseEvent &event,
     }
 }
 
+bool NumberField::keyPressed(const juce::KeyPress &key)
+{
+    if (!Surge::GUI::allowKeyboardEdits(storage))
+        return false;
+
+    bool got{false};
+    int amt = 1;
+    if (key.getKeyCode() == juce::KeyPress::leftKey || key.getKeyCode() == juce::KeyPress::downKey)
+    {
+        got = true;
+        amt = -1;
+    }
+    if (key.getKeyCode() == juce::KeyPress::rightKey || key.getKeyCode() == juce::KeyPress::upKey)
+    {
+        got = true;
+    }
+
+    if (got)
+    {
+        if (controlMode == Skin::Parameters::PB_DEPTH && extended &&
+            !key.getModifiers().isShiftDown())
+        {
+            amt = amt * 100;
+        }
+
+        notifyBeginEdit();
+        changeBy(amt);
+        notifyEndEdit();
+        repaint();
+    }
+    return got;
+}
+
 void NumberField::changeBy(int inc)
 {
     bounceToInt();

--- a/src/surge-xt/gui/widgets/NumberField.h
+++ b/src/surge-xt/gui/widgets/NumberField.h
@@ -109,9 +109,25 @@ struct NumberField : public juce::Component, public WidgetBaseMixin<NumberField>
         setMouseCursor(juce::MouseCursor::NormalCursor);
         repaint();
     }
+    void startHover(const juce::Point<float> &p) override
+    {
+        isHover = true;
+        repaint();
+    }
     void endHover() override
     {
         isHover = false;
+        repaint();
+    }
+    bool keyPressed(const juce::KeyPress &key) override;
+    void focusGained(juce::Component::FocusChangeType cause) override
+    {
+        startHover(getBounds().getBottomLeft().toFloat());
+        repaint();
+    }
+    void focusLost(juce::Component::FocusChangeType cause) override
+    {
+        endHover();
         repaint();
     }
 

--- a/src/surge-xt/gui/widgets/Switch.cpp
+++ b/src/surge-xt/gui/widgets/Switch.cpp
@@ -16,6 +16,7 @@
 #include "SurgeGUIEditor.h"
 #include "Switch.h"
 #include "SurgeImage.h"
+#include "SurgeGUIUtils.h"
 
 namespace Surge
 {
@@ -115,6 +116,50 @@ void Switch::mouseWheelMove(const juce::MouseEvent &event, const juce::MouseWhee
             }
         }
     }
+}
+
+bool Switch::keyPressed(const juce::KeyPress &key)
+{
+    if (!Surge::GUI::allowKeyboardEdits(storage))
+        return false;
+
+    bool got{false};
+    int mul = 1;
+    if (key.getKeyCode() == juce::KeyPress::leftKey)
+    {
+        got = true;
+        mul = -1;
+    }
+    if (key.getKeyCode() == juce::KeyPress::rightKey)
+    {
+        got = true;
+    }
+
+    if (got)
+    {
+
+        if (isMultiIntegerValued())
+        {
+            setValueDirection(mul);
+            notifyBeginEdit();
+            notifyValueChanged();
+            notifyEndEdit();
+        }
+        else
+        {
+            auto ov = value;
+            value = mul > 0 ? 1 : 0;
+
+            if (ov != value)
+            {
+                notifyBeginEdit();
+                notifyValueChanged();
+                notifyEndEdit();
+            }
+        }
+        repaint();
+    }
+    return got;
 }
 
 #if SURGE_JUCE_ACCESSIBLE

--- a/src/surge-xt/gui/widgets/Switch.h
+++ b/src/surge-xt/gui/widgets/Switch.h
@@ -23,6 +23,7 @@
 #include "juce_gui_basics/juce_gui_basics.h"
 
 class SurgeImage;
+class SurgeStorage;
 
 namespace Surge
 {
@@ -74,6 +75,27 @@ struct Switch : public juce::Component, public WidgetBaseMixin<Switch>
         isHovered = false;
         repaint();
     }
+
+    void startHover(const juce::Point<float> &) override
+    {
+        isHovered = true;
+        repaint();
+    }
+    bool keyPressed(const juce::KeyPress &key) override;
+
+    void focusGained(juce::Component::FocusChangeType cause) override
+    {
+        startHover(getBounds().getBottomLeft().toFloat());
+        repaint();
+    }
+    void focusLost(juce::Component::FocusChangeType cause) override
+    {
+        endHover();
+        repaint();
+    }
+
+    SurgeStorage *storage;
+    void setStorage(SurgeStorage *s) { storage = s; }
 
     Surge::GUI::WheelAccumulationHelper wheelHelper;
     void mouseWheelMove(const juce::MouseEvent &event,


### PR DESCRIPTION
As part of #4616, I learned that even though the accesibility
API has a well defined setvalue method which works, many accessible
users use arrow keys to adjust values. So this commit does three things

1. Makes widget focus follow tab order
2. Makes an optional arrow key to edit slider, button, number field, etc...
3. Make a system wide default for that which like the other kbd mods
   is off by default plugin and on standalone.

More to do here but I want to get this into the hands of the accesibility
testers so merging at this checkpoint.