### PR TITLE
Set SandboxTrue in the Audio Unit

### DIFF
--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -42,6 +42,7 @@ juce_add_plugin(${PROJECT_NAME}
   VST3_CATEGORIES Instrument Synth
   VST2_CATEGORY kPlugCategSynth
   AU_MAIN_TYPE kAudioUnitType_MusicDevice
+  AU_SANDBOX_SAFE TRUE
 
   LV2_URI https://surge-synthesizer.github.io/lv2/surge-xt
   LV2_SHARED_LIBRARY_NAME SurgeXT


### PR DESCRIPTION
This change sets sandboxEnabled true in the AU plist, allowing
loading into mac app store.

This requires a merge and full cycle to test alas, so I may revert
it, but before merging I made sure that

1. I could still sign the AU
2. The AU still loaded in Reaper and Logic

So lets see if this helps the fine folks over at #5633