### PR TITLE
Add define check for ARM32

### DIFF
--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -30,7 +30,7 @@
 #endif
 
 #if LINUX
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__arm__)
 #define ARM_NEON 1
 #endif
 #endif


### PR DESCRIPTION
We were on linux turning on ARM for aarch64 but not for 32 bit arm
so adjust accordingly.

Closes #5640