### PR TITLE
Start to do Accessible Edit Cleanup

### DIFF
--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -19,6 +19,8 @@
 #if SURGE_JUCE_ACCESSIBLE
 #include "Parameter.h"
 #include "SurgeGUIEditor.h"
+#include "SurgeStorage.h"
+#include "SurgeGUIUtils.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -252,6 +254,53 @@ struct OverlayAsAccessibleContainer : public juce::Component
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OverlayAsAccessibleContainer);
 };
+
+enum AccessibleKeyEditAction
+{
+    None,
+    Increase,
+    Decrease,
+    OpenMenu
+};
+
+enum AccessibleKeyModifier
+{
+    NoModifier,
+    Fine,
+    Quantized
+};
+
+inline std::tuple<AccessibleKeyEditAction, AccessibleKeyModifier>
+accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
+{
+    if (!Surge::GUI::allowKeyboardEdits(storage))
+        return {None, NoModifier};
+
+    if (key.getKeyCode() == juce::KeyPress::leftKey || key.getKeyCode() == juce ::KeyPress::downKey)
+    {
+        if (key.getModifiers().isShiftDown())
+            return {Decrease, Fine};
+        if (key.getModifiers().isCtrlDown())
+            return {Decrease, Quantized};
+        return {Decrease, NoModifier};
+    }
+
+    if (key.getKeyCode() == juce::KeyPress::rightKey || key.getKeyCode() == juce ::KeyPress::upKey)
+    {
+        if (key.getModifiers().isShiftDown())
+            return {Increase, Fine};
+        if (key.getModifiers().isCtrlDown())
+            return {Increase, Quantized};
+        return {Increase, NoModifier};
+    }
+
+    if (key.getKeyCode() == juce::KeyPress::F10Key && key.getModifiers().isShiftDown())
+    {
+        return {OpenMenu, NoModifier};
+    }
+
+    return {None, NoModifier};
+}
 
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3443,8 +3443,9 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
 
     bool kbAcc = getUseKeyboardAccEditors();
 
-    wfMenu.addItem(Surge::GUI::toOSCaseForMenu("Arrow Keys Modify Values"), true, kbAcc,
-                   [this]() { toggleUseKeyboardAccEditors(); });
+    wfMenu.addItem(
+        Surge::GUI::toOSCaseForMenu("Use Accessible Editor KeyBindings (Arrow Keys, etc)"), true,
+        kbAcc, [this]() { toggleUseKeyboardAccEditors(); });
 
     wfMenu.addSeparator();
 

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -345,30 +345,32 @@ std::unique_ptr<juce::AccessibilityHandler> MenuForDiscreteParams::createAccessi
 
 bool MenuForDiscreteParams::keyPressed(const juce::KeyPress &key)
 {
-    if (!Surge::GUI::allowKeyboardEdits(storage))
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
+
+    if (action == None)
         return false;
 
-    bool got{false};
-    int dir = -1;
-    if (key.getKeyCode() == juce::KeyPress::leftKey || key.getKeyCode() == juce::KeyPress::downKey)
+    if (action == OpenMenu)
     {
-        got = true;
-    }
-    if (key.getKeyCode() == juce::KeyPress::rightKey || key.getKeyCode() == juce::KeyPress::upKey)
-    {
-        got = true;
-        dir = 1;
+        notifyControlModifierClicked(juce::ModifierKeys(), true);
+        return true;
     }
 
-    if (got)
+    if (action != Increase && action != Decrease)
+        return false;
+
+    int dir = 1;
+    if (action == Decrease)
     {
-        notifyBeginEdit();
-        setValue(nextValueInOrder(value, -dir));
-        notifyValueChanged();
-        notifyEndEdit();
-        repaint();
+        dir = -1;
     }
-    return got;
+
+    notifyBeginEdit();
+    setValue(nextValueInOrder(value, -dir));
+    notifyValueChanged();
+    notifyEndEdit();
+    repaint();
+    return true;
 }
 
 } // namespace Widgets

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -223,32 +223,35 @@ void MultiSwitch::mouseWheelMove(const juce::MouseEvent &event,
 
 bool MultiSwitch::keyPressed(const juce::KeyPress &key)
 {
-    if (!Surge::GUI::allowKeyboardEdits(storage))
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
+
+    if (action == None)
         return false;
 
-    bool got{false};
-    int dir = 1;
-    if (key.getKeyCode() == juce::KeyPress::leftKey || key.getKeyCode() == juce::KeyPress::downKey)
+    if (action == OpenMenu)
     {
-        got = true;
+        notifyControlModifierClicked(juce::ModifierKeys(), true);
+        return true;
+    }
+
+    if (action != Increase && action != Decrease)
+        return false;
+
+    int dir = 1;
+    if (action == Decrease)
+    {
         dir = -1;
     }
-    if (key.getKeyCode() == juce::KeyPress::rightKey || key.getKeyCode() == juce::KeyPress::upKey)
-    {
-        got = true;
-    }
 
-    if (got)
-    {
-        auto iv = limit_range(getIntegerValue() + dir, 0, rows * columns - 1);
+    auto iv = limit_range(getIntegerValue() + dir, 0, rows * columns - 1);
 
-        setValue(1.f * iv / (rows * columns - 1));
-        notifyBeginEdit();
-        notifyValueChanged();
-        notifyEndEdit();
-        repaint();
-    }
-    return got;
+    setValue(1.f * iv / (rows * columns - 1));
+    notifyBeginEdit();
+    notifyValueChanged();
+    notifyEndEdit();
+    repaint();
+
+    return true;
 }
 
 #if SURGE_JUCE_ACCESSIBLE

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -203,35 +203,36 @@ void NumberField::mouseWheelMove(const juce::MouseEvent &event,
 
 bool NumberField::keyPressed(const juce::KeyPress &key)
 {
-    if (!Surge::GUI::allowKeyboardEdits(storage))
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
+
+    if (action == None)
         return false;
 
-    bool got{false};
-    int amt = 1;
-    if (key.getKeyCode() == juce::KeyPress::leftKey || key.getKeyCode() == juce::KeyPress::downKey)
+    if (action == OpenMenu)
     {
-        got = true;
+        notifyControlModifierClicked(juce::ModifierKeys(), true);
+        return true;
+    }
+
+    if (action != Increase && action != Decrease)
+        return false;
+
+    int amt = 1;
+    if (action == Decrease)
+    {
         amt = -1;
     }
-    if (key.getKeyCode() == juce::KeyPress::rightKey || key.getKeyCode() == juce::KeyPress::upKey)
+
+    if (controlMode == Skin::Parameters::PB_DEPTH && extended && !key.getModifiers().isShiftDown())
     {
-        got = true;
+        amt = amt * 100;
     }
 
-    if (got)
-    {
-        if (controlMode == Skin::Parameters::PB_DEPTH && extended &&
-            !key.getModifiers().isShiftDown())
-        {
-            amt = amt * 100;
-        }
-
-        notifyBeginEdit();
-        changeBy(amt);
-        notifyEndEdit();
-        repaint();
-    }
-    return got;
+    notifyBeginEdit();
+    changeBy(amt);
+    notifyEndEdit();
+    repaint();
+    return true;
 }
 
 void NumberField::changeBy(int inc)


### PR DESCRIPTION
This is the first of several commits to incorporate
feedback from the accessibile testers. It primarily does
the following

1: Centralize accessible keybindings in one place
2: Respond to Shift-F10 for menu on the activated components
3: General code cleanup and stuff as I get ready to do the harder items.

Addresses #4616