### PR TITLE
More Accessibility Work

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -161,12 +161,6 @@ void initMaps()
             case UseKeyboardShortcuts_Standalone:
                 r = "useKeyboardShortcutsStandalone";
                 break;
-            case UseKeyboardAccEditors_Plugin:
-                r = "useKeyboardAccEditorsPlugin";
-                break;
-            case UseKeyboardAccEditors_Standalone:
-                r = "useKeyboardAccEditorsStandalone";
-                break;
             case InfoWindowPopupOnIdle:
                 r = "infoWindowPopupOnIdle";
                 break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -70,10 +70,6 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     UseKeyboardShortcuts_Plugin,
     UseKeyboardShortcuts_Standalone,
 
-    // These allow arrow keys to edit sliders, switches, etc...
-    UseKeyboardAccEditors_Plugin,
-    UseKeyboardAccEditors_Standalone,
-
     TuningOverlayLocation,
     ModlistOverlayLocation,
     MSEGOverlayLocation,

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -276,7 +276,7 @@ accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
     if (!Surge::GUI::allowKeyboardEdits(storage))
         return {None, NoModifier};
 
-    if (key.getKeyCode() == juce::KeyPress::leftKey || key.getKeyCode() == juce ::KeyPress::downKey)
+    if (key.getKeyCode() == juce ::KeyPress::downKey)
     {
         if (key.getModifiers().isShiftDown())
             return {Decrease, Fine};
@@ -285,7 +285,7 @@ accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
         return {Decrease, NoModifier};
     }
 
-    if (key.getKeyCode() == juce::KeyPress::rightKey || key.getKeyCode() == juce ::KeyPress::upKey)
+    if (key.getKeyCode() == juce ::KeyPress::upKey)
     {
         if (key.getModifiers().isShiftDown())
             return {Increase, Fine};
@@ -295,6 +295,11 @@ accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
     }
 
     if (key.getKeyCode() == juce::KeyPress::F10Key && key.getModifiers().isShiftDown())
+    {
+        return {OpenMenu, NoModifier};
+    }
+
+    if (key.getKeyCode() == 93)
     {
         return {OpenMenu, NoModifier};
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -83,6 +83,7 @@ struct PatchStoreDialog;
 class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
                        public SurgeStorage::ErrorListener,
                        public juce::KeyListener,
+                       public juce::FocusChangeListener,
                        public SurgeSynthesizer::ModulationAPIListener
 {
   public:
@@ -128,6 +129,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::string showShortcutDescription(const std::string &shortcutDesc,
                                         const std::string &shortcutDescMac);
     std::string showShortcutDescription(const std::string &shortcutDesc);
+
+    bool debugFocus{false};
+    void globalFocusChanged(juce::Component *fc) override;
 
   protected:
     virtual void setParameter(long index, float value);
@@ -692,10 +696,6 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool getUseKeyboardShortcuts();
     void setUseKeyboardShortcuts(bool b);
     void toggleUseKeyboardShortcuts();
-
-    bool getUseKeyboardAccEditors();
-    void setUseKeyboardAccEditors(bool b);
-    void toggleUseKeyboardAccEditors();
 
   private:
     bool scannedForMidiPresets = false;

--- a/src/surge-xt/gui/SurgeGUIUtils.cpp
+++ b/src/surge-xt/gui/SurgeGUIUtils.cpp
@@ -55,12 +55,12 @@ bool allowKeyboardEdits(SurgeStorage *storage)
     if (isStandalone)
     {
         res = Surge::Storage::getUserDefaultValue(
-            storage, Surge::Storage::UseKeyboardAccEditors_Standalone, true);
+            storage, Surge::Storage::UseKeyboardShortcuts_Standalone, true);
     }
     else
     {
         res = Surge::Storage::getUserDefaultValue(
-            storage, Surge::Storage::UseKeyboardAccEditors_Plugin, false);
+            storage, Surge::Storage::UseKeyboardShortcuts_Plugin, false);
     }
 
     return res;

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -131,6 +131,16 @@ void EffectChooser::paint(juce::Graphics &g)
     }
 }
 
+void EffectChooser::resized()
+{
+    int i = 0;
+    for (const auto &q : slotAccOverlays)
+    {
+        q->setBounds(getEffectRectangle(i).translated(getBounds().getX(), getBounds().getY()));
+        i++;
+    }
+}
+
 void EffectChooser::drawSlotText(juce::Graphics &g, const juce::Rectangle<int> &r,
                                  const juce::Colour &txtcol, int fxid)
 {

--- a/src/surge-xt/gui/widgets/EffectChooser.h
+++ b/src/surge-xt/gui/widgets/EffectChooser.h
@@ -68,6 +68,9 @@ struct EffectChooser : public juce::Component, public WidgetBaseMixin<EffectChoo
         isHovered = false;
         repaint();
     }
+
+    void resized() override;
+
     // State for mouse events
     bool isHovered{false}, hasDragged{false};
     int currentHover{-1}, currentSceneHover{-1}, currentClicked{-1};

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -109,7 +109,8 @@ void LFOAndStepDisplay::resized()
         int yp = (i / 2) * 15 + left_panel.getY();
         shaperect[i] = juce::Rectangle<int>(xp, yp, 25, 15);
 #if SURGE_JUCE_ACCESSIBLE
-        typeAccOverlays[i]->setBounds(shaperect[i]);
+        typeAccOverlays[i]->setBounds(
+            shaperect[i].translated(getBounds().getX(), getBounds().getY()));
 #endif
     }
 

--- a/src/surge-xt/gui/widgets/MainFrame.h
+++ b/src/surge-xt/gui/widgets/MainFrame.h
@@ -46,6 +46,21 @@ struct MainFrame : public juce::Component
             bg->draw(g, 1.0);
     }
 
+    bool debugFocus{false};
+    juce::Rectangle<int> focusRectangle;
+    void paintOverChildren(juce::Graphics &g) override
+    {
+        if (!debugFocus)
+            return;
+        if (focusRectangle.getWidth() > 0 && focusRectangle.getHeight() > 0)
+        {
+            g.setColour(juce::Colours::red);
+            g.drawRect(focusRectangle.expanded(1), 2);
+            g.setColour(juce::Colours::yellow.withAlpha(0.1f));
+            g.fillRect(focusRectangle);
+        }
+    }
+
     void resized() override
     {
         for (auto &c : cgOverlays)

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -440,6 +440,12 @@ void ModulationSourceButton::mouseEnter(const juce::MouseEvent &event)
 
 void ModulationSourceButton::mouseExit(const juce::MouseEvent &event) { endHover(); }
 
+void ModulationSourceButton::startHover(const juce::Point<float> &f)
+{
+    isHovered = true;
+    repaint();
+}
+
 void ModulationSourceButton::endHover()
 {
     bool oh = isHovered;
@@ -449,6 +455,46 @@ void ModulationSourceButton::endHover()
     {
         repaint();
     }
+}
+
+bool ModulationSourceButton::keyPressed(const juce::KeyPress &key)
+{
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
+
+    if (action == None)
+        return false;
+
+    if (action == OpenMenu)
+    {
+        notifyControlModifierClicked(juce::ModifierKeys(), true);
+        return true;
+    }
+
+    if (action != Increase && action != Decrease)
+        return false;
+
+    if (isMeta)
+    {
+        float delta = 0.05;
+        if (mod == Fine)
+        {
+            delta = 0.01;
+        }
+        if (action == Decrease)
+            delta = -delta;
+
+        value = limit01(value + delta);
+        mouseMode = DRAG_VALUE;
+
+        notifyValueChanged();
+
+        mouseMode = NONE;
+
+        repaint();
+        return true;
+    }
+
+    return false;
 }
 
 void ModulationSourceButton::onSkinChanged()
@@ -633,7 +679,10 @@ void ModulationSourceButton::resized()
 {
     hamburgerHome = getLocalBounds().withWidth(11).reduced(2, 2);
 
-    auto b = getLocalBounds().withWidth(getHeight()).translated(getHeight(), 0);
+    auto b = getLocalBounds()
+                 .withWidth(getHeight())
+                 .translated(getHeight(), 0)
+                 .translated(getBounds().getX(), getBounds().getY());
     selectAccButton->setBounds(b);
     b = b.translated(getHeight(), 0);
     targetAccButton->setBounds(b);

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.h
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.h
@@ -151,7 +151,19 @@ struct ModulationSourceButton : public juce::Component,
 
     void mouseEnter(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override;
+    void startHover(const juce::Point<float> &f) override;
     void endHover() override;
+    bool keyPressed(const juce::KeyPress &key) override;
+    void focusGained(juce::Component::FocusChangeType cause) override
+    {
+        startHover(getBounds().getBottomLeft().toFloat());
+        repaint();
+    }
+    void focusLost(juce::Component::FocusChangeType cause) override
+    {
+        endHover();
+        repaint();
+    }
 
     void onSkinChanged() override;
 


### PR DESCRIPTION
All as discussed in #4616

1. Collapse keybindings into single binding
2. Keybindings for the macro slider
3. A focus debug mode (in the developer menu)
4. Position some accessible buttons correctly

Still a lot to do