### PR TITLE
Fix a Pedal Polymode problem

### DIFF
--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -391,8 +391,16 @@ class alignas(16) SurgeSynthesizer
 
     // hold pedal stuff
 
-    std::list<std::pair<int, int>> holdbuffer[n_scenes];
+    struct HoldBufferItem
+    {
+        int channel;
+        int key;
+        int originalChannel;
+        int originalKey;
+    };
+    std::list<HoldBufferItem> holdbuffer[n_scenes];
     void purgeHoldbuffer(int scene);
+    void purgeDuplicateHeldVoicesInPolyMode(int scehe, int channel, int key);
     quadr_osc sinus;
     int demo_counter = 0;
 

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -137,6 +137,7 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
     state.key = key;
     state.keyRetuningForKey = -1000;
     state.channel = channel;
+    state.voiceOrderAtCreate = voiceOrder;
 
     state.velocity = velocity;
     state.fvel = velocity / 127.f;

--- a/src/common/dsp/SurgeVoiceState.h
+++ b/src/common/dsp/SurgeVoiceState.h
@@ -37,6 +37,7 @@ struct SurgeVoiceState
     // pitch
     ControllerModulationSource mpePitchBend;
     float mpePitchBendRange;
+    int64_t voiceOrderAtCreate{-1};
 
     float getPitch(SurgeStorage *storage);
 };


### PR DESCRIPTION
In poly mode

pedal down
note 60 on
note 60 off
note 60 on
pedal release

would result in 2 voices playing not one. While this is not
wrong per-se, its not how other instruments (like pianos)
woudl work and it's not how most other synths work, so choose
the convention that we switch to 1 note playing for XT

Closes #5649