### PR TITLE
New bindings for experimental CLAP support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,14 +46,8 @@ target_compile_definitions(surge-juce INTERFACE
 
 set(SURGE_JUCE_FORMATS VST3)
 
-
-if(SURGE_CLAP_ROOT)
-  message( STATUS "Gathering CLAP from ${SURGE_CLAP_ROOT}")
-  if (NOT EXISTS "${SURGE_JUCE_PATH}/modules/juce_audio_plugin_client/juce_audio_plugin_client_CLAP.cpp")
-    message(FATAL_ERROR "To use CLAP you need to both set SURGE_CLAP_ROOT and have SURGE_JUCE_PATH point at a clap-enabled juce")
-  endif()
-  juce_set_clap_sdk_path("${SURGE_CLAP_ROOT}/clap" "${SURGE_CLAP_ROOT}/clap-helpers")
-  list(APPEND SURGE_JUCE_FORMATS CLAP)
+if (CLAP_JUCE_EXTENSIONS_ROOT)
+  add_subdirectory(${CLAP_JUCE_EXTENSIONS_ROOT} clap-extensions)
 endif()
 
 if(NOT SURGE_SKIP_STANDALONE)

--- a/src/surge-fx/CMakeLists.txt
+++ b/src/surge-fx/CMakeLists.txt
@@ -62,4 +62,9 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   juce::juce_audio_processors
 )
 
+if (CLAP_JUCE_EXTENSIONS_ROOT)
+  clap_juce_extensions_plugin(TARGET surge-fx
+          CLAP_ID "org.surge-synth-team.surge-xt-fx")
+endif()
+
 surge_juce_package(${PROJECT_NAME} "Surge XT Effects")

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -50,6 +50,12 @@ juce_add_plugin(${PROJECT_NAME}
   FORMATS ${SURGE_JUCE_FORMATS}
   )
 
+if (CLAP_JUCE_EXTENSIONS_ROOT)
+  clap_juce_extensions_plugin(TARGET surge-xt
+          CLAP_ID "org.surge-synth-team.surge-xt")
+  target_sources(${PROJECT_NAME}_CLAP PRIVATE plugin_type_extensions/SurgeSynthClapExtensions.cpp)
+endif()
+
 if(JUCE_ASIO_SUPPORT)
   target_compile_definitions(${PROJECT_NAME} PUBLIC JUCE_ASIO=1)
 endif()

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -23,7 +23,15 @@ SurgeSynthProcessor::SurgeSynthProcessor()
                                .withOutput("Scene A", juce::AudioChannelSet::stereo(), false)
                                .withOutput("Scene B", juce::AudioChannelSet::stereo(), false))
 {
-    std::cout << "SurgeXT " << getWrapperTypeDescription(wrapperType) << "\n"
+    // Since we are using 'external clap' this is the one JUCE API we can't override
+    std::string wrapperTypeString = getWrapperTypeDescription(wrapperType);
+
+#if HAS_CLAP_JUCE_EXTENSIONS
+    if (wrapperType == wrapperType_Undefined && is_clap)
+        wrapperTypeString = "Clap";
+#endif
+
+    std::cout << "SurgeXT " << wrapperTypeString << "\n"
               << "  - Version      : " << Surge::Build::FullVersionStr << " with JUCE " << std::hex
               << JUCE_VERSION << std::dec << "\n"
               << "  - Build Info   : " << Surge::Build::BuildDate << " " << Surge::Build::BuildTime
@@ -84,7 +92,7 @@ SurgeSynthProcessor::SurgeSynthProcessor()
     }
 
     surge->hostProgram = juce::PluginHostType().getHostDescription();
-    surge->juceWrapperType = getWrapperTypeDescription(wrapperType);
+    surge->juceWrapperType = wrapperTypeString;
     surge->setupActivateExtraOutputs();
 
     midiKeyboardState.addListener(this);

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -16,6 +16,10 @@
 
 #include "juce_audio_processors/juce_audio_processors.h"
 
+#if HAS_CLAP_JUCE_EXTENSIONS
+#include "clap-juce-extensions/clap-juce-extensions.h"
+#endif
+
 #include <unordered_map>
 
 #if MAC
@@ -146,6 +150,11 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
 #if SURGE_JUCE_VST3_EXTENSIONS
                             public juce::VST3ClientExtensions,
 #endif
+
+#if HAS_CLAP_JUCE_EXTENSIONS
+                            public clap_juce_extensions::clap_properties,
+#endif
+
                             public SurgeSynthesizer::PluginLayer,
                             public juce::MidiKeyboardState::Listener
 


### PR DESCRIPTION
As we slowly move to forkless-clap, add surge bindings so
we can use it as an experiment. Everything is off by default
of course.