### PR TITLE
A big set of Accesibility work

### DIFF
--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -159,11 +159,8 @@ target_sources(${PROJECT_NAME} PRIVATE
   gui/widgets/XMLConfiguredMenus.h
   )
 
-if(EXISTS ${SURGE_JUCE_PATH}/modules/juce_gui_basics/accessibility/juce_AccessibilityHandler.h)
-  set(SURGE_JUCE_ACCESSIBLE TRUE)
-  message(STATUS "Including JUCE accessibility support")
-else()
-  message(STATUS "No JUCE accessibility support in this version")
+if(NOT EXISTS ${SURGE_JUCE_PATH}/modules/juce_gui_basics/accessibility/juce_AccessibilityHandler.h)
+  message(FATAL_ERROR "You must build against at least a Juce 6.1 with Accessibility support")
 endif()
 
 if(EXISTS ${SURGE_JUCE_PATH}/modules/juce_audio_processors/processors/juce_AudioProcessorEditorHostContext.h)
@@ -181,7 +178,6 @@ else()
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC
-  SURGE_JUCE_ACCESSIBLE=$<BOOL:${SURGE_JUCE_ACCESSIBLE}>
   SURGE_JUCE_HOST_CONTEXT=$<BOOL:${SURGE_JUCE_HOST_CONTEXT}>
   SURGE_JUCE_VST3_EXTENSIONS=$<BOOL:${SURGE_JUCE_VST3_EXTENSIONS}>
 

--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -51,9 +51,7 @@ SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
         float newT = std::atof(tempoTypein->getText().toRawUTF8());
 
         processor.standaloneTempo = newT;
-#if SURGE_JUCE_ACCESSIBLE
         tempoTypein->giveAwayKeyboardFocus();
-#endif
     };
 
     tempoLabel = std::make_unique<juce::Label>("Tempo", "Tempo");

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -16,7 +16,6 @@
 #ifndef SURGE_XT_ACCESSIBLEHELPERS_H
 #define SURGE_XT_ACCESSIBLEHELPERS_H
 
-#if SURGE_JUCE_ACCESSIBLE
 #include "Parameter.h"
 #include "SurgeGUIEditor.h"
 #include "SurgeStorage.h"
@@ -76,18 +75,17 @@ struct GroupTagTraverser : public juce::ComponentTraverser
         if (!at && bt)
             return true;
 
-#if SURGE_JUCE_ACCESSIBLE
         auto cd = a->getDescription().compare(b->getDescription());
         if (cd < 0)
             return true;
         if (cd > 0)
             return false;
-#endif
 
         // so what the hell else to do?
         return a < b;
     }
 };
+
 template <typename T> struct DiscreteAHRange
 {
     static int iMaxV(T *t) { return t->iMax; }
@@ -247,6 +245,8 @@ template <typename T> struct OverlayAsAccessibleSlider : public juce::Component
     float getValue() { return 0; }
     void setValue(float f) {}
 
+    bool keyPressed(const juce::KeyPress &key) override;
+
     struct SValue : public juce::AccessibilityValueInterface
     {
         explicit SValue(OverlayAsAccessibleSlider<T> *s) : slider(s) {}
@@ -366,9 +366,27 @@ accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
     return {None, NoModifier};
 }
 
+template <typename T> bool OverlayAsAccessibleSlider<T>::keyPressed(const juce::KeyPress &key)
+{
+    if (!under->storage)
+        return false;
+
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, under->storage);
+
+    if (action == Increase)
+    {
+        std::cout << "Handle Slider Increase" << std::endl;
+        return true;
+    }
+    if (action == Decrease)
+    {
+        std::cout << "Handle Slider Decreaase" << std::endl;
+        return true;
+    }
+    return false;
+}
+
 } // namespace Widgets
 } // namespace Surge
-
-#endif
 
 #endif // SURGE_XT_ACCESSIBLEHELPERS_H

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1819,9 +1819,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
     debugLabel->setColour(juce::Label::textColourId, juce::Colours::white);
     debugLabel->setFont(Surge::GUI::getFontManager()->getFiraMonoAtSize(9));
     debugLabel->setJustificationType(juce::Justification::centred);
-#if SURGE_JUCE_ACCESSIBLE
     debugLabel->setAccessible(false);
-#endif
 
     addAndMakeVisibleWithTracking(frame.get(), *debugLabel);
 
@@ -5727,15 +5725,12 @@ void SurgeGUIEditor::setAccessibilityInformationByTitleAndAction(juce::Component
                                                                  const std::string &title,
                                                                  const std::string &action)
 {
-#if SURGE_JUCE_ACCESSIBLE
 #if MAC
     c->setDescription(title);
     c->setTitle(title);
 #else
     c->setDescription(action);
     c->setTitle(title);
-#endif
-
 #endif
 }
 
@@ -6426,9 +6421,11 @@ void SurgeGUIEditor::globalFocusChanged(juce::Component *fc)
     if (!frame)
         return;
 
+    auto newRect = juce::Rectangle<int>();
     if (fc)
     {
-        frame->focusRectangle = fc->getBounds();
+        newRect = frame->getLocalArea(fc->getParentComponent(), fc->getBounds());
+        frame->focusRectangle = newRect;
     }
     else
     {
@@ -6440,8 +6437,9 @@ void SurgeGUIEditor::globalFocusChanged(juce::Component *fc)
 
         std::cout << "FC [" << fc << "] ";
         if (fc)
-            std::cout << fc->getTitle() << " " << typeid(*fc).name() << " "
-                      << fc->getBounds().toString();
+        {
+            std::cout << fc->getTitle() << " " << typeid(*fc).name() << " " << newRect.toString();
+        }
         std::cout << std::endl;
     }
 }

--- a/src/surge-xt/gui/overlays/CoveringMessageOverlay.h
+++ b/src/surge-xt/gui/overlays/CoveringMessageOverlay.h
@@ -56,11 +56,9 @@ You can click to dismiss this message and the Surge UI will continue to operate,
 no sound will be produced under MIDI input unless you activate your audio system.
 )MSG");
 
-#if SURGE_JUCE_ACCESSIBLE
         setTitle(pt);
         setDescription(pt);
         setAccessible(true);
-#endif
     }
 
     void mouseUp(const juce::MouseEvent &e) override { editor->clearNoProcessingOverlay(); }

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -39,6 +39,12 @@ struct OverlayComponent : juce::Component
     void setHasIndependentClose(bool b) { hasIndependentClose = b; }
     bool getHasIndependentClose() { return hasIndependentClose; }
 
+    /*
+     * This is called when a parent wrapper finally decides to show me, which will
+     * be after I am added visibly to a hidden element. Basically use it to grab focus.
+     */
+    virtual void shownInParent() {}
+
     std::pair<bool, Surge::Storage::DefaultKey> canTearOut{false, Surge::Storage::nKeys};
     void setCanTearOut(std::pair<bool, Surge::Storage::DefaultKey> b) { canTearOut = b; }
     std::pair<bool, Surge::Storage::DefaultKey> getCanTearOut() { return canTearOut; }

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -135,6 +135,16 @@ void OverlayWrapper::buttonClicked(juce::Button *button)
     }
 }
 
+void OverlayWrapper::visibilityChanged()
+{
+    if (!isVisible() && !isShowing())
+        return;
+    if (auto olc = getPrimaryChildAsOverlayComponent())
+    {
+        olc->shownInParent();
+    }
+}
+
 bool OverlayWrapper::isTornOut() { return tearOutParent != nullptr; }
 
 struct TearOutWindow : public juce::DocumentWindow

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -65,6 +65,8 @@ struct OverlayWrapper : public juce::Component,
     void mouseDrag(const juce::MouseEvent &) override;
     void mouseDoubleClick(const juce::MouseEvent &e) override;
 
+    void visibilityChanged() override;
+
     SurgeImage *icon{nullptr};
     void setIcon(SurgeImage *d) { icon = d; }
 
@@ -106,6 +108,16 @@ struct OverlayWrapper : public juce::Component,
     void onSkinChanged() override;
 
     OverlayComponent *getPrimaryChildAsOverlayComponent();
+
+    /*
+     * All overlays should use default focus order not the wonky tag first and
+     * then description and so on order for the main frame (which is laying out controls
+     * in a differently structured way).
+     */
+    std::unique_ptr<juce::ComponentTraverser> createKeyboardFocusTraverser() override
+    {
+        return std::make_unique<juce::KeyboardFocusTraverser>();
+    }
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OverlayWrapper);
 };

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -172,16 +172,19 @@ PatchStoreDialog::PatchStoreDialog()
 
     okButton = std::make_unique<Widgets::SurgeTextButton>("patchOK");
     okButton->setButtonText("OK");
+    okButton->setWantsKeyboardFocus(true);
     okButton->addListener(this);
     addAndMakeVisible(*okButton);
 
     cancelButton = std::make_unique<Widgets::SurgeTextButton>("patchCancel");
     cancelButton->setButtonText("Cancel");
+    cancelButton->setWantsKeyboardFocus(true);
     cancelButton->addListener(this);
     addAndMakeVisible(*cancelButton);
 
     okOverButton = std::make_unique<Widgets::SurgeTextButton>("factoryOverwrite");
     okOverButton->setButtonText("Factory Overwrite");
+    okOverButton->setWantsKeyboardFocus(true);
     okOverButton->addListener(this);
     addAndMakeVisible(*okOverButton);
 
@@ -216,7 +219,7 @@ void PatchStoreDialog::setSurgeGUIEditor(SurgeGUIEditor *e)
     }
 }
 
-void PatchStoreDialog::parentHierarchyChanged()
+void PatchStoreDialog::shownInParent()
 {
     if (nameEd->isShowing() && isVisible())
         nameEd->grabKeyboardFocus();

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.h
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.h
@@ -43,7 +43,7 @@ struct PatchStoreDialog : public OverlayComponent,
     ~PatchStoreDialog();
     void paint(juce::Graphics &g) override;
     void resized() override;
-    void parentHierarchyChanged() override;
+    void shownInParent() override;
 
     SurgeGUIEditor *editor{nullptr};
     void setSurgeGUIEditor(SurgeGUIEditor *e);

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -27,15 +27,12 @@ namespace Widgets
 EffectChooser::EffectChooser()
 {
     setRepaintsOnMouseActivity(true);
-#if SURGE_JUCE_ACCESSIBLE
     setAccessible(true);
     setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
-#endif
 
     for (int i = 0; i < n_fx_slots; ++i)
     {
         fxTypes[i] = fxt_off;
-#if SURGE_JUCE_ACCESSIBLE
         auto q = std::make_unique<OverlayAsAccessibleButton<EffectChooser>>(this, fxslot_names[i]);
         q->setBounds(getEffectRectangle(i));
         q->onPress = [this, i](auto *t) {
@@ -44,7 +41,6 @@ EffectChooser::EffectChooser()
         };
         addAndMakeVisible(*q);
         slotAccOverlays[i] = std::move(q);
-#endif
     }
 };
 EffectChooser::~EffectChooser() = default;
@@ -136,7 +132,7 @@ void EffectChooser::resized()
     int i = 0;
     for (const auto &q : slotAccOverlays)
     {
-        q->setBounds(getEffectRectangle(i).translated(getBounds().getX(), getBounds().getY()));
+        q->setBounds(getEffectRectangle(i));
         i++;
     }
 }
@@ -449,8 +445,6 @@ void EffectChooser::getColorsForSlot(int fxslot, juce::Colour &bgcol, juce::Colo
     }
 }
 
-#if SURGE_JUCE_ACCESSIBLE
-
 template <> struct DiscreteAHRange<EffectChooser>
 {
     static int iMaxV(EffectChooser *t) { return n_fx_slots; }
@@ -474,6 +468,5 @@ std::unique_ptr<juce::AccessibilityHandler> EffectChooser::createAccessibilityHa
 {
     return std::make_unique<DiscreteAH<EffectChooser, juce::AccessibilityRole::group>>(this);
 }
-#endif
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/EffectChooser.h
+++ b/src/surge-xt/gui/widgets/EffectChooser.h
@@ -114,10 +114,8 @@ struct EffectChooser : public juce::Component, public WidgetBaseMixin<EffectChoo
     void getColorsForSlot(int fxslot, juce::Colour &bgcol, juce::Colour &frcol,
                           juce::Colour &txtcol);
 
-#if SURGE_JUCE_ACCESSIBLE
     std::array<std::unique_ptr<juce::Component>, n_fx_slots> slotAccOverlays;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EffectChooser);
 };

--- a/src/surge-xt/gui/widgets/EffectLabel.h
+++ b/src/surge-xt/gui/widgets/EffectLabel.h
@@ -31,9 +31,7 @@ struct EffectLabel : public juce::Component, public Surge::GUI::SkinConsumingCom
 {
     EffectLabel()
     {
-#if SURGE_JUCE_ACCESSIBLE
         setAccessible(false); // the param full name contains what we need
-#endif
     }
     ~EffectLabel() = default;
 

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -48,7 +48,6 @@ struct TimeB
 
 LFOAndStepDisplay::LFOAndStepDisplay()
 {
-#if SURGE_JUCE_ACCESSIBLE
     setTitle("LFO Type And Display");
     setAccessible(true);
     setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
@@ -86,7 +85,6 @@ LFOAndStepDisplay::LFOAndStepDisplay()
             stepTriggerOverlays[i] = std::move(q);
         }
     }
-#endif
 }
 
 void LFOAndStepDisplay::resized()
@@ -106,7 +104,7 @@ void LFOAndStepDisplay::resized()
     for (int i = 0; i < n_lfo_types; ++i)
     {
         int xp = (i % 2) * 25 + left_panel.getX();
-        int yp = (i / 2) * 15 + left_panel.getY();
+        int yp = (i / 2) * 15 + left_panel.getY() + margin + 2;
         shaperect[i] = juce::Rectangle<int>(xp, yp, 25, 15);
         typeAccOverlays[i]->setBounds(shaperect[i]);
     }
@@ -2043,7 +2041,6 @@ void LFOAndStepDisplay::updateShapeTo(int i)
 
 void LFOAndStepDisplay::setupAccessibility()
 {
-#if SURGE_JUCE_ACCESSIBLE
     bool showStepSliders{false}, showTriggers{false};
     if (lfodata->shape.val.i == lt_stepseq)
     {
@@ -2063,9 +2060,7 @@ void LFOAndStepDisplay::setupAccessibility()
     for (const auto &s : stepTriggerOverlays)
         if (s)
             s->setVisible(showTriggers);
-#endif
 }
-#if SURGE_JUCE_ACCESSIBLE
 template <> struct DiscreteAHRange<LFOAndStepDisplay>
 {
     static int iMaxV(LFOAndStepDisplay *t) { return n_lfo_types; }
@@ -2088,7 +2083,22 @@ std::unique_ptr<juce::AccessibilityHandler> LFOAndStepDisplay::createAccessibili
 {
     return std::make_unique<DiscreteAH<LFOAndStepDisplay, juce::AccessibilityRole::group>>(this);
 }
-#endif
+
+bool LFOAndStepDisplay::keyPressed(const juce::KeyPress &key)
+{
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
+
+    if (action == None)
+        return false;
+
+    if (action == OpenMenu)
+    {
+        notifyControlModifierClicked(juce::ModifierKeys(), true);
+        return true;
+    }
+
+    return false;
+}
 
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -132,6 +132,8 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
 
     void onSkinChanged() override;
 
+    bool keyPressed(const juce::KeyPress &key) override;
+
     SurgeImage *typeImg{nullptr}, *typeImgHover{nullptr}, *typeImgHoverOn{nullptr};
 
     const static int margin = 2;
@@ -154,14 +156,12 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
     void updateShapeTo(int i);
     void setupAccessibility();
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::Component> typeLayer, stepLayer;
     std::array<std::unique_ptr<juce::Component>, n_lfo_types> typeAccOverlays;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
 
     std::array<std::unique_ptr<juce::Component>, n_stepseqsteps> stepSliderOverlays;
     std::array<std::unique_ptr<juce::Component>, n_stepseqsteps> stepTriggerOverlays;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LFOAndStepDisplay);
 };

--- a/src/surge-xt/gui/widgets/MainFrame.cpp
+++ b/src/surge-xt/gui/widgets/MainFrame.cpp
@@ -24,12 +24,10 @@ namespace Widgets
 {
 MainFrame::MainFrame()
 {
-#if SURGE_JUCE_ACCESSIBLE
     setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
     setAccessible(true);
     setDescription("Surge XT");
     setTitle("Main Frame");
-#endif
 }
 void MainFrame::mouseDown(const juce::MouseEvent &event)
 {
@@ -58,10 +56,8 @@ juce::Component *MainFrame::getSynthControlsLayer()
         synthControls = std::make_unique<OverlayComponent>();
         synthControls->setBounds(getLocalBounds());
         synthControls->setInterceptsMouseClicks(false, true);
-#if SURGE_JUCE_ACCESSIBLE
         synthControls->setTitle("Surge Synth Controls");
         synthControls->setDescription("Surge Synth Controls");
-#endif
         synthControls->getProperties().set("ControlGroup", (int)12);
     }
 
@@ -79,10 +75,8 @@ juce::Component *MainFrame::getModButtonLayer()
         modGroup = std::make_unique<OverlayComponent>();
         modGroup->setBounds(getLocalBounds());
         modGroup->setInterceptsMouseClicks(false, true);
-#if SURGE_JUCE_ACCESSIBLE
         modGroup->setTitle("Modulators");
         modGroup->setDescription("Modulators");
-#endif
         modGroup->getProperties().set("ControlGroup", (int)endCG + 2000);
     }
 
@@ -100,7 +94,6 @@ juce::Component *MainFrame::getControlGroupLayer(ControlGroup cg)
         auto ol = std::make_unique<OverlayComponent>();
         ol->setBounds(getLocalBounds());
         ol->setInterceptsMouseClicks(false, true);
-#if SURGE_JUCE_ACCESSIBLE
         auto t = "Group " + std::to_string((int)cg);
         switch (cg)
         {
@@ -132,7 +125,6 @@ juce::Component *MainFrame::getControlGroupLayer(ControlGroup cg)
         ol->setDescription(t);
         ol->setTitle(t);
         ol->getProperties().set("ControlGroup", (int)cg + 1000);
-#endif
         cgOverlays[cg] = std::move(ol);
     }
 
@@ -149,7 +141,120 @@ void MainFrame::addChildComponentThroughEditor(juce::Component &c)
     editor->addComponentWithTracking(this, c);
 }
 
-#if SURGE_JUCE_ACCESSIBLE
+struct GlobalKeyboardTraverser : public juce::KeyboardFocusTraverser
+{
+    juce::Component *top{nullptr};
+    GlobalKeyboardTraverser(juce::Component *topParent)
+        : juce::KeyboardFocusTraverser(), top(topParent)
+    {
+    }
+
+    static void findAllComponents(const juce::Component *parent,
+                                  std::vector<juce::Component *> &components)
+    {
+        if (parent == nullptr || parent->getNumChildComponents() == 0)
+            return;
+
+        std::vector<juce::Component *> localComponents;
+
+        for (auto *c : parent->getChildren())
+            if (c->isVisible() && c->isEnabled())
+                localComponents.push_back(c);
+
+        auto compare = [](const juce::Component *a, const juce::Component *b) {
+            auto pcg = [](const juce::Component *p) {
+                while (p)
+                {
+                    auto cgp = p->getProperties().getVarPointer("ControlGroup");
+                    if (cgp)
+                        return (int)(*cgp);
+                    p = p->getParentComponent();
+                }
+                return -1;
+            };
+            auto cga = pcg(a);
+            auto cgb = pcg(b);
+
+            if (cga != cgb)
+                return cga < cgb;
+
+            auto at = dynamic_cast<const Surge::GUI::IComponentTagValue *>(a);
+            auto bt = dynamic_cast<const Surge::GUI::IComponentTagValue *>(b);
+
+            if (at && bt)
+                return at->getTag() < bt->getTag();
+
+            return false;
+        };
+
+        std::sort(localComponents.begin(), localComponents.end(), compare);
+
+        // Sort here
+        for (auto *c : localComponents)
+        {
+            components.push_back(c);
+
+            if (!(c->isKeyboardFocusContainer()))
+                findAllComponents(c, components);
+        }
+    }
+
+    juce::Component *navigate(juce::Component *c, int dir)
+    {
+        std::vector<juce::Component *> v;
+        findAllComponents(top, v);
+
+        const auto iter = std::find(v.cbegin(), v.cend(), c);
+        if (iter == v.cend())
+            return nullptr;
+
+        switch (dir)
+        {
+        case 1:
+            if (iter != std::prev(v.cend()))
+            {
+                return *std::next(iter);
+            }
+            break;
+        case -1:
+            if (iter != v.cbegin())
+            {
+                return *std::prev(iter);
+            }
+            break;
+        }
+        return nullptr;
+    }
+
+    juce::Component *traverse(juce::Component *c, int dir)
+    {
+        if (auto *tc = navigate(c, dir))
+        {
+            if (tc->getWantsKeyboardFocus())
+                return tc;
+            return traverse(tc, dir);
+        }
+        return nullptr;
+    }
+
+    juce::Component *getDefaultComponent(juce::Component *parentComponent) override
+    {
+        if (parentComponent == top)
+        {
+            // This never seems to get called
+            // std::cout << "Asked for default" << std::endl;
+        }
+        return nullptr;
+    }
+    juce::Component *getNextComponent(juce::Component *c) override { return traverse(c, +1); }
+    juce::Component *getPreviousComponent(juce::Component *c) override { return traverse(c, -1); }
+    std::vector<juce::Component *> getAllComponents(juce::Component *parentComponent) override
+    {
+        std::vector<juce::Component *> res;
+        findAllComponents(top, res);
+        return res;
+    }
+};
 
 std::unique_ptr<juce::ComponentTraverser> MainFrame::createFocusTraverser()
 {
@@ -161,7 +266,10 @@ std::unique_ptr<juce::ComponentTraverser> MainFrame::OverlayComponent::createFoc
     return std::make_unique<Surge::Widgets::GroupTagTraverser>(this);
 }
 
-#endif
+std::unique_ptr<juce::ComponentTraverser> MainFrame::createKeyboardFocusTraverser()
+{
+    return std::make_unique<GlobalKeyboardTraverser>(this);
+}
 
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/MainFrame.h
+++ b/src/surge-xt/gui/widgets/MainFrame.h
@@ -79,15 +79,13 @@ struct MainFrame : public juce::Component
     juce::Component *getModButtonLayer();
     juce::Component *getSynthControlsLayer();
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::ComponentTraverser> createFocusTraverser() override;
-#endif
+    std::unique_ptr<juce::ComponentTraverser> createKeyboardFocusTraverser() override;
 
     void mouseDown(const juce::MouseEvent &event) override;
 
     struct OverlayComponent : public juce::Component
     {
-#if SURGE_JUCE_ACCESSIBLE
         OverlayComponent()
         {
             setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
@@ -100,7 +98,6 @@ struct MainFrame : public juce::Component
                                                                 juce::AccessibilityRole::group);
         }
         std::unique_ptr<juce::ComponentTraverser> createFocusTraverser() override;
-#endif
     };
 
     void addChildComponentThroughEditor(juce::Component &comp);

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -37,7 +37,6 @@ void TinyLittleIconButton::paint(juce::Graphics &g)
         icons->draw(g, 1.0, t);
 }
 
-#if SURGE_JUCE_ACCESSIBLE
 struct TinyLittleIconButtonAH : public juce::AccessibilityHandler
 {
     explicit TinyLittleIconButtonAH(TinyLittleIconButton &itemComponentToWrap)
@@ -60,7 +59,6 @@ std::unique_ptr<juce::AccessibilityHandler> TinyLittleIconButton::createAccessib
 {
     return std::make_unique<TinyLittleIconButtonAH>(*this);
 }
-#endif
 
 void MenuTitleHelpComponent::getIdealSize(int &idealWidth, int &idealHeight)
 {
@@ -146,9 +144,9 @@ void MenuTitleHelpComponent::launchHelp()
     triggerMenuItem();
 }
 
-#if SURGE_JUCE_ACCESSIBLE
 struct MenuTitleHelpComponentAH : public juce::AccessibilityHandler
 {
+
     explicit MenuTitleHelpComponentAH(MenuTitleHelpComponent &itemComponentToWrap)
         : AccessibilityHandler(
               itemComponentToWrap, juce::AccessibilityRole::menuItem,
@@ -160,8 +158,6 @@ struct MenuTitleHelpComponentAH : public juce::AccessibilityHandler
 
     void showHelp() { itemComponent.launchHelp(); }
 
-    juce::String getTitle() const override { return itemComponent.label; }
-
     MenuTitleHelpComponent &itemComponent;
 };
 
@@ -169,7 +165,6 @@ std::unique_ptr<juce::AccessibilityHandler> MenuTitleHelpComponent::createAccess
 {
     return std::make_unique<MenuTitleHelpComponentAH>(*this);
 }
-#endif
 
 void MenuCenteredBoldLabel::getIdealSize(int &idealWidth, int &idealHeight)
 {
@@ -191,7 +186,6 @@ void MenuCenteredBoldLabel::addToMenu(juce::PopupMenu &m, const std::string labe
     m.addCustomItem(-1, std::make_unique<MenuCenteredBoldLabel>(label));
 }
 
-#if SURGE_JUCE_ACCESSIBLE
 //==============================================================================
 struct MenuCenteredBoldLabelAH : public juce::AccessibilityHandler
 {
@@ -211,7 +205,6 @@ std::unique_ptr<juce::AccessibilityHandler> MenuCenteredBoldLabel::createAccessi
 {
     return std::make_unique<MenuCenteredBoldLabelAH>(*this);
 }
-#endif
 
 ModMenuCustomComponent::ModMenuCustomComponent(const std::string &s, const std::string &a,
                                                std::function<void(OpType)> cb)
@@ -313,7 +306,6 @@ void ModMenuCustomComponent::onSkinChanged()
     mute->icons = icons;
 }
 
-#if SURGE_JUCE_ACCESSIBLE
 struct ModMenuCustomComponentAH : public juce::AccessibilityHandler
 {
     explicit ModMenuCustomComponentAH(ModMenuCustomComponent &itemComponentToWrap)
@@ -343,7 +335,6 @@ std::unique_ptr<juce::AccessibilityHandler> ModMenuCustomComponent::createAccess
 {
     return std::make_unique<ModMenuCustomComponentAH>(*this);
 }
-#endif
 
 // bit of a hack - the menus mean something different so do a cb on a cb
 ModMenuForAllComponent::ModMenuForAllComponent(std::function<void(AllAction)> cb)

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -55,9 +55,7 @@ struct TinyLittleIconButton : public juce::Component
     SurgeImage *icons{nullptr};
     int offset{0};
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TinyLittleIconButton);
 };
@@ -67,6 +65,9 @@ struct MenuTitleHelpComponent : juce::PopupMenu::CustomComponent, Surge::GUI::Sk
     MenuTitleHelpComponent(const std::string &l, const std::string &u)
         : label(l), url(u), juce::PopupMenu::CustomComponent(false)
     {
+        setTitle(l);
+        setDescription(l);
+        setAccessible(true);
     }
 
     void getIdealSize(int &idealWidth, int &idealHeight) override;
@@ -81,9 +82,7 @@ struct MenuTitleHelpComponent : juce::PopupMenu::CustomComponent, Surge::GUI::Sk
     void setCenterBold(bool b) { centerBold = b; }
     void launchHelp();
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MenuTitleHelpComponent);
 };
@@ -99,9 +98,7 @@ struct MenuCenteredBoldLabel : juce::PopupMenu::CustomComponent
     std::string label;
     static void addToMenu(juce::PopupMenu &m, const std::string label);
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 };
 
 struct TinyLittleIconButton;
@@ -132,9 +129,7 @@ struct ModMenuCustomComponent : juce::PopupMenu::CustomComponent, Surge::GUI::Sk
     std::string source, amount;
     std::function<void(OpType)> callback;
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModMenuCustomComponent);
 };

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -335,13 +335,10 @@ float MenuForDiscreteParams::nextValueInOrder(float v, int inc)
     return r;
 }
 
-#if SURGE_JUCE_ACCESSIBLE
-
 std::unique_ptr<juce::AccessibilityHandler> MenuForDiscreteParams::createAccessibilityHandler()
 {
     return std::make_unique<DiscreteAH<MenuForDiscreteParams>>(this);
 }
-#endif
 
 bool MenuForDiscreteParams::keyPressed(const juce::KeyPress &key)
 {

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
@@ -162,9 +162,7 @@ struct MenuForDiscreteParams : public juce::Component,
 
     float nextValueInOrder(float v, int inc);
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MenuForDiscreteParams);
 };

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -579,8 +579,6 @@ void ModulatableSlider::mouseWheelMove(const juce::MouseEvent &event,
     repaint();
 }
 
-#if SURGE_JUCE_ACCESSIBLE
-
 struct ModulatableSliderAH : public juce::AccessibilityHandler
 {
     struct MSValue : public juce::AccessibilityValueInterface
@@ -671,7 +669,6 @@ std::unique_ptr<juce::AccessibilityHandler> ModulatableSlider::createAccessibili
 {
     return std::make_unique<ModulatableSliderAH>(this);
 }
-#endif
 
 bool ModulatableSlider::keyPressed(const juce::KeyPress &key)
 {

--- a/src/surge-xt/gui/widgets/ModulatableSlider.h
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.h
@@ -158,9 +158,7 @@ struct ModulatableSlider : public juce::Component,
     // Where do we position the tray relative to local bounds?
     juce::AffineTransform trayPosition;
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModulatableSlider);
 };

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -30,7 +30,6 @@ namespace Widgets
 {
 ModulationSourceButton::ModulationSourceButton()
 {
-#if SURGE_JUCE_ACCESSIBLE
     setDescription("Modulator");
     setAccessible(true);
     setFocusContainerType(FocusContainerType::focusContainer);
@@ -61,7 +60,6 @@ ModulationSourceButton::ModulationSourceButton()
     };
     addChildComponent(*ol);
     targetAccButton = std::move(ol);
-#endif
 }
 void ModulationSourceButton::paint(juce::Graphics &g)
 {

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.h
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.h
@@ -51,14 +51,12 @@ struct ModulationSourceButton : public juce::Component,
 
     void setAccessibleLabel(const std::string &s)
     {
-#if SURGE_JUCE_ACCESSIBLE
 #if MAC
         setDescription(std::string("Modulator ") + s);
         setTitle(s);
 #else
         setDescription("Modulator");
         setTitle(s);
-#endif
 #endif
     }
 
@@ -81,13 +79,11 @@ struct ModulationSourceButton : public juce::Component,
         modlistIndex = limit_range(modlistIndex, 0, (int)(m.size() - 1));
         modlist = m;
         setAccessibleLabel(getCurrentModLabel());
-#if SURGE_JUCE_ACCESSIBLE
         selectAccButton->setVisible(true);
         if (isLFO())
         {
             targetAccButton->setVisible(true);
         }
-#endif
     }
     bool isMeta{false}, isBipolar{false};
     void setIsMeta(bool b) { isMeta = b; }
@@ -123,7 +119,6 @@ struct ModulationSourceButton : public juce::Component,
     void setState(int s)
     {
         state = s;
-#if SURGE_JUCE_ACCESSIBLE
         if ((state & 3) == 2)
         {
             toggleArmAccButton->setTitle("Disarm");
@@ -132,7 +127,6 @@ struct ModulationSourceButton : public juce::Component,
         {
             toggleArmAccButton->setTitle("Arm");
         }
-#endif
     }
     int getState() const { return state; }
     bool transientArmed{false}; // armed in drop state
@@ -216,9 +210,7 @@ struct ModulationSourceButton : public juce::Component,
 
     void resized() override;
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::Component> targetAccButton, selectAccButton, toggleArmAccButton;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModulationSourceButton);
 };

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -254,8 +254,6 @@ bool MultiSwitch::keyPressed(const juce::KeyPress &key)
     return true;
 }
 
-#if SURGE_JUCE_ACCESSIBLE
-
 struct MultiSwitchRadioButton : public juce::Component
 {
     MultiSwitchRadioButton(MultiSwitch *s, float value, int ival, const std::string &label)
@@ -265,6 +263,7 @@ struct MultiSwitchRadioButton : public juce::Component
         setTitle(label);
         setInterceptsMouseClicks(false, false);
         setAccessible(true);
+        setWantsKeyboardFocus(true);
     }
 
     MultiSwitch *mswitch;
@@ -401,9 +400,6 @@ std::unique_ptr<juce::AccessibilityHandler> MultiSwitch::createAccessibilityHand
         return std::make_unique<DiscreteAH<MultiSwitch, juce::AccessibilityRole::group>>(this);
     }
 }
-#else
-void MultiSwitch::setupAccessibility() {}
-#endif
 
 void MultiSwitchSelfDraw::paint(juce::Graphics &g)
 {

--- a/src/surge-xt/gui/widgets/MultiSwitch.h
+++ b/src/surge-xt/gui/widgets/MultiSwitch.h
@@ -102,10 +102,8 @@ struct MultiSwitch : public juce::Component, public WidgetBaseMixin<MultiSwitch>
     void setHoverOnSwitchDrawable(SurgeImage *d) { hoverOnSwitchD = d; }
 
     void setupAccessibility();
-#if SURGE_JUCE_ACCESSIBLE
     std::vector<std::unique_ptr<juce::Component>> selectionComponents;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MultiSwitch);
 };

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -256,11 +256,9 @@ int NumberField::getChangeMultiplier(const juce::MouseEvent &event)
     return 1;
 }
 
-#if SURGE_JUCE_ACCESSIBLE
 std::unique_ptr<juce::AccessibilityHandler> NumberField::createAccessibilityHandler()
 {
     return std::make_unique<DiscreteAH<NumberField>>(this);
 }
-#endif
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/NumberField.h
+++ b/src/surge-xt/gui/widgets/NumberField.h
@@ -143,9 +143,7 @@ struct NumberField : public juce::Component, public WidgetBaseMixin<NumberField>
         repaint();
     }
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(NumberField);
 };

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -30,7 +30,6 @@ namespace Widgets
 {
 OscillatorWaveformDisplay::OscillatorWaveformDisplay()
 {
-#if SURGE_JUCE_ACCESSIBLE
     setAccessible(true);
     setFocusContainerType(FocusContainerType::focusContainer);
 
@@ -59,7 +58,6 @@ OscillatorWaveformDisplay::OscillatorWaveformDisplay()
             oscdata->wt.queue_id = id;
     };
     menuOverlays[2] = std::move(ol);
-#endif
 }
 OscillatorWaveformDisplay::~OscillatorWaveformDisplay() = default;
 
@@ -1014,20 +1012,16 @@ void OscillatorWaveformDisplay::onOscillatorTypeChanged()
     {
         vis = true;
     }
-#if SURGE_JUCE_ACCESSIBLE
     for (const auto &ao : menuOverlays)
     {
         ao->setVisible(vis);
     }
-#endif
 }
 
-#if SURGE_JUCE_ACCESSIBLE
 std::unique_ptr<juce::AccessibilityHandler> OscillatorWaveformDisplay::createAccessibilityHandler()
 {
     return std::make_unique<juce::AccessibilityHandler>(*this, juce::AccessibilityRole::group);
 }
-#endif
 
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
@@ -92,10 +92,8 @@ struct OscillatorWaveformDisplay : public juce::Component, public Surge::GUI::Sk
     void drawEditorBox(juce::Graphics &g, const std::string &s);
     std::unique_ptr<juce::Component> customEditor;
 
-#if SURGE_JUCE_ACCESSIBLE
     std::array<std::unique_ptr<juce::Component>, 3> menuOverlays;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OscillatorWaveformDisplay);
 };

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -25,6 +25,7 @@
 #include "PatchDB.h"
 #include "fmt/core.h"
 #include "SurgeJUCEHelpers.h"
+#include "AccessibleHelpers.h"
 
 namespace Surge
 {
@@ -1014,7 +1015,18 @@ void PatchSelector::enableTypeAheadIfReady()
     }
 }
 
-#if SURGE_JUCE_ACCESSIBLE
+bool PatchSelector::keyPressed(const juce::KeyPress &key)
+{
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
+
+    if (action == OpenMenu)
+    {
+        showClassicMenu();
+        return true;
+    }
+    return false;
+}
+
 class PatchSelectorAH : public juce::AccessibilityHandler
 {
   public:
@@ -1060,7 +1072,6 @@ std::unique_ptr<juce::AccessibilityHandler> PatchSelector::createAccessibilityHa
 {
     return std::make_unique<PatchSelectorAH>(this);
 }
-#endif
 
 void PatchSelectorCommentTooltip::paint(juce::Graphics &g)
 {

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -48,6 +48,15 @@ struct PatchSelector : public juce::Component,
     {
         current_category = category;
         current_patch = patch;
+
+        if (auto *handler = getAccessibilityHandler())
+        {
+            if (handler->getValueInterface())
+            {
+                handler->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
+            }
+            handler->notifyAccessibilityEvent(juce::AccessibilityEvent::titleChanged);
+        }
     }
 
     bool isFavorite{false};
@@ -114,6 +123,7 @@ struct PatchSelector : public juce::Component,
         // toggleCommentTooltip(false);
         repaint();
     }
+    bool keyPressed(const juce::KeyPress &key) override;
     void showClassicMenu(bool singleCategory = false);
     bool optionallyAddFavorites(juce::PopupMenu &into, bool addColumnBreakAndHeader,
                                 bool addToSubmenu = true);
@@ -162,10 +172,8 @@ struct PatchSelector : public juce::Component,
     bool populatePatchMenuForCategory(int index, juce::PopupMenu &contextMenu, bool single_category,
                                       int &main_e, bool rootCall);
 
-#if SURGE_JUCE_ACCESSIBLE
   private:
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
   protected:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PatchSelector);

--- a/src/surge-xt/gui/widgets/SurgeTextButton.cpp
+++ b/src/surge-xt/gui/widgets/SurgeTextButton.cpp
@@ -41,9 +41,10 @@ void SurgeTextButton::paint(juce::Graphics &g)
 
     auto fc = getLocalBounds().toFloat().reduced(1.5, 1.5);
 
-    auto isHo = isOver();
+    auto isHo = isOver() || hasKeyboardFocus(false);
     auto isEn = isEnabled();
     auto isPr = isDown();
+    auto isFo = hasKeyboardFocus(false);
 
     auto fg = skin->getColor(clr::Text);
 

--- a/src/surge-xt/gui/widgets/Switch.cpp
+++ b/src/surge-xt/gui/widgets/Switch.cpp
@@ -27,9 +27,7 @@ namespace Widgets
 Switch::Switch()
 {
     setRepaintsOnMouseActivity(true);
-#if SURGE_JUCE_ACCESSIBLE
     setDescription("Switch");
-#endif
 }
 Switch::~Switch() = default;
 
@@ -164,7 +162,6 @@ bool Switch::keyPressed(const juce::KeyPress &key)
     return true;
 }
 
-#if SURGE_JUCE_ACCESSIBLE
 struct SwitchAH : public juce::AccessibilityHandler
 {
     explicit SwitchAH(Switch *s)
@@ -221,7 +218,6 @@ std::unique_ptr<juce::AccessibilityHandler> Switch::createAccessibilityHandler()
 {
     return std::make_unique<SwitchAH>(this);
 }
-#endif
 
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/Switch.h
+++ b/src/surge-xt/gui/widgets/Switch.h
@@ -107,9 +107,7 @@ struct Switch : public juce::Component, public WidgetBaseMixin<Switch>
     void setSwitchDrawable(SurgeImage *d) { switchD = d; }
     void setHoverSwitchDrawable(SurgeImage *d) { hoverSwitchD = d; }
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Switch);
 };

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -119,10 +119,8 @@ TypeAhead::TypeAhead(const std::string &l, TypeAheadDataProvider *p)
     lbox->setMultipleSelectionEnabled(false);
     lbox->setVisible(false);
     lbox->setRowHeight(p->getRowHeight());
-#if SURGE_JUCE_ACCESSIBLE
     setTitle(l);
     lbox->setTitle(l);
-#endif
     setColour(ColourIds::borderid, juce::Colours::black);
     setColour(ColourIds::emptyBackgroundId, juce::Colours::white);
 }

--- a/src/surge-xt/gui/widgets/VerticalLabel.cpp
+++ b/src/surge-xt/gui/widgets/VerticalLabel.cpp
@@ -23,9 +23,7 @@ namespace Widgets
 VerticalLabel::VerticalLabel()
 {
     setRepaintsOnMouseActivity(true);
-#if SURGE_JUCE_ACCESSIBLE
     setAccessible(false); // it's just derocative
-#endif
     setInterceptsMouseClicks(false, false);
 }
 VerticalLabel::~VerticalLabel() = default;

--- a/src/surge-xt/gui/widgets/VuMeter.cpp
+++ b/src/surge-xt/gui/widgets/VuMeter.cpp
@@ -25,9 +25,8 @@ namespace Widgets
 {
 VuMeter::VuMeter()
 {
-#if SURGE_JUCE_ACCESSIBLE
     setAccessible(false);
-#endif
+    setWantsKeyboardFocus(false);
     setInterceptsMouseClicks(false, false);
 }
 VuMeter::~VuMeter() = default;

--- a/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
@@ -354,8 +354,6 @@ void WaveShaperSelector::onSkinChanged()
         skin->hoverImageIdForResource(IDB_WAVESHAPER_BG, GUI::Skin::HOVER));
 }
 
-#if SURGE_JUCE_ACCESSIBLE
-
 template <> struct DiscreteAHRange<WaveShaperSelector>
 {
     static int iMaxV(WaveShaperSelector *t) { return n_ws_types - 1; }
@@ -377,7 +375,32 @@ std::unique_ptr<juce::AccessibilityHandler> WaveShaperSelector::createAccessibil
 {
     return std::make_unique<DiscreteAH<WaveShaperSelector>>(this);
 }
-#endif
+
+bool WaveShaperSelector::keyPressed(const juce::KeyPress &key)
+{
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
+
+    if (action == None)
+        return false;
+
+    if (action == OpenMenu)
+    {
+        notifyControlModifierClicked(juce::ModifierKeys(), true);
+        return true;
+    }
+
+    if (action != Increase && action != Decrease)
+        return false;
+
+    int dir = (action == Increase ? 1 : -1);
+    notifyBeginEdit();
+    setValue(nextValueInOrder(value, dir));
+    notifyValueChanged();
+    notifyEndEdit();
+    repaint();
+
+    return true;
+}
 
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/WaveShaperSelector.h
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.h
@@ -77,6 +77,23 @@ struct WaveShaperSelector : public juce::Component, public WidgetBaseMixin<WaveS
         repaint();
     }
 
+    void startHover(const juce::Point<float> &f) override
+    {
+        isWaveHovered = true;
+        repaint();
+    }
+    bool keyPressed(const juce::KeyPress &key) override;
+    void focusGained(juce::Component::FocusChangeType cause) override
+    {
+        startHover(getBounds().getBottomLeft().toFloat());
+        repaint();
+    }
+    void focusLost(juce::Component::FocusChangeType cause) override
+    {
+        endHover();
+        repaint();
+    }
+
     void jog(int by);
 
     void parentHierarchyChanged() override;
@@ -105,9 +122,7 @@ struct WaveShaperSelector : public juce::Component, public WidgetBaseMixin<WaveS
     bool isLabelHovered{false}, isWaveHovered{false}, isDeactivated{false};
     void setDeactivated(bool b) { isDeactivated = b; }
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WaveShaperSelector);
 };

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -318,10 +318,8 @@ void XMLMenuPopulator::populate()
 OscillatorMenu::OscillatorMenu()
 {
     strcpy(mtype, "osc");
-#if SURGE_JUCE_ACCESSIBLE
     setDescription("Oscillator Type");
     setTitle("Oscillator Type");
-#endif
 }
 
 OscillatorMenu::~OscillatorMenu() = default;
@@ -403,7 +401,36 @@ void OscillatorMenu::mouseExit(const juce::MouseEvent &event)
     repaint();
 }
 
-#if SURGE_JUCE_ACCESSIBLE
+bool OscillatorMenu::keyPressed(const juce::KeyPress &key)
+{
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
+
+    if (action == None)
+        return false;
+
+    if (action == OpenMenu)
+    {
+        menu.showMenuAsync(juce::PopupMenu::Options());
+        return true;
+    }
+
+    switch (action)
+    {
+    case Increase:
+        jogBy(+1);
+        return true;
+        break;
+    case Decrease:
+        jogBy(-1);
+        return true;
+        break;
+    default:
+        return false; // but bail out if it does
+        break;
+    }
+
+    return false;
+}
 
 template <typename T> struct XMLValue
 {
@@ -451,15 +478,12 @@ std::unique_ptr<juce::AccessibilityHandler> OscillatorMenu::createAccessibilityH
 {
     return std::make_unique<XMLMenuAH<OscillatorMenu>>(this);
 }
-#endif
 
 FxMenu::FxMenu()
 {
     strcpy(mtype, "fx");
-#if SURGE_JUCE_ACCESSIBLE
     setDescription("FX Type");
     setTitle("FX Type");
-#endif
 }
 
 void FxMenu::paint(juce::Graphics &g)
@@ -756,7 +780,36 @@ void FxMenu::mouseWheelMove(const juce::MouseEvent &event, const juce::MouseWhee
     }
 }
 
-#if SURGE_JUCE_ACCESSIBLE
+bool FxMenu::keyPressed(const juce::KeyPress &key)
+{
+    auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
+
+    if (action == None)
+        return false;
+
+    if (action == OpenMenu)
+    {
+        menu.showMenuAsync(juce::PopupMenu::Options());
+        return true;
+    }
+
+    switch (action)
+    {
+    case Increase:
+        jogBy(+1);
+        return true;
+        break;
+    case Decrease:
+        jogBy(-1);
+        return true;
+        break;
+    default:
+        return false; // but bail out if it does
+        break;
+    }
+
+    return false;
+}
 
 template <> struct XMLValue<FxMenu>
 {
@@ -773,7 +826,6 @@ std::unique_ptr<juce::AccessibilityHandler> FxMenu::createAccessibilityHandler()
 {
     return std::make_unique<XMLMenuAH<FxMenu>>(this);
 }
-#endif
 
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
@@ -149,15 +149,35 @@ struct OscillatorMenu : public juce::Component,
 
     void paint(juce::Graphics &g) override;
 
+    void startHover(const juce::Point<float> &) override
+    {
+        isHovered = true;
+        repaint();
+    }
+    void endHover() override
+    {
+        isHovered = false;
+        repaint();
+    }
+    bool keyPressed(const juce::KeyPress &key) override;
+    void focusGained(juce::Component::FocusChangeType cause) override
+    {
+        startHover(getBounds().getBottomLeft().toFloat());
+        repaint();
+    }
+    void focusLost(juce::Component::FocusChangeType cause) override
+    {
+        endHover();
+        repaint();
+    }
+
     bool text_allcaps{false};
     juce::Font::FontStyleFlags font_style{juce::Font::plain};
 
     int font_size{8}, text_hoffset{0}, text_voffset{0};
     juce::Justification text_align{juce::Justification::centred};
 
-#if SURGE_JUCE_ACCESSIBLE
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OscillatorMenu);
 };
@@ -212,9 +232,29 @@ struct FxMenu : public juce::Component, public XMLMenuPopulator, public WidgetBa
     void setBackgroundDrawable(SurgeImage *b) { bg = b; };
     void setHoverBackgroundDrawable(SurgeImage *bgh) { bgHover = bgh; }
 
-#if SURGE_JUCE_ACCESSIBLE
+    void startHover(const juce::Point<float> &) override
+    {
+        isHovered = true;
+        repaint();
+    }
+    void endHover() override
+    {
+        isHovered = false;
+        repaint();
+    }
+    bool keyPressed(const juce::KeyPress &key) override;
+    void focusGained(juce::Component::FocusChangeType cause) override
+    {
+        startHover(getBounds().getBottomLeft().toFloat());
+        repaint();
+    }
+    void focusLost(juce::Component::FocusChangeType cause) override
+    {
+        endHover();
+        repaint();
+    }
+
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
-#endif
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FxMenu);
 };


### PR DESCRIPTION
Still not done with #4616 but this fixes a lot

- Proper keyboard focus handler in a couple of places including MainFrame
  and the overlays (so patch dialog key handlng works)
- XML configured menus get keys
- Shift-F10 works everywhere
- The define SURGE_JUCE_ACCESSSIBLE is gone. Always compile with juce 6.1
- Focus debugger draws in the right place
- The waveshaper is accessible
- The LFO is keyboard bound
- Patch selector invalidates values on patch change
- Overlays have keyboard (but still don't have SS or MultiSwitch working)