### PR TITLE
Another swath of accessibility

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1565,6 +1565,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             // FIXOWN
             componentForSkinSessionOwnedByMember(skinCtrl->sessionid, effectChooser);
             effectChooser->addListener(this);
+            effectChooser->setStorage(&(synth->storage));
             effectChooser->setBounds(skinCtrl->getRect());
             effectChooser->setTag(tag_fx_select);
             effectChooser->setSkin(currentSkin, bitmapStore);
@@ -4397,8 +4398,11 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
 {
     miniEdit->setSkin(currentSkin, bitmapStore);
     miniEdit->setEditor(this);
+    miniEdit->setDescription(title);
+    miniEdit->setWindowTitle(title);
+
     addComponentWithTracking(frame.get(), *miniEdit);
-    miniEdit->setTitle(title);
+    miniEdit->setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
     miniEdit->setLabel(prompt);
     miniEdit->setValue(value);
     miniEdit->callback = std::move(onOK);

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -460,7 +460,7 @@ Surge::Overlays::OverlayWrapper *SurgeGUIEditor::addJuceEditorOverlay(
         ol = std::make_unique<Surge::Overlays::OverlayWrapper>();
         ol->setBounds(containerSize);
     }
-    ol->setTitle(editorTitle);
+    ol->setWindowTitle(editorTitle);
     ol->setSkin(currentSkin, bitmapStore);
     ol->setSurgeGUIEditor(this);
     ol->setStorage(&(this->synth->storage));

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -322,7 +322,13 @@ struct FormulaControlArea : public juce::Component,
     };
 
     FormulaModulatorEditor *overlay{nullptr};
-    FormulaControlArea(FormulaModulatorEditor *ol) : overlay(ol) {}
+    FormulaControlArea(FormulaModulatorEditor *ol) : overlay(ol)
+    {
+        setAccessible(true);
+        setTitle("Controls");
+        setDescription("Controls");
+        setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
+    }
 
     void resized() override
     {
@@ -357,6 +363,8 @@ struct FormulaControlArea : public juce::Component,
 
             codeS->setBounds(btnrect);
             codeS->setStorage(overlay->storage);
+            codeS->setTitle("Code Selection");
+            codeS->setDescription("Code Selection");
             codeS->setLabels({"Modulator", "Prelude"});
             codeS->addListener(this);
             codeS->setTag(tag_select_tab);
@@ -373,6 +381,8 @@ struct FormulaControlArea : public juce::Component,
             btnrect = juce::Rectangle<int>(getWidth() / 2 - 30, ypos - 1, 60, buttonHeight);
 
             applyS->setBounds(btnrect);
+            applyS->setTitle("Apply");
+            applyS->setDescription("Apply");
             applyS->setStorage(overlay->storage);
             applyS->setLabels({"Apply"});
             applyS->addListener(this);
@@ -522,6 +532,8 @@ FormulaModulatorEditor::FormulaModulatorEditor(SurgeGUIEditor *ed, SurgeStorage 
       lfo_id(lid)
 {
     mainEditor->setScrollbarThickness(8);
+    mainEditor->setTitle("LUA Modulator Code");
+    mainEditor->setDescription("LUA Modulator Code");
 
     mainDocument->insertText(0, fs->formulaString);
 
@@ -532,6 +544,8 @@ FormulaModulatorEditor::FormulaModulatorEditor(SurgeGUIEditor *ed, SurgeStorage 
     preludeDisplay->setTabSize(4, true);
     preludeDisplay->setReadOnly(true);
     preludeDisplay->setScrollbarThickness(8);
+    preludeDisplay->setTitle("LUA Prelude Code");
+    preludeDisplay->setDescription("LUA Prelude Code");
     EditorColors::setColorsFromSkin(preludeDisplay.get(), skin);
 
     controlArea = std::make_unique<FormulaControlArea>(this);

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -76,6 +76,10 @@ struct MSEGControlRegion : public juce::Component,
         this->lfodata = lfos;
         this->canvas = c;
         this->storage = storage;
+        setAccessible(true);
+        setTitle("Controls");
+        setDescription("Controls");
+        setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
         rebuild();
     };
 
@@ -128,6 +132,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         handleDrawable = b->getImage(IDB_MSEG_NODES);
         timeEditMode = (MSEGCanvas::TimeEdit)eds->timeEditMode;
         setOpaque(true);
+        setTitle("MSEG Display and Edit Canvas");
+        setDescription("MSEG Display and Edit Canvas");
     };
 
     /*

--- a/src/surge-xt/gui/overlays/MiniEdit.cpp
+++ b/src/surge-xt/gui/overlays/MiniEdit.cpp
@@ -27,12 +27,15 @@ namespace Overlays
 {
 MiniEdit::MiniEdit()
 {
+    setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
+    setAccessible(true);
     typein = std::make_unique<juce::TextEditor>("minieditTypein");
     typein->setJustification(juce::Justification::centred);
     typein->setFont(Surge::GUI::getFontManager()->getLatoAtSize(11));
     typein->setSelectAllWhenFocused(true);
     typein->setWantsKeyboardFocus(true);
     typein->addListener(this);
+    typein->setTitle("Value");
     addAndMakeVisible(*typein);
 
     okButton = std::make_unique<Surge::Widgets::SurgeTextButton>("minieditOK");

--- a/src/surge-xt/gui/overlays/MiniEdit.h
+++ b/src/surge-xt/gui/overlays/MiniEdit.h
@@ -43,9 +43,13 @@ struct MiniEdit : public juce::Component,
     void onSkinChanged() override;
     void visibilityChanged() override;
     std::string title, label;
-    void setTitle(const std::string t) { title = t; }
-    void setLabel(const std::string t) { label = t; }
-    void setValue(const std::string t) { typein->setText(t, juce::dontSendNotification); }
+    void setWindowTitle(const std::string &t)
+    {
+        title = t;
+        setTitle(title);
+    }
+    void setLabel(const std::string &t) { label = t; }
+    void setValue(const std::string &t) { typein->setText(t, juce::dontSendNotification); }
     std::function<void(const std::string &s)> callback;
 
     void resized() override;

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -37,12 +37,17 @@ OverlayWrapper::OverlayWrapper()
         getLookAndFeel().createDocumentWindowButton(juce::DocumentWindow::maximiseButton));
     tearOutButton->addListener(this);
     addChildComponent(*tearOutButton);
+
+    setAccessible(true);
+    setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
 }
 
 OverlayWrapper::OverlayWrapper(const juce::Rectangle<int> &cb) : OverlayWrapper()
 {
     componentBounds = cb;
     isModal = true;
+    setAccessible(true);
+    setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
 }
 
 void OverlayWrapper::paint(juce::Graphics &g)
@@ -120,6 +125,15 @@ void OverlayWrapper::addAndTakeOwnership(std::unique_ptr<juce::Component> c)
     }
 
     addAndMakeVisible(*primaryChild);
+
+    auto paintTitle = title;
+    if (auto oc = dynamic_cast<Surge::Overlays::OverlayComponent *>(primaryChild.get()))
+    {
+        paintTitle = oc->getEnclosingParentTitle();
+    }
+    std::cout << "Setting accessible title to " << paintTitle << std::endl;
+    setTitle(paintTitle);
+    setDescription(paintTitle);
 }
 
 void OverlayWrapper::buttonClicked(juce::Button *button)

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -41,7 +41,12 @@ struct OverlayWrapper : public juce::Component,
     static constexpr int titlebarSize = 14, margin = 1;
 
     std::string title;
-    void setTitle(const std::string t) { title = t; }
+    void setWindowTitle(const std::string &t)
+    {
+        title = t;
+        setTitle(t);
+        setDescription(t);
+    }
 
     void paint(juce::Graphics &g) override;
 

--- a/src/surge-xt/gui/overlays/TuningOverlays.cpp
+++ b/src/surge-xt/gui/overlays/TuningOverlays.cpp
@@ -1723,7 +1723,13 @@ struct TuningControlArea : public juce::Component,
         tag_open_library
     };
     TuningOverlay *overlay{nullptr};
-    TuningControlArea(TuningOverlay *ol) : overlay(ol) {}
+    TuningControlArea(TuningOverlay *ol) : overlay(ol)
+    {
+        setAccessible(true);
+        setTitle("Controls");
+        setDescription("Controls");
+        setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
+    }
 
     void resized() override
     {

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -39,6 +39,11 @@ EffectChooser::EffectChooser()
             this->currentEffect = i;
             this->notifyValueChanged();
         };
+        q->onReturnKey = [this, i](auto *t) {
+            this->currentEffect = i;
+            this->notifyValueChanged();
+            return true;
+        };
         addAndMakeVisible(*q);
         slotAccOverlays[i] = std::move(q);
     }

--- a/src/surge-xt/gui/widgets/EffectChooser.h
+++ b/src/surge-xt/gui/widgets/EffectChooser.h
@@ -25,6 +25,8 @@
 
 #include <array>
 
+class SurgeStorage;
+
 namespace Surge
 {
 namespace Widgets
@@ -113,6 +115,9 @@ struct EffectChooser : public juce::Component, public WidgetBaseMixin<EffectChoo
 
     void getColorsForSlot(int fxslot, juce::Colour &bgcol, juce::Colour &frcol,
                           juce::Colour &txtcol);
+
+    SurgeStorage *storage{nullptr};
+    void setStorage(SurgeStorage *s) { storage = s; }
 
     std::array<std::unique_ptr<juce::Component>, n_fx_slots> slotAccOverlays;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -46,6 +46,42 @@ struct TimeB
     std::chrono::time_point<std::chrono::high_resolution_clock> start;
 };
 
+template <>
+void jogOverlaySlider<LFOAndStepDisplay>(LFOAndStepDisplay *under,
+                                         OverlayAsAccessibleSlider<LFOAndStepDisplay> *that,
+                                         int dir, bool isShift, bool isCtrl)
+{
+    /*
+     * A bit off but this is only on keypress so the compares are OK
+     */
+    int step = -1;
+    for (auto i = 0; i < n_stepseqsteps; ++i)
+    {
+        if (under->stepSliderOverlays[i].get() == that)
+        {
+            step = i;
+        }
+    }
+    if (step >= 0)
+    {
+        auto f = under->ss->steps[step];
+        auto delt = 0.05;
+        if (isShift)
+            delt = 0.01;
+        if (isCtrl)
+            delt = (under->isUnipolar() ? 1.0 : 0.5) / 12.0;
+        if (dir < 0)
+            delt *= -1;
+
+        if (under->isUnipolar())
+            f = limit01(f + delt);
+        else
+            f = limitpm1(f + delt);
+        under->ss->steps[step] = f;
+        under->repaint();
+    }
+}
+
 LFOAndStepDisplay::LFOAndStepDisplay()
 {
     setTitle("LFO Type And Display");

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -37,6 +37,10 @@ OscillatorWaveformDisplay::OscillatorWaveformDisplay()
         this, "WaveTable: (Name Unknown)", juce::AccessibilityRole::button);
     addChildComponent(*ol);
     ol->onPress = [this](OscillatorWaveformDisplay *d) { showWavetableMenu(); };
+    ol->onMenuKey = [this](OscillatorWaveformDisplay *d) {
+        showWavetableMenu();
+        return true;
+    };
     menuOverlays[0] = std::move(ol);
 
     ol = std::make_unique<OverlayAsAccessibleButton<OscillatorWaveformDisplay>>(
@@ -199,7 +203,6 @@ void OscillatorWaveformDisplay::paint(juce::Graphics &g)
          */
         if (oscdata->wt.current_id != lastWavetableId)
         {
-            std::cout << "Got new OSCDATA ID " << getCurrentWavetableName() << std::endl;
             auto nd = std::string("WaveTable: ") + getCurrentWavetableName();
             menuOverlays[0]->setTitle(nd);
             menuOverlays[0]->setDescription(nd);


### PR DESCRIPTION
Addresses #4616

- Arrow keys on StepSequencer edits values
- Shift-F10 works on wavetable name
- Return selects effects as well as Press Action
- Overlays light up in accesibility
- Chunk of ModList and Formula content displayed
- MiniEdit accessible