### PR TITLE
Fix a regression in Rotary and Distortion

### DIFF
--- a/src/common/dsp/effects/DistortionEffect.cpp
+++ b/src/common/dsp/effects/DistortionEffect.cpp
@@ -89,6 +89,7 @@ void DistortionEffect::process(float *dataL, float *dataR)
     if (wsi < 0 || wsi >= n_fxws)
         wsi = 0;
     auto ws = FXWaveShapers[wsi];
+    // FXWaveShapers have value at wst_soft for 0; so don't add wst_soft
 
     float bL alignas(16)[BLOCK_SIZE << dist_OS_bits];
     float bR alignas(16)[BLOCK_SIZE << dist_OS_bits];
@@ -96,9 +97,9 @@ void DistortionEffect::process(float *dataL, float *dataR)
 
     drive.multiply_2_blocks(dataL, dataR, BLOCK_SIZE_QUAD);
 
-    bool useSSEShaper = (ws + wst_soft >= wst_sine);
+    bool useSSEShaper = (ws >= wst_sine);
 
-    auto wsop = GetQFPtrWaveshaper(wst_soft + ws);
+    auto wsop = GetQFPtrWaveshaper(ws);
 
     float dD = 0.f;
     float dNow = dS;
@@ -139,8 +140,8 @@ void DistortionEffect::process(float *dataL, float *dataR)
             }
             else
             {
-                L = lookup_waveshape(wst_soft + ws, L);
-                R = lookup_waveshape(wst_soft + ws, R);
+                L = lookup_waveshape(ws, L);
+                R = lookup_waveshape(ws, R);
             }
 
             L += a;

--- a/src/common/dsp/effects/RotarySpeakerEffect.cpp
+++ b/src/common/dsp/effects/RotarySpeakerEffect.cpp
@@ -196,6 +196,7 @@ void RotarySpeakerEffect::process(float *dataL, float *dataR)
     if (wsi < 0 || wsi >= n_fxws)
         wsi = 0;
     auto ws = FXWaveShapers[wsi];
+    // FX WaveShapers has values ike wst_soft and stuff so don't add +1 below
 
     /*
     ** This is a set of completely empirical scaling settings to offset gain being too crazy
@@ -205,7 +206,7 @@ void RotarySpeakerEffect::process(float *dataL, float *dataR)
     float compensateStartsAt = 0.18;
     bool square_drive_comp = false;
 
-    switch (ws + 1)
+    switch (ws)
     {
     case wst_hard:
     {
@@ -253,9 +254,9 @@ void RotarySpeakerEffect::process(float *dataL, float *dataR)
             gain_comp_factor = 1.f + ((drive.v - compensateStartsAt) * compensate);
     }
 
-    bool useSSEShaper = (ws + wst_soft >= wst_sine);
+    bool useSSEShaper = (ws >= wst_sine);
 
-    auto wsop = GetQFPtrWaveshaper(wst_soft + ws);
+    auto wsop = GetQFPtrWaveshaper(ws);
 
     for (k = 0; k < BLOCK_SIZE; k++)
     {
@@ -270,13 +271,12 @@ void RotarySpeakerEffect::process(float *dataL, float *dataR)
                 auto wsres = wsop(&wsState, inp, _mm_set1_ps(drive_factor));
                 float r[4];
                 _mm_store_ps(r, wsres);
-                input = r[0] * gain_tweak; // ws + 1 to start on wst_soft
+                input = r[0] * gain_tweak;
             }
             else
             {
                 input =
-                    lookup_waveshape(wst_soft + ws, 0.5f * (dataL[k] + dataR[k]) * drive_factor) *
-                    gain_tweak; // ws + 1 to start on wst_soft
+                    lookup_waveshape(ws, 0.5f * (dataL[k] + dataR[k]) * drive_factor) * gain_tweak;
             }
             input /= gain_comp_factor;
 


### PR DESCRIPTION
Rotary and Distortion had been changed to use a subset
of the saturation models (waveshapers) but in doing so
had not adjusted the internal lookup index correctly.
Remediate.

Closes #5686