### PR TITLE
Final push on accesibility

### DIFF
--- a/scripts/pyauto-tests/basics-show-open-menu.py
+++ b/scripts/pyauto-tests/basics-show-open-menu.py
@@ -1,0 +1,16 @@
+# The simplest use of the accessibility API. Grab a surge xt running instance
+# and dump the accesibility heirarchy
+
+
+import atomacos
+import sxttest
+
+sxt = sxttest.getSXT()
+mf = sxttest.getMainFrame(sxt)
+mf.activate()
+
+ot = sxttest.firstChildByTitle(mf, "Scene A Play Mode")
+ot.ShowMenu()
+oscMenu = sxttest.findAllMenus(sxt)[0]
+
+sxttest.recursiveDump(oscMenu, "OM>")

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -445,6 +445,22 @@ template <typename T> bool OverlayAsAccessibleButton<T>::keyPressed(const juce::
     return false;
 }
 
+inline void fixupJuceTextEditorAccessibility(const juce::Component &te)
+{
+#if MAC
+    for (auto c : te.getChildren())
+    {
+        c->setAccessible(false);
+    }
+#endif
+}
+
+struct HasAccessibleSubComponentForFocus
+{
+    virtual ~HasAccessibleSubComponentForFocus() = default;
+    virtual juce::Component *getCurrentAccessibleSelectionComponent() = 0;
+};
+
 } // namespace Widgets
 } // namespace Surge
 

--- a/src/surge-xt/gui/overlays/MiniEdit.cpp
+++ b/src/surge-xt/gui/overlays/MiniEdit.cpp
@@ -20,6 +20,7 @@
 #include "SurgeImage.h"
 #include "SurgeGUIEditor.h"
 #include "widgets/SurgeTextButton.h"
+#include "AccessibleHelpers.h"
 
 namespace Surge
 {
@@ -36,6 +37,8 @@ MiniEdit::MiniEdit()
     typein->setWantsKeyboardFocus(true);
     typein->addListener(this);
     typein->setTitle("Value");
+    Surge::Widgets::fixupJuceTextEditorAccessibility(*typein);
+
     addAndMakeVisible(*typein);
 
     okButton = std::make_unique<Surge::Widgets::SurgeTextButton>("minieditOK");

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -47,7 +47,6 @@ struct ModulationSideControls : public juce::Component,
     ModulationSideControls(ModulationEditor *e) : editor(e)
     {
         setAccessible(true);
-        setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
         setTitle("Controls");
         setDescription("Controls");
         create();
@@ -246,6 +245,8 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
                                .dawExtraState.editor.modulationEditorState.filterString);
             break;
         }
+
+        setAccessible(true);
     }
 
     void paint(juce::Graphics &g) override
@@ -310,6 +311,7 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
             clearButton->setAccessible(true);
             clearButton->setTitle("Clear");
             clearButton->setDescription("Clear");
+            clearButton->setWantsKeyboardFocus(true);
             addAndMakeVisible(*clearButton);
 
             muted = d.isMuted;
@@ -323,6 +325,7 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
                 contents->rebuildFrom(me->synth);
             });
             muteButton->setAccessible(true);
+            muteButton->setWantsKeyboardFocus(true);
             addAndMakeVisible(*muteButton);
 
             surgeLikeSlider = std::make_unique<Surge::Widgets::ModulatableSlider>();
@@ -335,10 +338,10 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
             surgeLikeSlider->setAccessible(true);
             surgeLikeSlider->setTitle("Depth");
             surgeLikeSlider->setDescription("Depth");
+            surgeLikeSlider->setWantsKeyboardFocus(true);
             addAndMakeVisible(*surgeLikeSlider);
 
             setAccessible(true);
-            setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
             resetValuesFromDatum();
         }
 
@@ -1371,6 +1374,8 @@ ModulationEditor::ModulationEditor(SurgeGUIEditor *ed, SurgeSynthesizer *s)
     modContents->rebuildFrom(synth);
     viewport = std::make_unique<juce::Viewport>();
     viewport->setViewedComponent(modContents.get(), false);
+    viewport->setAccessible(true);
+
     addAndMakeVisible(*viewport);
 
     struct IdleTimer : juce::Timer

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -131,7 +131,6 @@ void OverlayWrapper::addAndTakeOwnership(std::unique_ptr<juce::Component> c)
     {
         paintTitle = oc->getEnclosingParentTitle();
     }
-    std::cout << "Setting accessible title to " << paintTitle << std::endl;
     setTitle(paintTitle);
     setDescription(paintTitle);
 }

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -19,6 +19,7 @@
 #include "SurgeGUIUtils.h"
 #include "widgets/TypeAheadTextEditor.h"
 #include "widgets/SurgeTextButton.h"
+#include "AccessibleHelpers.h"
 
 namespace Surge
 {
@@ -128,7 +129,8 @@ PatchStoreDialog::PatchStoreDialog()
         auto ed = std::make_unique<juce::TextEditor>(n);
         ed->setJustification(juce::Justification::centredLeft);
         ed->setWantsKeyboardFocus(true);
-
+        Surge::Widgets::fixupJuceTextEditorAccessibility(*ed);
+        ed->setTitle(n);
         addAndMakeVisible(*ed);
         return std::move(ed);
     };
@@ -141,7 +143,9 @@ PatchStoreDialog::PatchStoreDialog()
     commentEd = makeEd("patch comment");
     commentEd->setMultiLine(true, true);
     commentEd->setReturnKeyStartsNewLine(true);
+    commentEd->setTitle("patch comment");
     commentEd->setJustification(juce::Justification::topLeft);
+    Surge::Widgets::fixupJuceTextEditorAccessibility(*commentEd);
 
 #if HAS_TAGS_FIELD
     tagEd = makeEd("patch tags");
@@ -191,6 +195,8 @@ PatchStoreDialog::PatchStoreDialog()
     storeTuningButton = std::make_unique<juce::ToggleButton>();
     storeTuningButton->setToggleState(false, juce::dontSendNotification);
     storeTuningButton->setButtonText("");
+    storeTuningButton->setTitle("Store Patch In Tuning");
+    storeTuningButton->setDescription("Store Patch In Tuning");
     addAndMakeVisible(*storeTuningButton);
 
     storeTuningLabel = makeL(Surge::GUI::toOSCaseForMenu("Store Tuning in Patch"));

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
@@ -16,6 +16,7 @@
 #include "TypeinParamEditor.h"
 #include "RuntimeFont.h"
 #include "SurgeGUIEditor.h"
+#include "AccessibleHelpers.h"
 
 namespace Surge
 {
@@ -23,13 +24,20 @@ namespace Overlays
 {
 TypeinParamEditor::TypeinParamEditor()
 {
+    setAccessible(true);
+    setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
+
     textEd = std::make_unique<juce::TextEditor>("typeinParamEditor");
     textEd->addListener(this);
     textEd->setSelectAllWhenFocused(true);
     textEd->setFont(Surge::GUI::getFontManager()->getLatoAtSize(11));
     textEd->setIndents(4, (textEd->getHeight() - textEd->getTextHeight()) / 2);
     textEd->setJustification(juce::Justification::centred);
+    textEd->setTitle("New Value");
+    textEd->setDescription("New Value");
+    Surge::Widgets::fixupJuceTextEditorAccessibility(*textEd);
     addAndMakeVisible(*textEd);
+
     textEd->setWantsKeyboardFocus(true);
 }
 

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.h
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.h
@@ -60,7 +60,12 @@ struct TypeinParamEditor : public juce::Component,
     }
 
     std::string mainLabel;
-    void setMainLabel(const std::string &s) { mainLabel = s; }
+    void setMainLabel(const std::string &s)
+    {
+        mainLabel = s;
+        setTitle("Edit " + mainLabel);
+        setDescription("Edit " + mainLabel);
+    }
     std::string primaryVal, secondaryVal;
     void setValueLabels(const std::string &pri, const std::string &sec)
     {

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -378,6 +378,15 @@ void MultiSwitch::setupAccessibility()
     }
 }
 
+juce::Component *MultiSwitch::getCurrentAccessibleSelectionComponent()
+{
+    if (getIntegerValue() < 0 || getIntegerValue() >= selectionComponents.size())
+    {
+        return nullptr;
+    }
+    return selectionComponents[getIntegerValue()].get();
+}
+
 template <> struct DiscreteAHRange<MultiSwitch>
 {
     static int iMaxV(MultiSwitch *t) { return t->rows * t->columns - 1; }

--- a/src/surge-xt/gui/widgets/MultiSwitch.h
+++ b/src/surge-xt/gui/widgets/MultiSwitch.h
@@ -18,6 +18,7 @@
 
 #include "SurgeJUCEHelpers.h"
 #include "WidgetBaseMixin.h"
+#include "AccessibleHelpers.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -32,7 +33,9 @@ namespace Widgets
  * MultiSwitch (f.k.a CHSwitch2 in VSTGUI land) takes a
  * glyph with rows and columns to allow multiple selection
  */
-struct MultiSwitch : public juce::Component, public WidgetBaseMixin<MultiSwitch>
+struct MultiSwitch : public juce::Component,
+                     public WidgetBaseMixin<MultiSwitch>,
+                     public Surge::Widgets::HasAccessibleSubComponentForFocus
 {
     MultiSwitch();
     ~MultiSwitch();
@@ -103,6 +106,7 @@ struct MultiSwitch : public juce::Component, public WidgetBaseMixin<MultiSwitch>
 
     void setupAccessibility();
     std::vector<std::unique_ptr<juce::Component>> selectionComponents;
+    juce::Component *getCurrentAccessibleSelectionComponent() override;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MultiSwitch);

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -15,6 +15,7 @@
 
 #include "TypeAheadTextEditor.h"
 #include "MainFrame.h"
+#include "AccessibleHelpers.h"
 
 namespace Surge
 {
@@ -123,6 +124,7 @@ TypeAhead::TypeAhead(const std::string &l, TypeAheadDataProvider *p)
     lbox->setTitle(l);
     setColour(ColourIds::borderid, juce::Colours::black);
     setColour(ColourIds::emptyBackgroundId, juce::Colours::white);
+    fixupJuceTextEditorAccessibility(*this);
 }
 
 TypeAhead::~TypeAhead() = default;


### PR DESCRIPTION
- TypeIn is accesible for edits
- The 'phantom extras' in miniedit and typein gone
- Text Editor Accesibility Corrected
- Patch Store Dialog Improved
- Tab Order with MultiSwitch into Child component
- Introduce HasAccessibleSubComponent interface to support above
- Modulation Editor Tab Order works

Addresses #4616