### PR TITLE
Four tab-order fixes

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1934,7 +1934,7 @@ bool SurgeGUIEditor::open(void *parent)
     frame = std::make_unique<Surge::Widgets::MainFrame>();
     frame->setBounds(0, 0, currentSkin->getWindowSizeX(), currentSkin->getWindowSizeY());
     frame->setSurgeGUIEditor(this);
-    frame->setWantsKeyboardFocus(true);
+    // frame->setWantsKeyboardFocus(true);
     juceEditor->addAndMakeVisible(*frame);
     juceEditor->addKeyListener(this);
 
@@ -6469,7 +6469,8 @@ void SurgeGUIEditor::globalFocusChanged(juce::Component *fc)
         std::cout << "FC [" << fc << "] ";
         if (fc)
         {
-            std::cout << fc->getTitle() << " " << typeid(*fc).name() << " " << newRect.toString();
+            std::cout << fc->getTitle() << " " << typeid(*fc).name() << " " << newRect.toString()
+                      << " " << fc->getAccessibilityHandler() << " " << fc->getTitle();
         }
         std::cout << std::endl;
     }

--- a/src/surge-xt/gui/widgets/MainFrame.cpp
+++ b/src/surge-xt/gui/widgets/MainFrame.cpp
@@ -18,6 +18,7 @@
 #include "SurgeGUICallbackInterfaces.h"
 #include "AccessibleHelpers.h"
 #include "MultiSwitch.h"
+#include "SurgeGUIEditorTags.h"
 
 namespace Surge
 {
@@ -25,7 +26,7 @@ namespace Widgets
 {
 MainFrame::MainFrame()
 {
-    setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
+    setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
     setAccessible(true);
     setDescription("Surge XT");
     setTitle("Main Frame");
@@ -183,7 +184,14 @@ struct GlobalKeyboardTraverser : public juce::KeyboardFocusTraverser
             auto bt = dynamic_cast<const Surge::GUI::IComponentTagValue *>(b);
 
             if (at && bt)
+            {
+                if (at->getTag() == tag_settingsmenu)
+                    return true;
+                if (bt->getTag() == tag_settingsmenu)
+                    return false;
+
                 return at->getTag() < bt->getTag();
+            }
 
             return false;
         };
@@ -231,8 +239,8 @@ struct GlobalKeyboardTraverser : public juce::KeyboardFocusTraverser
         if (!c)
             return nullptr;
 
-        const auto iter = std::find(v.cbegin(), v.cend(), c);
-        if (iter == v.cend())
+        auto iter = std::find(v.begin(), v.end(), c);
+        if (iter == v.end())
         {
             return nullptr;
         }
@@ -241,15 +249,25 @@ struct GlobalKeyboardTraverser : public juce::KeyboardFocusTraverser
         switch (dir)
         {
         case 1:
-            if (iter != std::prev(v.cend()))
+            while (!res && iter != std::prev(v.cend()))
             {
                 res = *std::next(iter);
+                iter++;
+            }
+            if (!res)
+            {
+                res = *(v.cbegin());
             }
             break;
         case -1:
-            if (iter != v.cbegin())
+            while (!res && iter != v.cbegin())
             {
                 res = *std::prev(iter);
+                iter--;
+            }
+            if (!res)
+            {
+                res = *(std::prev(v.cend()));
             }
             break;
         }

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -26,7 +26,12 @@ namespace Surge
 namespace Widgets
 {
 
-MultiSwitch::MultiSwitch() { setRepaintsOnMouseActivity(true); }
+MultiSwitch::MultiSwitch()
+{
+    setRepaintsOnMouseActivity(true);
+    setAccessible(true);
+    setWantsKeyboardFocus(true);
+}
 MultiSwitch::~MultiSwitch() = default;
 
 void MultiSwitch::paint(juce::Graphics &g)
@@ -380,6 +385,9 @@ void MultiSwitch::setupAccessibility()
 
 juce::Component *MultiSwitch::getCurrentAccessibleSelectionComponent()
 {
+    if (rows * columns <= 1)
+        return this;
+
     if (getIntegerValue() < 0 || getIntegerValue() >= selectionComponents.size())
     {
         return nullptr;


### PR DESCRIPTION
1: The MultiSwitch with rows=cols=1 would null out the children
   and confuse the tab order, basically making menu not tab order
   visible (and save!)
2: The tab didn't "loop" properly and dealt poorly with hitting
   null components; fix that
3: Make the frames focus containers but not keyboard focus containers
   to skip an ordering in the tab heirarchy
4: Make the main menu the 'first' item in tab order

Addresses #4616