### PR TITLE
Fix MSEG controls RMB menus not working, plus other minor stuff

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2688,8 +2688,10 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
             tuningSubMenu.addSeparator();
         }
 
+        std::string openname = isAnyOverlayPresent(TUNING_EDITOR) ? "Close " : "Open ";
+
         Surge::GUI::addMenuWithShortcut(tuningSubMenu,
-                                        Surge::GUI::toOSCaseForMenu("Open Tuning Editor..."),
+                                        Surge::GUI::toOSCaseForMenu(openname + "Tuning Editor..."),
                                         showShortcutDescription("Alt+T", "⌥T"),
                                         [this]() { this->toggleOverlay(TUNING_EDITOR); });
 

--- a/src/surge-xt/gui/overlays/TuningOverlays.cpp
+++ b/src/surge-xt/gui/overlays/TuningOverlays.cpp
@@ -939,8 +939,7 @@ struct IntervalMatrix : public juce::Component, public Surge::GUI::SkinConsuming
     {
         whatLabel->setText("Scale Rotation Intervals",
                            juce::NotificationType::dontSendNotification);
-        explLabel->setText("If you shift the scale root to note N\n"
-                           "show the interval to note M",
+        explLabel->setText("If you shift the scale root to note N, show the interval to note M",
                            juce::NotificationType::dontSendNotification);
         intervalPainter->mode = IntervalMatrix::IntervalPainter::ROTATION;
 
@@ -951,7 +950,7 @@ struct IntervalMatrix : public juce::Component, public Surge::GUI::SkinConsuming
     {
         whatLabel->setText("Interval Between Notes", juce::NotificationType::dontSendNotification);
         explLabel->setText(
-            "Given any two notes in the loaded scale\nshow the interval in cents between them",
+            "Given any two notes in the loaded scale, show the interval in cents between them",
             juce::NotificationType::dontSendNotification);
         intervalPainter->mode = IntervalMatrix::IntervalPainter::INTERV;
         repaint();
@@ -961,7 +960,7 @@ struct IntervalMatrix : public juce::Component, public Surge::GUI::SkinConsuming
     {
         whatLabel->setText("Interval to Equal Division",
                            juce::NotificationType::dontSendNotification);
-        explLabel->setText("Given any two notes in the loaded scale\nshow the distance to the "
+        explLabel->setText("Given any two notes in the loaded scale, show the distance to the "
                            "equal division interval",
                            juce::NotificationType::dontSendNotification);
         intervalPainter->mode = IntervalMatrix::IntervalPainter::DIST;

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -128,7 +128,7 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
     bool edit_trigmask{false};
     void setCanEditEnvelopes(bool b) { edit_trigmask = b; }
 
-    void showMSEGPopupMenu();
+    void showLFODisplayPopupMenu(SurgeGUIEditor::OverlayTags tag);
 
     void onSkinChanged() override;
 

--- a/src/surge-xt/gui/widgets/NumberField.h
+++ b/src/surge-xt/gui/widgets/NumberField.h
@@ -49,7 +49,7 @@ struct NumberField : public juce::Component, public WidgetBaseMixin<NumberField>
     int getIntValue() const { return iValue; }
     void setIntValue(int v)
     {
-        value = 1.f * (v - iMin) / (iMax - iMin);
+        value = Parameter::intScaledToFloat(v, iMax, iMin);
         bounceToInt();
         notifyValueChanged();
         repaint();


### PR DESCRIPTION
Also expand `showMSEGPopupMenu()` into covering both MSEG and Formula context menus.
Add context menu for Formula.
Show the keyboard shortcut for LFO editor overlays (Alt+E).
Make "Open Tuning Editor..." menu entry flip between Open/Close too.
Very minor label tweak in Tuning Editor (one line instead of two lines).