### PR TITLE
Add some prompts for accesible startup and destructive actions

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -161,6 +161,12 @@ void initMaps()
             case UseKeyboardShortcuts_Standalone:
                 r = "useKeyboardShortcutsStandalone";
                 break;
+            case PromptToActivateShortcutsOnAccKeypress:
+                r = "promptToActivateShortcutsOnAccKeypress";
+                break;
+            case PromptToActivateCategoryAndPatchOnKeypress:
+                r = "promptToActivateCategoryAndPatchOnKeypress";
+                break;
             case InfoWindowPopupOnIdle:
                 r = "infoWindowPopupOnIdle";
                 break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -69,6 +69,8 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
 
     UseKeyboardShortcuts_Plugin,
     UseKeyboardShortcuts_Standalone,
+    PromptToActivateShortcutsOnAccKeypress,
+    PromptToActivateCategoryAndPatchOnKeypress,
 
     TuningOverlayLocation,
     ModlistOverlayLocation,

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -408,11 +408,8 @@ enum AccessibleKeyModifier
 };
 
 inline std::tuple<AccessibleKeyEditAction, AccessibleKeyModifier>
-accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
+accessibleEditActionInternal(const juce::KeyPress &key)
 {
-    if (!Surge::GUI::allowKeyboardEdits(storage))
-        return {None, NoModifier};
-
     if (key.getKeyCode() == juce ::KeyPress::downKey)
     {
         if (key.getModifiers().isShiftDown())
@@ -462,6 +459,21 @@ accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
     }
 
     return {None, NoModifier};
+}
+
+inline std::tuple<AccessibleKeyEditAction, AccessibleKeyModifier>
+accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
+{
+    if (!Surge::GUI::allowKeyboardEdits(storage))
+        return {None, NoModifier};
+
+    return accessibleEditActionInternal(key);
+}
+
+inline bool isAccessibleKey(const juce::KeyPress &key)
+{
+    auto [a, m] = accessibleEditActionInternal(key);
+    return a != None;
 }
 
 template <typename T> bool OverlayAsAccessibleSlider<T>::keyPressed(const juce::KeyPress &key)

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -27,6 +27,8 @@
 #include "SkinSupport.h"
 #include "SkinColors.h"
 
+#include "UserDefaults.h"
+
 #include "overlays/OverlayComponent.h"
 #include "overlays/MSEGEditor.h"
 #include "overlays/OverlayWrapper.h" // This needs to be concrete for inline functions for now
@@ -698,6 +700,16 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool getUseKeyboardShortcuts();
     void setUseKeyboardShortcuts(bool b);
     void toggleUseKeyboardShortcuts();
+
+    std::unique_ptr<juce::AlertWindow> okcWithToggleAlertWindow;
+    std::unique_ptr<juce::ToggleButton> okcWithToggleToggleButton;
+    std::function<void()> okcWithToggleCallback;
+
+    // Return whether we called the OK action automatically or not
+    bool promptForOKCancelWithDontAskAgain(const ::std::string &title, const std::string &msg,
+                                           Surge::Storage::DefaultKey dontAskAgainKey,
+                                           std::function<void()> okCallback,
+                                           std::string ynMessage = "Remember my choice");
 
   private:
     bool scannedForMidiPresets = false;


### PR DESCRIPTION
1. If you press an accessible key and keyboard mapping isn't
   on, ask. Improves #4616
2. If you press shift/lr for patch and cmd/lr for category
   prompt before blowing away your patch
3. In both cases, have a 'sticky' option to remember your
   choice, and add that as a generic capability