### PR TITLE
Focus Management after Typeines

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3962,6 +3962,7 @@ void SurgeGUIEditor::promptForUserValueEntry(Parameter *p, juce::Component *c, i
 {
     if (typeinParamEditor->isVisible())
     {
+        typeinParamEditor->setReturnFocusTarget(nullptr);
         typeinParamEditor->setVisible(false);
     }
 
@@ -4063,6 +4064,7 @@ void SurgeGUIEditor::promptForUserValueEntry(Parameter *p, juce::Component *c, i
     typeinParamEditor->setBoundsToAccompany(c->getBounds(), frame->getBounds());
     typeinParamEditor->setVisible(true);
     typeinParamEditor->toFront(true);
+    typeinParamEditor->setReturnFocusTarget(c);
     typeinParamEditor->grabFocus();
 }
 
@@ -4397,7 +4399,8 @@ float SurgeGUIEditor::getModulationF01FromString(long tag, const std::string &s)
 
 void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::string &prompt,
                                        const std::string &title, const juce::Point<int> &iwhere,
-                                       std::function<void(const std::string &)> onOK)
+                                       std::function<void(const std::string &)> onOK,
+                                       juce::Component *returnFocusTo)
 {
     miniEdit->setSkin(currentSkin, bitmapStore);
     miniEdit->setEditor(this);
@@ -4412,6 +4415,7 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
     miniEdit->setBounds(0, 0, getWindowSizeX(), getWindowSizeY());
     miniEdit->setVisible(true);
     miniEdit->toFront(true);
+    miniEdit->setFocusReturnTarget(returnFocusTo);
     miniEdit->grabFocus();
 }
 
@@ -4575,10 +4579,12 @@ void SurgeGUIEditor::openMacroRenameDialog(const int ccid, const juce::Point<int
 
                 synth->refresh_editor = true;
             }
-        });
+        },
+        msb);
 }
 
-void SurgeGUIEditor::openLFORenameDialog(const int lfo_id, const juce::Point<int> where)
+void SurgeGUIEditor::openLFORenameDialog(const int lfo_id, const juce::Point<int> where,
+                                         juce::Component *c)
 {
     auto msi = modsource_index;
 
@@ -4592,7 +4598,7 @@ void SurgeGUIEditor::openLFORenameDialog(const int lfo_id, const juce::Point<int
         synth->storage.getPatch().LFOBankLabel[current_scene][lfo_id][msi],
         fmt::format("Enter a new name for {:s}:",
                     modulatorNameWithIndex(current_scene, modsource, msi, false, false, true)),
-        "Rename Modulator", juce::Point<int>(10, 10), callback);
+        "Rename Modulator", juce::Point<int>(10, 10), callback, c);
 }
 
 void SurgeGUIEditor::resetSmoothing(Modulator::SmoothingMode t)
@@ -5912,7 +5918,11 @@ bool SurgeGUIEditor::isAHiddenSendOrReturn(Parameter *p)
     return false;
 }
 
-void SurgeGUIEditor::hideTypeinParamEditor() { typeinParamEditor->setVisible(false); }
+void SurgeGUIEditor::hideTypeinParamEditor()
+{
+    typeinParamEditor->setReturnFocusTarget(nullptr);
+    typeinParamEditor->setVisible(false);
+}
 
 void SurgeGUIEditor::activateFromCurrentFx()
 {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -399,7 +399,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     void openMacroRenameDialog(const int ccid, const juce::Point<int> where,
                                Surge::Widgets::ModulationSourceButton *msb);
-    void openLFORenameDialog(const int lfo_id, const juce::Point<int> where);
+    void openLFORenameDialog(const int lfo_id, const juce::Point<int> where, juce::Component *r);
 
     void lfoShapeChanged(int prior, int curr);
     void broadcastMSEGState();
@@ -565,7 +565,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
   public:
     void promptForMiniEdit(const std::string &value, const std::string &prompt,
                            const std::string &title, const juce::Point<int> &where,
-                           std::function<void(const std::string &)> onOK);
+                           std::function<void(const std::string &)> onOK,
+                           juce::Component *returnFocusTo = nullptr);
 
     /*
      * This is the JUCE component management

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -976,7 +976,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                     Surge::GUI::toOSCaseForMenu("Rename Modulator..."), [this, control, lfo_id]() {
                         auto pos = control->asJuceComponent()->getBounds().getTopLeft();
 
-                        openLFORenameDialog(lfo_id, pos);
+                        openLFORenameDialog(lfo_id, pos, control->asJuceComponent());
                     });
 
                 contextMenu.addSeparator();

--- a/src/surge-xt/gui/overlays/MiniEdit.cpp
+++ b/src/surge-xt/gui/overlays/MiniEdit.cpp
@@ -161,6 +161,7 @@ void MiniEdit::buttonClicked(juce::Button *button)
         callback(typein->getText().toStdString());
     }
 
+    doReturnFocus();
     setVisible(false);
 }
 
@@ -182,14 +183,33 @@ void MiniEdit::visibilityChanged()
             editor->vkbForward--;
         }
     }
+
+    if (!isVisible())
+    {
+        doReturnFocus();
+    }
 }
 
 void MiniEdit::textEditorReturnKeyPressed(juce::TextEditor &editor)
 {
     callback(typein->getText().toStdString());
+    doReturnFocus();
     setVisible(false);
 }
 
-void MiniEdit::textEditorEscapeKeyPressed(juce::TextEditor &editor) { setVisible(false); }
+void MiniEdit::textEditorEscapeKeyPressed(juce::TextEditor &editor)
+{
+    doReturnFocus();
+    setVisible(false);
+}
+
+void MiniEdit::doReturnFocus()
+{
+    if (returnFocusComp)
+    {
+        returnFocusComp->grabKeyboardFocus();
+    }
+    returnFocusComp = nullptr;
+}
 } // namespace Overlays
 } // namespace Surge

--- a/src/surge-xt/gui/overlays/MiniEdit.h
+++ b/src/surge-xt/gui/overlays/MiniEdit.h
@@ -62,6 +62,10 @@ struct MiniEdit : public juce::Component,
     void textEditorEscapeKeyPressed(juce::TextEditor &editor) override;
     void textEditorReturnKeyPressed(juce::TextEditor &editor) override;
     void grabFocus() { typein->grabKeyboardFocus(); }
+
+    juce::Component *returnFocusComp{nullptr};
+    void setFocusReturnTarget(juce::Component *c) { returnFocusComp = c; }
+    void doReturnFocus();
     SurgeGUIEditor *editor{nullptr};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MiniEdit);

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
@@ -127,6 +127,11 @@ void TypeinParamEditor::visibilityChanged()
             editor->vkbForward--;
         }
     }
+
+    if (!isVisible())
+    {
+        doReturnFocus();
+    }
 }
 
 void TypeinParamEditor::onSkinChanged()
@@ -176,6 +181,7 @@ void TypeinParamEditor::textEditorReturnKeyPressed(juce::TextEditor &te)
 
     if (res)
     {
+        doReturnFocus();
         setVisible(false);
     }
     else
@@ -189,8 +195,21 @@ void TypeinParamEditor::textEditorReturnKeyPressed(juce::TextEditor &te)
     }
 }
 
-void TypeinParamEditor::textEditorEscapeKeyPressed(juce::TextEditor &te) { setVisible(false); }
+void TypeinParamEditor::textEditorEscapeKeyPressed(juce::TextEditor &te)
+{
+    doReturnFocus();
+    setVisible(false);
+}
 
 void TypeinParamEditor::grabFocus() { textEd->grabKeyboardFocus(); }
+
+void TypeinParamEditor::doReturnFocus()
+{
+    if (returnFocusComp)
+    {
+        returnFocusComp->grabKeyboardFocus();
+    }
+    returnFocusComp = nullptr;
+}
 } // namespace Overlays
 } // namespace Surge

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.h
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.h
@@ -39,6 +39,9 @@ struct TypeinParamEditor : public juce::Component,
     SurgeGUIEditor *editor{nullptr};
     void setSurgeGUIEditor(SurgeGUIEditor *e) { editor = e; }
     void grabFocus();
+    juce::Component *returnFocusComp{nullptr};
+    void setReturnFocusTarget(juce::Component *that) { returnFocusComp = that; }
+    void doReturnFocus();
     juce::Rectangle<int> getRequiredSize();
     void setBoundsToAccompany(const juce::Rectangle<int> &controlRect,
                               const juce::Rectangle<int> &parentRect);

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -438,7 +438,7 @@ void ModulationSourceButton::mouseDoubleClick(const juce::MouseEvent &event)
             int lfo_id = getCurrentModSource() - ms_lfo1;
             auto sge = firstListenerOfType<SurgeGUIEditor>();
 
-            sge->openLFORenameDialog(lfo_id, rect.getTopLeft());
+            sge->openLFORenameDialog(lfo_id, rect.getTopLeft(), this);
 
             return;
         }


### PR DESCRIPTION
Addresses #5756

When a typein is up and you dismiss it, you want focus to return
to the source. We have two codepaths to do this

- TypeinParamEditor gets a returnFocusTo and manages it
- And mini edits for rename operations