### PR TITLE
Fix double opened RMB context on waveshaper selector

### DIFF
--- a/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
@@ -187,14 +187,15 @@ void WaveShaperSelector::mouseDown(const juce::MouseEvent &event)
     everDragged = false;
     everMoved = false;
 
-    if (event.mods.isPopupMenu())
-    {
-        notifyControlModifierClicked(event.mods);
-    }
-    if (labelArea.contains(event.position.toInt()))
+    if (labelArea.contains(event.position.toInt()) && event.mods.isLeftButtonDown())
     {
         auto m = event.mods.withFlags(juce::ModifierKeys::popupMenuClickModifier);
         notifyControlModifierClicked(m);
+    }
+
+    if (event.mods.isPopupMenu())
+    {
+        notifyControlModifierClicked(event.mods);
     }
 }
 


### PR DESCRIPTION
So when right clicking in the label area of WS selector, the context menu would not close when clicking away. This PR fixes that.