### PR TITLE
(XT 1.1) Patches without Categories appear

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -820,6 +820,8 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir, string subdir,
         ** stack
         */
         std::vector<fs::path> alldirs;
+        if (userDir)
+            alldirs.push_back(patchpath);
         std::deque<fs::path> workStack;
         workStack.push_back(patchpath);
         while (!workStack.empty())
@@ -848,7 +850,12 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir, string subdir,
         for (auto &p : alldirs)
         {
             PatchCategory c;
-            c.name = path_to_string(p).substr(patchpathSubstrLength);
+            auto name = std::string("_Unsorted");
+            auto pn = path_to_string(p);
+            if (pn.size() > patchpathSubstrLength)
+                name = pn.substr(patchpathSubstrLength);
+
+            c.name = name;
             c.internalid = category;
             c.isFactory = !userDir;
 


### PR DESCRIPTION
- Put patches without categories in the "_Unsorted" directory
- This is a bug 1.9 and XT both have so merge after 1.0