### PR TITLE
(XT 1.1) Move to std::thread for patch load thread spawn

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1405,10 +1405,10 @@ class alignas(16) SurgeStorage
 
 #define DEBUG_RNG_THREADING 0
 #if DEBUG_RNG_THREADING
-    pthread_t audioThreadID = 0;
+    std::thread::id audioThreadID{0};
     inline void runningOnAudioThread()
     {
-        if (audioThreadID && pthread_self() != audioThreadID)
+        if (audioThreadID && std::this_thread::get_id() != audioThreadID)
         {
             std::cout << "BUM CALL ON NON AUDIO THREAD" << std::endl;
         }


### PR DESCRIPTION
The patch load thread spawner used pthreads/CreateThread, as one
has to do before c++11, but that was a decade ago so lets move
to std::thread

Closes #5494 