### PR TITLE
(XT 1.1) Improve TestCase runtime

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -72,8 +72,16 @@ double dsamplerate_os, dsamplerate_os_inv;
 
 using namespace std;
 
+std::string SurgeStorage::skipPatchLoadDataPathSentinel = "<SKIP-PATCH-SENTINEL>";
+
 SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
 {
+    bool loadWtAndPatch = true;
+    loadWtAndPatch = !skipLoadWtAndPatch && suppliedDataPath != skipPatchLoadDataPathSentinel;
+
+    if (suppliedDataPath == skipPatchLoadDataPathSentinel)
+        suppliedDataPath = "";
+
     if (samplerate == 0)
     {
         setSamplerate(48000);
@@ -432,10 +440,6 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
     load_midi_controllers();
 
     patchDB = std::make_unique<Surge::PatchStorage::PatchDB>(this);
-    bool loadWtAndPatch = true;
-
-    // skip loading during export, it pops up an irrelevant error dialog. Only used by LV2
-    loadWtAndPatch = !skipLoadWtAndPatch;
     if (loadWtAndPatch)
     {
         refresh_wtlist();

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -984,6 +984,7 @@ class alignas(16) SurgeStorage
     //	float sincoffset alignas(16)[(FIRipol_M)*FIRipol_N];	// deprecated
 
     SurgeStorage(std::string suppliedDataPath = "");
+    static std::string skipPatchLoadDataPathSentinel;
 
     // With XT surgestorage can now keep a cache of errors it reports to the user
     void reportError(const std::string &msg, const std::string &title);

--- a/src/surge-testrunner/HeadlessUtils.cpp
+++ b/src/surge-testrunner/HeadlessUtils.cpp
@@ -9,11 +9,12 @@ namespace Surge
 namespace Headless
 {
 static std::unique_ptr<HeadlessPluginLayerProxy> parent = nullptr;
-std::shared_ptr<SurgeSynthesizer> createSurge(int sr)
+std::shared_ptr<SurgeSynthesizer> createSurge(int sr, bool loadAllPatches)
 {
     if (parent.get() == nullptr)
         parent.reset(new HeadlessPluginLayerProxy());
-    auto surge = std::shared_ptr<SurgeSynthesizer>(new SurgeSynthesizer(parent.get()));
+    auto surge = std::shared_ptr<SurgeSynthesizer>(new SurgeSynthesizer(
+        parent.get(), loadAllPatches ? "" : SurgeStorage::skipPatchLoadDataPathSentinel));
     surge->setSamplerate(sr);
     surge->time_data.tempo = 120;
     surge->time_data.ppqPos = 0;

--- a/src/surge-testrunner/HeadlessUtils.h
+++ b/src/surge-testrunner/HeadlessUtils.h
@@ -11,7 +11,7 @@ namespace Surge
 namespace Headless
 {
 
-std::shared_ptr<SurgeSynthesizer> createSurge(int sr);
+std::shared_ptr<SurgeSynthesizer> createSurge(int sr, bool loadAllPatches = false);
 
 void writeToStream(const float *data, int nSamples, int nChannels, std::ostream &str);
 

--- a/src/surge-testrunner/UnitTestUtilities.cpp
+++ b/src/surge-testrunner/UnitTestUtilities.cpp
@@ -194,8 +194,20 @@ std::shared_ptr<SurgeSynthesizer> surgeOnPatch(const std::string &otp)
         return surge;
 }
 
-std::shared_ptr<SurgeSynthesizer> surgeOnSine() { return surgeOnPatch("Init Sine"); }
-std::shared_ptr<SurgeSynthesizer> surgeOnSaw() { return surgeOnPatch("Init Saw"); }
+std::shared_ptr<SurgeSynthesizer> surgeOnTemplate(const std::string &otp)
+{
+    auto surge = Surge::Headless::createSurge(44100);
+
+    auto templatePath = surge->storage.datapath / fs::path{"patches_factory"} /
+                        fs::path{"Templates"} / fs::path{otp + ".fxp"};
+
+    surge->loadPatchByPath(path_to_string(templatePath).c_str(), -1, "Test");
+
+    return surge;
+}
+
+std::shared_ptr<SurgeSynthesizer> surgeOnSine() { return surgeOnTemplate("Init Sine"); }
+std::shared_ptr<SurgeSynthesizer> surgeOnSaw() { return surgeOnTemplate("Init Saw"); }
 
 void makePlotPNGFromData(std::string pngFileName, std::string plotTitle, float *buffer, int nS,
                          int nC, int startSample, int endSample)

--- a/src/surge-testrunner/UnitTestsDSP.cpp
+++ b/src/surge-testrunner/UnitTestsDSP.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Simple Single Oscillator is Constant", "[dsp]")
 }
 TEST_CASE("Unison Absolute and Relative", "[osc]")
 {
-    auto surge = Surge::Headless::createSurge(44100);
+    auto surge = Surge::Headless::createSurge(44100, true);
     REQUIRE(surge);
 
     auto assertRelative = [surge](const char *pn) {
@@ -230,7 +230,7 @@ TEST_CASE("Unison at Sample Rates", "[osc]")
         for (auto sr : srs)
         {
             INFO("Wavetable test at " << sr);
-            auto surge = Surge::Headless::createSurge(sr);
+            auto surge = Surge::Headless::createSurge(sr, true);
 
             assertRelative(surge, "resources/test-data/patches/Wavetable-Sin-Uni2-Relative.fxp");
             assertAbsolute(surge, "resources/test-data/patches/Wavetable-Sin-Uni2-Absolute.fxp");
@@ -245,7 +245,7 @@ TEST_CASE("Unison at Sample Rates", "[osc]")
         for (auto sr : srs)
         {
             INFO("Window Oscillator test at " << sr);
-            auto surge = Surge::Headless::createSurge(sr);
+            auto surge = Surge::Headless::createSurge(sr, true);
 
             assertRelative(surge, "resources/test-data/patches/Window-Sin-Uni2-Relative.fxp");
             assertAbsolute(surge, "resources/test-data/patches/Window-Sin-Uni2-Absolute.fxp");
@@ -255,7 +255,7 @@ TEST_CASE("Unison at Sample Rates", "[osc]")
         for (auto sr : srs)
         {
             INFO("Classic Oscillator test at " << sr);
-            auto surge = Surge::Headless::createSurge(sr);
+            auto surge = Surge::Headless::createSurge(sr, true);
 
             assertRelative(surge, "resources/test-data/patches/Classic-Uni2-Relative.fxp");
             assertAbsolute(surge, "resources/test-data/patches/Classic-Uni2-Absolute.fxp");
@@ -265,7 +265,7 @@ TEST_CASE("Unison at Sample Rates", "[osc]")
         for (auto sr : srs)
         {
             INFO("SH Oscillator test at " << sr);
-            auto surge = Surge::Headless::createSurge(sr);
+            auto surge = Surge::Headless::createSurge(sr, true);
 
             assertRelative(surge, "resources/test-data/patches/SH-Uni2-Relative.fxp");
             assertAbsolute(surge, "resources/test-data/patches/SH-Uni2-Absolute.fxp");
@@ -778,7 +778,7 @@ TEST_CASE("Every Oscillator Plays", "[dsp]")
     {
         DYNAMIC_SECTION("Oscillator type " << osc_type_names[i])
         {
-            auto surge = Surge::Headless::createSurge(44100);
+            auto surge = Surge::Headless::createSurge(44100, true);
 
             for (int q = 0; q < BLOCK_SIZE; q++)
             {

--- a/src/surge-testrunner/UnitTestsFLT.cpp
+++ b/src/surge-testrunner/UnitTestsFLT.cpp
@@ -18,18 +18,18 @@ TEST_CASE("Run Every Filter", "[flt]")
 {
     for (int fn = 0; fn < n_fu_types; fn++)
     {
-        auto nst = std::max(1, fut_subcount[fn]);
-        for (int fs = 0; fs < nst; ++fs)
+        DYNAMIC_SECTION("Test Filter " << fut_names[fn])
         {
-            DYNAMIC_SECTION("Test Filter " << fut_names[fn] << " st: " << fs)
+            auto nst = std::max(1, fut_subcount[fn]);
+            auto surge = Surge::Headless::createSurge(44100);
+            REQUIRE(surge);
+            for (int fs = 0; fs < nst; ++fs)
             {
-                auto surge = Surge::Headless::createSurge(44100);
-                REQUIRE(surge);
-
+                INFO("SUBTYPE IS " << fs);
                 surge->storage.getPatch().scene[0].filterunit[0].type.val.i = fn;
                 surge->storage.getPatch().scene[0].filterunit[0].subtype.val.i = fs;
 
-                int len = 4410 * 5;
+                int len = BLOCK_SIZE * 5;
                 Surge::Headless::playerEvents_t heldC = Surge::Headless::makeHoldMiddleC(len);
                 REQUIRE(heldC.size() == 2);
 
@@ -52,17 +52,17 @@ TEST_CASE("Run Every Waveshaper", "[flt]")
 {
     for (int wt = 0; wt < n_ws_types; wt++)
     {
-        for (int q = 0; q < n_filter_configs; ++q)
+        DYNAMIC_SECTION("Test WaveShaper " << wst_names[wt])
         {
-            DYNAMIC_SECTION("Test WaveShaper " << wst_names[wt] << " " << fbc_names[q])
-            {
-                auto surge = Surge::Headless::createSurge(44100);
-                REQUIRE(surge);
+            auto surge = Surge::Headless::createSurge(44100);
+            REQUIRE(surge);
 
+            for (int q = 0; q < n_filter_configs; ++q)
+            {
                 surge->storage.getPatch().scene[0].wsunit.type.val.i = wt;
                 surge->storage.getPatch().scene[0].wsunit.drive.set_value_f01(0.8);
 
-                int len = 4410 * 5;
+                int len = BLOCK_SIZE * 4;
                 Surge::Headless::playerEvents_t heldC = Surge::Headless::makeHoldMiddleC(len);
                 REQUIRE(heldC.size() == 2);
 

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -60,7 +60,7 @@ TEST_CASE("We can read a collection of wavetables", "[io]")
 
 TEST_CASE("All .wt and .wav factory assets load", "[io]")
 {
-    auto surge = Surge::Headless::createSurge(44100);
+    auto surge = Surge::Headless::createSurge(44100, true);
     REQUIRE(surge.get());
     for (auto p : surge->storage.wt_list)
     {
@@ -76,7 +76,7 @@ TEST_CASE("All .wt and .wav factory assets load", "[io]")
 
 TEST_CASE("All Patches are Loadable", "[io]")
 {
-    auto surge = Surge::Headless::createSurge(44100);
+    auto surge = Surge::Headless::createSurge(44100, true);
     REQUIRE(surge.get());
     int i = 0;
     for (auto p : surge->storage.patch_list)
@@ -324,7 +324,7 @@ TEST_CASE("Stream WaveTable Names", "[io]")
 
     SECTION("Name Set when Loading Factory")
     {
-        auto surge = Surge::Headless::createSurge(44100);
+        auto surge = Surge::Headless::createSurge(44100, true);
         REQUIRE(surge);
 
         auto patch = &(surge->storage.getPatch());
@@ -358,8 +358,8 @@ TEST_CASE("Stream WaveTable Names", "[io]")
             // if(d) free(d);
         };
 
-        auto surgeS = Surge::Headless::createSurge(44100);
-        auto surgeD = Surge::Headless::createSurge(44100);
+        auto surgeS = Surge::Headless::createSurge(44100, true);
+        auto surgeD = Surge::Headless::createSurge(44100, true);
         REQUIRE(surgeD);
 
         for (int i = 0; i < 50; ++i)

--- a/src/surge-testrunner/UnitTestsMOD.cpp
+++ b/src/surge-testrunner/UnitTestsMOD.cpp
@@ -1072,7 +1072,7 @@ TEST_CASE("High Low Latest Note Modulator in All Modes", "[mod]")
             surge->releaseNote(ch, key, vel);
         else
             surge->playNote(ch, key, vel, 0);
-        for (int i = 0; i < 50; ++i)
+        for (int i = 0; i < 20; ++i)
             surge->process();
         for (auto v : surge->voices[0])
             if (v->state.gate)

--- a/src/surge-testrunner/UnitTestsTUN.cpp
+++ b/src/surge-testrunner/UnitTestsTUN.cpp
@@ -576,10 +576,10 @@ TEST_CASE("Channel to Octave Mapping", "[tun]")
     {
         auto surge = surgeOnSine();
         float f1, f2;
-        for (int key = 0; key < 90; key++)
+        for (int key = 30; key < 70; key += 3)
         {
-            f1 = frequencyForNote(surge, key, 2, 0, 0);
-            f2 = frequencyForNote(surge, key, 2, 0, 1);
+            f1 = frequencyForNote(surge, key, 1, 0, 0);
+            f2 = frequencyForNote(surge, key, 1, 0, 1);
             REQUIRE(f2 == Approx(f1).margin(0.001));
         }
     }
@@ -589,12 +589,12 @@ TEST_CASE("Channel to Octave Mapping", "[tun]")
         surge->storage.mapChannelToOctave = true;
         surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
         float f1, f2;
-        for (int key = 0; key < 90; key++)
+        for (int key = 30; key < 70; key += 3)
         { // Limited range because frequencyForNote starts having trouble measuring high
           // frequencies.
             INFO("key is " << key);
-            f1 = frequencyForNote(surge, key, 2, 0, 0);
-            f2 = frequencyForNote(surge, key, 2, 0, 1);
+            f1 = frequencyForNote(surge, key, 1, 0, 0);
+            f2 = frequencyForNote(surge, key, 1, 0, 1);
             REQUIRE(f2 == Approx(f1 * 2).margin(0.1));
         }
     }
@@ -606,10 +606,10 @@ TEST_CASE("Channel to Octave Mapping", "[tun]")
         Tunings::Scale s = Tunings::readSCLFile("resources/test-data/scl/31edo.scl");
         surge->storage.retuneToScale(s);
         float f1, f2;
-        for (int key = 0; key < 90; key++)
+        for (int key = 30; key < 70; key += 3)
         {
-            f1 = frequencyForNote(surge, key, 2, 0, 0);
-            f2 = frequencyForNote(surge, key, 2, 0, 1);
+            f1 = frequencyForNote(surge, key, 1, 0, 0);
+            f2 = frequencyForNote(surge, key, 1, 0, 1);
             REQUIRE(f2 == Approx(f1 * 2).margin(0.1));
         }
     }


### PR DESCRIPTION
Improve the testcase runtime by not scanning for patches
in all those surges we create. This adds a special sentinel
storage datapath which stops scans from happening, basically,
and then uses that in all the tests except the ones we can't

Closes #5482