### PR TITLE
Outline Menus on MacOS

### DIFF
--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -378,3 +378,15 @@ void SurgeJUCELookAndFeel::drawPopupMenuItem(Graphics &g, const Rectangle<int> &
         }
     }
 }
+
+void SurgeJUCELookAndFeel::drawPopupMenuBackgroundWithOptions(juce::Graphics &g, int width,
+                                                              int height,
+                                                              const juce::PopupMenu::Options &o)
+{
+    auto background = findColour(PopupMenu::backgroundColourId);
+
+    g.fillAll(background);
+
+    g.setColour(findColour(PopupMenu::textColourId).withAlpha(0.6f));
+    g.drawRect(0, 0, width, height);
+}

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.h
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.h
@@ -38,6 +38,8 @@ class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4, public Surge::GUI::Ski
 
     void onSkinChanged() override;
 
+    void drawPopupMenuBackgroundWithOptions(juce::Graphics &g, int w, int h,
+                                            const juce::PopupMenu::Options &o) override;
     void drawPopupMenuItem(juce::Graphics &g, const juce::Rectangle<int> &area,
                            const bool isSeparator, const bool isActive, const bool isHighlighted,
                            const bool isTicked, const bool hasSubMenu, const juce::String &text,


### PR DESCRIPTION
Menus on MacOS missed the outline; not sure why Juce has that
commented out but I was used to it, but then foudn out windows
didn't. So fix it up!