### PR TITLE
Duplicate Midi Event Timestamp bug

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -256,7 +256,7 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
 
     for (int i = 0; i < buffer.getNumSamples(); i++)
     {
-        if (i == nextMidi)
+        while (i == nextMidi)
         {
             applyMidi(*midiIt);
             midiIt++;


### PR DESCRIPTION
If two midi events arrived with the exact sample sample
timestep, they would push to the end of the block along
with the rest of the midi in that block. Fix it with
an if/while switch on processing the midi list.

Addresses #5830