### PR TITLE
Broadcast MSEG State at correct time

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -366,8 +366,15 @@ void SurgeGUIEditor::showOverlay(OverlayTags olt,
     switch (olt)
     {
     case MSEG_EDITOR:
-        broadcastMSEGState();
-        // no break on purpose
+        onClose = [this]() {
+            broadcastMSEGState();
+            if (lfoEditSwitch)
+            {
+                lfoEditSwitch->setValue(0.0);
+                lfoEditSwitch->asJuceComponent()->repaint();
+            }
+        };
+        break;
     case FORMULA_EDITOR:
         onClose = [this]() {
             if (lfoEditSwitch)


### PR DESCRIPTION
BroadcastMSEGState should be set up at open as a close callback
but instead was called at open. Fix while retaining lfo switch
toggle.

Closes #5841