### PR TITLE
A few cmake tweaks to XT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,19 @@ include(cmake/lib.cmake)
 
 message(STATUS "Using JUCE from ${SURGE_JUCE_PATH}")
 add_subdirectory(${SURGE_JUCE_PATH} ${CMAKE_BINARY_DIR}/JUCE EXCLUDE_FROM_ALL)
-add_subdirectory(../libs/clap-juce-extensions clap-extensions EXCLUDE_FROM_ALL)
+
+if(${CMAKE_VERSION} VERSION_LESS 3.21)
+  message(WARNING "CMake version less than 3.21. Skipping clap builds. Please "
+    "consider using a newer version of CMake")
+  set(SURGE_BUILD_CLAP FALSE)
+else()
+  message(STATUS "CMake version ${CMAKE_VERSION} allows CLAP build")
+  set(SURGE_BUILD_CLAP TRUE)
+endif()
+
+if(SURGE_BUILD_CLAP)
+  add_subdirectory(../libs/clap-juce-extensions clap-extensions EXCLUDE_FROM_ALL)
+endif()
 
 add_library(simde INTERFACE)
 target_include_directories(simde INTERFACE ${CMAKE_SOURCE_DIR}/libs/simde)

--- a/src/cmake/pluginval.cmake
+++ b/src/cmake/pluginval.cmake
@@ -1,24 +1,24 @@
   message(STATUS "Validate me! Please!")
 
-  if (APPLE)
+  if(APPLE)
     set(pluginval_url "https://github.com/Tracktion/pluginval/releases/latest/download/pluginval_macOS.zip")
     set(pluginval_exe pluginval/pluginval.app/Contents/MacOS/pluginval)
-  elseif (WIN32)
+  elseif(WIN32)
     set(pluginval_url "https://github.com/Tracktion/pluginval/releases/latest/download/pluginval_Windows.zip")
     set(pluginval_exe pluginval/pluginval.exe)
-  else ()
+  else()
     set(pluginval_url "https://github.com/Tracktion/pluginval/releases/latest/download/pluginval_Linux.zip")
     set(pluginval_exe pluginval/pluginval)
-  endif ()
+  endif()
 
   add_custom_target(stage-pluginval)
   add_custom_command(TARGET stage-pluginval
-          POST_BUILD
-          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-          COMMAND cmake -E make_directory pluginval
-          COMMAND curl -L ${pluginval_url} -o pluginval/pluginval.zip
-          COMMAND cd pluginval && unzip -o pluginval.zip
-          )
+    POST_BUILD
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMAND cmake -E make_directory pluginval
+    COMMAND curl -L ${pluginval_url} -o pluginval/pluginval.zip
+    COMMAND cd pluginval && unzip -o pluginval.zip
+    )
 
   add_custom_target(surge-pluginval-all)
   function(create_pluginval_target name target plugin)
@@ -28,17 +28,20 @@
     add_dependencies(${name} stage-pluginval)
     get_target_property(plugin_location ${target} LIBRARY_OUTPUT_DIRECTORY)
     add_custom_command(TARGET ${name}
-            POST_BUILD
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            COMMAND ${pluginval_exe} --validate-in-process --output-dir "." --validate "${plugin_location}/${plugin_name}" || exit 1
-            )
+      POST_BUILD
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      COMMAND ${pluginval_exe} --validate-in-process --output-dir "." --validate "${plugin_location}/${plugin_name}" || exit 1
+      )
     add_dependencies(surge-pluginval-all ${name})
   endfunction()
 
-  create_pluginval_target(surge-xt-pluginval-vst3 surge-xt_VST3 "Surge XT.vst3")
-  create_pluginval_target(surge-fx-pluginval-vst3 surge-fx_VST3 "${SURGE_FX_PRODUCT_NAME}.vst3")
+  get_target_property(fxn surge-fx JUCE_PRODUCT_NAME)
+  get_target_property(xtn surge-xt JUCE_PRODUCT_NAME)
 
-  if (APPLE)
-    create_pluginval_target(surge-xt-pluginval-au surge-xt_AU "Surge XT.component")
-    create_pluginval_target(surge-fx-pluginval-au surge-fx_AU "${SURGE_FX_PRODUCT_NAME}.component")
-  endif ()
+  create_pluginval_target(surge-xt-pluginval-vst3 surge-xt_VST3 "${xtn}.vst3")
+  create_pluginval_target(surge-fx-pluginval-vst3 surge-fx_VST3 "${fxn}.vst3")
+
+  if(APPLE)
+    create_pluginval_target(surge-xt-pluginval-au surge-xt_AU "${xtn}.component")
+    create_pluginval_target(surge-fx-pluginval-au surge-fx_AU "${fxn}.component")
+  endif()

--- a/src/surge-fx/CMakeLists.txt
+++ b/src/surge-fx/CMakeLists.txt
@@ -10,11 +10,11 @@ endif()
 file(GLOB SURGE_FX_BANK_RESOURCES_GLOB
   ${CMAKE_SOURCE_DIR}/resources/surge-fx/*.svg
   ${CMAKE_SOURCE_DIR}/resources/surge-fx/icons/*.svg
-)
+  )
 
 juce_add_binary_data(surge-fx-binary
   SOURCES ${SURGE_FX_BANK_RESOURCES_GLOB}
-)
+  )
 
 juce_add_plugin(${PROJECT_NAME}
   PRODUCT_NAME ${SURGE_FX_PRODUCT_NAME}
@@ -44,7 +44,7 @@ juce_add_plugin(${PROJECT_NAME}
   LV2_SHARED_LIBRARY_NAME SurgeXT_FX
 
   FORMATS ${SURGE_JUCE_FORMATS}
-)
+  )
 
 target_sources(${PROJECT_NAME} PRIVATE
   SurgeFXEditor.cpp
@@ -52,7 +52,7 @@ target_sources(${PROJECT_NAME} PRIVATE
   SurgeFXProcessor.cpp
   SurgeFXProcessor.h
   SurgeLookAndFeel.h
-)
+  )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
   surge::surge-common
@@ -60,9 +60,11 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   surge-juce
   juce::juce_audio_utils
   juce::juce_audio_processors
-)
+  )
 
-clap_juce_extensions_plugin(TARGET surge-fx
-        CLAP_ID "org.surge-synth-team.surge-xt-fx")
+if(SURGE_BUILD_CLAP)
+  clap_juce_extensions_plugin(TARGET surge-fx
+    CLAP_ID "org.surge-synth-team.surge-xt-fx")
+endif()
 
 surge_juce_package(${PROJECT_NAME} "Surge XT Effects")

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -50,9 +50,11 @@ juce_add_plugin(${PROJECT_NAME}
   FORMATS ${SURGE_JUCE_FORMATS}
   )
 
-clap_juce_extensions_plugin(TARGET surge-xt
-        CLAP_ID "org.surge-synth-team.surge-xt")
-target_sources(${PROJECT_NAME}_CLAP PRIVATE plugin_type_extensions/SurgeSynthClapExtensions.cpp)
+if(SURGE_BUILD_CLAP)
+  clap_juce_extensions_plugin(TARGET surge-xt
+    CLAP_ID "org.surge-synth-team.surge-xt")
+  target_sources(${PROJECT_NAME}_CLAP PRIVATE plugin_type_extensions/SurgeSynthClapExtensions.cpp)
+endif()
 
 if(JUCE_ASIO_SUPPORT)
   target_compile_definitions(${PROJECT_NAME} PUBLIC JUCE_ASIO=1)


### PR DESCRIPTION
- Use the correct PRODUCT_NAME in the pluginval. Closes #5834
- Conditionally deactivate CLAP builds for cmake versions
  less than 3.21. Closes #5862