### PR TITLE
Handle errors in skin-on-start load path

### DIFF
--- a/src/surge-xt/gui/SkinSupport.cpp
+++ b/src/surge-xt/gui/SkinSupport.cpp
@@ -68,7 +68,7 @@ std::shared_ptr<Skin> SkinDB::defaultSkin(SurgeStorage *storage)
 
         for (auto e : availableSkins)
         {
-            if (e.name == uds && (e.rootType == st || st == UNKNOWN))
+            if (e.name == uds && (e.rootType == st || st == UNKNOWN) && e.parseable)
                 return getSkin(e);
         }
         return getSkin(defaultSkinEntry);
@@ -197,8 +197,10 @@ void SkinDB::rescanForSkins(SurgeStorage *storage)
         if (!doc.LoadFile(string_to_path(x)))
         {
             e.displayName = e.name + " (parse error)";
+            e.parseable = false;
             continue;
         }
+        e.parseable = true;
         TiXmlElement *surgeskin = TINYXML_SAFE_TO_ELEMENT(doc.FirstChild("surge-skin"));
         if (!surgeskin)
         {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1959,7 +1959,19 @@ bool SurgeGUIEditor::open(void *parent)
 
     bitmapStore.reset(new SurgeImageStore());
     bitmapStore->setupBuiltinBitmaps();
-    currentSkin->reloadSkin(bitmapStore);
+    if (!currentSkin->reloadSkin(bitmapStore))
+    {
+        auto db = Surge::GUI::SkinDB::get();
+
+        std::ostringstream oss;
+        oss << "Unable to load current skin! Reverting the skin to Surge Classic.\n\nSkin Error:\n"
+            << db->getAndResetErrorString();
+
+        auto msg = std::string(oss.str());
+        this->currentSkin = db->defaultSkin(&(this->synth->storage));
+        this->currentSkin->reloadSkin(this->bitmapStore);
+        synth->storage.reportError(msg, "Skin Loading Error");
+    }
 
     reloadFromSkin();
     openOrRecreateEditor();


### PR DESCRIPTION
One location of a LoadSkin error was not trapped properly.
Handle and report accurately.

Closes #5821