### PR TITLE
Remove PPQ advance check in looping mode

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -209,7 +209,8 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         playhead->getCurrentPosition(cp);
         surge->time_data.tempo = cp.bpm;
 
-        if (cp.isPlaying || cp.isRecording || cp.isLooping)
+        // isRecording should always imply isPlaying but better safe than sorry
+        if (cp.isPlaying || cp.isRecording)
             surge->time_data.ppqPos = cp.ppqPosition;
 
         surge->time_data.timeSigNumerator = cp.timeSigNumerator;


### PR DESCRIPTION
I confused 'isLooping' to mean "is looping" when it actually
means "would be looping if playing" which meant my ppqpos
reset was improper.

Closes #5812