### PR TITLE
All Sounds Off has micro-fade

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1808,12 +1808,13 @@ void SurgeSynthesizer::channelController(char channel, int cc, int value)
 
         if (doAllSoundOff)
         {
-            releaseScene(0);
-            releaseScene(1);
+            approachingAllSoundsOff = true;
+            masterfade = 1.f;
         }
 
         return;
     }
+
     case 123: // all notes off
     {
         bool doAllNotesOff = true;
@@ -3709,6 +3710,18 @@ void SurgeSynthesizer::process()
             clear_block(output[0], BLOCK_SIZE_QUAD);
             clear_block(output[1], BLOCK_SIZE_QUAD);
             return;
+        }
+    }
+    else if (approachingAllSoundsOff)
+    {
+        masterfade = max(0.f, masterfade - 0.125f); // kill over 8 blocks
+        mfade = masterfade * masterfade;
+
+        if (masterfade < 0.0001f)
+        {
+            releaseScene(0);
+            releaseScene(1);
+            approachingAllSoundsOff = false;
         }
     }
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -361,6 +361,7 @@ class alignas(16) SurgeSynthesizer
   public:
     int CC0, CC32, PCH, patchid;
     float masterfade = 0;
+    bool approachingAllSoundsOff{false};
     HalfRateFilter halfbandA, halfbandB,
         halfbandIN; // TODO: FIX SCENE ASSUMPTION (for halfbandA/B - use std::array)
     std::list<SurgeVoice *> voices[n_scenes];


### PR DESCRIPTION
All sounds off was a brick wall sounds off. That meant
Logic Pro X 10.7.2 and others which sent it at transport stop
would pop on start and stop. Instead use the masterfade mechanism
to fade it out over 8 blocks from all sounds off.

Closes #5870