### PR TITLE
Menu Colors in Skins with a default Dark/Light also

### DIFF
--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -64,6 +64,7 @@ namespace Menu
 const Surge::Skin::Color Text("effect.menu.text", 0x000000, 0xFF),
     TextHover("effect.menu.text.hover", 0x000000, 0xFF);
 }
+
 namespace Grid
 {
 const Surge::Skin::Color Border("effect.grid.border", 0x000000, 0xFF);
@@ -231,6 +232,14 @@ const Surge::Skin::Color Name("menu.name", 0x000000, 0xFF), NameHover("menu.name
 const Surge::Skin::Color FilterValue("filtermenu.value", 0xFF9A10),
     FilterValueHover("filtermenu.value.hover", 0xFFFFFF);
 } // namespace Menu
+
+namespace PopupMenu
+{
+const Surge::Skin::Color Background("popupmenu.background", 0x303030),
+    HiglightedBackground("popupmenu.highghtedBackground", 0x606060),
+    Text("popupmenu.text", 0xFFFFFF), HeaderText("popupmenu.headertext", 0xFFFFFF),
+    HighlightedText("popupmenu.highlightedText", 0xEEEEFF);
+}
 
 namespace ModSource
 {

--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -184,6 +184,11 @@ extern const Surge::Skin::Color Name, NameHover, NameDeactivated, Value, ValueHo
     ValueDeactivated, FilterValue, FilterValueHover;
 }
 
+namespace PopupMenu
+{
+extern const Surge::Skin::Color Background, HiglightedBackground, Text, HeaderText, HighlightedText;
+}
+
 namespace ModSource
 {
 namespace Unused

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -200,6 +200,9 @@ void initMaps()
             case ModListValueDisplay:
                 r = "modListValueDisplay";
                 break;
+            case MenuLightness:
+                r = "menuLightness";
+                break;
             case nKeys:
                 break;
             }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -84,6 +84,7 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     FormulaOverlayLocationTearOut,
 
     ModListValueDisplay,
+    MenuLightness,
 
     nKeys
 };

--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -22,7 +22,7 @@
 SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
     : juce::AudioProcessorEditor(&p), processor(p)
 {
-    surgeLF = std::make_unique<SurgeJUCELookAndFeel>();
+    surgeLF = std::make_unique<SurgeJUCELookAndFeel>(&(processor.surge->storage));
 
     juce::LookAndFeel::setDefaultLookAndFeel(surgeLF.get());
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3651,6 +3651,19 @@ juce::PopupMenu SurgeGUIEditor::makeSkinMenu(const juce::Point<int> &where)
     });
 
     skinSubMenu.addSeparator();
+    auto menuMode =
+        Surge::Storage::getUserDefaultValue(&(synth->storage), Surge::Storage::MenuLightness, 2);
+    auto resetMenuTo = [this](int i) {
+        Surge::Storage::updateUserDefaultValue(&(synth->storage), Surge::Storage::MenuLightness, i);
+        juceEditor->surgeLF->onSkinChanged();
+    };
+    skinSubMenu.addItem(Surge::GUI::toOSCaseForMenu("Always Dark Menus"), true, menuMode == 0,
+                        [resetMenuTo]() { resetMenuTo(0); });
+    skinSubMenu.addItem(Surge::GUI::toOSCaseForMenu("Always Light Menus"), true, menuMode == 1,
+                        [resetMenuTo]() { resetMenuTo(1); });
+    skinSubMenu.addItem(Surge::GUI::toOSCaseForMenu("Menus From Skin"), true, menuMode == 2,
+                        [resetMenuTo]() { resetMenuTo(2); });
+    skinSubMenu.addSeparator();
 
     if (useDevMenu)
     {

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -21,6 +21,7 @@
 #include "version.h"
 
 #include <juce_audio_utils/juce_audio_utils.h>
+#include "UserDefaults.h"
 
 // here and only here we using namespace juce so I can copy and override stuff from v4 easily
 using namespace juce;
@@ -43,8 +44,36 @@ void SurgeJUCELookAndFeel::onSkinChanged()
     setColour(Slider::trackColourId, Colour(128, 128, 128));
     setColour(Slider::backgroundColourId, Colour((uint8)255, 255, 255, 20.f));
     setColour(ComboBox::backgroundColourId, Colour(32, 32, 32));
-    setColour(PopupMenu::backgroundColourId, Colour(48, 48, 48));
-    setColour(PopupMenu::highlightedBackgroundColourId, Colour(96, 96, 96));
+
+    int menuMode = 0;
+    if (storage)
+        menuMode = Surge::Storage::getUserDefaultValue(storage, Surge::Storage::MenuLightness, 2);
+    if (menuMode == 1)
+    {
+        setColour(PopupMenu::backgroundColourId, Colour(255, 255, 255));
+        setColour(PopupMenu::highlightedBackgroundColourId, Colour(220, 220, 230));
+        setColour(PopupMenu::textColourId, juce::Colours::black);
+        setColour(PopupMenu::headerTextColourId, juce::Colours::black);
+        setColour(PopupMenu::highlightedTextColourId, juce::Colour(0, 0, 40));
+    }
+    else if (menuMode == 0) // FIXME = mode 2 is follow skin
+    {
+        setColour(PopupMenu::backgroundColourId, Colour(48, 48, 48));
+        setColour(PopupMenu::highlightedBackgroundColourId, Colour(96, 96, 96));
+        setColour(PopupMenu::textColourId, juce::Colours::white);
+        setColour(PopupMenu::headerTextColourId, juce::Colours::white);
+        setColour(PopupMenu::highlightedTextColourId, juce::Colour(240, 240, 250));
+    }
+    else if (menuMode == 2)
+    {
+        setColour(PopupMenu::backgroundColourId, skin->getColor(Colors::PopupMenu::Background));
+        setColour(PopupMenu::highlightedBackgroundColourId,
+                  skin->getColor(Colors::PopupMenu::HiglightedBackground));
+        setColour(PopupMenu::textColourId, skin->getColor(Colors::PopupMenu::Text));
+        setColour(PopupMenu::headerTextColourId, skin->getColor(Colors::PopupMenu::HeaderText));
+        setColour(PopupMenu::highlightedTextColourId,
+                  skin->getColor(Colors::PopupMenu::HighlightedText));
+    }
 
     setColour(AlertWindow::backgroundColourId, skin->getColor(Colors::Dialog::Background));
     setColour(AlertWindow::outlineColourId, skin->getColor(Colors::Dialog::Border));
@@ -294,8 +323,8 @@ Button *SurgeJUCELookAndFeel::createDocumentWindowButton(int buttonType)
 
 juce::Font SurgeJUCELookAndFeel::getPopupMenuFont()
 {
-    // return Surge::GUI::getFontManager()->getLatoAtSize(15);
-    return juce::LookAndFeel_V4::getPopupMenuFont();
+    return Surge::GUI::getFontManager()->getLatoAtSize(15);
+    // return juce::LookAndFeel_V4::getPopupMenuFont();
 }
 // overridden here just to make the shortcut text same size as normal menu entry text
 void SurgeJUCELookAndFeel::drawPopupMenuItem(Graphics &g, const Rectangle<int> &area,

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.h
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.h
@@ -22,7 +22,7 @@
 class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4, public Surge::GUI::SkinConsumingComponent
 {
   public:
-    SurgeJUCELookAndFeel() {}
+    SurgeJUCELookAndFeel(SurgeStorage *s) : storage(s) {}
     void drawLabel(juce::Graphics &graphics, juce::Label &label) override;
     void drawTextEditorOutline(juce::Graphics &graphics, int width, int height,
                                juce::TextEditor &editor) override;
@@ -37,6 +37,7 @@ class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4, public Surge::GUI::Ski
                        bool isMouseDown) override;
 
     void onSkinChanged() override;
+    SurgeStorage *storage{nullptr};
 
     juce::Font getPopupMenuFont() override;
     void drawPopupMenuBackgroundWithOptions(juce::Graphics &g, int w, int h,


### PR DESCRIPTION
New feature in skins menu - menus always dark/light/follow skin
Colors in skin which map to current dark menus by default
Light mode works and sticks

Closes #5861