### PR TITLE
A Dirty Flag, but not much done with it

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2275,6 +2275,11 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
                 dawExtraState.mpeEnabled = ival;
 
+            p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("isDirty"));
+            dawExtraState.isDirty = false;
+            if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
+                dawExtraState.isDirty = ival;
+
             p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("mpePitchBendRange"));
             if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
                 dawExtraState.mpePitchBendRange = ival;
@@ -2837,6 +2842,10 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         TiXmlElement mppb("mpePitchBendRange");
         mppb.SetAttribute("v", dawExtraState.mpePitchBendRange);
         dawExtraXML.InsertEndChild(mppb);
+
+        TiXmlElement isDi("isDirty");
+        isDi.SetAttribute("v", dawExtraState.isDirty ? 1 : 0);
+        dawExtraXML.InsertEndChild(isDi);
 
         TiXmlElement mpm("monoPedalMode");
         mpm.SetAttribute("v", dawExtraState.monoPedalMode);

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -942,6 +942,8 @@ void SurgeStorage::perform_queued_wtloads()
         {
             if (patch.scene[sc].osc[o].wt.queue_id != -1)
             {
+                if (patch.scene[sc].osc[o].wt.everBuilt)
+                    patch.isDirty = true;
                 load_wt(patch.scene[sc].osc[o].wt.queue_id, &patch.scene[sc].osc[o].wt,
                         &patch.scene[sc].osc[o]);
                 patch.scene[sc].osc[o].wt.refresh_display = true;
@@ -967,6 +969,8 @@ void SurgeStorage::perform_queued_wtloads()
                 load_wt(patch.scene[sc].osc[o].wt.queue_filename, &patch.scene[sc].osc[o].wt,
                         &patch.scene[sc].osc[o]);
                 patch.scene[sc].osc[o].wt.refresh_display = true;
+                if (patch.scene[sc].osc[o].wt.everBuilt)
+                    patch.isDirty = true;
             }
         }
     }

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -817,6 +817,8 @@ struct DAWExtraStateStorage
 
     int monoPedalMode = 0;
     int oddsoundRetuneMode = 0;
+
+    bool isDirty{false};
 };
 
 struct PatchTuningStorage
@@ -896,6 +898,8 @@ class SurgePatch
         std::string tag;
     };
     std::vector<Tag> tags;
+
+    std::atomic<bool> isDirty{false};
 
     // macro controllers
 #define CUSTOM_CONTROLLER_LABEL_SIZE 20

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -201,6 +201,7 @@ void SurgeSynthesizer::loadPatch(int id)
 
     Patch e = storage.patch_list[id];
     loadPatchByPath(path_to_string(e.path).c_str(), e.category, e.name.c_str());
+    storage.getPatch().isDirty = false;
 }
 
 bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, const char *patchName)
@@ -360,7 +361,9 @@ bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, cons
     /*
     ** Notify the host display that the patch name has changed
     */
+    storage.getPatch().isDirty = false;
     updateDisplay();
+
     return true;
 }
 
@@ -426,6 +429,8 @@ void SurgeSynthesizer::loadRaw(const void *data, int size, bool preset)
                                                           &(storage.getPatch().formulamods[sc][m]));
         }
     }
+
+    storage.getPatch().isDirty = false;
 
     halt_engine = false;
     patch_loaded = true;
@@ -560,6 +565,7 @@ void SurgeSynthesizer::savePatch(bool factoryInPlace)
     {
         savePatchToPath(filename);
     }
+    storage.getPatch().isDirty = false;
 }
 
 void SurgeSynthesizer::savePatchToPath(fs::path filename)
@@ -609,6 +615,8 @@ void SurgeSynthesizer::savePatchToPath(fs::path filename)
     }
     refresh_editor = true;
     midiprogramshavechanged = true;
+
+    storage.getPatch().isDirty = false;
 }
 
 unsigned int SurgeSynthesizer::saveRaw(void **data) { return storage.getPatch().save_patch(data); }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -642,6 +642,11 @@ void SurgeGUIEditor::idle()
         if (patchSelector)
         {
             patchChanged = patchSelector->sel_id != synth->patchid;
+            if (synth->storage.getPatch().isDirty != patchSelector->isDirty)
+            {
+                patchSelector->isDirty = synth->storage.getPatch().isDirty;
+                patchSelector->repaint();
+            }
         }
 
         if (statusMPE)
@@ -4691,6 +4696,7 @@ void SurgeGUIEditor::openMacroRenameDialog(const int ccid, const juce::Point<int
                     msb->asJuceComponent()->repaint();
                 }
 
+                synth->storage.getPatch().isDirty = true;
                 synth->refresh_editor = true;
             }
         },
@@ -4705,6 +4711,7 @@ void SurgeGUIEditor::openLFORenameDialog(const int lfo_id, const juce::Point<int
     auto callback = [this, lfo_id, msi](const std::string &nv) {
         auto cp = synth->storage.getPatch().LFOBankLabel[current_scene][lfo_id][msi];
         strxcpy(cp, nv.c_str(), CUSTOM_CONTROLLER_LABEL_SIZE);
+        synth->storage.getPatch().isDirty = true;
         synth->refresh_editor = true;
     };
 
@@ -5696,6 +5703,12 @@ void SurgeGUIEditor::swapFX(int source, int target, SurgeSynthesizer::FXReorderM
 
 void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)
 {
+    if (prior != curr)
+    {
+        std::cout << "SETTING ISDIRTY IN LFO" << std::endl;
+        synth->storage.getPatch().isDirty = true;
+    }
+
     bool needs_refresh{false};
     // Currently only formula is indexed
     if (prior == lt_formula && curr != lt_formula)

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -3162,8 +3162,11 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
 
 bool SurgeGUIEditor::setParameterFromString(Parameter *p, const std::string &s)
 {
+    auto v = p->get_value_f01();
     if (p && p->set_value_from_string(s))
     {
+        if (v != p->get_value_f01())
+            synth->storage.getPatch().isDirty = true;
         repushAutomationFor(p);
         synth->refresh_editor = true;
         return true;
@@ -3189,6 +3192,7 @@ bool SurgeGUIEditor::setParameterModulationFromString(Parameter *p, modsources m
     {
         synth->setModulation(p->id, ms, modsourceScene, modidx, mv);
         synth->refresh_editor = true;
+        synth->storage.getPatch().isDirty = true;
     }
 
     if (ms >= ms_ctrl1 && ms <= ms_ctrl1 + n_customcontrollers)
@@ -3214,6 +3218,7 @@ bool SurgeGUIEditor::setControlFromString(modsources ms, const std::string &s)
         cms->set_output(0, val);
         cms->target[0] = val;
         synth->refresh_editor = true;
+        synth->storage.getPatch().isDirty = true;
         return true;
     }
     return false;

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -602,6 +602,7 @@ void FormulaModulatorEditor::onSkinChanged()
 void FormulaModulatorEditor::applyCode()
 {
     formulastorage->setFormula(mainDocument->getAllContent().toStdString());
+    storage->getPatch().isDirty = true;
     editor->repaintFrame();
     juce::SystemClipboard::copyTextToClipboard(formulastorage->formulaString);
     setApplyEnabled(false);

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -75,6 +75,7 @@ LFOAndStepDisplay::LFOAndStepDisplay()
             q->onGetValue = [this, i](auto *T) { return ss->steps[i]; };
             q->onSetValue = [this, i](auto *T, float f) {
                 ss->steps[i] = f;
+                storage->getPatch().isDirty = true;
                 repaint();
                 return;
             };
@@ -96,6 +97,7 @@ LFOAndStepDisplay::LFOAndStepDisplay()
                     else
                         f = limitpm1(f + delt);
                     ss->steps[step] = f;
+                    storage->getPatch().isDirty = true;
                     repaint();
                 }
             };
@@ -106,6 +108,8 @@ LFOAndStepDisplay::LFOAndStepDisplay()
                     ss->steps[i] = isUnipolar() ? 0.f : -1.f;
                 if (mmd == 0)
                     ss->steps[i] = 0.f;
+
+                storage->getPatch().isDirty = true;
                 repaint();
             };
             stepLayer->addChildComponent(*q);
@@ -204,11 +208,13 @@ LFOAndStepDisplay::LFOAndStepDisplay()
         l0->onGetValue = [this](auto *) { return ss->loop_start; };
         l0->onSetValue = [this](auto *, float f) {
             ss->loop_start = (int)round(f);
+            storage->getPatch().isDirty = true;
             repaint();
         };
         l0->onJogValue = [this](auto *, int dir, bool, bool) {
             auto n = limit_range(ss->loop_start + dir, 0, 15);
             ss->loop_start = n;
+            storage->getPatch().isDirty = true;
             repaint();
         };
         l0->onMinMaxDef = [this](auto *, int mmd) {
@@ -216,6 +222,7 @@ LFOAndStepDisplay::LFOAndStepDisplay()
                 ss->loop_start = ss->loop_end;
             else
                 ss->loop_start = 0;
+            storage->getPatch().isDirty = true;
             repaint();
         };
         loopEndOverlays[0] = std::move(l0);
@@ -228,11 +235,13 @@ LFOAndStepDisplay::LFOAndStepDisplay()
         l0->onGetValue = [this](auto *) { return ss->loop_end; };
         l0->onSetValue = [this](auto *, float f) {
             ss->loop_end = (int)round(f);
+            storage->getPatch().isDirty = true;
             repaint();
         };
         l0->onJogValue = [this](auto *, int dir, bool, bool) {
             auto n = limit_range(ss->loop_end + dir, 0, 15);
             ss->loop_end = n;
+            storage->getPatch().isDirty = true;
             repaint();
         };
         l0->onMinMaxDef = [this](auto *, int mmd) {
@@ -240,6 +249,7 @@ LFOAndStepDisplay::LFOAndStepDisplay()
                 ss->loop_end = ss->loop_end;
             else
                 ss->loop_end = 15;
+            storage->getPatch().isDirty = true;
             repaint();
         };
         loopEndOverlays[1] = std::move(l0);
@@ -1439,6 +1449,7 @@ void LFOAndStepDisplay::setStepToDefault(const juce::MouseEvent &event)
         if (steprect[i].contains(event.position))
         {
             ss->steps[i] = 0.f;
+            storage->getPatch().isDirty = true;
             repaint();
         }
     }
@@ -1497,6 +1508,7 @@ void LFOAndStepDisplay::setStepValue(const juce::MouseEvent &event)
             }
 
             ss->steps[i] = f;
+            storage->getPatch().isDirty = true;
 
             repaint();
         }
@@ -1588,6 +1600,7 @@ void LFOAndStepDisplay::mouseDown(const juce::MouseEvent &event)
                            (((ss->trigmask & 0x0000fffe00000000) >> 1) |
                             (((ss->trigmask & 0x100000000) << 15) & 0xffff00000000));
 
+            storage->getPatch().isDirty = true;
             repaint();
 
             return;
@@ -1611,6 +1624,7 @@ void LFOAndStepDisplay::mouseDown(const juce::MouseEvent &event)
                            (((ss->trigmask & 0x00007fff00000000) << 1) |
                             (((ss->trigmask & 0x0000800000000000) >> 15) & 0xffff00000000));
 
+            storage->getPatch().isDirty = true;
             repaint();
 
             return;
@@ -1696,6 +1710,7 @@ void LFOAndStepDisplay::mouseDown(const juce::MouseEvent &event)
                 ss->trigmask &= maskOff;
                 ss->trigmask |= maskOn;
 
+                storage->getPatch().isDirty = true;
                 repaint();
 
                 return;
@@ -1881,6 +1896,7 @@ void LFOAndStepDisplay::mouseDrag(const juce::MouseEvent &event)
             if (ss->loop_start != loopStart && loopStart >= 0)
             {
                 ss->loop_start = loopStart;
+                storage->getPatch().isDirty = true;
                 repaint();
             }
         }
@@ -1889,6 +1905,7 @@ void LFOAndStepDisplay::mouseDrag(const juce::MouseEvent &event)
             if (ss->loop_end != loopStart && loopStart >= 0)
             {
                 ss->loop_end = loopStart;
+                storage->getPatch().isDirty = true;
                 repaint();
             }
         }
@@ -2016,6 +2033,7 @@ void LFOAndStepDisplay::mouseUp(const juce::MouseEvent &event)
             }
 
             ss->steps[s] = fs;
+            storage->getPatch().isDirty = true;
 
             if (s != e)
             {
@@ -2046,6 +2064,7 @@ void LFOAndStepDisplay::mouseUp(const juce::MouseEvent &event)
                     }
 
                     ss->steps[q] = f;
+                    storage->getPatch().isDirty = true;
                 }
             }
 
@@ -2106,7 +2125,7 @@ void LFOAndStepDisplay::mouseWheelMove(const juce::MouseEvent &event,
             }
 
             ss->steps[i] = v;
-
+            storage->getPatch().isDirty = true;
             repaint();
         }
     }

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -225,7 +225,10 @@ void PatchSelector::paint(juce::Graphics &g)
             pbrowser.withLeft(searchRect.getRight()).withRight(favoritesRect.getX()).reduced(4, 0);
 
         g.setFont(Surge::GUI::getFontManager()->patchNameFont);
-        g.drawFittedText(pname, pnRect,
+        auto uname = pname;
+        if (isDirty)
+            uname += "*";
+        g.drawFittedText(uname, pnRect,
                          alignTop ? juce::Justification::centredTop : juce::Justification::centred,
                          1, 0.1);
 

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -146,6 +146,7 @@ struct PatchSelector : public juce::Component,
     std::string getPatchNameAccessibleValue() { return pname + " by " + author; }
 
     void onSkinChanged() override;
+    bool isDirty{false};
 
   protected:
     juce::Rectangle<int> favoritesRect, searchRect;


### PR DESCRIPTION
This adds a dirty flag to the patch which lets you see when you
have modified it. We currently don't *do* antyhing with the flag
other than put an * by the patch name, but in the future we can do
quite a lot.

But since we just show it this only addresses part of #733