### PR TITLE
"Activate individual scene outputs" overhaul

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -759,10 +759,12 @@ struct DAWExtraStateStorage
         int current_scene = 0;
         int current_fx = 0;
         int current_osc[n_scenes] = {0};
-        modsources modsource = ms_lfo1, modsource_editor[n_scenes] = {ms_lfo1, ms_lfo1};
         bool isMSEGOpen = false;
-
         bool msegStateIsPopulated = false;
+        modsources modsource = ms_lfo1, modsource_editor[n_scenes] = {ms_lfo1, ms_lfo1};
+
+        bool activateExtraOutputs = true;
+
         struct
         {
             int timeEditMode = 0;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4300,12 +4300,8 @@ void SurgeSynthesizer::loadFromDawExtraState()
 
 void SurgeSynthesizer::setupActivateExtraOutputs()
 {
-    bool defval = true;
-    if (hostProgram.find("Fruit") == 0) // FruityLoops default off
-        defval = false;
-
-    activateExtraOutputs = Surge::Storage::getUserDefaultValue(
-        &(storage), Surge::Storage::ActivateExtraOutputs, defval ? 1 : 0);
+    // default off for FL Studio
+    activateExtraOutputs = (hostProgram.find("Fruit") == 0) ? true : false;
 }
 
 void SurgeSynthesizer::swapMetaControllers(int c1, int c2)

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -71,9 +71,6 @@ void initMaps()
             case UseODDMTS:
                 r = "useODDMTS";
                 break;
-            case ActivateExtraOutputs:
-                r = "activateExtraOutputs";
-                break;
             case MonoPedalMode:
                 r = "monoPedalMode";
                 break;

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -71,6 +71,10 @@ void initMaps()
             case UseODDMTS:
                 r = "useODDMTS";
                 break;
+            case ActivateExtraOutputs:
+                // not used anymore, see GitHub issue #5657
+                r = "activateExtraOutputs";
+                break;
             case MonoPedalMode:
                 r = "monoPedalMode";
                 break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -29,7 +29,6 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     RestoreMSEGSnapFromPatch,
     UserDataPath,
     UseODDMTS,
-    ActivateExtraOutputs,
     MonoPedalMode,
     ShowCursorWhileEditing,
     TouchMouseMode,

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -29,6 +29,7 @@ enum DefaultKey // streamed as strings so feel free to change the order to whate
     RestoreMSEGSnapFromPatch,
     UserDataPath,
     UseODDMTS,
+    ActivateExtraOutputs,
     MonoPedalMode,
     ShowCursorWhileEditing,
     TouchMouseMode,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3430,15 +3430,14 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
 {
     auto wfMenu = juce::PopupMenu();
 
-    wfMenu.addItem(Surge::GUI::toOSCaseForMenu("Activate Individual Scene Outputs"), true,
-                   (synth->activateExtraOutputs), [this]() {
-                       this->synth->activateExtraOutputs = !this->synth->activateExtraOutputs;
-                       Surge::Storage::updateUserDefaultValue(
-                           &(this->synth->storage), Surge::Storage::ActivateExtraOutputs,
-                           this->synth->activateExtraOutputs ? 1 : 0);
-                   });
+    if (synth->hostProgram.find("Fruit") == 0) // only show this option for FL Studio
+    {
+        wfMenu.addItem(Surge::GUI::toOSCaseForMenu("Activate Individual Scene Outputs"), true,
+                       (synth->activateExtraOutputs),
+                       [this]() { synth->activateExtraOutputs = !synth->activateExtraOutputs; });
 
-    wfMenu.addSeparator();
+        wfMenu.addSeparator();
+    }
 
     bool tabPosMem = Surge::Storage::getUserDefaultValue(
         &(this->synth->storage), Surge::Storage::RememberTabPositionsPerScene, false);
@@ -6597,6 +6596,9 @@ void SurgeGUIEditor::populateDawExtraState(SurgeSynthesizer *synth)
     des->editor.current_scene = current_scene;
     des->editor.current_fx = current_fx;
     des->editor.modsource = modsource;
+
+    des->editor.activateExtraOutputs = synth->activateExtraOutputs;
+
     for (int i = 0; i < n_scenes; ++i)
     {
         des->editor.current_osc[i] = current_osc[i];
@@ -6651,6 +6653,8 @@ void SurgeGUIEditor::loadFromDAWExtraState(SurgeSynthesizer *synth)
         current_scene = des->editor.current_scene;
         current_fx = des->editor.current_fx;
         modsource = des->editor.modsource;
+
+        synth->activateExtraOutputs = des->editor.activateExtraOutputs;
 
         activateFromCurrentFx();
 


### PR DESCRIPTION
Remove activateExtraOutputs user option
Add it to DAWExtraState instead
Show the menu option to enable scene outputs only for FL Studio

Closes #5657