### PR TITLE
Remove Activate individual scene outputs option altogether

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -763,8 +763,6 @@ struct DAWExtraStateStorage
         bool msegStateIsPopulated = false;
         modsources modsource = ms_lfo1, modsource_editor[n_scenes] = {ms_lfo1, ms_lfo1};
 
-        bool activateExtraOutputs = true;
-
         struct
         {
             int timeEditMode = 0;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4298,12 +4298,6 @@ void SurgeSynthesizer::loadFromDawExtraState()
     }
 }
 
-void SurgeSynthesizer::setupActivateExtraOutputs()
-{
-    // default off for FL Studio
-    activateExtraOutputs = (hostProgram.find("Fruit") == 0) ? true : false;
-}
-
 void SurgeSynthesizer::swapMetaControllers(int c1, int c2)
 {
     char nt[CUSTOM_CONTROLLER_LABEL_SIZE + 4];

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -422,7 +422,6 @@ class alignas(16) SurgeSynthesizer
     std::string hostProgram = "Unknown Host";
     std::string juceWrapperType = "Unknown Wrapper Type";
     bool activateExtraOutputs = true;
-    void setupActivateExtraOutputs();
 
     void changeModulatorSmoothing(Modulator::SmoothingMode m);
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -93,7 +93,6 @@ SurgeSynthProcessor::SurgeSynthProcessor()
 
     surge->hostProgram = juce::PluginHostType().getHostDescription();
     surge->juceWrapperType = wrapperTypeString;
-    surge->setupActivateExtraOutputs();
 
     midiKeyboardState.addListener(this);
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3430,15 +3430,6 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
 {
     auto wfMenu = juce::PopupMenu();
 
-    if (synth->hostProgram.find("Fruit") == 0) // only show this option for FL Studio
-    {
-        wfMenu.addItem(Surge::GUI::toOSCaseForMenu("Activate Individual Scene Outputs"), true,
-                       (synth->activateExtraOutputs),
-                       [this]() { synth->activateExtraOutputs = !synth->activateExtraOutputs; });
-
-        wfMenu.addSeparator();
-    }
-
     bool tabPosMem = Surge::Storage::getUserDefaultValue(
         &(this->synth->storage), Surge::Storage::RememberTabPositionsPerScene, false);
 
@@ -6597,8 +6588,6 @@ void SurgeGUIEditor::populateDawExtraState(SurgeSynthesizer *synth)
     des->editor.current_fx = current_fx;
     des->editor.modsource = modsource;
 
-    des->editor.activateExtraOutputs = synth->activateExtraOutputs;
-
     for (int i = 0; i < n_scenes; ++i)
     {
         des->editor.current_osc[i] = current_osc[i];
@@ -6653,8 +6642,6 @@ void SurgeGUIEditor::loadFromDAWExtraState(SurgeSynthesizer *synth)
         current_scene = des->editor.current_scene;
         current_fx = des->editor.current_fx;
         modsource = des->editor.modsource;
-
-        synth->activateExtraOutputs = des->editor.activateExtraOutputs;
 
         activateFromCurrentFx();
 


### PR DESCRIPTION
Except leave it in for LV2.

Properly closes #5657