### PR TITLE
Accessible Announcements; Announce patch loads

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -477,6 +477,23 @@ void SurgeGUIEditor::idle()
         needsModUpdate = false;
     }
 
+    if (!accAnnounceStrings.empty())
+    {
+        auto h = frame->getAccessibilityHandler();
+        if (h)
+        {
+            auto &nm = accAnnounceStrings.front();
+            if (nm.second == 0)
+            {
+                h->postAnnouncement(nm.first,
+                                    juce::AccessibilityHandler::AnnouncementPriority::high);
+            }
+        }
+        accAnnounceStrings.front().second--;
+        if (accAnnounceStrings.front().second < 0)
+            accAnnounceStrings.pop_front();
+    }
+
     if (errorItemCount)
     {
         std::vector<std::pair<std::string, std::string>> cp;
@@ -680,6 +697,18 @@ void SurgeGUIEditor::idle()
             }
         }
 
+        if (patchChanged)
+        {
+            if (!firstTimePatchLoad)
+            {
+                std::ostringstream oss;
+                oss << "Surge XT loaded patch " << synth->storage.getPatch().name
+                    << " from Category " << synth->storage.getPatch().category << " by "
+                    << synth->storage.getPatch().author;
+                enqueueAccessibleAnnouncement(oss.str());
+            }
+            firstTimePatchLoad = false;
+        }
         if (queue_refresh || synth->refresh_editor || patchChanged)
         {
             queue_refresh = false;

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -412,6 +412,11 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     std::vector<DAWExtraStateStorage::EditorState::OverlayState> overlaysForNextIdle;
 
+    std::deque<std::pair<std::string, int>> accAnnounceStrings;
+    void enqueueAccessibleAnnouncement(const std::string &s)
+    {
+        accAnnounceStrings.push_back({s, 3});
+    }
     void setAccessibilityInformationByParameter(juce::Component *c, Parameter *p,
                                                 const std::string &action);
 
@@ -477,6 +482,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
   private:
     std::array<std::unique_ptr<Surge::Widgets::VuMeter>, n_fx_slots + 1> vu;
+    bool firstTimePatchLoad{true};
     std::unique_ptr<Surge::Widgets::PatchSelector> patchSelector;
     std::unique_ptr<Surge::Widgets::PatchSelectorCommentTooltip> patchSelectorComment;
     std::unique_ptr<Surge::Widgets::OscillatorMenu> oscMenu;


### PR DESCRIPTION
1. Put a queue in SGE so we can enqueue accessible announcements
   from anywhere on the UI thread
2. Use it to announce patch changes

Addresse #5714