### PR TITLE
Minor tweaks to 3D wavetable drawing

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1307,8 +1307,8 @@ void SurgeGUIEditor::openOrRecreateEditor()
             }
 
             // would be nice if this had worked, alas...
-            // auto ff = currentSkin->getFont(Fonts::Widgets::ModButtonFont);
-            // gui_modsrc[ms]->setFont(ff);
+            auto ff = currentSkin->getFont(Fonts::Widgets::ModButtonFont);
+            gui_modsrc[ms]->setFont(ff);
 
             gui_modsrc[ms]->setBounds(r);
             gui_modsrc[ms]->setTag(tag_mod_source0 + ms);

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -630,7 +630,7 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
             if (id >= 0)
             {
             }
-                oscdata->wt.queue_id = id;
+            oscdata->wt.queue_id = id;
         }
         else if (waveTableName.contains(event.position))
         {

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
@@ -73,7 +73,6 @@ struct OscillatorWaveformDisplay : public juce::Component, public Surge::GUI::Sk
     juce::Rectangle<float> leftJog, rightJog, waveTableName;
 
     void mouseDown(const juce::MouseEvent &event) override;
-    void mouseUp(const juce::MouseEvent &event) override;
     void mouseMove(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override;
 


### PR DESCRIPTION
Addresses #3617. Basic thinning out of number of frames and samples per frame drawn, parallax and gradient adjustment.

Also enable setting font for modbuttons in SGE::openOrRecreateEditor (font was too big otherwise)