### PR TITLE
Accessibility Work on the Weekend

### DIFF
--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -464,6 +464,7 @@ accessibleEditActionInternal(const juce::KeyPress &key)
 inline std::tuple<AccessibleKeyEditAction, AccessibleKeyModifier>
 accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
 {
+    jassert(storage);
     if (!Surge::GUI::allowKeyboardEdits(storage))
         return {None, NoModifier};
 
@@ -516,6 +517,7 @@ template <typename T> bool OverlayAsAccessibleSlider<T>::keyPressed(const juce::
 
 template <typename T> bool OverlayAsAccessibleButton<T>::keyPressed(const juce::KeyPress &key)
 {
+    jassert(under->storage);
     if (!under->storage)
         return false;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -5774,7 +5774,6 @@ void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)
 {
     if (prior != curr)
     {
-        std::cout << "SETTING ISDIRTY IN LFO" << std::endl;
         synth->storage.getPatch().isDirty = true;
     }
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2811,7 +2811,12 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                 csc->setIntegerValue(0);
             else
                 csc->setIntegerValue(a + 1);
+
+            auto h = csc->getAccessibilityHandler();
+            if (h)
+                h->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
         }
+
         if (bvf)
             bvf->repaint();
         synth->switch_toggled_queued = true;
@@ -3187,6 +3192,10 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
             ((Surge::Widgets::Switch *)filtersubtype[idx])->setIntegerValue(0);
         else
             ((Surge::Widgets::Switch *)filtersubtype[idx])->setIntegerValue(a + 1);
+
+        auto h = ((Surge::Widgets::Switch *)filtersubtype[idx])->getAccessibilityHandler();
+        if (h)
+            h->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
 
         filtersubtype[idx]->repaint();
     }

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -209,6 +209,9 @@ struct ExpandingFormulaDebugger : public juce::Component, public Surge::GUI::Ski
         lfoDebugger->attack();
 
         stepLfoDebugger();
+
+        if (editor && editor->editor)
+            editor->editor->enqueueAccessibleAnnouncement("Reset Debugger");
     }
 
     void stepLfoDebugger()
@@ -225,6 +228,9 @@ struct ExpandingFormulaDebugger : public juce::Component, public Surge::GUI::Ski
             debugTable->updateContent();
             debugTable->repaint();
         }
+
+        if (editor && editor->editor)
+            editor->editor->enqueueAccessibleAnnouncement("Stepped Debugger");
     }
 
     std::unique_ptr<juce::TableListBox> debugTable;

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -3210,6 +3210,7 @@ void MSEGControlRegion::rebuild()
 
         hSnapButton = std::make_unique<Surge::Widgets::Switch>();
         hSnapButton->setSkin(skin, associatedBitmapStore);
+        hSnapButton->setStorage(storage);
         hSnapButton->addListener(this);
         hSnapButton->setBounds(xpos, ypos - 1, btnWidth, buttonHeight);
         hSnapButton->setTag(tag_horizontal_snap);
@@ -3244,6 +3245,7 @@ void MSEGControlRegion::rebuild()
 
         vSnapButton = std::make_unique<Surge::Widgets::Switch>();
         vSnapButton->setSkin(skin, associatedBitmapStore);
+        vSnapButton->setStorage(storage);
         vSnapButton->addListener(this);
         vSnapButton->setBounds(xpos, ypos - 1, btnWidth, buttonHeight);
         vSnapButton->setTag(tag_vertical_snap);

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -88,6 +88,7 @@ struct ModulationSideControls : public juce::Component,
             w->setWantsKeyboardFocus(true);
             w->setTitle(acctitle);
             w->setDescription(acctitle);
+            w->setStorage(&(editor->synth->storage));
             addAndMakeVisible(*w);
             return w;
         };
@@ -172,6 +173,21 @@ struct ModulationSideControls : public juce::Component,
     }
 
     void valueChanged(GUI::IComponentTagValue *c) override;
+    int32_t controlModifierClicked(GUI::IComponentTagValue *p, const juce::ModifierKeys &mods,
+                                   bool isDoubleClickEvent) override
+    {
+        auto tag = p->getTag();
+
+        switch (tag)
+        {
+        case tag_filter_by:
+        case tag_add_source:
+        case tag_add_target:
+            valueChanged(p);
+            return true;
+        }
+        return true;
+    }
 
     modsources add_ms;
     int add_ms_idx, add_ms_sc;
@@ -348,19 +364,26 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
 
         void resetValuesFromDatum()
         {
+            std::string accPostfix = datum.sname + " to " + datum.pname;
+
             surgeLikeSlider->setValue((datum.moddepth01 + 1) * 0.5);
             surgeLikeSlider->setQuantitizedDisplayValue((datum.moddepth01 + 1) * 0.5);
             surgeLikeSlider->setIsModulationBipolar(datum.isBipolar);
+            surgeLikeSlider->setTitle("Depth " + accPostfix);
+            surgeLikeSlider->setDescription("Depth " + accPostfix);
 
             muteButton->offset = 2;
-            muteButton->setTitle("Mute");
-            muteButton->setDescription("Mute");
+            muteButton->setTitle("Mute " + accPostfix);
+            muteButton->setDescription("Mute " + accPostfix);
             if (datum.isMuted)
             {
-                muteButton->setTitle("UnMute");
-                muteButton->setDescription("UnMute");
+                muteButton->setTitle("UnMute " + accPostfix);
+                muteButton->setDescription("UnMute " + accPostfix);
                 muteButton->offset = 3;
             }
+
+            clearButton->setTitle("Clear " + accPostfix);
+            clearButton->setDescription("Clear " + accPostfix);
 
             auto t = std::string("Source: ") + datum.sname + (" to  Target: ") + datum.pname;
             setTitle(t);

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -169,8 +169,11 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
     void updateShapeTo(int i);
     void setupAccessibility();
 
+    void shiftLeft(), shiftRight();
+
     std::unique_ptr<juce::Component> typeLayer, stepLayer;
     std::array<std::unique_ptr<juce::Component>, n_lfo_types> typeAccOverlays;
+    std::array<std::unique_ptr<juce::Component>, 2> stepJogOverlays;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
 
     std::array<std::unique_ptr<juce::Component>, n_stepseqsteps> stepSliderOverlays;

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -337,7 +337,8 @@ float MenuForDiscreteParams::nextValueInOrder(float v, int inc)
 
 std::unique_ptr<juce::AccessibilityHandler> MenuForDiscreteParams::createAccessibilityHandler()
 {
-    return std::make_unique<DiscreteAH<MenuForDiscreteParams>>(this);
+    return std::make_unique<DiscreteAH<MenuForDiscreteParams, juce::AccessibilityRole::comboBox>>(
+        this);
 }
 
 bool MenuForDiscreteParams::keyPressed(const juce::KeyPress &key)

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -297,7 +297,10 @@ bool MultiSwitch::keyPressed(const juce::KeyPress &key)
         return true;
     }
 
-    if (action != Increase && action != Decrease)
+    bool doit =
+        action != Increase || action != Decrease || (rows * columns == 1 && action == Return);
+
+    if (!doit)
         return false;
 
     int dir = 1;
@@ -308,7 +311,14 @@ bool MultiSwitch::keyPressed(const juce::KeyPress &key)
 
     auto iv = limit_range(getIntegerValue() + dir, 0, rows * columns - 1);
 
-    setValue(1.f * iv / (rows * columns - 1));
+    if (rows * columns == 1)
+    {
+        setValue(0);
+    }
+    else
+    {
+        setValue(1.f * iv / (rows * columns - 1));
+    }
     notifyBeginEdit();
     notifyValueChanged();
     notifyEndEdit();

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -338,6 +338,10 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
             if (sge)
             {
                 sge->setPatchAsFavorite(isFavorite);
+                std::ostringstream oss;
+                oss << pname << (isFavorite ? " added to " : " removed from ")
+                    << "favorite patches.";
+                sge->enqueueAccessibleAnnouncement(oss.str());
                 repaint();
             }
         }

--- a/src/surge-xt/gui/widgets/Switch.cpp
+++ b/src/surge-xt/gui/widgets/Switch.cpp
@@ -140,6 +140,19 @@ bool Switch::keyPressed(const juce::KeyPress &key)
         return true;
     }
 
+    if (action == Return && !isMultiIntegerValued())
+    {
+        auto nv = 1.f;
+        if (value > 0.5)
+            nv = 0;
+        value = nv;
+        notifyBeginEdit();
+        notifyValueChanged();
+        notifyEndEdit();
+        repaint();
+        return true;
+    }
+
     if (action != Increase && action != Decrease)
         return false;
 


### PR DESCRIPTION
Addresses #5714

- Modulation Add/Filter buttons get enter and shift-f10 launching menu
- Tuning editor buttons (export etc) respond to return
- Debug-assert if key handler is silently dropped due to storage
- MSEG snap buttons respond to enter properly
- All other switches respond to enter properly
- Favorite add/remove announced to screen reader
- Announce init/step debugger stepping the debugger
- StepSequencer Changes
   - Steps then Trigmasks is tab order as opposed to step/trig
   - Rotate Buttons accessible
- Expanded names to ModList items (Depth -> "Depth Velcoity to A Osc1 Pitch")
- Add a few Notify calls (but doesn't fix the filter subtype)
- Change discrete menu type to ComboBox which is more accurate
  but still doesn't solve Twist not announcing on key change