### PR TITLE
Portable Patch Favorites

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6611,15 +6611,18 @@ std::string SurgeGUIEditor::showShortcutDescription(const std::string &shortcutD
     }
 }
 
-void SurgeGUIEditor::setPatchAsFavorite(bool b)
+void SurgeGUIEditor::setPatchAsFavorite(bool b) { setSpecificPatchAsFavorite(synth->patchid, b); }
+
+void SurgeGUIEditor::setSpecificPatchAsFavorite(int patchid, bool b)
 {
-    if (synth->patchid >= 0 && synth->patchid < synth->storage.patch_list.size())
+    if (patchid >= 0 && patchid < synth->storage.patch_list.size())
     {
-        synth->storage.patch_list[synth->patchid].isFavorite = b;
-        synth->storage.patchDB->setUserFavorite(
-            synth->storage.patch_list[synth->patchid].path.u8string(), b);
+        synth->storage.patch_list[patchid].isFavorite = b;
+        synth->storage.patchDB->setUserFavorite(synth->storage.patch_list[patchid].path.u8string(),
+                                                b);
     }
 }
+
 bool SurgeGUIEditor::isPatchFavorite()
 {
     if (synth->patchid >= 0 && synth->patchid < synth->storage.patch_list.size())

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -528,6 +528,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool isPatchFavorite();
     bool isPatchUser();
 
+    void setSpecificPatchAsFavorite(int patchid, bool b);
+
     /*
      * Modulation Client API
      */

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -127,6 +127,8 @@ struct PatchSelector : public juce::Component,
     void showClassicMenu(bool singleCategory = false);
     bool optionallyAddFavorites(juce::PopupMenu &into, bool addColumnBreakAndHeader,
                                 bool addToSubmenu = true);
+    void exportFavorites();
+    void importFavorites();
     void openPatchBrowser();
 
     void paint(juce::Graphics &g) override;


### PR DESCRIPTION
A function to export and import favorite lists in a filesystem
independent fashion (namely we replace the factory and user roots
with keys on export and replace them with paths on import)

Closes #5810