### PR TITLE
Add Tone filter (from Combulator) to Phaser

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -328,6 +328,7 @@ bool Parameter::can_deactivate() const
     switch (ctrltype)
     {
     case ct_percent_deactivatable:
+    case ct_percent_bipolar_deactivatable:
     case ct_freq_hpf:
     case ct_freq_audible_deactivatable:
     case ct_freq_audible_deactivatable_hp:
@@ -1009,6 +1010,7 @@ void Parameter::set_type(int ctrltype)
         break;
     case ct_modern_trimix:
     case ct_percent_bipolar:
+    case ct_percent_bipolar_deactivatable:
     case ct_percent_bipolar_stereo:
     case ct_percent_bipolar_pan:
     case ct_percent_bipolar_stringbal:
@@ -1303,6 +1305,7 @@ void Parameter::set_type(int ctrltype)
     {
     case ct_percent:
     case ct_dly_fb_clippingmodes:
+    case ct_percent_bipolar_deactivatable:
     case ct_percent_deactivatable:
     case ct_percent_oscdrift:
     case ct_percent200:
@@ -1624,6 +1627,7 @@ void Parameter::bound_value(bool force_integer)
         switch (ctrltype)
         {
         case ct_percent:
+        case ct_percent_bipolar_deactivatable:
         case ct_percent_deactivatable:
         case ct_dly_fb_clippingmodes:
         case ct_percent_oscdrift:
@@ -1884,6 +1888,7 @@ bool Parameter::supportsDynamicName() const
     case ct_lfophaseshuffle:
     case ct_percent:
     case ct_percent_bipolar:
+    case ct_percent_bipolar_deactivatable:
     case ct_percent_bipolar_w_dynamic_unipolar_formatting:
     case ct_twist_aux_mix:
     case ct_percent_deactivatable:
@@ -3876,6 +3881,7 @@ bool Parameter::can_setvalue_from_string() const
     case ct_percent_oscdrift:
     case ct_percent200:
     case ct_percent_bipolar:
+    case ct_percent_bipolar_deactivatable:
     case ct_percent_bipolar_stereo:
     case ct_percent_bipolar_pan:
     case ct_percent_bipolar_stringbal:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -43,6 +43,7 @@ enum ctrltypes
     ct_percent_deactivatable,
     ct_dly_fb_clippingmodes,
     ct_percent_bipolar,
+    ct_percent_bipolar_deactivatable,
     ct_percent_bipolar_stereo,    // bipolar with special text strings at -100% +100% and 0%
     ct_percent_bipolar_stringbal, // bipolar with special text strings
     ct_percent_bipolar_w_dynamic_unipolar_formatting,

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -98,6 +98,7 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 //                           added two additional FX slots to all FX chains
 //                           added new Conditioner parameter (Side Low Cut)
 // 17 -> 18 (XT 1.1 release) added clipping options to Delay Feedback parameter (via deform)
+//                           added Tone parameter to Phaser effect
 
 const int ff_revision = 18;
 

--- a/src/common/dsp/effects/CombulatorEffect.cpp
+++ b/src/common/dsp/effects/CombulatorEffect.cpp
@@ -343,10 +343,14 @@ void CombulatorEffect::process(float *dataL, float *dataR)
     copy_block(dataOS[0], L, BLOCK_SIZE_QUAD);
     copy_block(dataOS[1], R, BLOCK_SIZE_QUAD);
 
-    lp.process_block(L, R);
-    hp.process_block(L, R);
+    if (!fxdata->p[combulator_tone].deactivated)
+    {
+        lp.process_block(L, R);
+        hp.process_block(L, R);
+    }
 
     auto cm = clamp01(*f[combulator_mix]);
+
     mix.set_target_smoothed(cm);
     mix.fade_2_blocks_to(dataL, L, dataR, R, dataL, dataR, BLOCK_SIZE_QUAD);
 }
@@ -405,7 +409,7 @@ void CombulatorEffect::init_ctrltypes()
     fxdata->p[combulator_feedback].set_type(ct_percent_bipolar);
     fxdata->p[combulator_feedback].posy_offset = 3;
     fxdata->p[combulator_tone].set_name("Tone");
-    fxdata->p[combulator_tone].set_type(ct_percent_bipolar);
+    fxdata->p[combulator_tone].set_type(ct_percent_bipolar_deactivatable);
     fxdata->p[combulator_tone].posy_offset = 3;
 
     fxdata->p[combulator_gain1].set_name("Comb 1");
@@ -446,5 +450,15 @@ void CombulatorEffect::init_default_values()
     fxdata->p[combulator_pan2].val.f = 0.25f;
     fxdata->p[combulator_pan3].val.f = -0.25f;
     fxdata->p[combulator_tone].val.f = 0;
+    fxdata->p[combulator_tone].deactivated = false;
     fxdata->p[combulator_mix].val.f = 1.0f;
+}
+
+void CombulatorEffect::handleStreamingMismatches(int streamingRevision,
+                                                 int currentSynthStreamingRevision)
+{
+    if (streamingRevision <= 17)
+    {
+        fxdata->p[combulator_tone].deactivated = false;
+    }
 }

--- a/src/common/dsp/effects/CombulatorEffect.h
+++ b/src/common/dsp/effects/CombulatorEffect.h
@@ -62,6 +62,8 @@ class CombulatorEffect : public Effect
     virtual void init_default_values() override;
     virtual const char *group_label(int id) override;
     virtual int group_label_ypos(int id) override;
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
 
     sst::filters::QuadFilterUnitState *qfus = nullptr;
     HalfRateFilter halfbandOUT, halfbandIN;

--- a/src/common/dsp/effects/FlangerEffect.cpp
+++ b/src/common/dsp/effects/FlangerEffect.cpp
@@ -256,7 +256,7 @@ void FlangerEffect::process(float *dataL, float *dataR)
         fbv = sqrt(fbv);
 
     feedback.newValue(feedbackScale * fbv);
-    fb_lf_damping.newValue(0.4 * *f[fl_damping]);
+    fb_hf_damping.newValue(0.4 * *f[fl_damping]);
     float combs alignas(16)[2][BLOCK_SIZE];
 
     // Obviously when we implement stereo spread this will be different
@@ -336,7 +336,7 @@ void FlangerEffect::process(float *dataL, float *dataR)
             fbr = 1.5 * fbr - 0.5 * fbr * fbr * fbr;
 
             // and now we have clipped, apply the damping. FIXME - move to one mul form
-            float df = limit_range(fb_lf_damping.v, 0.01f, 0.99f);
+            float df = limit_range(fb_hf_damping.v, 0.01f, 0.99f);
             lpaL = lpaL * (1.0 - df) + fbl * df;
             fbl = fbl - lpaL;
 
@@ -391,7 +391,7 @@ void FlangerEffect::process(float *dataL, float *dataR)
         depth.process();
         mix.process();
         feedback.process();
-        fb_lf_damping.process();
+        fb_hf_damping.process();
         voices.process();
     }
 
@@ -481,7 +481,7 @@ void FlangerEffect::init_ctrltypes()
     fxdata->p[fl_feedback].set_name("Feedback");
     fxdata->p[fl_feedback].set_type(ct_percent);
 
-    fxdata->p[fl_damping].set_name("LF Damping");
+    fxdata->p[fl_damping].set_name("HF Damping");
     fxdata->p[fl_damping].set_type(ct_percent);
 
     fxdata->p[fl_width].set_name("Width");

--- a/src/common/dsp/effects/FlangerEffect.h
+++ b/src/common/dsp/effects/FlangerEffect.h
@@ -113,7 +113,7 @@ class FlangerEffect : public Effect
     lipol<float, true> lfoval[2][COMBS_PER_CHANNEL], delaybase[2][COMBS_PER_CHANNEL];
     lipol<float, true> depth, mix;
     lipol<float, true> voices, voice_detune, voice_chord;
-    lipol<float, true> feedback, fb_lf_damping;
+    lipol<float, true> feedback, fb_hf_damping;
     lag<float> vzeropitch;
     float lfosandhtarget[2][COMBS_PER_CHANNEL];
     float vweights[2][COMBS_PER_CHANNEL];

--- a/src/common/dsp/effects/PhaserEffect.h
+++ b/src/common/dsp/effects/PhaserEffect.h
@@ -58,19 +58,20 @@ class PhaserEffect : public Effect
         ph_stages,
         ph_spread,
         ph_mod_wave,
+        ph_tone,
 
         ph_num_params,
     };
 
   private:
-    lipol<float, true> feedback;
+    lipol<float, true> feedback, tone;
     static const int max_stages = 16;
     static const int default_stages = 4;
     int n_stages = default_stages;
     int n_bq_units = default_stages << 1;
     int n_bq_units_initialised = 0;
     float dL, dR;
-    BiquadFilter *biquad[max_stages * 2];
+    BiquadFilter *biquad[max_stages * 2], lp, hp;
     int bi; // block increment (to keep track of events not occurring every n blocks)
     void init_stages();
 

--- a/src/common/dsp/effects/chowdsp/SpringReverbEffect.cpp
+++ b/src/common/dsp/effects/chowdsp/SpringReverbEffect.cpp
@@ -74,7 +74,7 @@ void SpringReverbEffect::init_ctrltypes()
     fxdata->p[spring_reverb_reflections].val_default.f = 1.0f;
     fxdata->p[spring_reverb_reflections].posy_offset = 1;
 
-    fxdata->p[spring_reverb_damping].set_name("Damping");
+    fxdata->p[spring_reverb_damping].set_name("HF Damping");
     fxdata->p[spring_reverb_damping].set_type(ct_percent);
     fxdata->p[spring_reverb_damping].val_default.f = 0.5f;
     fxdata->p[spring_reverb_damping].posy_offset = 1;


### PR DESCRIPTION
Also make it deactivatable in both Combulator and Phaser (added ct_percent_bipolar_deactivatable).
Rename LF Damping in Flanger to HF Damping (because that's what it really is, in fact).
Rename Damping in Spring Reverb to HF Damping for consistency.

Pinging @VincyZed for manual update! 🙂 