### PR TITLE
fix for popup menu scaling on hidpi display

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Jani Frilander <http://github.com/janifr>
 Amy Furniss <http://github.com/amyfurniss>
 Cale Gibbard <cgibbard@gmail.com>
 Brian Ginsburg <https://github.com/bgins>
+Ben Goldwasser <https://github.com/sadguitarius>
 Nathan Kopp <nk.sg@nathankopp.com>
 Korridor <fabian.kempe@gmail.com>
 Mario Krušelj a.k.a. EvilDragon <http://github.com/mkruselj>

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2218,7 +2218,6 @@ juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions(const juce::Component 
     }
 }
 
-
 void SurgeGUIEditor::showZoomMenu(const juce::Point<int> &where,
                                   Surge::GUI::IComponentTagValue *launchFrom)
 {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2130,7 +2130,8 @@ void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene, Surge::Widget
                                synth->storage.getPatch().isDirty = true;
                        });
 
-    fxGridMenu.showMenuAsync(juce::PopupMenu::Options(), Surge::GUI::makeEndHoverCallback(c));
+    juce::Point<int> cwhere = c->asJuceComponent()->getBounds().getBottomLeft();
+    fxGridMenu.showMenuAsync(optionsForPosition(cwhere), Surge::GUI::makeEndHoverCallback(c));
 }
 
 void SurgeGUIEditor::controlBeginEdit(Surge::GUI::IComponentTagValue *control)
@@ -2193,6 +2194,7 @@ void SurgeGUIEditor::toggleMPE()
 juce::PopupMenu::Options SurgeGUIEditor::optionsForPosition(const juce::Point<int> &where)
 {
     auto o = juce::PopupMenu::Options();
+    o = o.withTargetComponent(juceEditor);
     if (where.x > 0 && where.y > 0)
     {
         auto r = juce::Rectangle<int>().withWidth(1).withHeight(1).withPosition(
@@ -5236,7 +5238,7 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
         if ((lfo_id >= 0) && (lfo_id < n_lfos))
         {
             if (!lfoDisplay)
-                lfoDisplay = std::make_unique<Surge::Widgets::LFOAndStepDisplay>();
+                lfoDisplay = std::make_unique<Surge::Widgets::LFOAndStepDisplay>(this);
             lfoDisplay->setBounds(skinCtrl->getRect());
             lfoDisplay->setSkin(currentSkin, bitmapStore, skinCtrl);
             lfoDisplay->setTag(p->id + start_paramtags);

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2130,8 +2130,7 @@ void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene, Surge::Widget
                                synth->storage.getPatch().isDirty = true;
                        });
 
-    juce::Point<int> cwhere = c->asJuceComponent()->getBounds().getBottomLeft();
-    fxGridMenu.showMenuAsync(optionsForPosition(cwhere), Surge::GUI::makeEndHoverCallback(c));
+    fxGridMenu.showMenuAsync(popupMenuOptions(c), Surge::GUI::makeEndHoverCallback(c));
 }
 
 void SurgeGUIEditor::controlBeginEdit(Surge::GUI::IComponentTagValue *control)
@@ -2191,7 +2190,7 @@ void SurgeGUIEditor::toggleMPE()
     }
 }
 
-juce::PopupMenu::Options SurgeGUIEditor::optionsForPosition(const juce::Point<int> &where)
+juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions(const juce::Point<int> &where)
 {
     auto o = juce::PopupMenu::Options();
     o = o.withTargetComponent(juceEditor);
@@ -2204,25 +2203,37 @@ juce::PopupMenu::Options SurgeGUIEditor::optionsForPosition(const juce::Point<in
     return o;
 }
 
+juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions(const juce::Component *c)
+{
+    auto where = c->getBounds().getBottomLeft();
+    return popupMenuOptions(where);
+}
+
+juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions()
+{
+    auto where = frame->getLocalPoint(nullptr, juce::Desktop::getMousePosition());
+    return popupMenuOptions(where);
+}
+
 void SurgeGUIEditor::showZoomMenu(const juce::Point<int> &where,
                                   Surge::GUI::IComponentTagValue *launchFrom)
 {
     auto m = makeZoomMenu(where, true);
-    m.showMenuAsync(optionsForPosition(where), Surge::GUI::makeEndHoverCallback(launchFrom));
+    m.showMenuAsync(popupMenuOptions(where), Surge::GUI::makeEndHoverCallback(launchFrom));
 }
 
 void SurgeGUIEditor::showMPEMenu(const juce::Point<int> &where,
                                  Surge::GUI::IComponentTagValue *launchFrom)
 {
     auto m = makeMpeMenu(where, true);
-    m.showMenuAsync(optionsForPosition(where), Surge::GUI::makeEndHoverCallback(launchFrom));
+    m.showMenuAsync(popupMenuOptions(where), Surge::GUI::makeEndHoverCallback(launchFrom));
 }
 
 void SurgeGUIEditor::showLfoMenu(const juce::Point<int> &where,
                                  Surge::GUI::IComponentTagValue *launchFrom)
 {
     auto m = makeLfoMenu(where);
-    m.showMenuAsync(optionsForPosition(where), Surge::GUI::makeEndHoverCallback(launchFrom));
+    m.showMenuAsync(popupMenuOptions(where), Surge::GUI::makeEndHoverCallback(launchFrom));
 }
 
 void SurgeGUIEditor::toggleTuning()
@@ -2243,7 +2254,7 @@ void SurgeGUIEditor::showTuningMenu(const juce::Point<int> &where,
 {
     auto m = makeTuningMenu(where, true);
 
-    m.showMenuAsync(optionsForPosition(where), Surge::GUI::makeEndHoverCallback(launchFrom));
+    m.showMenuAsync(popupMenuOptions(where), Surge::GUI::makeEndHoverCallback(launchFrom));
 }
 
 void SurgeGUIEditor::scaleFileDropped(const string &fn)
@@ -2473,7 +2484,7 @@ void SurgeGUIEditor::showSettingsMenu(const juce::Point<int> &where,
     Surge::GUI::addMenuWithShortcut(settingsMenu, "About Surge", showShortcutDescription("F12"),
                                     [this]() { this->showAboutScreen(); });
 
-    settingsMenu.showMenuAsync(optionsForPosition(where),
+    settingsMenu.showMenuAsync(popupMenuOptions(where),
                                Surge::GUI::makeEndHoverCallback(launchFrom));
 }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2203,17 +2203,21 @@ juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions(const juce::Point<int>
     return o;
 }
 
-juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions(const juce::Component *c)
+juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions(const juce::Component *c,
+                                                          bool useComponentBounds)
 {
-    auto where = c->getBounds().getBottomLeft();
-    return popupMenuOptions(where);
+    if (!c || !useComponentBounds)
+    {
+        auto where = frame->getLocalPoint(nullptr, juce::Desktop::getMousePosition());
+        return popupMenuOptions(where);
+    }
+    else
+    {
+        auto where = c->getBounds().getBottomLeft();
+        return popupMenuOptions(where);
+    }
 }
 
-juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions()
-{
-    auto where = frame->getLocalPoint(nullptr, juce::Desktop::getMousePosition());
-    return popupMenuOptions(where);
-}
 
 void SurgeGUIEditor::showZoomMenu(const juce::Point<int> &where,
                                   Surge::GUI::IComponentTagValue *launchFrom)

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -263,7 +263,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     juce::PopupMenu::Options popupMenuOptions(const juce::Point<int> &where);
     juce::PopupMenu::Options popupMenuOptions(const juce::Component *c = nullptr,
                                               bool useComponentBounds = true);
-   
+
     void showHTML(const std::string &s);
 
     void toggleMPE();

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -260,7 +260,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void showZoomMenu(const juce::Point<int> &where, Surge::GUI::IComponentTagValue *launchFrom);
     void showLfoMenu(const juce::Point<int> &where, Surge::GUI::IComponentTagValue *launchFrom);
 
-    juce::PopupMenu::Options optionsForPosition(const juce::Point<int> &where);
+    juce::PopupMenu::Options popupMenuOptions(const juce::Point<int> &where);
+    juce::PopupMenu::Options popupMenuOptions(const juce::Component *c);
+    juce::PopupMenu::Options popupMenuOptions();
 
     void showHTML(const std::string &s);
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -261,9 +261,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void showLfoMenu(const juce::Point<int> &where, Surge::GUI::IComponentTagValue *launchFrom);
 
     juce::PopupMenu::Options popupMenuOptions(const juce::Point<int> &where);
-    juce::PopupMenu::Options popupMenuOptions(const juce::Component *c);
-    juce::PopupMenu::Options popupMenuOptions();
-
+    juce::PopupMenu::Options popupMenuOptions(const juce::Component *c = nullptr,
+                                              bool useComponentBounds = true);
+   
     void showHTML(const std::string &s);
 
     void toggleMPE();

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -187,7 +187,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         auto ms = &synth->storage.getPatch().msegs[current_scene][lfo_id];
         auto mse = std::make_unique<Surge::Overlays::MSEGEditor>(
             &(synth->storage), lfodata, ms, &msegEditState[current_scene][lfo_id], currentSkin,
-            bitmapStore);
+            bitmapStore, this);
 
         mse->onModelChanged = [this]() {
             if (lfoDisplayRepaintCountdown == 0)

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -499,7 +499,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     });
             }
 
-            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
+            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
                                       Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
@@ -535,7 +535,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     queue_refresh = true;
                                 });
 
-            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
+            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
                                       Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
@@ -565,7 +565,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         tcomp->setSkin(currentSkin, bitmapStore);
         contextMenu.addCustomItem(-1, std::move(tcomp));
 
-        contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
+        contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
                                   Surge::GUI::makeEndHoverCallback(control));
 
         return 1;
@@ -1059,7 +1059,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 }
             }
 
-            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
+            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
                                       Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
@@ -2354,7 +2354,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 }
             }
 
-            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
+            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
                                       Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -452,8 +452,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         if (tag == tag_settingsmenu)
         {
             useDevMenu = true;
-            auto where =
-                frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+            auto where = frame->getLocalPoint(nullptr, juce::Desktop::getMousePosition());
             showSettingsMenu(where, control);
             return 1;
         }
@@ -461,8 +460,6 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         if (tag == tag_osc_select)
         {
             auto r = control->asJuceComponent()->getBounds();
-            auto where =
-                frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
 
             int a = current_osc[current_scene];
             // int a = limit_range((int)((3 * (where.x - r.getX())) / r.getWidth()), 0, 2);
@@ -502,8 +499,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     });
             }
 
-            juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
-            contextMenu.showMenuAsync(optionsForPosition(cwhere),
+            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
                                       Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
@@ -539,8 +535,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     queue_refresh = true;
                                 });
 
-            juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
-            contextMenu.showMenuAsync(optionsForPosition(cwhere),
+            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
                                       Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
@@ -570,8 +565,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         tcomp->setSkin(currentSkin, bitmapStore);
         contextMenu.addCustomItem(-1, std::move(tcomp));
 
-        juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
-        contextMenu.showMenuAsync(optionsForPosition(cwhere),
+        contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
                                   Surge::GUI::makeEndHoverCallback(control));
 
         return 1;
@@ -1065,8 +1059,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 }
             }
 
-            juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
-            contextMenu.showMenuAsync(optionsForPosition(cwhere),
+            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
                                       Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
@@ -2361,8 +2354,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 }
             }
 
-            juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
-            contextMenu.showMenuAsync(optionsForPosition(cwhere),
+            contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent()),
                                       Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -452,7 +452,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         if (tag == tag_settingsmenu)
         {
             useDevMenu = true;
-            auto where = frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+            auto where =
+                frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
             showSettingsMenu(where, control);
             return 1;
         }
@@ -1066,7 +1067,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
             contextMenu.showMenuAsync(optionsForPosition(cwhere),
-                                        Surge::GUI::makeEndHoverCallback(control));
+                                      Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
 
@@ -2362,7 +2363,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
             contextMenu.showMenuAsync(optionsForPosition(cwhere),
-                                        Surge::GUI::makeEndHoverCallback(control));
+                                      Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
         // reset to default value

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -452,7 +452,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         if (tag == tag_settingsmenu)
         {
             useDevMenu = true;
-            showSettingsMenu(juce::Point<int>{}, control);
+            auto where = frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+            showSettingsMenu(where, control);
             return 1;
         }
 
@@ -1063,8 +1064,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 }
             }
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options(),
-                                      Surge::GUI::makeEndHoverCallback(control));
+            juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
+            contextMenu.showMenuAsync(optionsForPosition(cwhere),
+                                        Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
 
@@ -2358,8 +2360,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 }
             }
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options(),
-                                      Surge::GUI::makeEndHoverCallback(control));
+            juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getBottomLeft();
+            contextMenu.showMenuAsync(optionsForPosition(cwhere),
+                                        Surge::GUI::makeEndHoverCallback(control));
             return 1;
         }
         // reset to default value
@@ -2563,8 +2566,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     if (tag == tag_lfo_menu)
     {
         control->setValue(0);
-        juce::Point<int> where{};
-
+        juce::Point<int> where = control->asJuceComponent()->getBounds().getBottomLeft();
         showLfoMenu(where, control);
         return;
     }
@@ -2921,9 +2923,9 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     break;
     case tag_settingsmenu:
     {
-        juce::Point<int> menuPoint;
+        juce::Point<int> cwhere = control->asJuceComponent()->getBounds().getTopLeft();
         useDevMenu = false;
-        showSettingsMenu(menuPoint, control);
+        showSettingsMenu(cwhere, control);
     }
     break;
     case tag_osc_select:

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -2638,7 +2638,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             typeTo(Surge::GUI::toOSCaseForMenu("Brownian Bridge"),
                    MSEGStorage::segment::Type::BROWNIAN);
 
-            auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+            auto where = guiEditor->frame.get()->getLocalPoint(
+                nullptr, juce::Desktop::getInstance().getMousePosition());
             contextMenu.showMenuAsync(guiEditor->optionsForPosition(where));
         }
     }
@@ -3041,7 +3042,8 @@ int32_t MSEGControlRegion::controlModifierClicked(Surge::GUI::IComponentTagValue
                                 showTypein);
         }
 
-        auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+        auto where = guiEditor->frame.get()->getLocalPoint(
+            nullptr, juce::Desktop::getInstance().getMousePosition());
         contextMenu.showMenuAsync(guiEditor->optionsForPosition(where));
     }
     return 1;
@@ -3284,7 +3286,8 @@ void MSEGControlRegion::rebuild()
 }
 
 MSEGEditor::MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, State *eds,
-                       Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> bmp, SurgeGUIEditor *ed)
+                       Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> bmp,
+                       SurgeGUIEditor *ed)
     : OverlayComponent("MSEG Editor")
 {
     // Leave these in for now
@@ -3295,7 +3298,8 @@ MSEGEditor::MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *
     setSkin(skin, bmp);
 
     canvas = std::make_unique<MSEGCanvas>(storage, lfodata, ms, eds, skin, bmp, ed);
-    controls = std::make_unique<MSEGControlRegion>(nullptr, storage, lfodata, ms, eds, skin, bmp, ed);
+    controls =
+        std::make_unique<MSEGControlRegion>(nullptr, storage, lfodata, ms, eds, skin, bmp, ed);
 
     canvas->controlregion = controls.get();
     controls->canvas = canvas.get();

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -67,7 +67,7 @@ struct MSEGControlRegion : public juce::Component,
 {
     MSEGControlRegion(MSEGCanvas *c, SurgeStorage *storage, LFOStorage *lfos, MSEGStorage *ms,
                       MSEGEditor::State *eds, Surge::GUI::Skin::ptr_t skin,
-                      std::shared_ptr<SurgeImageStore> b)
+                      std::shared_ptr<SurgeImageStore> b, SurgeGUIEditor *ed)
         : juce::Component("MSEG Control Region")
     {
         setSkin(skin, b);
@@ -76,6 +76,7 @@ struct MSEGControlRegion : public juce::Component,
         this->lfodata = lfos;
         this->canvas = c;
         this->storage = storage;
+        this->guiEditor = ed;
         setAccessible(true);
         setTitle("Controls");
         setDescription("Controls");
@@ -115,12 +116,13 @@ struct MSEGControlRegion : public juce::Component,
     MSEGCanvas *canvas = nullptr;
     LFOStorage *lfodata = nullptr;
     SurgeStorage *storage = nullptr;
+    SurgeGUIEditor *guiEditor = nullptr;
 };
 
 struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComponent
 {
     MSEGCanvas(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, MSEGEditor::State *eds,
-               Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> b)
+               Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> b, SurgeGUIEditor *ed)
         : juce::Component("MSEG Canvas")
     {
         setSkin(skin, b);
@@ -128,6 +130,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         this->ms = ms;
         this->eds = eds;
         this->lfodata = lfodata;
+        this->guiEditor = ed;
         Surge::MSEG::rebuildCache(ms);
         handleDrawable = b->getImage(IDB_MSEG_NODES);
         timeEditMode = (MSEGCanvas::TimeEdit)eds->timeEditMode;
@@ -2635,7 +2638,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             typeTo(Surge::GUI::toOSCaseForMenu("Brownian Bridge"),
                    MSEGStorage::segment::Type::BROWNIAN);
 
-            contextMenu.showMenuAsync(juce::PopupMenu::Options());
+            auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+            contextMenu.showMenuAsync(guiEditor->optionsForPosition(where));
         }
     }
 
@@ -2761,6 +2765,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
     SurgeStorage *storage = nullptr;
     float loopDragTime = -1, loopDragEnd = -1;
     bool loopDragIsStart = false;
+    SurgeGUIEditor *guiEditor;
 
     SurgeImage *handleDrawable{nullptr};
 };
@@ -3036,7 +3041,8 @@ int32_t MSEGControlRegion::controlModifierClicked(Surge::GUI::IComponentTagValue
                                 showTypein);
         }
 
-        contextMenu.showMenuAsync(juce::PopupMenu::Options());
+        auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+        contextMenu.showMenuAsync(guiEditor->optionsForPosition(where));
     }
     return 1;
 }
@@ -3278,7 +3284,7 @@ void MSEGControlRegion::rebuild()
 }
 
 MSEGEditor::MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, State *eds,
-                       Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> bmp)
+                       Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> bmp, SurgeGUIEditor *ed)
     : OverlayComponent("MSEG Editor")
 {
     // Leave these in for now
@@ -3288,8 +3294,8 @@ MSEGEditor::MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *
     }
     setSkin(skin, bmp);
 
-    canvas = std::make_unique<MSEGCanvas>(storage, lfodata, ms, eds, skin, bmp);
-    controls = std::make_unique<MSEGControlRegion>(nullptr, storage, lfodata, ms, eds, skin, bmp);
+    canvas = std::make_unique<MSEGCanvas>(storage, lfodata, ms, eds, skin, bmp, ed);
+    controls = std::make_unique<MSEGControlRegion>(nullptr, storage, lfodata, ms, eds, skin, bmp, ed);
 
     canvas->controlregion = controls.get();
     controls->canvas = canvas.get();

--- a/src/surge-xt/gui/overlays/MSEGEditor.h
+++ b/src/surge-xt/gui/overlays/MSEGEditor.h
@@ -46,7 +46,8 @@ struct MSEGEditor : public OverlayComponent,
         int timeEditMode = 0;
     };
     MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, State *eds,
-               Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> b, SurgeGUIEditor *ed);
+               Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> b,
+               SurgeGUIEditor *ed);
     ~MSEGEditor();
     void forceRefresh() override;
 

--- a/src/surge-xt/gui/overlays/MSEGEditor.h
+++ b/src/surge-xt/gui/overlays/MSEGEditor.h
@@ -21,8 +21,11 @@
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "OverlayComponent.h"
 
+class SurgeGUIEditor;
+
 namespace Surge
 {
+
 namespace Overlays
 {
 struct MSEGControlRegion;
@@ -43,7 +46,7 @@ struct MSEGEditor : public OverlayComponent,
         int timeEditMode = 0;
     };
     MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, State *eds,
-               Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> b);
+               Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> b, SurgeGUIEditor *ed);
     ~MSEGEditor();
     void forceRefresh() override;
 

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -1003,7 +1003,8 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
                 });
         }
 
-        auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+        auto where = guiEditor->frame.get()->getLocalPoint(
+            nullptr, juce::Desktop::getInstance().getMousePosition());
         men.showMenuAsync(guiEditor->optionsForPosition(where));
     }
     break;
@@ -1174,7 +1175,8 @@ void ModulationSideControls::showAddSourceMenu()
     men.addSubMenu("Envelopes", addEGBSub);
     men.addSubMenu("MIDI", addMIDIBSub);
 
-    auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+    auto where = guiEditor->frame.get()->getLocalPoint(
+        nullptr, juce::Desktop::getInstance().getMousePosition());
     men.showMenuAsync(guiEditor->optionsForPosition(where));
 }
 
@@ -1381,7 +1383,8 @@ void ModulationSideControls::showAddTargetMenu()
         si++;
     }
 
-    auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+    auto where = guiEditor->frame.get()->getLocalPoint(
+        nullptr, juce::Desktop::getInstance().getMousePosition());
     men.showMenuAsync(guiEditor->optionsForPosition(where));
 }
 

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -44,7 +44,7 @@ struct ModulationSideControls : public juce::Component,
     };
 
     ModulationEditor *editor{nullptr};
-    ModulationSideControls(ModulationEditor *e) : editor(e)
+    ModulationSideControls(ModulationEditor *e, SurgeGUIEditor *ed) : editor(e), guiEditor(ed)
     {
         setAccessible(true);
         setTitle("Controls");
@@ -218,6 +218,7 @@ struct ModulationSideControls : public juce::Component,
     std::unique_ptr<juce::Label> sortL, filterL, addL, dispL;
     std::unique_ptr<Surge::Widgets::MultiSwitchSelfDraw> sortW, filterW, addSourceW, addTargetW,
         dispW;
+    SurgeGUIEditor *guiEditor;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModulationSideControls);
 };
@@ -1002,7 +1003,8 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
                 });
         }
 
-        men.showMenuAsync(juce::PopupMenu::Options(), GUI::makeEndHoverCallback(filterW.get()));
+        auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+        men.showMenuAsync(guiEditor->optionsForPosition(where));
     }
     break;
     case tag_add_source:
@@ -1172,7 +1174,8 @@ void ModulationSideControls::showAddSourceMenu()
     men.addSubMenu("Envelopes", addEGBSub);
     men.addSubMenu("MIDI", addMIDIBSub);
 
-    men.showMenuAsync(juce::PopupMenu::Options(), GUI::makeEndHoverCallback(addSourceW.get()));
+    auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+    men.showMenuAsync(guiEditor->optionsForPosition(where));
 }
 
 void ModulationSideControls::showAddTargetMenu()
@@ -1378,7 +1381,8 @@ void ModulationSideControls::showAddTargetMenu()
         si++;
     }
 
-    men.showMenuAsync(juce::PopupMenu::Options(), GUI::makeEndHoverCallback(addTargetW.get()));
+    auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+    men.showMenuAsync(guiEditor->optionsForPosition(where));
 }
 
 void ModulationSideControls::doAdd()
@@ -1413,7 +1417,7 @@ ModulationEditor::ModulationEditor(SurgeGUIEditor *ed, SurgeSynthesizer *s)
 
     synth->addModulationAPIListener(this);
 
-    sideControls = std::make_unique<ModulationSideControls>(this);
+    sideControls = std::make_unique<ModulationSideControls>(this, ed);
 
     addAndMakeVisible(*sideControls);
 }

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -44,8 +44,9 @@ struct ModulationSideControls : public juce::Component,
     };
 
     ModulationEditor *editor{nullptr};
-    ModulationSideControls(ModulationEditor *e, SurgeGUIEditor *ed) : editor(e), guiEditor(ed)
+    ModulationSideControls(ModulationEditor *e, SurgeGUIEditor *sge) : editor(e)
     {
+        this->sge = sge;
         setAccessible(true);
         setTitle("Controls");
         setDescription("Controls");
@@ -218,7 +219,7 @@ struct ModulationSideControls : public juce::Component,
     std::unique_ptr<juce::Label> sortL, filterL, addL, dispL;
     std::unique_ptr<Surge::Widgets::MultiSwitchSelfDraw> sortW, filterW, addSourceW, addTargetW,
         dispW;
-    SurgeGUIEditor *guiEditor;
+    SurgeGUIEditor *sge;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModulationSideControls);
 };
@@ -1003,9 +1004,7 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
                 });
         }
 
-        auto where = guiEditor->frame.get()->getLocalPoint(
-            nullptr, juce::Desktop::getInstance().getMousePosition());
-        men.showMenuAsync(guiEditor->optionsForPosition(where));
+        men.showMenuAsync(sge->popupMenuOptions());
     }
     break;
     case tag_add_source:
@@ -1175,9 +1174,7 @@ void ModulationSideControls::showAddSourceMenu()
     men.addSubMenu("Envelopes", addEGBSub);
     men.addSubMenu("MIDI", addMIDIBSub);
 
-    auto where = guiEditor->frame.get()->getLocalPoint(
-        nullptr, juce::Desktop::getInstance().getMousePosition());
-    men.showMenuAsync(guiEditor->optionsForPosition(where));
+    men.showMenuAsync(sge->popupMenuOptions());
 }
 
 void ModulationSideControls::showAddTargetMenu()
@@ -1383,9 +1380,7 @@ void ModulationSideControls::showAddTargetMenu()
         si++;
     }
 
-    auto where = guiEditor->frame.get()->getLocalPoint(
-        nullptr, juce::Desktop::getInstance().getMousePosition());
-    men.showMenuAsync(guiEditor->optionsForPosition(where));
+    men.showMenuAsync(sge->popupMenuOptions());
 }
 
 void ModulationSideControls::doAdd()

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -288,7 +288,10 @@ void EffectChooser::mouseDown(const juce::MouseEvent &event)
 
             if (sge && sge->fxMenu)
             {
-                sge->fxMenu->menu.showMenuAsync(juce::PopupMenu::Options());
+                auto c = localPointToGlobal(getEffectRectangle(currentClicked).getBottomLeft());
+
+                auto where = sge->frame.get()->getLocalPoint(nullptr, c);
+                sge->fxMenu->menu.showMenuAsync(sge->optionsForPosition(where));
             }
         }
     }

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -290,8 +290,8 @@ void EffectChooser::mouseDown(const juce::MouseEvent &event)
             {
                 auto c = localPointToGlobal(getEffectRectangle(currentClicked).getBottomLeft());
 
-                auto where = sge->frame.get()->getLocalPoint(nullptr, c);
-                sge->fxMenu->menu.showMenuAsync(sge->optionsForPosition(where));
+                auto where = sge->frame->getLocalPoint(nullptr, c);
+                sge->fxMenu->menu.showMenuAsync(sge->popupMenuOptions(where));
             }
         }
     }

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -47,7 +47,7 @@ struct TimeB
     std::chrono::time_point<std::chrono::high_resolution_clock> start;
 };
 
-LFOAndStepDisplay::LFOAndStepDisplay()
+LFOAndStepDisplay::LFOAndStepDisplay(SurgeGUIEditor *e) : guiEditor(e)
 {
     setTitle("LFO Type And Display");
     setAccessible(true);
@@ -2259,7 +2259,8 @@ void LFOAndStepDisplay::showLFODisplayPopupMenu(SurgeGUIEditor::OverlayTags tag)
                             });
     }
 
-    contextMenu.showMenuAsync(juce::PopupMenu::Options());
+    auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+    contextMenu.showMenuAsync(guiEditor->optionsForPosition(where));
 }
 
 void LFOAndStepDisplay::populateLFOMS(LFOModulationSource *s)

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -2259,7 +2259,8 @@ void LFOAndStepDisplay::showLFODisplayPopupMenu(SurgeGUIEditor::OverlayTags tag)
                             });
     }
 
-    auto where = guiEditor->frame.get()->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+    auto where = guiEditor->frame.get()->getLocalPoint(
+        nullptr, juce::Desktop::getInstance().getMousePosition());
     contextMenu.showMenuAsync(guiEditor->optionsForPosition(where));
 }
 

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -2259,9 +2259,7 @@ void LFOAndStepDisplay::showLFODisplayPopupMenu(SurgeGUIEditor::OverlayTags tag)
                             });
     }
 
-    auto where = guiEditor->frame.get()->getLocalPoint(
-        nullptr, juce::Desktop::getInstance().getMousePosition());
-    contextMenu.showMenuAsync(guiEditor->optionsForPosition(where));
+    contextMenu.showMenuAsync(guiEditor->popupMenuOptions());
 }
 
 void LFOAndStepDisplay::populateLFOMS(LFOModulationSource *s)

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -27,7 +27,7 @@ namespace Widgets
 {
 struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAndStepDisplay>
 {
-    LFOAndStepDisplay();
+    LFOAndStepDisplay(SurgeGUIEditor *e);
     void paint(juce::Graphics &g) override;
     void paintWaveform(juce::Graphics &g);
     void paintStepSeq(juce::Graphics &g);
@@ -179,6 +179,8 @@ struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAnd
     std::array<std::unique_ptr<juce::Component>, n_stepseqsteps> stepSliderOverlays;
     std::array<std::unique_ptr<juce::Component>, n_stepseqsteps> stepTriggerOverlays;
     std::array<std::unique_ptr<juce::Component>, 2> loopEndOverlays;
+
+    SurgeGUIEditor *guiEditor;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LFOAndStepDisplay);
 };

--- a/src/surge-xt/gui/widgets/MainFrame.cpp
+++ b/src/surge-xt/gui/widgets/MainFrame.cpp
@@ -47,8 +47,9 @@ void MainFrame::mouseDown(const juce::MouseEvent &event)
 
     if (event.mods.isPopupMenu())
     {
+        auto where = getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
         editor->useDevMenu = false;
-        editor->showSettingsMenu(juce::Point<int>{}, nullptr);
+        editor->showSettingsMenu(where, nullptr);
     }
 }
 juce::Component *MainFrame::getSynthControlsLayer()

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -350,7 +350,8 @@ void ModulationSourceButton::mouseDown(const juce::MouseEvent &event)
 
         mouseMode = HAMBURGER;
 
-        menu.showMenuAsync(juce::PopupMenu::Options(), Surge::GUI::makeEndHoverCallback(this));
+        auto sge = firstListenerOfType<SurgeGUIEditor>();
+        menu.showMenuAsync(sge->popupMenuOptions(this), Surge::GUI::makeEndHoverCallback(this));
         return;
     }
 

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -704,9 +704,7 @@ void OscillatorWaveformDisplay::showWavetableMenu()
 
         populateMenu(menu, id);
 
-        // auto where = sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
         auto where = sge->frame.get()->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
-        // auto where = menuOverlays[0]->getBounds().getBottomLeft();
         menu.showMenuAsync(sge->optionsForPosition(where));
     }
 }
@@ -766,8 +764,6 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
 
             populateMenu(menu, id);
 
-            // auto where = sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
-            // auto where = menuOverlays[0]->getBounds().getBottomLeft();
             auto where = sge->frame.get()->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
             menu.showMenuAsync(sge->optionsForPosition(where));
         }

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -704,7 +704,8 @@ void OscillatorWaveformDisplay::showWavetableMenu()
 
         populateMenu(menu, id);
 
-        auto where = sge->frame.get()->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
+        auto where =
+            sge->frame.get()->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
         menu.showMenuAsync(sge->optionsForPosition(where));
     }
 }
@@ -764,7 +765,8 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
 
             populateMenu(menu, id);
 
-            auto where = sge->frame.get()->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
+            auto where =
+                sge->frame.get()->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
             menu.showMenuAsync(sge->optionsForPosition(where));
         }
     }
@@ -777,7 +779,8 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
 
             createWTMenuItems(contextMenu, true, true);
 
-            auto where = sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+            auto where =
+                sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
             contextMenu.showMenuAsync(sge->optionsForPosition(where));
 
             return;
@@ -886,7 +889,8 @@ struct WaveTable3DEditor : public juce::Component, Surge::GUI::SkinConsumingComp
 
     std::unique_ptr<juce::Image> backingImage;
 
-    WaveTable3DEditor(OscillatorWaveformDisplay *pD, SurgeStorage *s, OscillatorStorage *osc, SurgeGUIEditor *ed)
+    WaveTable3DEditor(OscillatorWaveformDisplay *pD, SurgeStorage *s, OscillatorStorage *osc,
+                      SurgeGUIEditor *ed)
         : parent(pD), storage(s), oscdata(osc), sge(ed)
     {
     }
@@ -1072,7 +1076,8 @@ struct WaveTable3DEditor : public juce::Component, Surge::GUI::SkinConsumingComp
 
             parent->createWTMenuItems(contextMenu, true, true);
 
-            auto where = sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+            auto where =
+                sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
             contextMenu.showMenuAsync(sge->optionsForPosition(where));
 
             return;
@@ -1091,7 +1096,8 @@ struct WaveTable3DEditor : public juce::Component, Surge::GUI::SkinConsumingComp
 
 struct AliasAdditiveEditor : public juce::Component, Surge::GUI::SkinConsumingComponent
 {
-    AliasAdditiveEditor(SurgeStorage *s, OscillatorStorage *osc, SurgeGUIEditor *ed) : storage(s), oscdata(osc), sge(ed)
+    AliasAdditiveEditor(SurgeStorage *s, OscillatorStorage *osc, SurgeGUIEditor *ed)
+        : storage(s), oscdata(osc), sge(ed)
     {
         for (int i = 0; i < AliasOscillator::n_additive_partials; ++i)
         {
@@ -1344,7 +1350,8 @@ struct AliasAdditiveEditor : public juce::Component, Surge::GUI::SkinConsumingCo
                 contextMenu.addItem("Reverse", action);
             }
 
-            auto where = sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
+            auto where =
+                sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
             contextMenu.showMenuAsync(sge->optionsForPosition(where));
 
             return;

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -704,9 +704,8 @@ void OscillatorWaveformDisplay::showWavetableMenu()
 
         populateMenu(menu, id);
 
-        auto where =
-            sge->frame.get()->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
-        menu.showMenuAsync(sge->optionsForPosition(where));
+        auto where = sge->frame->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
+        menu.showMenuAsync(sge->popupMenuOptions(where));
     }
 }
 
@@ -766,8 +765,8 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
             populateMenu(menu, id);
 
             auto where =
-                sge->frame.get()->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
-            menu.showMenuAsync(sge->optionsForPosition(where));
+                sge->frame->getLocalPoint(this, menuOverlays[0]->getBounds().getBottomLeft());
+            menu.showMenuAsync(sge->popupMenuOptions(where));
         }
     }
 
@@ -779,9 +778,7 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
 
             createWTMenuItems(contextMenu, true, true);
 
-            auto where =
-                sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
-            contextMenu.showMenuAsync(sge->optionsForPosition(where));
+            contextMenu.showMenuAsync(sge->popupMenuOptions());
 
             return;
         }
@@ -1076,9 +1073,7 @@ struct WaveTable3DEditor : public juce::Component, Surge::GUI::SkinConsumingComp
 
             parent->createWTMenuItems(contextMenu, true, true);
 
-            auto where =
-                sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
-            contextMenu.showMenuAsync(sge->optionsForPosition(where));
+            contextMenu.showMenuAsync(sge->popupMenuOptions());
 
             return;
         }
@@ -1350,9 +1345,7 @@ struct AliasAdditiveEditor : public juce::Component, Surge::GUI::SkinConsumingCo
                 contextMenu.addItem("Reverse", action);
             }
 
-            auto where =
-                sge->frame->getLocalPoint(nullptr, juce::Desktop::getInstance().getMousePosition());
-            contextMenu.showMenuAsync(sge->optionsForPosition(where));
+            contextMenu.showMenuAsync(sge->popupMenuOptions());
 
             return;
         }

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -324,7 +324,9 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
 
             if (haveFavs)
             {
-                menu.showMenuAsync(juce::PopupMenu::Options(),
+                auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+                menu.showMenuAsync(sge->popupMenuOptions(favoritesRect.getBottomLeft()),
                                    Surge::GUI::makeEndHoverCallback(this));
             }
 
@@ -700,7 +702,7 @@ void PatchSelector::showClassicMenu(bool single_category)
 
     if (sge)
     {
-        o = sge->optionsForPosition(getBounds().getBottomLeft());
+        o = sge->popupMenuOptions(getBounds().getBottomLeft());
     }
 
     contextMenu.showMenuAsync(o);

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -372,10 +372,9 @@ void OscillatorMenu::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
-    juce::Point<int> cwhere = getBounds().getBottomLeft();
     auto sge = firstListenerOfType<SurgeGUIEditor>();
 
-    menu.showMenuAsync(sge->optionsForPosition(cwhere),
+    menu.showMenuAsync(sge->popupMenuOptions(this),
                        Surge::GUI::makeAsyncCallback<OscillatorMenu>(this, [](auto *that, int) {
                            that->isHovered = false;
                            that->repaint();
@@ -413,7 +412,9 @@ bool OscillatorMenu::keyPressed(const juce::KeyPress &key)
 
     if (action == OpenMenu || action == Return)
     {
-        menu.showMenuAsync(juce::PopupMenu::Options());
+        auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+        menu.showMenuAsync(sge->popupMenuOptions());
         return true;
     }
 
@@ -514,10 +515,9 @@ void FxMenu::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
-    juce::Point<int> cwhere = getBounds().getBottomLeft();
     auto sge = firstListenerOfType<SurgeGUIEditor>();
 
-    menu.showMenuAsync(sge->optionsForPosition(cwhere),
+    menu.showMenuAsync(sge->popupMenuOptions(this),
                        Surge::GUI::makeAsyncCallback<FxMenu>(this, [](auto *that, int) {
                            that->isHovered = false;
                            that->repaint();
@@ -798,7 +798,9 @@ bool FxMenu::keyPressed(const juce::KeyPress &key)
 
     if (action == OpenMenu || action == Return)
     {
-        menu.showMenuAsync(juce::PopupMenu::Options());
+        auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+        menu.showMenuAsync(sge->popupMenuOptions(this));
         return true;
     }
 

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -372,7 +372,10 @@ void OscillatorMenu::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
-    menu.showMenuAsync(juce::PopupMenu::Options(),
+    juce::Point<int> cwhere = getBounds().getBottomLeft();
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+    menu.showMenuAsync(sge->optionsForPosition(cwhere),
                        Surge::GUI::makeAsyncCallback<OscillatorMenu>(this, [](auto *that, int) {
                            that->isHovered = false;
                            that->repaint();
@@ -511,7 +514,10 @@ void FxMenu::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
-    menu.showMenuAsync(juce::PopupMenu::Options(),
+    juce::Point<int> cwhere = getBounds().getBottomLeft();
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+    menu.showMenuAsync(sge->optionsForPosition(cwhere),
                        Surge::GUI::makeAsyncCallback<FxMenu>(this, [](auto *that, int) {
                            that->isHovered = false;
                            that->repaint();


### PR DESCRIPTION
Hi all, I've cobbled together a fix for #5811 that hopefully works for other platforms than mine (Windows 10), and also hopefully isn't a trash pile in terms of code quality. This is my first attempt at contributing to the Surge repo, and I'm only somewhat familiar with Juce and its mysteries. I tried to keep variable names and code style more or less in line with what I could find in the Surge code. Please let me know if there's anything that should be done to further clean this up. 

The one issue I'm still running into is that there doesn't seem to be an obvious way to control the scaling of the popup menus within the Lua editor. Does anyone know how to go about this?

Thanks!