### PR TITLE
Add LongPressMixin to other widgets

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2206,16 +2206,21 @@ juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions(const juce::Point<int>
 juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions(const juce::Component *c,
                                                           bool useComponentBounds)
 {
+    juce::Point<int> where;
+
     if (!c || !useComponentBounds)
     {
-        auto where = frame->getLocalPoint(nullptr, juce::Desktop::getMousePosition());
-        return popupMenuOptions(where);
+        where = frame->getLocalPoint(nullptr, juce::Desktop::getMousePosition());
     }
     else
     {
-        auto where = c->getBounds().getBottomLeft();
-        return popupMenuOptions(where);
+        where = c->getBounds().getBottomLeft();
     }
+
+    if (Surge::GUI::isTouchMode(&(synth->storage)))
+        where = c->getBounds().getBottomLeft();
+
+    return popupMenuOptions(where);
 }
 
 void SurgeGUIEditor::showZoomMenu(const juce::Point<int> &where,

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -251,6 +251,8 @@ void EffectChooser::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
+    mouseDownLongHold(event);
+
     hasDragged = false;
     currentClicked = -1;
 
@@ -302,6 +304,7 @@ void EffectChooser::mouseUp(const juce::MouseEvent &event)
     if (hasDragged)
     {
         setMouseCursor(juce::MouseCursor::NormalCursor);
+
         for (int i = 0; i < n_fx_slots; ++i)
         {
             auto r = getEffectRectangle(i);
@@ -334,6 +337,8 @@ void EffectChooser::mouseUp(const juce::MouseEvent &event)
         hasDragged = false;
         repaint();
     }
+
+    mouseUpLongHold(event);
 }
 
 void EffectChooser::mouseDrag(const juce::MouseEvent &event)
@@ -342,6 +347,8 @@ void EffectChooser::mouseDrag(const juce::MouseEvent &event)
     {
         return;
     }
+
+    mouseDragLongHold(event);
 
     if (event.getDistanceFromDragStart() > 3 && event.mods.isLeftButtonDown())
     {
@@ -361,6 +368,8 @@ void EffectChooser::mouseDrag(const juce::MouseEvent &event)
 
 void EffectChooser::mouseMove(const juce::MouseEvent &event)
 {
+    mouseMoveLongHold(event);
+
     int nextHover = -1;
     int nextSceneHover = -1;
 

--- a/src/surge-xt/gui/widgets/EffectChooser.h
+++ b/src/surge-xt/gui/widgets/EffectChooser.h
@@ -31,7 +31,9 @@ namespace Surge
 {
 namespace Widgets
 {
-struct EffectChooser : public juce::Component, public WidgetBaseMixin<EffectChooser>
+struct EffectChooser : public juce::Component,
+                       public WidgetBaseMixin<EffectChooser>,
+                       public LongHoldMixin<EffectChooser>
 {
     EffectChooser();
     ~EffectChooser();

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1574,6 +1574,8 @@ void LFOAndStepDisplay::mouseDown(const juce::MouseEvent &event)
         }
     }
 
+    mouseDownLongHold(event);
+
     if (waveform_display.contains(event.position.toInt()) && sge)
     {
         if (isMSEG() || isFormula())
@@ -1778,6 +1780,8 @@ void LFOAndStepDisplay::enterExitWaveform(bool isInWF)
 
 void LFOAndStepDisplay::mouseMove(const juce::MouseEvent &event)
 {
+    mouseMoveLongHold(event);
+
     int nextHover = -1;
 
     for (int i = 0; i < n_lfo_types; ++i)
@@ -1885,6 +1889,8 @@ void LFOAndStepDisplay::mouseDrag(const juce::MouseEvent &event)
     {
         return;
     }
+
+    mouseDragLongHold(event);
 
     if (dragMode != NONE && event.getDistanceFromDragStart() > 0)
     {
@@ -1997,6 +2003,8 @@ void LFOAndStepDisplay::mouseDrag(const juce::MouseEvent &event)
 
 void LFOAndStepDisplay::mouseUp(const juce::MouseEvent &event)
 {
+    mouseUpLongHold(event);
+
     if (event.mouseWasDraggedSinceMouseDown())
     {
         if (!Surge::GUI::showCursor(storage))

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -25,7 +25,9 @@ namespace Surge
 {
 namespace Widgets
 {
-struct LFOAndStepDisplay : public juce::Component, public WidgetBaseMixin<LFOAndStepDisplay>
+struct LFOAndStepDisplay : public juce::Component,
+                           public WidgetBaseMixin<LFOAndStepDisplay>,
+                           public LongHoldMixin<LFOAndStepDisplay>
 {
     LFOAndStepDisplay(SurgeGUIEditor *e);
     void paint(juce::Graphics &g) override;

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -187,6 +187,8 @@ void MenuForDiscreteParams::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
+    mouseDownLongHold(event);
+
     if (glyphMode && glyphPosition.contains(event.position))
     {
         mouseDownOrigin = event.position.toInt();
@@ -203,17 +205,21 @@ void MenuForDiscreteParams::mouseDown(const juce::MouseEvent &event)
     notifyControlModifierClicked(event.mods, true);
 }
 
-void MenuForDiscreteParams::mouseDrag(const juce::MouseEvent &e)
+void MenuForDiscreteParams::mouseDrag(const juce::MouseEvent &event)
 {
-    if (supressMainFrameMouseEvent(e))
+    if (supressMainFrameMouseEvent(event))
     {
         return;
     }
 
-    auto d = e.getDistanceFromDragStartX() - e.getDistanceFromDragStartY();
+    mouseDragLongHold(event);
+
+    auto d = event.getDistanceFromDragStartX() - event.getDistanceFromDragStartY();
+
     if (fabs(d - lastDragDistance) > 10)
     {
         int inc = 1;
+
         if (d - lastDragDistance < 0)
         {
             inc = -1;
@@ -226,16 +232,18 @@ void MenuForDiscreteParams::mouseDrag(const juce::MouseEvent &e)
     }
 }
 
-void MenuForDiscreteParams::mouseDoubleClick(const juce::MouseEvent &e)
+void MenuForDiscreteParams::mouseDoubleClick(const juce::MouseEvent &event)
 {
-    if (glyphMode && glyphPosition.contains(e.position))
+    if (glyphMode && glyphPosition.contains(event.position))
     {
-        notifyControlModifierDoubleClicked(e.mods.allKeyboardModifiers);
+        notifyControlModifierDoubleClicked(event.mods.allKeyboardModifiers);
     }
 }
 
-void MenuForDiscreteParams::mouseUp(const juce::MouseEvent &e)
+void MenuForDiscreteParams::mouseUp(const juce::MouseEvent &event)
 {
+    mouseUpLongHold(event);
+
     if (isDraggingGlyph && !Surge::GUI::showCursor(storage))
     {
         juce::Desktop::getInstance().getMainMouseSource().enableUnboundedMouseMovement(false);
@@ -246,7 +254,7 @@ void MenuForDiscreteParams::mouseUp(const juce::MouseEvent &e)
     isDraggingGlyph = false;
 }
 
-void MenuForDiscreteParams::mouseWheelMove(const juce::MouseEvent &e,
+void MenuForDiscreteParams::mouseWheelMove(const juce::MouseEvent &event,
                                            const juce::MouseWheelDetails &w)
 {
     int dir = wheelAccumulationHelper.accumulate(w, false, true);

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
@@ -39,6 +39,7 @@ namespace Widgets
  */
 struct MenuForDiscreteParams : public juce::Component,
                                public WidgetBaseMixin<MenuForDiscreteParams>,
+                               public LongHoldMixin<MenuForDiscreteParams>,
                                public ModulatableControlInterface
 
 {

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -342,6 +342,8 @@ void ModulationSourceButton::mouseDown(const juce::MouseEvent &event)
     everDragged = false;
     mouseDownLocation = event.position;
 
+    mouseDownLongHold(event);
+
     if (needsHamburger() && hamburgerHome.contains(event.position.toInt()))
     {
         auto menu = juce::PopupMenu();
@@ -523,6 +525,8 @@ void ModulationSourceButton::onSkinChanged()
 
 void ModulationSourceButton::mouseUp(const juce::MouseEvent &event)
 {
+    mouseUpLongHold(event);
+
     setMouseCursor(juce::MouseCursor::NormalCursor);
 
     transientArmed = false;
@@ -581,7 +585,11 @@ void ModulationSourceButton::mouseDrag(const juce::MouseEvent &event)
     auto distance = event.position.getX() - mouseDownLocation.getX();
 
     if (mouseMode == PREDRAG_VALUE && distance == 0)
+    {
         return;
+    }
+
+    mouseDragLongHold(event);
 
     if (mouseMode == PREDRAG_VALUE)
     {

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.h
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.h
@@ -31,7 +31,8 @@ namespace Surge
 namespace Widgets
 {
 struct ModulationSourceButton : public juce::Component,
-                                public WidgetBaseMixin<ModulationSourceButton>
+                                public WidgetBaseMixin<ModulationSourceButton>,
+                                public LongHoldMixin<ModulationSourceButton>
 {
     ModulationSourceButton();
 

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -149,6 +149,7 @@ void MultiSwitch::mouseDown(const juce::MouseEvent &event)
         juce::Timer::callAfterDelay(250, [this]() { this->setCursorToArrow(); });
     }
 
+    mouseDownLongHold(event);
     setValue(coordinateToValue(event.x, event.y));
     notifyValueChanged();
 
@@ -161,6 +162,8 @@ void MultiSwitch::mouseDown(const juce::MouseEvent &event)
 void MultiSwitch::mouseMove(const juce::MouseEvent &event)
 {
     int ohs = hoverSelection;
+
+    mouseMoveLongHold(event);
 
     hoverSelection = coordinateToSelection(event.x, event.y);
 
@@ -199,6 +202,8 @@ void MultiSwitch::mouseDrag(const juce::MouseEvent &event)
         return;
     }
 
+    mouseDragLongHold(event);
+
     if (draggable)
     {
         if (!everDragged)
@@ -227,6 +232,7 @@ void MultiSwitch::mouseDrag(const juce::MouseEvent &event)
 
 void MultiSwitch::mouseUp(const juce::MouseEvent &event)
 {
+    mouseUpLongHold(event);
     isMouseDown = false;
     setMouseCursor(juce::MouseCursor::NormalCursor);
 

--- a/src/surge-xt/gui/widgets/MultiSwitch.h
+++ b/src/surge-xt/gui/widgets/MultiSwitch.h
@@ -35,6 +35,7 @@ namespace Widgets
  */
 struct MultiSwitch : public juce::Component,
                      public WidgetBaseMixin<MultiSwitch>,
+                     public LongHoldMixin<MultiSwitch>,
                      public Surge::Widgets::HasAccessibleSubComponentForFocus
 {
     MultiSwitch();

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -135,6 +135,8 @@ void NumberField::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
+    mouseDownLongHold(event);
+
     mouseMode = DRAG;
 
     if (!Surge::GUI::showCursor(storage))
@@ -153,6 +155,8 @@ void NumberField::mouseDrag(const juce::MouseEvent &event)
         return;
     }
 
+    mouseDragLongHold(event);
+
     float d = -event.getDistanceFromDragStartY();
     float dD = d - lastDistanceChecked;
     float thresh = 10;
@@ -169,6 +173,8 @@ void NumberField::mouseDrag(const juce::MouseEvent &event)
 }
 void NumberField::mouseUp(const juce::MouseEvent &event)
 {
+    mouseUpLongHold(event);
+
     if (mouseMode == DRAG)
     {
         if (!Surge::GUI::showCursor(storage))
@@ -180,6 +186,7 @@ void NumberField::mouseUp(const juce::MouseEvent &event)
     }
     mouseMode = NONE;
 }
+
 void NumberField::mouseDoubleClick(const juce::MouseEvent &event)
 {
     if (supressMainFrameMouseEvent(event))
@@ -190,6 +197,7 @@ void NumberField::mouseDoubleClick(const juce::MouseEvent &event)
     notifyControlModifierDoubleClicked(event.mods);
     repaint();
 }
+
 void NumberField::mouseWheelMove(const juce::MouseEvent &event,
                                  const juce::MouseWheelDetails &wheel)
 {

--- a/src/surge-xt/gui/widgets/NumberField.h
+++ b/src/surge-xt/gui/widgets/NumberField.h
@@ -29,7 +29,9 @@ namespace Surge
 {
 namespace Widgets
 {
-struct NumberField : public juce::Component, public WidgetBaseMixin<NumberField>
+struct NumberField : public juce::Component,
+                     public WidgetBaseMixin<NumberField>,
+                     public LongHoldMixin<NumberField>
 {
     NumberField() : juce::Component(), WidgetBaseMixin<NumberField>() {}
 

--- a/src/surge-xt/gui/widgets/Switch.cpp
+++ b/src/surge-xt/gui/widgets/Switch.cpp
@@ -72,6 +72,8 @@ void Switch::mouseDown(const juce::MouseEvent &event)
         return;
     }
 
+    mouseDownLongHold(event);
+
     if (isMultiIntegerValued())
     {
         storage->getPatch().isDirty = true;

--- a/src/surge-xt/gui/widgets/Switch.h
+++ b/src/surge-xt/gui/widgets/Switch.h
@@ -38,7 +38,7 @@ namespace Widgets
  *
  * The rough contract is:
  */
-struct Switch : public juce::Component, public WidgetBaseMixin<Switch>
+struct Switch : public juce::Component, public WidgetBaseMixin<Switch>, public LongHoldMixin<Switch>
 {
     Switch();
     ~Switch();

--- a/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
@@ -176,12 +176,15 @@ void WaveShaperSelector::mouseDoubleClick(const juce::MouseEvent &event)
         notifyControlModifierDoubleClicked(event.mods.allKeyboardModifiers);
     }
 }
+
 void WaveShaperSelector::mouseDown(const juce::MouseEvent &event)
 {
     if (forwardedMainFrameMouseDowns(event))
     {
         return;
     }
+
+    mouseDownLongHold(event);
 
     lastDragDistance = 0;
     everDragged = false;
@@ -199,14 +202,17 @@ void WaveShaperSelector::mouseDown(const juce::MouseEvent &event)
     }
 }
 
-void WaveShaperSelector::mouseDrag(const juce::MouseEvent &e)
+void WaveShaperSelector::mouseDrag(const juce::MouseEvent &event)
 {
-    if (supressMainFrameMouseEvent(e))
+    if (supressMainFrameMouseEvent(event))
     {
         return;
     }
 
-    auto d = e.getDistanceFromDragStartX() - e.getDistanceFromDragStartY();
+    mouseDragLongHold(event);
+
+    auto d = event.getDistanceFromDragStartX() - event.getDistanceFromDragStartY();
+
     if (fabs(d - lastDragDistance) > 0)
     {
         if (!everMoved)
@@ -217,8 +223,10 @@ void WaveShaperSelector::mouseDrag(const juce::MouseEvent &e)
                     true);
             }
         }
+
         everMoved = true;
     }
+
     if (fabs(d - lastDragDistance) > 10)
     {
         if (!everDragged)
@@ -226,7 +234,9 @@ void WaveShaperSelector::mouseDrag(const juce::MouseEvent &e)
             notifyBeginEdit();
             everDragged = true;
         }
+
         int inc = 1;
+
         if (d - lastDragDistance < 0)
         {
             inc = -1;
@@ -239,29 +249,37 @@ void WaveShaperSelector::mouseDrag(const juce::MouseEvent &e)
     }
 }
 
-void WaveShaperSelector::mouseUp(const juce::MouseEvent &e)
+void WaveShaperSelector::mouseUp(const juce::MouseEvent &event)
 {
+    mouseUpLongHold(event);
+
     if (everMoved)
     {
         if (!Surge::GUI::showCursor(storage))
         {
             juce::Desktop::getInstance().getMainMouseSource().enableUnboundedMouseMovement(false);
-            auto p = e.mouseDownPosition;
+
+            auto p = event.mouseDownPosition;
             p = localPointToGlobal(p);
+
             juce::Desktop::getInstance().getMainMouseSource().setScreenPosition(p);
         }
     }
+
     if (everDragged)
     {
         notifyEndEdit();
     }
+
     everDragged = false;
     everMoved = false;
 }
 
-void WaveShaperSelector::mouseWheelMove(const juce::MouseEvent &e, const juce::MouseWheelDetails &w)
+void WaveShaperSelector::mouseWheelMove(const juce::MouseEvent &event,
+                                        const juce::MouseWheelDetails &w)
 {
     int dir = wheelAccumulationHelper.accumulate(w, false, true);
+
     if (dir != 0)
     {
         notifyBeginEdit();

--- a/src/surge-xt/gui/widgets/WaveShaperSelector.h
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.h
@@ -18,7 +18,9 @@ namespace Surge
 {
 namespace Widgets
 {
-struct WaveShaperSelector : public juce::Component, public WidgetBaseMixin<WaveShaperSelector>
+struct WaveShaperSelector : public juce::Component,
+                            public WidgetBaseMixin<WaveShaperSelector>,
+                            public LongHoldMixin<WaveShaperSelector>
 {
     WaveShaperSelector();
     ~WaveShaperSelector();

--- a/src/surge-xt/gui/widgets/WidgetBaseMixin.h
+++ b/src/surge-xt/gui/widgets/WidgetBaseMixin.h
@@ -238,13 +238,13 @@ template <typename T> struct LongHoldMixin
     }
     virtual void mouseMoveLongHold(const juce::MouseEvent &e)
     {
-        if (e.position.getDistanceFrom(startingHoldPosition) > 4)
+        if (e.position.getDistanceFrom(startingHoldPosition) > 8)
             if (timer && timer->isTimerRunning())
                 timer->stopTimer();
     }
     virtual void mouseDragLongHold(const juce::MouseEvent &e)
     {
-        if (e.position.getDistanceFrom(startingHoldPosition) > 1)
+        if (e.position.getDistanceFrom(startingHoldPosition) > 8)
             if (timer && timer->isTimerRunning())
                 timer->stopTimer();
     }


### PR DESCRIPTION
Closes #5802 after tweaking it a little more - for some reason long press doesn't activate context menu for EffectChooser.

Also long press context menu is not implemented in OscillatorWaveformDisplay (Alias additive editor has a context menu which would be nice to open via touch too).