### PR TITLE
Long press now works for EffectChooser

### DIFF
--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -286,21 +286,28 @@ void EffectChooser::mouseDown(const juce::MouseEvent &event)
     {
         if (event.mods.isRightButtonDown())
         {
-            auto sge = firstListenerOfType<SurgeGUIEditor>();
-
-            if (sge && sge->fxMenu)
-            {
-                auto c = localPointToGlobal(getEffectRectangle(currentClicked).getBottomLeft());
-
-                auto where = sge->frame->getLocalPoint(nullptr, c);
-                sge->fxMenu->menu.showMenuAsync(sge->popupMenuOptions(where));
-            }
+            createFXMenu();
         }
+    }
+}
+
+void EffectChooser::createFXMenu()
+{
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+    if (sge && sge->fxMenu)
+    {
+        auto c = localPointToGlobal(getEffectRectangle(currentClicked).getBottomLeft());
+
+        auto where = sge->frame->getLocalPoint(nullptr, c);
+        sge->fxMenu->menu.showMenuAsync(sge->popupMenuOptions(where));
     }
 }
 
 void EffectChooser::mouseUp(const juce::MouseEvent &event)
 {
+    mouseUpLongHold(event);
+
     if (hasDragged)
     {
         setMouseCursor(juce::MouseCursor::NormalCursor);
@@ -337,8 +344,6 @@ void EffectChooser::mouseUp(const juce::MouseEvent &event)
         hasDragged = false;
         repaint();
     }
-
-    mouseUpLongHold(event);
 }
 
 void EffectChooser::mouseDrag(const juce::MouseEvent &event)

--- a/src/surge-xt/gui/widgets/EffectChooser.h
+++ b/src/surge-xt/gui/widgets/EffectChooser.h
@@ -31,6 +31,10 @@ namespace Surge
 {
 namespace Widgets
 {
+struct EffectChooser;
+
+template <> void LongHoldMixin<EffectChooser>::onLongHold();
+
 struct EffectChooser : public juce::Component,
                        public WidgetBaseMixin<EffectChooser>,
                        public LongHoldMixin<EffectChooser>
@@ -121,11 +125,16 @@ struct EffectChooser : public juce::Component,
     SurgeStorage *storage{nullptr};
     void setStorage(SurgeStorage *s) { storage = s; }
 
+    void createFXMenu();
+
     std::array<std::unique_ptr<juce::Component>, n_fx_slots> slotAccOverlays;
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EffectChooser);
 };
+
+template <> inline void LongHoldMixin<EffectChooser>::onLongHold() { asT()->createFXMenu(); }
+
 } // namespace Widgets
 } // namespace Surge
 


### PR DESCRIPTION
Used template specialization similarly to OWD, works nicely now!

Closes #5980.