### PR TITLE
Correctly use aspect ratio constrainer

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -255,6 +255,12 @@ void SurgeSynthEditor::resized()
     auto wR = 1.0 * w / adapter->getWindowSizeX();
     auto hR = 1.0 * h / adapter->getWindowSizeY();
 
+    auto ar =
+        1.f * adapter->getWindowSizeX() /
+        (adapter->getWindowSizeY() + (drawExtendedControls ? extraYSpaceForVirtualKeyboard : 0));
+    if (getConstrainer())
+        getConstrainer()->setFixedAspectRatio(ar);
+
     auto zfn = std::min(wR, hR);
     if (wR < 1 && hR < 1)
         zfn = std::max(wR, hR);


### PR DESCRIPTION
This change correctly sets the aspect ratio constrainer for the
juce resize handler.

In standalone it perfectly preserves it
In bitwig mac vst3 it perfectly preserves it
In reaper mac the window is embedded and does not obey the content
aspect ratio
In logic there is no drag to resize

So seems it at least makes it 'better or same'. We should test this
in the daws showing problems in #5211 (which I dont have access to
right now) to see if it helps.