### PR TITLE
Prompts all have Return Focus target

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -622,7 +622,13 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void promptForMiniEdit(const std::string &value, const std::string &prompt,
                            const std::string &title, const juce::Point<int> &where,
                            std::function<void(const std::string &)> onOK,
-                           juce::Component *returnFocusTo = nullptr);
+                           juce::Component *returnFocusTo /* can be nullptr */);
+
+    /*
+     * Weak pointers to some logical items for focus return
+     */
+    juce::Component *mpeStatus{nullptr}, *zoomStatus{nullptr}, *tuneStatus{nullptr},
+        *mainMenu{nullptr}, *lfoMenuButton{nullptr};
 
     /*
      * This is the JUCE component management

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -488,12 +488,13 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
 
         if (sge)
         {
-            sge->promptForMiniEdit(c, "Enter a new name:", "Wavetable Display Name",
-                                   juce::Point<int>{}, [this](const std::string &s) {
-                                       strncpy(this->oscdata->wavetable_display_name, s.c_str(),
-                                               256);
-                                       this->repaint();
-                                   });
+            sge->promptForMiniEdit(
+                c, "Enter a new name:", "Wavetable Display Name", juce::Point<int>{},
+                [this](const std::string &s) {
+                    strncpy(this->oscdata->wavetable_display_name, s.c_str(), 256);
+                    this->repaint();
+                },
+                this);
         }
     };
 

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -710,13 +710,15 @@ void FxMenu::saveFX()
     auto *sge = firstListenerOfType<SurgeGUIEditor>();
     if (sge)
     {
-        sge->promptForMiniEdit("", "Enter the preset name:", "Save FX Preset", juce::Point<int>{},
-                               [this](const std::string &s) {
-                                   this->storage->fxUserPreset->saveFxIn(this->storage, fx, s);
-                                   auto *sge = firstListenerOfType<SurgeGUIEditor>();
-                                   if (sge)
-                                       sge->queueRebuildUI();
-                               });
+        sge->promptForMiniEdit(
+            "", "Enter the preset name:", "Save FX Preset", juce::Point<int>{},
+            [this](const std::string &s) {
+                this->storage->fxUserPreset->saveFxIn(this->storage, fx, s);
+                auto *sge = firstListenerOfType<SurgeGUIEditor>();
+                if (sge)
+                    sge->queueRebuildUI();
+            },
+            this);
     }
 }
 


### PR DESCRIPTION
Makes sure when you get a modal prompt and you interact with
it your focus returns to a reasonable spot. It's required for
all mini edits from now on too

Closes #5756