### PR TITLE
Various tweaks for keyboard shortcut manager

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2864,7 +2864,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
 
         Surge::GUI::addMenuWithShortcut(tuningSubMenu,
                                         Surge::GUI::toOSCaseForMenu(openname + "Tuning Editor..."),
-                                        showShortcutDescription("Alt+T", "⌥T"),
+                                        showShortcutDescription("Alt + T", u8"\U00002325T"),
                                         [this]() { this->toggleOverlay(TUNING_EDITOR); });
 
         tuningSubMenu.addSeparator();
@@ -3615,8 +3615,11 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
 
     wfMenu.addItem(Surge::GUI::toOSCaseForMenu("Use Keyboard Shortcuts"), true, kbShortcuts,
                    [this]() { toggleUseKeyboardShortcuts(); });
-    wfMenu.addItem(Surge::GUI::toOSCaseForMenu("Edit Keyboard Shortcuts..."), true, false,
-                   [this]() { toggleOverlay(KEYBINDINGS_EDITOR); });
+    Surge::GUI::addMenuWithShortcut(wfMenu,
+                                    Surge::GUI::toOSCaseForMenu("Edit Keyboard Shortcuts..."),
+                                    showShortcutDescription("Alt + B", u8"\U00002325B"), true,
+                                    false, [this]() { toggleOverlay(KEYBINDINGS_EDITOR); });
+
     wfMenu.addSeparator();
 
     bool showVirtualKeyboard = getShowVirtualKeyboard();
@@ -6282,35 +6285,16 @@ void SurgeGUIEditor::activateFromCurrentFx()
 void SurgeGUIEditor::setupKeymapManager()
 {
     if (!keyMapManager)
+    {
         keyMapManager =
             std::make_unique<keymap_t>(synth->storage.userDataPath, "SurgeXT",
                                        Surge::GUI::keyboardActionName, [](auto a, auto b) {});
+    }
 
     keyMapManager->clearBindings();
-    keyMapManager->addBinding(Surge::GUI::UNDO, {keymap_t::Modifiers::CONTROL, (int)'Z'});
-    keyMapManager->addBinding(Surge::GUI::OSC_1, {keymap_t::Modifiers::ALT, (int)'1'});
-    keyMapManager->addBinding(Surge::GUI::OSC_2, {keymap_t::Modifiers::ALT, (int)'2'});
-    keyMapManager->addBinding(Surge::GUI::OSC_3, {keymap_t::Modifiers::ALT, (int)'3'});
-    keyMapManager->addBinding(Surge::GUI::TOGGLE_SCENE, {keymap_t::Modifiers::ALT, (int)'S'});
-    keyMapManager->addBinding(Surge::GUI::SAVE_PATCH, {keymap_t::Modifiers::COMMAND, (int)'S'});
-    keyMapManager->addBinding(Surge::GUI::FIND_PATCH, {keymap_t::Modifiers::COMMAND, (int)'F'});
-    keyMapManager->addBinding(Surge::GUI::SHOW_TUNING_EDITOR, {keymap_t::Modifiers::ALT, (int)'T'});
-    keyMapManager->addBinding(Surge::GUI::SHOW_LFO_EDITOR, {keymap_t::Modifiers::ALT, (int)'E'});
-    keyMapManager->addBinding(Surge::GUI::FAVORITE_PATCH, {keymap_t::Modifiers::ALT, (int)'F'});
-    keyMapManager->addBinding(Surge::GUI::SHOW_MODLIST, {keymap_t::Modifiers::ALT, (int)'M'});
-    keyMapManager->addBinding(Surge::GUI::TOGGLE_DEBUG_CONSOLE,
-                              {keymap_t::Modifiers::ALT, (int)'D'});
-    keyMapManager->addBinding(Surge::GUI::TOGGLE_VIRTUAL_KEYBOARD,
-                              {keymap_t::Modifiers::ALT, (int)'K'});
-    keyMapManager->addBinding(Surge::GUI::OPEN_MANUAL, {juce::KeyPress::F1Key});
-    keyMapManager->addBinding(Surge::GUI::REFRESH_SKIN, {juce::KeyPress::F5Key});
-    keyMapManager->addBinding(Surge::GUI::TOGGLE_ABOUT, {juce::KeyPress::F12Key});
 
-    keyMapManager->addBinding(Surge::GUI::ZOOM_TO_DEFAULT, {keymap_t ::Modifiers::SHIFT, '/'});
-    keyMapManager->addBinding(Surge::GUI::ZOOM_PLUS_10, {keymap_t ::Modifiers::NONE, '+'});
-    keyMapManager->addBinding(Surge::GUI::ZOOM_PLUS_25, {keymap_t ::Modifiers::SHIFT, '+'});
-    keyMapManager->addBinding(Surge::GUI::ZOOM_MINUS_10, {keymap_t ::Modifiers::NONE, '-'});
-    keyMapManager->addBinding(Surge::GUI::ZOOM_MINUS_25, {keymap_t ::Modifiers::SHIFT, '-'});
+    keyMapManager->addBinding(Surge::GUI::UNDO, {keymap_t::Modifiers::COMMAND, (int)'Z'});
+    keyMapManager->addBinding(Surge::GUI::REDO, {keymap_t::Modifiers::COMMAND, (int)'Y'});
 
     keyMapManager->addBinding(Surge::GUI::PREV_PATCH,
                               {keymap_t::Modifiers::COMMAND, juce::KeyPress::leftKey});
@@ -6320,17 +6304,50 @@ void SurgeGUIEditor::setupKeymapManager()
                               {keymap_t::Modifiers::SHIFT, juce::KeyPress::leftKey});
     keyMapManager->addBinding(Surge::GUI::NEXT_CATEGORY,
                               {keymap_t::Modifiers::SHIFT, juce::KeyPress::rightKey});
+    keyMapManager->addBinding(Surge::GUI::FAVORITE_PATCH, {keymap_t::Modifiers::ALT, (int)'F'});
+    keyMapManager->addBinding(Surge::GUI::FIND_PATCH, {keymap_t::Modifiers::COMMAND, (int)'F'});
+    keyMapManager->addBinding(Surge::GUI::SAVE_PATCH, {keymap_t::Modifiers::COMMAND, (int)'S'});
+
+    // TODO: UPDATE WHEN ADDING MORE OSCILLATORS
+    keyMapManager->addBinding(Surge::GUI::OSC_1, {keymap_t::Modifiers::ALT, (int)'1'});
+    keyMapManager->addBinding(Surge::GUI::OSC_2, {keymap_t::Modifiers::ALT, (int)'2'});
+    keyMapManager->addBinding(Surge::GUI::OSC_3, {keymap_t::Modifiers::ALT, (int)'3'});
+
+    // TODO: FIX SCENE ASSUMPTION
+    keyMapManager->addBinding(Surge::GUI::TOGGLE_SCENE, {keymap_t::Modifiers::ALT, (int)'S'});
+
+#if WINDOWS
+    keyMapManager->addBinding(Surge::GUI::TOGGLE_DEBUG_CONSOLE,
+                              {keymap_t::Modifiers::ALT, (int)'D'});
+#endif
+    keyMapManager->addBinding(Surge::GUI::SHOW_KEYBINDINGS_EDITOR,
+                              {keymap_t::Modifiers::ALT, (int)'B'});
+    keyMapManager->addBinding(Surge::GUI::SHOW_LFO_EDITOR, {keymap_t::Modifiers::ALT, (int)'E'});
+    keyMapManager->addBinding(Surge::GUI::SHOW_MODLIST, {keymap_t::Modifiers::ALT, (int)'M'});
+    keyMapManager->addBinding(Surge::GUI::SHOW_TUNING_EDITOR, {keymap_t::Modifiers::ALT, (int)'T'});
+    keyMapManager->addBinding(Surge::GUI::TOGGLE_VIRTUAL_KEYBOARD,
+                              {keymap_t::Modifiers::ALT, (int)'K'});
+
+    keyMapManager->addBinding(Surge::GUI::ZOOM_TO_DEFAULT, {keymap_t ::Modifiers::SHIFT, '/'});
+    keyMapManager->addBinding(Surge::GUI::ZOOM_PLUS_10, {keymap_t ::Modifiers::NONE, '+'});
+    keyMapManager->addBinding(Surge::GUI::ZOOM_PLUS_25, {keymap_t ::Modifiers::SHIFT, '+'});
+    keyMapManager->addBinding(Surge::GUI::ZOOM_MINUS_10, {keymap_t ::Modifiers::NONE, '-'});
+    keyMapManager->addBinding(Surge::GUI::ZOOM_MINUS_25, {keymap_t ::Modifiers::SHIFT, '-'});
+
+    keyMapManager->addBinding(Surge::GUI::REFRESH_SKIN, {juce::KeyPress::F5Key});
+
+    keyMapManager->addBinding(Surge::GUI::OPEN_MANUAL, {juce::KeyPress::F1Key});
+    keyMapManager->addBinding(Surge::GUI::TOGGLE_ABOUT, {juce::KeyPress::F12Key});
 
     keyMapManager->unstreamFromXML();
 }
+
 bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *originatingComponent)
 {
     auto textChar = key.getTextCharacter();
     auto keyCode = key.getKeyCode();
 
-    /*
-     * We treat escape and tab separately outside the key manager
-     */
+    // We treat Escape and Tab separately outside of the key manager
     if (textChar == juce::KeyPress::tabKey)
     {
         auto tk = Surge::Storage::getUserDefaultValue(
@@ -6374,11 +6391,12 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
 
     bool triedKey = Surge::Widgets::isAccessibleKey(key);
     bool shortcutsUsed = getUseKeyboardShortcuts();
-
     auto mapMatch = keyMapManager->matches(key);
+
     if (mapMatch.has_value())
     {
         triedKey = true;
+
         if (shortcutsUsed)
         {
             auto action = *mapMatch;
@@ -6388,6 +6406,10 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
             case Surge::GUI::UNDO:
                 undoManager()->undo();
                 return true;
+            case Surge::GUI::REDO:
+                undoManager()->redo();
+                return true;
+            // TODO: UPDATE WHEN ADDING MORE OSCILLATORS
             case Surge::GUI::OSC_1:
                 changeSelectedOsc(0);
                 return true;
@@ -6397,6 +6419,7 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
             case Surge::GUI::OSC_3:
                 changeSelectedOsc(2);
                 return true;
+            // TODO: FIX SCENE ASSUMPTION
             case Surge::GUI::TOGGLE_SCENE:
             {
                 auto s = current_scene + 1;
@@ -6411,6 +6434,10 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
             case Surge::GUI::FIND_PATCH:
                 patchSelector->isTypeaheadSearchOn = !patchSelector->isTypeaheadSearchOn;
                 patchSelector->toggleTypeAheadSearch(patchSelector->isTypeaheadSearchOn);
+                return true;
+            case Surge::GUI::SHOW_KEYBINDINGS_EDITOR:
+                toggleOverlay(SurgeGUIEditor::KEYBINDINGS_EDITOR);
+                frame->repaint();
                 return true;
             case Surge::GUI::SHOW_TUNING_EDITOR:
                 toggleOverlay(SurgeGUIEditor::TUNING_EDITOR);
@@ -6436,9 +6463,11 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
                 toggleOverlay(SurgeGUIEditor::MODULATION_EDITOR);
                 frame->repaint();
                 return true;
-            case Surge::GUI::TOGGLE_DEBUG_CONSOLE: // Windows only
+#if WINDOWS
+            case Surge::GUI::TOGGLE_DEBUG_CONSOLE:
                 Surge::Debug::toggleConsole();
                 return true;
+#endif
             case Surge::GUI::TOGGLE_VIRTUAL_KEYBOARD:
                 toggleVirtualKeyboard();
                 return true;

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -17,6 +17,7 @@
 #define SURGE_SURGEGUIEDITORKEYBOARDACTIONS_H
 
 #include <string>
+#include "SurgeGUIUtils.h"
 
 namespace Surge
 {
@@ -25,6 +26,7 @@ namespace GUI
 enum KeyboardActions
 {
     UNDO,
+    REDO,
 
     SAVE_PATCH,
     FIND_PATCH,
@@ -35,26 +37,33 @@ enum KeyboardActions
     PREV_CATEGORY,
     NEXT_CATEGORY,
 
+    // TODO: UPDATE WHEN ADDING MORE OSCILLATORS
+    OSC_1,
+    OSC_2,
+    OSC_3,
+
+    // TODO: FIX SCENE ASSUMPTION
+    TOGGLE_SCENE,
+
+#if WINDOWS
+    TOGGLE_DEBUG_CONSOLE,
+#endif
+    SHOW_KEYBINDINGS_EDITOR,
+    SHOW_LFO_EDITOR,
+    SHOW_MODLIST,
+    SHOW_TUNING_EDITOR,
+    TOGGLE_VIRTUAL_KEYBOARD,
+
     ZOOM_TO_DEFAULT,
     ZOOM_PLUS_10,
     ZOOM_PLUS_25,
     ZOOM_MINUS_10,
     ZOOM_MINUS_25,
 
-    SHOW_TUNING_EDITOR,
-    SHOW_LFO_EDITOR,
-    SHOW_MODLIST,
-    TOGGLE_DEBUG_CONSOLE, // Windows only
-    TOGGLE_VIRTUAL_KEYBOARD,
+    REFRESH_SKIN,
 
     OPEN_MANUAL,
-    REFRESH_SKIN,
     TOGGLE_ABOUT,
-
-    OSC_1,
-    OSC_2,
-    OSC_3,
-    TOGGLE_SCENE,
 
     n_kbdActions
 };
@@ -65,17 +74,21 @@ inline std::string keyboardActionName(KeyboardActions a)
     {
     case UNDO:
         return "UNDO";
+    case REDO:
+        return "REDO";
 
+    // TODO: UPDATE WHEN ADDING MORE OSCILLATORS
     case OSC_1:
         return "OSC_1";
-
     case OSC_2:
         return "OSC_2";
     case OSC_3:
         return "OSC_3";
 
+    // TODO: FIX SCENE ASSUMPTION
     case TOGGLE_SCENE:
         return "TOGGLE_SCENE";
+
     case SAVE_PATCH:
         return "SAVE_PATCH";
     case FIND_PATCH:
@@ -83,14 +96,18 @@ inline std::string keyboardActionName(KeyboardActions a)
     case FAVORITE_PATCH:
         return "FAVORITE_PATCH";
 
+    case SHOW_KEYBINDINGS_EDITOR:
+        return "SHOW_KEYBINDINGS_EDITOR";
     case SHOW_TUNING_EDITOR:
         return "SHOW_TUNING_EDITOR";
     case SHOW_LFO_EDITOR:
         return "SHOW_LFO_EDITOR";
     case SHOW_MODLIST:
         return "SHOW_MODLIST";
-    case TOGGLE_DEBUG_CONSOLE: // Windows only
+#if WINDOWS
+    case TOGGLE_DEBUG_CONSOLE:
         return "TOGGLE_DEBUG_CONSOLE";
+#endif
     case TOGGLE_VIRTUAL_KEYBOARD:
         return "TOGGLE_VIRTUAL_KEYBOARD";
 
@@ -130,63 +147,103 @@ inline std::string keyboardActionName(KeyboardActions a)
 // This is the user-facing stringification of an action.
 inline std::string keyboardActionDescription(KeyboardActions a)
 {
+    std::string desc;
+    bool skipOSCase = false;
+
     switch (a)
     {
     case UNDO:
-        return "Undo changes";
+        desc = "Undo";
+        break;
+    case REDO:
+        desc = "Redo (WIP!)";
+        break;
     case SAVE_PATCH:
-        return "Open Save Patch Dialog";
+        desc = "Save Patch";
+        break;
     case FIND_PATCH:
-        return "Find Patch via Search";
+        desc = "Find Patch";
+        break;
     case FAVORITE_PATCH:
-        return "Toggle Patch Favorite";
+        desc = "Mark Patch as Favorite";
+        break;
     case PREV_PATCH:
-        return "Previous Patch";
+        desc = "Previous Patch";
+        break;
     case NEXT_PATCH:
-        return "Next Patch";
+        desc = "Next Patch";
+        break;
     case PREV_CATEGORY:
-        return "Previous Patch Category";
+        desc = "Previous Category";
+        break;
     case NEXT_CATEGORY:
-        return "Next Patch Category";
+        desc = "Next Category";
+        break;
     case ZOOM_TO_DEFAULT:
-        return "Zoom to Default Zoom";
+        desc = "Zoom to Default";
+        break;
     case ZOOM_PLUS_10:
-        return "Zoom up by 10pts";
+        desc = "Zoom +10%";
+        break;
     case ZOOM_PLUS_25:
-        return "Zoom up by 25pts";
+        desc = "Zoom +25%";
+        break;
     case ZOOM_MINUS_10:
-        return "Zoom down by 10pts";
+        desc = "Zoom -10%";
+        break;
     case ZOOM_MINUS_25:
-        return "Zoom down by 25pts";
+        desc = "Zoom -25%";
+        break;
+    case SHOW_KEYBINDINGS_EDITOR:
+        desc = "Keyboard Shortcut Editor";
+        break;
     case SHOW_TUNING_EDITOR:
-        return "Open Tuning Editor";
+        desc = "Tuning Editor";
+        break;
     case SHOW_LFO_EDITOR:
-        return "Open LFO Editor (MSEG, Formula)";
+        desc = "LFO Editor (MSEG or Formula)";
+        break;
     case SHOW_MODLIST:
-        return "Open Modulation List Editor";
+        desc = "Modulation List";
+        break;
+#if WINDOWS
     case TOGGLE_DEBUG_CONSOLE:
-        return "Toggle Debug Console (windows only)";
+        desc = "Debug Console";
+        break;
+#endif
     case TOGGLE_VIRTUAL_KEYBOARD:
-        return "Toggle Virtual Keyboard";
+        desc = "Virtual Keyboard";
+        break;
     case OPEN_MANUAL:
-        return "Open Manual";
+        desc = "Open Manual";
+        break;
     case REFRESH_SKIN:
-        return "Refresh Skin";
+        desc = "Refresh Skin";
+        break;
     case TOGGLE_ABOUT:
-        return "About";
+        desc = "About Surge XT";
+        skipOSCase = true;
+        break;
+    // TODO: UPDATE WHEN ADDING MORE OSCILLATORS
     case OSC_1:
-        return "Select Oscillator 1";
+        desc = "Select Oscillator 1";
+        break;
     case OSC_2:
-        return "Select Oscillator 2";
+        desc = "Select Oscillator 2";
+        break;
     case OSC_3:
-        return "Select Oscillator 3";
+        desc = "Select Oscillator 3";
+        break;
     case TOGGLE_SCENE:
-        return "Toggle Scene";
-    case n_kbdActions:
-        return "<ERROR>";
+        // TODO: FIX SCENE ASSUMPTION
+        desc = "Toggle Scene A/B";
+        break;
+    default:
+        desc = "<Unknown Action>";
+        break;
     };
 
-    return "<ERROR>";
+    return skipOSCase ? desc : Surge::GUI::toOSCaseForMenu(desc);
 }
 
 } // namespace GUI

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -350,7 +350,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
 
         kb->setSkin(currentSkin, bitmapStore);
         kb->setEnclosingParentPosition(posRect);
-        kb->setEnclosingParentTitle("Edit Keybindings");
+        kb->setEnclosingParentTitle("Keyboard Shortcut Editor");
         return kb;
     }
     default:
@@ -362,15 +362,18 @@ void SurgeGUIEditor::showOverlay(OverlayTags olt,
                                  std::function<void(Surge::Overlays::OverlayComponent *)> setup)
 {
     auto ol = createOverlay(olt);
+
     if (!ol)
     {
         juceOverlays.erase(olt);
         return;
     }
+
     // copy these before the std::move below
     auto t = ol->getEnclosingParentTitle();
     auto r = ol->getEnclosingParentPosition();
     auto c = ol->getHasIndependentClose();
+
     setup(ol.get());
 
     std::function<void()> onClose = []() {};

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -424,6 +424,7 @@ void SurgeJUCELookAndFeel::drawPopupMenuItem(Graphics &g, const Rectangle<int> &
 
         if (shortcutKeyText.isNotEmpty())
         {
+            g.setFont(juce::LookAndFeel_V4::getPopupMenuFont().withHeight(13));
             g.drawText(shortcutKeyText, r, Justification::centredRight, true);
         }
     }

--- a/src/surge-xt/gui/UndoManager.cpp
+++ b/src/surge-xt/gui/UndoManager.cpp
@@ -252,6 +252,9 @@ struct UndoManagerImpl
         return false;
     }
 
+    // TODO: implement redo
+    bool redo() { return false; }
+
     void dumpStack()
     {
         for (const auto &q : undoStack)
@@ -285,6 +288,8 @@ void UndoManager::pushOscillator(int scene, int oscnum) { impl->pushOscillator(s
 void UndoManager::pushFX(int fxslot) { impl->pushFX(fxslot); }
 
 bool UndoManager::undo() { return impl->undo(); }
+
+bool UndoManager::redo() { return impl->redo(); }
 
 void UndoManager::dumpStack() { impl->dumpStack(); }
 

--- a/src/surge-xt/gui/UndoManager.h
+++ b/src/surge-xt/gui/UndoManager.h
@@ -41,6 +41,7 @@ struct UndoManager
     void pushOscillator(int scene, int oscnum);
     void pushFX(int fxslot);
     bool undo();
+    bool redo();
     void dumpStack();
 };
 } // namespace GUI

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
@@ -30,13 +30,13 @@ struct KeyBindingsListRow : public juce::Component
     KeyBindingsListRow(Surge::GUI::KeyboardActions a, SurgeGUIEditor *ed) : action(a), editor(ed)
     {
         active = std::make_unique<juce::ToggleButton>();
-        active->setToggleState(editor->keyMapManager->bindings[action].active,
-                               juce::dontSendNotification);
         active->setButtonText("");
         active->onStateChange = [this]() {
             editor->keyMapManager->bindings[action].active = active->getToggleState();
         };
         active->setAccessible(true);
+        active->setToggleState(editor->keyMapManager->bindings[action].active,
+                               juce::dontSendNotification);
         active->setTitle(std::string("Toggle ") + Surge::GUI::keyboardActionDescription(action));
         active->setDescription(std::string("Toggle ") +
                                Surge::GUI::keyboardActionDescription(action));
@@ -47,6 +47,30 @@ struct KeyBindingsListRow : public juce::Component
         name->setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
         name->setAccessible(true);
         addAndMakeVisible(*name);
+
+        std::string desc = "";
+        keyDesc = std::make_unique<juce::Label>("keyDesc", desc);
+        keyDesc->setColour(juce::Label::textColourId, juce::Colours::white);
+        // TODO FIXME: Font should be juce::LNF_v4::getPopupMenuFont(), just for Mac symbols!
+        keyDesc->setFont(10.0);
+        keyDesc->setJustificationType(juce::Justification::right);
+        keyDesc->setAccessible(true);
+        addAndMakeVisible(*keyDesc);
+
+        setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
+
+        resetValues();
+    }
+
+    void resetValues()
+    {
+        active->setToggleState(editor->keyMapManager->bindings[action].active,
+                               juce::dontSendNotification);
+        active->setTitle(std::string("Toggle ") + Surge::GUI::keyboardActionDescription(action));
+        active->setDescription(std::string("Toggle ") +
+                               Surge::GUI::keyboardActionDescription(action));
+
+        name->setText(Surge::GUI::keyboardActionDescription(action), juce::dontSendNotification);
 
         const auto &binding = editor->keyMapManager->bindings[action];
         auto flags = juce::ModifierKeys::noModifiers;
@@ -86,16 +110,14 @@ struct KeyBindingsListRow : public juce::Component
 #else
         desc[0] = std::toupper(desc[0]);
 #endif
+        keyDesc->setText(desc, juce::dontSendNotification);
+    }
 
-        keyDesc = std::make_unique<juce::Label>("keyDesc", desc);
-        keyDesc->setColour(juce::Label::textColourId, juce::Colours::white);
-        // TODO FIXME: Font should be juce::LNF_v4::getPopupMenuFont(), just for Mac symbols!
-        keyDesc->setFont(10.0);
-        keyDesc->setJustificationType(juce::Justification::right);
-        keyDesc->setAccessible(true);
-        addAndMakeVisible(*keyDesc);
-
-        setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
+    void setAction(Surge::GUI::KeyboardActions a)
+    {
+        action = a;
+        resetValues();
+        repaint();
     }
 
     void resized()
@@ -144,6 +166,8 @@ struct KeyBindingsListBoxModel : public juce::ListBoxModel
 
             rc = new KeyBindingsListRow((Surge::GUI::KeyboardActions)rowNumber, editor);
         }
+
+        rc->setAction((Surge::GUI::KeyboardActions)rowNumber);
 
         return rc;
     }

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "KeyBindingsOverlay.h"
+#include <SurgeJUCELookAndFeel.h>
 #include "RuntimeFont.h"
 
 namespace Surge
@@ -25,6 +26,7 @@ struct KeyBindingsListRow : public juce::Component
 {
     SurgeGUIEditor *editor{nullptr};
     Surge::GUI::KeyboardActions action;
+
     KeyBindingsListRow(Surge::GUI::KeyboardActions a, SurgeGUIEditor *ed) : action(a), editor(ed)
     {
         active = std::make_unique<juce::ToggleButton>();
@@ -48,6 +50,7 @@ struct KeyBindingsListRow : public juce::Component
 
         const auto &binding = editor->keyMapManager->bindings[action];
         auto flags = juce::ModifierKeys::noModifiers;
+
         switch (binding.modifier)
         {
         case SurgeGUIEditor::keymap_t::SHIFT:
@@ -66,21 +69,35 @@ struct KeyBindingsListRow : public juce::Component
             break;
         }
 
-        auto kp = juce::KeyPress(binding.keyCode, juce::ModifierKeys(flags), binding.keyCode);
+        auto kp = juce::KeyPress(binding.keyCode, flags, binding.keyCode);
+
         if (binding.type == SurgeGUIEditor::keymap_t::Binding::TEXTCHAR)
         {
             kp = juce::KeyPress(binding.textChar, flags, binding.textChar);
         }
 
-        keyDesc = std::make_unique<juce::Label>("keyDesc", kp.getTextDescription());
+        auto desc = kp.getTextDescription().toStdString();
+
+#if MAC
+        Surge::Storage::findReplaceSubstring(desc, "command", u8"\U00002318");
+        Surge::Storage::findReplaceSubstring(desc, "option", u8"\U00002325");
+        Surge::Storage::findReplaceSubstring(desc, "shift", u8"\U000021E7");
+        Surge::Storage::findReplaceSubstring(desc, "ctrl", u8"\U00002303");
+#else
+        desc[0] = std::toupper(desc[0]);
+#endif
+
+        keyDesc = std::make_unique<juce::Label>("keyDesc", desc);
         keyDesc->setColour(juce::Label::textColourId, juce::Colours::white);
-        keyDesc->setFont(Surge::GUI::getFontManager()->getLatoAtSize(9));
+        // TODO FIXME: Font should be juce::LNF_v4::getPopupMenuFont(), just for Mac symbols!
+        keyDesc->setFont(10.0);
         keyDesc->setJustificationType(juce::Justification::right);
         keyDesc->setAccessible(true);
         addAndMakeVisible(*keyDesc);
 
         setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
     }
+
     void resized()
     {
         auto r = getLocalBounds().reduced(2);
@@ -90,6 +107,7 @@ struct KeyBindingsListRow : public juce::Component
         name->setBounds(a2.withWidth(300));
         keyDesc->setBounds(a2.withTrimmedLeft(300));
     }
+
     std::unique_ptr<juce::ToggleButton> active;
     std::unique_ptr<juce::Label> name, keyDesc;
 };
@@ -97,39 +115,43 @@ struct KeyBindingsListRow : public juce::Component
 struct KeyBindingsListBoxModel : public juce::ListBoxModel
 {
     SurgeGUIEditor *editor;
+
     KeyBindingsListBoxModel(SurgeGUIEditor *ed) : editor(ed) {}
 
     int getNumRows() override { return SurgeGUIEditor::keymap_t::numFuncs; }
+
     void paintListBoxItem(int rowNumber, juce::Graphics &g, int width, int height,
                           bool rowIsSelected) override
     {
-        auto rb = rowNumber / 3;
-
-        if (rb % 2 == 0)
-            g.fillAll(juce::Colour(50, 50, 50));
+        if (rowNumber % 2 == 1)
+        {
+            g.fillAll(juce::Colour(40, 40, 40));
+        }
     }
 
     juce::Component *refreshComponentForRow(int rowNumber, bool isRowSelected,
                                             juce::Component *existingComponentToUpdate) override
     {
         auto rc = dynamic_cast<KeyBindingsListRow *>(existingComponentToUpdate);
+
         if (!rc)
         {
             // Should never happen but
             if (existingComponentToUpdate)
+            {
                 delete existingComponentToUpdate;
-            rc = new KeyBindingsListRow((Surge::GUI::KeyboardActions)rowNumber, editor);
-        }
+            }
 
-        if (rc)
-        {
+            rc = new KeyBindingsListRow((Surge::GUI::KeyboardActions)rowNumber, editor);
         }
 
         return rc;
     }
+
     juce::String getNameForRow(int rowNumber) override
     {
         auto action = (Surge::GUI::KeyboardActions)rowNumber;
+
         return Surge::GUI::keyboardActionDescription(action);
     }
 };
@@ -138,30 +160,34 @@ KeyBindingsOverlay::KeyBindingsOverlay(SurgeStorage *st, SurgeGUIEditor *ed)
     : storage(st), editor(ed)
 {
     setAccessible(true);
-    setTitle("Key Binding Editor");
-    setDescription("Key Binding Editor");
+    setTitle("Keyboard Shortcut Editor");
+    setDescription("Keyboard Shortcut Editor");
     setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
 
-    okS = std::make_unique<Surge::Widgets::SelfDrawButton>("Ok");
+    okS = std::make_unique<Surge::Widgets::SelfDrawButton>("OK");
+
     okS->onClick = [this]() {
         editor->keyMapManager->streamToXML();
         editor->setupKeymapManager();
         editor->closeOverlay(SurgeGUIEditor::KEYBINDINGS_EDITOR);
     };
+
     okS->setStorage(storage);
     addAndMakeVisible(*okS);
 
     cancelS = std::make_unique<Surge::Widgets::SelfDrawButton>("Cancel");
+
     cancelS->onClick = [this]() {
         // We need to restore to prior state here
         editor->setupKeymapManager();
         editor->closeOverlay(SurgeGUIEditor::KEYBINDINGS_EDITOR);
     };
+
     cancelS->setStorage(storage);
     addAndMakeVisible(*cancelS);
 
     bindingListBoxModel = std::make_unique<KeyBindingsListBoxModel>(editor);
-    bindingList = std::make_unique<juce::ListBox>("Key Bindings", bindingListBoxModel.get());
+    bindingList = std::make_unique<juce::ListBox>("Keyboard Shortcuts", bindingListBoxModel.get());
     addAndMakeVisible(*bindingList);
 }
 
@@ -174,6 +200,7 @@ void KeyBindingsOverlay::paint(juce::Graphics &g)
         g.fillAll(juce::Colours::black);
         return;
     }
+
     g.fillAll(skin->getColor(Colors::MSEGEditor::Background));
 
     auto r = getLocalBounds().withTrimmedTop(getHeight() - okCancelAreaHeight);


### PR DESCRIPTION
Add Alt+B shortcut for opening the keyboard shortcut editor.
Add scaffolding for redo action.
Debug console action shows only on Windows.
Revert to JUCE default font for keyboard shortcut description