### PR TITLE
Fix a longhold crash fix

### DIFF
--- a/src/surge-xt/gui/widgets/WidgetBaseMixin.h
+++ b/src/surge-xt/gui/widgets/WidgetBaseMixin.h
@@ -237,7 +237,9 @@ template <typename T> struct LongHoldMixin
     bool shouldLongHold()
     {
         // return true;
-        return GUI::isTouchMode(asT()->storage);
+        if (asT()->storage)
+            return GUI::isTouchMode(asT()->storage);
+        return false;
     }
 
     juce::Point<float> startingHoldPosition;


### PR DESCRIPTION
If storage is null it woudl core out, and some things had storage
null (like generate in tuning editor)