### PR TITLE
Start on Hover remediation

### DIFF
--- a/src/surge-xt/gui/SurgeGUICallbackInterfaces.h
+++ b/src/surge-xt/gui/SurgeGUICallbackInterfaces.h
@@ -28,8 +28,25 @@ struct IComponentTagValue
     virtual float getValue() const = 0;
     virtual void setValue(float) = 0;
 
-    virtual void startHover(const juce::Point<float> &) {}
-    virtual void endHover() {}
+    int hoverCount{0};
+    virtual int incrementHover()
+    {
+        hoverCount++;
+        return hoverCount;
+    }
+    virtual int decrementHover()
+    {
+        hoverCount--;
+        return hoverCount;
+    }
+    virtual void forceEndHover()
+    {
+        hoverCount = 1;
+        endHover();
+    }
+
+    virtual void startHover(const juce::Point<float> &) { incrementHover(); }
+    virtual void endHover() { decrementHover(); }
 
     juce::Component *asJuceComponent()
     {

--- a/src/surge-xt/gui/SurgeJUCEHelpers.h
+++ b/src/surge-xt/gui/SurgeJUCEHelpers.h
@@ -49,13 +49,15 @@ inline std::function<void(int)> makeEndHoverCallback(Surge::GUI::IComponentTagVa
     if (!that)
         return [](int) {};
 
+    that->incrementHover();
+
     return
         [safethat = juce::Component::SafePointer<juce::Component>(that->asJuceComponent())](int x) {
             if (safethat)
             {
                 auto igtv = dynamic_cast<Surge::GUI::IComponentTagValue *>(safethat.getComponent());
                 if (igtv)
-                    igtv->endHover();
+                    igtv->forceEndHover();
             }
         };
 }

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -378,6 +378,9 @@ void ModulatableSlider::onSkinChanged()
 void ModulatableSlider::mouseEnter(const juce::MouseEvent &event) { startHover(event.position); }
 void ModulatableSlider::startHover(const juce::Point<float> &p)
 {
+    if (incrementHover() > 1)
+        return;
+
     enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::START, p);
     isHovered = true;
     auto sge = firstListenerOfType<SurgeGUIEditor>();
@@ -391,6 +394,9 @@ void ModulatableSlider::mouseExit(const juce::MouseEvent &event) { endHover(); }
 
 void ModulatableSlider::endHover()
 {
+    if (decrementHover() != 0)
+        return;
+
     enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::LEAVE);
     isHovered = false;
     auto sge = firstListenerOfType<SurgeGUIEditor>();

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -246,6 +246,9 @@ void MultiSwitch::mouseEnter(const juce::MouseEvent &event) { startHover(event.p
 
 void MultiSwitch::startHover(const juce::Point<float> &p)
 {
+    if (incrementHover() > 1)
+        return;
+
     if (everDragged && isMouseDown) // don't change hover state during a drag
     {
         hoverSelection = getIntegerValue();
@@ -261,6 +264,9 @@ void MultiSwitch::mouseExit(const juce::MouseEvent &event) { endHover(); }
 
 void MultiSwitch::endHover()
 {
+    if (decrementHover() != 0)
+        return;
+
     isHovered = false;
     repaint();
 }


### PR DESCRIPTION
Juce fixed a bug where menu launch didn't exit a complent
but that screwed up our hover management. Start fixing it.

Addresses #5318