### PR TITLE
Greatly reduce param -> overlay repaints

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -3268,9 +3268,17 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                 {
                     lfoDisplay->repaint();
                 }
-                for (auto &el : juceOverlays)
+                for (const auto &[olTag, ol] : juceOverlays)
                 {
-                    el.second->repaint();
+                    auto olpc = ol->getPrimaryChildAsOverlayComponent();
+                    if (olpc && olpc->shouldRepaintOnParamChange(getPatch(), p))
+                    {
+                        olpc->repaint();
+                    }
+                    else
+                    {
+                        // std::cout << "Skipping param repaint" << std::endl;
+                    }
                 }
             }
             if (p->ctrltype == ct_filtertype)

--- a/src/surge-xt/gui/overlays/LuaEditors.h
+++ b/src/surge-xt/gui/overlays/LuaEditors.h
@@ -103,6 +103,11 @@ struct FormulaModulatorEditor : public CodeEditorContainerWithApply
     std::unique_ptr<juce::CodeDocument> preludeDocument;
     std::unique_ptr<juce::CodeEditorComponent> preludeDisplay;
 
+    bool shouldRepaintOnParamChange(const SurgePatch &patch, Parameter *p) override
+    {
+        return false;
+    }
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FormulaModulatorEditor);
 };
 

--- a/src/surge-xt/gui/overlays/MSEGEditor.h
+++ b/src/surge-xt/gui/overlays/MSEGEditor.h
@@ -54,6 +54,11 @@ struct MSEGEditor : public OverlayComponent,
     void resized() override;
     void paint(juce::Graphics &g) override;
 
+    bool shouldRepaintOnParamChange(const SurgePatch &patch, Parameter *p) override
+    {
+        return false;
+    }
+
     std::unique_ptr<MSEGControlRegion> controls;
     std::unique_ptr<MSEGCanvas> canvas;
 

--- a/src/surge-xt/gui/overlays/ModulationEditor.h
+++ b/src/surge-xt/gui/overlays/ModulationEditor.h
@@ -70,6 +70,12 @@ class ModulationEditor : public OverlayComponent,
 
     void updateParameterById(const SurgeSynthesizer::ID &pid);
 
+    bool shouldRepaintOnParamChange(const SurgePatch &patch, Parameter *p) override
+    {
+        // You would think this would be true, but the subscriptions will get us there
+        return false;
+    }
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModulationEditor);
 };
 

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -19,6 +19,9 @@
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "UserDefaults.h"
 
+class Parameter;
+class SurgePatch;
+
 namespace Surge
 {
 namespace Overlays
@@ -38,6 +41,7 @@ struct OverlayComponent : juce::Component
     bool hasIndependentClose{true};
     void setHasIndependentClose(bool b) { hasIndependentClose = b; }
     bool getHasIndependentClose() { return hasIndependentClose; }
+    virtual bool shouldRepaintOnParamChange(const SurgePatch &, Parameter *p) { return true; }
 
     /*
      * This is called when a parent wrapper finally decides to show me, which will

--- a/src/surge-xt/gui/overlays/TuningOverlays.h
+++ b/src/surge-xt/gui/overlays/TuningOverlays.h
@@ -88,6 +88,11 @@ struct TuningOverlay : public OverlayComponent,
     bool isInterestedInFileDrag(const juce::StringArray &files) override;
     void filesDropped(const juce::StringArray &files, int x, int y) override;
 
+    bool shouldRepaintOnParamChange(const SurgePatch &patch, Parameter *p) override
+    {
+        return false;
+    }
+
     std::unique_ptr<TuningTableListBoxModel> tuningKeyboardTableModel;
     std::unique_ptr<juce::TableListBox> tuningKeyboardTable;
 

--- a/src/surge-xt/gui/overlays/WaveShaperAnalysis.cpp
+++ b/src/surge-xt/gui/overlays/WaveShaperAnalysis.cpp
@@ -254,6 +254,19 @@ float WaveShaperAnalysis::getDbValue()
     }
     return sliderDb;
 }
+bool WaveShaperAnalysis::shouldRepaintOnParamChange(const SurgePatch &patch, Parameter *p)
+{
+    if (p->ctrlgroup == cg_GLOBAL)
+    {
+        for (int i = 0; i < n_scenes; ++i)
+        {
+            auto &ws = patch.scene[i].wsunit;
+            if (p->id == ws.type.id || p->id == ws.drive.id)
+                return true;
+        }
+    }
+    return false;
+}
 
 } // namespace Overlays
 }; // namespace Surge

--- a/src/surge-xt/gui/overlays/WaveShaperAnalysis.h
+++ b/src/surge-xt/gui/overlays/WaveShaperAnalysis.h
@@ -54,6 +54,7 @@ struct WaveShaperAnalysis : public OverlayComponent,
     std::unique_ptr<Surge::Widgets::ModulatableSlider> tryitSlider;
     std::unique_ptr<Surge::Widgets::SelfDrawToggleButton> linkButton;
 
+    bool shouldRepaintOnParamChange(const SurgePatch &patch, Parameter *p) override;
     bool linked{true};
     void linkToggled();
 


### PR DESCRIPTION
Param changes would repaint all overlays every change, almost
definitely leading to the problem in #5555. Make it so an
overlay gets an option using a basic API, make a few of them
param change neutral.