### PR TITLE
[skip-ci] "Use MIDI Channel for Octave Shift" grayed out if MPE active

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3119,8 +3119,8 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                     tuneStatus);
             });
 
-        tuningSubMenu.addItem(Surge::GUI::toOSCase("Use MIDI Channel for Octave Shift"), true,
-                              (synth->storage.mapChannelToOctave), [this]() {
+        tuningSubMenu.addItem(Surge::GUI::toOSCase("Use MIDI Channel for Octave Shift"),
+                              !synth->mpeEnabled, (synth->storage.mapChannelToOctave), [this]() {
                                   this->synth->storage.mapChannelToOctave =
                                       !(this->synth->storage.mapChannelToOctave);
                               });


### PR DESCRIPTION
Addresses #5908 (doesn't fix the underlying issue, this is just visual prep)