### PR TITLE
Some overlay improvmeents

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1914,6 +1914,10 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
     for (const auto &el : juceOverlays)
     {
+        if (el.second->getPrimaryChildAsOverlayComponent())
+        {
+            el.second->getPrimaryChildAsOverlayComponent()->forceDataRefresh();
+        }
         if (!el.second->isTornOut())
         {
             addAndMakeVisibleWithTracking(frame.get(), *(el.second));

--- a/src/surge-xt/gui/overlays/FilterAnalysis.cpp
+++ b/src/surge-xt/gui/overlays/FilterAnalysis.cpp
@@ -330,6 +330,8 @@ void FilterAnalysis::resized()
 
     f1Button->setBounds(2, 2, 40, 15);
     f2Button->setBounds(w - 42, 2, 40, 15);
+
+    catchUpStore = evaluator->outboundUpdates - 1; // because we need to rebuild the path
 }
 
 } // namespace Overlays

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -213,6 +213,13 @@ void OverlayWrapper::supressInteriorDecoration()
     primaryChild->setBounds(getLocalBounds());
 }
 
+void OverlayWrapper::resized()
+{
+    if (isTornOut())
+    {
+        primaryChild->setBounds(getLocalBounds());
+    }
+}
 void OverlayWrapper::doTearOut(const juce::Point<int> &showAt)
 {
     parentBeforeTearOut = getParentComponent();
@@ -245,6 +252,7 @@ void OverlayWrapper::doTearOut(const juce::Point<int> &showAt)
     dw->setContentNonOwned(this, false);
     dw->setContentComponentSize(w, h);
     dw->setVisible(true);
+    dw->setResizable(true, true);
     if (showAt.x >= 0 && showAt.y >= 0)
         dw->setTopLeftPosition(showAt.x, showAt.y);
     else

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -72,6 +72,8 @@ struct OverlayWrapper : public juce::Component,
 
     void visibilityChanged() override;
 
+    void resized() override;
+
     SurgeImage *icon{nullptr};
     void setIcon(SurgeImage *d) { icon = d; }
 


### PR DESCRIPTION
1. Refresh data on rebuild. Avoids a stale filter overlay
2. Make torn out overlays resizable. Still some state work to do
   and we may back this out of 1.1 if we can't get it