### PR TITLE
Tearout Resize Management

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -169,9 +169,7 @@ std::string defaultKeyToString(DefaultKey k)
     case FilterAnalysisOverlayLocation:
         r = "filterAnalysisOverlayLocation";
         break;
-    case FilterAnalysisOverlayTearOut:
-        r = "filterAnalysisOverlayTearOut";
-        break;
+
     case TuningOverlayLocationTearOut:
         r = "tuningOverlayLocationTearOut";
         break;
@@ -184,6 +182,26 @@ std::string defaultKeyToString(DefaultKey k)
     case FormulaOverlayLocationTearOut:
         r = "FormulaOverlayLocationTearOut";
         break;
+    case FilterAnalysisOverlayLocationTearOut:
+        r = "filterAnalysisOverlayLocationTearOut";
+        break;
+
+    case TuningOverlaySizeTearOut:
+        r = "tuningOverlaySizeTearOut";
+        break;
+    case ModlistOverlaySizeTearOut:
+        r = "modlistOverlaySizeTearOut";
+        break;
+    case MSEGOverlaySizeTearOut:
+        r = "msegOverlaySizeTearOut";
+        break;
+    case FormulaOverlaySizeTearOut:
+        r = "FormulaOverlaySizeTearOut";
+        break;
+    case FilterAnalysisOverlaySizeTearOut:
+        r = "filterAnalysisOverlaySizeTearOut";
+        break;
+
     case ModListValueDisplay:
         r = "modListValueDisplay";
         break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -81,12 +81,18 @@ enum DefaultKey
     FormulaOverlayLocation,
     WSAnalysisOverlayLocation,
     FilterAnalysisOverlayLocation,
-    FilterAnalysisOverlayTearOut,
 
     TuningOverlayLocationTearOut,
     ModlistOverlayLocationTearOut,
     MSEGOverlayLocationTearOut,
     FormulaOverlayLocationTearOut,
+    FilterAnalysisOverlayLocationTearOut,
+
+    TuningOverlaySizeTearOut,
+    ModlistOverlaySizeTearOut,
+    MSEGOverlaySizeTearOut,
+    FormulaOverlaySizeTearOut,
+    FilterAnalysisOverlaySizeTearOut,
 
     ModListValueDisplay,
     MenuLightness,

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -410,6 +410,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         std::function<void()> onClose = []() {}, bool forceModal = false);
     std::unordered_map<OverlayTags, std::unique_ptr<Surge::Overlays::OverlayWrapper>> juceOverlays;
     std::vector<std::unique_ptr<Surge::Overlays::OverlayWrapper>> juceDeleteOnIdle;
+    std::unordered_map<OverlayTags, bool> isTornOut;
     void rezoomOverlays();
     void frontNonModalOverlays();
 

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -55,6 +55,19 @@ struct OverlayComponent : juce::Component
     std::pair<bool, Surge::Storage::DefaultKey> getCanTearOut() { return canTearOut; }
     virtual void onTearOutChanged(bool isTornOut) {}
 
+    std::pair<bool, Surge::Storage::DefaultKey> canTearOutResize{false, Surge::Storage::nKeys};
+    void setCanTearOutResize(std::pair<bool, Surge::Storage::DefaultKey> b)
+    {
+        canTearOutResize = b;
+    }
+    std::pair<bool, Surge::Storage::DefaultKey> getCanTearOutResize() { return canTearOutResize; }
+    int minw{-1}, minh{-1};
+    void setMinimumSize(int w, int h)
+    {
+        minw = w;
+        minh = h;
+    }
+
     std::pair<bool, Surge::Storage::DefaultKey> canMoveAround{false, Surge::Storage::nKeys};
     void setCanMoveAround(std::pair<bool, Surge::Storage::DefaultKey> b) { canMoveAround = b; }
     bool getCanMoveAround() { return canMoveAround.first; }

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -84,6 +84,14 @@ struct OverlayWrapper : public juce::Component,
         canTearOutPair = b;
         canTearOut = b.first;
     }
+    std::pair<bool, Surge::Storage::DefaultKey> canTearOutResizePair{false, Surge::Storage::nKeys};
+    bool canTearOutResize;
+    void setCanTearOutResize(std::pair<bool, Surge::Storage::DefaultKey> b)
+    {
+        canTearOutResizePair = b;
+        canTearOutResize = b.first;
+    }
+
     void doTearOut(const juce::Point<int> &showAt = juce::Point<int>(-1, -1));
     void doTearIn();
     bool isTornOut();


### PR DESCRIPTION
1. Size remembered as pref
2. In a session if you are torn out is sticky
3. Minimum resize size

Closes #6050