### PR TITLE
Adjust minimum torn out overlay sizes

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -206,7 +206,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         mse->setEnclosingParentTitle(title);
         mse->setCanTearOut({true, Surge::Storage::MSEGOverlayLocationTearOut});
         mse->setCanTearOutResize({true, Surge::Storage::MSEGOverlaySizeTearOut});
-        mse->setMinimumSize(300, 300);
+        mse->setMinimumSize(600, 250);
         locationGet(mse.get(), Surge::Skin::Connector::NonParameterConnection::MSEG_EDITOR_WINDOW,
                     Surge::Storage::MSEGOverlayLocation);
 
@@ -255,7 +255,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         fme->setEnclosingParentTitle(title);
         fme->setCanTearOut({true, Surge::Storage::FormulaOverlayLocationTearOut});
         fme->setCanTearOutResize({true, Surge::Storage::FormulaOverlaySizeTearOut});
-        fme->setMinimumSize(300, 300);
+        fme->setMinimumSize(500, 250);
         locationGet(fme.get(),
                     Surge::Skin::Connector::NonParameterConnection::FORMULA_EDITOR_WINDOW,
                     Surge::Storage::FormulaOverlayLocation);
@@ -279,7 +279,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         te->setEnclosingParentTitle("Tuning Editor");
         te->setCanTearOut({true, Surge::Storage::TuningOverlayLocationTearOut});
         te->setCanTearOutResize({true, Surge::Storage::TuningOverlaySizeTearOut});
-        te->setMinimumSize(300, 300);
+        te->setMinimumSize(730, 400);
         locationGet(te.get(), Surge::Skin::Connector::NonParameterConnection::TUNING_EDITOR_WINDOW,
                     Surge::Storage::TuningOverlayLocation);
 
@@ -369,7 +369,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         pt->setCanMoveAround(std::make_pair(true, Surge::Storage::FilterAnalysisOverlayLocation));
         pt->setCanTearOut({true, Surge::Storage::FilterAnalysisOverlayLocationTearOut});
         pt->setCanTearOutResize({true, Surge::Storage::FilterAnalysisOverlaySizeTearOut});
-        pt->setMinimumSize(250, 150);
+        pt->setMinimumSize(300, 200);
 
         return pt;
     }
@@ -380,7 +380,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         me->setEnclosingParentTitle("Modulation List");
         me->setCanTearOut({true, Surge::Storage::ModlistOverlayLocationTearOut});
         me->setCanTearOutResize({true, Surge::Storage::ModlistOverlaySizeTearOut});
-        me->setMinimumSize(300, 300);
+        me->setMinimumSize(600, 300);
         me->setSkin(currentSkin, bitmapStore);
         locationGet(me.get(), Surge::Skin::Connector::NonParameterConnection::MOD_LIST_WINDOW,
                     Surge::Storage::ModlistOverlayLocation);

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -221,23 +221,29 @@ void OverlayWrapper::resized()
         {
             if (oc->minh > 0 && oc->minw > 0)
             {
+                auto w = getWidth(), h = getHeight();
                 auto mw = oc->minw;
                 auto mh = oc->minh;
+
                 primaryChild->getTransform().transformPoint(mw, mh);
-                if (getWidth() < mw || getHeight() < mh)
+
+                mw = w < mw ? mw : w;
+                mh = h < mh ? mh : h;
+
+                if (w < mw || h < mh)
                 {
-                    auto nw = oc->minw;
-                    auto nh = oc->minh;
                     tearOutParent->setContentComponentSize(mw, mh);
                     return;
                 }
             }
         }
+
         primaryChild->setBounds(getLocalBounds());
         Surge::Storage::updateUserDefaultValue(storage, canTearOutResizePair.second,
                                                std::make_pair(getWidth(), getHeight()));
     }
 }
+
 void OverlayWrapper::doTearOut(const juce::Point<int> &showAt)
 {
     parentBeforeTearOut = getParentComponent();
@@ -247,6 +253,7 @@ void OverlayWrapper::doTearOut(const juce::Point<int> &showAt)
 
     auto w = getWidth();
     auto h = getHeight();
+
     if (editor)
     {
         auto sc = 1.0 * editor->getZoomFactor() / 100.0;


### PR DESCRIPTION
Also restrict filter analysis overlay width and height separately rather than whenever either goes below bounds.