### PR TITLE
Patch Undo and Redo/Undo Cleanup

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2342,6 +2342,21 @@ void SurgeGUIEditor::setTuningFromUndo(const Tunings::Tuning &t)
     tuningChanged();
 }
 const Tunings::Tuning &SurgeGUIEditor::getTuningForRedo() { return synth->storage.currentTuning; }
+const fs::path SurgeGUIEditor::pathForCurrentPatch()
+{
+    if (patchSelector->sel_id >= 0 && patchSelector->sel_id < synth->storage.patch_list.size())
+    {
+        return synth->storage.patch_list[patchSelector->sel_id].path;
+    }
+    return {};
+}
+
+void SurgeGUIEditor::setPatchFromUndo(void *data, size_t datasz)
+{
+    synth->enqueuePatchForLoad(data, datasz);
+    synth->processAudioThreadOpsWhenAudioEngineUnavailable();
+    synth->refresh_editor = true;
+}
 
 void SurgeGUIEditor::ensureParameterItemIsFocused(Parameter *p)
 {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -446,6 +446,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     void queuePatchFileLoad(const std::string &file)
     {
+        undoManager()->pushPatch();
+        strncpy(synth->patchid_file, file.c_str(), FILENAME_MAX);
         strncpy(synth->patchid_file, file.c_str(), FILENAME_MAX);
         synth->has_patchid_file = true;
         synth->processAudioThreadOpsWhenAudioEngineUnavailable();
@@ -499,7 +501,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void setMacroValueFromUndo(int ccid, float val);
     void setTuningFromUndo(const Tunings::Tuning &);
     const Tunings::Tuning &getTuningForRedo();
+    const fs::path pathForCurrentPatch();
     void ensureParameterItemIsFocused(Parameter *p);
+    void setPatchFromUndo(void *data, size_t datasz);
 
   private:
     juce::Rectangle<int> positionForModulationGrid(modsources entry);
@@ -615,7 +619,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
                   bool mute) override;
     void modCleared(long ptag, modsources modsource, int modsourceScene, int index) override;
 
-    const SurgePatch &getPatch() { return synth->storage.getPatch(); }
+    SurgePatch &getPatch() { return synth->storage.getPatch(); }
 
   private:
     std::unique_ptr<Surge::Widgets::EffectChooser> effectChooser;

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -447,6 +447,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
     if (button.isCommandDown() && (tag == tag_mp_patch || tag == tag_mp_category))
     {
+        undoManager()->pushPatch();
         synth->selectRandomPatch();
         return 1;
     }
@@ -3034,6 +3035,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     break;
     case tag_mp_category:
     {
+        undoManager()->pushPatch();
         closeOverlay(SAVE_PATCH);
 
         loadPatchWithDirtyCheck((control->getValue() > 0.5f), true);
@@ -3043,6 +3045,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     break;
     case tag_mp_patch:
     {
+        undoManager()->pushPatch();
         closeOverlay(SAVE_PATCH);
 
         auto insideCategory = Surge::Storage::getUserDefaultValue(

--- a/src/surge-xt/gui/UndoManager.h
+++ b/src/surge-xt/gui/UndoManager.h
@@ -60,6 +60,8 @@ struct UndoManager
 
     void pushTuning(const Tunings::Tuning &t);
 
+    void pushPatch(); // args TK
+
     bool undo();
     bool redo();
 

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -621,6 +621,7 @@ void PatchSelector::showClassicMenu(bool single_category)
             sge->fileChooser->launchAsync(
                 juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
                 [this, patchPath, sge](const juce::FileChooser &c) {
+                    sge->undoManager()->pushPatch();
                     auto ress = c.getResults();
                     if (ress.size() != 1)
                         return;
@@ -1073,6 +1074,10 @@ void PatchSelector::loadPatch(int id)
 {
     if (id >= 0)
     {
+        auto sge = firstListenerOfType<SurgeGUIEditor>();
+        if (sge)
+            sge->undoManager()->pushPatch();
+
         enqueue_sel_id = id;
         notifyValueChanged();
     }


### PR DESCRIPTION
- Redo/Undo through patch changes
- Have an approximate undo/redo memory threshold
- Trip undo/redo based on being over thresholds
- Cleanup memory here and there from the patch thing

Addresses #694