### PR TITLE
Support JUCE7 LV2 Builds (if you pull JUCE7)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,11 @@ if(JUCE_SUPPORTS_LV2)
   add_compile_options(-Wno-error=deprecated-declarations)
 endif()
 
+if(EXISTS ${SURGE_JUCE_PATH}/modules/juce_audio_plugin_client/LV2/juce_LV2_Client.cpp)
+  message(STATUS "JUCE7 LV2 support present; activating LV2")
+  list(APPEND SURGE_JUCE_FORMATS LV2)
+endif()
+
 
 if(DEFINED ENV{ASIOSDK_DIR} OR BUILD_USING_MY_ASIO_LICENSE)
   if(BUILD_USING_MY_ASIO_LICENSE)

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -44,7 +44,10 @@ juce_add_plugin(${PROJECT_NAME}
   AU_MAIN_TYPE kAudioUnitType_MusicDevice
   AU_SANDBOX_SAFE TRUE
 
+  # JUCE7 made a different choice than community branch
   LV2_URI https://surge-synthesizer.github.io/lv2/surge-xt
+  LV2URI https://surge-synthesizer.github.io/lv2/surge-xt
+
   LV2_SHARED_LIBRARY_NAME SurgeXT
 
   FORMATS ${SURGE_JUCE_FORMATS}


### PR DESCRIPTION
If you have a build against JUCE7, the LV2 builds will fire
up as targets all OSes.