### PR TITLE
Juce7 LV2 can have 6 outs

### DIFF
--- a/src/surge-xt/plugin_type_extensions/SurgeSynthLV2Extensions.cpp
+++ b/src/surge-xt/plugin_type_extensions/SurgeSynthLV2Extensions.cpp
@@ -21,10 +21,12 @@
 
 void SurgeSynthProcessorSpecificExtensions(SurgeSynthProcessor *p, SurgeSynthesizer *s)
 {
+#if !SURGE_HAS_JUCE7
     p->surge->activateExtraOutputs = false;
     p->canRemoveBusValue = true;
     p->removeBus(false);
     p->removeBus(false);
     p->canRemoveBusValue = false;
+#endif
 }
 void SurgeSynthEditorSpecificExtensions(SurgeSynthEditor *e, SurgeGUIEditor *sed) {}


### PR DESCRIPTION
The community fork couldn't so 4 where removed for lv2.
With juce7 this also triggers a neverending assertion
(juce_AudioProcessor.cpp:375),
so turn it off when building with juce7.