### PR TITLE
Correct a Numbus Indexing Error which could impact Delays

### DIFF
--- a/src/common/dsp/effects/NimbusEffect.h
+++ b/src/common/dsp/effects/NimbusEffect.h
@@ -79,12 +79,15 @@ class NimbusEffect : public Effect
 
     SRC_STATE_tag *surgeSR_to_euroSR, *euroSR_to_surgeSR;
 
-    static constexpr int raw_out_sz = BLOCK_SIZE_OS << 3; // power of 2 pls
+    static constexpr int raw_out_sz = BLOCK_SIZE_OS << 4; // power of 2 pls
     float resampled_output[raw_out_sz][2];                // at sr
     size_t resampReadPtr = 0, resampWritePtr = 1;         // see comment in init
-    float stub_input[2];                                  // This is the extra sample we have around
-    bool hasStubInput = false;
+
+    static constexpr int nimbusprocess_blocksize = 8;
+    float stub_input[2][nimbusprocess_blocksize]; // This is the extra sample we have around
+    size_t numStubs{0};
     int consumed = 0, created = 0;
+    bool builtBuffer{false};
 };
 
 #endif // SURGE_NIMBUSEFFECT_H


### PR DESCRIPTION
Nimbus had an indexing error which made the looping delay in some
cases catastrophically bitcrush. While cleaning it up I realized
I just wanted to go to fixed nimbus blocks anyway since the compelxity
which led to that bug came from the offsets and so on.

Anyway this removes some mis-renderes in Nimbus both in the synth
and especially the fX plugin

Closes #5954