### PR TITLE
TypeIn in the FX Bank

### DIFF
--- a/src/surge-fx/SurgeFXEditor.cpp
+++ b/src/surge-fx/SurgeFXEditor.cpp
@@ -248,6 +248,9 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
         fxParamDisplay[i].setName(processor.getParamName(i).c_str());
         fxParamDisplay[i].setDisplay(processor.getParamValue(i));
         fxParamDisplay[i].setEnabled(processor.getParamEnabled(i));
+        fxParamDisplay[i].onOverlayEntered = [i, this](const std::string &s) {
+            processor.setParameterByString(i, s);
+        };
 
         addAndMakeVisibleRecordOrder(&(fxParamDisplay[i]));
     }
@@ -290,6 +293,8 @@ void SurgefxAudioProcessorEditor::resetLabels()
         fxParamDisplay[i].setDisplay(processor.getParamValue(i).c_str());
         fxParamDisplay[i].setGroup(processor.getParamGroup(i).c_str());
         fxParamDisplay[i].setName(processor.getParamName(i).c_str());
+        fxParamDisplay[i].allowsTypein = processor.canSetParameterByString(i);
+
         fxParamDisplay[i].setEnabled(processor.getParamEnabled(i));
         fxParamDisplay[i].setAppearsDeactivated(processor.getFXStorageAppearsDeactivated(i));
         fxParamSliders[i].setEnabled(processor.getParamEnabled(i) &&

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -517,6 +517,22 @@ void SurgefxAudioProcessor::updateJuceParamsFromStorage()
     triggerAsyncUpdate();
 }
 
+void SurgefxAudioProcessor::setParameterByString(int i, const std::string &s)
+{
+    auto *p = &(fxstorage->p[fx_param_remap[i]]);
+
+    p->set_value_from_string(s);
+    *(fxParams[i]) = fxstorage->p[fx_param_remap[i]].get_value_f01();
+    changedParamsValue[i] = fxstorage->p[fx_param_remap[i]].get_value_f01();
+    triggerAsyncUpdate();
+}
+
+bool SurgefxAudioProcessor::canSetParameterByString(int i)
+{
+    auto *p = &(fxstorage->p[fx_param_remap[i]]);
+    return p->can_setvalue_from_string();
+}
+
 void SurgefxAudioProcessor::copyGlobaldataSubset(int start, int end)
 {
     for (int i = start; i < end; ++i)

--- a/src/surge-fx/SurgeFXProcessor.h
+++ b/src/surge-fx/SurgeFXProcessor.h
@@ -309,5 +309,10 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
     void copyGlobaldataSubset(int start, int end);
     void setupStorageRanges(Parameter *start, Parameter *endIncluding);
 
+  public:
+    void setParameterByString(int i, const std::string &s);
+    bool canSetParameterByString(int i);
+
+  private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SurgefxAudioProcessor)
 };


### PR DESCRIPTION
You can either double click or press enter when focused on a label
and get a typein which goes to the string converter. Only works
for string->value params of course. Accessible bindings to enter
and ::press

Closes #6072