### PR TITLE
Start on typeahead-stay-open for Patches

### DIFF
--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -121,6 +121,7 @@ PatchSelector::PatchSelector()
     typeAhead->setVisible(false);
     typeAhead->addTypeAheadListener(this);
     typeAhead->setToElementZeroOnReturn = true;
+    typeAhead->dismissMode = TypeAhead::DISMISS_ON_RETURN_RETAIN_ON_CMD_RETURN;
     addChildComponent(*typeAhead);
 
     setWantsKeyboardFocus(true);

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -48,6 +48,13 @@ struct TypeAhead : public juce::TextEditor, juce::TextEditor::Listener
         borderid
     };
 
+    enum DismissMode
+    {
+        DISMISS_ON_RETURN,
+        DISMISS_ON_RETURN_RETAIN_ON_CMD_RETURN,
+        DISMISS_ON_CMD_RETURN_RETAIN_ON_RETURN
+    } dismissMode{DISMISS_ON_RETURN};
+
     TypeAhead(const std::string &l, TypeAheadDataProvider *p); // does not take ownership
     ~TypeAhead();
 
@@ -64,7 +71,7 @@ struct TypeAhead : public juce::TextEditor, juce::TextEditor::Listener
     void addTypeAheadListener(TypeAheadListener *l) { taList.insert(l); }
     void removeTypeAheadListener(TypeAheadListener *l) { taList.erase(l); }
 
-    void dismissWithValue(int providerIdx, const std::string &s);
+    void dismissWithValue(int providerIdx, const std::string &s, const juce::ModifierKeys &mod);
     void dismissWithoutValue();
 
     std::unique_ptr<juce::ListBox> lbox;


### PR DESCRIPTION
1. Add a dismiss mode to the TypeAhead widget
2. Set ti to DISMISS_ON_RETURN_RETAIN_ON_CMD_RETURN in patch selector
3. Adjust so that that does roughly what you would want, at least
   roughly
4. Merge for feedback on the edge cases, of which I bet there are
   many

Addresses #6063