### PR TITLE
Few last Undo bits and bobs

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -718,6 +718,7 @@ void SurgePatch::init_default_values()
             else
                 osc.wt.queue_id = -1;
             osc.wt.queue_filename[0] = 0;
+            osc.wt.current_filename[0] = 0;
         }
         scene[sc].fm_depth.val.f = -24.f;
         scene[sc].portamento.val.f = scene[sc].portamento.val_min.f;
@@ -1028,6 +1029,7 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
                     scene[sc].osc[osc].wt.queue_id = -1;
                     scene[sc].osc[osc].wt.queue_filename[0] = 0;
                     scene[sc].osc[osc].wt.current_id = -1;
+                    scene[sc].osc[osc].wt.current_filename[0] = 0;
 
                     void *d = (void *)((char *)dr + sizeof(wt_header));
 

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1028,6 +1028,7 @@ void SurgeStorage::load_wt(int id, Wavetable *wt, OscillatorStorage *osc)
 
 void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *osc)
 {
+    strncpy(wt->current_filename, wt->queue_filename, 256);
     wt->queue_filename[0] = 0;
     string extension = filename.substr(filename.find_last_of('.'), filename.npos);
     for (unsigned int i = 0; i < extension.length(); i++)

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -47,6 +47,7 @@ class Wavetable
     int current_id, queue_id;
     bool refresh_display;
     char queue_filename[256];
+    char current_filename[256];
 };
 
 enum wtflags

--- a/src/surge-xt/gui/UndoManager.h
+++ b/src/surge-xt/gui/UndoManager.h
@@ -50,6 +50,9 @@ struct UndoManager
     void pushModulationChange(int paramId, const Parameter *p, modsources modsource, int scene,
                               int index, float val, bool muted, Target to = UNDO);
     void pushOscillator(int scene, int oscnum);
+    void pushWavetable(int scene, int oscnum);
+    void pushOscillatorExtraConfig(int scene, int oscnum);
+
     void pushStepSequencer(int scene, int lfoid, const StepSequencerStorage &pushValue);
     void pushMSEG(int scene, int lfoid, const MSEGStorage &pushValue);
     void pushFullLFO(int scene, int lfoid);


### PR DESCRIPTION
Closes #6080

- Alias Additive gets Undo support
- WaveTable selection changes are undoable (even back to epoch of
  load-from-patch)