### PR TITLE
Allow the FX bank to manually override the DAW-driven latency

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -211,6 +211,11 @@ std::string defaultKeyToString(DefaultKey k)
     case MenuLightness:
         r = "menuLightness";
         break;
+
+    case FXUnitAssumeFixedBlock:
+        r = "fxAssumeFixedBlock";
+        break;
+
     case nKeys:
         break;
     }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -99,6 +99,9 @@ enum DefaultKey
     ModListValueDisplay,
     MenuLightness,
 
+    // Some FX Bank specific ones
+    FXUnitAssumeFixedBlock,
+
     nKeys
 };
 

--- a/src/surge-fx/SurgeFXEditor.h
+++ b/src/surge-fx/SurgeFXEditor.h
@@ -39,6 +39,7 @@ class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor, juce::Asy
     std::unique_ptr<juce::Component> picker;
     void makeMenu();
     void showMenu();
+    void toggleLatencyMode();
 
     //==============================================================================
     void paint(juce::Graphics &) override;

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -11,6 +11,7 @@
 #include "SurgeFXProcessor.h"
 #include "SurgeFXEditor.h"
 #include "DebugHelpers.h"
+#include "UserDefaults.h"
 
 //==============================================================================
 SurgefxAudioProcessor::SurgefxAudioProcessor()
@@ -19,12 +20,16 @@ SurgefxAudioProcessor::SurgefxAudioProcessor()
                          .withOutput("Output", juce::AudioChannelSet::stereo(), true)
                          .withInput("Sidechain", juce::AudioChannelSet::stereo(), true))
 {
+    storage.reset(new SurgeStorage());
+    storage->userDefaultsProvider->addOverride(Surge::Storage::HighPrecisionReadouts, false);
+
     nonLatentBlockMode = !juce::PluginHostType().isFruityLoops();
+    nonLatentBlockMode = Surge::Storage::getUserDefaultValue(
+        storage.get(), Surge::Storage::FXUnitAssumeFixedBlock, nonLatentBlockMode);
+
     setLatencySamples(nonLatentBlockMode ? 0 : BLOCK_SIZE);
 
     effectNum = fxt_off;
-    storage.reset(new SurgeStorage());
-    storage->userDefaultsProvider->addOverride(Surge::Storage::HighPrecisionReadouts, false);
 
     fxstorage = &(storage->getPatch().fx[0]);
     audio_thread_surge_effect.reset();


### PR DESCRIPTION
Basically make it so FL users can run in zero latency mode but
then they need to set up their DAW to have fixed sized blocks.

Closes #5918