### PR TITLE
Fix tuning overlay font-time application

### DIFF
--- a/src/surge-xt/gui/SkinFontLoader.cpp
+++ b/src/surge-xt/gui/SkinFontLoader.cpp
@@ -33,8 +33,6 @@ void Surge::GUI::loadTypefacesFromPath(const fs::path &p,
 
                 auto tf = juce::Typeface::createSystemTypefaceFor((void *)(&contents[0]),
                                                                   contents.size());
-                std::cout << path_to_string(d.stem()) << " " << path_to_string(d.filename()) << " "
-                          << path_to_string(d) << std::endl;
                 result[key] = tf;
             }
         }


### PR DESCRIPTION
The font from skin was properly done in onSkin but a few places
where we also change components after the skin is set, and so on.
Just edge cases. But all fixed.

Closes #6074