### PR TITLE
More String Improvements

### DIFF
--- a/resources/surge-shared/configuration.xml
+++ b/resources/surge-shared/configuration.xml
@@ -25,7 +25,7 @@
 <type i="6" name="FM2" retrigger="1" p6_extend_range="1"/>
 <type i="5" name="FM3" retrigger="1" p1_extend_range="0" p3_extend_range="0" p5_extend_range="0" p6_extend_range="1"/>
 <separator/>
-<type i="9" name="String" p0="0" p4_extend_range="0"/>
+<type i="9" name="String" p0="0" p4_extend_range="0" p6_deform_type="256"/>
 <type i="10" name="Twist" p4_extend_range="0"/>
 <separator/>
 <type i="11" name="Alias" p4_extend_range="0"/>

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -238,6 +238,7 @@ bool Parameter::can_extend_range() const
 {
     switch (ctrltype)
     {
+    case ct_percent_with_extend_to_bipolar:
     case ct_pitch_semi7bp:
     case ct_pitch_semi7bp_absolutable:
     case ct_freq_reson_band1:
@@ -323,6 +324,7 @@ bool Parameter::has_deformoptions() const
     {
     case ct_freq_hpf:
     case ct_percent_with_string_deform_hook:
+    case ct_percent_bipolar_with_string_filter_hook:
     case ct_lfodeform:
     case ct_modern_trimix:
     case ct_alias_mask:
@@ -358,8 +360,10 @@ bool Parameter::is_bipolar() const
     case ct_decibel_extendable:
     case ct_freq_mod:
     case ct_percent_bipolar:
+    case ct_percent_bipolar_with_string_filter_hook:
     case ct_percent_bipolar_stereo:
     case ct_percent_bipolar_pan:
+    case ct_percent_bipolar_stringbal:
     case ct_percent_bipolar_w_dynamic_unipolar_formatting:
     case ct_twist_aux_mix:
     case ct_freq_shift:
@@ -380,6 +384,12 @@ bool Parameter::is_bipolar() const
     case ct_fmratio:
     {
         if (extend_range && !absolute)
+            res = true;
+    }
+    break;
+    case ct_percent_with_extend_to_bipolar:
+    {
+        if (extend_range)
             res = true;
     }
     break;
@@ -923,6 +933,7 @@ void Parameter::set_type(int ctrltype)
         break;
     case ct_percent:
     case ct_percent_with_string_deform_hook:
+    case ct_percent_with_extend_to_bipolar:
     case ct_percent_deactivatable:
     case ct_dly_fb_clippingmodes:
     case ct_percent_oscdrift:
@@ -971,6 +982,7 @@ void Parameter::set_type(int ctrltype)
         break;
     case ct_modern_trimix:
     case ct_percent_bipolar:
+    case ct_percent_bipolar_with_string_filter_hook:
     case ct_percent_bipolar_deactivatable:
     case ct_percent_bipolar_stereo:
     case ct_percent_bipolar_pan:
@@ -1265,6 +1277,7 @@ void Parameter::set_type(int ctrltype)
     switch (ctrltype)
     {
     case ct_percent:
+    case ct_percent_with_extend_to_bipolar:
     case ct_percent_with_string_deform_hook:
     case ct_dly_fb_clippingmodes:
     case ct_percent_bipolar_deactivatable:
@@ -1272,6 +1285,7 @@ void Parameter::set_type(int ctrltype)
     case ct_percent_oscdrift:
     case ct_percent200:
     case ct_percent_bipolar:
+    case ct_percent_bipolar_with_string_filter_hook:
     case ct_lfodeform:
     case ct_rotarydrive:
     case ct_countedset_percent:
@@ -1589,6 +1603,7 @@ void Parameter::bound_value(bool force_integer)
         switch (ctrltype)
         {
         case ct_percent:
+        case ct_percent_with_extend_to_bipolar:
         case ct_percent_with_string_deform_hook:
         case ct_percent_bipolar_deactivatable:
         case ct_percent_deactivatable:
@@ -1596,6 +1611,7 @@ void Parameter::bound_value(bool force_integer)
         case ct_percent_oscdrift:
         case ct_percent200:
         case ct_percent_bipolar:
+        case ct_percent_bipolar_with_string_filter_hook:
         case ct_percent_bipolar_stereo:
         case ct_percent_bipolar_pan:
         case ct_percent_bipolar_stringbal:
@@ -1850,7 +1866,6 @@ bool Parameter::supportsDynamicName() const
     case ct_modern_trimix:
     case ct_lfophaseshuffle:
     case ct_percent:
-    case ct_percent_with_string_deform_hook:
     case ct_percent_bipolar:
     case ct_percent_bipolar_deactivatable:
     case ct_percent_bipolar_w_dynamic_unipolar_formatting:
@@ -2056,6 +2071,12 @@ float Parameter::get_extended(float f) const
             return -((16 - f) * 31.f / 16.f + 1);
         }
     }
+    break;
+    case ct_percent_with_extend_to_bipolar:
+    {
+        return 2 * f - 1;
+    }
+    break;
     default:
     {
         return f;
@@ -3842,12 +3863,14 @@ bool Parameter::can_setvalue_from_string() const
     switch (ctrltype)
     {
     case ct_percent:
+    case ct_percent_with_extend_to_bipolar:
     case ct_percent_with_string_deform_hook:
     case ct_percent_deactivatable:
     case ct_dly_fb_clippingmodes:
     case ct_percent_oscdrift:
     case ct_percent200:
     case ct_percent_bipolar:
+    case ct_percent_bipolar_with_string_filter_hook:
     case ct_percent_bipolar_deactivatable:
     case ct_percent_bipolar_stereo:
     case ct_percent_bipolar_pan:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -47,7 +47,9 @@ enum ctrltypes
     ct_percent_bipolar_deactivatable,
     ct_percent_bipolar_stereo,    // bipolar with special text strings at -100% +100% and 0%
     ct_percent_bipolar_stringbal, // bipolar with special text strings
+    ct_percent_bipolar_with_string_filter_hook,
     ct_percent_bipolar_w_dynamic_unipolar_formatting,
+    ct_percent_with_extend_to_bipolar,
     ct_twist_aux_mix,
     ct_pitch_octave,
     ct_pitch_semi7bp,

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2048,6 +2048,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         break;
                     }
                     case ct_percent_with_string_deform_hook:
+                    case ct_percent_bipolar_with_string_filter_hook:
                     {
                         auto addDef = [this, p,
                                        &contextMenu](StringOscillator::deform_modes dm,
@@ -2069,27 +2070,33 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                 });
                         };
 
-                        contextMenu.addSeparator();
-                        addDef(StringOscillator::os_onex, StringOscillator::os_all,
-                               "1x Oversample");
-                        addDef(StringOscillator::os_twox, StringOscillator::os_all,
-                               "2x Oversample");
+                        if (p->ctrltype == ct_percent_with_string_deform_hook)
+                        {
+                            contextMenu.addSeparator();
+                            addDef(StringOscillator::os_onex, StringOscillator::os_all,
+                                   "1x Oversample");
+                            addDef(StringOscillator::os_twox, StringOscillator::os_all,
+                                   "2x Oversample");
 
-                        contextMenu.addSeparator();
-                        addDef(StringOscillator::interp_zoh, StringOscillator::interp_all,
-                               "ZoH Interpolation");
-                        addDef(StringOscillator::interp_lin, StringOscillator::interp_all,
-                               "Linear Interpolation");
-                        addDef(StringOscillator::interp_sinc, StringOscillator::interp_all,
-                               "Sinc Interpolation");
-
-                        contextMenu.addSeparator();
-                        addDef(StringOscillator::filter_fixed, StringOscillator::filter_all,
-                               "Fixed Filter Frequency");
-                        addDef(StringOscillator::filter_keytrack, StringOscillator::filter_all,
-                               "Keytracked Filter Frequency");
-                        addDef(StringOscillator::filter_compensate, StringOscillator::filter_all,
-                               "Keytracked Pitch Compensated Model");
+                            contextMenu.addSeparator();
+                            addDef(StringOscillator::interp_zoh, StringOscillator::interp_all,
+                                   "ZoH Interpolation");
+                            addDef(StringOscillator::interp_lin, StringOscillator::interp_all,
+                                   "Linear Interpolation");
+                            addDef(StringOscillator::interp_sinc, StringOscillator::interp_all,
+                                   "Sinc Interpolation");
+                        }
+                        if (p->ctrltype == ct_percent_bipolar_with_string_filter_hook)
+                        {
+                            contextMenu.addSeparator();
+                            addDef(StringOscillator::filter_fixed, StringOscillator::filter_all,
+                                   "Fixed Filter Frequency");
+                            addDef(StringOscillator::filter_keytrack, StringOscillator::filter_all,
+                                   "Keytracked Filter Frequency");
+                            addDef(StringOscillator::filter_compensate,
+                                   StringOscillator::filter_all,
+                                   "Keytracked Pitch Compensated Model");
+                        }
 
                         break;
                     }

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -575,6 +575,9 @@ void FxMenu::loadSnapshot(int type, TiXmlElement *e, int idx)
                 snprintf(sublbl, TXT_SIZE, "p%i_deactivated", i);
                 fxbuffer->p[i].deactivated =
                     ((e->QueryIntAttribute(sublbl, &j) == TIXML_SUCCESS) && (j == 1));
+                snprintf(sublbl, TXT_SIZE, "p%i_deform_type", i);
+                if (e->QueryIntAttribute(sublbl, &j) == TIXML_SUCCESS)
+                    fxbuffer->p[i].deform_type = j;
             }
         }
         else


### PR DESCRIPTION
1. Add extendable for -ve feedback decay
2. Move the filter controls to the stiffness slider
3. Fix the balance to be bipolar
4. Make the default model compensated (and add deform to the
   XML snapshot tool too)
5. Confirm that audio in and 2x oversample work although it doesn't
   help much