### PR TITLE
More Typein Error tweaks

### DIFF
--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -443,7 +443,7 @@ class Parameter
     void set_error_message(std::string &errMsg, const std::string value, const std::string unit,
                            const ErrorMessageMode mode);
     void set_extend_range(bool er);
-    double get_freq_from_note_name(const std::string s);
+    double get_freq_from_note_name(const std::string s, double defv);
 
     /*
      * These two functions convert the modulation depth to a -1,1 range appropriate


### PR DESCRIPTION
1. Fix a regression with note names
2. Handle the subset of the invalid modulation typein cases we
   catch with a correct error message

Addresses #5715