### PR TITLE
Support CLAP NotePorts

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -115,7 +115,7 @@ SurgeSynthProcessor::~SurgeSynthProcessor() {}
 //==============================================================================
 const juce::String SurgeSynthProcessor::getName() const { return JucePlugin_Name; }
 
-bool SurgeSynthProcessor::acceptsMidi() const { return false; }
+bool SurgeSynthProcessor::acceptsMidi() const { return true; }
 
 bool SurgeSynthProcessor::producesMidi() const { return false; }
 


### PR DESCRIPTION
NotePorts are required in clap 0.24 to get midi in or out
but BWS didn't enforce this strictly, Another host did so
do the correct implementation in the wrappers.