### PR TITLE
MIDI Controllers need SapmleRate for Smoothing

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2197,6 +2197,7 @@ ControllerModulationSource *SurgeSynthesizer::AddControlInterpolator(int Id, boo
     {
         // Already exists, return it
         AlreadyExisted = true;
+        mControlInterpolator[Index].set_samplerate(storage.samplerate, storage.samplerate_inv);
         return &mControlInterpolator[Index];
     }
 
@@ -2208,6 +2209,7 @@ ControllerModulationSource *SurgeSynthesizer::AddControlInterpolator(int Id, boo
         mControlInterpolator[Index].id = Id;
         mControlInterpolatorUsed[Index] = true;
 
+        mControlInterpolator[Index].set_samplerate(storage.samplerate, storage.samplerate_inv);
         mControlInterpolator[Index].smoothingMode = storage.smoothingMode; // IMPLEMENT THIS HERE
         return &mControlInterpolator[Index];
     }


### PR DESCRIPTION
Midi Controllers go through a ControllerModulationSource
for uniform smoothing. Those CMSs are the only ones created
outside the normal modluation path, so they didn't get a sapmle
rate set which, defacto, meant only immediate mode (namely
UI) edits worked but midi edits did not.

Closes #6139