### PR TITLE
WIP: Support for Note ID, Poly and Mono modulation and more

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -817,6 +817,13 @@ void SurgePatch::copy_scenedata(pdata *d, int scene)
         // d[i].f = param_ptr[i+s]->val.f;
         d[i].i = param_ptr[i + s]->val.i;
     }
+
+    for (int i = 0; i < paramModulationCount; ++i)
+    {
+        auto &pm = monophonicParamModulations[i];
+        if (pm.param_id >= s && pm.param_id < s + n_scene_params)
+            d[pm.param_id - s].f += pm.value;
+    }
 }
 
 void SurgePatch::copy_globaldata(pdata *d)
@@ -825,6 +832,13 @@ void SurgePatch::copy_globaldata(pdata *d)
     {
         // if (param_ptr[i]->valtype == vt_float)
         d[i].i = param_ptr[i]->val.i; // int is safer (no exceptions or anything)
+    }
+
+    for (int i = 0; i < paramModulationCount; ++i)
+    {
+        auto &pm = monophonicParamModulations[i];
+        if (pm.param_id < n_global_params)
+            d[pm.param_id].f += pm.value;
     }
 }
 // pdata scenedata[n_scenes][n_scene_params];

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -919,6 +919,15 @@ class SurgePatch
 
     FilterSelectorMapper patchFilterSelectorMapper;
     WaveShaperSelectorMapper patchWaveshaperSelectorMapper;
+
+    struct MonophonicParamModulation
+    {
+        int32_t param_id{0};
+        double value{0};
+    };
+    int32_t paramModulationCount{0};
+    static constexpr int maxMonophonicParamModulations = 256;
+    std::array<MonophonicParamModulation, maxMonophonicParamModulations> monophonicParamModulations;
 };
 
 struct Patch

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -300,7 +300,6 @@ bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, cons
             {
                 if (ot)
                 {
-                    std::cout << "Resetting Tuning" << std::endl;
                     if (storage.getPatch().patchTuning.scaleContents.size() > 1)
                     {
                         storage.retuneToScale(
@@ -316,7 +315,6 @@ bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, cons
                 {
                     if (storage.getPatch().patchTuning.mappingContents.size() > 1)
                     {
-                        std::cout << "Resetting Mapping" << std::endl;
                         auto kb =
                             Tunings::parseKBMData(storage.getPatch().patchTuning.mappingContents);
                         if (storage.getPatch().patchTuning.mappingName.size() > 1)

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -39,7 +39,8 @@ class alignas(16) SurgeVoice
     SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *scene, pdata *params, int key,
                int velocity, int channel, int scene_id, float detune, MidiKeyState *keyState,
                MidiChannelState *mainChannelState, MidiChannelState *voiceChannelState,
-               bool mpeEnabled, int64_t voiceOrder);
+               bool mpeEnabled, int64_t voiceOrder, int32_t host_note_id,
+               int16_t originating_host_key, int16_t originating_host_channel);
     ~SurgeVoice();
 
     void release();
@@ -54,6 +55,23 @@ class alignas(16) SurgeVoice
     int osctype[n_oscs];
     SurgeVoiceState state;
     int age, age_release;
+
+    /*
+     * Begin implementing host-provided identifiers for voices for polyphonic
+     * modulators, note expressions, and so on
+     */
+    int32_t host_note_id{-1};
+    int16_t originating_host_key{-1}, originating_host_channel{-1};
+
+    struct PolyphonicParamModulation
+    {
+        int32_t param_id{0};
+        double value{0};
+    };
+    int32_t paramModulationCount{0};
+    static constexpr int maxPolyphonicParamModulations = 64;
+    std::array<PolyphonicParamModulation, maxPolyphonicParamModulations> polyphonicParamModulations;
+    void applyPolyphonicParamModulation(Parameter *, double value);
 
     /*
     ** Given a note0 and an oscillator this returns the appropriate note.

--- a/src/surge-testrunner/CMakeLists.txt
+++ b/src/surge-testrunner/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(${PROJECT_NAME}
   UnitTestsMIDI.cpp
   UnitTestsMOD.cpp
   UnitTestsMSEG.cpp
+  UnitTestsNOTEID.cpp
   UnitTestsPARAM.cpp
   UnitTestsQUERY.cpp
   UnitTestsTUN.cpp

--- a/src/surge-testrunner/UnitTestsNOTEID.cpp
+++ b/src/surge-testrunner/UnitTestsNOTEID.cpp
@@ -1,0 +1,668 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <algorithm>
+
+#include "HeadlessUtils.h"
+#include "catch2/catch2.hpp"
+
+TEST_CASE("Note ID in Poly Mode Basics", "[noteid]")
+{
+    SECTION("Single On Off, Default Sustain")
+    {
+        auto surge = Surge::Headless::createSurge(48000);
+        for (int i = 0; i < 5; ++i)
+            surge->process();
+        surge->playNote(0, 60, 127, 0, 1423);
+
+        for (int i = 0; i < 20; ++i)
+        {
+            surge->process();
+            REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+            for (auto v : surge->voices[0])
+            {
+                REQUIRE(v->host_note_id == 1423);
+                REQUIRE(v->originating_host_channel == 0);
+                REQUIRE(v->originating_host_key == 60);
+            }
+        }
+
+        surge->releaseNote(0, 60, 127);
+        while (!surge->voices[0].empty())
+        {
+            surge->process();
+        }
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+        REQUIRE(surge->endedHostNoteIds[0] == 1423);
+        REQUIRE(surge->endedHostNoteOriginalChannel[0] == 0);
+        REQUIRE(surge->endedHostNoteOriginalKey[0] == 60);
+
+        surge->process();
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+    }
+    SECTION("Dual Distinct On Off, Long Sustain")
+    {
+        auto surge = Surge::Headless::createSurge(48000);
+        surge->storage.getPatch().scene[0].adsr[0].r.val.f = 0.5;
+
+        for (int i = 0; i < 5; ++i)
+            surge->process();
+        surge->playNote(0, 60, 127, 0, 1423);
+
+        for (int i = 0; i < 5; ++i)
+            surge->process();
+        surge->playNote(0, 65, 127, 0, 8702);
+
+        for (int i = 0; i < 20; ++i)
+        {
+            surge->process();
+            REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+            for (auto v : surge->voices[0])
+            {
+                if (v->originating_host_key == 65)
+                    REQUIRE(v->host_note_id == 8702);
+                else if (v->originating_host_key == 60)
+                    REQUIRE(v->host_note_id == 1423);
+                else
+                    REQUIRE(false);
+            }
+        }
+
+        surge->releaseNote(0, 65, 0);
+        for (int i = 0; i < 20; ++i)
+            surge->process();
+        surge->releaseNote(0, 60, 0);
+
+        // staggered voice winddown
+        REQUIRE(surge->voices[0].size() == 2);
+        while (surge->voices[0].size() == 2)
+            surge->process();
+        REQUIRE(surge->voices[0].size() == 1);
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+        REQUIRE(surge->endedHostNoteIds[0] == 8702);
+        REQUIRE(surge->endedHostNoteOriginalKey[0] == 65);
+        while (surge->voices[0].size() == 1)
+            surge->process();
+        REQUIRE(surge->voices[0].size() == 0);
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+        REQUIRE(surge->endedHostNoteIds[0] == 1423);
+        REQUIRE(surge->endedHostNoteOriginalKey[0] == 60);
+    }
+
+    SECTION("Dual Mode, Differeing Sustaing")
+    {
+        auto surge = Surge::Headless::createSurge(48000);
+        surge->storage.getPatch().scenemode.val.i = sm_dual;
+        surge->storage.getPatch().scene[1].adsr[0].r.val.f = 1;
+
+        for (int i = 0; i < 5; ++i)
+            surge->process();
+        surge->playNote(0, 60, 127, 0, 1497);
+
+        for (int i = 0; i < 20; ++i)
+        {
+            surge->process();
+            REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+            REQUIRE(surge->voices[0].size() == 1);
+            REQUIRE(surge->voices[1].size() == 1);
+            for (auto v : {surge->voices[0].front(), surge->voices[1].front()})
+            {
+                REQUIRE(v->host_note_id == 1497);
+                REQUIRE(v->originating_host_channel == 0);
+                REQUIRE(v->originating_host_key == 60);
+            }
+        }
+
+        surge->releaseNote(0, 60, 127);
+        while (!(surge->voices[0].empty() && surge->voices[1].empty()))
+        {
+            REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+            surge->process();
+        }
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+        REQUIRE(surge->endedHostNoteIds[0] == 1497);
+        REQUIRE(surge->endedHostNoteOriginalChannel[0] == 0);
+        REQUIRE(surge->endedHostNoteOriginalKey[0] == 60);
+
+        surge->process();
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+    }
+
+    SECTION("Same Note On Off, Long Sustain")
+    {
+        auto surge = Surge::Headless::createSurge(48000);
+        surge->storage.getPatch().scene[0].adsr[0].r.val.f = 0.5;
+
+        int blocksBetween = 400;
+
+        for (int i = 0; i < 5; ++i)
+            surge->process();
+        surge->playNote(0, 60, 127, 0, 1423);
+
+        for (int i = 0; i < 5; ++i)
+            surge->process();
+        surge->releaseNote(0, 60, 0);
+
+        for (int i = 0; i < blocksBetween; ++i)
+            surge->process();
+        surge->playNote(0, 65, 127, 0, 8702);
+
+        for (int i = 0; i < 20; ++i)
+        {
+            surge->process();
+            REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+            REQUIRE(surge->voices[0].size() == 2);
+            int32_t nid[2], idx{0};
+            for (auto v : surge->voices[0])
+            {
+                nid[idx] = v->host_note_id;
+                idx++;
+            }
+            REQUIRE(nid[0] == 1423);
+            REQUIRE(nid[1] == 8702);
+        }
+
+        surge->releaseNote(0, 65, 0);
+        for (int i = 0; i < 20; ++i)
+            surge->process();
+        surge->releaseNote(0, 60, 0);
+
+        // staggered voice winddown
+        REQUIRE(surge->voices[0].size() == 2);
+        int pc2{0}, pc1{0};
+        while (surge->voices[0].size() == 2)
+        {
+            pc2++;
+            surge->process();
+        }
+        REQUIRE(surge->voices[0].size() == 1);
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+        REQUIRE(surge->endedHostNoteIds[0] == 1423);
+        REQUIRE(surge->endedHostNoteOriginalKey[0] == 60);
+        while (surge->voices[0].size() == 1)
+        {
+            pc1++;
+            surge->process();
+        }
+        REQUIRE(surge->voices[0].size() == 0);
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+        REQUIRE(surge->endedHostNoteIds[0] == 8702);
+        REQUIRE(surge->endedHostNoteOriginalKey[0] == 65);
+
+        REQUIRE(pc1 > blocksBetween);
+        REQUIRE(pc1 < blocksBetween + 50); // we have a non-click end of voice
+    }
+}
+
+TEST_CASE("Sustain Pedal in Poly Mode", "[noteid]")
+{
+    SECTION("Distinct Notes")
+    {
+        auto surge = Surge::Headless::createSurge(48000);
+        surge->storage.getPatch().scene[0].adsr[0].r.val.f = -3;
+
+        surge->process();
+
+        surge->channelController(0, 64, 127);
+        surge->process();
+        int nidbase = 84923;
+        for (int i = 0; i < 5; ++i)
+        {
+            surge->playNote(0, 60 + i * 2, 127, 0, nidbase + i);
+            for (int q = 0; q < 4; ++q)
+                surge->process();
+        }
+
+        REQUIRE(surge->voices[0].size() == 5);
+
+        for (int i = 0; i < 5; ++i)
+        {
+            surge->releaseNote(0, 60 + i * 2, 0);
+            for (int q = 0; q < 4; ++q)
+                surge->process();
+        }
+
+        REQUIRE(surge->voices[0].size() == 5);
+
+        for (int i = 0; i < 500; ++i)
+        {
+            surge->process();
+            REQUIRE(surge->voices[0].size() == 5);
+        }
+
+        // Now release the sustain pedal
+        surge->channelController(0, 64, 0);
+
+        // And in theory we should all run out in about 20 blocks
+        while (surge->voices[0].size() == 5)
+        {
+            surge->process();
+        }
+        REQUIRE(surge->voices[0].size() == 0);
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 5);
+        for (int i = 0; i < 5; ++i)
+        {
+            REQUIRE(surge->endedHostNoteOriginalKey[i] == 60 + i * 2);
+            REQUIRE(surge->endedHostNoteOriginalChannel[i] == 0);
+            REQUIRE(surge->endedHostNoteIds[i] == nidbase + i);
+        }
+    }
+    SECTION("Same Note")
+    {
+        auto surge = Surge::Headless::createSurge(48000);
+        surge->storage.getPatch().scene[0].adsr[0].r.val.f = -3;
+
+        surge->process();
+
+        surge->channelController(0, 64, 127);
+        surge->process();
+        int nidbase = 71231;
+        // press release here rather than press press press release release release
+        for (int i = 0; i < 5; ++i)
+        {
+            surge->playNote(0, 60 + i * 2, 127, 0, nidbase + i);
+            for (int q = 0; q < 4; ++q)
+                surge->process();
+            surge->releaseNote(0, 60 + i * 2, 0);
+            for (int q = 0; q < 4; ++q)
+                surge->process();
+        }
+
+        REQUIRE(surge->voices[0].size() == 5);
+
+        REQUIRE(surge->voices[0].size() == 5);
+
+        for (int i = 0; i < 500; ++i)
+        {
+            surge->process();
+            REQUIRE(surge->voices[0].size() == 5);
+        }
+
+        // Now release the sustain pedal
+        surge->channelController(0, 64, 0);
+
+        // And in theory we should all run out in about 20 blocks
+        while (surge->voices[0].size() == 5)
+        {
+            surge->process();
+        }
+        REQUIRE(surge->voices[0].size() == 0);
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 5);
+        for (int i = 0; i < 5; ++i)
+        {
+            REQUIRE(surge->endedHostNoteOriginalKey[i] == 60 + i * 2);
+            REQUIRE(surge->endedHostNoteOriginalChannel[i] == 0);
+            REQUIRE(surge->endedHostNoteIds[i] == nidbase + i);
+        }
+    }
+}
+
+TEST_CASE("Overlapping Notes", "[noteid]")
+{
+    SECTION("5 notes overlap; no id on release")
+    {
+        auto surge = Surge::Headless::createSurge(48000);
+        surge->process();
+
+        // OK so lets send 5 note ons that overlap without note offs
+        int nidbase = 7223;
+        // press release here rather than press press press release release release
+        for (int i = 0; i < 5; ++i)
+        {
+            surge->playNote(0, 60, 127, 0, nidbase + i);
+            for (int q = 0; q < 4; ++q)
+                surge->process();
+        }
+
+        REQUIRE(surge->voices[0].size() == 5);
+        int idx = 0;
+        for (auto v : surge->voices[0])
+        {
+            REQUIRE(v->originating_host_key == 60);
+            REQUIRE(v->originating_host_channel == 0);
+            REQUIRE(v->host_note_id == nidbase + idx);
+            idx++;
+        }
+
+        // OK so we can stack them on. How do we turn them off. Right now the releaseNote
+        // releases all notes on that key if you don't provide a noteid so here you look
+        // for all the voices to go to release mode with a single releaseNote
+        surge->releaseNote(0, 60, 0);
+        while (surge->voices[0].size() == 5)
+            surge->process();
+        REQUIRE(surge->voices[0].empty());
+        REQUIRE(surge->hostNoteEndedDuringBlockCount == 5);
+        for (int i = 0; i < 5; ++i)
+        {
+            REQUIRE(surge->endedHostNoteOriginalKey[i] == 60);
+            REQUIRE(surge->endedHostNoteOriginalChannel[i] == 0);
+            REQUIRE(surge->endedHostNoteIds[i] == nidbase + i);
+        }
+
+        // And the other 4 release notes don't do any harm
+        for (int i = 0; i < 5 - 1; ++i)
+        {
+            surge->releaseNote(0, 60, 0);
+            for (int q = 0; q < 50; ++q)
+            {
+                REQUIRE(surge->voices[0].empty());
+                surge->process();
+            }
+        }
+    }
+
+    SECTION("5 notes overlap; release with id")
+    {
+        auto surge = Surge::Headless::createSurge(48000);
+        surge->process();
+
+        // OK so lets send 5 note ons that overlap without note offs
+        int nidbase = 7223;
+        // press release here rather than press press press release release release
+        for (int i = 0; i < 5; ++i)
+        {
+            surge->playNote(0, 60, 127, 0, nidbase + i);
+            for (int q = 0; q < 4; ++q)
+                surge->process();
+        }
+
+        REQUIRE(surge->voices[0].size() == 5);
+        int idx = 0;
+        for (auto v : surge->voices[0])
+        {
+            REQUIRE(v->originating_host_key == 60);
+            REQUIRE(v->originating_host_channel == 0);
+            REQUIRE(v->host_note_id == nidbase + idx);
+            idx++;
+        }
+
+        // If release note comes with an ID we can stack the releases also, as
+        // we show here.
+        for (int i = 0; i < 5; ++i)
+        {
+            INFO("Releasing note " << i);
+            surge->releaseNote(0, 60, 0, nidbase + i);
+            while (surge->voices[0].size() == 5 - i)
+            {
+                surge->process();
+            }
+            REQUIRE(surge->voices[0].size() == 4 - i);
+            REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+            REQUIRE(surge->endedHostNoteOriginalKey[0] == 60);
+            REQUIRE(surge->endedHostNoteOriginalChannel[0] == 0);
+            REQUIRE(surge->endedHostNoteIds[0] == nidbase + i);
+
+            for (int q = 0; q < 100; ++q)
+                surge->process();
+        }
+    }
+}
+
+TEST_CASE("Mono Modes", "[noteid]")
+{
+    for (auto mode : {pm_mono, pm_mono_st, pm_mono_fp, pm_mono_st_fp})
+    {
+        /*
+         * There's no way to retrigger DAW envelopes on hammer off, so lets
+         * have all our mono modes treat the note id as if it is legato.
+         * That means we expect
+         *
+         * -> ON k=60 id=1
+         * [ voice stack size 1 with k=60, id=1 ]
+         * -> ON k=61 id=2
+         * [ voice stack size 1 with k=61, id=1 ]
+         * <- VOICE END K=61 ID=2
+         * -> OFF k=61 id=2
+         * [ voice stack size 1 with k=60, id=1 on it
+         * -> OFF k=60
+         * <- VOICE END K=60 ID=1
+         * [ voice stack empty]
+         */
+
+        DYNAMIC_SECTION("One note hammer on off in mode " << play_mode_names[mode])
+        {
+            auto surge = Surge::Headless::createSurge(48000);
+            REQUIRE(surge);
+            surge->storage.getPatch().scene[0].polymode.val.i = mode;
+            for (int i = 0; i < 10; ++i)
+                surge->process();
+
+            int nidbase = 14000;
+            surge->playNote(0, 60, 127, 0, nidbase);
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    if (v->state.gate)
+                    {
+                        ct++;
+                        REQUIRE(v->host_note_id == nidbase); // it is re-used
+                        REQUIRE(v->originating_host_key == 60);
+                    }
+                }
+                REQUIRE(ct == 1);
+            }
+
+            surge->playNote(0, 61, 127, 0, nidbase + 1);
+
+            bool sawOne = false;
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    if (v->state.gate)
+                    {
+                        ct++;
+                        REQUIRE(v->host_note_id == nidbase); // it is re-used
+                        REQUIRE(v->originating_host_key == 60);
+                    }
+                }
+                REQUIRE(ct == 1);
+
+                if (surge->hostNoteEndedDuringBlockCount > 0)
+                {
+                    sawOne = true;
+                    REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+                    REQUIRE(surge->endedHostNoteIds[0] == nidbase + 1);
+                    REQUIRE(surge->endedHostNoteOriginalKey[0] == 61);
+                }
+            }
+            REQUIRE(sawOne);
+
+            surge->releaseNote(0, 61, 127);
+
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    if (v->state.gate)
+                    {
+                        ct++;
+                        REQUIRE(v->host_note_id == nidbase); // it is re-used
+                        REQUIRE(v->originating_host_key == 60);
+                    }
+                }
+                REQUIRE(ct == 1);
+                REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+            }
+
+            sawOne = false;
+            surge->releaseNote(0, 60, 127);
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    REQUIRE(!v->state.gate);
+                }
+                if (surge->hostNoteEndedDuringBlockCount > 0)
+                {
+                    sawOne = true;
+                    REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+                    // We kill the recycled
+                    REQUIRE(surge->endedHostNoteIds[0] == nidbase);
+                    REQUIRE(surge->endedHostNoteOriginalKey[0] == 60);
+                }
+            }
+            REQUIRE(sawOne);
+        }
+
+        DYNAMIC_SECTION("Three Note hammer on off in mode " << play_mode_names[mode])
+        {
+            auto surge = Surge::Headless::createSurge(48000);
+            REQUIRE(surge);
+            surge->storage.getPatch().scene[0].polymode.val.i = mode;
+            for (int i = 0; i < 10; ++i)
+                surge->process();
+
+            int nidbase = 14000;
+            surge->playNote(0, 60, 127, 0, nidbase);
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    if (v->state.gate)
+                    {
+                        ct++;
+                        REQUIRE(v->host_note_id == nidbase); // it is re-used
+                        REQUIRE(v->originating_host_key == 60);
+                    }
+                }
+                REQUIRE(ct == 1);
+            }
+
+            surge->playNote(0, 61, 127, 0, nidbase + 1);
+
+            bool sawOne = false;
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    if (v->state.gate)
+                    {
+                        ct++;
+                        REQUIRE(v->host_note_id == nidbase); // it is re-used
+                        REQUIRE(v->originating_host_key == 60);
+                    }
+                }
+                REQUIRE(ct == 1);
+
+                if (surge->hostNoteEndedDuringBlockCount > 0)
+                {
+                    sawOne = true;
+                    REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+                    REQUIRE(surge->endedHostNoteIds[0] == nidbase + 1);
+                    REQUIRE(surge->endedHostNoteOriginalKey[0] == 61);
+                }
+            }
+            REQUIRE(sawOne);
+
+            surge->playNote(0, 63, 127, 0, nidbase + 2);
+
+            sawOne = false;
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    if (v->state.gate)
+                    {
+                        ct++;
+                        REQUIRE(v->host_note_id == nidbase); // it is re-used
+                        REQUIRE(v->originating_host_key == 60);
+                    }
+                }
+                REQUIRE(ct == 1);
+
+                if (surge->hostNoteEndedDuringBlockCount > 0)
+                {
+                    sawOne = true;
+                    REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+                    REQUIRE(surge->endedHostNoteIds[0] == nidbase + 2);
+                    REQUIRE(surge->endedHostNoteOriginalKey[0] == 63);
+                }
+            }
+            REQUIRE(sawOne);
+
+            surge->releaseNote(0, 60, 127);
+
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    if (v->state.gate)
+                    {
+                        ct++;
+                        REQUIRE(v->host_note_id == nidbase); // it is re-used
+                        REQUIRE(v->originating_host_key == 60);
+                    }
+                }
+                REQUIRE(ct == 1);
+                REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+            }
+
+            sawOne = false;
+            surge->releaseNote(0, 63, 127);
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    if (v->state.gate)
+                    {
+                        ct++;
+                        REQUIRE(v->host_note_id == nidbase); // it is re-used
+                        REQUIRE(v->originating_host_key == 60);
+                    }
+                }
+                REQUIRE(ct == 1);
+                REQUIRE(surge->hostNoteEndedDuringBlockCount == 0);
+            }
+
+            sawOne = false;
+            surge->releaseNote(0, 61, 127);
+            for (int i = 0; i < 50; ++i)
+            {
+                surge->process();
+                int ct = 0;
+                for (auto v : surge->voices[0])
+                {
+                    REQUIRE(!v->state.gate);
+                }
+                if (surge->hostNoteEndedDuringBlockCount > 0)
+                {
+                    sawOne = true;
+                    REQUIRE(surge->hostNoteEndedDuringBlockCount == 1);
+                    // We kill the recycled
+                    REQUIRE(surge->endedHostNoteIds[0] == nidbase);
+                    REQUIRE(surge->endedHostNoteOriginalKey[0] == 60);
+                }
+            }
+            REQUIRE(sawOne);
+        }
+    }
+}
+
+// TODO
+// mono and poly dual mix
+// mpe poly
+// mpe mono
+// mpe sustain pedal
+// mono sustain pedal


### PR DESCRIPTION
This commit allows a host of surge, if the host provides it,
to thread a note id through the voice management so you can
handle start/end note with id messages (end coming from surge
back to the daw). It also allows all the parameters and macros
to separate modulation from value optionaly.

Given that, and given the update to clap-juce-extensions,
it re-implements the ::process loop inside SurgeSynthProcessor
to have an optional clap process loop which provides polyphonic
modulation.

Addresses #6137