### PR TITLE
Adjust Freerun LFO Attack

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -578,16 +578,20 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
     {
         for (int l = 0; l < n_lfos_scene; l++)
         {
-            if (storage.getPatch().scene[scene].lfo[n_lfos_voice + l].shape.val.i == lt_formula)
+            auto lms = dynamic_cast<LFOModulationSource *>(
+                storage.getPatch().scene[scene].modsources[ms_slfo1 + l]);
+
+            auto &lfod = storage.getPatch().scene[scene].lfo[n_lfos_voice + l];
+            if (lfod.shape.val.i == lt_formula)
             {
-                auto lms = dynamic_cast<LFOModulationSource *>(
-                    storage.getPatch().scene[scene].modsources[ms_slfo1 + l]);
                 if (lms)
                 {
                     Surge::Formula::setupEvaluatorStateFrom(lms->formulastate, storage.getPatch());
                 }
             }
-            storage.getPatch().scene[scene].modsources[ms_slfo1 + l]->attack();
+
+            if (lfod.trigmode.val.i == lm_keytrigger || !lms->everAttacked)
+                storage.getPatch().scene[scene].modsources[ms_slfo1 + l]->attack();
         }
     }
 

--- a/src/common/dsp/modulators/LFOModulationSource.cpp
+++ b/src/common/dsp/modulators/LFOModulationSource.cpp
@@ -178,6 +178,7 @@ void LFOModulationSource::attack()
     env_val = 0.f;
     env_phase = 0;
     ratemult = 1.f;
+    everAttacked = true;
 
     if (localcopy[idelay].f == lfo->delay.val_min.f)
     {

--- a/src/common/dsp/modulators/LFOModulationSource.h
+++ b/src/common/dsp/modulators/LFOModulationSource.h
@@ -78,6 +78,8 @@ class LFOModulationSource : public ModulationSource
     bool retrigger_FEG;
     bool retrigger_AEG;
 
+    bool everAttacked{false};
+
   private:
     LFOStorage *lfo;
     SurgeVoiceState *state;


### PR DESCRIPTION
Freerun LFO Attack would occur whenver a key was pressed from
0 to one keys. This had the ugly result that the SNH and Noise
modulators were incorrect.

Make it so freerun LFOs only trigger their envelope once.