### PR TITLE
Fix a couple of MSEG paint issues

### DIFF
--- a/src/common/dsp/modulators/LFOModulationSource.cpp
+++ b/src/common/dsp/modulators/LFOModulationSource.cpp
@@ -24,6 +24,8 @@ void LFOModulationSource::assign(SurgeStorage *storage, LFOStorage *lfo, pdata *
     this->is_display = is_display;
 
     Surge::Formula::cleanEvaluatorState(formulastate);
+    if (is_display)
+        msegstate = Surge::MSEG::EvaluatorState();
 
     iout = 0;
     output = 0;
@@ -166,7 +168,8 @@ void LFOModulationSource::initPhaseFromStartPhase()
 void LFOModulationSource::attack()
 {
     // For VLFO you don't need this but SLFO get recycled, so you do
-    msegstate = Surge::MSEG::EvaluatorState();
+    if (!is_display)
+        msegstate = Surge::MSEG::EvaluatorState();
 
     if (!phaseInitialized)
     {

--- a/src/surge-xt/gui/overlays/MSEGEditor.h
+++ b/src/surge-xt/gui/overlays/MSEGEditor.h
@@ -56,6 +56,8 @@ struct MSEGEditor : public OverlayComponent,
 
     bool shouldRepaintOnParamChange(const SurgePatch &patch, Parameter *p) override
     {
+        if (p->ctrlgroup == cg_LFO)
+            return true;
         return false;
     }
 


### PR DESCRIPTION
1. The fixed seed for display didn't work reliably in the lower
   display
2. The repaint of the MSEG window on param change was too
   conservative after our prior optimization in 10389fcb

Closes #6152