### PR TITLE
Basic Note Expression Support

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1568,8 +1568,8 @@ void SurgeSynthesizer::releaseNotePostHoldCheck(int scene, char channel, char ke
     }
 }
 
-void SurgeSynthesizer::setNoteExpression(NoteExpressionType net, int16_t key, int16_t channel,
-                                         float value)
+void SurgeSynthesizer::setNoteExpression(SurgeVoice::NoteExpressionType net, int32_t note_id,
+                                         int16_t key, int16_t channel, float value)
 {
     for (int sc = 0; sc < n_scenes; sc++)
     {
@@ -1577,10 +1577,10 @@ void SurgeSynthesizer::setNoteExpression(NoteExpressionType net, int16_t key, in
         {
             if ((v->state.key == key && v->state.channel == channel) ||
                 (v->originating_host_key >= 0 && v->originating_host_key == key &&
-                 v->originating_host_channel >= 0 && v->originating_host_channel == channel))
+                 v->originating_host_channel >= 0 && v->originating_host_channel == channel) ||
+                (note_id >= 0 && v->host_note_id == note_id))
             {
-                std::cout << "Got a voice match for " << net << " on " << key << " " << channel
-                          << std::endl;
+                v->applyNoteExpression(net, value);
             }
         }
     }

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -248,15 +248,8 @@ class alignas(16) SurgeSynthesizer
     float getMacroParameter01(long macroNum) const;
     void applyMacroMonophonicModulation(long macroNum, float val);
 
-    enum NoteExpressionType
-    {
-        VOLUME,  // maps to per voice volume in all voices
-        PAN,     // maps to per voice pan in all voices
-        PITCH,   // maps to the tuning
-        TIMBRE,  // maps to the MPE Timbre parameter
-        PRESSURE // maps to "channel AT" in MPE mode and "ply AT" in non-MPE mode
-    };
-    void setNoteExpression(NoteExpressionType net, int16_t key, int16_t channel, float value);
+    void setNoteExpression(SurgeVoice::NoteExpressionType net, int32_t note_id, int16_t key,
+                           int16_t channel, float value);
 
     bool getParameterIsBoolean(const ID &index) const;
 

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -73,6 +73,20 @@ class alignas(16) SurgeVoice
     std::array<PolyphonicParamModulation, maxPolyphonicParamModulations> polyphonicParamModulations;
     void applyPolyphonicParamModulation(Parameter *, double value);
 
+    enum NoteExpressionType
+    {
+        VOLUME,   // maps to per voice volume in all voices
+                  // 0 < x < = 4, amp = 20 * log(x)
+        PAN,      // maps to per voice pan in all voices, 0..1 with 0.5 center
+        PITCH,    // maps to the tuning -120 to 120 in keys
+        TIMBRE,   // maps to the MPE Timbre parameter 0 .. 1
+        PRESSURE, // maps to "channel AT" in MPE mode and "poly AT" in non-MPE mode 0 .. 1
+        UNKNOWN
+    };
+    void applyNoteExpression(NoteExpressionType net, float value);
+    static constexpr int numNoteExpressionTypes = (int)UNKNOWN;
+    std::array<float, numNoteExpressionTypes> noteExpressions;
+
     /*
     ** Given a note0 and an oscillator this returns the appropriate note.
     ** This is a pretty easy calculation in non-absolute mode. Just add.

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -604,6 +604,42 @@ void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)
     }
     break;
 
+    case CLAP_EVENT_NOTE_EXPRESSION:
+    {
+        auto pevt = reinterpret_cast<const clap_event_note_expression *>(evt);
+        jassert(pevt->note_id == -1); // note expressions come to channel/key
+        SurgeVoice::NoteExpressionType net = SurgeVoice::UNKNOWN;
+        switch (pevt->expression_id)
+        {
+        // with 0 < x <= 4, plain = 20 * log(x)
+        case CLAP_NOTE_EXPRESSION_VOLUME:
+            net = SurgeVoice::VOLUME;
+            break;
+        // pan, 0 left, 0.5 center, 1 right
+        case CLAP_NOTE_EXPRESSION_PAN:
+            net = SurgeVoice::PAN;
+            break;
+        // relative tuning in semitone, from -120 to +120
+        case CLAP_NOTE_EXPRESSION_TUNING:
+            net = SurgeVoice::PITCH;
+            break;
+
+            // 0..1
+        case CLAP_NOTE_EXPRESSION_BRIGHTNESS:
+            net = SurgeVoice::TIMBRE;
+            break;
+        case CLAP_NOTE_EXPRESSION_PRESSURE:
+            net = SurgeVoice::PRESSURE;
+            break;
+        case CLAP_NOTE_EXPRESSION_VIBRATO:
+        case CLAP_NOTE_EXPRESSION_EXPRESSION:
+            break;
+        }
+        if (net != SurgeVoice::UNKNOWN)
+            surge->setNoteExpression(net, pevt->note_id, pevt->key, pevt->channel, pevt->value);
+    }
+    break;
+
     case CLAP_EVENT_TRANSPORT:
     case CLAP_EVENT_NOTE_END:
     default:


### PR DESCRIPTION
This provides basic note expression support for the SURGE Clap
in BWS 4.3 beta 1. Still work to do, which I'll jot down in
the issue, but this should be mergable.