### PR TITLE
Fix a small technical problem with the mixin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND UNIX AND NOT APPLE AND NOT SURGE_SKIP
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+  if (${SURGE_SANITIZE})
+    message(STATUS "Sanitizer is On" )
+  endif()
   # Any Clang or any GCC
   add_compile_options(
     -Wno-multichar
@@ -55,11 +58,13 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<COMPILE_LANGUAGE:CXX>>:-fvisibility-inlines-hidden>
 
     # BP note: If you want to turn on llvm/gcc sanitize undo this and the link options below
-    # -fsanitize=address -fsanitize=undefined
+    $<$<BOOL:${SURGE_SANITIZE}>:-fsanitize=address>
+    $<$<BOOL:${SURGE_SANITIZE}>:-fsanitize=undefined>
   )
 
   add_link_options(
-    # -fsanitize=address -fsanitize=undefinec
+    $<$<BOOL:${SURGE_SANITIZE}>:-fsanitize=address>
+    $<$<BOOL:${SURGE_SANITIZE}>:-fsanitize=undefined>
   )
 
   # Enable SSE2 on x86-32 only. It's implied on x86-64 and N/A elsewhere.

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -36,7 +36,7 @@ std::array<int, n_fx_slots> displayOrder{
     fxslot_global1, fxslot_global2, fxslot_global3, fxslot_global4,
 };
 
-EffectChooser::EffectChooser()
+EffectChooser::EffectChooser() : juce::Component(), WidgetBaseMixin<EffectChooser>(this)
 {
     setRepaintsOnMouseActivity(true);
     setAccessible(true);

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -47,7 +47,8 @@ struct TimeB
     std::chrono::time_point<std::chrono::high_resolution_clock> start;
 };
 
-LFOAndStepDisplay::LFOAndStepDisplay(SurgeGUIEditor *e) : guiEditor(e)
+LFOAndStepDisplay::LFOAndStepDisplay(SurgeGUIEditor *e)
+    : juce::Component(), WidgetBaseMixin<LFOAndStepDisplay>(this), guiEditor(e)
 {
     setTitle("LFO Type And Display");
     setAccessible(true);

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -24,7 +24,8 @@ namespace Surge
 {
 namespace Widgets
 {
-MenuForDiscreteParams::MenuForDiscreteParams() = default;
+MenuForDiscreteParams::MenuForDiscreteParams()
+    : juce::Component(), WidgetBaseMixin<MenuForDiscreteParams>(this){};
 MenuForDiscreteParams::~MenuForDiscreteParams() = default;
 
 void MenuForDiscreteParams::paint(juce::Graphics &g)

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -30,7 +30,10 @@ ModulatableSlider::MoveRateState ModulatableSlider::sliderMoveRateState =
     ModulatableSlider::MoveRateState::kUnInitialized;
 ModulatableSlider::TouchscreenMode ModulatableSlider::touchscreenMode =
     ModulatableSlider::TouchscreenMode::kUnassigned;
-ModulatableSlider::ModulatableSlider() { setRepaintsOnMouseActivity(true); }
+ModulatableSlider::ModulatableSlider() : juce::Component(), WidgetBaseMixin<ModulatableSlider>(this)
+{
+    setRepaintsOnMouseActivity(true);
+}
 
 ModulatableSlider::~ModulatableSlider() {}
 

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -30,6 +30,7 @@ namespace Surge
 namespace Widgets
 {
 ModulationSourceButton::ModulationSourceButton()
+    : juce::Component(), WidgetBaseMixin<ModulationSourceButton>(this)
 {
     setDescription("Modulator");
     setAccessible(true);

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -26,7 +26,7 @@ namespace Surge
 namespace Widgets
 {
 
-MultiSwitch::MultiSwitch()
+MultiSwitch::MultiSwitch() : juce::Component(), WidgetBaseMixin<MultiSwitch>(this)
 {
     setRepaintsOnMouseActivity(true);
     setAccessible(true);

--- a/src/surge-xt/gui/widgets/NumberField.h
+++ b/src/surge-xt/gui/widgets/NumberField.h
@@ -33,7 +33,7 @@ struct NumberField : public juce::Component,
                      public WidgetBaseMixin<NumberField>,
                      public LongHoldMixin<NumberField>
 {
-    NumberField() : juce::Component(), WidgetBaseMixin<NumberField>() {}
+    NumberField() : juce::Component(), WidgetBaseMixin<NumberField>(this) {}
 
     SurgeStorage *storage{nullptr};
     void setStorage(SurgeStorage *s) { storage = s; }

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -114,7 +114,7 @@ struct PatchDBTypeAheadProvider : public TypeAheadDataProvider,
     }
 };
 
-PatchSelector::PatchSelector()
+PatchSelector::PatchSelector() : juce::Component(), WidgetBaseMixin<PatchSelector>(this)
 {
     patchDbProvider = std::make_unique<PatchDBTypeAheadProvider>();
     typeAhead = std::make_unique<Surge::Widgets::TypeAhead>("patch select", patchDbProvider.get());

--- a/src/surge-xt/gui/widgets/Switch.cpp
+++ b/src/surge-xt/gui/widgets/Switch.cpp
@@ -24,7 +24,7 @@ namespace Surge
 namespace Widgets
 {
 
-Switch::Switch()
+Switch::Switch() : juce::Component(), WidgetBaseMixin<Switch>(this)
 {
     setRepaintsOnMouseActivity(true);
     setDescription("Switch");

--- a/src/surge-xt/gui/widgets/VuMeter.cpp
+++ b/src/surge-xt/gui/widgets/VuMeter.cpp
@@ -23,7 +23,7 @@ namespace Surge
 {
 namespace Widgets
 {
-VuMeter::VuMeter()
+VuMeter::VuMeter() : juce::Component(), WidgetBaseMixin<VuMeter>(this)
 {
     setAccessible(false);
     setWantsKeyboardFocus(false);

--- a/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.cpp
@@ -18,7 +18,10 @@ using WaveshaperType = sst::waveshapers::WaveshaperType;
 std::array<std::vector<std::pair<float, float>>, (int)WaveshaperType::n_ws_types>
     WaveShaperSelector::wsCurves;
 
-WaveShaperSelector::WaveShaperSelector() {}
+WaveShaperSelector::WaveShaperSelector()
+    : juce::Component(), WidgetBaseMixin<WaveShaperSelector>(this)
+{
+}
 
 WaveShaperSelector::~WaveShaperSelector() {}
 

--- a/src/surge-xt/gui/widgets/WidgetBaseMixin.h
+++ b/src/surge-xt/gui/widgets/WidgetBaseMixin.h
@@ -35,7 +35,7 @@ template <typename T>
 struct WidgetBaseMixin : public Surge::GUI::SkinConsumingComponent,
                          public Surge::GUI::IComponentTagValue
 {
-    WidgetBaseMixin() { asT()->setWantsKeyboardFocus(true); }
+    WidgetBaseMixin(juce::Component *c) { c->setWantsKeyboardFocus(true); }
     inline T *asT() { return static_cast<T *>(this); }
 
     uint32_t tag{0};

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -315,7 +315,7 @@ void XMLMenuPopulator::populate()
     maxIdx = allPresets.size();
 }
 
-OscillatorMenu::OscillatorMenu()
+OscillatorMenu::OscillatorMenu() : juce::Component(), WidgetBaseMixin<OscillatorMenu>(this)
 {
     strcpy(mtype, "osc");
     setDescription("Oscillator Type");
@@ -478,7 +478,7 @@ std::unique_ptr<juce::AccessibilityHandler> OscillatorMenu::createAccessibilityH
     return std::make_unique<XMLMenuAH<OscillatorMenu>>(this);
 }
 
-FxMenu::FxMenu()
+FxMenu::FxMenu() : juce::Component(), WidgetBaseMixin<FxMenu>(this)
 {
     strcpy(mtype, "fx");
     setDescription("FX Type");


### PR DESCRIPTION
The mixi CTOR called asT() to static cast to T but that
is before the T constructor runs. Not really a problem per-se
in our use case, but ASAN complained, so fix it. Also makje it so
you can cmake toggle on ASAN

Closes #6133