### PR TITLE
More Accessibility Progress

### DIFF
--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -50,6 +50,8 @@ Component MultiSwitch =
         .withProperty(Component::DRAGGABLE_HSWITCH, {"draggable"},
                       {"Is the switch draggable as a slider via mouse/touch or not. Valid values: "
                        "true, false"})
+        .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, {"accessible_as_buttons"},
+                      {"Is the accesible display buttons (true) or radio buttons (false, def)"})
         .withProperty(Component::HOVER_IMAGE, {"hover_image"},
                       {"Hover image of the switch - required if you "
                        "set the base image and want feedback on mouse hover"})
@@ -83,10 +85,13 @@ Component Slider =
         .withProperty(Component::HIDE_SLIDER_LABEL, {"hide_slider_label"},
                       {"Hides the parameter name label"});
 
-Component Switch = Component("CSwitchControl")
-                       .withAlias("Switch")
-                       .withProperty(Component::BACKGROUND, {"image", "bg_resource", "bg_id"},
-                                     {"Base image of the switch"});
+Component Switch =
+    Component("CSwitchControl")
+        .withAlias("Switch")
+        .withProperty(Component::BACKGROUND, {"image", "bg_resource", "bg_id"},
+                      {"Base image of the switch"})
+        .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, {"accessible_as_buttons"},
+                      {"Is the accesible display buttons (true) or radio buttons (false, def)"});
 
 Component FilterSelector =
     Component("FilterSelector")
@@ -496,7 +501,8 @@ Connector lfo_title_label =
     Connector("lfo.title", 6, 498, 11, 71, Components::Custom, Connector::LFO_LABEL);
 Connector lfo_presets =
     Connector("lfo.presets", 6, 484, 13, 11, Components::Switch, Connector::LFO_MENU)
-        .withBackground(IDB_LFO_PRESET_MENU);
+        .withBackground(IDB_LFO_PRESET_MENU)
+        .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, true);
 
 Connector lfo_main_panel = Connector("lfo.main.panel", 28, 478, Components::Group);
 Connector rate = Connector("lfo.rate", 0, 0).asHorizontal().inParent("lfo.main.panel");
@@ -515,7 +521,8 @@ Connector shape = Connector("lfo.shape", 235, 480, 359, 84, Components::LFODispl
 
 Connector mseg_editor =
     Connector("lfo.mseg_editor", 597, 484, 11, 11, Components::Switch, Connector::MSEG_EDITOR_OPEN)
-        .withBackground(IDB_LFO_MSEG_EDIT);
+        .withBackground(IDB_LFO_MSEG_EDIT)
+        .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, true);
 
 Connector lfo_eg_panel = Connector("lfo.envelope.panel", 616, 493, Components::Group);
 Connector delay = Connector("lfo.delay", 0, 0).inParent("lfo.envelope.panel");
@@ -548,15 +555,18 @@ Connector patch_jog =
 
 Connector action_undo =
     Connector("controls.action.undo", 433, 42, 16, 12, Components::Switch, Connector::ACTION_UNDO)
-        .withBackground(IDB_UNDO_BUTTON);
+        .withBackground(IDB_UNDO_BUTTON)
+        .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, true);
 Connector action_redo =
     Connector("controls.action.redo", 448, 42, 16, 12, Components::Switch, Connector::ACTION_REDO)
-        .withBackground(IDB_REDO_BUTTON);
+        .withBackground(IDB_REDO_BUTTON)
+        .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, true);
 
 Connector patch_save = Connector("controls.patch.save", 510, 42, 37, 12, Components::MultiSwitch,
                                  Connector::SAVE_PATCH)
                            .withHSwitch2Properties(IDB_SAVE_PATCH, 1, 1, 1)
-                           .withProperty(Component::DRAGGABLE_HSWITCH, false);
+                           .withProperty(Component::DRAGGABLE_HSWITCH, false)
+                           .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, true);
 
 Connector status_panel = Connector("controls.status.panel", 562, 12, Components::Group);
 Connector status_mpe =

--- a/src/common/SkinModel.h
+++ b/src/common/SkinModel.h
@@ -130,6 +130,7 @@ struct Component
         FRAMES,
         FRAME_OFFSET,
         DRAGGABLE_HSWITCH,
+        ACCESSIBLE_AS_MOMENTARY_BUTTON,
 
         NUMBERFIELD_CONTROLMODE,
 

--- a/src/common/SkinModelImpl.cpp
+++ b/src/common/SkinModelImpl.cpp
@@ -130,6 +130,7 @@ std::string Component::propertyEnumToString(Properties p)
         PN(FRAME_OFFSET)
         PN(NUMBERFIELD_CONTROLMODE)
         PN(DRAGGABLE_HSWITCH)
+        PN(ACCESSIBLE_AS_MOMENTARY_BUTTON)
         PN(BACKGROUND_COLOR)
         PN(FRAME_COLOR)
 
@@ -245,7 +246,8 @@ Connector &Connector::asJogPlusMinus() noexcept
     payload->w = 32;
     payload->h = 12;
     return withHSwitch2Properties(IDB_PREVNEXT_JOG, 2, 1, 2)
-        .withProperty(Component::DRAGGABLE_HSWITCH, false);
+        .withProperty(Component::DRAGGABLE_HSWITCH, false)
+        .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, true);
 }
 
 Connector &Connector::asStackedGroupLeader() { return *this; }

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -497,6 +497,8 @@ void SurgeGUIEditor::showOverlay(OverlayTags olt,
             getOverlayWrapperIfOpen(olt)->doTearOut();
         }
     }
+
+    getOverlayIfOpen(olt)->grabKeyboardFocus();
 }
 void SurgeGUIEditor::closeOverlay(OverlayTags olt)
 {

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
@@ -66,12 +66,20 @@ struct KeyBindingsListRow : public juce::Component
         reset->setStorage(editor->getStorage());
         reset->setAccessible(true);
         reset->onClick = [this]() { resetToDefault(); };
+        reset->setTitle(std::string("Reset ") + Surge::GUI::keyboardActionDescription(action));
+        reset->setDescription(std::string("Reset ") +
+                              Surge::GUI::keyboardActionDescription(action));
+
         addAndMakeVisible(*reset);
 
         learn = std::make_unique<Surge::Widgets::SelfDrawToggleButton>("Learn");
         learn->setSkin(editor->currentSkin);
         learn->setStorage(editor->getStorage());
         learn->setAccessible(true);
+        learn->setTitle(std::string("Learn ") + Surge::GUI::keyboardActionDescription(action));
+        learn->setDescription(std::string("Learn ") +
+                              Surge::GUI::keyboardActionDescription(action));
+
         learn->onToggle = [this]() {
             if (learn->getValue() > 0.5)
             {

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -1496,6 +1496,7 @@ void ModulationSideControls::doAdd()
     addSourceW->setLabels({"Select Source"});
     addTargetW->setLabels({"Select Target"});
     addTargetW->setEnabled(false);
+    addSourceW->grabKeyboardFocus();
     repaint();
 }
 

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -206,7 +206,7 @@ void MenuCenteredBoldLabel::paint(juce::Graphics &g)
 
 void MenuCenteredBoldLabel::addToMenu(juce::PopupMenu &m, const std::string label)
 {
-    m.addCustomItem(-1, std::make_unique<MenuCenteredBoldLabel>(label));
+    m.addCustomItem(-1, std::make_unique<MenuCenteredBoldLabel>(label), nullptr, label);
 }
 
 //==============================================================================

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -91,6 +91,8 @@ struct MenuCenteredBoldLabel : juce::PopupMenu::CustomComponent
 {
     MenuCenteredBoldLabel(const std::string &s) : label(s), juce::PopupMenu::CustomComponent(true)
     {
+        setAccessible(true);
+        setTitle(label);
     }
     void getIdealSize(int &idealWidth, int &idealHeight) override;
     void paint(juce::Graphics &g) override;

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -485,6 +485,7 @@ void ModulatableSlider::mouseDrag(const juce::MouseEvent &event)
 
 void ModulatableSlider::mouseDown(const juce::MouseEvent &event)
 {
+    initiatedChange = false;
     enqueueFutureInfowindow(SurgeGUIEditor::InfoQAction::CANCEL);
     mouseDownFloatPosition = event.position;
 
@@ -505,6 +506,7 @@ void ModulatableSlider::mouseDown(const juce::MouseEvent &event)
     modValueOnMouseDown = modValue;
     lastDistance = 0.f;
     editTypeWas = NOEDIT;
+    initiatedChange = true;
     notifyBeginEdit();
     showInfowindow(isEditingModulation);
 }
@@ -548,7 +550,9 @@ void ModulatableSlider::mouseUp(const juce::MouseEvent &event)
 
     if (editTypeWas != DRAG)
     {
-        notifyEndEdit();
+        if (initiatedChange)
+            notifyEndEdit();
+        initiatedChange = false;
         editTypeWas = NOEDIT;
         return;
     }

--- a/src/surge-xt/gui/widgets/ModulatableSlider.h
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.h
@@ -63,6 +63,8 @@ struct ModulatableSlider : public juce::Component,
     virtual void setIsLightStyle(bool b) { isLightStyle = b; }
     bool isLightStyle{false};
 
+    bool initiatedChange{false};
+
     /**
      * Vertical sliders have smaller vertical footprints in the LFO region, as a remnant from
      * the classic skin. Support the option of intent here even though subclasses may do nothing

--- a/src/surge-xt/gui/widgets/MultiSwitch.h
+++ b/src/surge-xt/gui/widgets/MultiSwitch.h
@@ -107,6 +107,10 @@ struct MultiSwitch : public juce::Component,
     void setHoverSwitchDrawable(SurgeImage *d) { hoverSwitchD = d; }
     void setHoverOnSwitchDrawable(SurgeImage *d) { hoverOnSwitchD = d; }
 
+    bool iam{false};
+    bool isAlwaysAccessibleMomentary() const { return iam; }
+    void setIsAlwaysAccessibleMomentary(bool b) { iam = b; }
+
     void setupAccessibility();
     std::vector<std::unique_ptr<juce::Component>> selectionComponents;
     juce::Component *getCurrentAccessibleSelectionComponent() override;

--- a/src/surge-xt/gui/widgets/Switch.cpp
+++ b/src/surge-xt/gui/widgets/Switch.cpp
@@ -187,8 +187,9 @@ struct SwitchAH : public juce::AccessibilityHandler
     explicit SwitchAH(Switch *s)
         : mswitch(s), juce::AccessibilityHandler(
                           *s,
-                          s->isMultiIntegerValued() ? juce::AccessibilityRole::button
-                                                    : juce::AccessibilityRole::toggleButton,
+                          (s->isMultiIntegerValued() || s->isAlwaysAccessibleMomentary())
+                              ? juce::AccessibilityRole::button
+                              : juce::AccessibilityRole::toggleButton,
                           juce::AccessibilityActions()
                               .addAction(juce::AccessibilityActionType::showMenu,
                                          [this]() { this->showMenu(); })

--- a/src/surge-xt/gui/widgets/Switch.h
+++ b/src/surge-xt/gui/widgets/Switch.h
@@ -47,6 +47,10 @@ struct Switch : public juce::Component, public WidgetBaseMixin<Switch>, public L
     bool isMultiIntegerValued() const { return iit; };
     void setIsMultiIntegerValued(bool b) { iit = b; };
 
+    bool iam{false};
+    bool isAlwaysAccessibleMomentary() const { return iam; }
+    void setIsAlwaysAccessibleMomentary(bool b) { iam = b; }
+
     int iv{0}, im{1};
     void setIntegerValue(int i) { iv = i; }
     void setIntegerMax(int i) { im = i; }


### PR DESCRIPTION
Addresses #5714

- Switches as Momentary (LFO menu, save, etc...) show as button not toggle
- Accesibility Supress the Filter and Waveshaper Analyzer Graphical Overlay Laumch
- Make the jog button sub-components actually buttons
- Formula debug table now shows values
- Supress no-label warning on custom component
- Get rid of unbalanced start/end in slider (closes #6163)
- Keybinding Overlays get Acc labels
- Stop focus from vanishing when adding a modulation in modlist
- Grab focus in an overlay when it opens
- Move WaveShaper into the filter overlay group