### PR TITLE
Be a bit more careful about a patch load race

### DIFF
--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -374,7 +374,7 @@ class alignas(16) SurgeSynthesizer
     bool refresh_overflow = false;
     float refresh_ctrl_queue_value[8];
     bool process_input;
-    bool has_patchid_file;
+    std::atomic<bool> has_patchid_file;
     char patchid_file[FILENAME_MAX];
     std::atomic<int> patchid_queue;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -446,10 +446,12 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     void queuePatchFileLoad(const std::string &file)
     {
-        undoManager()->pushPatch();
-        strncpy(synth->patchid_file, file.c_str(), FILENAME_MAX);
-        strncpy(synth->patchid_file, file.c_str(), FILENAME_MAX);
-        synth->has_patchid_file = true;
+        {
+            std::lock_guard<std::mutex> mg(synth->patchLoadSpawnMutex);
+            undoManager()->pushPatch();
+            strncpy(synth->patchid_file, file.c_str(), FILENAME_MAX);
+            synth->has_patchid_file = true;
+        }
         synth->processAudioThreadOpsWhenAudioEngineUnavailable();
     }
 


### PR DESCRIPTION
In #6140 we had reports of logic sometimes resetting to default
rather than loading the stored patch. I could occasionally reproduce
this and I think it is a race condition between unstream state and
processing starting and the patchid_queue being set. So when
you unstream state, reset the patch id queue completely to make sure
nothing loads after you.

Addresses #6140. Will revert to users for testing before closing.