### PR TITLE
Hide typein option when param is temposynced

### DIFF
--- a/doc/Surge Architecture.md
+++ b/doc/Surge Architecture.md
@@ -7,8 +7,8 @@ and works. This is not a developer how-to. That information is covered in [our D
 document for our future selves**. As such, it is rather casual and incomplete now. Sorry!
 
 * [Code Layout](#code-layout)
-* [SurgeStorage, Parameter and SurgeSynthesizer](#parameter-and-surge-synthesizer)
-* [SurgeGUIEditor](#surgegui)
+* [SurgeStorage, Parameter and SurgeSynthesizer](#surgestorage-parameter-and-surgesynthesizer)
+* [SurgeGUIEditor](#surgeguieditor)
 * [Voices and MPE](#voices-and-mpe)
 * [DSP](#dsp)
 * [Headless](#headless)

--- a/doc/wavetables.md
+++ b/doc/wavetables.md
@@ -5,13 +5,13 @@ of short (128-1024 or so) sample waves which have multiple waves in a single fil
 parameter in the wavetable oscillator walks through the tables interpolating.
 
 The `.wt` file is a simple header plus collection of raw binary data, and is documented
-[here](https://github.com/surge-synthesizer/surge/blob/master/resources/data/wavetables/wt%20fileformat.txt) but
+[here](https://github.com/surge-synthesizer/surge/blob/main/resources/data/wavetables/WT%20fileformat.txt) but
 many users have asked us how to create these.
 
 The program **AudioTerm** runs on Windows and creates **Surge** wavetable files, but is Windows only
 and is an extensive program. The program [**WaveEdit**](http://synthtech.com/waveedit) is multiplatform and is able to export `.wav`-files of 256 sample length, and these have been demonstrated to be usable with the following knowledge to create **Surge** compatible `.wt` -files. You can also create your own 256, 512, 1024 sample length wavefiles, place them in a folder and use the script to create a brand new `.wt`. Just make sure that they are all 44.1khz, 16-bit, mono files at a specific length (power of 2).
 
-In order to make manipulating wavetables easier, the **Surge** devs have put together some simple Python code to read, explode, and create `.wt` files. To use these you need a **Python3** install on your computer and to be comfortable with the command line. You also need the [**GitHub** repo](http://github.com/surge-synthesizer/surge) cloned or to at least grab a copy of the [script](https://github.com/surge-synthesizer/surge/tree/master/scripts)
+In order to make manipulating wavetables easier, the **Surge** devs have put together some simple Python code to read, explode, and create `.wt` files. To use these you need a **Python3** install on your computer and to be comfortable with the command line. You also need the [**GitHub** repo](https://github.com/surge-synthesizer/surge) cloned or to at least grab a copy of the [script](https://github.com/surge-synthesizer/surge/tree/main/scripts/wt-tool)
 
 Please note that this is pretty experimental. Error checking and so on needs to be improved over time.
 We are throwing this out there to see if people use and improve it.
@@ -59,4 +59,4 @@ Creating 'newC.wt' with 45 tables of length 128
 
 ## I wish this did x, y, or z
 
-Hop on [Slack](https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU), [open an issue](http://github.com/surge-synthesizer/surge/issues/new), or crack open a python book and fire in a pull request! We're all ears on this stuff.
+Hop on [Discord](https://raw.githubusercontent.com/surge-synthesizer/surge-synthesizer.github.io/master/_includes/discord_invite_link), [open an issue](https://github.com/surge-synthesizer/surge/issues/new), or crack open a python book and fire in a pull request! We're all ears on this stuff.

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2808,9 +2808,8 @@ void SurgeGUIEditor::showSettingsMenu(const juce::Point<int> &where,
         juce::URL(fmt::format("{}feedback", stringWebsite)).launchInDefaultBrowser();
     });
 
-    settingsMenu.addItem(Surge::GUI::toOSCase("Read the Code..."), []() {
-        juce::URL(fmt::format("{}surge", stringRepository)).launchInDefaultBrowser();
-    });
+    settingsMenu.addItem(Surge::GUI::toOSCase("Read the Code..."),
+                         []() { juce::URL(stringRepository).launchInDefaultBrowser(); });
 
     settingsMenu.addItem(Surge::GUI::toOSCase("Download Additional Content..."), []() {
         juce::URL(fmt::format("{}surge-synthesizer.github.io/wiki/Additional-Content",

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1235,7 +1235,15 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             char txt[TXT_SIZE], txt2[512];
             p->get_display(txt);
-            snprintf(txt2, 512, "%s: %s", Surge::GUI::toOSCase("Edit Value").c_str(), txt);
+
+            if (!p->temposync)
+            {
+                snprintf(txt2, 512, "%s: %s", Surge::GUI::toOSCase("Edit Value").c_str(), txt);
+            }
+            else
+            {
+                snprintf(txt2, 512, "%s", txt);
+            }
 
             if (p->valtype == vt_float)
             {


### PR DESCRIPTION
- as editing it doesn't work in that mode.
  only show chosen value instead.
- fix more links