### PR TITLE
Fix a crash (but not mis-render) in Reverb2 at very high SR

### DIFF
--- a/src/common/dsp/effects/Reverb2Effect.cpp
+++ b/src/common/dsp/effects/Reverb2Effect.cpp
@@ -9,7 +9,7 @@ Reverb2Effect::allpass::allpass()
     memset(_data, 0, MAX_ALLPASS_LEN * sizeof(float));
 }
 
-void Reverb2Effect::allpass::setLen(int len) { _len = len; }
+void Reverb2Effect::allpass::setLen(int len) { _len = std::clamp(len, 0, MAX_ALLPASS_LEN - 1); }
 
 float Reverb2Effect::allpass::process(float in, float coeff)
 {
@@ -29,7 +29,7 @@ Reverb2Effect::delay::delay()
     memset(_data, 0, MAX_DELAY_LEN * sizeof(float));
 }
 
-void Reverb2Effect::delay::setLen(int len) { _len = len; }
+void Reverb2Effect::delay::setLen(int len) { _len = std::clamp(len, 0, MAX_DELAY_LEN - 1); }
 
 float Reverb2Effect::delay::process(float in, int tap1, float &tap_out1, int tap2, float &tap_out2,
                                     int modulation)
@@ -81,6 +81,9 @@ int msToSamples(float ms, float scale, float samplerate)
 {
     float a = samplerate * ms * 0.001f;
     float b = a * scale;
+    // these are clamped out above
+    // assert( b < Reverb2Effect::MAX_ALLPASS_LEN);
+    // assert( b < Reverb2Effect::MAX_DELAY_LEN);
     return (int)(b);
 }
 

--- a/src/common/dsp/effects/Reverb2Effect.h
+++ b/src/common/dsp/effects/Reverb2Effect.h
@@ -24,12 +24,13 @@
 
 class Reverb2Effect : public Effect
 {
+    // These are set to make sure we have delay lengths up to 384k
     static const int NUM_BLOCKS = 4, NUM_INPUT_ALLPASSES = 4, NUM_ALLPASSES_PER_BLOCK = 2,
-                     MAX_ALLPASS_LEN = 16384, MAX_DELAY_LEN = 16384,
+                     MAX_ALLPASS_LEN = 16384 * 8, MAX_DELAY_LEN = 16384 * 8,
                      DELAY_LEN_MASK = MAX_DELAY_LEN - 1, DELAY_SUBSAMPLE_BITS = 8,
                      DELAY_SUBSAMPLE_RANGE = (1 << DELAY_SUBSAMPLE_BITS),
-                     PREDELAY_BUFFER_SIZE = 48000 * 4 * 4, // max sample rate is 48000 * 4 probably
-        PREDELAY_BUFFER_SIZE_LIMIT = 48000 * 4 * 3;        // allow for one second of diffusion
+                     PREDELAY_BUFFER_SIZE = 48000 * 8 * 4, // max sample rate is 48000 * 8 probably
+        PREDELAY_BUFFER_SIZE_LIMIT = 48000 * 8 * 3;        // allow for one second of diffusion
 
     class allpass
     {

--- a/src/surge-testrunner/UnitTestsFX.cpp
+++ b/src/surge-testrunner/UnitTestsFX.cpp
@@ -231,3 +231,37 @@ TEST_CASE("FX Move with Modulation", "[fx]")
         confirmDestinations(surge, {{0, 3}, {1, 2}});
     }
 }
+
+TEST_CASE("High Samplerate Reverb2", "[fx]")
+{
+    SECTION("Make Reverb2")
+    {
+        auto surge = Surge::Headless::createSurge(48000 * 32);
+        REQUIRE(surge);
+
+        for (int i = 0; i < 10; ++i)
+            surge->process();
+
+        auto *pt = &(surge->storage.getPatch().fx[0].type);
+        auto awv = 1.f * fxt_reverb2 / (pt->val_max.i - pt->val_min.i);
+
+        auto did = surge->idForParameter(pt);
+        surge->setParameter01(did, awv, false);
+
+        for (int i = 0; i < 10; ++i)
+        {
+            surge->process();
+        }
+
+        surge->playNote(0, 60, 127, 0);
+        for (int i = 0; i < 100; ++i)
+        {
+            surge->process();
+        }
+        surge->releaseNote(0, 60, 0);
+        for (int i = 0; i < 1000; ++i)
+        {
+            surge->process();
+        }
+    }
+}


### PR DESCRIPTION
Run reverb2 at 48000 * 32 khz and it would crash. Now it just
mis-renders the reverb some insted.

Don't use sample rates that high! But surge should never crash.