### PR TITLE
More Accesibility Fixes

### DIFF
--- a/src/surge-xt/gui/SurgeJUCEHelpers.h
+++ b/src/surge-xt/gui/SurgeJUCEHelpers.h
@@ -33,6 +33,15 @@ inline std::function<void(int)> makeAsyncCallback(T *that, std::function<void(T 
     };
 }
 
+template <typename T>
+inline std::function<void()> makeSafeCallback(T *that, std::function<void(T *)> cb)
+{
+    return [safethat = juce::Component::SafePointer<T>(that), cb]() {
+        if (safethat)
+            cb(safethat);
+    };
+}
+
 template <typename T> inline std::function<void(int)> makeEndHoverCallback(T *that)
 {
     return [safethat = juce::Component::SafePointer<T>(that)](int x) {

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -107,10 +107,10 @@ LFOAndStepDisplay::LFOAndStepDisplay(SurgeGUIEditor *e)
             {
                 auto f = ss->steps[step];
                 auto delt = 0.05;
-                if (isShift)
-                    delt = 0.01;
                 if (isControl)
-                    delt = (isUnipolar() ? 1.0 : 0.5) / 12.0;
+                    delt = 0.01;
+                if (isShift)
+                    delt = 1.0 / 12.0;
                 if (dir < 0)
                     delt *= -1;
 

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -346,7 +346,8 @@ float MenuForDiscreteParams::nextValueInOrder(float v, int inc)
 
 std::unique_ptr<juce::AccessibilityHandler> MenuForDiscreteParams::createAccessibilityHandler()
 {
-    return std::make_unique<DiscreteAH<MenuForDiscreteParams, juce::AccessibilityRole::comboBox>>(
+    // Why a slider? combo box announces wrong
+    return std::make_unique<DiscreteAH<MenuForDiscreteParams, juce::AccessibilityRole::slider>>(
         this);
 }
 

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -758,7 +758,7 @@ bool ModulatableSlider::keyPressed(const juce::KeyPress &key)
         return true;
     }
 
-    float dv{0.05};
+    float dv = 1.0 / range;
     switch (action)
     {
     case Increase:
@@ -789,6 +789,7 @@ bool ModulatableSlider::keyPressed(const juce::KeyPress &key)
 
     if (isEditingModulation)
     {
+        // Value is PM1
         if (action == Increase || action == Decrease)
             modValue = limitpm1(modValue + dv);
         else if (action == ToMax)
@@ -798,12 +799,13 @@ bool ModulatableSlider::keyPressed(const juce::KeyPress &key)
     }
     else
     {
+        // Value is 01
         if (action == Increase || action == Decrease)
             value = limit01(value + dv);
         else if (action == ToMax)
             value = 1;
         else if (action == ToMin)
-            value = -1;
+            value = 0;
     }
 
     notifyBeginEdit();

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -55,8 +55,16 @@ OscillatorWaveformDisplay::OscillatorWaveformDisplay()
 
         if (id >= 0)
         {
+            std::string announce = "Loaded Wavetable ";
+            announce += storage->wt_list[id].name;
+            sge->enqueueAccessibleAnnouncement(announce);
+
             oscdata->wt.queue_id = id;
         }
+    };
+    ol->onReturnKey = [ov = ol.get()](OscillatorWaveformDisplay *d) {
+        ov->onPress(d);
+        return true;
     };
 
     addChildComponent(*ol);
@@ -73,8 +81,16 @@ OscillatorWaveformDisplay::OscillatorWaveformDisplay()
 
         if (id >= 0)
         {
+            std::string announce = "Loaded Wavetable ";
+            announce += storage->wt_list[id].name;
+            sge->enqueueAccessibleAnnouncement(announce);
+
             oscdata->wt.queue_id = id;
         }
+    };
+    ol->onReturnKey = [ov = ol.get()](OscillatorWaveformDisplay *d) {
+        ov->onPress(d);
+        return true;
     };
 
     menuOverlays[2] = std::move(ol);
@@ -673,7 +689,12 @@ void OscillatorWaveformDisplay::loadWavetable(int id)
     if (id >= 0 && (id < storage->wt_list.size()))
     {
         if (sge)
+        {
             sge->undoManager()->pushWavetable(scene, oscInScene);
+            std::string announce = "Loaded Wavetable ";
+            announce += storage->wt_list[id].name;
+            sge->enqueueAccessibleAnnouncement(announce);
+        }
         oscdata->wt.queue_id = id;
     }
 }
@@ -759,6 +780,13 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
                     sge->undoManager()->pushWavetable(scene, oscInScene);
                 id = storage->getAdjacentWaveTable(oscdata->wt.current_id, false);
 
+                if (sge)
+                {
+                    std::string announce = "Loaded Wavetable ";
+                    announce += storage->wt_list[id].name;
+                    sge->enqueueAccessibleAnnouncement(announce);
+                }
+
                 if (id >= 0)
                 {
                     oscdata->wt.queue_id = id;
@@ -777,6 +805,13 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
                     sge->undoManager()->pushWavetable(scene, oscInScene);
 
                 id = storage->getAdjacentWaveTable(oscdata->wt.current_id, true);
+
+                if (sge)
+                {
+                    std::string announce = "Loaded Wavetable ";
+                    announce += storage->wt_list[id].name;
+                    sge->enqueueAccessibleAnnouncement(announce);
+                }
 
                 if (id >= 0)
                 {

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -26,6 +26,7 @@
 #include "fmt/core.h"
 #include "SurgeJUCEHelpers.h"
 #include "AccessibleHelpers.h"
+#include "SurgeJUCEHelpers.h"
 
 namespace Surge
 {
@@ -283,7 +284,8 @@ void PatchSelector::mouseEnter(const juce::MouseEvent &)
     if (tooltipCountdown < 0)
     {
         tooltipCountdown = 5;
-        juce::Timer::callAfterDelay(100, [this]() { shouldTooltip(); });
+        juce::Timer::callAfterDelay(100, Surge::GUI::makeSafeCallback<PatchSelector>(
+                                             this, [](auto *that) { that->shouldTooltip(); }));
     }
 }
 
@@ -426,7 +428,8 @@ void PatchSelector::shouldTooltip()
     }
     else
     {
-        juce::Timer::callAfterDelay(200, [this]() { shouldTooltip(); });
+        juce::Timer::callAfterDelay(200, Surge::GUI::makeSafeCallback<PatchSelector>(
+                                             this, [](auto *that) { that->shouldTooltip(); }));
     }
 }
 

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -259,7 +259,7 @@ void XMLMenuPopulator::populate()
                 case FACPS:
                 {
                     auto idx = c->idx;
-                    m.addItem(c->name, [host, idx]() { host->loadByIndex(idx); });
+                    m.addItem(c->name, [host, idx, n = c->name]() { host->loadByIndex(n, idx); });
                 }
                 break;
                 case USPS:
@@ -271,7 +271,7 @@ void XMLMenuPopulator::populate()
                         m.addSectionHeader("USER PRESETS");
                     }
                     auto idx = c->idx;
-                    m.addItem(c->name, [host, idx]() { host->loadByIndex(idx); });
+                    m.addItem(c->name, [host, n = c->name, idx]() { host->loadByIndex(n, idx); });
                 }
                 break;
                 case SEP:
@@ -766,7 +766,7 @@ void FxMenu::scanExtraPresets()
     }
 }
 
-void FxMenu::loadByIndex(int index)
+void FxMenu::loadByIndex(const std::string &name, int index)
 {
     auto q = allPresets[index];
     if (q.xmlElement)
@@ -780,6 +780,12 @@ void FxMenu::loadByIndex(int index)
     selectedIdx = index;
     if (getControlListener())
         getControlListener()->valueChanged(asControlValueInterface());
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+    if (sge)
+    {
+        auto announce = std::string("Loaded FX Preset  ") + name;
+        sge->enqueueAccessibleAnnouncement(announce);
+    }
     repaint();
 }
 

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
@@ -80,7 +80,7 @@ struct XMLMenuPopulator
     };
     virtual void scanExtraPresets() {}
     std::vector<Item> allPresets;
-    virtual void loadByIndex(int idx)
+    virtual void loadByIndex(const std::string &name, int idx)
     {
         auto q = allPresets[idx];
         if (q.xmlElement)
@@ -107,7 +107,7 @@ struct XMLMenuPopulator
             if (idx >= (int)allPresets.size())
                 idx = 0;
         } while (allPresets[idx].isSeparator || allPresets[idx].isSectionHeader);
-        loadByIndex(idx);
+        loadByIndex(allPresets[idx].name, idx);
     }
     int maxIdx;
     char mtype[64];
@@ -228,7 +228,7 @@ struct FxMenu : public juce::Component, public XMLMenuPopulator, public WidgetBa
     void pasteFX();
     void saveFX();
 
-    void loadByIndex(int index) override;
+    void loadByIndex(const std::string &name, int index) override;
     void loadUserPreset(const Surge::Storage::FxUserPreset::Preset &p);
 
     SurgeImage *bg{}, *bgHover{};


### PR DESCRIPTION
Addresses #5714

- Home/End on modlist go to right value. (Really Slider was sending
  wrong value in 'value' mode for min, but that was clamped elsewhere
  in every case *except* the mod list)
- Update mod keys by same amount as mouse
- Menu to a slider for better VO announcement
- Proceted a pointer on patch selector tooltip
- Swap shift/control for step seq key bindings
- Announce FX Presets
- Announce Wavetables
- Enter works on wavetable jog