### PR TITLE
Add contextual help for filter analysis

### DIFF
--- a/resources/surge-shared/paramdocumentation.xml
+++ b/resources/surge-shared/paramdocumentation.xml
@@ -28,7 +28,8 @@
   <special id="lfo-presets" help_url="#lfo-presets"/>
   <special id="fx-selector" help_url="#effect-unit-selector"/>
   <special id="fx-presets" help_url="#effect-and-preset-picker"/>
-  <special id="waveshaper-preview" help_url="#waveshaper"/>
+  <special id="filter-analysis" help_url="#filter-controls"/>
+  <special id="waveshaper-analysis" help_url="#waveshaper"/>
   <special id="alias-shape" help_url="#shape"/>
   <special id="action-history" help_url="#action-history"/>
 

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -331,7 +331,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         }
 
         pt->setEnclosingParentPosition(p);
-        pt->setEnclosingParentTitle("Waveshaper Preview");
+        pt->setEnclosingParentTitle("Waveshaper Analysis");
         pt->setWSType(synth->storage.getPatch().scene[current_scene].wsunit.type.val.i);
         pt->defaultLocation = dl;
         pt->setCanMoveAround(std::make_pair(true, Surge::Storage::WSAnalysisOverlayLocation));

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -497,6 +497,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         tcomp->setSkin(currentSkin, bitmapStore);
         contextMenu.addCustomItem(-1, std::move(tcomp));
 
+        // TODO: Implement!
+        /*
         if (tag == tag_action_undo || tag == tag_action_redo)
         {
             contextMenu.addSeparator();
@@ -504,6 +506,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             contextMenu.addItem(Surge::GUI::toOSCase("Open Action History..."),
                                 [this]() { toggleOverlay(ACTION_HISTORY); });
         }
+         */
 
         contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
                                   Surge::GUI::makeEndHoverCallback(control));
@@ -664,7 +667,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
     if (tag == tag_analyzewaveshape)
     {
         auto contextMenu = juce::PopupMenu();
-        auto hu = helpURLForSpecial("waveshaper");
+        auto hu = helpURLForSpecial("waveshaper-analysis");
         auto lurl = hu;
 
         if (lurl != "")
@@ -672,6 +675,27 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
         auto tcomp =
             std::make_unique<Surge::Widgets::MenuTitleHelpComponent>("Waveshaper Analysis", lurl);
+
+        tcomp->setSkin(currentSkin, bitmapStore);
+        contextMenu.addCustomItem(-1, std::move(tcomp));
+
+        contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
+                                  Surge::GUI::makeEndHoverCallback(control));
+
+        return 1;
+    }
+
+    if (tag == tag_analyzefilters)
+    {
+        auto contextMenu = juce::PopupMenu();
+        auto hu = helpURLForSpecial("filter-analysis");
+        auto lurl = hu;
+
+        if (lurl != "")
+            lurl = fullyResolvedHelpURL(hu);
+
+        auto tcomp =
+            std::make_unique<Surge::Widgets::MenuTitleHelpComponent>("Filter Analysis", lurl);
 
         tcomp->setSkin(currentSkin, bitmapStore);
         contextMenu.addCustomItem(-1, std::move(tcomp));


### PR DESCRIPTION
Also fix inconsistent naming for waveshaper analysis overlay title. Hide "Open Action History" menu entry too.