### PR TITLE
Don't set audio_processing true in prepareToPlay

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -230,6 +230,8 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, const std::string &suppl
     mpeGlobalPitchBendRange = 0;
 
     int pid = 0;
+    patchid_queue = -1;
+    has_patchid_file = false;
     bool lookingForFactory = (storage.initPatchCategoryType == "Factory");
     for (auto p : storage.patch_list)
     {
@@ -245,6 +247,7 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, const std::string &suppl
     if (patchid_queue >= 0)
         processAudioThreadOpsWhenAudioEngineUnavailable(true); // DANGER MODE IS ON
     patchid_queue = -1;
+    has_patchid_file = false;
 }
 
 SurgeSynthesizer::~SurgeSynthesizer()
@@ -3651,6 +3654,8 @@ void SurgeSynthesizer::processAudioThreadOpsWhenAudioEngineUnavailable(bool dang
     if (!audio_processing_active || dangerMode)
     {
         processEnqueuedPatchIfNeeded();
+
+        auto lg = std::lock_guard<std::mutex>(patchLoadSpawnMutex);
 
         // if the audio processing is inactive, patchloading should occur anyway
         if (patchid_queue >= 0)

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -410,6 +410,7 @@ void SurgeSynthesizer::processEnqueuedPatchIfNeeded()
         loadFromDawExtraState();
 
         rawLoadNeedsUIDawExtraState = true;
+        refresh_editor = true;
     }
 }
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -178,7 +178,9 @@ void SurgeSynthProcessor::changeProgramName(int index, const juce::String &newNa
 void SurgeSynthProcessor::prepareToPlay(double sr, int samplesPerBlock)
 {
     surge->setSamplerate(sr);
-    surge->audio_processing_active = true;
+    // It used to be I would set audio processing active true here *but* REAPER calls this for
+    // inactive muted channels so we didn't load if that was the case. Set it true only
+    // if we actually have an audio process going! See #6173
 }
 
 void SurgeSynthProcessor::releaseResources()


### PR DESCRIPTION
Reaper for muted tracks which don't run calls prepareToPlay
before it calls setStateInformation and then never calls
process, which means a muted track won't load the preset
until you unmute it, but if you then save your track, it will
save the wrong thing, so that's all confusing. Also make sure
I am locked in one spot, but that wasn't the bug.

Addresses #6173. Will close once I get user confirm