### PR TITLE
Tearout Improvements

### DIFF
--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -92,6 +92,7 @@ struct OverlayWrapper : public juce::Component,
         canTearOutResize = b.first;
     }
 
+    bool resizeRecordsSize{true};
     void doTearOut(const juce::Point<int> &showAt = juce::Point<int>(-1, -1));
     void doTearIn();
     bool isTornOut();
@@ -119,6 +120,7 @@ struct OverlayWrapper : public juce::Component,
     bool getIsModal() const { return isModal; }
 
     std::unique_ptr<juce::DocumentWindow> tearOutParent;
+    std::unique_ptr<juce::ComponentBoundsConstrainer> tearOutConstrainer;
 
     void onSkinChanged() override;
 


### PR DESCRIPTION
- Use the constrainer to constrain the size
- Include the border to stop resize blinks
- Do initial sizing correctly on restart
- Don't rewrite size when tearing out, causing jitter

Addresses #6115