### PR TITLE
Window Pin to Top; Filter Analyzer Flash

### DIFF
--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -313,7 +313,7 @@ Button *SurgeJUCELookAndFeel::createDocumentWindowButton(int buttonType)
                                                              shape, shape);
     }
 
-    if (buttonType == DocumentWindow::maximiseButton)
+    if (buttonType == DocumentWindow::maximiseButton) // HACK
     {
         shape.addLineSegment({0.0f, 0.0f, 1.0f, 0.0f}, crossThickness); // top
         shape.addRectangle(0.0f, 0.0f, 1.0f, 1.0f);

--- a/src/surge-xt/gui/overlays/FilterAnalysis.cpp
+++ b/src/surge-xt/gui/overlays/FilterAnalysis.cpp
@@ -256,27 +256,36 @@ void FilterAnalysis::paint(juce::Graphics &g)
         bool started = false;
         const auto nPoints = freqAxis.size();
 
-        for (int i = 0; i < nPoints; ++i)
+        if (nPoints == 0)
         {
-            if (freqAxis[i] < lowFreq / 2.f || freqAxis[i] > highFreq * 1.01f)
+            auto yDraw = dbToY(-6, height);
+            plotPath.startNewSubPath(0, yDraw);
+            plotPath.lineTo(dRect.getX() + width, yDraw);
+        }
+        else
+        {
+            for (int i = 0; i < nPoints; ++i)
             {
-                continue;
-            }
+                if (freqAxis[i] < lowFreq / 2.f || freqAxis[i] > highFreq * 1.01f)
+                {
+                    continue;
+                }
 
-            auto xDraw = freqToX(freqAxis[i], width);
-            auto yDraw = dbToY(magResponseDBSmoothed[i], height);
+                auto xDraw = freqToX(freqAxis[i], width);
+                auto yDraw = dbToY(magResponseDBSmoothed[i], height);
 
-            xDraw += dRect.getX();
-            yDraw += dRect.getY();
+                xDraw += dRect.getX();
+                yDraw += dRect.getY();
 
-            if (!started)
-            {
-                plotPath.startNewSubPath(xDraw, yDraw);
-                started = true;
-            }
-            else
-            {
-                plotPath.lineTo(xDraw, yDraw);
+                if (!started)
+                {
+                    plotPath.startNewSubPath(xDraw, yDraw);
+                    started = true;
+                }
+                else
+                {
+                    plotPath.lineTo(xDraw, yDraw);
+                }
             }
         }
     }


### PR DESCRIPTION
- Tearout windows can pin to top (need better button)
- Filter analyzer flashes bad path while doing first calc; fix

Addresses #6115