### PR TITLE
Fix and adjust a number of tearout things

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -183,7 +183,10 @@ std::string defaultKeyToString(DefaultKey k)
         r = "msegOverlayLocationTearOut";
         break;
     case FormulaOverlayLocationTearOut:
-        r = "FormulaOverlayLocationTearOut";
+        r = "formulaOverlayLocationTearOut";
+        break;
+    case WSAnalysisOverlayLocationTearOut:
+        r = "wsAnalysisOverlayLocationTearOut";
         break;
     case FilterAnalysisOverlayLocationTearOut:
         r = "filterAnalysisOverlayLocationTearOut";
@@ -199,10 +202,32 @@ std::string defaultKeyToString(DefaultKey k)
         r = "msegOverlaySizeTearOut";
         break;
     case FormulaOverlaySizeTearOut:
-        r = "FormulaOverlaySizeTearOut";
+        r = "formulaOverlaySizeTearOut";
+        break;
+    case WSAnalysisOverlaySizeTearOut:
+        r = "wsAnalysisOverlaySizeTearOut";
         break;
     case FilterAnalysisOverlaySizeTearOut:
         r = "filterAnalysisOverlaySizeTearOut";
+        break;
+
+    case TuningOverlayTearOutAlwaysOnTop:
+        r = "tuningOverlayTearOutAlwaysOnTop";
+        break;
+    case ModlistOverlayTearOutAlwaysOnTop:
+        r = "modlistOverlayTearOutAlwaysOnTop";
+        break;
+    case MSEGOverlayTearOutAlwaysOnTop:
+        r = "msegOverlayTearOutAlwaysOnTop";
+        break;
+    case FormulaOverlayTearOutAlwaysOnTop:
+        r = "formulaOverlayTearOutAlwaysOnTop";
+        break;
+    case WSAnalysisOverlayTearOutAlwaysOnTop:
+        r = "wsAnalysisOverlayTearOutAlwaysOnTop";
+        break;
+    case FilterAnalysisOverlayTearOutAlwaysOnTop:
+        r = "filterAnalysisOverlayTearOutAlwaysOnTop";
         break;
 
     case ModListValueDisplay:

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -88,18 +88,27 @@ enum DefaultKey
     ModlistOverlayLocationTearOut,
     MSEGOverlayLocationTearOut,
     FormulaOverlayLocationTearOut,
+    WSAnalysisOverlayLocationTearOut,
     FilterAnalysisOverlayLocationTearOut,
 
     TuningOverlaySizeTearOut,
     ModlistOverlaySizeTearOut,
     MSEGOverlaySizeTearOut,
     FormulaOverlaySizeTearOut,
+    WSAnalysisOverlaySizeTearOut,
     FilterAnalysisOverlaySizeTearOut,
+
+    TuningOverlayTearOutAlwaysOnTop,
+    ModlistOverlayTearOutAlwaysOnTop,
+    MSEGOverlayTearOutAlwaysOnTop,
+    FormulaOverlayTearOutAlwaysOnTop,
+    WSAnalysisOverlayTearOutAlwaysOnTop,
+    FilterAnalysisOverlayTearOutAlwaysOnTop,
 
     ModListValueDisplay,
     MenuLightness,
 
-    // Some FX Bank specific ones
+    // Surge XT Effects specific defaults
     FXUnitAssumeFixedBlock,
 
     nKeys

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
 
         jassert(false); // Make a key for me please!
 
-        pt->setCanTearOut({true, Surge::Storage::nKeys});
+        pt->setCanTearOut({true, Surge::Storage::nKeys, Surge::Storage::nKeys});
 
         return pt;
     }
@@ -204,7 +204,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         Surge::Storage::findReplaceSubstring(title, std::string("LFO"), std::string("MSEG"));
 
         mse->setEnclosingParentTitle(title);
-        mse->setCanTearOut({true, Surge::Storage::MSEGOverlayLocationTearOut});
+        mse->setCanTearOut({true, Surge::Storage::MSEGOverlayLocationTearOut,
+                            Surge::Storage::MSEGOverlayTearOutAlwaysOnTop});
         mse->setCanTearOutResize({true, Surge::Storage::MSEGOverlaySizeTearOut});
         mse->setMinimumSize(600, 250);
         locationGet(mse.get(), Surge::Skin::Connector::NonParameterConnection::MSEG_EDITOR_WINDOW,
@@ -253,7 +254,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
 
         fme->setSkin(currentSkin, bitmapStore);
         fme->setEnclosingParentTitle(title);
-        fme->setCanTearOut({true, Surge::Storage::FormulaOverlayLocationTearOut});
+        fme->setCanTearOut({true, Surge::Storage::FormulaOverlayLocationTearOut,
+                            Surge::Storage::FormulaOverlayTearOutAlwaysOnTop});
         fme->setCanTearOutResize({true, Surge::Storage::FormulaOverlaySizeTearOut});
         fme->setMinimumSize(500, 250);
         locationGet(fme.get(),
@@ -277,7 +279,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         te->setSkin(currentSkin, bitmapStore);
         te->setTuning(synth->storage.currentTuning);
         te->setEnclosingParentTitle("Tuning Editor");
-        te->setCanTearOut({true, Surge::Storage::TuningOverlayLocationTearOut});
+        te->setCanTearOut({true, Surge::Storage::TuningOverlayLocationTearOut,
+                           Surge::Storage::TuningOverlayTearOutAlwaysOnTop});
         te->setCanTearOutResize({true, Surge::Storage::TuningOverlaySizeTearOut});
         te->setMinimumSize(730, 400);
         locationGet(te.get(), Surge::Skin::Connector::NonParameterConnection::TUNING_EDITOR_WINDOW,
@@ -317,6 +320,10 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         wsa->setSkin(currentSkin, bitmapStore);
         wsa->setEnclosingParentTitle("Waveshaper Analysis");
         wsa->setWSType(synth->storage.getPatch().scene[current_scene].wsunit.type.val.i);
+        wsa->setCanTearOut({true, Surge::Storage::WSAnalysisOverlayLocationTearOut,
+                            Surge::Storage::WSAnalysisOverlayTearOutAlwaysOnTop});
+        wsa->setCanTearOutResize({true, Surge::Storage::WSAnalysisOverlaySizeTearOut});
+        wsa->setMinimumSize(300, 160);
 
         return wsa;
     }
@@ -331,7 +338,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
 
         fa->setSkin(currentSkin, bitmapStore);
         fa->setEnclosingParentTitle("Filter Analysis");
-        fa->setCanTearOut({true, Surge::Storage::FilterAnalysisOverlayLocationTearOut});
+        fa->setCanTearOut({true, Surge::Storage::FilterAnalysisOverlayLocationTearOut,
+                           Surge::Storage::FilterAnalysisOverlayTearOutAlwaysOnTop});
         fa->setCanTearOutResize({true, Surge::Storage::FilterAnalysisOverlaySizeTearOut});
         fa->setMinimumSize(300, 200);
 
@@ -342,7 +350,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
     {
         auto me = std::make_unique<Surge::Overlays::ModulationEditor>(this, this->synth);
         me->setEnclosingParentTitle("Modulation List");
-        me->setCanTearOut({true, Surge::Storage::ModlistOverlayLocationTearOut});
+        me->setCanTearOut({true, Surge::Storage::ModlistOverlayLocationTearOut,
+                           Surge::Storage::ModlistOverlayTearOutAlwaysOnTop});
         me->setCanTearOutResize({true, Surge::Storage::ModlistOverlaySizeTearOut});
         me->setMinimumSize(600, 300);
         me->setSkin(currentSkin, bitmapStore);
@@ -533,6 +542,7 @@ Surge::Overlays::OverlayWrapper *SurgeGUIEditor::addJuceEditorOverlay(
     });
 
     auto olc = dynamic_cast<Surge::Overlays::OverlayComponent *>(c.get());
+
     if (olc)
     {
         ol->setCanTearOut(olc->getCanTearOut());

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -50,9 +50,16 @@ struct OverlayComponent : juce::Component
      */
     virtual void shownInParent() {}
 
-    std::pair<bool, Surge::Storage::DefaultKey> canTearOut{false, Surge::Storage::nKeys};
-    void setCanTearOut(std::pair<bool, Surge::Storage::DefaultKey> b) { canTearOut = b; }
-    std::pair<bool, Surge::Storage::DefaultKey> getCanTearOut() { return canTearOut; }
+    std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> canTearOut{
+        false, Surge::Storage::nKeys, Surge::Storage::nKeys};
+    void setCanTearOut(std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> t)
+    {
+        canTearOut = t;
+    }
+    std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> getCanTearOut()
+    {
+        return canTearOut;
+    }
     virtual void onTearOutChanged(bool isTornOut) {}
 
     std::pair<bool, Surge::Storage::DefaultKey> canTearOutResize{false, Surge::Storage::nKeys};

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -77,13 +77,20 @@ struct OverlayWrapper : public juce::Component,
     SurgeImage *icon{nullptr};
     void setIcon(SurgeImage *d) { icon = d; }
 
-    std::pair<bool, Surge::Storage::DefaultKey> canTearOutPair{false, Surge::Storage::nKeys};
-    bool canTearOut;
-    void setCanTearOut(std::pair<bool, Surge::Storage::DefaultKey> b)
+    std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> canTearOutData{
+        false, Surge::Storage::nKeys, Surge::Storage::nKeys};
+    bool canTearOut, isAlwaysOnTop;
+    void setCanTearOut(std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> t)
     {
-        canTearOutPair = b;
-        canTearOut = b.first;
+        canTearOutData = t;
+        canTearOut = std::get<0>(t);
+        isAlwaysOnTop = Surge::Storage::getUserDefaultValue(storage, std::get<2>(t), false);
     }
+    std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> getCanTearOut()
+    {
+        return canTearOutData;
+    }
+
     std::pair<bool, Surge::Storage::DefaultKey> canTearOutResizePair{false, Surge::Storage::nKeys};
     bool canTearOutResize;
     void setCanTearOutResize(std::pair<bool, Surge::Storage::DefaultKey> b)
@@ -98,7 +105,7 @@ struct OverlayWrapper : public juce::Component,
     bool isTornOut();
     juce::Point<int> currentTearOutLocation();
     juce::Rectangle<int> locationBeforeTearOut, childLocationBeforeTearOut;
-    juce::Component *parentBeforeTearOut{nullptr};
+    juce::Component::SafePointer<juce::Component> parentBeforeTearOut{nullptr};
 
     bool hasInteriorDec{true};
     void supressInteriorDecoration();


### PR DESCRIPTION
Improved Always-on-top icon (it also switches sides on Mac now!)
Remember Always-on-top status for each overlay
Make Waveshaper Analysis tornable and resizable
Fix crash when attempting to open a tearout after restart and minimizing an already opened tearout