### PR TITLE
Accessibility Improvements

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -237,6 +237,10 @@ std::string defaultKeyToString(DefaultKey k)
         r = "menuLightness";
         break;
 
+    case UseNarratorAnnouncements:
+        r = "useNarratorAnnouncements";
+        break;
+
     case FXUnitAssumeFixedBlock:
         r = "fxAssumeFixedBlock";
         break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -108,6 +108,8 @@ enum DefaultKey
     ModListValueDisplay,
     MenuLightness,
 
+    UseNarratorAnnouncements,
+
     // Surge XT Effects specific defaults
     FXUnitAssumeFixedBlock,
 

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -22,6 +22,7 @@
 #include "SurgeGUIUtils.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
+#include <fmt/core.h>
 
 namespace Surge
 {
@@ -352,7 +353,7 @@ template <typename T> struct OverlayAsAccessibleSlider : public juce::Component
     std::function<float(T *)> onGetValue = [](T *) { return 0.f; };
     std::function<void(T *, float f)> onSetValue = [](T *, float f) { return; };
     std::function<std::string(T *, float f)> onValueToString = [](T *, float f) {
-        return std::to_string(f);
+        return fmt::format("{:.3f}", f);
     };
     std::function<void(T *, int, bool, bool)> onJogValue = [](T *, int, bool, bool) {
         jassert(false);
@@ -483,33 +484,44 @@ template <typename T> bool OverlayAsAccessibleSlider<T>::keyPressed(const juce::
         return false;
 
     auto [action, mod] = Surge::Widgets::accessibleEditAction(key, under->storage);
+    auto ah = getAccessibilityHandler();
 
     if (action == Increase)
     {
         onJogValue(under, +1, key.getModifiers().isShiftDown(), key.getModifiers().isCtrlDown());
+        if (ah)
+            ah->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
         return true;
     }
     if (action == Decrease)
     {
         onJogValue(under, -1, key.getModifiers().isShiftDown(), key.getModifiers().isCtrlDown());
+        if (ah)
+            ah->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
         return true;
     }
 
     if (action == ToMax)
     {
         onMinMaxDef(under, 1);
+        if (ah)
+            ah->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
         return true;
     }
 
     if (action == ToMin)
     {
         onMinMaxDef(under, -1);
+        if (ah)
+            ah->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
         return true;
     }
 
     if (action == ToDefault)
     {
         onMinMaxDef(under, 0);
+        if (ah)
+            ah->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
         return true;
     }
     return false;

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -469,10 +469,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::vector<DAWExtraStateStorage::EditorState::OverlayState> overlaysForNextIdle;
 
     std::deque<std::pair<std::string, int>> accAnnounceStrings;
-    void enqueueAccessibleAnnouncement(const std::string &s)
-    {
-        accAnnounceStrings.push_back({s, 3});
-    }
+    void enqueueAccessibleAnnouncement(const std::string &s);
     void setAccessibilityInformationByParameter(juce::Component *c, Parameter *p,
                                                 const std::string &action);
 
@@ -764,6 +761,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     float blinktimer = 0;
     bool blinkstate = false;
     int firstIdleCountdown = 0;
+    int sendStructureChangeIn = -1;
 
     juce::PopupMenu makeSmoothMenu(const juce::Point<int> &where,
                                    const Surge::Storage::DefaultKey &key, int defaultValue,

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -709,6 +709,7 @@ void FormulaModulatorEditor::applyCode()
     editor->repaintFrame();
     juce::SystemClipboard::copyTextToClipboard(formulastorage->formulaString);
     setApplyEnabled(false);
+    mainEditor->grabKeyboardFocus();
 }
 
 void FormulaModulatorEditor::setApplyEnabled(bool b)

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -211,11 +211,11 @@ LFOAndStepDisplay::LFOAndStepDisplay(SurgeGUIEditor *e)
             switch (q)
             {
             case 1:
-                return "Trigger FEG + AEG";
+                return "Trigger Filter env and Amp env";
             case 2:
-                return "Trigger FEG";
+                return "Trigger Filter env";
             case 3:
-                return "Trigger AEG";
+                return "Trigger Amp env";
             }
             return "No Triggers";
         };

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -1254,6 +1254,13 @@ bool PatchSelector::keyPressed(const juce::KeyPress &key)
         showClassicMenu();
         return true;
     }
+
+    if (action == Return)
+    {
+        showClassicMenu();
+        return true;
+    }
+
     return false;
 }
 
@@ -1265,7 +1272,7 @@ class PatchSelectorAH : public juce::AccessibilityHandler
                              *sel, juce::AccessibilityRole::label,
                              juce::AccessibilityActions()
                                  .addAction(juce::AccessibilityActionType::press,
-                                            [sel] { sel->openPatchBrowser(); })
+                                            [sel] { sel->showClassicMenu(); })
                                  .addAction(juce::AccessibilityActionType::showMenu,
                                             [sel] { sel->showClassicMenu(); }),
                              {std::make_unique<PatchSelectorValueInterface>(sel)})

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -361,6 +361,9 @@ void OscillatorMenu::loadSnapshot(int type, TiXmlElement *e, int idx)
         auto sc = sge->current_scene;
         sge->oscilatorMenuIndex[sc][sge->current_osc[sc]] = idx;
         sge->undoManager()->pushOscillator(sc, sge->current_osc[sc]);
+
+        auto announce = std::string("Oscillator Type is ") + osc_type_names[type];
+        sge->enqueueAccessibleAnnouncement(announce);
     }
     osc->queue_type = type;
     osc->queue_xmldata = e;


### PR DESCRIPTION
Addresses #5714

- LuaEditor apply re-focuses code
- "Return" on patch selector opens classic menu
- "Press" action on patch selector opens classic menu
- Delay the structure change message to avoid "One Item Updated"
  clobbering the legitmate change on mac VO
- Announce the oscillator change explicitly
- Macro and Step sliders announce value changes on key motion
- Replace "Trigger FEG" with "Trigger Filter Env" since "FEG"
  was pronounced monosylabically by VoiceOver.
- Add option to supress extra narration accesibility to work around
  an oddity where windows can start talking when using the magnifier
- Update surge branch with three menu changes
   - isTicked adds the " (Ticked)" to accessible name
   - hasSubMenu adds " (has SubMenu)" to accessible name Mac only
   - Enter as well as Right Arrow opens a sub menu