### PR TITLE
Accessibility Close to the End

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -60,6 +60,9 @@ enum KeyboardActions
     ZOOM_MINUS_10,
     ZOOM_MINUS_25,
 
+    FOCUS_NEXT_CONTROL_GROUP,
+    FOCUS_PRIOR_CONTROL_GROUP,
+
     REFRESH_SKIN,
     SKIN_LAYOUT_GRID,
 
@@ -136,6 +139,11 @@ inline std::string keyboardActionName(KeyboardActions a)
         return "REFRESH_SKIN";
     case SKIN_LAYOUT_GRID:
         return "SKIN_LAYOUT_GRID";
+
+    case FOCUS_NEXT_CONTROL_GROUP:
+        return "FOCUS_NEXT_CONTROL_GROUP";
+    case FOCUS_PRIOR_CONTROL_GROUP:
+        return "FOCUS_PRIOR_CONTROL_GROUP";
 
     case OPEN_MANUAL:
         return "OPEN_MANUAL";
@@ -247,6 +255,13 @@ inline std::string keyboardActionDescription(KeyboardActions a)
         break;
     case SKIN_LAYOUT_GRID:
         desc = "Toggle Layout Grid";
+        break;
+
+    case FOCUS_NEXT_CONTROL_GROUP:
+        desc = "Move Focus to Next Control Group";
+        break;
+    case FOCUS_PRIOR_CONTROL_GROUP:
+        desc = "Move Focus to Prior Control Group";
         break;
 
     case OPEN_MANUAL:

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -118,7 +118,9 @@ struct PatchStoreDialogCategoryProvider : public Surge::Widgets::TypeAheadDataPr
     std::string textBoxValueForIndex(int idx) override
     {
         if (storage)
+        {
             return storage->patch_category[idx].name;
+        }
         return "";
     }
 };

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -150,6 +150,8 @@ struct PatchSelector : public juce::Component,
     bool isTypeaheadSearchOn{false};
     void toggleTypeAheadSearch(bool);
     void enableTypeAheadIfReady();
+    void searchUpdated();
+    uint32_t outstandingSearches{0};
     std::unique_ptr<Surge::Widgets::TypeAhead> typeAhead;
     std::unique_ptr<PatchDBTypeAheadProvider> patchDbProvider;
 

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -33,6 +33,7 @@ struct TypeAheadDataProvider
     virtual ~TypeAheadDataProvider() = default;
     virtual std::vector<int> searchFor(const std::string &s) = 0;
     virtual std::string textBoxValueForIndex(int idx) = 0;
+    virtual std::string accessibleTextForIndex(int idx) { return textBoxValueForIndex(idx); }
     virtual int getRowHeight() { return 15; }
     virtual int getDisplayedRows() { return 9; }
     virtual void paintDataItem(int searchIndex, juce::Graphics &g, int width, int height,


### PR DESCRIPTION
- Alt . and Alt , navigate between focus groups
- PatchSelector Typeahead has Accesibility
	- 3 second delay to show count
	- navigate the field cleanly
- Category selector accesibilty also correct