### PR TITLE
Rename default macro names for host automation

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -162,19 +162,19 @@ struct SurgeMacroToJuceParamAdapter : public SurgeBaseParam
         : s(s), macroNum(macroNum), range(0.f, 1.f, 0.001f),
           SurgeBaseParam(
 #if SURGE_HAS_JUCE7
-              juce::ParameterID(std::string("macro_") + std::to_string(macroNum), 1),
+              juce::ParameterID(std::string("Macro ") + std::to_string(macroNum + 1), 1),
 #else
-              std::string("macro_") + std::to_string(macroNum),
+              std::string("Macro ") + std::to_string(macroNum + 1),
 #endif
 
-              std::string("C: ") + std::to_string(macroNum), "")
+              std::string("Macro ") + std::to_string(macroNum + 1), "")
     {
         setValueNotifyingHost(getValue());
     }
 
     juce::String getName(int i) const override
     {
-        juce::String res = "C" + std::to_string(macroNum) + ": ";
+        juce::String res = "M" + std::to_string(macroNum + 1) + ": ";
         res += SurgeParamToJuceInfo::getMacroName(s, macroNum);
 
         res = res.substring(0, i);


### PR DESCRIPTION
From "c0:" to "M1" etc.