### PR TITLE
Some more accessible feedback

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -167,14 +167,14 @@ struct SurgeMacroToJuceParamAdapter : public SurgeBaseParam
               std::string("macro_") + std::to_string(macroNum),
 #endif
 
-              std::string("C: ") + std::to_string(macroNum), "")
+              std::string("M") + std::to_string(macroNum + 1), "")
     {
         setValueNotifyingHost(getValue());
     }
 
     juce::String getName(int i) const override
     {
-        juce::String res = "C" + std::to_string(macroNum) + ": ";
+        juce::String res = "M" + std::to_string(macroNum + 1) + ": ";
         res += SurgeParamToJuceInfo::getMacroName(s, macroNum);
 
         res = res.substring(0, i);

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1362,7 +1362,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
                 gui_modsrc[ms]->setCurrentModLabel(
                     synth->storage.getPatch().CustomControllerLabel[ms - ms_ctrl1]);
                 gui_modsrc[ms]->setIsMeta(true);
-                gui_modsrc[ms]->setBipolar(
+                gui_modsrc[ms]->setIsBipolar(
                     synth->storage.getPatch().scene[current_scene].modsources[ms]->is_bipolar());
                 gui_modsrc[ms]->setValue(((ControllerModulationSource *)synth->storage.getPatch()
                                               .scene[current_scene]

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1110,7 +1110,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         if (msb)
                         {
-                            msb->setBipolar(bp);
+                            msb->setIsBipolar(bp);
                         }
 
                         refresh_mod();

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -124,6 +124,7 @@ struct ModulationSideControls : public juce::Component,
         dispL = makeL("Value Display");
         dispW = makeW({"None", "Depths", "Values and Depths", "Values, Depths and Ranges"},
                       tag_value_disp, true, "Value Displays", true);
+        dispW->setAccessible(false);
 
         auto dwv = Surge::Storage::getUserDefaultValue(&(editor->synth->storage),
                                                        Storage::ModListValueDisplay, 3);

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.h
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.h
@@ -88,7 +88,7 @@ struct ModulationSourceButton : public juce::Component,
     }
     bool isMeta{false}, isBipolar{false};
     void setIsMeta(bool b) { isMeta = b; }
-    void setBipolar(bool b) { isBipolar = b; }
+    void setIsBipolar(bool b);
 
     bool containsModSource(modsources ms)
     {


### PR DESCRIPTION
1. Macro VST/CLAP names are "M N : Foo" rather than "C N-1: Foo"
2. The value display control in amcro list is accesible off
3. The macro slider is 01 clamped
4. The macro slider speaks the right value in bipolar mode

Addresses #5714