### PR TITLE
Clap note expression and port tweaks

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1578,10 +1578,11 @@ void SurgeSynthesizer::setNoteExpression(SurgeVoice::NoteExpressionType net, int
     {
         for (auto v : voices[sc])
         {
-            if ((v->state.key == key && v->state.channel == channel) ||
-                (v->originating_host_key >= 0 && v->originating_host_key == key &&
-                 v->originating_host_channel >= 0 && v->originating_host_channel == channel) ||
-                (note_id >= 0 && v->host_note_id == note_id))
+            if ((note_id == -1 &&
+                 ((v->state.key == key && v->state.channel == channel) ||
+                  (v->originating_host_key >= 0 && v->originating_host_key == key &&
+                   v->originating_host_channel >= 0 && v->originating_host_channel == channel))) ||
+                (note_id != -1 && v->host_note_id == note_id))
             {
                 v->applyNoteExpression(net, value);
             }
@@ -3251,7 +3252,11 @@ void SurgeSynthesizer::applyParameterPolyphonicModulation(Parameter *p, int32_t 
 
     for (auto v : voices[p->scene - 1])
     {
-        if (v->host_note_id == note_id)
+        if ((note_id != -1 && v->host_note_id == note_id) ||
+            (note_id == -1 &&
+             (((v->state.key == key && v->state.channel == channel) ||
+               (v->originating_host_key >= 0 && v->originating_host_key == key &&
+                v->originating_host_channel >= 0 && v->originating_host_channel == channel)))))
         {
             v->applyPolyphonicParamModulation(p, depth);
         }


### PR DESCRIPTION
1. Support CLAP_NOTE_DIALECT_NOTE_CLAP properly through extensions
   upgrade
2. Handle polyphonic modulation without a note id since I say I can
   be addressed by channel
3. Make note_id = -1 the sentinel for absent note id as opposed to
   note_id > 0 the sentinel for present note id

Closes #6212