### PR TITLE
Handle an omission on multiple voice starts and polyphony

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -442,7 +442,7 @@ void SurgeSynthesizer::playNote(char channel, char key, char velocity, char detu
 void SurgeSynthesizer::softkillVoice(int s)
 {
     list<SurgeVoice *>::iterator iter, max_playing, max_released;
-    int max_age = 0, max_age_release = 0;
+    int max_age = -1, max_age_release = -1;
     iter = voices[s].begin();
 
     while (iter != voices[s].end())
@@ -467,9 +467,9 @@ void SurgeSynthesizer::softkillVoice(int s)
         }
         iter++;
     }
-    if (max_age_release)
+    if (max_age_release >= 0)
         (*max_released)->uber_release();
-    else if (max_age)
+    else if (max_age >= 0)
         (*max_playing)->uber_release();
 }
 


### PR DESCRIPTION
If you started multiple notes in the exact same block
then the polyphony coutner would not reap them. This meant
defacto that N voice chords hard quantized played N > M
notes at polyphony level M.

Fix this by reaping gated notes which have no age, as opposed
to just gated notes with positive age, if all our notes have
no age.

Closes #6221