### PR TITLE
Fix a problem with SNH Attack

### DIFF
--- a/src/common/dsp/modulators/LFOModulationSource.h
+++ b/src/common/dsp/modulators/LFOModulationSource.h
@@ -115,6 +115,5 @@ class LFOModulationSource : public ModulationSource
     std::default_random_engine gen;
     std::uniform_real_distribution<float> distro;
     std::function<float()> urng;
-    static int urngSeed;
     quadr_osc sinus;
 };


### PR DESCRIPTION
in Deform mode 1, the first and only first modulator
value of SNH was always the same. Remediate this by
(effectively) running forward a few steps on attack.
Do the same for noise, but since noise has a peculiar
phase behaviour, that may be less handy.