### PR TITLE
Start of CLAP non-destructive mods on integers and bools

### DIFF
--- a/src/common/DebugHelpers.h
+++ b/src/common/DebugHelpers.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <chrono>
 
-#define _DBGCOUT std::cout << __func__ << ":" << __LINE__ << "| "
+#define _DBGCOUT std::cout << __FILE__ << ":" << __LINE__ << "|" << __func__ << "| "
 #define _D(x) " " << (#x) << "=" << x
 #define _R(x, y) Surge::Debug::LifeCycleToConsole y(x);
 #define _DUMPR(r)                                                                                  \

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -822,7 +822,27 @@ void SurgePatch::copy_scenedata(pdata *d, int scene)
     {
         auto &pm = monophonicParamModulations[i];
         if (pm.param_id >= s && pm.param_id < s + n_scene_params)
-            d[pm.param_id - s].f += pm.value;
+        {
+            switch (pm.vt_type)
+            {
+            case vt_float:
+                d[pm.param_id - s].f += pm.value;
+                break;
+            case vt_int:
+            {
+                auto v =
+                    std::clamp((int)(round)(d[pm.param_id - s].i + pm.value), pm.imin, pm.imax);
+                d[pm.param_id - s].i = v;
+                break;
+            }
+            case vt_bool:
+                if (pm.value > 0.5) // true + 0.5 is true; false + 0.5 is true
+                    d[pm.param_id - s].b = true;
+                if (pm.value < 0.5)
+                    d[pm.param_id - s].b = false;
+                break;
+            }
+        }
     }
 }
 
@@ -838,7 +858,26 @@ void SurgePatch::copy_globaldata(pdata *d)
     {
         auto &pm = monophonicParamModulations[i];
         if (pm.param_id < n_global_params)
-            d[pm.param_id].f += pm.value;
+        {
+            switch (pm.vt_type)
+            {
+            case vt_float:
+                d[pm.param_id].f += pm.value;
+                break;
+            case vt_int:
+            {
+                auto v = std::clamp((int)(round)(d[pm.param_id].i + pm.value), pm.imin, pm.imax);
+                d[pm.param_id].i = v;
+                break;
+            }
+            case vt_bool:
+                if (pm.value > 0.5) // true + 0.5 is true; false + 0.5 is true
+                    d[pm.param_id].b = true;
+                if (pm.value < 0.5)
+                    d[pm.param_id].b = false;
+                break;
+            }
+        }
     }
 }
 // pdata scenedata[n_scenes][n_scene_params];

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -926,6 +926,10 @@ class SurgePatch
     {
         int32_t param_id{0};
         double value{0};
+        valtypes vt_type{vt_float};
+
+        // Integer modulation is new and doesn't internally clamp so clamp at the modulation edge
+        int imin{0}, imax{1};
     };
     int32_t paramModulationCount{0};
     static constexpr int maxMonophonicParamModulations = 256;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3231,14 +3231,45 @@ void SurgeSynthesizer::applyParameterMonophonicModulation(Parameter *p, float de
     {
         if (pt.monophonicParamModulations[i].param_id == p->id)
         {
-            pt.monophonicParamModulations[i].value = depth * (p->val_max.f - p->val_min.f);
+            pt.monophonicParamModulations[i].vt_type = (valtypes)p->valtype;
+            switch (p->valtype)
+            {
+            case vt_float:
+                pt.monophonicParamModulations[i].value = depth * (p->val_max.f - p->val_min.f);
+                break;
+            case vt_int:
+                pt.monophonicParamModulations[i].value = depth * (p->val_max.i - p->val_min.i);
+                pt.monophonicParamModulations[i].imin = p->val_min.i;
+                pt.monophonicParamModulations[i].imax = p->val_max.i;
+
+                break;
+            case vt_bool:
+                pt.monophonicParamModulations[i].value = depth;
+                break;
+            }
             return;
         }
     }
 
     assert(pt.paramModulationCount < pt.maxMonophonicParamModulations);
     pt.monophonicParamModulations[pt.paramModulationCount].param_id = p->id;
-    pt.monophonicParamModulations[pt.paramModulationCount].value = depth;
+    pt.monophonicParamModulations[pt.paramModulationCount].vt_type = (valtypes)p->valtype;
+    switch (p->valtype)
+    {
+    case vt_float:
+        pt.monophonicParamModulations[pt.paramModulationCount].value =
+            depth * (p->val_max.f - p->val_min.f);
+        break;
+    case vt_int:
+        pt.monophonicParamModulations[pt.paramModulationCount].value =
+            depth * (p->val_max.i - p->val_min.i);
+        pt.monophonicParamModulations[pt.paramModulationCount].imin = p->val_min.i;
+        pt.monophonicParamModulations[pt.paramModulationCount].imax = p->val_max.i;
+        break;
+    case vt_bool:
+        pt.monophonicParamModulations[pt.paramModulationCount].value = depth;
+        break;
+    }
     pt.paramModulationCount++;
     return;
 }

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -247,7 +247,7 @@ class alignas(16) SurgeSynthesizer
     void setMacroParameter01(long macroNum, float val);
     float getMacroParameter01(long macroNum) const;
     void applyMacroMonophonicModulation(long macroNum, float val);
-    ;
+
     void setNoteExpression(SurgeVoice::NoteExpressionType net, int32_t note_id, int16_t key,
                            int16_t channel, float value);
 

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -67,6 +67,9 @@ class alignas(16) SurgeVoice
     {
         int32_t param_id{0};
         double value{0};
+        // see the comments in the monophonic implementation
+        valtypes vt_type{vt_float};
+        int imin{0}, imax{1};
     };
     int32_t paramModulationCount{0};
     static constexpr int maxPolyphonicParamModulations = 64;


### PR DESCRIPTION
This change means that non-destructive and polyphonic modulations
on integers and bools transmits through to surge. Surge, however,
does not read them reliably since they are placed in the mod matrix
and our DSP code has been indifferent to raw param val vs modulation
val access for ints and bools, as surge is not internally integer
and bool modulatable.

As such it starts to, but does not completely, address #6229

This commit makes oscillator octave modulatabple properly in clap