### PR TITLE
Remediate FX .val.i pdata_ival for modulation

### DIFF
--- a/src/common/dsp/effects/MSToolEffect.cpp
+++ b/src/common/dsp/effects/MSToolEffect.cpp
@@ -95,7 +95,7 @@ void MSToolEffect::process(float *dataL, float *dataR)
 
     float M alignas(16)[BLOCK_SIZE], S alignas(16)[BLOCK_SIZE];
 
-    int io = (fxdata->p[mstl_matrix].val.i);
+    int io = *(pdata_ival[mstl_matrix]); // (fxdata->p[mstl_matrix].val.i);
     switch (io)
     {
     case 0:

--- a/src/common/dsp/effects/PhaserEffect.cpp
+++ b/src/common/dsp/effects/PhaserEffect.cpp
@@ -59,7 +59,7 @@ void PhaserEffect::init()
 
 inline void PhaserEffect::init_stages()
 {
-    n_stages = fxdata->p[ph_stages].val.i;
+    n_stages = *(pdata_ival[ph_stages]);
     n_bq_units = n_stages * 2;
 
     if (n_bq_units_initialised < n_bq_units)

--- a/src/common/dsp/effects/Reverb1Effect.cpp
+++ b/src/common/dsp/effects/Reverb1Effect.cpp
@@ -183,8 +183,8 @@ void Reverb1Effect::process(float *dataL, float *dataR)
 {
     float wetL alignas(16)[BLOCK_SIZE], wetR alignas(16)[BLOCK_SIZE];
 
-    if (fxdata->p[rev1_shape].val.i != shape)
-        loadpreset(fxdata->p[rev1_shape].val.i);
+    if (*(pdata_ival[rev1_shape]) != shape)
+        loadpreset(*(pdata_ival[rev1_shape]));
     if ((b == 0) && (fabs(*f[rev1_roomsize] - lastf[rev1_roomsize]) > 0.001f))
         loadpreset(shape);
     //	if(fabs(*f[rev1_variation] - lastf[rev1_variation]) > 0.001f) update_rsize();

--- a/src/common/dsp/effects/VocoderEffect.cpp
+++ b/src/common/dsp/effects/VocoderEffect.cpp
@@ -161,7 +161,7 @@ void VocoderEffect::process(float *dataL, float *dataR)
     {
         setvars(false);
     }
-    modulator_mode = fxdata->p[voc_mod_input].val.i;
+    modulator_mode = *(pdata_ival[voc_mod_input]); // fxdata->p[voc_mod_input].val.i;
     wet = *f[voc_mix];
     float EnvFRate = 0.001f * powf(2.f, 4.f * *f[voc_envfollow]);
 

--- a/src/common/dsp/effects/airwindows/AirWindowsEffect.cpp
+++ b/src/common/dsp/effects/airwindows/AirWindowsEffect.cpp
@@ -185,7 +185,7 @@ void AirWindowsEffect::process(float *dataL, float *dataR)
         hasInvalidated = true;
     }
 
-    if (!airwin || fxdata->p[0].val.i != lastSelected || fxdata->p[0].user_data == nullptr)
+    if (!airwin || *(pdata_ival[0]) != lastSelected || fxdata->p[0].user_data == nullptr)
     {
         /*
         ** So do we want to let Airwindows set params as defaults or do we want
@@ -203,7 +203,7 @@ void AirWindowsEffect::process(float *dataL, float *dataR)
         {
             useStreamedValues = true;
         }
-        setupSubFX(fxdata->p[0].val.i, useStreamedValues);
+        setupSubFX(*(pdata_ival[0]), useStreamedValues);
     }
 
     if (!airwin)


### PR DESCRIPTION
Addresses #6229

Most uses of .val.i were appropriate or assignments but a few
needed to swap to *(pdata_ival)