### PR TITLE
Fix Custom Menus both Key and accessible

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1293,7 +1293,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             auto hmen =
                 std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(p->get_full_name(), lurl);
             hmen->setSkin(currentSkin, bitmapStore);
-            contextMenu.addCustomItem(-1, std::move(hmen));
+            contextMenu.addCustomItem(-1, std::move(hmen), nullptr, p->get_full_name());
 
             contextMenu.addSeparator();
 
@@ -2409,10 +2409,12 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                                 break;
                                                 }
                                             });
+                                    auto comptitle = comp->getTitle();
                                     comp->setSkin(currentSkin, bitmapStore);
                                     comp->setIsMuted(
                                         synth->isModulationMuted(ptag, (modsources)ms, sc, modidx));
-                                    contextMenu.addCustomItem(-1, std::move(comp));
+                                    contextMenu.addCustomItem(-1, std::move(comp), nullptr,
+                                                              comptitle);
                                 }
                             }
                         }
@@ -2462,7 +2464,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                 synth->refresh_editor = true;
                             });
                         allThree->setSkin(currentSkin, bitmapStore);
-                        contextMenu.addCustomItem(-1, std::move(allThree));
+                        auto comptitle = allThree->getTitle();
+
+                        contextMenu.addCustomItem(-1, std::move(allThree), nullptr, comptitle);
                     }
                 }
 

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -160,6 +160,15 @@ void MenuTitleHelpComponent::paint(juce::Graphics &g)
 }
 
 void MenuTitleHelpComponent::mouseUp(const juce::MouseEvent &e) { launchHelp(); }
+bool MenuTitleHelpComponent::keyPressed(const juce::KeyPress &k)
+{
+    if (k.isKeyCode(juce::KeyPress::returnKey) || k.isKeyCode(juce::KeyPress::spaceKey))
+    {
+        launchHelp();
+        return true;
+    }
+    return false;
+}
 
 void MenuTitleHelpComponent::launchHelp()
 {
@@ -200,7 +209,17 @@ void MenuCenteredBoldLabel::paint(juce::Graphics &g)
     auto ft = getLookAndFeel().getPopupMenuFont();
     ft = ft.withHeight(ft.getHeight() - 1).boldened();
     g.setFont(ft);
-    g.setColour(getLookAndFeel().findColour(juce::PopupMenu::ColourIds::textColourId));
+    if (isItemHighlighted())
+    {
+        g.setColour(findColour(juce::PopupMenu::highlightedBackgroundColourId));
+        g.fillRect(r);
+
+        g.setColour(findColour(juce::PopupMenu::highlightedTextColourId));
+    }
+    else
+    {
+        g.setColour(getLookAndFeel().findColour(juce::PopupMenu::ColourIds::textColourId));
+    }
     g.drawText(label, r, juce::Justification::centredTop);
 }
 
@@ -256,6 +275,11 @@ ModMenuCustomComponent::ModMenuCustomComponent(const std::string &s, const std::
     addAndMakeVisible(*tb);
     edit = std::move(tb);
     edit->accLabel = "Edit " + s;
+
+    setAccessible(true);
+    setTitle(std::string("From ") + source + " by " + amount);
+    setDescription(getTitle());
+    setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
 }
 
 ModMenuCustomComponent::~ModMenuCustomComponent() noexcept = default;
@@ -319,6 +343,17 @@ void ModMenuCustomComponent::mouseUp(const juce::MouseEvent &e)
 {
     callback(EDIT);
     triggerMenuItem();
+}
+
+bool ModMenuCustomComponent::keyPressed(const juce::KeyPress &k)
+{
+    if (k.isKeyCode(juce::KeyPress::returnKey) || k.isKeyCode(juce::KeyPress::spaceKey))
+    {
+        callback(EDIT);
+        triggerMenuItem();
+        return true;
+    }
+    return false;
 }
 
 void ModMenuCustomComponent::onSkinChanged()

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -73,6 +73,7 @@ struct MenuTitleHelpComponent : juce::PopupMenu::CustomComponent, Surge::GUI::Sk
     void getIdealSize(int &idealWidth, int &idealHeight) override;
 
     void mouseUp(const juce::MouseEvent &e) override;
+    bool keyPressed(const juce::KeyPress &k) override;
     void paint(juce::Graphics &g) override;
     void onSkinChanged() override;
 
@@ -126,6 +127,7 @@ struct ModMenuCustomComponent : juce::PopupMenu::CustomComponent, Surge::GUI::Sk
     SurgeImage *icons{nullptr};
 
     void mouseUp(const juce::MouseEvent &e) override;
+    bool keyPressed(const juce::KeyPress &k) override;
 
     std::unique_ptr<TinyLittleIconButton> clear, mute, edit;
     std::string source, amount;

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -677,7 +677,7 @@ void FxMenu::populate()
         hmen->setSkin(skin, associatedBitmapStore);
         hmen->setCenterBold(false);
 
-        menu.addCustomItem(-1, std::move(hmen));
+        menu.addCustomItem(-1, std::move(hmen), nullptr, "FX Presets");
     }
 }
 


### PR DESCRIPTION
1. Keyboard selection of custom menus returns
2. Accessible name of custom menus is correct

Addresses #5714

Requires a patch to juce 6.1.6