### PR TITLE
Keyboard for Edit; Edit Keys can follow mouse

### DIFF
--- a/src/common/DebugHelpers.h
+++ b/src/common/DebugHelpers.h
@@ -12,13 +12,8 @@
 
 #define _DBGCOUT std::cout << __FILE__ << ":" << __LINE__ << "|" << __func__ << "| "
 #define _D(x) " " << (#x) << "=" << x
+#define _DTN(x) " typeof:" << (#x) << "=" << typeid(x).name()
 #define _R(x, y) Surge::Debug::LifeCycleToConsole y(x);
-#define _DUMPR(r)                                                                                  \
-    " " << (#r) << "=(L/X=" << r.left << ",T/Y=" << r.top << ")+(W=" << r.getWidth()               \
-        << ",H=" << r.getHeight() << ")+(R=" << r.right << ",B=" << r.bottom << ")"
-#define _DUMPCOL(c)                                                                                \
-    " " << (#c) << "r=" << (int)c.red << " g=" << (int)c.green << " b=" << (int)c.blue             \
-        << " a=" << (int)c.alpha
 
 namespace Surge
 {

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -245,6 +245,10 @@ std::string defaultKeyToString(DefaultKey k)
         r = "fxAssumeFixedBlock";
         break;
 
+    case MenuAndEditKeybindingsFollowKeyboardFocus:
+        r = "menuAndEditKeybindingsFollowKeyboardFocus";
+        break;
+
     case nKeys:
         break;
     }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -67,6 +67,7 @@ enum DefaultKey
     LastPatchPath,
 
     TabKeyArmsModulators,
+    MenuAndEditKeybindingsFollowKeyboardFocus,
 
     InfoWindowPopupOnIdle,
 

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -469,6 +469,11 @@ accessibleEditAction(const juce::KeyPress &key, SurgeStorage *storage)
     if (!storage || !Surge::GUI::allowKeyboardEdits(storage))
         return {None, NoModifier};
 
+    if (storage &&
+        !Surge::Storage::getUserDefaultValue(
+            storage, Surge::Storage::DefaultKey::MenuAndEditKeybindingsFollowKeyboardFocus, true))
+        return {None, NoModifier};
+
     return accessibleEditActionInternal(key);
 }
 

--- a/src/surge-xt/gui/SurgeGUICallbackInterfaces.h
+++ b/src/surge-xt/gui/SurgeGUICallbackInterfaces.h
@@ -34,6 +34,7 @@ struct IComponentTagValue
 
     virtual void startHover(const juce::Point<float> &) {}
     virtual void endHover() {}
+    virtual bool isCurrentlyHovered() { return false; }
 
     juce::Component *asJuceComponent()
     {

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -37,6 +37,8 @@ enum KeyboardActions
     PREV_CATEGORY,
     NEXT_CATEGORY,
 
+    EDIT_PARAM_VALUE,
+
     // TODO: UPDATE WHEN ADDING MORE OSCILLATORS
     OSC_1,
     OSC_2,
@@ -87,6 +89,9 @@ inline std::string keyboardActionName(KeyboardActions a)
         return "FIND_PATCH";
     case FAVORITE_PATCH:
         return "FAVORITE_PATCH";
+
+    case EDIT_PARAM_VALUE:
+        return "EDIT_PARAM_VALUE";
 
     case PREV_PATCH:
         return "PREV_PATCH";
@@ -211,6 +216,10 @@ inline std::string keyboardActionDescription(KeyboardActions a)
     // TODO: FIX SCENE ASSUMPTION
     case TOGGLE_SCENE:
         desc = "Toggle Scene A/B";
+        break;
+
+    case EDIT_PARAM_VALUE:
+        desc = "Edit Parameter Value";
         break;
 
 #if WINDOWS

--- a/src/surge-xt/gui/widgets/ModulatableSlider.h
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.h
@@ -93,6 +93,7 @@ struct ModulatableSlider : public juce::Component,
                         const juce::MouseWheelDetails &wheel) override;
     void startHover(const juce::Point<float> &) override;
     void endHover() override;
+    bool isCurrentlyHovered() override { return isHovered; }
     bool keyPressed(const juce::KeyPress &key) override;
     void focusGained(juce::Component::FocusChangeType cause) override
     {

--- a/src/surge-xt/gui/widgets/MultiSwitch.h
+++ b/src/surge-xt/gui/widgets/MultiSwitch.h
@@ -101,6 +101,7 @@ struct MultiSwitch : public juce::Component,
 
     bool isHovered{false};
     int hoverSelection{0};
+    bool isCurrentlyHovered() override { return isHovered; }
 
     SurgeImage *switchD{nullptr}, *hoverSwitchD{nullptr}, *hoverOnSwitchD{nullptr};
     void setSwitchDrawable(SurgeImage *d) { switchD = d; }


### PR DESCRIPTION
1. Alt-V opens the value editor on a focused component
   which supports value edits.
2. The focused component can be either the keyboard focus
   (the default) or if you opt in, the mouse hover focus.
   This applies to all edit gestures (Shift-F10, Arrow, AltV)

Closes #6233