### PR TITLE
Menu Accessibility Work continues

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2210,7 +2210,8 @@ void SurgeGUIEditor::addHelpHeaderTo(const std::string &lab, const std::string &
     auto tc = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(lab, hu);
 
     tc->setSkin(currentSkin, bitmapStore);
-    m.addCustomItem(-1, std::move(tc));
+    auto ht = tc->getTitle();
+    m.addCustomItem(-1, std::move(tc), nullptr, ht);
 }
 
 void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene, Surge::Widgets::EffectChooser *c)

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -495,7 +495,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(txt, fullyResolvedHelpURL(hu));
         tcomp->setSkin(currentSkin, bitmapStore);
 
-        contextMenu.addCustomItem(-1, std::move(tcomp));
+        auto hment = tcomp->getTitle();
+
+        contextMenu.addCustomItem(-1, std::move(tcomp), nullptr, hment);
 
 #ifdef DEBUG
         if (tag == tag_action_undo || tag == tag_action_redo)
@@ -621,7 +623,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             auto tcomp = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(
                 fmt::format("Osc {:d}", a + 1), lurl);
             tcomp->setSkin(currentSkin, bitmapStore);
-            contextMenu.addCustomItem(-1, std::move(tcomp));
+            auto hment = tcomp->getTitle();
+
+            contextMenu.addCustomItem(-1, std::move(tcomp), nullptr, hment);
 
             contextMenu.addSeparator();
 
@@ -662,8 +666,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             auto tcomp = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(
                 fmt::format("Scene {:c}", 'A' + current_scene), lurl);
             tcomp->setSkin(currentSkin, bitmapStore);
+            auto hment = tcomp->getTitle();
 
-            contextMenu.addCustomItem(-1, std::move(tcomp));
+            contextMenu.addCustomItem(-1, std::move(tcomp), nullptr, hment);
 
             contextMenu.addSeparator();
 
@@ -697,8 +702,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             auto hmen = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(olname, hurl);
             hmen->setSkin(currentSkin, bitmapStore);
+            auto hment = hmen->getTitle();
+
             auto contextMenu = juce::PopupMenu();
-            contextMenu.addCustomItem(-1, std::move(hmen));
+            contextMenu.addCustomItem(-1, std::move(hmen), nullptr, hment);
             contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
                                       Surge::GUI::makeEndHoverCallback(control));
         }
@@ -715,9 +722,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
         auto tcomp =
             std::make_unique<Surge::Widgets::MenuTitleHelpComponent>("Waveshaper Analysis", lurl);
+        auto hment = tcomp->getTitle();
 
         tcomp->setSkin(currentSkin, bitmapStore);
-        contextMenu.addCustomItem(-1, std::move(tcomp));
+        contextMenu.addCustomItem(-1, std::move(tcomp), nullptr, hment);
 
         contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
                                   Surge::GUI::makeEndHoverCallback(control));
@@ -736,9 +744,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
         auto tcomp =
             std::make_unique<Surge::Widgets::MenuTitleHelpComponent>("Filter Analysis", lurl);
+        auto hment = tcomp->getTitle();
 
         tcomp->setSkin(currentSkin, bitmapStore);
-        contextMenu.addCustomItem(-1, std::move(tcomp));
+        contextMenu.addCustomItem(-1, std::move(tcomp), nullptr, hment);
 
         contextMenu.showMenuAsync(popupMenuOptions(control->asJuceComponent(), false),
                                   Surge::GUI::makeEndHoverCallback(control));
@@ -781,7 +790,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 modulatorNameWithIndex(current_scene, modsource, modsource_index, false, false),
                 lurl);
             hmen->setSkin(currentSkin, bitmapStore);
-            contextMenu.addCustomItem(-1, std::move(hmen));
+            auto hment = hmen->getTitle();
+            contextMenu.addCustomItem(-1, std::move(hmen), nullptr, hment);
 
             contextMenu.addSeparator();
 
@@ -974,7 +984,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             modMenu->setSkin(currentSkin, bitmapStore);
                             modMenu->setIsMuted(synth->isModulationMuted(
                                 parameter->id, (modsources)thisms, use_scene, modidx));
-                            contextMenu.addCustomItem(-1, std::move(modMenu));
+                            auto mmt = modMenu->getTitle();
+                            contextMenu.addCustomItem(-1, std::move(modMenu), nullptr, mmt);
                             first_destination = false;
                             n_md++;
                         }
@@ -1051,7 +1062,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             synth->refresh_editor = true;
                         });
                     allThree->setSkin(currentSkin, bitmapStore);
-                    contextMenu.addCustomItem(-1, std::move(allThree));
+                    auto at = allThree->getTitle();
+                    contextMenu.addCustomItem(-1, std::move(allThree), nullptr, at);
                 }
             }
             int sc = limit_range(synth->storage.getPatch().scene_active.val.i, 0, n_scenes - 1);

--- a/src/surge-xt/gui/SurgeJUCEHelpers.h
+++ b/src/surge-xt/gui/SurgeJUCEHelpers.h
@@ -23,7 +23,6 @@ namespace Surge
 {
 namespace GUI
 {
-
 template <typename T>
 inline std::function<void(int)> makeAsyncCallback(T *that, std::function<void(T *, int)> cb)
 {

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -460,3 +460,10 @@ void SurgeJUCELookAndFeel::updateDarkIfNeeded()
         }
     }
 }
+void SurgeJUCELookAndFeel::drawPopupMenuSectionHeaderWithOptions(Graphics &graphics,
+                                                                 const Rectangle<int> &area,
+                                                                 const String &sectionName,
+                                                                 const PopupMenu::Options &options)
+{
+    LookAndFeel_V2::drawPopupMenuSectionHeaderWithOptions(graphics, area, sectionName, options);
+}

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.h
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.h
@@ -47,6 +47,10 @@ class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4, public Surge::GUI::Ski
                            const bool isTicked, const bool hasSubMenu, const juce::String &text,
                            const juce::String &shortcutKeyText, const juce::Drawable *icon,
                            const juce::Colour *const textColourToUse) override;
+    void drawPopupMenuSectionHeaderWithOptions(juce::Graphics &graphics,
+                                               const juce::Rectangle<int> &area,
+                                               const juce::String &sectionName,
+                                               const juce::PopupMenu::Options &options) override;
 
     void drawCornerResizer(juce::Graphics &g, int w, int h, bool, bool) override{};
 

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -2358,7 +2358,9 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
         auto tcomp = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>("MSEG Segment", hurl);
         tcomp->setSkin(skin, associatedBitmapStore);
-        contextMenu.addCustomItem(-1, std::move(tcomp));
+        auto hment = tcomp->getTitle();
+
+        contextMenu.addCustomItem(-1, std::move(tcomp), nullptr, hment);
 
         contextMenu.addSeparator();
 
@@ -3029,8 +3031,9 @@ int32_t MSEGControlRegion::controlModifierClicked(Surge::GUI::IComponentTagValue
         auto tcomp = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(menuName, hurl);
 
         tcomp->setSkin(skin, associatedBitmapStore);
+        auto hment = tcomp->getTitle();
 
-        contextMenu.addCustomItem(-1, std::move(tcomp));
+        contextMenu.addCustomItem(-1, std::move(tcomp), nullptr, hment);
 
         contextMenu.addSeparator();
 

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -1034,7 +1034,7 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
 
         if (!sources.empty() && !targets.empty())
         {
-            men.addSectionHeader("BY SOURCE");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(men, "BY SOURCE");
 
             for (auto s : sources)
                 men.addItem(s, [this, s]() {
@@ -1045,7 +1045,7 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
                 });
 
             men.addColumnBreak();
-            men.addSectionHeader("BY TARGET");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(men, "BY TARGET");
 
             for (auto t : targets)
                 men.addItem(t, [this, t]() {
@@ -1056,7 +1056,8 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
                 });
 
             men.addColumnBreak();
-            men.addSectionHeader("BY TARGET SECTION");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(men,
+                                                                            "BY TARGET SECTION");
 
             for (int t = cg_GLOBAL; t < endCG; ++t)
             {
@@ -1074,7 +1075,7 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
             }
 
             men.addColumnBreak();
-            men.addSectionHeader("BY TARGET SCENE");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(men, "BY TARGET SCENE");
 
             for (int t = 0; t < n_scenes + 1; ++t)
             {
@@ -1114,7 +1115,8 @@ void ModulationSideControls::valueChanged(GUI::IComponentTagValue *c)
         tcomp->setSkin(skin, associatedBitmapStore);
         tcomp->setCenterBold(false);
 
-        men.addCustomItem(-1, std::move(tcomp));
+        auto hment = tcomp->getTitle();
+        men.addCustomItem(-1, std::move(tcomp), nullptr, hment);
 
         men.showMenuAsync(sge->popupMenuOptions());
     }
@@ -1186,8 +1188,9 @@ void ModulationSideControls::showAddSourceMenu()
 
     auto tcomp =
         std::make_unique<Surge::Widgets::MenuTitleHelpComponent>("Add Modulation From", hurl);
+    auto hment = tcomp->getTitle();
     tcomp->setSkin(skin, associatedBitmapStore);
-    men.addCustomItem(-1, std::move(tcomp));
+    men.addCustomItem(-1, std::move(tcomp), nullptr, hment);
     men.addSeparator();
 
     for (int sc = 0; sc < n_scenes; ++sc)
@@ -1276,16 +1279,16 @@ void ModulationSideControls::showAddSourceMenu()
             }
         }
     }
-    men.addSectionHeader("GLOBAL");
+    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(men, "GLOBAL");
     men.addSubMenu("Macros", addMacroSub);
     men.addSubMenu("MIDI", addMIDISub);
     men.addSubMenu("Internal", addMiscSub);
-    men.addSectionHeader("SCENE A");
+    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(men, "SCENE A");
     men.addSubMenu("Voice LFOs", addVLFOASub);
     men.addSubMenu("Scene LFOs", addSLFOASub);
     men.addSubMenu("Envelopes", addEGASub);
     men.addSubMenu("MIDI", addMIDIASub);
-    men.addSectionHeader("SCENE B");
+    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(men, "SCENE B");
     men.addSubMenu("Voice LFOs", addVLFOBSub);
     men.addSubMenu("Scene LFOs", addSLFOBSub);
     men.addSubMenu("Envelopes", addEGBSub);
@@ -1311,8 +1314,9 @@ void ModulationSideControls::showAddTargetMenu()
 
     auto tcomp =
         std::make_unique<Surge::Widgets::MenuTitleHelpComponent>("Add Modulation To", hurl);
+    auto hment = tcomp->getTitle();
     tcomp->setSkin(skin, associatedBitmapStore);
-    men.addCustomItem(-1, std::move(tcomp));
+    men.addCustomItem(-1, std::move(tcomp), nullptr, hment);
     men.addSeparator();
 
     std::array<std::map<int, std::map<int, std::vector<std::pair<int, std::string>>>>, n_scenes + 1>
@@ -1425,13 +1429,14 @@ void ModulationSideControls::showAddTargetMenu()
             switch (si)
             {
             case 0:
-                men.addSectionHeader("GLOBAL");
+                Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(men, "GLOBAL");
                 break;
             default:
                 char ai = 'A';
                 ai += si;
                 ai -= 1;
-                men.addSectionHeader(std::string("SCENE ") + ai);
+                Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                    men, std::string("SCENE ") + ai);
                 break;
             }
         }

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -2198,7 +2198,9 @@ void LFOAndStepDisplay::showLFODisplayPopupMenu(SurgeGUIEditor::OverlayTags tag)
 
     auto hmen = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(olname, hurl);
     hmen->setSkin(skin, associatedBitmapStore);
-    contextMenu.addCustomItem(-1, std::move(hmen));
+    auto hment = hmen->getTitle();
+
+    contextMenu.addCustomItem(-1, std::move(hmen), nullptr, hment);
 
     contextMenu.addSeparator();
 

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -220,12 +220,22 @@ void MenuCenteredBoldLabel::paint(juce::Graphics &g)
     {
         g.setColour(getLookAndFeel().findColour(juce::PopupMenu::ColourIds::textColourId));
     }
-    g.drawText(label, r, juce::Justification::centredTop);
+    if (isSectionHeader)
+        g.drawText(label, r.withTrimmedLeft(5), juce::Justification::centredLeft);
+    else
+        g.drawText(label, r, juce::Justification::centredTop);
 }
 
 void MenuCenteredBoldLabel::addToMenu(juce::PopupMenu &m, const std::string label)
 {
     m.addCustomItem(-1, std::make_unique<MenuCenteredBoldLabel>(label), nullptr, label);
+}
+
+void MenuCenteredBoldLabel::addToMenuAsSectionHeader(juce::PopupMenu &m, const std::string label)
+{
+    auto q = std::make_unique<MenuCenteredBoldLabel>(label);
+    q->isSectionHeader = true;
+    m.addCustomItem(-1, std::move(q), nullptr, label);
 }
 
 //==============================================================================

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -99,7 +99,9 @@ struct MenuCenteredBoldLabel : juce::PopupMenu::CustomComponent
     void paint(juce::Graphics &g) override;
 
     std::string label;
+    bool isSectionHeader{false};
     static void addToMenu(juce::PopupMenu &m, const std::string label);
+    static void addToMenuAsSectionHeader(juce::PopupMenu &m, const std::string label);
 
     std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
 };
@@ -152,6 +154,7 @@ struct ModMenuForAllComponent : ModMenuCustomComponent
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModMenuForAllComponent);
 };
+
 } // namespace Widgets
 } // namespace Surge
 

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -567,7 +567,9 @@ void OscillatorWaveformDisplay::createWTMenuItems(juce::PopupMenu &contextMenu, 
             tc->setSkin(skin, associatedBitmapStore);
             tc->setCenterBold(centerBold);
 
-            contextMenu.addCustomItem(-1, std::move(tc));
+            auto hment = tc->getTitle();
+
+            contextMenu.addCustomItem(-1, std::move(tc), nullptr, hment);
         }
 
         if (add2D3Dswitch)
@@ -1369,9 +1371,11 @@ struct AliasAdditiveEditor : public juce::Component,
             auto tc = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(
                 "Alias Additive Options", hurl);
 
+            auto hment = tc->getTitle();
+
             tc->setSkin(skin, associatedBitmapStore);
 
-            contextMenu.addCustomItem(-1, std::move(tc));
+            contextMenu.addCustomItem(-1, std::move(tc), nullptr, hment);
 
             contextMenu.addSeparator();
         }

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -747,7 +747,8 @@ void PatchSelector::showClassicMenu(bool single_category)
 
         hmen->setSkin(skin, associatedBitmapStore);
         hmen->setCenterBold(false);
-        contextMenu.addCustomItem(-1, std::move(hmen));
+        auto hment = hmen->getTitle();
+        contextMenu.addCustomItem(-1, std::move(hmen), nullptr, hment);
     }
 
     auto o = juce::PopupMenu::Options();


### PR DESCRIPTION
1. Use the 'four arg' version of addCustomCoponent everywhere
   Closes #6238
2. Add a MenuCenteredBoldLabel:;addAsSectionHeader method which
   doesn't center align but gives you an accessible section header
   Addresses #6241
3. Use that to redo the headers in the Modulation List menus