### PR TITLE
Minor UI niggles

### DIFF
--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -323,19 +323,6 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
 
         DataRowEditor(const Datum &d, ModulationListContents *c) : datum(d), contents(c)
         {
-            pencilButton = std::make_unique<ModListIconButton>(0, [this]() {
-                auto sge = contents->editor->ed;
-                auto p = contents->editor->synth->storage.getPatch()
-                             .param_ptr[datum.destination_id + datum.idBase];
-                sge->promptForUserValueEntry(p, pencilButton.get(), datum.source_id,
-                                             datum.source_scene, datum.source_index);
-            });
-            pencilButton->setAccessible(true);
-            pencilButton->setTitle("Edit");
-            pencilButton->setDescription("Edit");
-            pencilButton->setWantsKeyboardFocus(true);
-            addAndMakeVisible(*pencilButton);
-
             clearButton = std::make_unique<ModListIconButton>(1, [this]() {
                 auto me = contents->editor;
                 ModulationEditor::SelfModulationGuard g(me);
@@ -376,6 +363,19 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
             muteButton->setWantsKeyboardFocus(true);
             addAndMakeVisible(*muteButton);
 
+            pencilButton = std::make_unique<ModListIconButton>(0, [this]() {
+                auto sge = contents->editor->ed;
+                auto p = contents->editor->synth->storage.getPatch()
+                             .param_ptr[datum.destination_id + datum.idBase];
+                sge->promptForUserValueEntry(p, pencilButton.get(), datum.source_id,
+                                             datum.source_scene, datum.source_index);
+            });
+            pencilButton->setAccessible(true);
+            pencilButton->setTitle("Edit");
+            pencilButton->setDescription("Edit");
+            pencilButton->setWantsKeyboardFocus(true);
+            addAndMakeVisible(*pencilButton);
+
             surgeLikeSlider = std::make_unique<Surge::Widgets::ModulatableSlider>();
             surgeLikeSlider->setOrientation(Surge::ParamConfig::kHorizontal);
             surgeLikeSlider->setBipolarFn([]() { return true; });
@@ -407,6 +407,7 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
             muteButton->offset = 2;
             muteButton->setTitle("Mute " + accPostfix);
             muteButton->setDescription("Mute " + accPostfix);
+
             if (datum.isMuted)
             {
                 muteButton->setTitle("UnMute " + accPostfix);
@@ -585,12 +586,13 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
             int bY = ((height - bh) / 2) - 1;
             int sY = (height - sh) / 2 + 2;
 
-            pencilButton->setBounds(startX, bY, bh, bh);
-            startX += bh + 2;
             clearButton->setBounds(startX, bY, bh, bh);
             startX += bh + 2;
             muteButton->setBounds(startX, bY, bh, bh);
+            startX += bh + 2;
+            pencilButton->setBounds(startX, bY, bh, bh);
             startX += bh + 70;
+
             surgeLikeSlider->setBounds(startX, sY, 140, sh);
         }
 
@@ -633,16 +635,16 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
 
         void onSkinChanged() override
         {
-            pencilButton->icons = associatedBitmapStore->getImage(IDB_MODMENU_ICONS);
             clearButton->icons = associatedBitmapStore->getImage(IDB_MODMENU_ICONS);
             muteButton->icons = associatedBitmapStore->getImage(IDB_MODMENU_ICONS);
+            pencilButton->icons = associatedBitmapStore->getImage(IDB_MODMENU_ICONS);
             surgeLikeSlider->setSkin(skin, associatedBitmapStore);
         }
 
         bool muted{false};
-        std::unique_ptr<ModListIconButton> pencilButton;
         std::unique_ptr<ModListIconButton> clearButton;
         std::unique_ptr<ModListIconButton> muteButton;
+        std::unique_ptr<ModListIconButton> pencilButton;
         std::unique_ptr<Surge::Widgets::ModulatableSlider> surgeLikeSlider;
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DataRowEditor);
     };

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -223,7 +223,7 @@ void MenuCenteredBoldLabel::paint(juce::Graphics &g)
     if (isSectionHeader)
         g.drawText(label, r.withTrimmedLeft(5), juce::Justification::centredLeft);
     else
-        g.drawText(label, r, juce::Justification::centredTop);
+        g.drawText(label, r, juce::Justification::centred);
 }
 
 void MenuCenteredBoldLabel::addToMenu(juce::PopupMenu &m, const std::string label)


### PR DESCRIPTION
MenuCenteredBoldLabel centers vertically when "not section header" instead of to top

In Mod List, put pencil button after clear and mute buttons, like in parameter context menu