### PR TITLE
Several UX tweaks

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6711,8 +6711,7 @@ void SurgeGUIEditor::setupKeymapManager()
 
     keyMapManager->addBinding(Surge::GUI::UNDO, {keymap_t::Modifiers::COMMAND, (int)'Z'});
     keyMapManager->addBinding(Surge::GUI::REDO, {keymap_t::Modifiers::COMMAND, (int)'Y'});
-    keyMapManager->addBinding(Surge::GUI::EDIT_PARAM_VALUE,
-                              {keymap_t::Modifiers::COMMAND, (int)'V'});
+    keyMapManager->addBinding(Surge::GUI::EDIT_PARAM_VALUE, {keymap_t::Modifiers::ALT, (int)'V'});
 
     keyMapManager->addBinding(Surge::GUI::PREV_PATCH,
                               {keymap_t::Modifiers::COMMAND, juce::KeyPress::leftKey});

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -37,8 +37,6 @@ enum KeyboardActions
     PREV_CATEGORY,
     NEXT_CATEGORY,
 
-    EDIT_PARAM_VALUE,
-
     // TODO: UPDATE WHEN ADDING MORE OSCILLATORS
     OSC_1,
     OSC_2,
@@ -55,6 +53,8 @@ enum KeyboardActions
     SHOW_MODLIST,
     SHOW_TUNING_EDITOR,
     TOGGLE_VIRTUAL_KEYBOARD,
+
+    EDIT_PARAM_VALUE,
 
     ZOOM_TO_DEFAULT,
     ZOOM_PLUS_10,
@@ -270,7 +270,7 @@ inline std::string keyboardActionDescription(KeyboardActions a)
         desc = "Move Focus to Next Control Group";
         break;
     case FOCUS_PRIOR_CONTROL_GROUP:
-        desc = "Move Focus to Prior Control Group";
+        desc = "Move Focus to Previous Control Group";
         break;
 
     case OPEN_MANUAL:

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -545,11 +545,16 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
 
 void OscillatorWaveformDisplay::createWTMenu(const bool useComponentBounds = true)
 {
-    auto contextMenu = juce::PopupMenu();
+    bool usesWT = uses_wavetabledata(oscdata->type.val.i);
 
-    createWTMenuItems(contextMenu, true, true);
+    if (usesWT)
+    {
+        auto contextMenu = juce::PopupMenu();
 
-    contextMenu.showMenuAsync(sge->popupMenuOptions(useComponentBounds ? this : nullptr));
+        createWTMenuItems(contextMenu, true, true);
+
+        contextMenu.showMenuAsync(sge->popupMenuOptions(useComponentBounds ? this : nullptr));
+    }
 }
 
 void OscillatorWaveformDisplay::createWTMenuItems(juce::PopupMenu &contextMenu, bool centerBold,


### PR DESCRIPTION
1. Shortcut for Edit Parameter Value is Alt+V not Ctrl+V (Ctrl+V is commonly used for "paste")
2. Right click context menu that shows wavetable info and 2D/3D switch only shows for oscillators that use WT (it used to bleed through if you right click on Alias additive editor EDIT button)