### PR TITLE
Adjust height of Alias additive editor

### DIFF
--- a/src/surge-xt/gui/widgets/EffectChooser.h
+++ b/src/surge-xt/gui/widgets/EffectChooser.h
@@ -80,6 +80,8 @@ struct EffectChooser : public juce::Component,
         repaint();
     }
 
+    bool isCurrentlyHovered() override { return (currentHover >= 0) || (currentSceneHover >= 0); }
+
     void resized() override;
 
     // State for mouse events

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -227,7 +227,7 @@ LFOAndStepDisplay::LFOAndStepDisplay(SurgeGUIEditor *e)
     auto l0 =
         std::make_unique<OverlayAsAccessibleSlider<LFOAndStepDisplay>>(this, "Loop Start Point");
     l0->min = 0;
-    l0->max = 16;
+    l0->max = n_stepseqsteps;
     l0->step = 1;
     l0->onGetValue = [this](auto *) { return ss->loop_start; };
     l0->onSetValue = [this](auto *, float f) {
@@ -257,7 +257,7 @@ LFOAndStepDisplay::LFOAndStepDisplay(SurgeGUIEditor *e)
 
     l0 = std::make_unique<OverlayAsAccessibleSlider<LFOAndStepDisplay>>(this, "Loop End Point");
     l0->min = 0;
-    l0->max = 16;
+    l0->max = n_stepseqsteps;
     l0->step = 1;
     l0->onGetValue = [this](auto *) { return ss->loop_end; };
     l0->onSetValue = [this](auto *, float f) {
@@ -1506,6 +1506,9 @@ void LFOAndStepDisplay::setStepValue(const juce::MouseEvent &event)
 
         float rx0 = r.getX();
         float rx1 = r.getX() + r.getWidth();
+        float ry0 = r.getY();
+        float ry1 = r.getY() + r.getHeight();
+
         if (event.position.x >= rx0 && event.position.x < rx1)
         {
             auto bscg = BeginStepGuard(this);
@@ -1773,8 +1776,8 @@ void LFOAndStepDisplay::mouseExit(const juce::MouseEvent &event)
     {
         enterExitWaveform(false);
     }
-    overWaveform = false;
-    repaint();
+
+    endHover();
 }
 
 void LFOAndStepDisplay::enterExitWaveform(bool isInWF)
@@ -2048,7 +2051,7 @@ void LFOAndStepDisplay::mouseUp(const juce::MouseEvent &event)
             quantStep = storage->currentScale.count;
         }
 
-        for (int i = 0; i < 16; ++i)
+        for (int i = 0; i < n_stepseqsteps; ++i)
         {
             if (steprect[i].contains(rmStepStart))
             {

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -126,11 +126,12 @@ struct LFOAndStepDisplay : public juce::Component,
         repaint();
     }
 
-    void focusLost(juce::Component::FocusChangeType cause) override
+    bool isCurrentlyHovered() override
     {
-        endHover();
-        repaint();
+        return (lfoTypeHover >= 0) || (stepSeqShiftHover >= 0) || overWaveform;
     }
+
+    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
 
     struct BeginStepGuard
     {

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
@@ -123,6 +123,7 @@ struct MenuForDiscreteParams : public juce::Component,
         isHovered = true;
         repaint();
     }
+
     void endHover() override
     {
         if (stuckHover)
@@ -138,17 +139,16 @@ struct MenuForDiscreteParams : public juce::Component,
         repaint();
     }
 
+    bool isCurrentlyHovered() override { return isHovered; }
+
     bool keyPressed(const juce::KeyPress &key) override;
+
     void focusGained(juce::Component::FocusChangeType cause) override
     {
         startHover(getBounds().getBottomLeft().toFloat());
-        repaint();
     }
-    void focusLost(juce::Component::FocusChangeType cause) override
-    {
-        endHover();
-        repaint();
-    }
+
+    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
 
     juce::Point<int> mouseDownOrigin;
     bool isDraggingGlyph{false};

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.h
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.h
@@ -153,21 +153,20 @@ struct ModulationSourceButton : public juce::Component,
 
     bool isHovered{false};
 
+    bool isCurrentlyHovered() override { return isHovered; }
+
     void mouseEnter(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override;
     void startHover(const juce::Point<float> &f) override;
     void endHover() override;
     bool keyPressed(const juce::KeyPress &key) override;
+
     void focusGained(juce::Component::FocusChangeType cause) override
     {
         startHover(getBounds().getBottomLeft().toFloat());
-        repaint();
     }
-    void focusLost(juce::Component::FocusChangeType cause) override
-    {
-        endHover();
-        repaint();
-    }
+
+    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
 
     void onSkinChanged() override;
 

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -251,6 +251,8 @@ void MultiSwitch::startHover(const juce::Point<float> &p)
 
     isHovered = true;
     hoverSelection = coordinateToSelection(p.x, p.y);
+
+    repaint();
 }
 
 void MultiSwitch::mouseExit(const juce::MouseEvent &event) { endHover(); }

--- a/src/surge-xt/gui/widgets/MultiSwitch.h
+++ b/src/surge-xt/gui/widgets/MultiSwitch.h
@@ -87,13 +87,10 @@ struct MultiSwitch : public juce::Component,
     {
         // fixme - probably use the location of the current element
         startHover(valueToCoordinate(getValue()));
-        repaint();
     }
-    void focusLost(juce::Component::FocusChangeType cause) override
-    {
-        endHover();
-        repaint();
-    }
+
+    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
+
     bool keyPressed(const juce::KeyPress &key) override;
     Surge::GUI::WheelAccumulationHelper wheelHelper;
     void mouseWheelMove(const juce::MouseEvent &event,

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -69,14 +69,21 @@ void NumberField::paint(juce::Graphics &g)
     jassert(skin);
 
     bg->draw(g, 1.0);
-    if (bgHover && isHover)
+
+    if (bgHover && isHovered)
+    {
         bgHover->draw(g, 1.0);
+    }
 
     g.setFont(skin->getFont(Fonts::Widgets::NumberField));
 
     g.setColour(textColour);
-    if (isHover)
+
+    if (isHovered)
+    {
         g.setColour(textHoverColour);
+    }
+
     g.drawText(valueToDisplay(), getLocalBounds(), juce::Justification::centred);
 }
 

--- a/src/surge-xt/gui/widgets/NumberField.h
+++ b/src/surge-xt/gui/widgets/NumberField.h
@@ -98,41 +98,45 @@ struct NumberField : public juce::Component,
 
     Surge::GUI::WheelAccumulationHelper wheelAccumulationHelper;
 
-    bool isHover{false};
+    bool isHovered{false};
+
     void mouseEnter(const juce::MouseEvent &event) override
     {
         startHover(event.position);
         setMouseCursor(juce::MouseCursor::UpDownResizeCursor);
     }
+
     void mouseExit(const juce::MouseEvent &event) override
     {
         endHover();
         setMouseCursor(juce::MouseCursor::NormalCursor);
     }
+
     void startHover(const juce::Point<float> &p) override
     {
-        isHover = true;
+        isHovered = true;
         repaint();
     }
+
     void endHover() override
     {
         if (stuckHover)
             return;
 
-        isHover = false;
+        isHovered = false;
         repaint();
     }
+
+    bool isCurrentlyHovered() override { return isHovered; }
+
     bool keyPressed(const juce::KeyPress &key) override;
+
     void focusGained(juce::Component::FocusChangeType cause) override
     {
         startHover(getBounds().getBottomLeft().toFloat());
-        repaint();
     }
-    void focusLost(juce::Component::FocusChangeType cause) override
-    {
-        endHover();
-        repaint();
-    }
+
+    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
 
     juce::Colour textColour, textHoverColour;
     void setTextColour(juce::Colour c)

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
@@ -94,6 +94,11 @@ struct OscillatorWaveformDisplay : public juce::Component,
     bool isCustomEditorHovered{false}, isJogRHovered{false}, isJogLHovered{false},
         isWtNameHovered{false};
 
+    /*     bool isCurrentlyHovered() override
+        {
+            return isCustomEditorHovered || isJogRHovered || isJogLHovered || isWtNameHovered;
+        } */
+
     juce::Rectangle<float> customEditorBox;
     bool supportsCustomEditor();
     void showCustomEditor();

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -116,6 +116,8 @@ struct PatchSelector : public juce::Component,
     void mouseEnter(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override { endHover(); }
 
+    bool isCurrentlyHovered() override { return favoritesHover || searchHover || browserHover; }
+
     void endHover() override
     {
         if (stuckHover)
@@ -128,6 +130,7 @@ struct PatchSelector : public juce::Component,
         // toggleCommentTooltip(false);
         repaint();
     }
+
     bool keyPressed(const juce::KeyPress &key) override;
     void showClassicMenu(bool singleCategory = false);
     bool optionallyAddFavorites(juce::PopupMenu &into, bool addColumnBreakAndHeader,

--- a/src/surge-xt/gui/widgets/Switch.h
+++ b/src/surge-xt/gui/widgets/Switch.h
@@ -74,6 +74,7 @@ struct Switch : public juce::Component, public WidgetBaseMixin<Switch>, public L
     void mouseDown(const juce::MouseEvent &event) override;
     void mouseEnter(const juce::MouseEvent &event) override;
     void mouseExit(const juce::MouseEvent &event) override;
+
     void endHover() override
     {
         if (stuckHover)
@@ -88,18 +89,17 @@ struct Switch : public juce::Component, public WidgetBaseMixin<Switch>, public L
         isHovered = true;
         repaint();
     }
+
+    bool isCurrentlyHovered() override { return isHovered; }
+
     bool keyPressed(const juce::KeyPress &key) override;
 
     void focusGained(juce::Component::FocusChangeType cause) override
     {
         startHover(getBounds().getBottomLeft().toFloat());
-        repaint();
     }
-    void focusLost(juce::Component::FocusChangeType cause) override
-    {
-        endHover();
-        repaint();
-    }
+
+    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
 
     SurgeStorage *storage{nullptr};
     void setStorage(SurgeStorage *s) { storage = s; }

--- a/src/surge-xt/gui/widgets/WaveShaperSelector.h
+++ b/src/surge-xt/gui/widgets/WaveShaperSelector.h
@@ -87,17 +87,17 @@ struct WaveShaperSelector : public juce::Component,
         isWaveHovered = true;
         repaint();
     }
+
+    bool isCurrentlyHovered() override { return isLabelHovered || isWaveHovered; }
+
     bool keyPressed(const juce::KeyPress &key) override;
+
     void focusGained(juce::Component::FocusChangeType cause) override
     {
         startHover(getBounds().getBottomLeft().toFloat());
-        repaint();
     }
-    void focusLost(juce::Component::FocusChangeType cause) override
-    {
-        endHover();
-        repaint();
-    }
+
+    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
 
     void jog(int by);
 

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
@@ -154,6 +154,7 @@ struct OscillatorMenu : public juce::Component,
         isHovered = true;
         repaint();
     }
+
     void endHover() override
     {
         if (stuckHover)
@@ -162,17 +163,17 @@ struct OscillatorMenu : public juce::Component,
         isHovered = false;
         repaint();
     }
+
+    bool isCurrentlyHovered() override { return isHovered; }
+
     bool keyPressed(const juce::KeyPress &key) override;
+
     void focusGained(juce::Component::FocusChangeType cause) override
     {
         startHover(getBounds().getBottomLeft().toFloat());
-        repaint();
     }
-    void focusLost(juce::Component::FocusChangeType cause) override
-    {
-        endHover();
-        repaint();
-    }
+
+    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
 
     bool text_allcaps{false};
     juce::Font::FontStyleFlags font_style{juce::Font::plain};
@@ -240,6 +241,7 @@ struct FxMenu : public juce::Component, public XMLMenuPopulator, public WidgetBa
         isHovered = true;
         repaint();
     }
+
     void endHover() override
     {
         if (stuckHover)
@@ -248,12 +250,17 @@ struct FxMenu : public juce::Component, public XMLMenuPopulator, public WidgetBa
         isHovered = false;
         repaint();
     }
+
+    bool isCurrentlyHovered() override { return isHovered; }
+
     bool keyPressed(const juce::KeyPress &key) override;
+
     void focusGained(juce::Component::FocusChangeType cause) override
     {
         startHover(getBounds().getBottomLeft().toFloat());
         repaint();
     }
+
     void focusLost(juce::Component::FocusChangeType cause) override
     {
         endHover();


### PR DESCRIPTION
...because it looked bad in Royal Surge skin. Plus now it has the same height as waveform display, so switching between the two modes looks nice, actually.

Also addressed #6244 by fixing some cases of Shift+F10 not working, and adding the required method elsewhere (but for some reason it's not working in those other cases)