### PR TITLE
A couple of step seq out of bounds edit fixes

### DIFF
--- a/src/surge-xt/gui/SurgeGUIUtils.cpp
+++ b/src/surge-xt/gui/SurgeGUIUtils.cpp
@@ -60,8 +60,8 @@ bool allowKeyboardEdits(SurgeStorage *storage)
  * Returns true if the two lines (p0-p1 and p2-p3) intersect.
  * In addition, if the lines intersect, the intersection point may be stored to floats i_x and i_y.
  */
-bool get_line_intersection(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
-                           float p3_x, float p3_y, float *i_x, float *i_y)
+bool getLineIntersection(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
+                         float p3_x, float p3_y, float *i_x, float *i_y)
 {
     float s1_x, s1_y, s2_x, s2_y;
     float s, t;
@@ -78,12 +78,46 @@ bool get_line_intersection(float p0_x, float p0_y, float p1_x, float p1_y, float
     {
         // Collision detected
         if (i_x != NULL)
+        {
             *i_x = p0_x + (t * s1_x);
+        }
+
         if (i_y != NULL)
+        {
             *i_y = p0_y + (t * s1_y);
+        }
+
         return true;
     }
+
     return false; // No collision
+}
+
+void constrainPointOnLineWithinRectangle(const juce::Rectangle<float> rect,
+                                         const juce::Line<float> l, juce::Point<float> &p)
+{
+    auto th = juce::Line<float>{rect.getTopLeft(), rect.getTopRight()};
+    auto bh = juce::Line<float>{rect.getBottomLeft(), rect.getBottomRight()};
+    auto lv = juce::Line<float>{rect.getTopLeft(), rect.getBottomLeft()};
+    auto rv = juce::Line<float>{rect.getTopRight(), rect.getBottomRight()};
+    juce::Point<float> pt;
+
+    if (l.intersects(th, pt))
+    {
+        p = pt;
+    }
+    else if (l.intersects(bh, pt))
+    {
+        p = pt;
+    }
+    else if (l.intersects(lv, pt))
+    {
+        p = pt;
+    }
+    else if (l.intersects(rv, pt))
+    {
+        p = pt;
+    }
 }
 
 void openFileOrFolder(const std::string &f)

--- a/src/surge-xt/gui/SurgeGUIUtils.h
+++ b/src/surge-xt/gui/SurgeGUIUtils.h
@@ -2,6 +2,7 @@
 
 #include "SurgeStorage.h"
 #include "UserDefaults.h"
+#include "juce_gui_basics/juce_gui_basics.h"
 
 namespace Surge
 {
@@ -11,8 +12,11 @@ extern bool showCursor(SurgeStorage *storage);
 extern bool allowKeyboardEdits(SurgeStorage *storage);
 extern bool isTouchMode(SurgeStorage *storage);
 
-bool get_line_intersection(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
-                           float p3_x, float p3_y, float *i_x, float *i_y);
+bool getLineIntersection(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
+                         float p3_x, float p3_y, float *i_x, float *i_y);
+
+void constrainPointOnLineWithinRectangle(const juce::Rectangle<float> rect,
+                                         const juce::Line<float> l, juce::Point<float> &p);
 
 void openFileOrFolder(const std::string &f);
 inline void openFileOrFolder(const fs::path &f) { openFileOrFolder(path_to_string(f)); }

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1309,29 +1309,9 @@ void LFOAndStepDisplay::paintStepSeq(juce::Graphics &g)
     if (dragMode == ARROW)
     {
         auto l = juce::Line<float>{arrowStart, arrowEnd};
-        juce::Point<float> p;
 
-        auto th = juce::Line<float>{rect_steps.getTopLeft(), rect_steps.getTopRight()};
-        auto bh = juce::Line<float>{rect_steps.getBottomLeft(), rect_steps.getBottomRight()};
-        auto lv = juce::Line<float>{rect_steps.getTopLeft(), rect_steps.getBottomLeft()};
-        auto rv = juce::Line<float>{rect_steps.getTopRight(), rect_steps.getBottomRight()};
+        Surge::GUI::constrainPointOnLineWithinRectangle(rect_steps, l, arrowEnd);
 
-        if (l.intersects(th, p))
-        {
-            arrowEnd = p;
-        }
-        else if (l.intersects(bh, p))
-        {
-            arrowEnd = p;
-        }
-        else if (l.intersects(lv, p))
-        {
-            arrowEnd = p;
-        }
-        else if (l.intersects(rv, p))
-        {
-            arrowEnd = p;
-        }
         l = juce::Line<float>{arrowStart, arrowEnd};
 
         auto ph = juce::Path();
@@ -1987,7 +1967,7 @@ void LFOAndStepDisplay::mouseDrag(const juce::MouseEvent &event)
             auto r = gaterect[i];
             auto otm = ss->trigmask;
 
-            if (r.contains(event.position))
+            if (event.position.x >= r.getX() && event.position.x < r.getX() + r.getWidth())
             {
                 auto off = UINT64_MAX & ~(UINT64_C(1) << i) & ~(UINT64_C(1) << (i + 16)) &
                            ~(UINT64_C(1) << (i + 32));
@@ -2034,6 +2014,10 @@ void LFOAndStepDisplay::mouseUp(const juce::MouseEvent &event)
 
     if (dragMode == ARROW)
     {
+        auto l = juce::Line<float>{arrowStart, arrowEnd};
+
+        Surge::GUI::constrainPointOnLineWithinRectangle(rect_steps, l, arrowEnd);
+
         auto rmStepStart = arrowStart;
         auto rmStepCurr = arrowEnd;
 
@@ -2058,7 +2042,9 @@ void LFOAndStepDisplay::mouseUp(const juce::MouseEvent &event)
                 startStep = i;
             }
 
-            if (steprect[i].contains(rmStepCurr))
+            // we expand steprect so that we accept edge points on the rectangle
+            // since .contains() only checks if a point is within the rect, not ON its edges
+            if (steprect[i].expanded(1, 1).contains(rmStepCurr))
             {
                 endStep = i;
             }


### PR DESCRIPTION
First, when sweep dragging step seq triggers, these were constrained to just trigger rects. Update this so that we use event.pos.x so even if mouse leaves the trigger rects, the edits will apply.

Second, right mouse arrow drag in step seq would not be applied if mouse was released out of bounds. Fix this by applying the same point on line within rectangle constrant as done in paintStepSeq(). Abstract that into a method in SurgeGUIUtils.