### PR TITLE
Fix a problem with CLAP Modulator Stacking

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1417,8 +1417,12 @@ void SurgeVoice::freeAllocatedElements()
     }
 }
 
-void SurgeVoice::applyPolyphonicParamModulation(Parameter *p, double value)
+void SurgeVoice::applyPolyphonicParamModulation(Parameter *p, double value,
+                                                double underlyingMonoMod)
 {
+    // For a discussion of underlyingMonoMod please see the comment in
+    // SurgeSynthesizer::applyParameterPolyphonicModulation
+
     // quickly do a search to see if i'm there
     int param_id = p->param_id_in_scene;
     for (int i = 0; i < paramModulationCount; ++i)
@@ -1441,6 +1445,7 @@ void SurgeVoice::applyPolyphonicParamModulation(Parameter *p, double value)
                 pp.value = value;
             }
 
+            pp.value -= underlyingMonoMod;
             return;
         }
     }
@@ -1465,6 +1470,7 @@ void SurgeVoice::applyPolyphonicParamModulation(Parameter *p, double value)
             pp.value = value;
         }
 
+        pp.value -= underlyingMonoMod;
         paramModulationCount++;
     }
 }

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -74,7 +74,8 @@ class alignas(16) SurgeVoice
     int32_t paramModulationCount{0};
     static constexpr int maxPolyphonicParamModulations = 64;
     std::array<PolyphonicParamModulation, maxPolyphonicParamModulations> polyphonicParamModulations;
-    void applyPolyphonicParamModulation(Parameter *, double value);
+    // See comment in SurgeSynthesizer::applyParameterPolyphonicModulation for why this has 2 args
+    void applyPolyphonicParamModulation(Parameter *, double value, double underlyingMonoMod);
 
     enum NoteExpressionType
     {


### PR DESCRIPTION
The CLAP spec states clearly that a polyphonic modulation event
*includes* any monophonic modulation events for a given parameter
so targeting a particular voice should use only the poly event
not the sum. Surge modulators are stacking, so take the easy approach
of back out any global mono modulators from poly modulators at modulation
time.