### PR TITLE
Send Param Automation for Filter Subtypes

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -3171,6 +3171,10 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                 h->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
         }
 
+        SurgeSynthesizer::ID ptagid;
+        if (synth->fromSynthSideId(tag - start_paramtags, ptagid))
+            synth->sendParameterAutomation(ptagid, synth->getParameter01(ptagid));
+
         if (bvf)
             bvf->repaint();
         synth->switch_toggled_queued = true;


### PR DESCRIPTION
Paramter Automation messages were not sent because
basically filter subtypes are kinda screwed in how we
implement them both GUI wise and model wise. It's all a hack.
Anyway added an explicit send automation call and now when you
toggle through with clicks you end up getting the DAW showing changes.

My theory is this is the problem in #6264 but will wait for user
confirm before we close it.