### PR TITLE
Restore mouse-click to select typeahead

### DIFF
--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -134,6 +134,8 @@ struct TypeAheadListBoxModel : public juce::ListBoxModel
 #endif
         }
 
+        void mouseUp(const juce::MouseEvent &e) override { model->returnKeyPressed(row); }
+
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TARow);
     };
 


### PR DESCRIPTION
The accesibility changes meant the new top component ate
the click. So don't eat the click any more

Closes #6266