### PR TITLE
A few virtual keyboard improvements

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1680,6 +1680,9 @@ void SurgeSynthesizer::pitchBend(char channel, int value)
     {
         storage.pitch_bend = value / 8192.f;
 
+        pitchbendMIDIVal = value;
+        hasUpdatedMidiCC = true;
+
         for (int sc = 0; sc < n_scenes; sc++)
         {
             ((ControllerModulationSource *)storage.getPatch().scene[sc].modsources[ms_pitchbend])
@@ -1838,6 +1841,9 @@ void SurgeSynthesizer::channelController(char channel, int cc, int value)
             ((ControllerModulationSource *)storage.getPatch().scene[sc].modsources[ms_modwheel])
                 ->set_target(fval);
         }
+
+        modwheelCC = value;
+        hasUpdatedMidiCC = true;
         break;
     case 2:
         for (int sc = 0; sc < n_scenes; sc++)
@@ -1894,6 +1900,9 @@ void SurgeSynthesizer::channelController(char channel, int cc, int value)
             ((ControllerModulationSource *)storage.getPatch().scene[sc].modsources[ms_sustain])
                 ->set_target(fval);
         }
+
+        sustainpedalCC = value;
+        hasUpdatedMidiCC = true;
 
         channelState[channel].hold = value > 63; // check hold pedal
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -380,6 +380,8 @@ class alignas(16) SurgeSynthesizer
 
     // updated in audio thread, read from UI, so have assignments be atomic
     std::atomic<int> polydisplay;
+    std::atomic<int> hasUpdatedMidiCC;
+    std::atomic<int> modwheelCC, pitchbendMIDIVal, sustainpedalCC;
 
     float vu_peak[8];
 

--- a/src/surge-xt/SurgeSynthEditor.h
+++ b/src/surge-xt/SurgeSynthEditor.h
@@ -79,7 +79,8 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     bool drawExtendedControls{false};
     int midiKeyboardOctave{5};
     float midiKeyboardVelocity{96.f / 127.f};
-    std::unique_ptr<juce::Component> pitchwheel, modwheel;
+    void setPitchModSustainGUI(int pitch, int mod, int sus);
+    std::unique_ptr<juce::Component> pitchwheel, modwheel, suspedal;
     std::unique_ptr<juce::MidiKeyboardComponent> keyboard;
     std::unique_ptr<juce::Label> tempoLabel;
     std::unique_ptr<juce::TextEditor> tempoTypein;

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -393,6 +393,10 @@ void SurgeSynthProcessor::processBlockMidiFromGUI()
         {
             surge->channelController(rec.ch, 1, rec.cval);
         }
+        if (rec.type == midiR::SUSPEDAL)
+        {
+            surge->channelController(rec.ch, 64, rec.cval);
+        }
     }
 }
 

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -296,6 +296,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
             NOTE,
             MODWHEEL,
             PITCHWHEEL,
+            SUSPEDAL,
         } type{NOTE};
         int ch{0}, note{0}, vel{0};
         bool on{false};

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -506,6 +506,13 @@ void SurgeGUIEditor::idle()
             accAnnounceStrings.pop_front();
     }
 
+    if (getShowVirtualKeyboard() && synth->hasUpdatedMidiCC)
+    {
+        synth->hasUpdatedMidiCC = false;
+        juceEditor->setPitchModSustainGUI(synth->pitchbendMIDIVal, synth->modwheelCC,
+                                          synth->sustainpedalCC);
+    }
+
     if (errorItemCount)
     {
         std::vector<std::pair<std::string, std::string>> cp;


### PR DESCRIPTION
1. The widgets stay synced with the midi stream; wiggle your
   mod wheel and the vkb mod wheel wiggles!
2. There's a sustain pedal button below the wheels which
   works both as sending sustain and recieving it from midi

Closes #6246