### PR TITLE
Revert "Change default MIDI/MPE bend smoothing to fast linear (#6305)"

### DIFF
--- a/src/common/ModulationSource.h
+++ b/src/common/ModulationSource.h
@@ -317,7 +317,7 @@ template <int NDX = 1> class ControllerModulationSourceVector : public Modulatio
 {
   public:
     // Smoothing and Shaping Behaviors
-    Modulator::SmoothingMode smoothingMode = Modulator::SmoothingMode::FAST_LINE;
+    Modulator::SmoothingMode smoothingMode = Modulator::SmoothingMode::LEGACY;
 
     ControllerModulationSourceVector()
     {
@@ -327,7 +327,7 @@ template <int NDX = 1> class ControllerModulationSourceVector : public Modulatio
             value[i] = 0.f;
             changed[i] = true;
         }
-        smoothingMode = Modulator::SmoothingMode::FAST_LINE;
+        smoothingMode = Modulator::SmoothingMode::LEGACY;
         bipolar = false;
     }
     ControllerModulationSourceVector(Modulator::SmoothingMode mode)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1361,8 +1361,8 @@ class alignas(16) SurgeStorage
         return res;
     }
 
-    Modulator::SmoothingMode smoothingMode = Modulator::SmoothingMode::FAST_LINE;
-    Modulator::SmoothingMode pitchSmoothingMode = Modulator::SmoothingMode::FAST_LINE;
+    Modulator::SmoothingMode smoothingMode = Modulator::SmoothingMode::LEGACY;
+    Modulator::SmoothingMode pitchSmoothingMode = Modulator::SmoothingMode::LEGACY;
     float mpePitchBendRange = -1.0f;
 
     std::atomic<int> otherscene_clients;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -92,9 +92,9 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, const std::string &suppl
     SurgePatch &patch = storage.getPatch();
 
     storage.smoothingMode = (Modulator::SmoothingMode)(int)Surge::Storage::getUserDefaultValue(
-        &storage, Surge::Storage::SmoothingMode, (int)(Modulator::SmoothingMode::FAST_LINE));
+        &storage, Surge::Storage::SmoothingMode, (int)(Modulator::SmoothingMode::LEGACY));
     storage.pitchSmoothingMode = (Modulator::SmoothingMode)(int)Surge::Storage::getUserDefaultValue(
-        &storage, Surge::Storage::PitchSmoothingMode, (int)(Modulator::SmoothingMode::FAST_LINE));
+        &storage, Surge::Storage::PitchSmoothingMode, (int)(Modulator::SmoothingMode::DIRECT));
 
     patch.polylimit.val.i = DEFAULT_POLYLIMIT;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3057,7 +3057,7 @@ juce::PopupMenu SurgeGUIEditor::makeMpeMenu(const juce::Point<int> &where, bool 
     });
 
     auto smoothMenu = makeSmoothMenu(where, Surge::Storage::PitchSmoothingMode,
-                                     (int)Modulator::SmoothingMode::FAST_LINE,
+                                     (int)Modulator::SmoothingMode::DIRECT,
                                      [this](auto md) { this->resetPitchSmoothing(md); });
 
     mpeSubMenu.addSubMenu(Surge::GUI::toOSCase("MPE Pitch Bend Smoothing"), smoothMenu);
@@ -4322,9 +4322,9 @@ juce::PopupMenu SurgeGUIEditor::makeMidiMenu(const juce::Point<int> &where)
 {
     auto midiSubMenu = juce::PopupMenu();
 
-    auto smen = makeSmoothMenu(where, Surge::Storage::SmoothingMode,
-                               (int)Modulator::SmoothingMode::FAST_LINE,
-                               [this](auto md) { this->resetSmoothing(md); });
+    auto smen =
+        makeSmoothMenu(where, Surge::Storage::SmoothingMode, (int)Modulator::SmoothingMode::LEGACY,
+                       [this](auto md) { this->resetSmoothing(md); });
     midiSubMenu.addSubMenu(Surge::GUI::toOSCase("Controller Smoothing"), smen);
 
     auto mmom = makeMonoModeOptionsMenu(where, true);


### PR DESCRIPTION
This reverts commit 3c31f8411df384464a4cf7bc257b425f49888f18.

For some reason we don't understand, this diff breaks our regtests
with some reliability. Revert while we figure it out (after my
vaca probably)