### PR TITLE
Fixes to improve the CLAP validator

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1928,8 +1928,8 @@ char *Parameter::get_storage_value(char *str) const
         sst.imbue(std::locale::classic());
         sst << std::fixed;
         sst << std::showpoint;
-        sst << std::setprecision(6);
-        sst << val.f;
+        sst << std::setprecision(14);
+        sst << (double)val.f;
         strxcpy(str, sst.str().c_str(), TXT_SIZE);
         break;
     };
@@ -4180,6 +4180,19 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
         }
         else
         {
+            // Try the inverse mapping
+            for (int i = val_min.i; i <= val_max.i; ++i)
+            {
+                char txt[TXT_SIZE];
+                auto nv = Parameter::intScaledToFloat(i, val_max.i, val_min.i);
+                get_display(txt, true, nv);
+                if (strcasecmp(txt, s.c_str()) == 0)
+                {
+                    ontoThis.i = i;
+                    return true;
+                }
+            }
+
             ErrorMessageMode isLarger =
                 (ni > val_max.f) ? ErrorMessageMode::IsLarger : ErrorMessageMode::IsSmaller;
             auto bound = isLarger ? val_max.i : val_min.i;
@@ -4192,6 +4205,34 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
         }
 
         return false;
+    }
+
+    if (valtype == vt_bool)
+    {
+        if (strcmp(s.c_str(), "On") == 0)
+        {
+            ontoThis.b = true;
+            return true;
+        }
+
+        if (strcmp(s.c_str(), "Off") == 0)
+        {
+            ontoThis.b = false;
+            return true;
+        }
+
+        return false;
+    }
+
+    if (strcmp(displayInfo.maxLabel, s.c_str()) == 0)
+    {
+        ontoThis.f = val_max.f;
+        return true;
+    }
+    if (strcmp(displayInfo.minLabel, s.c_str()) == 0)
+    {
+        ontoThis.f = val_min.f;
+        return true;
     }
 
     auto nv = std::atof(c);
@@ -4468,6 +4509,7 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
     break;
 
     default:
+
         return false;
     }
 

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -4186,7 +4186,7 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
                 char txt[TXT_SIZE];
                 auto nv = Parameter::intScaledToFloat(i, val_max.i, val_min.i);
                 get_display(txt, true, nv);
-                if (strcasecmp(txt, s.c_str()) == 0)
+                if (_stricmp(txt, s.c_str()) == 0)
                 {
                     ontoThis.i = i;
                     return true;
@@ -4209,13 +4209,13 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
 
     if (valtype == vt_bool)
     {
-        if (strcmp(s.c_str(), "On") == 0)
+        if (_stricmp(s.c_str(), "On") == 0)
         {
             ontoThis.b = true;
             return true;
         }
 
-        if (strcmp(s.c_str(), "Off") == 0)
+        if (_stricmp(s.c_str(), "Off") == 0)
         {
             ontoThis.b = false;
             return true;
@@ -4224,12 +4224,12 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
         return false;
     }
 
-    if (strcmp(displayInfo.maxLabel, s.c_str()) == 0)
+    if (_stricmp(displayInfo.maxLabel, s.c_str()) == 0)
     {
         ontoThis.f = val_max.f;
         return true;
     }
-    if (strcmp(displayInfo.minLabel, s.c_str()) == 0)
+    if (_stricmp(displayInfo.minLabel, s.c_str()) == 0)
     {
         ontoThis.f = val_min.f;
         return true;

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2744,10 +2744,14 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         TiXmlElement p("entry");
         p.SetAttribute("i", l);
         p.SetAttribute("bipolar", scene[0].modsources[ms_ctrl1 + l]->is_bipolar() ? 1 : 0);
-        p.SetAttribute(
-            "v", float_to_str(
-                     ((ControllerModulationSource *)scene[0].modsources[ms_ctrl1 + l])->target[0],
-                     txt2));
+
+        std::stringstream sst;
+        sst.imbue(std::locale::classic());
+        sst << std::fixed;
+        sst << std::showpoint;
+        sst << std::setprecision(14);
+        sst << (double)((ControllerModulationSource *)scene[0].modsources[ms_ctrl1 + l])->target[0];
+        p.SetAttribute("v", sst.str().c_str());
         p.SetAttribute("label", CustomControllerLabel[l]);
 
         cc.InsertEndChild(p);

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3519,6 +3519,13 @@ float SurgeSynthesizer::getMacroParameter01(long macroNum) const
     return storage.getPatch().scene[0].modsources[ms_ctrl1 + macroNum]->get_output01(0);
 }
 
+float SurgeSynthesizer::getMacroParameterTarget01(long macroNum) const
+{
+    return ((ControllerModulationSource *)storage.getPatch().scene[0].modsources[ms_ctrl1 +
+                                                                                 macroNum])
+        ->target[0];
+}
+
 void SurgeSynthesizer::setMacroParameter01(long macroNum, float val)
 {
     storage.getPatch().isDirty = true;

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -246,6 +246,7 @@ class alignas(16) SurgeSynthesizer
 
     void setMacroParameter01(long macroNum, float val);
     float getMacroParameter01(long macroNum) const;
+    float getMacroParameterTarget01(long macroNum) const;
     void applyMacroMonophonicModulation(long macroNum, float val);
 
     void setNoteExpression(SurgeVoice::NoteExpressionType net, int32_t note_id, int16_t key,

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -582,6 +582,7 @@ void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)
         surge->playNote(nevt->channel, nevt->key, 127 * nevt->velocity, 0, nevt->note_id);
     }
     break;
+    case CLAP_EVENT_NOTE_CHOKE:
     case CLAP_EVENT_NOTE_OFF:
     {
         auto nevt = reinterpret_cast<const clap_event_note *>(evt);
@@ -591,7 +592,9 @@ void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)
     case CLAP_EVENT_MIDI:
     {
         auto mevt = reinterpret_cast<const clap_event_midi *>(evt);
-        applyMidi(juce::MidiMessageMetadata(mevt->data, 3, mevt->header.time));
+        auto sz = juce::MidiMessage::getMessageLengthFromFirstByte(mevt->data[0]);
+        jassert(sz <= 3 && sz > 0);
+        applyMidi(juce::MidiMessageMetadata(mevt->data, sz, mevt->header.time));
     }
     break;
     case CLAP_EVENT_PARAM_VALUE:
@@ -658,7 +661,7 @@ void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)
     case CLAP_EVENT_NOTE_END:
     default:
     {
-        DBG("Unknown message type " << (int)(evt->type));
+        DBG("Unknown CLAP Message type in Surge Direct " << (int)(evt->type));
         // In theory I should never get this.
         // jassertfalse
     }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -183,7 +183,16 @@ struct SurgeMacroToJuceParamAdapter : public SurgeBaseParam
         res = res.substring(0, i);
         return res;
     }
-    float getValue() const override { return s->getMacroParameter01(macroNum); }
+    float getValue() const override
+    {
+        /*
+         * So why the target here? When we setValue we want the immediate
+         * getValue to return the same thing, but setValue sets the target
+         * So basically hide the smoothing from the externalizaion of the
+         * parameter to meet th econstraint
+         */
+        return s->getMacroParameterTarget01(macroNum);
+    }
     float getValueForText(const juce::String &text) const override
     {
         auto tf = std::atof(text.toRawUTF8());


### PR DESCRIPTION
1. More int typeins work
2. More accurate patch streaming so as to not truncate
3. The Maco param value is always the target; it shouldn't get a random
   smothing mid-way snapshot