### PR TITLE
Several Threading Fixes

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1119,6 +1119,7 @@ unsigned int SurgePatch::save_patch(void **data)
         {
             if (uses_wavetabledata(scene[sc].osc[osc].type.val.i))
             {
+                assert(scene[sc].osc[osc].wt.everBuilt);
                 memset(wth[sc][osc].tag, 0, 4);
                 wth[sc][osc].n_samples = scene[sc].osc[osc].wt.size;
                 wth[sc][osc].n_tables = scene[sc].osc[osc].wt.n_tables;

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -353,6 +353,7 @@ class alignas(16) SurgeSynthesizer
     void loadPatch(int id);
     bool loadPatchByPath(const char *fxpPath, int categoryId, const char *name);
     void selectRandomPatch();
+    std::unique_ptr<std::thread> patchLoadThread;
 
     // if increment is true, we go to next patch, else go to previous patch
     void jogCategory(bool increment);


### PR DESCRIPTION
1. The patchLoadThread should not be left active if the object
   is destroyed, so clean up / join in the destructor rather than
   just firing it detached

2. In the performUnsafeBlahDeBlah also load queued wavetables which
   will allow us to properly save if we have never run. Assert that
   we have built at least some wavetable before streaming it.