### PR TITLE
Send Automation events Always

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -3497,6 +3497,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
 
                 if (synth->setParameter01(ptagid, val, false, force_integer))
                 {
+                    synth->sendParameterAutomation(ptagid, synth->getParameter01(ptagid));
                     queue_refresh = true;
                     return;
                 }


### PR DESCRIPTION
A particular subset of discrete params would end up not generating
automation events - sort of a hodge podge. This is older code but
we should still send the event.

Without this change things like envelope type (digital/analog) didnt
toggle values in the bitwig param browser and weren't clickable in
cubase 12.

Closes #6284