### PR TITLE
Mono-Legato Envelope mode

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1596,17 +1596,34 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
     {
         for (int sc = 0; sc < n_scenes; ++sc)
         {
-            std::string mvname = "monoVoicePrority_" + std::to_string(sc);
-            auto *mv1 = TINYXML_SAFE_TO_ELEMENT(nonparamconfig->FirstChild(mvname.c_str()));
-            storage->getPatch().scene[sc].monoVoicePriorityMode = ALWAYS_LATEST;
-            if (mv1)
             {
-                // Get value
-                int mvv;
-                if (mv1->QueryIntAttribute("v", &mvv) == TIXML_SUCCESS)
+                std::string mvname = "monoVoicePrority_" + std::to_string(sc);
+                auto *mv1 = TINYXML_SAFE_TO_ELEMENT(nonparamconfig->FirstChild(mvname.c_str()));
+                storage->getPatch().scene[sc].monoVoicePriorityMode = ALWAYS_LATEST;
+                if (mv1)
                 {
-                    storage->getPatch().scene[sc].monoVoicePriorityMode =
-                        (MonoVoicePriorityMode)mvv;
+                    // Get value
+                    int mvv;
+                    if (mv1->QueryIntAttribute("v", &mvv) == TIXML_SUCCESS)
+                    {
+                        storage->getPatch().scene[sc].monoVoicePriorityMode =
+                            (MonoVoicePriorityMode)mvv;
+                    }
+                }
+            }
+            {
+                std::string mvname = "monoVoiceEnvelope_" + std::to_string(sc);
+                auto *mv1 = TINYXML_SAFE_TO_ELEMENT(nonparamconfig->FirstChild(mvname.c_str()));
+                storage->getPatch().scene[sc].monoVoiceEnvelopeMode = RESTART_FROM_ZERO;
+                if (mv1)
+                {
+                    // Get value
+                    int mvv;
+                    if (mv1->QueryIntAttribute("v", &mvv) == TIXML_SUCCESS)
+                    {
+                        storage->getPatch().scene[sc].monoVoiceEnvelopeMode =
+                            (MonoVoiceEnvelopeMode)mvv;
+                    }
                 }
             }
         }
@@ -1881,6 +1898,14 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
     if (revision <= 15 && polylimit.val.i == 8)
     {
         polylimit.val.i = DEFAULT_POLYLIMIT;
+    }
+
+    if (revision < 20)
+    {
+        for (auto &sc : scene)
+        {
+            sc.monoVoiceEnvelopeMode = RESTART_FROM_ZERO;
+        }
     }
 
     // ensure that filtersubtype is a valid value
@@ -2618,6 +2643,14 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         std::string mvname = "monoVoicePrority_" + std::to_string(sc);
         TiXmlElement mvv(mvname.c_str());
         mvv.SetAttribute("v", storage->getPatch().scene[sc].monoVoicePriorityMode);
+        nonparamconfig.InsertEndChild(mvv);
+    }
+
+    for (int sc = 0; sc < n_scenes; ++sc)
+    {
+        std::string mvname = "monoVoiceEnvelope_" + std::to_string(sc);
+        TiXmlElement mvv(mvname.c_str());
+        mvv.SetAttribute("v", storage->getPatch().scene[sc].monoVoiceEnvelopeMode);
         nonparamconfig.InsertEndChild(mvv);
     }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -100,11 +100,12 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 //                             added new Conditioner parameter (Side Low Cut)
 // 17 -> 18 (XT 1.1 nightlies) added clipping options to Delay Feedback parameter (via deform)
 //                             added Tone parameter to Phaser effect
-// 18 -> 19 (XT 1.1 release)   added String deform options (interpolation, bipolar Decay params, Stiffness options)
+// 18 -> 19 (XT 1.1 nightlies) added String deform options (interpolation, bipolar Decay params, Stiffness options)
 //                             added Extend to Delay Feedback parameter (allows negative delay)
+// 19 -> 20 (XT 1.1 release)   added voice envelope mode, but super late so don't break 19
 // clang-format on
 
-const int ff_revision = 19;
+const int ff_revision = 20;
 
 const int n_scene_params = 273;
 const int n_global_params = 11 + n_fx_slots * (n_fx_params + 1); // each param plus a type
@@ -487,6 +488,12 @@ enum MonoVoicePriorityMode
     ALWAYS_LOWEST,
 };
 
+enum MonoVoiceEnvelopeMode
+{
+    RESTART_FROM_ZERO,
+    RESTART_FROM_LATEST
+};
+
 struct MidiKeyState
 {
     int keystate;
@@ -611,6 +618,7 @@ struct SurgeSceneStorage
     bool modsource_doprocess[n_modsources];
 
     MonoVoicePriorityMode monoVoicePriorityMode = ALWAYS_LATEST;
+    MonoVoiceEnvelopeMode monoVoiceEnvelopeMode = RESTART_FROM_ZERO;
 };
 
 const int n_stepseqsteps = 16;

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -117,7 +117,8 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
                        int velocity, int channel, int scene_id, float detune,
                        MidiKeyState *keyState, MidiChannelState *mainChannelState,
                        MidiChannelState *voiceChannelState, bool mpeEnabled, int64_t voiceOrder,
-                       int32_t host_nid, int16_t host_key, int16_t host_chan)
+                       int32_t host_nid, int16_t host_key, int16_t host_chan, float aegStart,
+                       float fegStart)
 //: fb(storage,oscene)
 {
     // assign pointers
@@ -327,8 +328,8 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
 
     applyModulationToLocalcopy<true>();
 
-    ampEGSource.attack();
-    filterEGSource.attack();
+    ampEGSource.attackFrom(aegStart);
+    filterEGSource.attackFrom(fegStart);
 
     for (int i = 0; i < n_lfos_voice; i++)
     {

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -40,7 +40,8 @@ class alignas(16) SurgeVoice
                int velocity, int channel, int scene_id, float detune, MidiKeyState *keyState,
                MidiChannelState *mainChannelState, MidiChannelState *voiceChannelState,
                bool mpeEnabled, int64_t voiceOrder, int32_t host_note_id,
-               int16_t originating_host_key, int16_t originating_host_channel);
+               int16_t originating_host_key, int16_t originating_host_channel, float aegStart,
+               float fegStart);
     ~SurgeVoice();
 
     void release();
@@ -169,6 +170,11 @@ class alignas(16) SurgeVoice
         }
     }
 
+    void getAEGFEGLevel(float &aeg, float &feg)
+    {
+        aeg = ampEGSource.get_output(0);
+        feg = filterEGSource.get_output(0);
+    }
     static float channelKeyEquvialent(float key, int channel, bool isMpeEnabled,
                                       SurgeStorage *storage, bool remapKeyForTuning = true);
 

--- a/src/common/dsp/modulators/ADSRModulationSource.h
+++ b/src/common/dsp/modulators/ADSRModulationSource.h
@@ -77,16 +77,36 @@ class ADSRModulationSource : public ModulationSource
             attack();
     }
 
-    virtual void attack() override
+    virtual void attack() override { attackFrom(0.f); }
+
+    virtual void attackFrom(float start)
     {
         phase = 0;
         output = 0;
         idlecount = 0;
         scalestage = 1.f;
 
+        if (start > 0)
+        {
+            output = start;
+            switch (lc[a_s].i)
+            {
+            case 0:
+                // output = sqrt(phase);
+                phase = output * output;
+                break;
+            case 1:
+                phase = output;
+                break;
+            case 2:
+                // output = phase * phase;
+                phase = sqrt(output);
+                break;
+            };
+        }
         // Reset the analog state machine too
-        _v_c1 = 0.f;
-        _v_c1_delayed = 0.f;
+        _v_c1 = start;
+        _v_c1_delayed = start;
         _discharge = 0.f;
 
         envstate = s_attack;

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1673,29 +1673,54 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             (p->val.i == pm_mono || p->val.i == pm_mono_st ||
                              p->val.i == pm_mono_fp || p->val.i == pm_mono_st_fp))
                         {
-                            std::vector<std::string> labels = {"Last", "High", "Low", "Legacy"};
-                            std::vector<MonoVoicePriorityMode> vals = {
-                                ALWAYS_LATEST, ALWAYS_HIGHEST, ALWAYS_LOWEST,
-                                NOTE_ON_LATEST_RETRIGGER_HIGHEST};
-
-                            contextMenu.addSectionHeader("NOTE PRIORITY");
-
-                            for (int i = 0; i < 4; ++i)
                             {
-                                bool isChecked = (vals[i] == synth->storage.getPatch()
-                                                                 .scene[current_scene]
-                                                                 .monoVoicePriorityMode);
-                                contextMenu.addItem(Surge::GUI::toOSCase(labels[i]), true,
-                                                    isChecked, [this, isChecked, vals, i]() {
-                                                        synth->storage.getPatch()
-                                                            .scene[current_scene]
-                                                            .monoVoicePriorityMode = vals[i];
-                                                        if (!isChecked)
-                                                            synth->storage.getPatch().isDirty =
-                                                                true;
-                                                    });
+                                std::vector<std::string> labels = {"Last", "High", "Low", "Legacy"};
+                                std::vector<MonoVoicePriorityMode> vals = {
+                                    ALWAYS_LATEST, ALWAYS_HIGHEST, ALWAYS_LOWEST,
+                                    NOTE_ON_LATEST_RETRIGGER_HIGHEST};
+
+                                contextMenu.addSectionHeader("NOTE PRIORITY");
+
+                                for (int i = 0; i < 4; ++i)
+                                {
+                                    bool isChecked = (vals[i] == synth->storage.getPatch()
+                                                                     .scene[current_scene]
+                                                                     .monoVoicePriorityMode);
+                                    contextMenu.addItem(Surge::GUI::toOSCase(labels[i]), true,
+                                                        isChecked, [this, isChecked, vals, i]() {
+                                                            synth->storage.getPatch()
+                                                                .scene[current_scene]
+                                                                .monoVoicePriorityMode = vals[i];
+                                                            if (!isChecked)
+                                                                synth->storage.getPatch().isDirty =
+                                                                    true;
+                                                        });
+                                }
                             }
 
+                            {
+                                std::vector<std::string> labels = {"Zero", "Current"};
+                                std::vector<MonoVoiceEnvelopeMode> vals = {RESTART_FROM_ZERO,
+                                                                           RESTART_FROM_LATEST};
+
+                                contextMenu.addSectionHeader("ENVELOPE RESTART FROM");
+
+                                for (int i = 0; i < 2; ++i)
+                                {
+                                    bool isChecked = (vals[i] == synth->storage.getPatch()
+                                                                     .scene[current_scene]
+                                                                     .monoVoiceEnvelopeMode);
+                                    contextMenu.addItem(Surge::GUI::toOSCase(labels[i]), true,
+                                                        isChecked, [this, isChecked, vals, i]() {
+                                                            synth->storage.getPatch()
+                                                                .scene[current_scene]
+                                                                .monoVoiceEnvelopeMode = vals[i];
+                                                            if (!isChecked)
+                                                                synth->storage.getPatch().isDirty =
+                                                                    true;
+                                                        });
+                                }
+                            }
                             contextMenu.addSeparator();
 
                             contextMenu.addSubMenu(


### PR DESCRIPTION
Add a new mode for the AEG and FEG where in mono modes you
can retrigger the envelope start not from 0 / 0 phase / 0 charge
but from a phase / charge which matches the envelope levels of
the previously playing and stolen voice, if one is present (and
start from 0 otherwise).

Closes #824