### PR TITLE
LFO Hover State correct

### DIFF
--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -123,6 +123,7 @@ struct LFOAndStepDisplay : public juce::Component,
 
         lfoTypeHover = -1;
         stepSeqShiftHover = -1;
+        overWaveform = false;
         repaint();
     }
 


### PR DESCRIPTION
LFO Hover State was reported correctly, making it a bad actor in
the follow mouse mapping. Correct. Closes #6244