### PR TITLE
Remove an ancient, unused load

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -339,9 +339,6 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
         refresh_patchlist();
     }
 
-    getPatch().scene[0].osc[0].wt.dt = 1.0f / 512.f;
-    load_wt(0, &getPatch().scene[0].osc[0].wt, &getPatch().scene[0].osc[0]);
-
     if (!load_wt_wt_mem(SurgeSharedBinary::windows_wt, SurgeSharedBinary::windows_wtSize,
                         &WindowWT))
     {


### PR DESCRIPTION
Back when surge was open sourced, it always loaded at least
one wavetable on startup. We have since replaced this with the
far more robust 'everBuilt' mechanism which populates all the
wavetables. But this little fragment still hung around. That meant
that the scene[0].osc[0] would load before everbuilt, but after wavetable
names were initialized, which caused the bug in #6248, of a name being
lost on init/save

Closes #6248