### PR TITLE
Fix typos

### DIFF
--- a/resources/data/skins/Tutorials/05 Labels And Modulators.surge-skin/skin.xml
+++ b/resources/data/skins/Tutorials/05 Labels And Modulators.surge-skin/skin.xml
@@ -4,7 +4,7 @@ an installation, though, and in Surge 1.8, you can use that font to draw labels 
 This would allow you, in theory, to have text-free graphical assets for the background and render
 labels as strings. Button assets would still require text-in-SVGs for now.
 
-In Surge 1.8, there is minimal control over the positiong of the modulation section in the UI.
+In Surge 1.8, there is minimal control over the positioning of the modulation section in the UI.
 You can adjust the x and y position of the entire panel, or the color of an individual element
 using the mechanism described in Tutorial 02 and 03 and the labels from the skin inspector.
 In Surge 1.9, we expect to expand the ability to reponsition modulation source controls.

--- a/resources/data/skins/Tutorials/06 Using PNG.surge-skin/skin.xml
+++ b/resources/data/skins/Tutorials/06 Using PNG.surge-skin/skin.xml
@@ -35,7 +35,7 @@
         zooms (but more on that below) so a good scattering of resolutions is recommended.
 
         To specify a multi-resolution PNG image, use the tag <multi-image rather than <image
-        whih has image children with a zoom level tag. If you do not have the "100" tag the
+        which has image children with a zoom level tag. If you do not have the "100" tag the
         skin engine will raise an error.
 
         We generally try to use the naming convention "name_ZZZ.png" where ZZZ is the soom
@@ -51,7 +51,7 @@
     </multi-image>
 
     <!--[doc]
-      The same aplies to a background image, of course, which we set
+      The same applies to a background image, of course, which we set
       with the special global tag 'background'
     [doc]-->
     <multi-image id="frac-bg">

--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -51,7 +51,7 @@ Component MultiSwitch =
                       {"Is the switch draggable as a slider via mouse/touch or not. Valid values: "
                        "true, false"})
         .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, {"accessible_as_buttons"},
-                      {"Is the accesible display buttons (true) or radio buttons (false, def)"})
+                      {"Is the accessible display buttons (true) or radio buttons (false, def)"})
         .withProperty(Component::HOVER_IMAGE, {"hover_image"},
                       {"Hover image of the switch - required if you "
                        "set the base image and want feedback on mouse hover"})
@@ -91,7 +91,7 @@ Component Switch =
         .withProperty(Component::BACKGROUND, {"image", "bg_resource", "bg_id"},
                       {"Base image of the switch"})
         .withProperty(Component::ACCESSIBLE_AS_MOMENTARY_BUTTON, {"accessible_as_buttons"},
-                      {"Is the accesible display buttons (true) or radio buttons (false, def)"});
+                      {"Is the accessible display buttons (true) or radio buttons (false, def)"});
 
 Component FilterSelector =
     Component("FilterSelector")
@@ -176,7 +176,7 @@ Component Label =
                       {"Resource name of the image to be displayed by the label. Overrides "
                        "background and frame/border colors"});
 
-// ToDo - obvioulsy expand properties
+// ToDo - obviously expand properties
 Component WaveShaperSelector = Component("WaveShaperSelector");
 
 } // namespace Components

--- a/src/common/SurgeMemoryPools.h
+++ b/src/common/SurgeMemoryPools.h
@@ -29,7 +29,7 @@ struct SurgeMemoryPools
     SurgeMemoryPools(SurgeStorage *s) : stringDelayLines(s->sinctable) {}
 
     /*
-     * The largest number of oscillator instances of a particlar
+     * The largest number of oscillator instances of a particular
      * type are scenes * oscs * max voices, but add some pad
      */
     static constexpr int maxosc = n_scenes * n_oscs * (MAX_VOICES + 8);

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1100,7 +1100,7 @@ void SurgeSynthesizer::releaseNote(char channel, char key, char velocity, int32_
         {
             /*
              * OK so we have a key we are about to put in the hold buffer. BUT in the
-             * RELEASE_IF_OTHERS_HELD mode we dont' want to hold it if we have other keys
+             * RELEASE_IF_OTHERS_HELD mode we don't want to hold it if we have other keys
              * down. So do we?
              */
             for (auto k = 127; k >= 0; k--) // search downwards

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -99,7 +99,7 @@ class alignas(16) SurgeSynthesizer
      * processAudioThreadOpsWhenAudioEngineUnavailable reloads a patch if the audio thread
      * isn't running but if it is running lets the deferred queue handle it. But it has an option
      * which is *extremely dangerous* to force you to load in the current thread immediately.
-     * If you use this option and dont' know what you are doing it will explode - basically
+     * If you use this option and don't know what you are doing it will explode - basically
      * we only use it in the startup constructor path.
      */
     void

--- a/src/common/dsp/oscillators/ClassicOscillator.cpp
+++ b/src/common/dsp/oscillators/ClassicOscillator.cpp
@@ -65,7 +65,7 @@
 ** The storage buffer is sized so there is enough room to run a FIR model of the DAC
 ** forward in time from the point of the current buffer. This means when we wrap
 ** the buffer position we need to copy the back-end FIR buffer into the front of the new
-** buffer. Other than that subtletly, the buffer is just a ring.
+** buffer. Other than that subtlety, the buffer is just a ring.
 **
 ** There's lots more details but that's the basic operating model you will see in
 ** ::process_block once you know that ::convolute generates the next blast

--- a/src/common/dsp/oscillators/ModernOscillator.cpp
+++ b/src/common/dsp/oscillators/ModernOscillator.cpp
@@ -100,7 +100,7 @@
  * So rather than that approach, what we do is: at every sample, figure out the
  * frequency desired *at that sample*. We then figure out the 3 generators
  * for that frequency at that sample (prior, prior - 1, and prior - 2) and differentiate
- * using a numercial second derivative. This is more CPU intensive, but it is rock
+ * using a numerical second derivative. This is more CPU intensive, but it is rock
  * solid under all sorts of frequency modulation, including FM, pitch shifts, and sync.
  *
  * Finally, that numerical integration. I use the standard second derivative form
@@ -110,7 +110,7 @@
  * having the candidate phases be +1/0/-1 rather than 0/-1/-2 but that somehow felt
  * a wee bit like cheating. Anyway, the difference is negligible.
  *
- * Other than that, FM is obivous, sync runs two clocks and resets obviously,
+ * Other than that, FM is obvious, sync runs two clocks and resets obviously,
  * and the rest is just mixing and lagging. All pretty obvious.
  */
 
@@ -361,7 +361,7 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
                     sphase[u] -= floor(sphase[u]); // just in case we have a very high sync
 
                     /*
-                     * So the way we do synch can be a bit aliasy. Basically we move the phase
+                     * So the way we do sync can be a bit aliasy. Basically we move the phase
                      * forward and then difference over the new phase. WHat we should really do is
                      * figure out continuous generators with sync in but ugh that's super hard and
                      * it is late in the 1.9 cycle. So instead what we do is a little compensating

--- a/src/common/dsp/oscillators/SineOscillator.cpp
+++ b/src/common/dsp/oscillators/SineOscillator.cpp
@@ -22,8 +22,8 @@
  *
  * With Surge 1.9, we undertook a bunch of work to optimize the sine oscillator runtime at high
  * unison count with odd shapes. Basically at high unison we were doing large numbers of loops,
- * branches and so forth, and not using any of the advantage you could get by realizing the paralle
- * structure of unison. So we fixed that.
+ * branches and so forth, and not using any of the advantage you could get by realizing the
+ * parallel structure of unison. So we fixed that.
  *
  * There's two core fixes.
  *

--- a/src/common/dsp/oscillators/StringOscillator.cpp
+++ b/src/common/dsp/oscillators/StringOscillator.cpp
@@ -377,7 +377,7 @@ float StringOscillator::pitchAdjustmentForStiffness()
     {
         // I just whacked at it in a tuner at levels and came up with this. These are pitch shifts
         // so basically i ran A/69/440 into a tuner with the burst chirp and saw how far we were
-        // off in frequency at 0, 25, 50 etcc then converted to notes using 12TET
+        // off in frequency at 0, 25, 50 etc... then converted to notes using 12TET
         static constexpr float retunes[] = {-0.0591202, -0.122405, -0.225738, -0.406056,
                                             -0.7590243};
         float fidx = limit_range(-4 * tv, 0.f, 4.f);

--- a/src/common/dsp/utilities/DSPUtils.h
+++ b/src/common/dsp/utilities/DSPUtils.h
@@ -218,7 +218,7 @@ inline float quad_bspline(float y0, float y1, float y2, float mu)
     return 0.5f * (y2 * (mu * mu) + y1 * (-2 * mu * mu + 2 * mu + 1) + y0 * (mu * mu - 2 * mu + 1));
 }
 
-// panning which always lets both channels through unattenuated (seperate hard-panning)
+// panning which always lets both channels through unattenuated (separate hard-panning)
 inline void trixpan(float &L, float &R, float x)
 {
     if (x < 0.f)

--- a/src/surge-python/surgepy.cpp
+++ b/src/surge-python/surgepy.cpp
@@ -23,7 +23,7 @@ static std::mutex spysetup_mutex;
 
 /*
  * The way we've decided to expose to python is through some wrapper objects
- * which give us the control gorup / control group entry / param hierarchy.
+ * which give us the control group / control group entry / param hierarchy.
  * So here's some small helper objects
  */
 

--- a/src/surge-xt/gui/SkinSupport.cpp
+++ b/src/surge-xt/gui/SkinSupport.cpp
@@ -1034,7 +1034,7 @@ bool Skin::recursiveGroupParse(ControlGroup::ptr_t parent, TiXmlElement *control
     {
         /*
          * We now need to create all the base parent objects before we go
-         * and resolve them, since that resolutino can be recursive when
+         * and resolve them, since that resolution can be recursive when
          * looping over controls, and we don't want to actually modify controls
          * while resolving.
          */

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -940,7 +940,7 @@ void SurgeGUIEditor::idle()
                 ** properties, so you can control them from a DAW. The
                 ** DAW control works - everything up to this path (as described
                 ** in #160) works fine and sets the value but since there's
-                ** no CControl in param the above bails out. But ading
+                ** no CControl in param the above bails out. But adding
                 ** all these controls to param[] would have the unintended
                 ** side effect of giving them all the other param[] behaviours.
                 ** So have a second array and drop select items in here so we

--- a/src/surge-xt/gui/overlays/TuningOverlays.cpp
+++ b/src/surge-xt/gui/overlays/TuningOverlays.cpp
@@ -526,7 +526,7 @@ class RadialScaleGraph : public juce::Component,
 
         if (selfEditGuard == 0)
         {
-            // Someone dragged something onto me or somehing. Reset the tuning knobs
+            // Someone dragged something onto me or something. Reset the tuning knobs
             for (const auto &tk : toneKnobs)
             {
                 tk->angle = 0;

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -276,7 +276,7 @@ void MultiSwitch::mouseWheelMove(const juce::MouseEvent &event,
 
     int dir = wheelHelper.accumulate(wheel);
 
-    // Veritcally aligned switches have higher values at the bottom
+    // Vertically aligned switches have higher values at the bottom
     if (rows > 1)
     {
         dir = -dir;

--- a/src/surge-xt/gui/widgets/VerticalLabel.h
+++ b/src/surge-xt/gui/widgets/VerticalLabel.h
@@ -26,7 +26,7 @@ namespace Widgets
 {
 /*
  * This is a pure play juce component which is referred to as such so doesn't
- * need any fo the EFVG and Mixin stuff to interact with the value callback mechanism
+ * need any for the EFVG and Mixin stuff to interact with the value callback mechanism
  */
 struct VerticalLabel : public juce::Component
 {


### PR DESCRIPTION
Found via `codespell -q 3 -S ./libs -L adres,applys,doesnt,fo,nd,olt,ontext,ot,pard,parm,ro,ser,tbe,te,whichs,wth`