### PR TITLE
Change all menu section headers to our custom menu component

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -512,7 +512,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             if (!redoStack.empty())
             {
-                contextMenu.addSectionHeader("Redo Stack");
+                Surge::Widgets::MenuCenteredBoldLabel::addToMenu(contextMenu, "REDO STACK");
 
                 int nRedo = redoStack.size();
 
@@ -531,7 +531,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             if (!undoStack.empty())
             {
-                contextMenu.addSectionHeader("Undo Stack");
+                Surge::Widgets::MenuCenteredBoldLabel::addToMenu(contextMenu, "UNDO STACK");
 
                 int nUndo = 1;
 
@@ -846,6 +846,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             if (first_destination)
                             {
                                 contextMenu.addSeparator();
+
                                 Surge::Widgets::MenuCenteredBoldLabel::addToMenu(contextMenu,
                                                                                  "TARGETS");
                             }
@@ -1679,7 +1680,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     ALWAYS_LATEST, ALWAYS_HIGHEST, ALWAYS_LOWEST,
                                     NOTE_ON_LATEST_RETRIGGER_HIGHEST};
 
-                                contextMenu.addSectionHeader("NOTE PRIORITY");
+                                Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                                    contextMenu, "NOTE PRIORITY");
 
                                 for (int i = 0; i < 4; ++i)
                                 {
@@ -1704,7 +1706,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                 std::vector<MonoVoiceEnvelopeMode> vals = {RESTART_FROM_ZERO,
                                                                            RESTART_FROM_LATEST};
 
-                                contextMenu.addSectionHeader("ENVELOPE RETRIGGER BEHAVIOR");
+                                Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                                    contextMenu, "ENVELOPE RETRIGGER BEHAVIOR");
 
                                 for (int i = 0; i < 2; ++i)
                                 {
@@ -1879,7 +1882,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 {
                     contextMenu.addSeparator();
 
-                    contextMenu.addSectionHeader("OPTIONS");
+                    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                                    "OPTIONS");
 
                     bool isChecked = p->porta_constrate;
 
@@ -1905,7 +1909,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                             p->porta_retrigger = !p->porta_retrigger;
                                         });
 
-                    contextMenu.addSectionHeader("CURVE");
+                    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                                    "CURVE");
 
                     isChecked = (p->porta_curve == -1);
 
@@ -1940,7 +1945,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                     {
                         contextMenu.addSeparator();
 
-                        contextMenu.addSectionHeader("SLOPE");
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                                        "SLOPE");
 
                         for (int i = 0; i < synth->n_hpBQ; i++)
                         {
@@ -1967,7 +1973,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         {
                             contextMenu.addSeparator();
 
-                            contextMenu.addSectionHeader("DEFORM");
+                            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                                contextMenu, "DEFORM");
 
                             for (int i = 0; i < lt_num_deforms[lfodata->shape.val.i]; i++)
                             {
@@ -2007,7 +2014,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         bool isChecked = false;
 
-                        contextMenu.addSectionHeader("WAVEFORM");
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                                        "WAVEFORM");
 
                         for (int m : waves)
                         {
@@ -2030,7 +2038,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         isChecked = (p->deform_type & subosc);
 
-                        contextMenu.addSectionHeader("SUB-OSCILLATOR");
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                            contextMenu, "SUB-OSCILLATOR");
 
                         contextMenu.addItem(
                             Surge::GUI::toOSCase("Enabled"), true, isChecked, [p, subosc, this]() {
@@ -2103,7 +2112,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         std::vector<std::string> tapeHysteresisModes = {"Normal", "Medium", "High",
                                                                         "Very High"};
 
-                        contextMenu.addSectionHeader("PRECISION");
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                            contextMenu, "PRECISION");
 
                         for (int i = 0; i < tapeHysteresisModes.size(); ++i)
                         {
@@ -2129,7 +2139,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                     {
                         contextMenu.addSeparator();
 
-                        contextMenu.addSectionHeader("LIMITING");
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                                        "LIMITING");
 
                         std::vector<std::string> fbClipModes = {
                             "Disabled (DANGER!)", "Soft Clip (cubic)", "Soft Clip (tanh)",
@@ -2184,14 +2195,16 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         {
                             contextMenu.addSeparator();
 
-                            contextMenu.addSectionHeader("OVERSAMPLING");
+                            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                                contextMenu, "OVERSAMPLING");
 
                             addDef(StringOscillator::os_onex, StringOscillator::os_all, "1x");
                             addDef(StringOscillator::os_twox, StringOscillator::os_all, "2x");
 
                             contextMenu.addSeparator();
 
-                            contextMenu.addSectionHeader("INTERPOLATION");
+                            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                                contextMenu, "INTERPOLATION");
 
                             addDef(StringOscillator::interp_zoh, StringOscillator::interp_all,
                                    Surge::GUI::toOSCase("Zero Order Hold"));
@@ -2205,7 +2218,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         {
                             contextMenu.addSeparator();
 
-                            contextMenu.addSectionHeader("STIFFNESS FILTER");
+                            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                                contextMenu, "STIFFNESS FILTER");
 
                             addDef(StringOscillator::filter_fixed, StringOscillator::filter_all,
                                    "Static");

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -241,24 +241,14 @@ void MenuCenteredBoldLabel::paint(juce::Graphics &g)
 
 void MenuCenteredBoldLabel::addToMenu(juce::PopupMenu &m, const std::string label)
 {
-    auto q = new MenuCenteredBoldLabel(label);
-    int w, h;
-
-    q->getIdealSize(w, h);
-
-    m.addCustomItem(-1, *q, w, h, false, nullptr, label);
+    m.addCustomItem(-1, std::make_unique<MenuCenteredBoldLabel>(label), nullptr, label);
 }
 
 void MenuCenteredBoldLabel::addToMenuAsSectionHeader(juce::PopupMenu &m, const std::string label)
 {
-    auto q = new MenuCenteredBoldLabel(label);
-    int w, h;
-
-    q->getIdealSize(w, h);
-
+    auto q = std::make_unique<MenuCenteredBoldLabel>(label);
     q->isSectionHeader = true;
-
-    m.addCustomItem(-1, *q, w, h, false, nullptr, label);
+    m.addCustomItem(-1, std::move(q), nullptr, label);
 }
 
 //==============================================================================

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -92,11 +92,12 @@ struct MenuTitleHelpComponent : juce::PopupMenu::CustomComponent, Surge::GUI::Sk
 
 struct MenuCenteredBoldLabel : juce::PopupMenu::CustomComponent
 {
-    MenuCenteredBoldLabel(const std::string &s) : label(s), juce::PopupMenu::CustomComponent(true)
+    MenuCenteredBoldLabel(const std::string &s) : label(s), juce::PopupMenu::CustomComponent(false)
     {
         setAccessible(true);
         setTitle(label);
     }
+
     void getIdealSize(int &idealWidth, int &idealHeight) override;
     void paint(juce::Graphics &g) override;
 

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -448,7 +448,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
     {
         if (idx == storage->firstThirdPartyWTCategory)
         {
-            contextMenu.addSectionHeader("3RD PARTY WAVETABLES");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                            "3RD PARTY WAVETABLES");
         }
 
         if (idx == storage->firstUserWTCategory &&
@@ -462,7 +463,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
         // only add this section header if we actually have any factory WTs installed
         if (idx == 1)
         {
-            contextMenu.addSectionHeader("FACTORY WAVETABLES");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                            "FACTORY WAVETABLES");
         }
 
         PatchCategory cat = storage->wt_category[c];
@@ -474,7 +476,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
 
         if (addUserLabel)
         {
-            contextMenu.addSectionHeader("USER WAVETABLES");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                            "USER WAVETABLES");
             addUserLabel = false;
         }
 
@@ -605,7 +608,8 @@ void OscillatorWaveformDisplay::createWTMenuItems(juce::PopupMenu &contextMenu, 
 
             contextMenu.addSeparator();
 
-            contextMenu.addSectionHeader("INFO");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "INFO");
+
             contextMenu.addItem(
                 Surge::GUI::toOSCase(fmt::format("Number of Frames: {}", oscdata->wt.n_tables)),
                 false, false, nullptr);

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -357,7 +357,7 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
             tooltipCountdown = -1;
             toggleCommentTooltip(false);
 
-            menu.addSectionHeader("FAVORITES");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(menu, "FAVORITES");
 
             auto haveFavs = optionallyAddFavorites(menu, false, false);
 
@@ -514,7 +514,8 @@ void PatchSelector::showClassicMenu(bool single_category)
 
         std::transform(menuName.begin(), menuName.end(), menuName.begin(), ::toupper);
 
-        contextMenu.addSectionHeader("PATCHES (" + menuName + ")");
+        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+            contextMenu, "PATCHES (" + menuName + ")");
 
         populatePatchMenuForCategory(rightMouseCategory, contextMenu, single_category, main_e,
                                      false);
@@ -524,7 +525,8 @@ void PatchSelector::showClassicMenu(bool single_category)
         bool addedFavorites = false;
         if (patch_cat_size && storage->firstThirdPartyCategory > 0)
         {
-            contextMenu.addSectionHeader("FACTORY PATCHES");
+            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                            "FACTORY PATCHES");
         }
 
         for (int i = 0; i < patch_cat_size; i++)
@@ -545,7 +547,7 @@ void PatchSelector::showClassicMenu(bool single_category)
                 }
 
                 contextMenu.addColumnBreak();
-                contextMenu.addSectionHeader(txt);
+                Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, txt);
                 if (favs && optionallyAddFavorites(contextMenu, false))
                     contextMenu.addSeparator();
                 addedFavorites = true;
@@ -572,7 +574,7 @@ void PatchSelector::showClassicMenu(bool single_category)
     }
 
     contextMenu.addColumnBreak();
-    contextMenu.addSectionHeader("FUNCTIONS");
+    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "FUNCTIONS");
 
     auto initAction = [this]() {
         int i = 0;
@@ -791,7 +793,7 @@ bool PatchSelector::optionallyAddFavorites(juce::PopupMenu &p, bool addColumnBre
     if (addColumnBreak)
     {
         p.addColumnBreak();
-        p.addSectionHeader("FAVORITES");
+        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(p, "FAVORITES");
     }
 
     if (addToSubMenu)
@@ -1030,7 +1032,7 @@ bool PatchSelector::populatePatchMenuForCategory(int c, juce::PopupMenu &context
 
                 if (single_category)
                 {
-                    subMenu->addSectionHeader("");
+                    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(*subMenu, "");
                 }
             }
         }

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -248,7 +248,8 @@ void XMLMenuPopulator::populate()
 
             if (depth == 1 && hasFac && hasUser)
             {
-                m.addSectionHeader("FACTORY PRESETS");
+                Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(m,
+                                                                                "FACTORY PRESETS");
             }
 
             for (auto c : children)
@@ -268,7 +269,8 @@ void XMLMenuPopulator::populate()
                     {
                         inFac = false;
                         m.addColumnBreak();
-                        m.addSectionHeader("USER PRESETS");
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                            m, "USER PRESETS");
                     }
                     auto idx = c->idx;
                     m.addItem(c->name, [host, n = c->name, idx]() { host->loadByIndex(n, idx); });
@@ -283,7 +285,7 @@ void XMLMenuPopulator::populate()
                 {
                     if (c->colBreak)
                         m.addColumnBreak();
-                    m.addSectionHeader(c->name);
+                    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(m, c->name);
                 }
                 break;
                 case FOLD:
@@ -684,7 +686,7 @@ void FxMenu::populate()
     XMLMenuPopulator::populate();
 
     menu.addColumnBreak();
-    menu.addSectionHeader("FUNCTIONS");
+    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(menu, "FUNCTIONS");
 
     menu.addItem(Surge::GUI::toOSCase("Clear Current FX Unit"), [this]() {
         loadSnapshot(fxt_off, nullptr, 0);


### PR DESCRIPTION
Additional improvements: these custom headers of ours now match JUCE's in that they don't have highlight on hover, and positioning and vertical padding is pretty much the same now. Oh and also they don't respond to mouse clicks, as well!

Closes #6241

Also helps with a11y some, I bet.