### PR TITLE
UI Display of Wavetable Off by One Continuous

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1796,9 +1796,9 @@ void Parameter::bound_value(bool force_integer)
             CountedSetUserData *cs = reinterpret_cast<CountedSetUserData *>(user_data);
             auto count = cs->getCountedSetSize();
             // OK so now val.f is between 0 and 1. So
-            auto fraccount = val.f * count;
+            auto fraccount = val.f * (count - extend_range);
             auto intcount = (int)fraccount;
-            val.f = 1.0 * intcount / count;
+            val.f = limit_range(1.0 * intcount / (count - extend_range) + 0.0001, 0., 1.);
             break;
         }
         case ct_alias_mask:
@@ -2968,8 +2968,8 @@ void Parameter::get_display_alt(char *txt, bool external, float ef) const
             float f = val.f;
             CountedSetUserData *cs = reinterpret_cast<CountedSetUserData *>(user_data);
             auto count = cs->getCountedSetSize();
-            auto tl = count * f;
-            snprintf(txt, TXT_SIZE, "%.2f / %d", tl, count);
+            auto tl = (count - extend_range) * f;
+            snprintf(txt, TXT_SIZE, "%.2f / %d", tl, (count - extend_range));
         }
 
         break;

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -1170,18 +1170,20 @@ struct WaveTable3DEditor : public juce::Component,
         auto &wt = oscdata->wt;
         auto pos = -1.f;
 
+        bool off = false;
         switch (oscdata->type.val.i)
         {
         case ot_wavetable:
         case ot_window:
             pos = oscdata->p[0].val.f;
+            off = oscdata->p[0].extend_range;
             break;
         default:
             pos = 0.f;
             break;
         };
 
-        auto tpos = pos * wt.n_tables;
+        auto tpos = pos * (wt.n_tables - off);
 
         // OK so now go backwards through the tables but also tilt and raise for the 3D effect
         auto smp = wt.size;


### PR DESCRIPTION
So in continuous mode with wavetables your last frame is between
n-2 and n-1; but in discrete mode it is between n-1 and a coyp of n-1
so that there are effectively n tables. This allows in discrete mode each
modulation range to be conssitent. But means we need to get those
off-by-ones in there based on extend or not.

This is a UI only change. The wavetable and parameter value have always
been right; this is just the string and snap

Closes #6362