### PR TITLE
Param typins; Clap validator

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -4098,6 +4098,14 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
 
         switch (ctrltype)
         {
+        case ct_fmconfig:
+        {
+            // So FMConfig has names like "2 > 1 < 3" which actually *work* with
+            // std::atoi so just clobber that and use the str compare
+            if (s.length() > 1 && s.c_str()[1] == ' ')
+                ni = val_min.i - 1;
+        }
+        break;
         case ct_midikey_or_channel:
         {
             auto sm = storage->getPatch().scenemode.val.i;
@@ -4327,6 +4335,12 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
         ** log2(v/a)/b = x;
         */
 
+        // Special case where we have a minLabelValue
+        if (nv == 0 && displayInfo.minLabelValue == 0)
+        {
+            ontoThis.f = val_min.f;
+            return true;
+        }
         if (nv <= 0 || !std::isfinite(nv))
         {
             set_error_message(errMsg, "Invalid value input!", "", ErrorMessageMode::Special);

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -584,6 +584,8 @@ void SurgeSynthProcessor::clap_direct_paramsFlush(const clap_input_events *in,
             auto jp = static_cast<JUCEParameterVariant *>(pevt->cookie);
         }
     }
+    // Setting params can change internal state so give the synth a chance to react
+    surge->process();
 }
 
 void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)


### PR DESCRIPTION
1. Param typein of '0' on portamento reailzes the special lower
   bound and accepts it. Closes #6278
2. Typein of fmconfig handles fact that it starts with a number,
   blowing up the atoi
3. In paramsFlush call process so the synth can react.

2 and 3 mean we pass the current clap validator