### PR TITLE
Add an option to explod Mod Workflow menus

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -255,7 +255,7 @@ std::string defaultKeyToString(DefaultKey k)
     case ExpandModMenusWithSubMenus:
         r = "expandModMenusWithSubmenus";
         break;
-        
+
     case nKeys:
         break;
     }

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -252,6 +252,10 @@ std::string defaultKeyToString(DefaultKey k)
         r = "menuAndEditKeybindingsFollowKeyboardFocus";
         break;
 
+    case ExpandModMenusWithSubMenus:
+        r = "expandModMenusWithSubmenus";
+        break;
+        
     case nKeys:
         break;
     }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -108,6 +108,7 @@ enum DefaultKey
 
     ModListValueDisplay,
     MenuLightness,
+    ExpandModMenusWithSubMenus,
 
     UseNarratorAnnouncements,
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3970,6 +3970,16 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
                            !doAccAnn);
                    });
 
+    bool doExpMen = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::ExpandModMenusWithSubMenus, false);
+
+    wfMenu.addItem(Surge::GUI::toOSCase("Add SubMenus to Modulation Menu Items"), true,
+                   doExpMen, [this, doExpMen]() {
+                       Surge::Storage::updateUserDefaultValue(
+                           &(this->synth->storage), Surge::Storage::ExpandModMenusWithSubMenus,
+                           !doExpMen);
+                   });
+
     wfMenu.addSeparator();
 
     bool showVirtualKeyboard = getShowVirtualKeyboard();

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3973,8 +3973,8 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
     bool doExpMen = Surge::Storage::getUserDefaultValue(
         &(this->synth->storage), Surge::Storage::ExpandModMenusWithSubMenus, false);
 
-    wfMenu.addItem(Surge::GUI::toOSCase("Add SubMenus to Modulation Menu Items"), true,
-                   doExpMen, [this, doExpMen]() {
+    wfMenu.addItem(Surge::GUI::toOSCase("Add SubMenus to Modulation Menu Items"), true, doExpMen,
+                   [this, doExpMen]() {
                        Surge::Storage::updateUserDefaultValue(
                            &(this->synth->storage), Surge::Storage::ExpandModMenusWithSubMenus,
                            !doExpMen);

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -987,7 +987,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             modMenu->setIsMuted(synth->isModulationMuted(
                                 parameter->id, (modsources)thisms, use_scene, modidx));
                             auto mmt = modMenu->getTitle();
-                            contextMenu.addCustomItem(-1, std::move(modMenu), nullptr, mmt);
+                            auto pm = modMenu->createAccessibleSubMenu(&synth->storage);
+                            contextMenu.addCustomItem(-1, std::move(modMenu),
+                                                      pm.get() ? std::move(pm) : nullptr, mmt);
                             first_destination = false;
                             n_md++;
                         }
@@ -2491,7 +2493,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     comp->setSkin(currentSkin, bitmapStore);
                                     comp->setIsMuted(
                                         synth->isModulationMuted(ptag, (modsources)ms, sc, modidx));
-                                    contextMenu.addCustomItem(-1, std::move(comp), nullptr,
+                                    auto pm = comp->createAccessibleSubMenu(&synth->storage);
+                                    contextMenu.addCustomItem(-1, std::move(comp),
+                                                              pm.get() ? std::move(pm) : nullptr,
                                                               comptitle);
                                 }
                             }

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -16,6 +16,7 @@
 #include "MenuCustomComponents.h"
 #include "SurgeImageStore.h"
 #include "SurgeImage.h"
+#include "UserDefaults.h"
 #include <StringOps.h>
 
 namespace Surge
@@ -335,6 +336,22 @@ void ModMenuCustomComponent::paint(juce::Graphics &g)
     g.setFont(ft);
     g.drawText(source, r, juce::Justification::centredLeft);
     g.drawText(amount, r, juce::Justification::centredRight);
+}
+
+std::unique_ptr<juce::PopupMenu> ModMenuCustomComponent::createAccessibleSubMenu(SurgeStorage *s)
+{
+    bool doExpMen =
+        Surge::Storage::getUserDefaultValue(s, Surge::Storage::ExpandModMenusWithSubMenus, false);
+
+    if (!doExpMen)
+        return nullptr;
+
+    auto res = std::make_unique<juce::PopupMenu>();
+    auto fn = callback;
+    res->addItem(edit->accLabel, [fn]() { fn(EDIT); });
+    res->addItem(mute->accLabel, [fn]() { fn(MUTE); });
+    res->addItem(clear->accLabel, [fn]() { fn(CLEAR); });
+    return std::move(res);
 }
 
 void ModMenuCustomComponent::setIsMuted(bool b)

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -134,6 +134,8 @@ struct ModMenuCustomComponent : juce::PopupMenu::CustomComponent, Surge::GUI::Sk
     void mouseUp(const juce::MouseEvent &e) override;
     bool keyPressed(const juce::KeyPress &k) override;
 
+    std::unique_ptr<juce::PopupMenu> createAccessibleSubMenu(SurgeStorage *s);
+
     std::unique_ptr<TinyLittleIconButton> clear, mute, edit;
     std::string source, amount;
     std::function<void(OpType)> callback;

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -408,7 +408,7 @@ void OscillatorMenu::populate()
 
     if (sge)
     {
-        auto hu = sge->helpURLForSpecial("oscillators");
+        auto hu = sge->helpURLForSpecial("osc-select");
         auto lurl = hu;
 
         if (hu != "")


### PR DESCRIPTION
The modulation menu (edit/clear/mute) is very clumsy in screen
readers. So add a workflow option to keep the menu unchanged but
also adds a screen-reader friendly sub-menu with the edit/mute/clear
option. This will almost definitely only be used by screen reader users.

Addresses #5714