### PR TITLE
Provide a narrator workaround for patch search on win

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -240,6 +240,9 @@ std::string defaultKeyToString(DefaultKey k)
     case UseNarratorAnnouncements:
         r = "useNarratorAnnouncements";
         break;
+    case UseNarratorAnnouncementsForPatchTypeahead:
+        r = "useNarratorAnnouncementsForPatchTypeahead";
+        break;
 
     case FXUnitAssumeFixedBlock:
         r = "fxAssumeFixedBlock";

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -111,6 +111,7 @@ enum DefaultKey
     ExpandModMenusWithSubMenus,
 
     UseNarratorAnnouncements,
+    UseNarratorAnnouncementsForPatchTypeahead,
 
     // Surge XT Effects specific defaults
     FXUnitAssumeFixedBlock,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3973,6 +3973,19 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
                            !doAccAnn);
                    });
 
+#if WINDOWS
+    bool doAccAnnPatch = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::UseNarratorAnnouncementsForPatchTypeahead, true);
+
+    wfMenu.addItem(Surge::GUI::toOSCase("Announce Patch Browser (Windows Workaround)"), true,
+                   doAccAnnPatch, [this, doAccAnnPatch]() {
+                       Surge::Storage::updateUserDefaultValue(
+                           &(this->synth->storage),
+                           Surge::Storage::UseNarratorAnnouncementsForPatchTypeahead,
+                           !doAccAnnPatch);
+                   });
+#endif
+
     bool doExpMen = Surge::Storage::getUserDefaultValue(
         &(this->synth->storage), Surge::Storage::ExpandModMenusWithSubMenus, false);
 

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -138,7 +138,7 @@ PatchSelector::PatchSelector() : juce::Component(), WidgetBaseMixin<PatchSelecto
 
     setWantsKeyboardFocus(true);
 };
-PatchSelector::~PatchSelector() = default;
+PatchSelector::~PatchSelector() { typeAhead->removeTypeAheadListener(this); };
 
 void PatchSelector::setStorage(SurgeStorage *s)
 {
@@ -1114,6 +1114,23 @@ void PatchSelector::itemSelected(int providerIndex)
     {
         sge->queuePatchFileLoad(sr.file);
     }
+}
+
+void PatchSelector::itemFocused(int providerIndex)
+{
+#if WINDOWS
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+    if (!sge)
+        return;
+
+    auto sr = patchDbProvider->lastSearchResult[providerIndex];
+    auto doAcc = Surge::Storage::getUserDefaultValue(
+        storage, Surge::Storage::UseNarratorAnnouncementsForPatchTypeahead, true);
+    if (doAcc)
+    {
+        sge->enqueueAccessibleAnnouncement(sr.name + " in " + sr.cat);
+    }
+#endif
 }
 
 void PatchSelector::idle() { wasTypeaheadCanceledSinceLastIdle = false; }

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -107,6 +107,7 @@ struct PatchSelector : public juce::Component,
 
     /// TypeAhead API
     void itemSelected(int providerIndex) override;
+    void itemFocused(int providerIndex) override;
     void typeaheadCanceled() override;
 
     void resized() override;

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -151,6 +151,11 @@ struct TypeAheadListBoxModel : public juce::ListBoxModel
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TARow);
     };
 
+    void selectedRowsChanged(int lastRowSelected) override
+    {
+        ta->updateSelected(search[lastRowSelected]);
+    }
+
     juce::Component *refreshComponentForRow(int rowNumber, bool isRowSelected,
                                             juce::Component *existingComponentToUpdate) override
     {
@@ -280,6 +285,14 @@ void TypeAhead::dismissWithoutValue()
     for (auto l : taList)
     {
         l->typeaheadCanceled();
+    }
+}
+
+void TypeAhead::updateSelected(int providerIdx)
+{
+    for (auto l : taList)
+    {
+        l->itemFocused(providerIdx);
     }
 }
 

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -63,6 +63,7 @@ struct TypeAhead : public juce::TextEditor, juce::TextEditor::Listener
     struct TypeAheadListener
     {
         virtual ~TypeAheadListener() = default;
+        virtual void itemFocused(int providerIndex) {}
         virtual void itemSelected(int providerIndex) = 0;
         virtual void typeaheadCanceled() = 0;
     };
@@ -75,6 +76,7 @@ struct TypeAhead : public juce::TextEditor, juce::TextEditor::Listener
 
     void dismissWithValue(int providerIdx, const std::string &s, const juce::ModifierKeys &mod);
     void dismissWithoutValue();
+    void updateSelected(int providerIdx);
 
     std::unique_ptr<juce::ListBox> lbox;
     std::unique_ptr<TypeAheadListBoxModel> lboxmodel;


### PR DESCRIPTION
On win I just cant get the focus on the right announced element.
And my win box is not running. So follow @pietermach idea of at
least doing a narrated announcement on select.

Addresses #5714