### PR TITLE
Consistently announce Favorites change

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6918,7 +6918,7 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
                 patchSelector->toggleTypeAheadSearch(patchSelector->isTypeaheadSearchOn);
                 return true;
             case Surge::GUI::FAVORITE_PATCH:
-                setPatchAsFavorite(!isPatchFavorite());
+                setPatchAsFavorite(synth->storage.getPatch().name, !isPatchFavorite());
                 patchSelector->setIsFavorite(isPatchFavorite());
                 return true;
 
@@ -7343,7 +7343,14 @@ std::string SurgeGUIEditor::showShortcutDescription(const std::string &shortcutD
     }
 }
 
-void SurgeGUIEditor::setPatchAsFavorite(bool b) { setSpecificPatchAsFavorite(synth->patchid, b); }
+void SurgeGUIEditor::setPatchAsFavorite(const std::string &pname, bool b)
+{
+    std::ostringstream oss;
+    oss << pname << (b ? " added to " : " removed from ") << "favorite patches.";
+    enqueueAccessibleAnnouncement(oss.str());
+
+    setSpecificPatchAsFavorite(synth->patchid, b);
+}
 
 void SurgeGUIEditor::setSpecificPatchAsFavorite(int patchid, bool b)
 {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -598,7 +598,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     /*
      * Favorites support
      */
-    void setPatchAsFavorite(bool b);
+    void setPatchAsFavorite(const std::string &pname, bool b);
     bool isPatchFavorite();
     bool isPatchUser();
 

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -382,11 +382,7 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
 
             if (sge)
             {
-                sge->setPatchAsFavorite(isFavorite);
-                std::ostringstream oss;
-                oss << pname << (isFavorite ? " added to " : " removed from ")
-                    << "favorite patches.";
-                sge->enqueueAccessibleAnnouncement(oss.str());
+                sge->setPatchAsFavorite(pname, isFavorite);
                 repaint();
             }
         }


### PR DESCRIPTION
Adding or Removing to favorites with the button in patch selector
announced but not with the keybinding. CHange the API so the SGE
method to set favorites does an announce consistently and now both
the button and keybinding announce with VO on.