### PR TITLE
Retrigger String and Twist in new play modes

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4958,6 +4958,7 @@ void SurgeSynthesizer::reclaimVoiceFor(SurgeVoice *v, char key, char channel, ch
     v->resetVelocity((unsigned int)velocity);
     v->restartAEGFEGAttack(aegStart, fegStart);
     v->retriggerLFOEnvelopes();
+    v->retriggerOSCWithIndependentAttacks();
     v->resetPortamentoFrom(priorKey, channel);
 
     // Now end this note unless it is used by another scene

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1511,3 +1511,25 @@ void SurgeVoice::resetPortamentoFrom(int key, int channel)
     state.priorpkey = state.portasrc_key;
     state.portaphase = 0;
 }
+
+void SurgeVoice::retriggerOSCWithIndependentAttacks()
+{
+    for (int i = 0; i < n_oscs; ++i)
+    {
+        if (osc[i])
+        {
+            /*
+             * This is awfully special case but it's the best solution
+             */
+            if (scene->osc[i].type.val.i == ot_string)
+            {
+                osc[i]->init(state.getPitch(storage));
+            }
+            if (scene->osc[i].type.val.i == ot_twist &&
+                !scene->osc[i].p[n_osc_params - 2].deactivated)
+            {
+                osc[i]->init(state.getPitch(storage));
+            }
+        }
+    }
+}

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -190,6 +190,7 @@ class alignas(16) SurgeVoice
     }
 
     void retriggerLFOEnvelopes();
+    void retriggerOSCWithIndependentAttacks();
     void resetPortamentoFrom(int key, int channel);
 
     static float channelKeyEquvialent(float key, int channel, bool isMpeEnabled,

--- a/src/common/dsp/oscillators/TwistOscillator.cpp
+++ b/src/common/dsp/oscillators/TwistOscillator.cpp
@@ -291,7 +291,6 @@ TwistOscillator::TwistOscillator(SurgeStorage *storage, OscillatorStorage *oscda
     voice = std::make_unique<plaits::Voice>();
     shared_buffer = new char[16384];
     alloc = std::make_unique<stmlib::BufferAllocator>(shared_buffer, 16384);
-    voice->Init(alloc.get());
     patch = std::make_unique<plaits::Patch>();
     mod = std::make_unique<plaits::Modulations>();
 
@@ -321,6 +320,8 @@ float TwistOscillator::tuningAwarePitch(float pitch)
 
 void TwistOscillator::init(float pitch, bool is_display, bool nonzero_drift)
 {
+    voice->Init(alloc.get());
+
     charFilt.init(storage->getPatch().character.val.i);
 
     float tpitch = tuningAwarePitch(pitch);


### PR DESCRIPTION
Basically since these oscillators have independent attacks of
their own (string always and twist with LPG) retrigger them
when you reuse a voice

Closes #6422