### PR TITLE
Alt and Rand along with LFO Retrig in new Modes

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1484,6 +1484,19 @@ void SurgeVoice::retriggerLFOEnvelopes()
             anLfo.retriggerEnvelope();
         }
     }
+
+    int ao = scene->modsources[ms_random_unipolar]->get_active_outputs();
+    rndUni.set_active_outputs(ao);
+    for (int w = 0; w < ao; ++w)
+        rndUni.set_output(w, scene->modsources[ms_random_unipolar]->get_output(w));
+
+    ao = scene->modsources[ms_random_bipolar]->get_active_outputs();
+    rndBi.set_active_outputs(ao);
+    for (int w = 0; w < ao; ++w)
+        rndBi.set_output(w, scene->modsources[ms_random_bipolar]->get_output(w));
+
+    altUni.set_output(0, scene->modsources[ms_alternate_unipolar]->get_output(0));
+    altBi.set_output(0, scene->modsources[ms_alternate_bipolar]->get_output(0));
 }
 
 void SurgeVoice::resetPortamentoFrom(int key, int channel)

--- a/src/common/dsp/effects/ModControl.h
+++ b/src/common/dsp/effects/ModControl.h
@@ -186,7 +186,7 @@ class ModControl
                 if (thisrate >= 0.98f) // this means we skip all the time
                     lfoval.newValue(lfosandhtarget);
                 else
-                    lfoval.newValue(cv + diff);
+                    lfoval.newValue(std::clamp(cv + diff, -1.f, 1.f));
             }
             else
             {

--- a/src/surge-testrunner/UnitTestsMOD.cpp
+++ b/src/surge-testrunner/UnitTestsMOD.cpp
@@ -1392,7 +1392,7 @@ TEST_CASE("ModLFO is well behaved", "[mod]")
     {
         DYNAMIC_SECTION("Mod Control Boundsd for type " << m)
         {
-            for (int tries = 0; tries < 10; ++tries)
+            for (int tries = 0; tries < 1000; ++tries)
             {
                 float rate = (float)rand() / (float)RAND_MAX * 10;
                 float phase_offset = 0.1 * tries;


### PR DESCRIPTION
In the new modes, make sure to also re-snap alt and rand along
with lfo envelopes when a voice is retriggered.

Closes #6439