### PR TITLE
Defend against malformed time sig from host

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3842,6 +3842,10 @@ void SurgeSynthesizer::processAudioThreadOpsWhenAudioEngineUnavailable(bool dang
 
 void SurgeSynthesizer::resetStateFromTimeData()
 {
+    if (time_data.timeSigNumerator < 1)
+        time_data.timeSigNumerator = 4;
+    if (time_data.timeSigDenominator < 1)
+        time_data.timeSigDenominator = 4;
     storage.songpos = time_data.ppqPos;
     if (time_data.tempo > 0)
     {


### PR DESCRIPTION
If a host sends a time signature with a numerator or denominator
< 1 we would crash in our repaint. A host shouldn't do this, but there's
lots of partial hosts using Surge as a test case nowadays, so be a bit
defensive.