### PR TITLE
Handle a note_id == 0 CLAP PolyMode bug

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -561,7 +561,7 @@ SurgeVoice *SurgeSynthesizer::getUnusedVoice(int scene)
 
 void SurgeSynthesizer::freeVoice(SurgeVoice *v)
 {
-    if (v->host_note_id > 0)
+    if (v->host_note_id >= 0)
     {
         bool used_away = false;
         // does any other voice have this voiceid


### PR DESCRIPTION
NoteId == 0 is a valid note id; but it isn't one that bitwig
ever sends. So the first person to send us one tripped up.