### PR TITLE
Set hostArchitectures in macOS installer

### DIFF
--- a/scripts/installer_mac/make_installer.sh
+++ b/scripts/installer_mac/make_installer.sh
@@ -209,7 +209,7 @@ cat > $TMPDIR/distribution.xml << XMLEND
     ${FXLV2_PKG_REF}
     ${FXAPP_PKG_REF}
     <pkg-ref id="org.surge-synth-team.surge-xt.resources.pkg"/>
-    <options require-scripts="false" customize="always" />
+    <options require-scripts="false" customize="always" hostArchitectures="x86_64,arm64"/>
     <choices-outline>
         ${VST3_CHOICE}
         ${AU_CHOICE}


### PR DESCRIPTION
This should, in theory, allow the installer to run on a non
rosetta machine.

Addresees #6453