### PR TITLE
Turn on CLAP in mac installer

### DIFF
--- a/scripts/installer_mac/Resources/Readme.rtf
+++ b/scripts/installer_mac/Resources/Readme.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2513
+{\rtf1\ansi\ansicpg1252\cocoartf2639
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;}
 {\colortbl;\red255\green255\blue255;}
 {\*\expandedcolortbl;;}
@@ -15,9 +15,9 @@
 
 \f1\b0 Please read this important compatibility information. \
 \
-Surge XT is maintained by a group of volunteers and is distributed as an AU, VST3 and Standalone app. This package also contains the Surge XT Effects Bank, also as an AU VST3 and Standalone.\
+Surge XT is maintained by a group of volunteers and is distributed as an AU, CLAP, VST3 and Standalone app. This package also contains the Surge XT Effects Bank, also as an AU, CLAP, VST3 and Standalone.\
 \
-The Surge mac team tests regularly on Intel Logic Reaper and Bitwig.\
+The Surge mac team tests regularly in Logic Reaper and Bitwig.\
 \
 If you want to chat with the Surge XT maintainers, we strongly encourage you to join our discord!\
 \

--- a/scripts/installer_mac/make_installer.sh
+++ b/scripts/installer_mac/make_installer.sh
@@ -153,7 +153,7 @@ fi
 if [[ -d $INDIR/$CLAP ]]; then
 	CLAP_PKG_REF='<pkg-ref id="org.surge-synth-team.surge-xt.clap.pkg"/>'
   CLAP_CHOICE='<line choice="org.surge-synth-team.surge-xt.clap.pkg"/>'
-	CLAP_CHOICE_DEF="<choice id=\"org.surge-synth-team.surge-xt.clap.pkg\" visible=\"true\" start_selected=\"false\" title=\"Surge XT CLAP\"><pkg-ref id=\"org.surge-synth-team.surge-xt.clap.pkg\"/></choice><pkg-ref id=\"org.surge-synth-team.surge-xt.clap.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_XT_CLAP.pkg</pkg-ref>"
+	CLAP_CHOICE_DEF="<choice id=\"org.surge-synth-team.surge-xt.clap.pkg\" visible=\"true\" start_selected=\"true\" title=\"Surge XT CLAP\"><pkg-ref id=\"org.surge-synth-team.surge-xt.clap.pkg\"/></choice><pkg-ref id=\"org.surge-synth-team.surge-xt.clap.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_XT_CLAP.pkg</pkg-ref>"
 fi
 if [[ -d $INDIR/$LV2 ]]; then
 	LV2_PKG_REF='<pkg-ref id="org.surge-synth-team.surge-xt.lv2.pkg"/>'
@@ -179,7 +179,7 @@ fi
 if [[ -d $INDIR/$FXCLAP ]]; then
 	FXCLAP_PKG_REF='<pkg-ref id="org.surge-synth-team.surge-xt-fx.clap.pkg"/>'
 	FXCLAP_CHOICE='<line choice="org.surge-synth-team.surge-xt-fx.clap.pkg"/>'
-	FXCLAP_CHOICE_DEF="<choice id=\"org.surge-synth-team.surge-xt-fx.clap.pkg\" visible=\"true\" start_selected=\"false\" title=\"Surge XT Effects CLAP\"><pkg-ref id=\"org.surge-synth-team.surge-xt-fx.clap.pkg\"/></choice><pkg-ref id=\"org.surge-synth-team.surge-xt-fx.clap.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_XT_FXCLAP.pkg</pkg-ref>"
+	FXCLAP_CHOICE_DEF="<choice id=\"org.surge-synth-team.surge-xt-fx.clap.pkg\" visible=\"true\" start_selected=\"true\" title=\"Surge XT Effects CLAP\"><pkg-ref id=\"org.surge-synth-team.surge-xt-fx.clap.pkg\"/></choice><pkg-ref id=\"org.surge-synth-team.surge-xt-fx.clap.pkg\" version=\"${VERSION}\" onConclusion=\"none\">Surge_XT_FXCLAP.pkg</pkg-ref>"
 fi
 if [[ -d $INDIR/$FXLV2 ]]; then
 	FXLV2_PKG_REF='<pkg-ref id="org.surge-synth-team.surge-xt-fx.lv2.pkg"/>'


### PR DESCRIPTION
It was off by default but there. Also mention it in the README.

Closes #6466