### PR TITLE
Defensive implementation of paramsFlush

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -573,7 +573,6 @@ void SurgeSynthProcessor::clap_direct_paramsFlush(const clap_input_events *in,
                                                   const clap_output_events *out) noexcept
 {
     uint32_t sz = in->size(in);
-    DBG("Param flush called with " << (int)sz);
     for (uint32_t i = 0; i < sz; ++i)
     {
         auto ev = in->get(in, i);
@@ -582,10 +581,16 @@ void SurgeSynthProcessor::clap_direct_paramsFlush(const clap_input_events *in,
         {
             auto pevt = reinterpret_cast<const clap_event_param_value *>(ev);
             auto jp = static_cast<JUCEParameterVariant *>(pevt->cookie);
+            jp->processorParam->setValue(pevt->value);
         }
     }
-    // Setting params can change internal state so give the synth a chance to react
-    surge->process();
+    if (!is_clap_processing)
+    {
+        // Setting params can change internal state so give the synth a chance to react
+        // although the spec is unclear whether this can be called when processing, so don't
+        // call surge process if we are!
+        surge->process();
+    }
 }
 
 void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)


### PR DESCRIPTION
CLAP spec very strongly suggests (and i hope will soon unambivuously
say) that paramsFlush is for the case when processing is not active
but in CLAP 1.1.1 it is ambiguous and for a moment REAPER chose to
call paramsFlush when you called requestFlus even if processing was
going. That meant our defensive call to surge->process interfered
with audio. So do not call surge->process in paramsFlush if processing
is active, even though REAPER will rpobably stop calling me in this
case anyway.