### PR TITLE
Handle F2 Offset Scene Copy and Paste Error

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1569,6 +1569,27 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry, modsources ms
             getPatch().param_ptr[pid]->porta_retrigger = p.porta_retrigger;
             getPatch().param_ptr[pid]->porta_curve = p.porta_curve;
             getPatch().param_ptr[pid]->deform_type = p.deform_type;
+
+            /*
+             * This is a really nasty special case that the bool relative switch
+             * modifies the cross-param *type* of the filter cutoff when it is setvalue01ed
+             * This is a gross workaround for the bug in #6475 which I will ponder after pushing.
+             */
+            if (pid == getPatch().scene[scene].f2_cutoff_is_offset.id)
+            {
+                auto down = p.val.b;
+                if (down)
+                {
+                    getPatch().scene[scene].filterunit[1].cutoff.set_type(ct_freq_mod);
+                    getPatch().scene[scene].filterunit[1].cutoff.set_name("Offset");
+                }
+                else
+                {
+                    getPatch().scene[scene].filterunit[1].cutoff.set_type(
+                        ct_freq_audible_with_tunability);
+                    getPatch().scene[scene].filterunit[1].cutoff.set_name("Cutoff");
+                }
+            }
         }
 
         if (type & cp_osc)


### PR DESCRIPTION
F2 offset copied properly but didn't update the params correctly
so the slider had the wrong type. This is done as one of several
things and we need to review them, as discussed in #6486 but
until then, lets just do the gross thing to address this one case.

Closes #6475