### PR TITLE
Change Accesible Name of FX Slot

### DIFF
--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -521,6 +521,20 @@ void EffectChooser::getColorsForSlot(int fxslot, juce::Colour &bgcol, juce::Colo
     }
 }
 
+void EffectChooser::setEffectType(int index, int type)
+{
+    fxTypes[index] = type;
+
+    if (slotAccOverlays[index] && slotAccOverlays[index]->getAccessibilityHandler())
+    {
+        std::string newd = std::string(fxslot_names[index]) + ": " + fx_type_names[type];
+        slotAccOverlays[index]->setTitle(newd);
+        slotAccOverlays[index]->setDescription(newd);
+        slotAccOverlays[index]->getAccessibilityHandler()->notifyAccessibilityEvent(
+            juce::AccessibilityEvent::titleChanged);
+    }
+}
+
 template <> struct DiscreteAHRange<EffectChooser>
 {
     static int iMaxV(EffectChooser *t) { return n_fx_slots; }

--- a/src/surge-xt/gui/widgets/EffectChooser.h
+++ b/src/surge-xt/gui/widgets/EffectChooser.h
@@ -57,7 +57,7 @@ struct EffectChooser : public juce::Component,
     int getCurrentEffect() const { return currentEffect; }
     int currentEffect{0};
 
-    void setEffectType(int index, int type) { fxTypes[index] = type; }
+    void setEffectType(int index, int type);
     std::array<int, n_fx_slots> fxTypes;
 
     void mouseDoubleClick(const juce::MouseEvent &event) override;


### PR DESCRIPTION
The name used to be "A 1" or "Send 2" but it is now
"A 1: Nimbus" or "Send 2: Combulator"

Closes #6491