### PR TITLE
Key strokes while patch scanning get eaten

### DIFF
--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -1188,7 +1188,7 @@ void PatchSelector::toggleTypeAheadSearch(bool b)
         if (storage->patchDB->numberOfJobsOutstanding() > 0)
         {
             enable = false;
-            txt = "Updating Patch Database: " +
+            txt = "Updating patch database: " +
                   std::to_string(storage->patchDB->numberOfJobsOutstanding()) + " items left";
         }
 
@@ -1274,6 +1274,17 @@ void PatchSelector::enableTypeAheadIfReady()
 
 bool PatchSelector::keyPressed(const juce::KeyPress &key)
 {
+    if (isTypeaheadSearchOn && storage->patchDB->numberOfJobsOutstanding() > 0)
+    {
+        // Any keypress while we are waiting is ignored other than perhaps escape
+        if (key.getKeyCode() == juce::KeyPress::escapeKey)
+        {
+            toggleTypeAheadSearch(false);
+            repaint();
+        }
+        return true;
+    }
+
     auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
 
     if (action == OpenMenu)


### PR DESCRIPTION
It was the case that start a search, do index, type a key
and that key goes all the way to your DAW. That's undesriable since
2 seconds later it would be a search key. So eat all keystrokes
when re-indexing except escape which turns the display back.

Closes #6414