### PR TITLE
Reveal in Finder for Patches

### DIFF
--- a/src/surge-xt/gui/SurgeJUCEHelpers.h
+++ b/src/surge-xt/gui/SurgeJUCEHelpers.h
@@ -18,6 +18,7 @@
 
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "SurgeGUICallbackInterfaces.h"
+#include <filesystem/import.h>
 
 namespace Surge
 {
@@ -119,6 +120,30 @@ inline void addMenuWithShortcut(juce::PopupMenu &m, const std::string &lab,
                                 const std::string &shortcut, std::function<void()> action)
 {
     addMenuWithShortcut(m, lab, shortcut, true, false, action);
+}
+
+inline void addRevealInFinder(juce::PopupMenu &m, const fs::path &p)
+{
+#if LINUX
+    return;
+#else
+    try
+    {
+        if (fs::exists(p) && fs::is_regular_file(p))
+        {
+            auto f = juce::File(p.u8string());
+#if MAC
+            std::string s = "Reveal in Finder...";
+#else
+            std::string s = "Open In Explorer...";
+#endif
+            m.addItem(s, [f]() { f.revealToUser(); });
+        }
+    }
+    catch (fs::filesystem_error &)
+    {
+    }
+#endif
 }
 
 } // namespace GUI

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -711,6 +711,11 @@ void PatchSelector::showClassicMenu(bool single_category)
 
     contextMenu.addSeparator();
 
+    if (current_patch >= 0 && current_patch < storage->patch_list.size())
+    {
+        Surge::GUI::addRevealInFinder(contextMenu, storage->patch_list[current_patch].path);
+    }
+
     contextMenu.addItem(Surge::GUI::toOSCase("Open User Patches Folder..."),
                         [this]() { Surge::GUI::openFileOrFolder(this->storage->userPatchesPath); });
 


### PR DESCRIPTION
Patches reveal in finder / open in explorer on the oscillator
menu. Wavetables and Presets still require a bit of work.

Addresses #6488