### PR TITLE
Remove includes for half rate filter where unnecessary

### DIFF
--- a/src/common/dsp/effects/BBDEnsembleEffect.h
+++ b/src/common/dsp/effects/BBDEnsembleEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 #include "ModControl.h"
 #include "SSESincDelayLine.h"

--- a/src/common/dsp/effects/ChorusEffect.h
+++ b/src/common/dsp/effects/ChorusEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 template <int v> class ChorusEffect : public Effect

--- a/src/common/dsp/effects/ConditionerEffect.h
+++ b/src/common/dsp/effects/ConditionerEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 const int lookahead_bits = 7;

--- a/src/common/dsp/effects/DelayEffect.h
+++ b/src/common/dsp/effects/DelayEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 class DelayEffect : public Effect

--- a/src/common/dsp/effects/DistortionEffect.cpp
+++ b/src/common/dsp/effects/DistortionEffect.cpp
@@ -1,5 +1,4 @@
 #include "DistortionEffect.h"
-#include <vembertech/halfratefilter.h>
 #include "DebugHelpers.h"
 
 // feedback can get tricky with packed SSE

--- a/src/common/dsp/effects/FlangerEffect.h
+++ b/src/common/dsp/effects/FlangerEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 class FlangerEffect : public Effect

--- a/src/common/dsp/effects/FrequencyShifterEffect.h
+++ b/src/common/dsp/effects/FrequencyShifterEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 class FrequencyShifterEffect : public Effect

--- a/src/common/dsp/effects/GraphicEQ11BandEffect.h
+++ b/src/common/dsp/effects/GraphicEQ11BandEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 class GraphicEQ11BandEffect : public Effect

--- a/src/common/dsp/effects/ParametricEQ3BandEffect.h
+++ b/src/common/dsp/effects/ParametricEQ3BandEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 class ParametricEQ3BandEffect : public Effect

--- a/src/common/dsp/effects/PhaserEffect.h
+++ b/src/common/dsp/effects/PhaserEffect.h
@@ -20,7 +20,6 @@
 #include "AllpassFilter.h"
 #include "ModControl.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 class PhaserEffect : public Effect

--- a/src/common/dsp/effects/ResonatorEffect.h
+++ b/src/common/dsp/effects/ResonatorEffect.h
@@ -16,6 +16,7 @@
 #pragma once
 #include "Effect.h"
 #include "DSPUtils.h"
+
 #include <vembertech/lipol.h>
 
 class ResonatorEffect : public Effect

--- a/src/common/dsp/effects/Reverb1Effect.h
+++ b/src/common/dsp/effects/Reverb1Effect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 const int revbits = 15;

--- a/src/common/dsp/effects/Reverb2Effect.h
+++ b/src/common/dsp/effects/Reverb2Effect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 class Reverb2Effect : public Effect

--- a/src/common/dsp/effects/RingModulatorEffect.h
+++ b/src/common/dsp/effects/RingModulatorEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 class RingModulatorEffect : public Effect

--- a/src/common/dsp/effects/RotarySpeakerEffect.h
+++ b/src/common/dsp/effects/RotarySpeakerEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 #include "sst/waveshapers.h"

--- a/src/common/dsp/effects/TreemonsterEffect.h
+++ b/src/common/dsp/effects/TreemonsterEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 class TreemonsterEffect : public Effect

--- a/src/common/dsp/effects/VocoderEffect.h
+++ b/src/common/dsp/effects/VocoderEffect.h
@@ -21,7 +21,6 @@
 
 #include "VectorizedSVFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 const int n_vocoder_bands = 20;

--- a/src/common/dsp/effects/WaveShaperEffect.h
+++ b/src/common/dsp/effects/WaveShaperEffect.h
@@ -19,7 +19,6 @@
 #include "DSPUtils.h"
 #include "AllpassFilter.h"
 
-#include <vembertech/halfratefilter.h>
 #include <vembertech/lipol.h>
 
 #include "sst/waveshapers.h"


### PR DESCRIPTION
In a lot of cases it's already imported by DSPUtils.h, in other cases it was just plain superfluous.