### PR TITLE
Mousewheel can change presets / categorys/ FX presets again

### DIFF
--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -269,7 +269,10 @@ void MultiSwitch::endHover()
 void MultiSwitch::mouseWheelMove(const juce::MouseEvent &event,
                                  const juce::MouseWheelDetails &wheel)
 {
-    if (!draggable)
+    // If we aren't draggable and a drag is happening, ignore the mouse wheel gesture
+    // This (vs just a plain !draggable) reverts the 1.9 behaviour of mosue wheel throuhg
+    // the presets.
+    if (!draggable && (event.mouseWasDraggedSinceMouseDown() || event.getLengthOfMousePress() > 0))
     {
         return;
     }


### PR DESCRIPTION
The draggable protection was a bit too strong in the JUCE
port

Closes #6522