### PR TITLE
Fixes for LuaJit in Standalone on 10.14

### DIFF
--- a/libs/LuaJitLib/build-fat-luajit.sh
+++ b/libs/LuaJitLib/build-fat-luajit.sh
@@ -25,11 +25,11 @@ cp -r LuaJIT/ "${SD}"
 
 cd "${SD}"
 MACOSX_DEPLOYMENT_TARGET=10.11 make clean
-MACOSX_DEPLOYMENT_TARGET=10.11 make -j HOST_CC="clang -target `uname -m`-apple-macos10.11" TARGET_CC="xcrun --toolchain arm64 clang -target arm64-apply-macos10.11 -isysroot $(xcrun --sdk macosx --show-sdk-path) -fvisibility=hidden -fvisibility-inlines-hidden"  || echo "That's OK though"
+MACOSX_DEPLOYMENT_TARGET=10.11 make -j HOST_CC="clang -target `uname -m`-apple-macos10.11" TARGET_CC="xcrun --toolchain arm64 clang -target arm64-apply-macos10.11 -isysroot $(xcrun --sdk macosx --show-sdk-path) -fvisibility=hidden -fvisibility-inlines-hidden" TARGET_CFLAGS="-O3"  || echo "That's OK though"
 mv src/lib*a "${OD}/arm64"
 
 MACOSX_DEPLOYMENT_TARGET=10.11 make clean
-MACOSX_DEPLOYMENT_TARGET=10.11 make -j HOST_CC="clang -target `uname -m`-apple-macos10.11" TARGET_CC="xcrun --toolchain x86_64 clang -target x86_64-apply-macos10.11 -isysroot $(xcrun --sdk macosx --show-sdk-path) -fvisibility=hidden -fvisibility-inlines-hidden"  || echo "That's OK though"
+MACOSX_DEPLOYMENT_TARGET=10.11 make -j HOST_CC="clang -target `uname -m`-apple-macos10.11" TARGET_CC="xcrun --toolchain x86_64 clang -target x86_64-apply-macos10.11 -isysroot $(xcrun --sdk macosx --show-sdk-path) -fvisibility=hidden -fvisibility-inlines-hidden" TARGET_CFLAGS="-O3"  || echo "That's OK though"
 
 mv src/lib*a "${OD}/x86_64"
 

--- a/scripts/installer_mac/Resources/entitlements.plist
+++ b/scripts/installer_mac/Resources/entitlements.plist
@@ -4,6 +4,8 @@
 <dict>
    <key>com.apple.security.cs.allow-jit</key>
    <true/>
+   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+   <true/>
    <key>com.apple.security.device.audio-input</key>
    <true/>
 </dict>


### PR DESCRIPTION
The LuaJit in 10.14 ran into signing problems either because
it wasn't forced to non-debug symbols or because it had
incorrect hardened permissions. This fixes the problem
at the slight cost of having a relatively high hardening
exception.

Closes #6420