### PR TITLE
Don't prompt for usaved patch change by default

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3911,7 +3911,7 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
                    });
 
     int patchDirtyCheck = Surge::Storage::getUserDefaultValue(
-        &(this->synth->storage), Surge::Storage::PromptToLoadOverDirtyPatch, DUNNO);
+        &(this->synth->storage), Surge::Storage::PromptToLoadOverDirtyPatch, ALWAYS);
 
     wfMenu.addItem(Surge::GUI::toOSCase("Confirm Patch Loading if Unsaved Changes Exist"), true,
                    (patchDirtyCheck != ALWAYS), [this, patchDirtyCheck]() {
@@ -7619,11 +7619,9 @@ void SurgeGUIEditor::globalFocusChanged(juce::Component *fc)
     }
 }
 
-bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(const ::std::string &title,
-                                                       const std::string &msg,
-                                                       Surge::Storage::DefaultKey dontAskAgainKey,
-                                                       std::function<void()> okCallback,
-                                                       std::string ynMessage)
+bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(
+    const ::std::string &title, const std::string &msg, Surge::Storage::DefaultKey dontAskAgainKey,
+    std::function<void()> okCallback, std::string ynMessage, AskAgainStates askAgainDef)
 {
     if (okcWithToggleAlertWindow)
     {
@@ -7632,7 +7630,8 @@ bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(const ::std::string &titl
         return false;
     }
 
-    auto bypassed = Surge::Storage::getUserDefaultValue(&(synth->storage), dontAskAgainKey, DUNNO);
+    auto bypassed =
+        Surge::Storage::getUserDefaultValue(&(synth->storage), dontAskAgainKey, askAgainDef);
 
     if (bypassed == NEVER)
     {
@@ -7708,7 +7707,8 @@ void SurgeGUIEditor::loadPatchWithDirtyCheck(bool increment, bool isCategory, bo
                 closeOverlay(SAVE_PATCH);
 
                 synth->jogPatchOrCategory(increment, isCategory, insideCategory);
-            });
+            },
+            "Don't ask me again", ALWAYS);
     }
     else
     {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -812,7 +812,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool promptForOKCancelWithDontAskAgain(const ::std::string &title, const std::string &msg,
                                            Surge::Storage::DefaultKey dontAskAgainKey,
                                            std::function<void()> okCallback,
-                                           std::string ynMessage = "Don't ask me again");
+                                           std::string ynMessage = "Don't ask me again",
+                                           AskAgainStates askAgainDefault = DUNNO);
 
   private:
     bool scannedForMidiPresets = false;


### PR DESCRIPTION
Now that we have Undo it is nowhere near as pressing.
Accomplish this by setting the default to "AWLAYS" which
means always pick OK, but leaving the option and stuff in place
if people want it

Closes #6495