### PR TITLE
Correct AW Lifecycle; Restore AD-Clip

### DIFF
--- a/src/common/dsp/effects/airwindows/AirWindowsEffect.cpp
+++ b/src/common/dsp/effects/airwindows/AirWindowsEffect.cpp
@@ -185,11 +185,7 @@ void AirWindowsEffect::process(float *dataL, float *dataR)
         hasInvalidated = true;
     }
 
-    // Once we are setup, an fx type of 0 is just an init cycle mistake
-    if (*(pdata_ival[0]) == 0 && fxdata->p[0].user_data)
-        return;
-
-    if (!airwin || *(pdata_ival[0]) != lastSelected || fxdata->p[0].user_data == nullptr)
+    if (!airwin || fxdata->p[0].val.i != lastSelected || fxdata->p[0].user_data == nullptr)
     {
         /*
         ** So do we want to let Airwindows set params as defaults or do we want
@@ -207,7 +203,7 @@ void AirWindowsEffect::process(float *dataL, float *dataR)
         {
             useStreamedValues = true;
         }
-        setupSubFX(*(pdata_ival[0]), useStreamedValues);
+        setupSubFX(fxdata->p[0].val.i, useStreamedValues);
     }
 
     if (!airwin)


### PR DESCRIPTION
The fix in 91bc21cb75 was not quite correct. The actual problem was
that the the local ivalues were updated at the wrong point in the cycle
for the re-start effect hence the 'phantom 0' in the pdata_ival
but that phantom 0 is not in fxdata, which is correct, so adjust the
code, preservbing the fix from the prior commit but also restoring
the functionality of AD-Clip, aka AirWin ID 0

Closes #6479