### PR TITLE
Modulation: Keybind to Arm and Restore Middle Mouse

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6805,7 +6805,7 @@ void SurgeGUIEditor::setupKeymapManager()
     // TODO: FIX SCENE ASSUMPTION
     keyMapManager->addBinding(Surge::GUI::TOGGLE_SCENE, {keymap_t::Modifiers::ALT, (int)'S'});
     keyMapManager->addBinding(Surge::GUI::TOGGLE_MODULATOR_ARM,
-                              {keymap_t::Modifiers::COMMAND, (int)'A'});
+                              {keymap_t::Modifiers::ALT, (int)'A'});
 
 #if WINDOWS
     keyMapManager->addBinding(Surge::GUI::TOGGLE_DEBUG_CONSOLE,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6804,6 +6804,8 @@ void SurgeGUIEditor::setupKeymapManager()
 
     // TODO: FIX SCENE ASSUMPTION
     keyMapManager->addBinding(Surge::GUI::TOGGLE_SCENE, {keymap_t::Modifiers::ALT, (int)'S'});
+    keyMapManager->addBinding(Surge::GUI::TOGGLE_MODULATOR_ARM,
+                              {keymap_t::Modifiers::COMMAND, (int)'A'});
 
 #if WINDOWS
     keyMapManager->addBinding(Surge::GUI::TOGGLE_DEBUG_CONSOLE,
@@ -6975,6 +6977,12 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
                 }
 
                 changeSelectedScene(s);
+                return true;
+            }
+
+            case Surge::GUI::TOGGLE_MODULATOR_ARM:
+            {
+                toggle_mod_editing();
                 return true;
             }
 

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -44,6 +44,7 @@ enum KeyboardActions
 
     // TODO: FIX SCENE ASSUMPTION
     TOGGLE_SCENE,
+    TOGGLE_MODULATOR_ARM,
 
 #if WINDOWS
     TOGGLE_DEBUG_CONSOLE,
@@ -108,6 +109,8 @@ inline std::string keyboardActionName(KeyboardActions a)
     // TODO: FIX SCENE ASSUMPTION
     case TOGGLE_SCENE:
         return "TOGGLE_SCENE";
+    case TOGGLE_MODULATOR_ARM:
+        return "TOGGLE_MODULATOR_ARM";
 
 #if WINDOWS
     case TOGGLE_DEBUG_CONSOLE:
@@ -211,6 +214,10 @@ inline std::string keyboardActionDescription(KeyboardActions a)
     // TODO: FIX SCENE ASSUMPTION
     case TOGGLE_SCENE:
         desc = "Toggle Scene A/B";
+        break;
+
+    case TOGGLE_MODULATOR_ARM:
+        desc = "Toggle Modulator Armed State";
         break;
 
 #if WINDOWS

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -411,6 +411,11 @@ void ModulationSourceButton::buildHamburgerMenu(juce::PopupMenu &menu,
 
 void ModulationSourceButton::mouseDown(const juce::MouseEvent &event)
 {
+    if (forwardedMainFrameMouseDowns(event))
+    {
+        return;
+    }
+
     mouseMode = CLICK;
     everDragged = false;
     mouseDownLocation = event.position;


### PR DESCRIPTION
1. Keybind CMD-A toggles modulation
2. The middle mouse button forward-to-main-frame wasn't in
   ModulationSourceButton so that command selected and armed
   which wasn't desired.

Closes #6549