### PR TITLE
Acc Tweaks: Step Sequencer and WT Info

### DIFF
--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -97,6 +97,18 @@ LFOAndStepDisplay::LFOAndStepDisplay(SurgeGUIEditor *e)
         std::string sn = "Step Value " + std::to_string(i + 1);
         auto q = std::make_unique<OverlayAsAccessibleSlider<LFOAndStepDisplay>>(this, sn);
         q->onGetValue = [this, i](auto *T) { return ss->steps[i]; };
+        q->onValueToString = [this, i](auto *T, float f) -> std::string {
+            auto q = f * 12.f;
+            if (fabs(q - std::round(q)) < 0.001)
+            {
+                auto twl = std::string("twelths");
+                if ((int)fabs(std::round(q)) == 1)
+                    twl = "twelth";
+                auto res = fmt::format("{:.3f} ({} {})", f, (int)std::round(q), twl);
+                return res;
+            }
+            return fmt::format("{:.3f}", f);
+        };
         q->onSetValue = [this, i](auto *T, float f) {
             auto bscg = BeginStepGuard(this);
             ss->steps[i] = f;

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -619,12 +619,13 @@ void OscillatorWaveformDisplay::createWTMenuItems(juce::PopupMenu &contextMenu, 
 
             Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "INFO");
 
+            // These are enabled simply so they show up in the screen reader
             contextMenu.addItem(
                 Surge::GUI::toOSCase(fmt::format("Number of Frames: {}", oscdata->wt.n_tables)),
-                false, false, nullptr);
+                true, false, nullptr);
             contextMenu.addItem(
                 Surge::GUI::toOSCase(fmt::format("Frame Length: {} samples", oscdata->wt.size)),
-                false, false, nullptr);
+                true, false, nullptr);
         }
     }
 }


### PR DESCRIPTION
1. Step Sequencer announces 12ths in voice over if appropriate.
   Closes #6432
2. Activate the wavetalbe info display so it shows up in screen
   readers on the menu. Closes #6431