### PR TITLE
Fix a surge crash case on menu close in reaper

### DIFF
--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -762,9 +762,12 @@ void PatchSelector::showClassicMenu(bool single_category)
         o = sge->popupMenuOptions(getBounds().getBottomLeft());
     }
 
-    contextMenu.showMenuAsync(o, [this](int) {
-        stuckHover = false;
-        endHover();
+    contextMenu.showMenuAsync(o, [that = juce::Component::SafePointer(this)](int) {
+        if (that)
+        {
+            that->stuckHover = false;
+            that->endHover();
+        }
     });
 }
 


### PR DESCRIPTION
Escape-closing surge with the patch menu open would segv because we didn't
do the safe pointer thing. We really need to do that everywhere (See
Closes #6558