### PR TITLE
Guard all our lambdas with SafePointers

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2989,14 +2989,14 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     if (tag == tag_action_undo)
     {
         undoManager()->undo();
-        juce::Timer::callAfterDelay(25, [this, control]() { control->setValue(0); });
+        juce::Timer::callAfterDelay(25, [control]() { control->setValue(0); });
         return;
     }
 
     if (tag == tag_action_redo)
     {
         undoManager()->redo();
-        juce::Timer::callAfterDelay(25, [this, control]() { control->setValue(0); });
+        juce::Timer::callAfterDelay(25, [control]() { control->setValue(0); });
         return;
     }
 

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -312,7 +312,12 @@ struct TearOutWindow : public juce::DocumentWindow, public Surge::GUI::SkinConsu
 
         outstandingMoves++;
         // writing every move would be "bad". Add a 1 second delay.
-        juce::Timer::callAfterDelay(1000, [this]() { this->moveUpdate(); });
+        juce::Timer::callAfterDelay(1000, [that = juce::Component::SafePointer(this)]() {
+            if (that)
+            {
+                that->moveUpdate();
+            }
+        });
     }
 
     void moveUpdate()

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
@@ -213,9 +213,12 @@ void TypeinParamEditor::textEditorReturnKeyPressed(juce::TextEditor &te)
     {
         wasInputInvalid = true;
         repaint();
-        juce::Timer::callAfterDelay(5000, [this]() {
-            wasInputInvalid = false;
-            repaint();
+        juce::Timer::callAfterDelay(5000, [that = juce::Component::SafePointer(this)]() {
+            if (that)
+            {
+                that->wasInputInvalid = false;
+                that->repaint();
+            }
         });
     }
 }

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -142,7 +142,10 @@ void MultiSwitch::mouseDown(const juce::MouseEvent &event)
 
     if (draggable)
     {
-        juce::Timer::callAfterDelay(250, [this]() { this->setCursorToArrow(); });
+        juce::Timer::callAfterDelay(250, [that = juce::Component::SafePointer(this)]() {
+            if (that)
+                that->setCursorToArrow();
+        });
     }
 
     mouseDownLongHold(event);

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -367,9 +367,12 @@ void PatchSelector::mouseDown(const juce::MouseEvent &e)
 
                 stuckHover = true;
                 menu.showMenuAsync(sge->popupMenuOptions(favoritesRect.getBottomLeft()),
-                                   [this](int) {
-                                       stuckHover = false;
-                                       endHover();
+                                   [that = juce::Component::SafePointer(this)](int) {
+                                       if (that)
+                                       {
+                                           that->stuckHover = false;
+                                           that->endHover();
+                                       }
                                    });
             }
 
@@ -1225,7 +1228,10 @@ void PatchSelector::toggleTypeAheadSearch(bool b)
 
         if (!enable)
         {
-            juce::Timer::callAfterDelay(250, [this]() { this->enableTypeAheadIfReady(); });
+            juce::Timer::callAfterDelay(250, [that = juce::Component::SafePointer(this)]() {
+                if (that)
+                    that->enableTypeAheadIfReady();
+            });
         }
         else
         {
@@ -1277,7 +1283,10 @@ void PatchSelector::enableTypeAheadIfReady()
     }
     else
     {
-        juce::Timer::callAfterDelay(250, [this]() { this->enableTypeAheadIfReady(); });
+        juce::Timer::callAfterDelay(250, [that = juce::Component::SafePointer(this)]() {
+            if (that)
+                that->enableTypeAheadIfReady();
+        });
     }
 }
 


### PR DESCRIPTION
We had a bunch of lambdas which referenced 'this' rather than
'that = SafePointer' for callbacks on timers and I think
perhaps one of those is what caused the very occasional crash-on
close in reaper reported in #6421 so review them and push a change.

Keep the issue open for a bit while we look for crashes tho