### PR TITLE
Improvements to the FX Effect Menu for Screen Readers

### DIFF
--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -67,6 +67,12 @@ EffectChooser::EffectChooser() : juce::Component(), WidgetBaseMixin<EffectChoose
             this->notifyValueChanged();
             return true;
         };
+        q->onMenuKey = [this, mapi](auto *t) {
+            this->currentEffect = mapi;
+            this->notifyValueChanged();
+            this->createFXMenu();
+            return true;
+        };
         q->onGetIsChecked = [this, mapi](auto *t) {
             if (this->currentEffect == mapi)
                 return true;


### PR DESCRIPTION
1. Shift-F10 selects the right component without pressing enter
2. Add a 'decativate' toggle
3. Deactivate Clear if you are already on OFF
4. Label the clear and deactivate wiht th eslot name
5. Have expanded voiceover text for the custom item so it announces the slot and type

Addresses #6557

I think it probably closes it also but @mkruselj will probably do a once
over