### PR TITLE
Modify CMake so Surge can be a proper sub-library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ message(STATUS "Targeting ${SURGE_BITNESS}-bit configuration")
 # }}}
 
 # Make Sure the REpo is properly cloned {{{
-if (NOT EXISTS "${CMAKE_SOURCE_DIR}/libs/tuning-library/README.md")
+set(SURGE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+if (NOT EXISTS "${SURGE_SOURCE_DIR}/libs/tuning-library/README.md")
   message(FATAL_ERROR "Cannot find the contents of the tuning-library submodule, but this usually means"
           " that you haven't done a git submodule update; and so your repo will not build properly. "
           "To resolve this, please run `git submodule update --init --recursive` and re-run cmake")

--- a/src/cmake/lib.cmake
+++ b/src/cmake/lib.cmake
@@ -67,7 +67,7 @@ function(surge_juce_package target product_name)
 endfunction()
 
 function(surge_add_lib_subdirectory libname)
-  add_subdirectory(${CMAKE_SOURCE_DIR}/libs/${libname} ${CMAKE_BINARY_DIR}/libs/${libname} EXCLUDE_FROM_ALL)
+  add_subdirectory(${SURGE_SOURCE_DIR}/libs/${libname} ${CMAKE_BINARY_DIR}/libs/${libname} EXCLUDE_FROM_ALL)
 endfunction()
 
 function(surge_make_installers)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -35,11 +35,11 @@ if (NOT SURGE_SKIP_JUCE_FOR_RACK)
     NAMESPACE SurgeSharedBinary
     HEADER_NAME SurgeSharedBinary.h
     SOURCES
-    ${CMAKE_SOURCE_DIR}/resources/surge-shared/configuration.xml
-    ${CMAKE_SOURCE_DIR}/resources/surge-shared/README_UserArea.txt
-    ${CMAKE_SOURCE_DIR}/resources/surge-shared/memoryWavetable.wt
-    ${CMAKE_SOURCE_DIR}/resources/surge-shared/windows.wt
-    ${CMAKE_SOURCE_DIR}/resources/surge-shared/paramdocumentation.xml
+    ${SURGE_SOURCE_DIR}/resources/surge-shared/configuration.xml
+    ${SURGE_SOURCE_DIR}/resources/surge-shared/README_UserArea.txt
+    ${SURGE_SOURCE_DIR}/resources/surge-shared/memoryWavetable.wt
+    ${SURGE_SOURCE_DIR}/resources/surge-shared/windows.wt
+    ${SURGE_SOURCE_DIR}/resources/surge-shared/paramdocumentation.xml
     )
   target_compile_definitions(surge-common-binary PUBLIC HAS_JUCE=1 SKIP_JUCE=0)
 
@@ -253,6 +253,7 @@ add_library(${PROJECT_NAME}
   version.h
   )
 
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 if(APPLE)
   target_compile_definitions(${PROJECT_NAME} PUBLIC MAC=1)
   target_link_libraries(${PROJECT_NAME}
@@ -290,22 +291,22 @@ endif()
 option(SURGE_RELIABLE_VERSION_INFO "Update version info on every build (off: generate only at configuration time)" ON)
 if(SURGE_RELIABLE_VERSION_INFO)
   add_custom_target(version-info BYPRODUCTS ${CMAKE_BINARY_DIR}/geninclude/version.cpp
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${SURGE_SOURCE_DIR}
     COMMAND ${CMAKE_COMMAND} -D CMAKE_PROJECT_VERSION_MAJOR=${CMAKE_PROJECT_VERSION_MAJOR}
     -D CMAKE_PROJECT_VERSION_MINOR=${CMAKE_PROJECT_VERSION_MINOR}
-    -D SURGESRC=${CMAKE_SOURCE_DIR} -D SURGEBLD=${CMAKE_BINARY_DIR}
+    -D SURGESRC=${SURGE_SOURCE_DIR} -D SURGEBLD=${CMAKE_BINARY_DIR}
     -D AZURE_PIPELINE=${AZURE_PIPELINE}
     -D WIN32=${WIN32}
     -D CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     -D CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}
     -D CMAKE_CXX_COMPILER_VERSION=${CMAKE_CXX_COMPILER_VERSION}
-    -P ${CMAKE_SOURCE_DIR}/cmake/versiontools.cmake
+    -P ${SURGE_SOURCE_DIR}/cmake/versiontools.cmake
     )
   add_dependencies(${PROJECT_NAME} version-info)
 else()
-  set(SURGESRC ${CMAKE_SOURCE_DIR})
+  set(SURGESRC ${SURGE_SOURCE_DIR})
   set(SURGEBLD ${CMAKE_BINARY_DIR})
-  include(${CMAKE_SOURCE_DIR}/cmake/versiontools.cmake)
+  include(${SURGE_SOURCE_DIR}/cmake/versiontools.cmake)
 endif()
 target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/geninclude/version.cpp)
 


### PR DESCRIPTION
We used ${CMAKE_SORUCE_DIRECTORY} too freely; so set a
SURGE_SOURCE_DIRECTORY at the top cmake and use that for
some of our paths and stuff.