### PR TITLE
Display CPU load on VU meter

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1944,6 +1944,8 @@ void SurgeStorage::init_tables()
     // ballistics at any sample rate!
     // We have also decided to make the meters less sluggish, so we increased the cutoff to 60 Hz
     vu_falloff = exp(-2 * M_PI * (60.f * samplerate_inv));
+
+    cpu_falloff = exp(-2 * M_PI * (60.f * samplerate_inv));
 }
 
 float SurgeStorage::note_to_pitch(float x)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1129,6 +1129,7 @@ class alignas(16) SurgeStorage
     float poly_aftertouch[2][16][128]; // TODO: FIX SCENE ASSUMPTION
     float modsource_vu[n_modsources];
     void setSamplerate(float sr);
+    float cpu_falloff;
 
     bool getOverrideDataHome(std::string &value);
     void createUserDirectory();

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4101,6 +4101,8 @@ void SurgeSynthesizer::process()
     memset(endedHostNoteIds, 0, 512 * sizeof(int32_t));
 #endif
 
+    auto process_start = std::chrono::high_resolution_clock::now();
+
     if (hostNoteEndedToPushToNextBlock)
     {
         for (int i = 0; i < hostNoteEndedToPushToNextBlock; ++i)
@@ -4549,6 +4551,19 @@ void SurgeSynthesizer::process()
     {
         amp_mute.multiply_2_blocks(sceneout[sc][0], sceneout[sc][1], BLOCK_SIZE_QUAD);
     }
+
+    // Calculate how close we are to overloading the CPU (how close is the process duration to max
+    // duration)
+    auto d = std::chrono::high_resolution_clock::now() - process_start;
+    auto duration_usec = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - process_start);
+    auto max_duration_usec = BLOCK_SIZE * storage.dsamplerate_inv * 1000000;
+    float ratio = duration_usec.count() / max_duration_usec;
+
+    float c = cpu_level.load();
+    int window = max_duration_usec;
+    auto smoothed_ratio = (c * (window - 1) + ratio) / window;
+    c = c * storage.cpu_falloff;
+    cpu_level.store(max(c, smoothed_ratio));
 }
 
 SurgeSynthesizer::PluginLayer *SurgeSynthesizer::getParent()

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -391,6 +391,7 @@ class alignas(16) SurgeSynthesizer
     std::atomic<int> modwheelCC, pitchbendMIDIVal, sustainpedalCC;
 
     float vu_peak[8];
+    std::atomic<float> cpu_level{0.f};
 
     void populateDawExtraState();
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -810,6 +810,12 @@ void SurgeGUIEditor::idle()
 
             vu[0]->setIsAudioActive(synth->audio_processing_active);
 
+            if (synth->cpu_level != vu[0]->getCpuLevel())
+            {
+                vu[0]->setCpuLevel(synth->cpu_level);
+                vuInvalid = true;
+            }
+
             if (vuInvalid)
             {
                 vu[0]->repaint();

--- a/src/surge-xt/gui/widgets/VuMeter.cpp
+++ b/src/surge-xt/gui/widgets/VuMeter.cpp
@@ -119,6 +119,25 @@ void VuMeter::paint(juce::Graphics &g)
         if (stereo)
             g.fillRect(dR);
     }
+
+    if (cpuLevel > 1.0)
+    {
+        g.setColour(juce::Colour(0xFFFF0000));
+        g.setFont(skin->fontManager->getLatoAtSize(10, juce::Font::bold));
+    }
+    else if(cpuLevel > 0.70)
+    {
+        g.setColour(juce::Colour(0xFFFF9000));
+        g.setFont(skin->fontManager->getLatoAtSize(10));
+    }
+    else
+    {
+        g.setColour(juce::Colour(0xFF00FF00));
+        g.setFont(skin->fontManager->getLatoAtSize(10));
+    }
+    std::string text = std::string("");
+    text += std::to_string((int)(cpuLevel * 100));
+    g.drawText(text, getLocalBounds().withTrimmedBottom(1).withTrimmedRight(2), juce::Justification::right);
 }
 
 void VuMeter::onSkinChanged()

--- a/src/surge-xt/gui/widgets/VuMeter.h
+++ b/src/surge-xt/gui/widgets/VuMeter.h
@@ -38,6 +38,10 @@ struct VuMeter : public juce::Component, public WidgetBaseMixin<VuMeter>
     void setValueR(float f) { vR = f; }
     float getValueR() const { return vR; }
 
+    float cpuLevel{0.f};
+    void setCpuLevel(float f) { cpuLevel = f; }
+    float getCpuLevel() const { return cpuLevel; }
+
     Surge::ParamConfig::VUType vu_type{Surge::ParamConfig::vut_off};
     void setType(Surge::ParamConfig::VUType t) { vu_type = t; };
 


### PR DESCRIPTION
An approximation to CPU load is displayed on the VU meter. On my dev machine the value shown accurately reflects the ability of the synth to accurately render/process the specified sound. The value is smoothed out with a running average and has falloff but it still changes very quickly. 

Related issue #6576 