### PR TITLE
Towards a Variable Block Size

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,9 @@ option(SURGE_BUILD_XT "Build Surge XT synth" ON)
 option(SURGE_BUILD_PYTHON_BINDINGS "Build Surge Python bindings with pybind11" OFF)
 option(SURGE_COPY_TO_PRODUCTS "Copy built plugins to the products directory" ON)
 option(SURGE_COPY_AFTER_BUILD "Copy JUCE plugins to system plugin area after build" OFF)
+if (NOT SURGE_COMPILE_BLOCK_SIZE)
+  set(SURGE_COMPILE_BLOCK_SIZE 32)
+endif()
 
 set(SURGE_JUCE_PATH "${CMAKE_SOURCE_DIR}/libs/JUCE" CACHE STRING "Path to JUCE library source tree")
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -254,6 +254,7 @@ add_library(${PROJECT_NAME}
   )
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(${PROJECT_NAME} PUBLIC SURGE_COMPILE_BLOCK_SIZE=${SURGE_COMPILE_BLOCK_SIZE})
 if(APPLE)
   target_compile_definitions(${PROJECT_NAME} PUBLIC MAC=1)
   target_link_libraries(${PROJECT_NAME}

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4174,7 +4174,7 @@ void SurgeSynthesizer::process()
         hardclip_block8(input[1], BLOCK_SIZE_QUAD);
         copy_block(input[0], storage.audio_in_nonOS[0], BLOCK_SIZE_QUAD);
         copy_block(input[1], storage.audio_in_nonOS[1], BLOCK_SIZE_QUAD);
-        halfbandIN.process_block_U2(input[0], input[1], storage.audio_in[0], storage.audio_in[1]);
+        halfbandIN.process_block_U2(input[0], input[1], storage.audio_in[0], storage.audio_in[1], BLOCK_SIZE_OS);
     }
     else
     {
@@ -4359,7 +4359,7 @@ void SurgeSynthesizer::process()
             break;
         }
 
-        halfbandA.process_block_D2(sceneout[0][0], sceneout[0][1]);
+        halfbandA.process_block_D2(sceneout[0][0], sceneout[0][1], BLOCK_SIZE_OS);
     }
 
     if (play_scene[1])
@@ -4378,7 +4378,7 @@ void SurgeSynthesizer::process()
             break;
         }
 
-        halfbandB.process_block_D2(sceneout[1][0], sceneout[1][1]);
+        halfbandB.process_block_D2(sceneout[1][0], sceneout[1][1], BLOCK_SIZE_OS);
     }
 
     // TODO: FIX SCENE ASSUMPTION

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4174,7 +4174,8 @@ void SurgeSynthesizer::process()
         hardclip_block8(input[1], BLOCK_SIZE_QUAD);
         copy_block(input[0], storage.audio_in_nonOS[0], BLOCK_SIZE_QUAD);
         copy_block(input[1], storage.audio_in_nonOS[1], BLOCK_SIZE_QUAD);
-        halfbandIN.process_block_U2(input[0], input[1], storage.audio_in[0], storage.audio_in[1], BLOCK_SIZE_OS);
+        halfbandIN.process_block_U2(input[0], input[1], storage.audio_in[0], storage.audio_in[1],
+                                    BLOCK_SIZE_OS);
     }
     else
     {

--- a/src/common/dsp/effects/CombulatorEffect.cpp
+++ b/src/common/dsp/effects/CombulatorEffect.cpp
@@ -173,7 +173,7 @@ void CombulatorEffect::process(float *dataL, float *dataR)
 
     // Upsample the input
     float dataOS alignas(16)[2][BLOCK_SIZE_OS];
-    halfbandIN.process_block_U2(dataL, dataR, dataOS[0], dataOS[1]);
+    halfbandIN.process_block_U2(dataL, dataR, dataOS[0], dataOS[1], BLOCK_SIZE_OS);
 
     /*
      * Select the coefficients. Here you have to base yourself on the mode switch and
@@ -339,7 +339,7 @@ void CombulatorEffect::process(float *dataL, float *dataR)
     }
 
     /* Downsample out */
-    halfbandOUT.process_block_D2(dataOS[0], dataOS[1]);
+    halfbandOUT.process_block_D2(dataOS[0], dataOS[1], BLOCK_SIZE_OS);
     copy_block(dataOS[0], L, BLOCK_SIZE_QUAD);
     copy_block(dataOS[1], R, BLOCK_SIZE_QUAD);
 
@@ -349,10 +349,12 @@ void CombulatorEffect::process(float *dataL, float *dataR)
         hp.process_block(L, R);
     }
 
+
     auto cm = clamp01(*f[combulator_mix]);
 
     mix.set_target_smoothed(cm);
     mix.fade_2_blocks_to(dataL, L, dataR, R, dataL, dataR, BLOCK_SIZE_QUAD);
+
 }
 
 void CombulatorEffect::suspend() { init(); }

--- a/src/common/dsp/effects/CombulatorEffect.cpp
+++ b/src/common/dsp/effects/CombulatorEffect.cpp
@@ -349,12 +349,10 @@ void CombulatorEffect::process(float *dataL, float *dataR)
         hp.process_block(L, R);
     }
 
-
     auto cm = clamp01(*f[combulator_mix]);
 
     mix.set_target_smoothed(cm);
     mix.fade_2_blocks_to(dataL, L, dataR, R, dataL, dataR, BLOCK_SIZE_QUAD);
-
 }
 
 void CombulatorEffect::suspend() { init(); }

--- a/src/common/dsp/effects/DelayEffect.cpp
+++ b/src/common/dsp/effects/DelayEffect.cpp
@@ -226,6 +226,7 @@ void DelayEffect::process(float *dataL, float *dataR)
         hp.process_block(tbufferL, tbufferR);
     }
 
+
     pan.trixpan_blocks(dataL, dataR, wbL, wbR, BLOCK_SIZE_QUAD);
 
     feedback.MAC_2_blocks_to(tbufferL, tbufferR, wbL, wbR, BLOCK_SIZE_QUAD);

--- a/src/common/dsp/effects/DelayEffect.cpp
+++ b/src/common/dsp/effects/DelayEffect.cpp
@@ -226,7 +226,6 @@ void DelayEffect::process(float *dataL, float *dataR)
         hp.process_block(tbufferL, tbufferR);
     }
 
-
     pan.trixpan_blocks(dataL, dataR, wbL, wbR, BLOCK_SIZE_QUAD);
 
     feedback.MAC_2_blocks_to(tbufferL, tbufferR, wbL, wbR, BLOCK_SIZE_QUAD);

--- a/src/common/dsp/effects/DistortionEffect.cpp
+++ b/src/common/dsp/effects/DistortionEffect.cpp
@@ -158,8 +158,8 @@ void DistortionEffect::process(float *dataL, float *dataR)
         }
     }
 
-    hr_a.process_block_D2(bL, bR, 128);
-    hr_b.process_block_D2(bL, bR, 64);
+    hr_a.process_block_D2(bL, bR, BLOCK_SIZE * 4);
+    hr_b.process_block_D2(bL, bR, BLOCK_SIZE * 2);
 
     outgain.multiply_2_blocks_to(bL, bR, dataL, dataR, BLOCK_SIZE_QUAD);
 

--- a/src/common/dsp/effects/ResonatorEffect.cpp
+++ b/src/common/dsp/effects/ResonatorEffect.cpp
@@ -101,7 +101,7 @@ void ResonatorEffect::process(float *dataL, float *dataR)
     float dataOS alignas(16)[2][BLOCK_SIZE_OS];
 
     // Upsample the input
-    halfbandIN.process_block_U2(dataL, dataR, dataOS[0], dataOS[1]);
+    halfbandIN.process_block_U2(dataL, dataR, dataOS[0], dataOS[1], BLOCK_SIZE_OS);
 
     /*
      * Select the coefficients. Here you have to base yourself on the mode switch and
@@ -269,7 +269,7 @@ void ResonatorEffect::process(float *dataL, float *dataR)
     }
 
     /* Downsample out */
-    halfbandOUT.process_block_D2(dataOS[0], dataOS[1]);
+    halfbandOUT.process_block_D2(dataOS[0], dataOS[1], BLOCK_SIZE_OS);
     copy_block(dataOS[0], L, BLOCK_SIZE_QUAD);
     copy_block(dataOS[1], R, BLOCK_SIZE_QUAD);
 

--- a/src/common/dsp/effects/RingModulatorEffect.cpp
+++ b/src/common/dsp/effects/RingModulatorEffect.cpp
@@ -82,7 +82,7 @@ void RingModulatorEffect::process(float *dataL, float *dataR)
 #if OVERSAMPLE
     // Now upsample
     float dataOS alignas(16)[2][BLOCK_SIZE_OS];
-    halfbandIN.process_block_U2(dataL, dataR, dataOS[0], dataOS[1]);
+    halfbandIN.process_block_U2(dataL, dataR, dataOS[0], dataOS[1], BLOCK_SIZE_OS);
     sri = storage->dsamplerate_os_inv;
     ub = BLOCK_SIZE_OS;
 #else
@@ -157,7 +157,7 @@ void RingModulatorEffect::process(float *dataL, float *dataR)
     }
 
 #if OVERSAMPLE
-    halfbandOUT.process_block_D2(dataOS[0], dataOS[1]);
+    halfbandOUT.process_block_D2(dataOS[0], dataOS[1], BLOCK_SIZE_OS);
     copy_block(dataOS[0], wetL, BLOCK_SIZE_QUAD);
     copy_block(dataOS[1], wetR, BLOCK_SIZE_QUAD);
 #endif

--- a/src/common/dsp/effects/WaveShaperEffect.cpp
+++ b/src/common/dsp/effects/WaveShaperEffect.cpp
@@ -132,7 +132,7 @@ void WaveShaperEffect::process(float *dataL, float *dataR)
 
     // Now upsample
     float dataOS alignas(16)[2][BLOCK_SIZE_OS];
-    halfbandIN.process_block_U2(wetL, wetR, dataOS[0], dataOS[1]);
+    halfbandIN.process_block_U2(wetL, wetR, dataOS[0], dataOS[1], BLOCK_SIZE_OS);
 
     if (wsptr)
     {
@@ -160,7 +160,7 @@ void WaveShaperEffect::process(float *dataL, float *dataR)
         }
     }
 
-    halfbandOUT.process_block_D2(dataOS[0], dataOS[1]);
+    halfbandOUT.process_block_D2(dataOS[0], dataOS[1], BLOCK_SIZE_OS);
 
     copy_block(dataOS[0], wetL, BLOCK_SIZE_QUAD);
     copy_block(dataOS[1], wetR, BLOCK_SIZE_QUAD);

--- a/src/common/dsp/oscillators/AliasOscillator.cpp
+++ b/src/common/dsp/oscillators/AliasOscillator.cpp
@@ -153,7 +153,7 @@ void AliasOscillator::process_block_internal(const float pitch, const float drif
     case AliasOscillator::ao_waves::aow_audiobuffer:
         // TODO: correct size check here.
         // should really check BLOCK_SIZE_OS etc, make sure everything is as expected
-        static_assert(sizeof(storage->audio_in) > 0xFF,
+        static_assert(sizeof(storage->audio_in) >= 2 * BLOCK_SIZE_OS * sizeof(float),
                       "Memory region not large enough to be indexed by Alias");
 
         wavetable_mode = true;

--- a/src/common/dsp/vembertech/basic_dsp.h
+++ b/src/common/dsp/vembertech/basic_dsp.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "shared.h"
+#include <cstring>
 
 template <typename T> inline T limit_range(const T &x, const T &low, const T &high)
 {
@@ -32,7 +33,7 @@ inline void accumulate_block(float *src, float *dst, unsigned int nquads)
 
 inline void copy_block(float *src, float *dst, unsigned int nquads)
 {
-    memcpy(dst, src, (nquads << 2) * sizeof(float));
+    std::memcpy((void *)dst, (const void *)src, (nquads << 2) * sizeof(float));
 }
 
 inline void mul_block(float *src1, float *src2, float *dst, unsigned int nquads)

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -56,10 +56,14 @@ static inline int _stricmp(const char *s1, const char *s2) { return strcasecmp(s
 #define _SURGE_STR(x) #x
 #define SURGE_STR(x) _SURGE_STR(x)
 
+#if !defined(SURGE_COMPILE_BLOCK_SIZE)
+#error You must compile with -DSURGE_COMPILE_BLOCK_SIZE=32 (or whatnot)
+#endif
+
 const int BASE_WINDOW_SIZE_X = 913;
 const int BASE_WINDOW_SIZE_Y = 569;
 const int NAMECHARS = 64;
-const int BLOCK_SIZE = 32;
+const int BLOCK_SIZE = SURGE_COMPILE_BLOCK_SIZE;
 const int OSC_OVERSAMPLING = 2;
 const int BLOCK_SIZE_OS = OSC_OVERSAMPLING * BLOCK_SIZE;
 const int BLOCK_SIZE_QUAD = BLOCK_SIZE >> 2;

--- a/src/surge-xt/gui/overlays/AboutScreen.cpp
+++ b/src/surge-xt/gui/overlays/AboutScreen.cpp
@@ -179,7 +179,8 @@ void AboutScreen::populateData()
     lowerLeft.emplace_back("Build:", buildinfo, "");
     lowerLeft.emplace_back("System:", system, "");
 
-    auto srString = fmt::format("{:.1f} kHz", storage->samplerate / 1000.0);
+    auto srString =
+        fmt::format("{:.1f} kHz / {} Sample Surge Block", storage->samplerate / 1000.0, BLOCK_SIZE);
 
     if (host != "Unknown")
     {

--- a/src/surge-xt/gui/widgets/MainFrame.cpp
+++ b/src/surge-xt/gui/widgets/MainFrame.cpp
@@ -50,7 +50,8 @@ void MainFrame::paint(juce::Graphics &g)
     r = r.withTrimmedTop(14);
     g.drawText(std::string(Surge::Build::BuildDate) + " " + Surge::Build::BuildTime, r,
                juce::Justification::centredTop);
-    g.drawText("DEBUG", r.reduced(2), juce::Justification::bottomLeft);
+    g.drawText(std::string("DEBUG BS=") + std::to_string(BLOCK_SIZE), r.reduced(2),
+               juce::Justification::bottomLeft);
 #endif
 }
 


### PR DESCRIPTION
This diff

1. Makes the BLOCK_SIZE something you can set form CMake at compile time
2. Fixes the associated half rate filter problems
3. Confirms oscillators, filters, waveshapers, FM work
4. Fixes the copy_block error which resulted in Combulator, Resonator,
   RingModulate nd Waveshaper effect
5. Fix Delay and Distortion due to mis-coded basic_dsp for small blocks
6. More basic_dsp fixes for small blocks
7. Nimbus doesn't work in block size 8; merge and fix separately