### PR TITLE
Add an option to toggle CPU meter

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -61,6 +61,9 @@ std::string defaultKeyToString(DefaultKey k)
     case ShowGhostedLFOWaveReference:
         r = "showGhostedLFOWaveReference";
         break;
+    case ShowCPUUsage:
+        r = "showCPUUsage";
+        break;
     case Use3DWavetableView:
         r = "use3DWavetableView";
         break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -21,63 +21,74 @@ namespace Storage
 // streamed as strings so feel free to change the order to whatever you want
 enum DefaultKey
 {
-    HighPrecisionReadouts,
-    SmoothingMode,
-    PitchSmoothingMode,
-    MiddleC,
-    MPEPitchBendRange,
-    RestoreMSEGSnapFromPatch,
-    UserDataPath,
-    UseODDMTS,
-    ActivateExtraOutputs,
-    MonoPedalMode,
-    ShowCursorWhileEditing,
-    TouchMouseMode,
-    ShowGhostedLFOWaveReference,
-    Use3DWavetableView,
+    // these are all the various menu options
+    DefaultZoom,
+
     DefaultSkin,
     DefaultSkinRootType,
-    DefaultZoom,
-    SliderMoveRateState,
-    RememberTabPositionsPerScene,
+    MenuLightness,
+    LayoutGridResolution,
 
-    PatchJogWraparound,
-    RetainPatchSearchboxAfterLoad,
+    HighPrecisionReadouts,
+    ModWindowShowsValues,
+    InfoWindowPopupOnIdle,
+    ShowGhostedLFOWaveReference,
+    ShowCPUUsage,
+    MiddleC,
+
+    UserDataPath,
+
+    SliderMoveRateState,
+    ShowCursorWhileEditing,
+    TouchMouseMode,
+
+    DefaultPatchAuthor,
+    DefaultPatchComment,
+    InitialPatchName,
+    InitialPatchCategory,
+    InitialPatchCategoryType,
+    AppendOriginalPatchBy,
 
     OverrideTuningOnPatchLoad,
     OverrideMappingOnPatchLoad,
 
-    DefaultPatchAuthor,
-    DefaultPatchComment,
-    AppendOriginalPatchBy,
-
-    ModWindowShowsValues,
-    LayoutGridResolution,
-
+    RememberTabPositionsPerScene,
+    RestoreMSEGSnapFromPatch,
+    ActivateExtraOutputs, // TODO: remove in XT2
+    PatchJogWraparound,
+    RetainPatchSearchboxAfterLoad,
+    PromptToLoadOverDirtyPatch,
+    TabKeyArmsModulators, // TODO: remove in XT2
+    UseKeyboardShortcuts_Plugin,
+    UseKeyboardShortcuts_Standalone,
+    MenuAndEditKeybindingsFollowKeyboardFocus,
+    UseNarratorAnnouncements,
+    UseNarratorAnnouncementsForPatchTypeahead,
+    ExpandModMenusWithSubMenus,
     ShowVirtualKeyboard_Plugin,
     ShowVirtualKeyboard_Standalone,
 
-    InitialPatchName,
-    InitialPatchCategory,
-    InitialPatchCategoryType,
+    MPEPitchBendRange,
+    PitchSmoothingMode,
 
+    SmoothingMode,
+    MonoPedalMode,
+
+    // these are persistent options sprinkled outside of the menu
+    UseODDMTS,
+    Use3DWavetableView,
+    ModListValueDisplay,
+
+    // dialog related stuff
     LastSCLPath,
     LastKBMPath,
     LastWavetablePath,
     LastPatchPath,
 
-    TabKeyArmsModulators, // TODO: remove in XT2
-    MenuAndEditKeybindingsFollowKeyboardFocus,
-
-    InfoWindowPopupOnIdle,
-
-    UseKeyboardShortcuts_Plugin,
-    UseKeyboardShortcuts_Standalone,
-
     PromptToActivateShortcutsOnAccKeypress,
     PromptToActivateCategoryAndPatchOnKeypress,
-    PromptToLoadOverDirtyPatch,
 
+    // overlay related stuff
     TuningOverlayLocation,
     ModlistOverlayLocation,
     MSEGOverlayLocation,
@@ -105,13 +116,6 @@ enum DefaultKey
     FormulaOverlayTearOutAlwaysOnTop,
     WSAnalysisOverlayTearOutAlwaysOnTop,
     FilterAnalysisOverlayTearOutAlwaysOnTop,
-
-    ModListValueDisplay,
-    MenuLightness,
-    ExpandModMenusWithSubMenus,
-
-    UseNarratorAnnouncements,
-    UseNarratorAnnouncementsForPatchTypeahead,
 
     // Surge XT Effects specific defaults
     FXUnitAssumeFixedBlock,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1774,6 +1774,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
             vu[0]->setBounds(skinCtrl->getRect());
             vu[0]->setSkin(currentSkin, bitmapStore);
             vu[0]->setType(Surge::ParamConfig::vut_vu_stereo);
+            vu[0]->setStorage(&(synth->storage));
 
             addAndMakeVisibleWithTracking(frame.get(), *vu[0]);
 
@@ -3836,6 +3837,18 @@ juce::PopupMenu SurgeGUIEditor::makeValueDisplaysMenu(const juce::Point<int> &wh
                             Surge::Storage::updateUserDefaultValue(
                                 &(this->synth->storage),
                                 Surge::Storage::ShowGhostedLFOWaveReference, !lfoone);
+                            this->frame->repaint();
+                        });
+
+    dispDefMenu.addSeparator();
+
+    bool cpumeter = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
+                                                        Surge::Storage::ShowCPUUsage, false);
+
+    dispDefMenu.addItem(Surge::GUI::toOSCase("Show CPU Usage in VU Meter"), true, cpumeter,
+                        [this, cpumeter]() {
+                            Surge::Storage::updateUserDefaultValue(
+                                &(this->synth->storage), Surge::Storage::ShowCPUUsage, !cpumeter);
                             this->frame->repaint();
                         });
 

--- a/src/surge-xt/gui/widgets/VuMeter.h
+++ b/src/surge-xt/gui/widgets/VuMeter.h
@@ -42,6 +42,9 @@ struct VuMeter : public juce::Component, public WidgetBaseMixin<VuMeter>
     void setCpuLevel(float f) { cpuLevel = f; }
     float getCpuLevel() const { return cpuLevel; }
 
+    SurgeStorage *storage{nullptr};
+    void setStorage(SurgeStorage *s) { storage = s; }
+
     Surge::ParamConfig::VUType vu_type{Surge::ParamConfig::vut_off};
     void setType(Surge::ParamConfig::VUType t) { vu_type = t; };
 


### PR DESCRIPTION
Adjust the colors a bit (still fixed not skinnable) - 4 levels instead of 3 now
Clamped the CPU usage display to 100%.
Ordered the userdefaults enums to match the menu structure closer.