### PR TITLE
Fix crash/assert with sge->effectChooser->currentClicked being -1

### DIFF
--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -697,11 +697,14 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
     if (sge)
     {
         cfxid = sge->effectChooser->currentClicked;
-        auto deactbm = sge->effectChooser->getDeactivatedBitmask();
-        addDeact = true;
-        isDeact = deactbm & (1 << cfxid);
-        cfxtype = sge->effectChooser->fxTypes[cfxid];
-        enableClear = cfxtype != fxt_off;
+        if (cfxid >= 0)
+        {
+            auto deactbm = sge->effectChooser->getDeactivatedBitmask();
+            addDeact = true;
+            isDeact = deactbm & (1 << cfxid);
+            cfxtype = sge->effectChooser->fxTypes[cfxid];
+            enableClear = cfxtype != fxt_off;
+        }
     }
 
     auto cfx = std::string{"Current FX Slot"};


### PR DESCRIPTION
On Linux.

`sge->effectChooser->currentClicked` cause an assert on `cfxtype = sge->effectChooser->fxTypes[cfxid];` is it is `-1` (build with assertion on like it is the default for the flatpak). This on opening the standalone version or opening the UI on the LV2. (not sure about the VST3).
