### PR TITLE
Expose some more stuff from surge-common for Rack

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -56,9 +56,15 @@ else()
           ../../libs/JUCE/modules/juce_dsp/juce_dsp.cpp
           )
   if (APPLE)
-    target_sources(juce_dsp_rack_sub PUBLIC ../../libs/JUCE/modules/juce_core/juce_core.mm)
+    target_sources(juce_dsp_rack_sub PUBLIC
+            ../../libs/JUCE/modules/juce_core/juce_core.mm
+            ../../libs/JUCE/modules/juce_audio_formats/juce_audio_formats.mm
+            )
   else()
-    target_sources(juce_dsp_rack_sub PUBLIC ../../libs/JUCE/modules/juce_core/juce_core.cpp)
+    target_sources(juce_dsp_rack_sub PUBLIC
+            ../../libs/JUCE/modules/juce_core/juce_core.cpp
+            ../../libs/JUCE/modules/juce_audio_formats/juce_audio_formats.cpp
+            )
   endif()
   target_compile_definitions(juce_dsp_rack_sub PUBLIC
           NDEBUG=$<IF:$<CONFIG:Release>,1,0>
@@ -66,6 +72,7 @@ else()
           JUCE_MODULE_AVAILABLE_juce_dsp=1
           JUCE_MODULE_AVAILABLE_juce_audio_basics=1
           JUCE_MODULE_AVAILABLE_juce_core=1
+          JUCE_MODULE_VAILABLE_juce_audio_formats=1
           JUCE_STANDALONE_APPLICATION=0
           JUCE_USE_CURL=0
           JUCE_WEB_BROWSER=0
@@ -110,6 +117,7 @@ add_library(${PROJECT_NAME}
   UserDefaults.cpp
   UserDefaults.h
   WAVFileSupport.cpp
+  dsp/DSPExternalAdapterUtils.cpp
   dsp/Effect.cpp
   dsp/Effect.h
   dsp/Oscillator.cpp
@@ -349,6 +357,7 @@ target_link_libraries(${PROJECT_NAME}
   sst-plugininfra::tinyxml
   sst-plugininfra::strnatcmp
   sst-filters
+  sst-filters-extras
   sst-waveshapers
 
   surge::oddsound-mts

--- a/src/common/dsp/DSPExternalAdapterUtils.cpp
+++ b/src/common/dsp/DSPExternalAdapterUtils.cpp
@@ -1,0 +1,21 @@
+//
+// Created by Paul Walker on 9/11/22.
+//
+
+#include "DSPExternalAdapterUtils.h"
+#include "sst/filters/FilterPlotter.h"
+
+namespace surge
+{
+std::pair<std::vector<float>, std::vector<float>>
+calculateFilterResponseCurve(sst::filters::FilterType type, sst::filters::FilterSubType subtype,
+                             float cutoff, float resonance, float gain)
+{
+    auto fp = sst::filters::FilterPlotter(15);
+    auto par = sst::filters::FilterPlotParameters();
+    par.inputAmplitude *= gain;
+    auto data = fp.plotFilterMagnitudeResponse(type, subtype, cutoff, resonance, par);
+    return data;
+}
+
+} // namespace surge

--- a/src/common/dsp/DSPExternalAdapterUtils.h
+++ b/src/common/dsp/DSPExternalAdapterUtils.h
@@ -1,0 +1,18 @@
+/*
+ * API points we need for the rack port, basically, because of the somewhat
+ * screwy make system
+ */
+
+#ifndef SURGE_DSPEXTERNALADAPTERUTILS_H
+#define SURGE_DSPEXTERNALADAPTERUTILS_H
+
+#include <vector>
+#include <sst/filters.h>
+namespace surge
+{
+std::pair<std::vector<float>, std::vector<float>>
+calculateFilterResponseCurve(sst::filters::FilterType type, sst::filters::FilterSubType subtype,
+                             float cutoff, float resonance, float gain);
+}
+
+#endif // RACK_HACK_DSPEXTERNALADAPTERUTILS_H


### PR DESCRIPTION
Basically the linkage of the filter plotter into rack without the SurgeCommon jacks intermediating is too painful so just have a little free function which can run the FilterPlotter in surge common for now.