### PR TITLE
docs: update references to Arch Linux port

### DIFF
--- a/doc/Linux-and-other-Unix-like-distributions.md
+++ b/doc/Linux-and-other-Unix-like-distributions.md
@@ -66,13 +66,13 @@ Users can install it with the command: <br/>
 
 ## Surge on Arch Linux
 
-The Arch Linux port is available and maintained in the official repositories.
+The Arch Linux port is [available](https://archlinux.org/packages/community/x86_64/surge-xt/) and maintained in the official repositories.
 
 Users can install it with the command: <br/>
 `pacman -Syu surge-xt` <br/>
 
-If there are any issues specific to this port, please e-mail the maintainer
-or file a bug report on the bug tracker.
+If there are any issues specific to this port, please e-mail the maintainers (contact details found in above link)
+or file a bug report on the [bug tracker](https://bugs.archlinux.org/).
 
 ## Surge on Flathub
 

--- a/doc/Linux-and-other-Unix-like-distributions.md
+++ b/doc/Linux-and-other-Unix-like-distributions.md
@@ -66,16 +66,13 @@ Users can install it with the command: <br/>
 
 ## Surge on Arch Linux
 
-There are currently two packages in the AUR available for Arch(based) distros.
+The Arch Linux port is available and maintained in the official repositories.
 
-http://aur.archlinux.org/packages/surge-xt-bin
-seems to be the recommended one
+Users can install it with the command: <br/>
+`pacman -Syu surge-xt` <br/>
 
-http://aur.archlinux.org/packages/surge-xt
-seems to be problematic with certain hardware configurations (see comment there).
-
-When in doubt, contact the package maintainers <br/>
-*and please update this document if the situation changes*
+If there are any issues specific to this port, please e-mail the maintainer
+or file a bug report on the bug tracker.
 
 ## Surge on Flathub
 


### PR DESCRIPTION
Hello! :wave:

Package maintainer for Arch Linux here, I've just added `surge-xt` to our repositories.

Hopefully this change to documentation is acceptable, let me know if it requires any further changes.