### PR TITLE
Velocity 0 == note off; CLAP features

### DIFF
--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -56,7 +56,7 @@ juce_add_plugin(${PROJECT_NAME}
 if(SURGE_BUILD_CLAP)
   clap_juce_extensions_plugin(TARGET surge-xt
     CLAP_ID "org.surge-synth-team.surge-xt"
-    CLAP_FEATURES "instrument" "hybrid" "free and open source")
+    CLAP_FEATURES "instrument" "synthesizer" "hybrid" "free and open source")
   target_sources(${PROJECT_NAME}_CLAP PRIVATE plugin_type_extensions/SurgeSynthClapExtensions.cpp)
 endif()
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -603,7 +603,11 @@ void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)
     case CLAP_EVENT_NOTE_ON:
     {
         auto nevt = reinterpret_cast<const clap_event_note *>(evt);
-        surge->playNote(nevt->channel, nevt->key, 127 * nevt->velocity, 0, nevt->note_id);
+
+        if (nevt->velocity != 0)
+            surge->playNote(nevt->channel, nevt->key, 127 * nevt->velocity, 0, nevt->note_id);
+        else
+            surge->releaseNote(nevt->channel, nevt->key, 127 * nevt->velocity, nevt->note_id);
     }
     break;
     case CLAP_EVENT_NOTE_CHOKE:
@@ -705,7 +709,10 @@ void SurgeSynthProcessor::applyMidi(const juce::MidiMessageMetadata &it)
     if (m.isNoteOn())
     {
         // no note ids coming from juce- or ui- land
-        surge->playNote(ch, m.getNoteNumber(), m.getVelocity(), 0, -1);
+        if (m.getVelocity() != 0)
+            surge->playNote(ch, m.getNoteNumber(), m.getVelocity(), 0, -1);
+        else
+            surge->releaseNote(ch, m.getNoteNumber(), m.getVelocity(), -1);
     }
     else if (m.isNoteOff())
     {


### PR DESCRIPTION
1. Velocity 0 == Note Off was not working in the CLAP_NOTE_EVENT stream. Correct and defensively correct in the juce stream also (although I think juce will have pre-converted for me)
2. Add "synthesizer" as a CLAP feature to surge xt, since surge xt is, in fact, a synthesizer :)

Closes #6621