### PR TITLE
Some straggler issues I can clean up

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -850,6 +850,8 @@ juce::AudioProcessorParameter *SurgeSynthProcessor::getBypassParameter() const
     return bypassParameter;
 }
 
+void SurgeSynthProcessor::reset() { blockPos = 0; }
+
 //==============================================================================
 // This creates new instances of the plugin..
 juce::AudioProcessor *JUCE_CALLTYPE createPluginFilter() { return new SurgeSynthProcessor(); }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -352,6 +352,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
 
     std::string paramClumpName(int clumpid);
     juce::MidiKeyboardState midiKeyboardState;
+    void reset() override;
 
     bool getPluginHasMainInput() const override { return false; }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6641,6 +6641,9 @@ void SurgeGUIEditor::showAboutScreen(int devModeGrid)
 
     // this is special - it can't make a rebuild so just add it normally
     frame->addAndMakeVisible(*aboutScreen);
+
+    auto ann = std::string("Surge XT About Screen. Version ") + Surge::Build::FullVersionStr;
+    enqueueAccessibleAnnouncement(ann);
 }
 
 void SurgeGUIEditor::hideAboutScreen()

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1346,8 +1346,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 lurl = fullyResolvedHelpURL(helpurl);
             auto hmen =
                 std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(p->get_full_name(), lurl);
+            auto hment = hmen->getTitle();
             hmen->setSkin(currentSkin, bitmapStore);
-            contextMenu.addCustomItem(-1, std::move(hmen), nullptr, p->get_full_name());
+            contextMenu.addCustomItem(-1, std::move(hmen), nullptr, hment);
 
             contextMenu.addSeparator();
 

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -62,19 +62,20 @@ struct TinyLittleIconButton : public juce::Component
 
 struct MenuTitleHelpComponent : juce::PopupMenu::CustomComponent, Surge::GUI::SkinConsumingComponent
 {
+    std::string manualAccTag = " (open manual)";
     MenuTitleHelpComponent(const std::string &l, const std::string &u)
         : label(l), url(u), juce::PopupMenu::CustomComponent(false)
     {
-        setTitle(l);
-        setDescription(l);
+        setTitle(l + manualAccTag);
+        setDescription(l + manualAccTag);
         setAccessible(true);
     }
 
     MenuTitleHelpComponent(const std::string &l, const std::string &accL, const std::string &u)
         : label(l), url(u), juce::PopupMenu::CustomComponent(false)
     {
-        setTitle(accL);
-        setDescription(accL);
+        setTitle(accL + manualAccTag);
+        setDescription(accL + manualAccTag);
         setAccessible(true);
     }
 


### PR DESCRIPTION
- Announce version when you open the about screen. Closes #6617
- Reset block position in AudioPorcessor::reset. Closes #6610
- Menu help items accesible name is "Foo 2 Pitch (open manual)". Closes #6578