### PR TITLE
Add an oscilloscope (spectrum analyzer).

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Amy Furniss <http://github.com/amyfurniss>
 Cale Gibbard <cgibbard@gmail.com>
 Brian Ginsburg <https://github.com/bgins>
 Ben Goldwasser <https://github.com/sadguitarius>
+Morgan Kanter <https://github.com/mx>
 Nathan Kopp <nk.sg@nathankopp.com>
 Korridor <fabian.kempe@gmail.com>
 Mario Krušelj a.k.a. EvilDragon <http://github.com/mkruselj>

--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -600,6 +600,9 @@ Connector mod_list =
 Connector filter_analysis = Connector("filter.filter_analysis.window", 300, 263, 450, 212,
                                       Components::Custom, Connector::FILTER_ANALYSIS_WINDOW);
 
+Connector oscilloscope = Connector("oscilloscope.window", 0, 0, 800, 400, Components::Custom,
+                                   Connector::OSCILLOSCOPE_WINDOW);
+
 Connector ws_analysis = Connector("filter.waveshaper_analysis.window", 450, 237, 300, 160,
                                   Components::Custom, Connector::WAVESHAPER_ANALYSIS_WINDOW);
 

--- a/src/common/SkinModel.h
+++ b/src/common/SkinModel.h
@@ -271,6 +271,7 @@ struct Connector
         LFO_MENU,
 
         FILTER_ANALYSIS_WINDOW,
+        OSCILLOSCOPE_WINDOW,
         WAVESHAPER_ANALYSIS_WINDOW,
         FORMULA_EDITOR_WINDOW,
         TUNING_EDITOR_WINDOW,
@@ -445,7 +446,7 @@ extern Surge::Skin::Connector mseg_editor, formula_editor, tuning_editor;
 
 extern Surge::Skin::Connector mod_list;
 
-extern Surge::Skin::Connector filter_analysis, ws_analysis;
+extern Surge::Skin::Connector filter_analysis, oscilloscope, ws_analysis;
 
 extern Surge::Skin::Connector save_patch_dialog;
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -21,6 +21,7 @@
 
 #include "tinyxml/tinyxml.h"
 #include "filesystem/import.h"
+#include "sst/cpputils.h"
 
 #include <vector>
 #include <memory>
@@ -1043,6 +1044,9 @@ class alignas(16) SurgeStorage
     float samplerate{0}, samplerate_inv{1};
     double dsamplerate{0}, dsamplerate_inv{1};
     double dsamplerate_os{0}, dsamplerate_os_inv{1};
+    // Ring buffer that holds the audio output, used for the oscilloscope. Will hold a bit under 1/4
+    // second of data, assuming the sample rate is 48k.
+    sst::cpputils::StereoRingBuffer<float, 8192> audioOut;
 
     SurgeStorage(std::string suppliedDataPath = "");
     static std::string skipPatchLoadDataPathSentinel;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1896,7 +1896,7 @@ void SurgeSynthesizer::onRPN(int channel, int lsbRPN, int msbRPN, int lsbValue, 
         ** I thought it came from a roli. But I since changed the MPE state management so
         ** with 1.6.5 do this:
         */
-#if 0      
+#if 0
        // This is the invalid message which the ROLI sends. Rather than have the Roli not work
        mpeEnabled = true;
        mpeVoices = msbValue & 0xF;
@@ -4498,6 +4498,12 @@ void SurgeSynthesizer::process()
     copy_block(sceneout[0][1], output[1], BLOCK_SIZE_QUAD);
     accumulate_block(sceneout[1][0], output[0], BLOCK_SIZE_QUAD);
     accumulate_block(sceneout[1][1], output[1], BLOCK_SIZE_QUAD);
+
+    // Send output to the oscilloscope, if anyone is listening.
+    if (storage.audioOut.subscribed())
+    {
+        storage.audioOut.push(output[0], output[1], BLOCK_SIZE);
+    }
 
     bool sendused[4] = {false, false, false, false};
     // add send effects

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -179,6 +179,9 @@ std::string defaultKeyToString(DefaultKey k)
     case FilterAnalysisOverlayLocation:
         r = "filterAnalysisOverlayLocation";
         break;
+    case OscilloscopeOverlayLocation:
+        r = "oscilloscopeOverlayLocation";
+        break;
 
     case TuningOverlayLocationTearOut:
         r = "tuningOverlayLocationTearOut";
@@ -197,6 +200,9 @@ std::string defaultKeyToString(DefaultKey k)
         break;
     case FilterAnalysisOverlayLocationTearOut:
         r = "filterAnalysisOverlayLocationTearOut";
+        break;
+    case OscilloscopeOverlayLocationTearOut:
+        r = "oscilloscopeOverlayLocationTearOut";
         break;
 
     case TuningOverlaySizeTearOut:
@@ -217,6 +223,9 @@ std::string defaultKeyToString(DefaultKey k)
     case FilterAnalysisOverlaySizeTearOut:
         r = "filterAnalysisOverlaySizeTearOut";
         break;
+    case OscilloscopeOverlaySizeTearOut:
+        r = "oscilloscopeOverlaySizeTearOut";
+        break;
 
     case TuningOverlayTearOutAlwaysOnTop:
         r = "tuningOverlayTearOutAlwaysOnTop";
@@ -235,6 +244,9 @@ std::string defaultKeyToString(DefaultKey k)
         break;
     case FilterAnalysisOverlayTearOutAlwaysOnTop:
         r = "filterAnalysisOverlayTearOutAlwaysOnTop";
+        break;
+    case OscilloscopeOverlayTearOutAlwaysOnTop:
+        r = "oscilloscopeOverlayTearOutAlwaysOnTop";
         break;
 
     case ModListValueDisplay:

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -96,6 +96,7 @@ enum DefaultKey
     FormulaOverlayLocation,
     WSAnalysisOverlayLocation,
     FilterAnalysisOverlayLocation,
+    OscilloscopeOverlayLocation,
 
     TuningOverlayLocationTearOut,
     ModlistOverlayLocationTearOut,
@@ -103,6 +104,7 @@ enum DefaultKey
     FormulaOverlayLocationTearOut,
     WSAnalysisOverlayLocationTearOut,
     FilterAnalysisOverlayLocationTearOut,
+    OscilloscopeOverlayLocationTearOut,
 
     TuningOverlaySizeTearOut,
     ModlistOverlaySizeTearOut,
@@ -110,6 +112,7 @@ enum DefaultKey
     FormulaOverlaySizeTearOut,
     WSAnalysisOverlaySizeTearOut,
     FilterAnalysisOverlaySizeTearOut,
+    OscilloscopeOverlaySizeTearOut,
 
     TuningOverlayTearOutAlwaysOnTop,
     ModlistOverlayTearOutAlwaysOnTop,
@@ -117,6 +120,7 @@ enum DefaultKey
     FormulaOverlayTearOutAlwaysOnTop,
     WSAnalysisOverlayTearOutAlwaysOnTop,
     FilterAnalysisOverlayTearOutAlwaysOnTop,
+    OscilloscopeOverlayTearOutAlwaysOnTop,
 
     // Surge XT Effects specific defaults
     FXUnitAssumeFixedBlock,

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -113,6 +113,8 @@ target_sources(${PROJECT_NAME} PRIVATE
   gui/overlays/MiniEdit.h
   gui/overlays/ModulationEditor.cpp
   gui/overlays/ModulationEditor.h
+  gui/overlays/Oscilloscope.cpp
+  gui/overlays/Oscilloscope.h
   gui/overlays/OverlayWrapper.cpp
   gui/overlays/OverlayWrapper.h
   gui/overlays/PatchDBViewer.cpp

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1854,6 +1854,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
         case Surge::Skin::Connector::NonParameterConnection::TUNING_EDITOR_WINDOW:
         case Surge::Skin::Connector::NonParameterConnection::MOD_LIST_WINDOW:
         case Surge::Skin::Connector::NonParameterConnection::FILTER_ANALYSIS_WINDOW:
+        case Surge::Skin::Connector::NonParameterConnection::OSCILLOSCOPE_WINDOW:
         case Surge::Skin::Connector::NonParameterConnection::WAVESHAPER_ANALYSIS_WINDOW:
         case Surge::Skin::Connector::NonParameterConnection::N_NONCONNECTED:
             break;
@@ -4088,6 +4089,9 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
     Surge::GUI::addMenuWithShortcut(wfMenu, Surge::GUI::toOSCase("Show Virtual Keyboard"),
                                     showShortcutDescription("Alt + K", u8"\U00002325K"), true,
                                     showVirtualKeyboard, [this]() { toggleVirtualKeyboard(); });
+
+    wfMenu.addItem(Surge::GUI::toOSCase("Open Oscilloscope"),
+                   [this]() { showOverlay(OSCILLOSCOPE); });
 
     return wfMenu;
 }
@@ -7442,7 +7446,8 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
     {
         promptForOKCancelWithDontAskAgain(
             "Enable Keyboard Shortcuts",
-            "You have used a keyboard shortcut that Surge XT has assigned to a certain action,\n"
+            "You have used a keyboard shortcut that Surge XT has assigned to a certain "
+            "action,\n"
             "but the option to use keyboard shortcuts is currently disabled. "
             "\nWould you like to enable it?\n\n"
             "You can change this option later in the Workflow menu.",

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -372,6 +372,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         TUNING_EDITOR,
         WAVESHAPER_ANALYZER,
         FILTER_ANALYZER,
+        OSCILLOSCOPE,
         KEYBINDINGS_EDITOR,
         ACTION_HISTORY,
 

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -22,6 +22,7 @@
 #include "overlays/TuningOverlays.h"
 #include "overlays/WaveShaperAnalysis.h"
 #include "overlays/FilterAnalysis.h"
+#include "overlays/Oscilloscope.h"
 #include "overlays/OverlayWrapper.h"
 #include "overlays/KeyBindingsOverlay.h"
 #include "widgets/MainFrame.h"
@@ -344,6 +345,24 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         fa->setMinimumSize(300, 200);
 
         return fa;
+    }
+
+    case OSCILLOSCOPE:
+    {
+        auto scope = std::make_unique<Surge::Overlays::Oscilloscope>(this, &(this->synth->storage));
+
+        locationGet(scope.get(),
+                    Surge::Skin::Connector::NonParameterConnection::OSCILLOSCOPE_WINDOW,
+                    Surge::Storage::OscilloscopeOverlayLocation);
+
+        scope->setSkin(currentSkin, bitmapStore);
+        scope->setEnclosingParentTitle("Oscilloscope");
+        scope->setCanTearOut({true, Surge::Storage::OscilloscopeOverlayLocationTearOut,
+                              Surge::Storage::OscilloscopeOverlayTearOutAlwaysOnTop});
+        scope->setCanTearOutResize({true, Surge::Storage::OscilloscopeOverlaySizeTearOut});
+        scope->setMinimumSize(800, 400);
+
+        return scope;
     }
 
     case MODULATION_EDITOR:

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -1,0 +1,362 @@
+/*
+ ** Surge Synthesizer is Free and Open Source Software
+ **
+ ** Surge is made available under the Gnu General Public License, v3.0
+ ** https://www.gnu.org/licenses/gpl-3.0.en.html
+ **
+ ** Copyright 2004-2021 by various individuals as described by the Git transaction log
+ **
+ ** All source at: https://github.com/surge-synthesizer/surge.git
+ **
+ ** Surge was a commercial product from 2004-2018, with Copyright and ownership
+ ** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+ ** open source in September 2018.
+ */
+
+#include "Oscilloscope.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <functional>
+#include "RuntimeFont.h"
+#include "SkinColors.h"
+
+using namespace std::chrono_literals;
+
+namespace Surge
+{
+namespace Overlays
+{
+
+// TODO:
+// (1) Give configuration to the user to choose FFT params (namely, desired Hz resolution).
+// (2) Provide a mode that shows waveshape, not spectrum.
+Oscilloscope::Oscilloscope(SurgeGUIEditor *e, SurgeStorage *s)
+    : editor_(e), storage_(s), forward_fft_(fftOrder),
+      window_(fftSize, juce::dsp::WindowingFunction<float>::hann), pos_(0), complete_(false),
+      fft_thread_(std::bind(std::mem_fn(&Oscilloscope::pullData), this)), repainted_(true),
+      channel_selection_(STEREO), left_chan_button_("L"), right_chan_button_("R")
+{
+    setAccessible(true);
+
+    auto onToggle = std::bind(std::mem_fn(&Oscilloscope::toggleChannel), this);
+    left_chan_button_.setStorage(storage_);
+    left_chan_button_.setToggleState(true);
+    left_chan_button_.onToggle = onToggle;
+    left_chan_button_.setAccessible(true);
+    left_chan_button_.setTitle("L CHAN");
+    left_chan_button_.setDescription("Enable input from left channel.");
+    right_chan_button_.setStorage(storage_);
+    right_chan_button_.setToggleState(true);
+    right_chan_button_.onToggle = onToggle;
+    right_chan_button_.setAccessible(true);
+    right_chan_button_.setTitle("R CHAN");
+    right_chan_button_.setDescription("Enable input from left channel.");
+    addAndMakeVisible(left_chan_button_);
+    addAndMakeVisible(right_chan_button_);
+
+    storage_->audioOut.subscribe();
+}
+
+Oscilloscope::~Oscilloscope()
+{
+    // complete_ should come before any condition variables get signaled, to allow the data thread
+    // to finish up.
+    complete_.store(true, std::memory_order_seq_cst);
+    channels_off_.notify_all();
+    repainted_.signal();
+    fft_thread_.join();
+    // Data thread can perform subscriptions, so do a final unsubscribe after it's done.
+    storage_->audioOut.unsubscribe();
+}
+
+void Oscilloscope::onSkinChanged()
+{
+    left_chan_button_.setSkin(skin, associatedBitmapStore);
+    right_chan_button_.setSkin(skin, associatedBitmapStore);
+}
+
+void Oscilloscope::paint(juce::Graphics &g)
+{
+    g.fillAll(skin->getColor(Colors::MSEGEditor::Background));
+
+    auto lb = getLocalBounds().transformedBy(getTransform().inverted());
+    auto scopeRect = lb.withTrimmedBottom(15).withTrimmedTop(15).withTrimmedRight(30).reduced(8);
+    auto width = scopeRect.getWidth();
+    auto height = scopeRect.getHeight();
+    auto labelHeight = 9;
+    auto font = skin->fontManager->getLatoAtSize(7);
+    auto primaryLine = skin->getColor(Colors::MSEGEditor::Grid::Primary);
+    auto secondaryLine = skin->getColor(Colors::MSEGEditor::Grid::SecondaryVertical);
+    auto curveColor = skin->getColor(Colors::MSEGEditor::Curve);
+
+    // Horizontal grid.
+    {
+        auto gs = juce::Graphics::ScopedSaveState(g);
+        g.addTransform(juce::AffineTransform().translated(scopeRect.getX(), scopeRect.getY()));
+        g.setFont(font);
+
+        // Draw frequency lines.
+        for (float freq : {20.f, 30.f, 40.f, 60.f, 80.f, 100.f, 200.f, 300.f, 400.f, 600.f, 800.f,
+                           1000.f, 2000.f, 3000.f, 4000.f, 6000.f, 8000.f, 10000.f, 20000.f})
+        {
+            const auto xPos = freqToX(freq, width);
+            juce::Line line{juce::Point{xPos, 0.f}, juce::Point{xPos, (float)height}};
+
+            if (freq == 100.f || freq == 1000.f || freq == 10000.f)
+            {
+                g.setColour(primaryLine);
+            }
+            else
+            {
+                g.setColour(secondaryLine);
+            }
+
+            g.drawLine(line);
+
+            const bool over1000 = freq >= 1000.f;
+            const auto freqString =
+                juce::String(over1000 ? freq / 1000.f : freq) + (over1000 ? "k" : "");
+            // Label will go past the end of the scopeRect.
+            const auto labelRect = juce::Rectangle{font.getStringWidth(freqString), labelHeight}
+                                       .withBottomY(height + 13)
+                                       .withRightX((int)xPos);
+
+            g.setColour(skin->getColor(Colors::MSEGEditor::Axis::Text));
+            g.drawFittedText(freqString, labelRect, juce::Justification::bottom, 1);
+        }
+    }
+
+    // Vertical grid.
+    {
+        auto gs = juce::Graphics::ScopedSaveState(g);
+        g.addTransform(juce::AffineTransform().translated(scopeRect.getX(), scopeRect.getY()));
+        g.setFont(font);
+
+        // Draw dB lines.
+        for (float dB :
+             {-100.f, -90.f, -80.f, -70.f, -60.f, -50.f, -40.f, -30.f, -20.f, -10.f, 0.f})
+        {
+            const auto yPos = dbToY(dB, height);
+
+            juce::Line line{juce::Point{0.f, yPos}, juce::Point{(float)width, yPos}};
+
+            if (dB == 0.f)
+            {
+                g.setColour(primaryLine);
+            }
+            else
+            {
+                g.setColour(secondaryLine);
+            }
+            g.drawLine(line);
+
+            const auto dbString = juce::String(dB) + " dB";
+            // Label will go past the end of the scopeRect.
+            const auto labelRect = juce::Rectangle{font.getStringWidth(dbString), labelHeight}
+                                       .withBottomY((int)yPos)
+                                       .withRightX(width + 30); // -2
+
+            g.setColour(skin->getColor(Colors::MSEGEditor::Axis::SecondaryText));
+            g.drawFittedText(dbString, labelRect, juce::Justification::right, 1);
+        }
+    }
+
+    // Scope data.
+    {
+        auto gs = juce::Graphics::ScopedSaveState(g);
+        g.addTransform(juce::AffineTransform().translated(scopeRect.getX(), scopeRect.getY()));
+
+        auto path = juce::Path();
+        bool started = false;
+        float binHz = storage_->samplerate / static_cast<float>(fftSize);
+        std::lock_guard<std::mutex> l(scope_data_guard_);
+        for (int i = 0; i < fftSize / 2; i++)
+        {
+            float hz = binHz * static_cast<float>(i);
+            if (hz < lowFreq || hz > highFreq)
+            {
+                continue;
+            }
+
+            float x = freqToX(hz, width);
+            float y = dbToY(scope_data_[i], height);
+            if (y > 0)
+            {
+                if (started)
+                {
+                    path.lineTo(x, y);
+                }
+                else
+                {
+                    path.startNewSubPath(x, y);
+                    started = true;
+                }
+            }
+            else
+            {
+                started = false;
+            }
+        }
+        g.setColour(curveColor);
+        g.fillPath(path);
+        repainted_.signal();
+    }
+}
+
+void Oscilloscope::resized()
+{
+    auto t = getTransform().inverted();
+    auto h = getHeight();
+    auto w = getWidth();
+    t.transformPoint(w, h);
+
+    left_chan_button_.setBounds(8, 4, 15, 15);
+    right_chan_button_.setBounds(23, 4, 15, 15);
+}
+
+void Oscilloscope::visibilityChanged()
+{
+    // Not sure aside from construction when visibility might be changed in Juce, so putting this
+    // here for additional safety.
+    if (isVisible())
+    {
+        storage_->audioOut.subscribe();
+    }
+    else
+    {
+        storage_->audioOut.unsubscribe();
+    }
+}
+
+float Oscilloscope::freqToX(float freq, int width) const
+{
+    static const float ratio = std::log(highFreq / lowFreq);
+    float xNorm = std::log(freq / lowFreq) / ratio;
+    return xNorm * (float)width;
+}
+
+float Oscilloscope::xToFreq(float x, int width) const
+{
+    static const float ratio = std::log(highFreq / lowFreq);
+    return lowFreq * std::exp(ratio * x / width);
+}
+
+float Oscilloscope::dbToY(float db, int height) const
+{
+    return (float)height * (dbMax - db) / dbRange;
+}
+
+void Oscilloscope::calculateScopeData()
+{
+    window_.multiplyWithWindowingTable(fft_data_.data(), fftSize);
+    forward_fft_.performFrequencyOnlyForwardTransform(fft_data_.data());
+
+    float binHz = storage_->samplerate / static_cast<float>(fftSize);
+    std::lock_guard<std::mutex> l(scope_data_guard_);
+    for (int i = 0; i < fftSize / 2; i++)
+    {
+        float hz = binHz * static_cast<float>(i);
+        if (hz < lowFreq || hz > highFreq)
+        {
+            scope_data_[i] = dbMin;
+        }
+        else
+        {
+            scope_data_[i] = juce::jlimit(dbMin, dbMax,
+                                          juce::Decibels::gainToDecibels(fft_data_[i]) -
+                                              juce::Decibels::gainToDecibels((float)fftSize));
+        }
+    }
+}
+
+void Oscilloscope::pullData()
+{
+    while (!complete_.load(std::memory_order_seq_cst))
+    {
+        std::unique_lock csl(channel_selection_guard_);
+        if (channel_selection_ == OFF)
+        {
+            // We want to unsubscribe and sleep if we aren't going to be looking at the data, to
+            // prevent useless accumulation and CPU usage.
+            storage_->audioOut.unsubscribe();
+            channels_off_.wait(csl, [this]() {
+                return channel_selection_ != OFF || complete_.load(std::memory_order_seq_cst);
+            });
+            storage_->audioOut.subscribe();
+            continue;
+        }
+        ChannelSelect cs = channel_selection_;
+        csl.unlock();
+
+        std::pair<std::vector<float>, std::vector<float>> data = storage_->audioOut.popall();
+        std::vector<float> &dataL = data.first;
+        std::vector<float> &dataR = data.second;
+        if (dataL.empty())
+        {
+            // Sleep for long enough to accumulate about 4096 samples.
+            std::this_thread::sleep_for(std::chrono::duration<float, std::chrono::seconds::period>(
+                4096.f / storage_->samplerate));
+            continue;
+        }
+
+        // We'll use "dataL" as our storage regardless of the channel choice.
+        if (cs == STEREO)
+        {
+            std::transform(dataL.cbegin(), dataL.cend(), dataR.cbegin(), dataL.begin(),
+                           [](float x, float y) { return (x + y) / 2.f; });
+        }
+        else if (cs == RIGHT)
+        {
+            dataL = dataR;
+        }
+
+        int sz = dataL.size();
+        if (pos_ + sz >= fftSize)
+        {
+            int mv = fftSize - pos_;
+            int leftovers = sz - mv;
+            std::move(dataL.begin(), dataL.begin() + mv, fft_data_.begin() + pos_);
+            calculateScopeData();
+            // We want to let at least one painting happen, so it drains the data we just queued up.
+            repainted_.reset();
+            // Is the following line safe, if the Window gets closed and the class gets
+            // destructed?
+            juce::MessageManager::getInstance()->callAsync([this]() { this->repaint(); });
+            repainted_.wait();
+            std::move(dataL.begin() + mv, dataL.end(), fft_data_.begin());
+            pos_ = leftovers;
+        }
+        else
+        {
+            std::move(dataL.begin(), dataL.end(), fft_data_.begin() + pos_);
+            pos_ += sz;
+        }
+    }
+}
+
+void Oscilloscope::toggleChannel()
+{
+    std::lock_guard l(channel_selection_guard_);
+    if (left_chan_button_.getToggleState() && right_chan_button_.getToggleState())
+    {
+        channel_selection_ = STEREO;
+    }
+    else if (left_chan_button_.getToggleState())
+    {
+        channel_selection_ = LEFT;
+    }
+    else if (right_chan_button_.getToggleState())
+    {
+        channel_selection_ = RIGHT;
+    }
+    else
+    {
+        channel_selection_ = OFF;
+    }
+    channels_off_.notify_all();
+}
+
+} // namespace Overlays
+} // namespace Surge

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -1,0 +1,102 @@
+/*
+ ** Surge Synthesizer is Free and Open Source Software
+ **
+ ** Surge is made available under the Gnu General Public License, v3.0
+ ** https://www.gnu.org/licenses/gpl-3.0.en.html
+ **
+ ** Copyright 2004-2021 by various individuals as described by the Git transaction log
+ **
+ ** All source at: https://github.com/surge-synthesizer/surge.git
+ **
+ ** Surge was a commercial product from 2004-2018, with Copyright and ownership
+ ** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+ ** open source in September 2018.
+ */
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "OverlayComponent.h"
+#include "SkinSupport.h"
+#include "SurgeGUICallbackInterfaces.h"
+#include "SurgeGUIEditor.h"
+#include "SurgeStorage.h"
+#include "widgets/MultiSwitch.h"
+
+#include "juce_core/juce_core.h"
+#include "juce_dsp/juce_dsp.h"
+
+namespace Surge
+{
+namespace Overlays
+{
+
+class Oscilloscope : public OverlayComponent,
+                     public Surge::GUI::SkinConsumingComponent,
+                     public Surge::GUI::Hoverable
+{
+  public:
+    static constexpr int fftOrder = 13;
+    static constexpr int fftSize = 8192;
+
+    Oscilloscope(SurgeGUIEditor *e, SurgeStorage *s);
+    virtual ~Oscilloscope();
+
+    void onSkinChanged() override;
+    void paint(juce::Graphics &g) override;
+    void resized() override;
+    void visibilityChanged() override;
+
+  private:
+    enum ChannelSelect
+    {
+        LEFT = 1,
+        RIGHT = 2,
+        STEREO = 3,
+        OFF = 4,
+    };
+
+    float freqToX(float freq, int width) const;
+    float xToFreq(float x, int width) const;
+    float dbToY(float db, int height) const;
+
+    void calculateScopeData();
+    void pullData();
+    void toggleChannel();
+
+    static constexpr float lowFreq = 10;
+    static constexpr float highFreq = 24000;
+    static constexpr float dbMin = -100;
+    static constexpr float dbMax = 0;
+    static constexpr float dbRange = dbMax - dbMin;
+
+    SurgeGUIEditor *editor_{nullptr};
+    SurgeStorage *storage_{nullptr};
+    juce::dsp::FFT forward_fft_;
+    juce::dsp::WindowingFunction<float> window_;
+    std::array<float, 2 * fftSize> fft_data_;
+    int pos_;
+    std::array<float, fftSize> scope_data_;
+    std::mutex scope_data_guard_;
+    ChannelSelect channel_selection_;
+    std::mutex channel_selection_guard_;
+
+    // Members for the data-pulling thread.
+    std::thread fft_thread_;
+    std::atomic_bool complete_;
+    juce::WaitableEvent repainted_;
+    std::condition_variable channels_off_;
+
+    // Visual elements.
+    Surge::Widgets::SelfDrawToggleButton left_chan_button_;
+    Surge::Widgets::SelfDrawToggleButton right_chan_button_;
+};
+
+} // namespace Overlays
+} // namespace Surge


### PR DESCRIPTION
Works as a tearout overlay. Accessed through the menu. Can display the spectrum of the left channel, right channel, or stereo (averaged).

Currently no waveform display.

Does require the most recent PR from sst-cpputils, not sure if that has to be merged before this PR can go in or not (or even be successfully built -- not sure how submodules work in a case like this).