### PR TITLE
Additional minor Oscilloscope enhancements

### DIFF
--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -600,7 +600,7 @@ Connector mod_list =
 Connector filter_analysis = Connector("filter.filter_analysis.window", 300, 263, 450, 212,
                                       Components::Custom, Connector::FILTER_ANALYSIS_WINDOW);
 
-Connector oscilloscope = Connector("oscilloscope.window", 0, 0, 800, 400, Components::Custom,
+Connector oscilloscope = Connector("oscilloscope.window", 300, 263, 450, 212, Components::Custom,
                                    Connector::OSCILLOSCOPE_WINDOW);
 
 Connector ws_analysis = Connector("filter.waveshaper_analysis.window", 450, 237, 300, 160,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4090,8 +4090,11 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
                                     showShortcutDescription("Alt + K", u8"\U00002325K"), true,
                                     showVirtualKeyboard, [this]() { toggleVirtualKeyboard(); });
 
-    wfMenu.addItem(Surge::GUI::toOSCase("Open Oscilloscope"),
-                   [this]() { showOverlay(OSCILLOSCOPE); });
+    bool showOscilloscope = isAnyOverlayPresent(OSCILLOSCOPE);
+
+    Surge::GUI::addMenuWithShortcut(wfMenu, Surge::GUI::toOSCase("Open Oscilloscope"),
+                                    showShortcutDescription("Alt + O", u8"\U00002325O"), true,
+                                    showOscilloscope, [this]() { toggleOverlay(OSCILLOSCOPE); });
 
     return wfMenu;
 }
@@ -6948,6 +6951,8 @@ void SurgeGUIEditor::setupKeymapManager()
     keyMapManager->addBinding(Surge::GUI::SHOW_TUNING_EDITOR, {keymap_t::Modifiers::ALT, (int)'T'});
     keyMapManager->addBinding(Surge::GUI::TOGGLE_VIRTUAL_KEYBOARD,
                               {keymap_t::Modifiers::ALT, (int)'K'});
+    keyMapManager->addBinding(Surge::GUI::TOGGLE_OSCILLOSCOPE,
+                              {keymap_t::Modifiers::ALT, (int)'O'});
 
     keyMapManager->addBinding(Surge::GUI::ZOOM_TO_DEFAULT, {keymap_t::Modifiers::SHIFT, '/'});
     keyMapManager->addBinding(Surge::GUI::ZOOM_PLUS_10, {keymap_t::Modifiers::NONE, '+'});
@@ -7148,6 +7153,9 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
                 return true;
             case Surge::GUI::TOGGLE_VIRTUAL_KEYBOARD:
                 toggleVirtualKeyboard();
+                return true;
+            case Surge::GUI::TOGGLE_OSCILLOSCOPE:
+                toggleOverlay(SurgeGUIEditor::OSCILLOSCOPE);
                 return true;
 
             case Surge::GUI::ZOOM_TO_DEFAULT:

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -54,6 +54,7 @@ enum KeyboardActions
     SHOW_MODLIST,
     SHOW_TUNING_EDITOR,
     TOGGLE_VIRTUAL_KEYBOARD,
+    TOGGLE_OSCILLOSCOPE,
 
     ZOOM_TO_DEFAULT,
     ZOOM_PLUS_10,
@@ -126,6 +127,8 @@ inline std::string keyboardActionName(KeyboardActions a)
         return "SHOW_TUNING_EDITOR";
     case TOGGLE_VIRTUAL_KEYBOARD:
         return "TOGGLE_VIRTUAL_KEYBOARD";
+    case TOGGLE_OSCILLOSCOPE:
+        return "TOGGLE_OSCILLOSCOPE";
 
     case ZOOM_TO_DEFAULT:
         return "ZOOM_TO_DEFAULT";
@@ -239,6 +242,9 @@ inline std::string keyboardActionDescription(KeyboardActions a)
         break;
     case TOGGLE_VIRTUAL_KEYBOARD:
         desc = "Virtual Keyboard";
+        break;
+    case TOGGLE_OSCILLOSCOPE:
+        desc = "Oscilloscope";
         break;
 
     case ZOOM_TO_DEFAULT:

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -360,7 +360,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         scope->setCanTearOut({true, Surge::Storage::OscilloscopeOverlayLocationTearOut,
                               Surge::Storage::OscilloscopeOverlayTearOutAlwaysOnTop});
         scope->setCanTearOutResize({true, Surge::Storage::OscilloscopeOverlaySizeTearOut});
-        scope->setMinimumSize(800, 400);
+        scope->setMinimumSize(300, 200);
 
         return scope;
     }

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -171,7 +171,10 @@ void Oscilloscope::paint(juce::Graphics &g)
         auto path = juce::Path();
         bool started = false;
         float binHz = storage_->samplerate / static_cast<float>(fftSize);
+        float zeroPoint = dbToY(-100, height);
         std::lock_guard<std::mutex> l(scope_data_guard_);
+        // Start path.
+        path.startNewSubPath(freqToX(lowFreq, width), zeroPoint);
         for (int i = 0; i < fftSize / 2; i++)
         {
             float hz = binHz * static_cast<float>(i);
@@ -190,14 +193,23 @@ void Oscilloscope::paint(juce::Graphics &g)
                 }
                 else
                 {
-                    path.startNewSubPath(x, y);
+                    path.startNewSubPath(x, zeroPoint);
+                    path.lineTo(x, y);
                     started = true;
                 }
             }
             else
             {
+                path.lineTo(x, zeroPoint);
+                path.closeSubPath();
                 started = false;
             }
+        }
+        // End path.
+        if (started)
+        {
+            path.lineTo(freqToX(highFreq, width), zeroPoint);
+            path.closeSubPath();
         }
         g.setColour(curveColor);
         g.fillPath(path);

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -64,7 +64,11 @@ Oscilloscope::~Oscilloscope()
     // complete_ should come before any condition variables get signaled, to allow the data thread
     // to finish up.
     complete_.store(true, std::memory_order_seq_cst);
-    channels_off_.notify_all();
+    {
+        std::lock_guard l(channel_selection_guard_);
+        channel_selection_ = OFF;
+        channels_off_.notify_all();
+    }
     repainted_.signal();
     fft_thread_.join();
     // Data thread can perform subscriptions, so do a final unsubscribe after it's done.

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -52,7 +52,7 @@ Oscilloscope::Oscilloscope(SurgeGUIEditor *e, SurgeStorage *s)
     right_chan_button_.onToggle = onToggle;
     right_chan_button_.setAccessible(true);
     right_chan_button_.setTitle("R CHAN");
-    right_chan_button_.setDescription("Enable input from left channel.");
+    right_chan_button_.setDescription("Enable input from right channel.");
     addAndMakeVisible(left_chan_button_);
     addAndMakeVisible(right_chan_button_);
 


### PR DESCRIPTION
This fixes the floor drawing issue (so it will always be anchored correctly) which was reported by several users. Also addresses other bits requested by users: keyboard shortcut to toggle, sizing. Also *might* help with the reported freezing issue on Mac, but I haven't been able to reproduce that so this is a guess.