### PR TITLE
Smooth 60FPS operation for the Oscilloscope

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1158,17 +1158,7 @@ void SurgeGUIEditor::idle()
     auto scope = getOverlayIfOpenAs<Surge::Overlays::Oscilloscope>(OSCILLOSCOPE);
     if (scope)
     {
-#if 0
-        // Only update every other frame.
-        if (!lastOverlayRefresh)
-        {
-            scope->updateDrawing();
-            lastOverlayRefresh = 1;
-        }
-        lastOverlayRefresh--;
-#else
         scope->updateDrawing();
-#endif
     }
 
     if (scanJuceSkinComponents)

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1158,13 +1158,17 @@ void SurgeGUIEditor::idle()
     auto scope = getOverlayIfOpenAs<Surge::Overlays::Oscilloscope>(OSCILLOSCOPE);
     if (scope)
     {
+#if 0
         // Only update every other frame.
-        if (lastOverlayRefresh)
+        if (!lastOverlayRefresh)
         {
             scope->updateDrawing();
-            lastOverlayRefresh = 0;
+            lastOverlayRefresh = 1;
         }
-        lastOverlayRefresh++;
+        lastOverlayRefresh--;
+#else
+        scope->updateDrawing();
+#endif
     }
 
     if (scanJuceSkinComponents)

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -72,6 +72,7 @@ Oscilloscope::Oscilloscope(SurgeGUIEditor *e, SurgeStorage *s)
     left_chan_button_.setAccessible(true);
     left_chan_button_.setTitle("L CHAN");
     left_chan_button_.setDescription("Enable input from left channel.");
+    left_chan_button_.setWantsKeyboardFocus(false);
     right_chan_button_.setStorage(storage_);
     right_chan_button_.setToggleState(true);
     right_chan_button_.onToggle = onToggle;
@@ -80,6 +81,7 @@ Oscilloscope::Oscilloscope(SurgeGUIEditor *e, SurgeStorage *s)
     right_chan_button_.setAccessible(true);
     right_chan_button_.setTitle("R CHAN");
     right_chan_button_.setDescription("Enable input from right channel.");
+    right_chan_button_.setWantsKeyboardFocus(false);
     addAndMakeVisible(background_);
     addAndMakeVisible(left_chan_button_);
     addAndMakeVisible(right_chan_button_);

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -67,12 +67,16 @@ Oscilloscope::Oscilloscope(SurgeGUIEditor *e, SurgeStorage *s)
     left_chan_button_.setStorage(storage_);
     left_chan_button_.setToggleState(true);
     left_chan_button_.onToggle = onToggle;
+    left_chan_button_.setOpaque(true);
+    left_chan_button_.setBufferedToImage(true);
     left_chan_button_.setAccessible(true);
     left_chan_button_.setTitle("L CHAN");
     left_chan_button_.setDescription("Enable input from left channel.");
     right_chan_button_.setStorage(storage_);
     right_chan_button_.setToggleState(true);
     right_chan_button_.onToggle = onToggle;
+    right_chan_button_.setOpaque(true);
+    right_chan_button_.setBufferedToImage(true);
     right_chan_button_.setAccessible(true);
     right_chan_button_.setTitle("R CHAN");
     right_chan_button_.setDescription("Enable input from right channel.");
@@ -124,8 +128,12 @@ void Oscilloscope::resized()
 
 void Oscilloscope::updateDrawing()
 {
-    spectrogram_.tick();
-    spectrogram_.repaintIfDirty();
+    std::lock_guard l(channel_selection_guard_);
+    if (channel_selection_ != OFF)
+    {
+        spectrogram_.tick();
+        spectrogram_.repaintIfDirty();
+    }
 }
 
 void Oscilloscope::visibilityChanged()
@@ -220,7 +228,7 @@ void Oscilloscope::pullData()
             std::move(dataL.begin(), dataL.begin() + mv, fft_data_.begin() + pos_);
             calculateScopeData();
             spectrogram_.updateScopeData(scope_data_.begin(), scope_data_.end());
-            juce::MessageManager::getInstance()->callAsync([this]() { spectrogram_.repaint(); });
+            //juce::MessageManager::getInstance()->callAsync([this]() { spectrogram_.repaint(); });
             std::move(dataL.begin() + mv, dataL.end(), fft_data_.begin());
             pos_ = leftovers;
         }

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -43,8 +43,8 @@ class Oscilloscope : public OverlayComponent,
                      public Surge::GUI::Hoverable
 {
   public:
-    static constexpr int fftOrder = 12;
-    static constexpr int fftSize = 4096;
+    static constexpr int fftOrder = 13;
+    static constexpr int fftSize = 8192;
     static constexpr float lowFreq = 10;
     static constexpr float highFreq = 24000;
     static constexpr float dbMin = -100;
@@ -93,9 +93,7 @@ class Oscilloscope : public OverlayComponent,
         Spectrogram(SurgeGUIEditor *e, SurgeStorage *s);
 
         void paint(juce::Graphics &g) override;
-        void repaintIfDirty();
         void resized() override;
-        void tick();
         void updateScopeData(FftScopeType::iterator begin, FftScopeType::iterator end);
 
       private:
@@ -109,8 +107,10 @@ class Oscilloscope : public OverlayComponent,
         std::mutex data_lock_;
         FftScopeType new_scope_data_;
         FftScopeType displayed_data_;
-        bool dirty_;
     };
+
+    static float freqToX(float freq, int width);
+    static float dbToY(float db, int height);
 
     void calculateScopeData();
     juce::Rectangle<int> getScopeRect();

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -94,19 +94,21 @@ class Oscilloscope : public OverlayComponent,
 
         void paint(juce::Graphics &g) override;
         void repaintIfDirty();
+        void resized() override;
         void tick();
         void updateScopeData(FftScopeType::iterator begin, FftScopeType::iterator end);
 
       private:
-        // Want it to fully decay from 0dB to -100dB over about 4 seconds. We're painting at 20hz.
-        static constexpr float decayNum = (100.f / 4.f) * (20.f / 60.f);
+        float interpolate(const float y0, const float y1,
+                          std::chrono::time_point<std::chrono::steady_clock> t) const;
+
         SurgeGUIEditor *editor_;
         SurgeStorage *storage_;
+        std::chrono::duration<float> mtbs_;
+        std::chrono::time_point<std::chrono::steady_clock> last_updated_time_;
         std::mutex data_lock_;
-        //FftScopeType current_scope_data_;
         FftScopeType new_scope_data_;
-        FftScopeType maxes_;
-        std::chrono::time_point<std::chrono::steady_clock> last_updated_;
+        FftScopeType displayed_data_;
         bool dirty_;
     };
 

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -43,8 +43,8 @@ class Oscilloscope : public OverlayComponent,
                      public Surge::GUI::Hoverable
 {
   public:
-    static constexpr int fftOrder = 13;
-    static constexpr int fftSize = 8192;
+    static constexpr int fftOrder = 12;
+    static constexpr int fftSize = 4096;
     static constexpr float lowFreq = 10;
     static constexpr float highFreq = 24000;
     static constexpr float dbMin = -100;
@@ -94,14 +94,19 @@ class Oscilloscope : public OverlayComponent,
 
         void paint(juce::Graphics &g) override;
         void repaintIfDirty();
+        void tick();
         void updateScopeData(FftScopeType::iterator begin, FftScopeType::iterator end);
 
       private:
+        // Want it to fully decay from 0dB to -100dB over about 4 seconds. We're painting at 20hz.
+        static constexpr float decayNum = (100.f / 4.f) * (20.f / 60.f);
         SurgeGUIEditor *editor_;
         SurgeStorage *storage_;
         std::mutex data_lock_;
-        std::vector<float> current_scope_data_;
-        std::vector<float> new_scope_data_;
+        //FftScopeType current_scope_data_;
+        FftScopeType new_scope_data_;
+        FftScopeType maxes_;
+        std::chrono::time_point<std::chrono::steady_clock> last_updated_;
         bool dirty_;
     };
 

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -39,6 +39,7 @@ OverlayWrapper::OverlayWrapper()
     addChildComponent(*tearOutButton);
 
     setAccessible(true);
+    setOpaque(true);
     setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
 }
 


### PR DESCRIPTION
This should make the Oscilloscope much smoother (60 FPS!), at barely any hit to CPU.

**PLEASE VERIFY, BEFORE MERGING THIS, THE CHANGE IN OverlayWrapper.cpp**. I noticed that OverlayWrappers were not set to opaque. This meant that everything that partially intersected with some OverlayWrappers would get repainted at the same rate that the (non-opaque?) children get repainted. This is a big CPU hit as like 10+ sliders get repainted at 60 FPS. I'm not sure if not making OverlayWrapper opaque was intentional or not, so please verify before merging this PR.