### PR TITLE
Fix a LIVE feedback bug

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -438,13 +438,17 @@ void SurgeSynthEditor::filesDropped(const juce::StringArray &files, int x, int y
 
 void SurgeSynthEditor::beginParameterEdit(Parameter *p)
 {
+    // std::cout << "BEGIN EDIT " << p->get_name() << std::endl;
     auto par = processor.paramsByID[processor.surge->idForParameter(p)];
+    par->inEditGesture = true;
     par->beginChangeGesture();
 }
 
 void SurgeSynthEditor::endParameterEdit(Parameter *p)
 {
+    //  std::cout << "END EDIT " << p->get_name() << std::endl;
     auto par = processor.paramsByID[processor.surge->idForParameter(p)];
+    par->inEditGesture = false;
     par->endChangeGesture();
 }
 

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -94,6 +94,8 @@ struct SurgeParamToJuceParamAdapter : SurgeBaseParam
         setValueNotifyingHost(getValue());
     }
 
+    std::atomic<bool> inEditGesture{false};
+
     juce::String getName(int i) const override
     {
         juce::String res = SurgeParamToJuceInfo::getParameterName(s, p);
@@ -104,9 +106,21 @@ struct SurgeParamToJuceParamAdapter : SurgeBaseParam
     float getDefaultValue() const override { return 0.0; /* FIXME */ }
     void setValue(float f) override
     {
-        if (f != getValue())
+        auto matches = (f == getValue());
+        if (!matches && !inEditGesture)
+        {
             s->setParameter01(s->idForParameter(p), f, true);
+        }
+        /*
+         * In LIVE 11.1 and 11.2 this will fire and matches will be false
+        else if (inEditGesture)
+        {
+            std::cout << ">>> VST3 SUPRESSED >>> " << f << " " << (matches ? "match" : "DIFFERENT")
+                      << std::endl;
+        }
+         */
     }
+
     int getNumSteps() const override { return RangedAudioParameter::getNumSteps(); }
     float getValueForText(const juce::String &text) const override
     {


### PR DESCRIPTION
Live sends me VST3 param events when dragging with a value different from my slider, which causes a feedback loop. Supress those write events when editing.

Addresses #6648