### PR TITLE
Don't try and DB Index invalid patches

### DIFF
--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -844,6 +844,12 @@ CREATE TABLE IF NOT EXISTS Favorites (
         auto *ph = (patch_header *)phd;
         auto xmlSz = vt_read_int32LE(ph->xmlsize);
 
+        if (!memcpy(ph->tag, "sub3", 4) || xmlSz < 0 || xmlSz > 1024 * 1024 * 1024)
+        {
+            std::cerr << "Skipping invalid patch : [" << p.path.u8string() << "]" << std::endl;
+            return;
+        }
+
         auto xd = phd + sizeof(patch_header);
         std::string xml(xd, xd + xmlSz);
 


### PR DESCRIPTION
Invalid patches (without the sub3 tag or with a ridiculous XML size marker) skip indexing to avoid crashes.

Closes #6643