### PR TITLE
Temporarily deactivate a few features for a 1.1.2 branch release

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4098,12 +4098,16 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
                                     showShortcutDescription("Alt + K", u8"\U00002325K"), true,
                                     showVirtualKeyboard, [this]() { toggleVirtualKeyboard(); });
 
+#if 0
+    // Revert after 112
     bool showOscilloscope = isAnyOverlayPresent(OSCILLOSCOPE);
 
     Surge::GUI::addMenuWithShortcut(wfMenu, Surge::GUI::toOSCase("Open Oscilloscope"),
                                     showShortcutDescription("Alt + O", u8"\U00002325O"), true,
                                     showOscilloscope, [this]() { toggleOverlay(OSCILLOSCOPE); });
 
+    // end revert after 112
+#endif
     return wfMenu;
 }
 
@@ -6959,8 +6963,13 @@ void SurgeGUIEditor::setupKeymapManager()
     keyMapManager->addBinding(Surge::GUI::SHOW_TUNING_EDITOR, {keymap_t::Modifiers::ALT, (int)'T'});
     keyMapManager->addBinding(Surge::GUI::TOGGLE_VIRTUAL_KEYBOARD,
                               {keymap_t::Modifiers::ALT, (int)'K'});
+
+#if 0
+    // REVERT AFTER 112
     keyMapManager->addBinding(Surge::GUI::TOGGLE_OSCILLOSCOPE,
                               {keymap_t::Modifiers::ALT, (int)'O'});
+    // END REVERT AFTER 112
+#endif
 
     keyMapManager->addBinding(Surge::GUI::ZOOM_TO_DEFAULT, {keymap_t::Modifiers::SHIFT, '/'});
     keyMapManager->addBinding(Surge::GUI::ZOOM_PLUS_10, {keymap_t::Modifiers::NONE, '+'});
@@ -7162,9 +7171,10 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
             case Surge::GUI::TOGGLE_VIRTUAL_KEYBOARD:
                 toggleVirtualKeyboard();
                 return true;
-            case Surge::GUI::TOGGLE_OSCILLOSCOPE:
-                toggleOverlay(SurgeGUIEditor::OSCILLOSCOPE);
-                return true;
+                // Revert after 112
+                // case Surge::GUI::TOGGLE_OSCILLOSCOPE:
+                //    toggleOverlay(SurgeGUIEditor::OSCILLOSCOPE);
+                //    return true;
 
             case Surge::GUI::ZOOM_TO_DEFAULT:
             {

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -54,7 +54,8 @@ enum KeyboardActions
     SHOW_MODLIST,
     SHOW_TUNING_EDITOR,
     TOGGLE_VIRTUAL_KEYBOARD,
-    TOGGLE_OSCILLOSCOPE,
+    // REVERT AFTER 112
+    // TOGGLE_OSCILLOSCOPE,
 
     ZOOM_TO_DEFAULT,
     ZOOM_PLUS_10,
@@ -127,8 +128,10 @@ inline std::string keyboardActionName(KeyboardActions a)
         return "SHOW_TUNING_EDITOR";
     case TOGGLE_VIRTUAL_KEYBOARD:
         return "TOGGLE_VIRTUAL_KEYBOARD";
-    case TOGGLE_OSCILLOSCOPE:
-        return "TOGGLE_OSCILLOSCOPE";
+
+        // REVERT AFTER 112
+        // case TOGGLE_OSCILLOSCOPE:
+        //   return "TOGGLE_OSCILLOSCOPE";
 
     case ZOOM_TO_DEFAULT:
         return "ZOOM_TO_DEFAULT";
@@ -243,9 +246,10 @@ inline std::string keyboardActionDescription(KeyboardActions a)
     case TOGGLE_VIRTUAL_KEYBOARD:
         desc = "Virtual Keyboard";
         break;
-    case TOGGLE_OSCILLOSCOPE:
-        desc = "Oscilloscope";
-        break;
+        // REVERT AFTER 112
+        // case TOGGLE_OSCILLOSCOPE:
+        //     desc = "Oscilloscope";
+        //     break;
 
     case ZOOM_TO_DEFAULT:
         desc = "Zoom to Default";

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -3491,7 +3491,10 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                             return;
                         }
 
-                        psd->setShowTagsField(showTags);
+                        // REVERT AFTER 112
+                        psd->setShowTagsField(false /*showTags*/);
+
+                        // END REVERT AFTER 112
                     });
     }
     break;


### PR DESCRIPTION
1. Remove the scope launching
2. Remove the tag editing

Addresses #6661

Revert this commit immediately after 1.1.2 is out