### PR TITLE
Fix various typos

### DIFF
--- a/doc/Dynamic Names, Deactivation and Bipolarity.md
+++ b/doc/Dynamic Names, Deactivation and Bipolarity.md
@@ -63,7 +63,7 @@ or null if there is no parent.
 
 So basically, a good implementation of `getValue()` is to look up the parent param and
 return its decctivation status, and for `getPrimaryActivationDriver()` to look up the
-parent parameter and return a pointer to it. LPG parameteres in EuroTwist do precisely this.
+parent parameter and return a pointer to it. LPG parameters in EuroTwist do precisely this.
 
 ### Follow Value Pattern
 

--- a/doc/Patch Tag Data Model.md
+++ b/doc/Patch Tag Data Model.md
@@ -73,7 +73,7 @@ Let's take the factory patch "Keyboards/DX EP.fxp". One would imagine tagging it
 - author_license: GPL-3.0-or-later
 - author_url: https://surge-synthesizer.github.io/
 
-Or imagine a sequnced MPE patch I made for a project I'm working on called "ChamberSynth":
+Or imagine a sequenced MPE patch I made for a project I'm working on called "ChamberSynth":
 
 - name: That Pad From CS4
 - author: baconpaul

--- a/resources/data/skins/Tutorials/07 The FX Section.surge-skin/skin.xml
+++ b/resources/data/skins/Tutorials/07 The FX Section.surge-skin/skin.xml
@@ -1,6 +1,6 @@
 <!--[doc]
 In Surge 1.8, the FX section can only be changed in the most cursory way. The panels and components may be moved
-but individual sliders, although addressible, cannot be relocated. As such, this tutorial is blank until
+but individual sliders, although addressable, cannot be relocated. As such, this tutorial is blank until
 Surge 1.9 releases in Summer 2020.
 [doc]-->
 <surge-skin name="07 The FX Section" category="Tutorials" author="Surge Synth Team" authorURL="https://surge-synth-team.org/" version="2">

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -557,7 +557,7 @@ class Parameter
     // I know this is a bit gross but we have a runtime type
     ParamUserData *user_data = nullptr;
 
-    // I take a shallow copy and don't assume ownership and assume I am referencable
+    // I take a shallow copy and don't assume ownership and assume I am referenceable
     void set_user_data(ParamUserData *ud);
 
     bool supportsDynamicName() const;

--- a/src/common/dsp/QuadFilterChain.h
+++ b/src/common/dsp/QuadFilterChain.h
@@ -70,7 +70,7 @@
  * various connected filters (QuadFilterChain.cpp) down to the individual filters
  * (QuadFilterUnit.cpp) which then do the parallel evaluation.
  *
- * Those evluators get an 'active' mask on the QuadFilterChainState which tells them which voice
+ * Those evaluators get an 'active' mask on the QuadFilterChainState which tells them which voice
  * is on and off, useful if you need to unroll.
  *
  * So now the only thing we are missing is: how do we make coefficients and maintain state, since

--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -1230,7 +1230,7 @@ void mirrorMSEG(MSEGStorage *ms)
 
     while (h < t)
     {
-        // endponts become starting points
+        // endpoints become starting points
         std::swap(ms->segments[h], ms->segments[t]);
         ms->segments[h].v0 = ms->segments[h].nv1;
         ms->segments[t].v0 = ms->segments[t].nv1;

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -115,7 +115,7 @@ struct SurgeParamToJuceParamAdapter : SurgeBaseParam
          * In LIVE 11.1 and 11.2 this will fire and matches will be false
         else if (inEditGesture)
         {
-            std::cout << ">>> VST3 SUPRESSED >>> " << f << " " << (matches ? "match" : "DIFFERENT")
+            std::cout << ">>> VST3 SUPPRESSED >>> " << f << " " << (matches ? "match" : "DIFFERENT")
                       << std::endl;
         }
          */

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -278,7 +278,7 @@ void MultiSwitch::mouseWheelMove(const juce::MouseEvent &event,
                                  const juce::MouseWheelDetails &wheel)
 {
     // If we aren't draggable and a drag is happening, ignore the mouse wheel gesture
-    // This (vs just a plain !draggable) reverts the 1.9 behaviour of mosue wheel throuhg
+    // This (vs just a plain !draggable) reverts the 1.9 behaviour of mouse wheel through
     // the presets.
     if (!draggable && (event.mouseWasDraggedSinceMouseDown() || event.getLengthOfMousePress() > 0))
     {


### PR DESCRIPTION
Found via `codespell -q 3 -S ./libs -L adres,applys,doesnt,doubleclick,fo,nd,olt,ontext,ot,pard,parm,ro,ser,tbe,te,upto,whichs,wth`