### PR TITLE
Allow LFO Envelopes to retrigger from non-zero values

### DIFF
--- a/src/common/dsp/modulators/LFOModulationSource.h
+++ b/src/common/dsp/modulators/LFOModulationSource.h
@@ -46,11 +46,21 @@ class LFOModulationSource : public ModulationSource
     float bend1(float x);
     float bend2(float x);
     float bend3(float x);
-    virtual void attack() override;
+    virtual void attack() override { attackFrom(0.f); }
+    void attackFrom(float);
     virtual void release() override;
     virtual void process_block() override;
-    virtual void retriggerEnvelope();
+    virtual void retriggerEnvelope() { attackFrom(0.f); }
+    virtual void retriggerEnvelopeFrom(float);
     virtual void completedModulation();
+
+    enum EnvelopeRetriggerMode
+    {
+        FROM_ZERO,
+        FROM_LAST
+    } envRetrigMode{FROM_ZERO};
+
+    float envelopeStart{0.f};
 
     int get_active_outputs() override
     {


### PR DESCRIPTION
This diff allows LFO envelopes to retrigger from non-zero values when either attacking or just envelope retriggering. It compensates for deform and envelope LFO cases also.

It defaults to being FROM_ZERO, the current surge behavior, and does not activate the new behavior in surge VST. Surge XT Rack will end up turning this on before the 1.0 release though.