### PR TITLE
Add the ability to specify a frame-size for untagged wav

### DIFF
--- a/src/common/WAVFileSupport.cpp
+++ b/src/common/WAVFileSupport.cpp
@@ -350,7 +350,15 @@ bool SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
     bool loopData = hasSMPL || hasCLM || hasSRGE;
     int loopLen =
         hasCLM ? clmLEN : (hasCUE ? cueLEN : (hasSRGE ? srgeLEN : (hasSMPL ? smplLEN : -1)));
+    bool fullRange = false;
 
+    if (loopLen == -1 && wt->frame_size_if_absent > 0)
+    {
+        loopLen = wt->frame_size_if_absent;
+        loopData = true;
+        fullRange = true;
+        wt->frame_size_if_absent = -1;
+    }
     if (loopLen == 0)
     {
         std::ostringstream oss;
@@ -494,6 +502,10 @@ bool SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
 
     if (wavdata && wt)
     {
+        if (fullRange && (wh.flags & wtf_int16))
+        {
+            wh.flags |= wtf_int16_is_16;
+        }
         if (numChannels == 1)
         {
             waveTableDataMutex.lock();

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -48,6 +48,7 @@ class Wavetable
     bool refresh_display;
     char queue_filename[256];
     char current_filename[256];
+    int frame_size_if_absent{-1};
 };
 
 enum wtflags


### PR DESCRIPTION
If the wav doesn't have a frame size tag, we default to one shot. This adds an optio on the WT you can set pre-load to offer up a default wavetable size. It is used in the "Load WaveEdit Wavetable" option in XT Rack only right now