### PR TITLE
Add an optional LFO onepole for FROM_LAST envelope mode

### DIFF
--- a/src/common/dsp/modulators/LFOModulationSource.cpp
+++ b/src/common/dsp/modulators/LFOModulationSource.cpp
@@ -77,6 +77,9 @@ void LFOModulationSource::assign(SurgeStorage *storage, LFOStorage *lfo, pdata *
     {
         wf_history[i] = 0.f;
     }
+
+    for (int i = 0; i < 3; ++i)
+        onepoleState[i] = 0.f;
 }
 
 float LFOModulationSource::bend1(float x)
@@ -1288,6 +1291,16 @@ void LFOModulationSource::process_block()
         {
             output_multi[1] *= useenvval;
             output_multi[1] += useenv0;
+        }
+
+        if (envRetrigMode == FROM_LAST && lfo->deform.deform_type != type_3)
+        {
+            // Now appy the one pole
+            float alpha = onepoleFactor;
+            output_multi[0] = (1.0 - alpha) * output_multi[0] + alpha * onepoleState[0];
+            output_multi[1] = (1.0 - alpha) * output_multi[1] + alpha * onepoleState[1];
+            onepoleState[0] = output_multi[0];
+            onepoleState[1] = output_multi[1];
         }
     }
 }

--- a/src/common/dsp/modulators/LFOModulationSource.h
+++ b/src/common/dsp/modulators/LFOModulationSource.h
@@ -110,7 +110,7 @@ class LFOModulationSource : public ModulationSource
     inline int getIntPhase() { return unwrappedphase_intpart; }
     inline int getEnvState() { return env_state; }
     inline int getStep() { return step; }
-    
+
     float onepoleFactor{0};
 
   private:

--- a/src/common/dsp/modulators/LFOModulationSource.h
+++ b/src/common/dsp/modulators/LFOModulationSource.h
@@ -110,6 +110,8 @@ class LFOModulationSource : public ModulationSource
     inline int getIntPhase() { return unwrappedphase_intpart; }
     inline int getEnvState() { return env_state; }
     inline int getStep() { return step; }
+    
+    float onepoleFactor{0};
 
   private:
     pdata *localcopy;
@@ -127,6 +129,8 @@ class LFOModulationSource : public ModulationSource
     bool is_display;
     int step, shuffle_id;
     int magn, rate, iattack, idecay, idelay, ihold, isustain, irelease, startphase, ideform;
+
+    float onepoleState[3];
 
     std::default_random_engine gen;
     std::uniform_real_distribution<float> distro;


### PR DESCRIPTION
In envelope mode with high deform in FROM_LAST mode the signal from the envelope is not continuous. This is basically unsolvable analytically - the deform plus state is too hard - and so leave it on by default but add an optional one pole to smooth it out, which may be useful in some cases.

Expose configurations of that to the rack LFO

Addresses https://github.com/surge-synthesizer/surge-rack/issues/607