### PR TITLE
Fix WT-length-one clamp error

### DIFF
--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -77,7 +77,7 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
     float intpart;
     shape *= ((float)oscdata->wt.n_tables - 1.f + nointerp) * 0.99999f;
     tableipol = modff(shape, &intpart);
-    tableid = limit_range((int)intpart, 0, (int)oscdata->wt.n_tables - 2 + nointerp);
+    tableid = limit_range((int)intpart, 0, std::max((int)oscdata->wt.n_tables - 2 + nointerp, 0));
     last_tableipol = tableipol;
     last_tableid = tableid;
     hskew = 0.f;

--- a/src/common/dsp/vembertech/basic_dsp.h
+++ b/src/common/dsp/vembertech/basic_dsp.h
@@ -4,6 +4,7 @@
 
 template <typename T> inline T limit_range(const T &x, const T &low, const T &high)
 {
+    assert(low <= high);
     return std::clamp(x, low, high);
 }
 


### PR DESCRIPTION
In recent versions we allowed wavetables of length one but when doing so missed this clamp which resulted in hi < lo. that is UB (but defacto clamped to low) but that inversion triggers an assert on some configurations.

So (1) add a debug assert to our limit range and (2) use a max of 0 on the upper bound.

Closes #6702