### PR TITLE
Change for RACK ARM build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Any Clang
     add_compile_options(
+      -Wno-unused-command-line-argument
       -Wno-deprecated-declarations
       -Werror=inconsistent-missing-override
       -Werror=logical-op-parentheses


### PR DESCRIPTION
RACK ARM adds a flag we don't need to our compile which isn't used but we compile with werror and unused compile flag is an error so supress that.