### PR TITLE
String Oscillator Alloc Tweak

### DIFF
--- a/src/common/dsp/oscillators/StringOscillator.cpp
+++ b/src/common/dsp/oscillators/StringOscillator.cpp
@@ -113,8 +113,10 @@ void StringOscillator::init(float pitch, bool is_display, bool nzi)
     else
     {
         ownDelayLines = false;
-        delayLine[0] = storage->memoryPools->stringDelayLines.getItem(storage->sinctable);
-        delayLine[1] = storage->memoryPools->stringDelayLines.getItem(storage->sinctable);
+        if (!delayLine[0])
+            delayLine[0] = storage->memoryPools->stringDelayLines.getItem(storage->sinctable);
+        if (!delayLine[1])
+            delayLine[1] = storage->memoryPools->stringDelayLines.getItem(storage->sinctable);
     }
 
     memset((void *)dustBuffer, 0, 2 * (BLOCK_SIZE_OS) * sizeof(float));


### PR DESCRIPTION
The string oscillator assumed that `init` was only called once per instance, so checked out a delay line from the pre-allocated pool in init. But if init was called twoce it would check out again but not return first.

In surge proper this doesn't matter since we in-place new a new instance for each voice on. but in rack where we make external retriggers available it did; this manifested itself as a string oscillator leak in rack

The delay lines are pre-initialized to null so simply check if they are null before accessing from the memory pool and this fixes the rack leak