### PR TITLE
Add an AirWindows Build Time OptOut

### DIFF
--- a/libs/airwindows/CMakeLists.txt
+++ b/libs/airwindows/CMakeLists.txt
@@ -1,202 +1,224 @@
 project(airwindows VERSION 0.0.0 LANGUAGES CXX)
 
+set(BUILD_AIRWINDOWS TRUE)
+if (${SURGE_SKIP_AIRWINDOWS})
+    set(BUILD_AIRWINDOWS FALSE)
+endif()
+
+if (${BUILD_AIRWINDOWS})
+    message(STATUS "Will build all of airwindows")
+else()
+    message(STATUS "Airwindows Build Skipped")
+endif()
+
 add_library(${PROJECT_NAME}
-  src/ADClip7.cpp
-  src/ADClip7.h
-  src/ADClip7Proc.cpp
-  src/Air.cpp
-  src/Air.h
-  src/AirProc.cpp
-  src/Apicolypse.cpp
-  src/Apicolypse.h
-  src/ApicolypseProc.cpp
-  src/BassDrive.cpp
-  src/BassDrive.h
-  src/BassDriveProc.cpp
-  src/BitGlitter.cpp
-  src/BitGlitter.h
-  src/BitGlitterProc.cpp
-  src/BlockParty.cpp
-  src/BlockParty.h
-  src/BlockPartyProc.cpp
-  src/BrightAmbience2.cpp
-  src/BrightAmbience2.h
-  src/BrightAmbience2Proc.cpp
-  src/BussColors4.cpp
-  src/BussColors4.h
-  src/BussColors4Proc.cpp
-  src/ButterComp2.cpp
-  src/ButterComp2.h
-  src/ButterComp2Proc.cpp
-  src/Cabs.cpp
-  src/Cabs.h
-  src/CabsProc.cpp
-  src/Capacitor.cpp
-  src/Capacitor.h
-  src/CapacitorProc.cpp
-  src/Chamber.cpp
-  src/ChamberProc.cpp
-  src/ChromeOxide.cpp
-  src/ChromeOxideProc.cpp
-  src/Cojones.cpp
-  src/Cojones.h
-  src/CojonesProc.cpp
-  src/Compresaturator.cpp
-  src/Compresaturator.h
-  src/CompresaturatorProc.cpp
-  src/CrunchyGrooveWear.cpp
-  src/CrunchyGrooveWear.h
-  src/CrunchyGrooveWearProc.cpp
-  src/DeBess.cpp
-  src/DeBess.h
-  src/DeBessProc.cpp
-  src/DeEss.cpp
-  src/DeEss.h
-  src/DeEssProc.cpp
-  src/DeRez2.cpp
-  src/DeRez2.h
-  src/DeRez2Proc.cpp
-  src/DeckWrecka.cpp
-  src/DeckWrecka.h
-  src/DeckWreckaProc.cpp
-  src/Density.cpp
-  src/Density.h
-  src/DensityProc.cpp
-  src/Drive.cpp
-  src/Drive.h
-  src/DriveProc.cpp
-  src/DrumSlam.cpp
-  src/DrumSlam.h
-  src/DrumSlamProc.cpp
-  src/DubSub.cpp
-  src/DubSubProc.cpp
-  src/DubCenter.cpp
-  src/DubCenterProc.cpp
-  src/DustBunny.cpp
-  src/DustBunny.h
-  src/DustBunnyProc.cpp
-  src/FireAmp.cpp
-  src/FireAmpProc.cpp
-  src/Focus.cpp
-  src/Focus.h
-  src/FocusProc.cpp
-  src/Fracture.cpp
-  src/Fracture.h
-  src/FractureProc.cpp
-  src/Galactic.cpp
-  src/Galactic.h
-  src/GalacticProc.cpp
-  src/GlitchShifter.cpp
-  src/GlitchShifterProc.cpp
-  src/GrooveWear.cpp
-  src/GrooveWear.h
-  src/GrooveWearProc.cpp
-  src/HardVacuum.cpp
-  src/HardVacuum.h
-  src/HardVacuumProc.cpp
-  src/Hombre.cpp
-  src/Hombre.h
-  src/HombreProc.cpp
-  src/Infinity.cpp
-  src/Infinity.h
-  src/InfinityProc.cpp
-  src/IronOxide5.cpp
-  src/IronOxide5.h
-  src/IronOxide5Proc.cpp
-  src/Logical4.cpp
-  src/Logical4.h
-  src/Logical4Proc.cpp
-  src/Loud.cpp
-  src/Loud.h
-  src/LoudProc.cpp
-  src/Mackity.cpp
-  src/Mackity.h
-  src/MackityProc.cpp
-  src/MackEQ.cpp
-  src/MackEQ.h
-  src/MackEQProc.cpp
-  src/MatrixVerb.cpp
-  src/MatrixVerb.h
-  src/MatrixVerbProc.cpp
-  src/Melt.cpp
-  src/Melt.h
-  src/MeltProc.cpp
-  src/Mojo.cpp
-  src/Mojo.h
-  src/MojoProc.cpp
-  src/NCSeventeen.cpp
-  src/NCSeventeen.h
-  src/NCSeventeenProc.cpp
-  src/Noise.cpp
-  src/Noise.h
-  src/NoiseProc.cpp
-  src/NonlinearSpace.cpp
-  src/NonlinearSpaceProc.cpp
-  src/OneCornerClip.cpp
-  src/OneCornerClip.h
-  src/OneCornerClipProc.cpp
-  src/Pafnuty.cpp
-  src/PafnutyProc.cpp
-  src/PocketVerbs.cpp
-  src/PocketVerbs.h
-  src/PocketVerbsProc.cpp
-  src/Point.cpp
-  src/Point.h
-  src/PointProc.cpp
-  src/Pop.cpp
-  src/Pop.h
-  src/PopProc.cpp
-  src/PowerSag.cpp
-  src/PowerSagProc.cpp
-  src/Pressure4.cpp
-  src/Pressure4.h
-  src/Pressure4Proc.cpp
-  src/PyeWacket.cpp
-  src/PyeWacket.h
-  src/PyeWacketProc.cpp
-  src/SingleEndedTriode.cpp
-  src/SingleEndedTriode.h
-  src/SingleEndedTriodeProc.cpp
-  src/Slew.cpp
-  src/Slew.h
-  src/Slew2.cpp
-  src/Slew2.h
-  src/Slew2Proc.cpp
-  src/SlewProc.cpp
-  src/Spiral2.cpp
-  src/Spiral2.h
-  src/Spiral2Proc.cpp
-  src/StarChild.cpp
-  src/StarChild.h
-  src/StarChildProc.cpp
-  src/Surge.cpp
-  src/Surge.h
-  src/SurgeProc.cpp
-  src/TapeDust.cpp
-  src/TapeDustProc.cpp
-  src/ToTape6.cpp
-  src/ToTape6.h
-  src/ToTape6Proc.cpp
-  src/ToVinyl4.cpp
-  src/ToVinyl4Proc.cpp
-  src/TripleSpread.cpp
-  src/TripleSpread.h
-  src/TripleSpreadProc.cpp
-  src/UnBox.cpp
-  src/UnBox.h
-  src/UnBoxProc.cpp
-  src/Verbity.cpp
-  src/Verbity.h
-  src/VerbityProc.cpp
-  src/VariMu.cpp
-  src/VariMu.h
-  src/VariMuProc.cpp
-  src/VoiceOfTheStarship.cpp
-  src/VoiceOfTheStarship.h
-  src/VoiceOfTheStarshipProc.cpp
   src/AirWinBaseClass_pluginRegistry.cpp
   include/${PROJECT_NAME}/AirWinBaseClass.h
   )
+
+if (${BUILD_AIRWINDOWS})
+    target_sources(${PROJECT_NAME} PRIVATE
+    src/ADClip7.cpp
+src/ADClip7.h
+src/ADClip7Proc.cpp
+src/Air.cpp
+src/Air.h
+src/AirProc.cpp
+src/Apicolypse.cpp
+src/Apicolypse.h
+src/ApicolypseProc.cpp
+src/BassDrive.cpp
+src/BassDrive.h
+src/BassDriveProc.cpp
+src/BitGlitter.cpp
+src/BitGlitter.h
+src/BitGlitterProc.cpp
+src/BlockParty.cpp
+src/BlockParty.h
+src/BlockPartyProc.cpp
+src/BrightAmbience2.cpp
+src/BrightAmbience2.h
+src/BrightAmbience2Proc.cpp
+src/BussColors4.cpp
+src/BussColors4.h
+src/BussColors4Proc.cpp
+src/ButterComp2.cpp
+src/ButterComp2.h
+src/ButterComp2Proc.cpp
+src/Cabs.cpp
+src/Cabs.h
+src/CabsProc.cpp
+src/Capacitor.cpp
+src/Capacitor.h
+src/CapacitorProc.cpp
+src/Chamber.cpp
+src/ChamberProc.cpp
+src/ChromeOxide.cpp
+src/ChromeOxideProc.cpp
+src/Cojones.cpp
+src/Cojones.h
+src/CojonesProc.cpp
+src/Compresaturator.cpp
+src/Compresaturator.h
+src/CompresaturatorProc.cpp
+src/CrunchyGrooveWear.cpp
+src/CrunchyGrooveWear.h
+src/CrunchyGrooveWearProc.cpp
+src/DeBess.cpp
+src/DeBess.h
+src/DeBessProc.cpp
+src/DeEss.cpp
+src/DeEss.h
+src/DeEssProc.cpp
+src/DeRez2.cpp
+src/DeRez2.h
+src/DeRez2Proc.cpp
+src/DeckWrecka.cpp
+src/DeckWrecka.h
+src/DeckWreckaProc.cpp
+src/Density.cpp
+src/Density.h
+src/DensityProc.cpp
+src/Drive.cpp
+src/Drive.h
+src/DriveProc.cpp
+src/DrumSlam.cpp
+src/DrumSlam.h
+src/DrumSlamProc.cpp
+src/DubSub.cpp
+src/DubSubProc.cpp
+src/DubCenter.cpp
+src/DubCenterProc.cpp
+src/DustBunny.cpp
+src/DustBunny.h
+src/DustBunnyProc.cpp
+src/FireAmp.cpp
+src/FireAmpProc.cpp
+src/Focus.cpp
+src/Focus.h
+src/FocusProc.cpp
+src/Fracture.cpp
+src/Fracture.h
+src/FractureProc.cpp
+src/Galactic.cpp
+src/Galactic.h
+src/GalacticProc.cpp
+src/GlitchShifter.cpp
+src/GlitchShifterProc.cpp
+src/GrooveWear.cpp
+src/GrooveWear.h
+src/GrooveWearProc.cpp
+src/HardVacuum.cpp
+src/HardVacuum.h
+src/HardVacuumProc.cpp
+src/Hombre.cpp
+src/Hombre.h
+src/HombreProc.cpp
+src/Infinity.cpp
+src/Infinity.h
+src/InfinityProc.cpp
+src/IronOxide5.cpp
+src/IronOxide5.h
+src/IronOxide5Proc.cpp
+src/Logical4.cpp
+src/Logical4.h
+src/Logical4Proc.cpp
+src/Loud.cpp
+src/Loud.h
+src/LoudProc.cpp
+src/Mackity.cpp
+src/Mackity.h
+src/MackityProc.cpp
+src/MackEQ.cpp
+src/MackEQ.h
+src/MackEQProc.cpp
+src/MatrixVerb.cpp
+src/MatrixVerb.h
+src/MatrixVerbProc.cpp
+src/Melt.cpp
+src/Melt.h
+src/MeltProc.cpp
+src/Mojo.cpp
+src/Mojo.h
+src/MojoProc.cpp
+src/NCSeventeen.cpp
+src/NCSeventeen.h
+src/NCSeventeenProc.cpp
+src/Noise.cpp
+src/Noise.h
+src/NoiseProc.cpp
+src/NonlinearSpace.cpp
+src/NonlinearSpaceProc.cpp
+src/OneCornerClip.cpp
+src/OneCornerClip.h
+src/OneCornerClipProc.cpp
+src/Pafnuty.cpp
+src/PafnutyProc.cpp
+src/PocketVerbs.cpp
+src/PocketVerbs.h
+src/PocketVerbsProc.cpp
+src/Point.cpp
+src/Point.h
+src/PointProc.cpp
+src/Pop.cpp
+src/Pop.h
+src/PopProc.cpp
+src/PowerSag.cpp
+src/PowerSagProc.cpp
+src/Pressure4.cpp
+src/Pressure4.h
+src/Pressure4Proc.cpp
+src/PyeWacket.cpp
+src/PyeWacket.h
+src/PyeWacketProc.cpp
+src/SingleEndedTriode.cpp
+src/SingleEndedTriode.h
+src/SingleEndedTriodeProc.cpp
+src/Slew.cpp
+src/Slew.h
+src/Slew2.cpp
+src/Slew2.h
+src/Slew2Proc.cpp
+src/SlewProc.cpp
+src/Spiral2.cpp
+src/Spiral2.h
+src/Spiral2Proc.cpp
+src/StarChild.cpp
+src/StarChild.h
+src/StarChildProc.cpp
+src/Surge.cpp
+src/Surge.h
+src/SurgeProc.cpp
+src/TapeDust.cpp
+src/TapeDustProc.cpp
+src/ToTape6.cpp
+src/ToTape6.h
+src/ToTape6Proc.cpp
+src/ToVinyl4.cpp
+src/ToVinyl4Proc.cpp
+src/TripleSpread.cpp
+src/TripleSpread.h
+src/TripleSpreadProc.cpp
+src/UnBox.cpp
+src/UnBox.h
+src/UnBoxProc.cpp
+src/Verbity.cpp
+src/Verbity.h
+src/VerbityProc.cpp
+src/VariMu.cpp
+src/VariMu.h
+src/VariMuProc.cpp
+src/VoiceOfTheStarship.cpp
+src/VoiceOfTheStarship.h
+src/VoiceOfTheStarshipProc.cpp)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC
+            SURGE_INCLUDE_AIRWINDOWS=1
+            )
+else()
+    target_compile_definitions(${PROJECT_NAME} PUBLIC
+            SURGE_INCLUDE_AIRWINDOWS=0
+            )
+endif()
 target_compile_definitions(${PROJECT_NAME} PRIVATE
   AudioEffectX=AirWinBaseClass
   VstPlugCategory=long

--- a/libs/airwindows/src/AirWinBaseClass_pluginRegistry.cpp
+++ b/libs/airwindows/src/AirWinBaseClass_pluginRegistry.cpp
@@ -1,3 +1,4 @@
+#if SURGE_INCLUDE_AIRWINDOWS
 #include "ADClip7.h"
 #include "Air.h"
 #include "Apicolypse.h"
@@ -66,13 +67,19 @@
 #include "Verbity.h"
 #include "VariMu.h"
 #include "VoiceOfTheStarship.h"
+#else
+#include "airwindows/AirWinBaseClass.h"
+#endif
+
 #include <map>
 
 namespace
 {
 
 template <typename T> constexpr bool requiresDenorm() { return false; }
+#if SURGE_INCLUDE_AIRWINDOWS
 template <> constexpr bool requiresDenorm<DeRez2::DeRez2>() { return true; }
+#endif
 
 template <typename T> std::unique_ptr<AirWinBaseClass> create(int id, double sr, int dp)
 {
@@ -94,6 +101,11 @@ std::vector<AirWinBaseClass::Registration> AirWinBaseClass::pluginRegistry()
 
     if (!reg.empty())
         return reg;
+
+#if !SURGE_INCLUDE_AIRWINDOWS
+    int id = 0;
+    reg.emplace_back(create<AirWindowsNoOp>, id++, -1, "NoOp", "NoOp (Airwindows Build Skipped)");
+#else
 
     /*
      * Register with streaming ID (which must be increasing and can never change), display order ID
@@ -213,6 +225,7 @@ std::vector<AirWinBaseClass::Registration> AirWinBaseClass::pluginRegistry()
     reg.emplace_back(create<PowerSag::PowerSag>, id++, 362, gnSaturation, "Power Sag");
     reg.emplace_back(create<TapeDust::TapeDust>, id++, 205, gnNoise, "Tape Dust");
     reg.emplace_back(create<ToVinyl4::ToVinyl4>, id++, 195, gnLoFi, "To Vinyl");
+#endif
 
     return reg;
 }


### PR DESCRIPTION
Surge VST would never want this but since we don't currently include the AW FX in Surge XT for Rack, the build isn't needed. So stub out to be a single NoOp effect so the FX will still work just do nothing.

Addresses https://github.com/surge-synthesizer/surge-rack/issues/652