### PR TITLE
Fix build with mingw

### DIFF
--- a/src/common/dsp/oscillators/WindowOscillator.cpp
+++ b/src/common/dsp/oscillators/WindowOscillator.cpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 #include "DebugHelpers.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <intrin.h>
 #else
 namespace


### PR DESCRIPTION
The function `_BitScanReverse` also exists in mingw, and was causing a build failure for surge-xt in Cardinal.
