### PR TITLE
Disable unwanted/not-needed sqlite features

### DIFF
--- a/libs/sqlite-3.23.3/CMakeLists.txt
+++ b/libs/sqlite-3.23.3/CMakeLists.txt
@@ -4,3 +4,9 @@ message(STATUS "Including local sqlite" )
 add_library(${PROJECT_NAME} sqlite3.c sqlite3.h)
 add_library(surge::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} INTERFACE .)
+target_compile_definitions(${PROJECT_NAME} PUBLIC
+    SQLITE_OMIT_AUTHORIZATION=1
+    SQLITE_OMIT_COMPILEOPTION_DIAGS=1
+    SQLITE_OMIT_DEPRECATED=1
+    SQLITE_OMIT_LOAD_EXTENSION=1
+    SQLITE_OMIT_WAL=1)


### PR DESCRIPTION
The built-in sqlite has all default features enabled, we can remove some that are unused.
Specially important is the "load extension" which uses dlopen/dlsym/dlclose/etc, these are superfulous and introduce extra library links (libdl.so on Linux) without being needed.

The other ones I picked based on a quick check through the code, these seem to me the more obvious ones to take out.
