### PR TITLE
Allow to skip oddsound-mts usage

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -504,6 +504,7 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
         getPatch().scene[s].drift.set_extend_range(true);
     }
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     bool mtsMode = Surge::Storage::getUserDefaultValue(this, Surge::Storage::UseODDMTS, false);
     if (mtsMode)
     {
@@ -514,6 +515,7 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
         oddsound_mts_client = nullptr;
         oddsound_mts_active = false;
     }
+#endif
 
     initPatchName =
         Surge::Storage::getUserDefaultValue(this, Surge::Storage::InitialPatchName, "Init Saw");
@@ -1952,7 +1954,12 @@ void SurgeStorage::load_midi_controllers()
     }
 }
 
-SurgeStorage::~SurgeStorage() { deinitialize_oddsound(); }
+SurgeStorage::~SurgeStorage()
+{
+#ifndef SURGE_SKIP_ODDSOUND_MTS
+    deinitialize_oddsound();
+#endif
+}
 
 double shafted_tanh(double x) { return (exp(x) - exp(-x * 1.2)) / (exp(x) + exp(-x)); }
 
@@ -2378,6 +2385,7 @@ void SurgeStorage::storeMidiMappingToName(std::string name)
     }
 }
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
 void SurgeStorage::initialize_oddsound()
 {
     if (oddsound_mts_client)
@@ -2415,6 +2423,7 @@ void SurgeStorage::setOddsoundMTSActiveTo(bool b)
         tuningApplicationMode = patchStoredTuningApplicationMode;
     }
 }
+#endif
 
 void SurgeStorage::toggleTuningToCache()
 {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1368,11 +1368,13 @@ class alignas(16) SurgeStorage
 
     void setTuningApplicationMode(const TuningApplicationMode m);
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     void initialize_oddsound();
     void deinitialize_oddsound();
+    void setOddsoundMTSActiveTo(bool b);
+#endif
     MTSClient *oddsound_mts_client = nullptr;
     std::atomic<bool> oddsound_mts_active{false};
-    void setOddsoundMTSActiveTo(bool b);
     uint32_t oddsound_mts_on_check = 0;
     enum OddsoundRetuneMode
     {

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -372,6 +372,7 @@ void SurgeSynthesizer::playNote(char channel, char key, char velocity, char detu
         return;
     }
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     if (storage.oddsound_mts_client && storage.oddsound_mts_active)
     {
         if (MTS_ShouldFilterNote(storage.oddsound_mts_client, key, channel))
@@ -379,6 +380,7 @@ void SurgeSynthesizer::playNote(char channel, char key, char velocity, char detu
             return;
         }
     }
+#endif
 
     if (learn_param_from_note >= 0 &&
         storage.getPatch().param_ptr[learn_param_from_note]->ctrltype == ct_midikey_or_channel)
@@ -4090,6 +4092,7 @@ void SurgeSynthesizer::processControl()
         if (fx[i])
             refresh_editor |= fx[i]->checkHasInvalidatedUI();
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     if (storage.oddsound_mts_client)
     {
         storage.oddsound_mts_on_check = (storage.oddsound_mts_on_check + 1) & (1024 - 1);
@@ -4104,6 +4107,7 @@ void SurgeSynthesizer::processControl()
             }
         }
     }
+#endif
 }
 
 void SurgeSynthesizer::process()

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -48,6 +48,7 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
     */
     auto res = key + /* mainChannelState->pitchBendInSemitones + */ mpeBend + detune;
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     if (storage->oddsound_mts_client && storage->oddsound_mts_active)
     {
         if (storage->oddsoundRetuneMode == SurgeStorage::RETUNE_CONSTANT ||
@@ -60,8 +61,10 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
 
         res = res + rkey;
     }
-    else if (!storage->isStandardTuning &&
-             storage->tuningApplicationMode == SurgeStorage::RETUNE_MIDI_ONLY)
+    else
+#endif
+        if (!storage->isStandardTuning &&
+            storage->tuningApplicationMode == SurgeStorage::RETUNE_MIDI_ONLY)
     {
         res = storage->remapKeyInMidiOnlyMode(res);
     }
@@ -400,6 +403,7 @@ void SurgeVoice::retriggerPortaIfKeyChanged()
             return storage->currentTuning.logScaledFrequencyForMidiNote(k) * 12;
         };
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
         if (storage->oddsound_mts_client && storage->oddsound_mts_active)
         {
             v4k = [this](int k) {
@@ -408,6 +412,7 @@ void SurgeVoice::retriggerPortaIfKeyChanged()
                        12;
             };
         }
+#endif
 
         auto ckey = state.pkey;
         auto start = state.priorpkey - 2;
@@ -1477,12 +1482,14 @@ void SurgeVoice::resetPortamentoFrom(int key, int channel)
     else
     {
         float lk = key;
+#ifndef SURGE_SKIP_ODDSOUND_MTS
         if (storage->oddsound_mts_client && storage->oddsound_mts_active)
         {
             lk += MTS_RetuningInSemitones(storage->oddsound_mts_client, lk, channel);
             state.portasrc_key = lk;
         }
         else
+#endif
         {
             if (storage->mapChannelToOctave && !mpeEnabled)
                 state.portasrc_key =


### PR DESCRIPTION
From what I could understand, the oddsound-mts library is only partly open-source.
All the code from https://github.com/ODDSound/MTS-ESP references a system library that must be loaded at runtime.
There is no public code for libMTS.so

I even suspect this is a GPL violation, the MTS client code is directly calling a proprietary library and Surge is using MTS client code. Would need a deeper investigation..

For now I would appreciate a way to disable this feature, I was surprised to find there is a reliance on an external library from a plugin (even if optional)
There is likely more stuff needed, but my knowledge of cmake is very lacking so I just did the code.
