### PR TITLE
Allow a SURGE build without any libMTS

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -4,7 +4,16 @@ project(surge-common)
 surge_add_lib_subdirectory(airwindows)
 surge_add_lib_subdirectory(eurorack)
 surge_add_lib_subdirectory(fmt)
-surge_add_lib_subdirectory(oddsound-mts)
+
+# Make MTS optional
+if (NOT SURGE_SKIP_ODDSOUND_MTS)
+   surge_add_lib_subdirectory(oddsound-mts)
+else()
+   add_library(oddsound-mts INTERFACE)
+   target_compile_definitions(oddsound-mts INTERFACE SURGE_SKIP_ODDSOUND_MTS)
+   add_library(surge::oddsound-mts ALIAS oddsound-mts)
+endif()
+
 if(MINGW)
   set(HAVE_VISIBILITY 0 CACHE INTERNAL "Force-disable libsamplerate's visibility check on MinGW")
 endif()

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -37,7 +37,9 @@
 #include "version.h"
 
 #include "sst/plugininfra/strnatcmp.h"
+#ifndef SURGE_SKIP_ODDSOUND_MTS
 #include "libMTSClient.h"
+#endif
 #include "FxPresetAndClipboardManager.h"
 #include "ModulatorPresetManager.h"
 #include "SurgeMemoryPools.h"
@@ -504,6 +506,7 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
         getPatch().scene[s].drift.set_extend_range(true);
     }
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     bool mtsMode = Surge::Storage::getUserDefaultValue(this, Surge::Storage::UseODDMTS, false);
     if (mtsMode)
     {
@@ -514,6 +517,7 @@ SurgeStorage::SurgeStorage(std::string suppliedDataPath) : otherscene_clients(0)
         oddsound_mts_client = nullptr;
         oddsound_mts_active = false;
     }
+#endif
 
     initPatchName =
         Surge::Storage::getUserDefaultValue(this, Surge::Storage::InitialPatchName, "Init Saw");
@@ -1952,7 +1956,12 @@ void SurgeStorage::load_midi_controllers()
     }
 }
 
-SurgeStorage::~SurgeStorage() { deinitialize_oddsound(); }
+SurgeStorage::~SurgeStorage()
+{
+#ifndef SURGE_SKIP_ODDSOUND_MTS
+    deinitialize_oddsound();
+#endif
+}
 
 double shafted_tanh(double x) { return (exp(x) - exp(-x * 1.2)) / (exp(x) + exp(-x)); }
 
@@ -2378,6 +2387,7 @@ void SurgeStorage::storeMidiMappingToName(std::string name)
     }
 }
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
 void SurgeStorage::initialize_oddsound()
 {
     if (oddsound_mts_client)
@@ -2415,6 +2425,7 @@ void SurgeStorage::setOddsoundMTSActiveTo(bool b)
         tuningApplicationMode = patchStoredTuningApplicationMode;
     }
 }
+#endif
 
 void SurgeStorage::toggleTuningToCache()
 {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1368,11 +1368,13 @@ class alignas(16) SurgeStorage
 
     void setTuningApplicationMode(const TuningApplicationMode m);
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     void initialize_oddsound();
     void deinitialize_oddsound();
+    void setOddsoundMTSActiveTo(bool b);
+#endif
     MTSClient *oddsound_mts_client = nullptr;
     std::atomic<bool> oddsound_mts_active{false};
-    void setOddsoundMTSActiveTo(bool b);
     uint32_t oddsound_mts_on_check = 0;
     enum OddsoundRetuneMode
     {

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -25,7 +25,10 @@
 
 #include <thread>
 #include <set>
+#ifndef SURGE_SKIP_ODDSOUND_MTS
 #include "libMTSClient.h"
+#endif
+
 #include "SurgeMemoryPools.h"
 
 using namespace std;
@@ -372,6 +375,7 @@ void SurgeSynthesizer::playNote(char channel, char key, char velocity, char detu
         return;
     }
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     if (storage.oddsound_mts_client && storage.oddsound_mts_active)
     {
         if (MTS_ShouldFilterNote(storage.oddsound_mts_client, key, channel))
@@ -379,6 +383,7 @@ void SurgeSynthesizer::playNote(char channel, char key, char velocity, char detu
             return;
         }
     }
+#endif
 
     if (learn_param_from_note >= 0 &&
         storage.getPatch().param_ptr[learn_param_from_note]->ctrltype == ct_midikey_or_channel)
@@ -4090,6 +4095,7 @@ void SurgeSynthesizer::processControl()
         if (fx[i])
             refresh_editor |= fx[i]->checkHasInvalidatedUI();
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     if (storage.oddsound_mts_client)
     {
         storage.oddsound_mts_on_check = (storage.oddsound_mts_on_check + 1) & (1024 - 1);
@@ -4104,6 +4110,7 @@ void SurgeSynthesizer::processControl()
             }
         }
     }
+#endif
 }
 
 void SurgeSynthesizer::process()

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -17,7 +17,9 @@
 #include "DSPUtils.h"
 #include "QuadFilterChain.h"
 #include <cmath>
+#ifndef SURGE_SKIP_ODDSOUND_MTS
 #include "libMTSClient.h"
+#endif
 
 using namespace std;
 
@@ -48,6 +50,7 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
     */
     auto res = key + /* mainChannelState->pitchBendInSemitones + */ mpeBend + detune;
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     if (storage->oddsound_mts_client && storage->oddsound_mts_active)
     {
         if (storage->oddsoundRetuneMode == SurgeStorage::RETUNE_CONSTANT ||
@@ -60,8 +63,10 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
 
         res = res + rkey;
     }
-    else if (!storage->isStandardTuning &&
-             storage->tuningApplicationMode == SurgeStorage::RETUNE_MIDI_ONLY)
+    else
+#endif
+        if (!storage->isStandardTuning &&
+            storage->tuningApplicationMode == SurgeStorage::RETUNE_MIDI_ONLY)
     {
         res = storage->remapKeyInMidiOnlyMode(res);
     }
@@ -400,6 +405,7 @@ void SurgeVoice::retriggerPortaIfKeyChanged()
             return storage->currentTuning.logScaledFrequencyForMidiNote(k) * 12;
         };
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
         if (storage->oddsound_mts_client && storage->oddsound_mts_active)
         {
             v4k = [this](int k) {
@@ -408,6 +414,7 @@ void SurgeVoice::retriggerPortaIfKeyChanged()
                        12;
             };
         }
+#endif
 
         auto ckey = state.pkey;
         auto start = state.priorpkey - 2;
@@ -1477,12 +1484,14 @@ void SurgeVoice::resetPortamentoFrom(int key, int channel)
     else
     {
         float lk = key;
+#ifndef SURGE_SKIP_ODDSOUND_MTS
         if (storage->oddsound_mts_client && storage->oddsound_mts_active)
         {
             lk += MTS_RetuningInSemitones(storage->oddsound_mts_client, lk, channel);
             state.portasrc_key = lk;
         }
         else
+#endif
         {
             if (storage->mapChannelToOctave && !mpeEnabled)
                 state.portasrc_key =

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -73,7 +73,9 @@
 #include <codecvt>
 #include "version.h"
 #include "ModernOscillator.h"
+#ifndef SURGE_SKIP_ODDSOUND_MTS
 #include "libMTSClient.h"
+#endif
 
 #include "filesystem/import.h"
 #include "RuntimeFont.h"
@@ -3238,6 +3240,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
         tuningSubMenu.addSeparator();
     }
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     if (isOddsoundOn)
     {
         std::string mtsScale = MTS_GetScaleName(synth->storage.oddsound_mts_client);
@@ -3247,6 +3250,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
 
         tuningSubMenu.addSeparator();
     }
+#endif
 
     if (!isOddsoundOn)
     {
@@ -3501,6 +3505,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
         tuningSubMenu.addSeparator();
     }
 
+#ifndef SURGE_SKIP_ODDSOUND_MTS
     if (synth->juceWrapperType.compare("Standalone") != 0)
     {
         bool tsMode = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
@@ -3556,6 +3561,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
             return tuningSubMenu;
         }
     }
+#endif
 
     return tuningSubMenu;
 }


### PR DESCRIPTION
Adding the cmake option -DSURGE_SKIP_ODDSOUND_MTS=TRUE means that surge will not consume an libMTS code and will not present users the MTS options. The default build settings include MTS so if you want an MTS free surge, you need to actively set the option.

See the discussion in #6724