### PR TITLE
Use the defaulted copy and assignment constructors, instead of memcpy…

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -66,11 +66,10 @@ SurgeSynthesizer::SurgeSynthesizer(PluginLayer *parent, const std::string &suppl
     memset(storage.getPatch().scenedata[1], 0, sizeof(pdata) * n_scene_params);
     memset(storage.getPatch().globaldata, 0, sizeof(pdata) * n_global_params);
     memset(mControlInterpolatorUsed, 0, sizeof(bool) * num_controlinterpolators);
-    memset((void *)fxsync, 0, sizeof(FxStorage) * n_fx_slots);
 
-    std::copy(storage.getPatch().fx, storage.getPatch().fx + n_fx_slots, fxsync);
     for (int i = 0; i < n_fx_slots; i++)
     {
+        fxsync[i] = storage.getPatch().fx[i];
         fx_reload[i] = false;
         fx_reload_mod[i] = false;
     }
@@ -2727,7 +2726,8 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
 
             if (/*!force_reload_all && */ storage.getPatch().fx[s].type.val.i)
             {
-                std::copy(fxsync[s].p, fxsync[s].p + n_fx_params, storage.getPatch().fx[s].p);
+                std::copy(std::begin(fxsync[s].p), std::end(fxsync[s].p),
+                          std::begin(storage.getPatch().fx[s].p));
             }
 
             fx[s].reset(spawn_effect(storage.getPatch().fx[s].type.val.i, &storage,
@@ -2848,7 +2848,8 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
             // OFF
             storage.getPatch().isDirty = true;
             if (storage.getPatch().fx[s].type.val.i != fxt_off)
-                std::copy(fxsync[s].p, fxsync[s].p + n_fx_params, storage.getPatch().fx[s].p);
+                std::copy(std::begin(fxsync[s].p), std::end(fxsync[s].p),
+                          std::begin(storage.getPatch().fx[s].p));
             if (fx[s])
             {
                 std::lock_guard<std::mutex> g(fxSpawnMutex);

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2727,7 +2727,7 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
 
             if (/*!force_reload_all && */ storage.getPatch().fx[s].type.val.i)
             {
-                std::copy(fxsync[s].p, fxsync[s].p+n_fx_params, storage.getPatch().fx[s].p);
+                std::copy(fxsync[s].p, fxsync[s].p + n_fx_params, storage.getPatch().fx[s].p);
             }
 
             fx[s].reset(spawn_effect(storage.getPatch().fx[s].type.val.i, &storage,

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -428,7 +428,7 @@ void SurgeSynthesizer::loadRaw(const void *data, int size, bool preset)
     storage.getPatch().update_controls(false, nullptr, true);
     for (int i = 0; i < n_fx_slots; i++)
     {
-        memcpy((void *)&fxsync[i], (void *)&storage.getPatch().fx[i], sizeof(FxStorage));
+        fxsync[i] = storage.getPatch().fx[i];
         fx_reload[i] = true;
     }
 

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -466,7 +466,7 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
     if (lfodata->rate.deactivated)
     {
         hasFullWave = true;
-        memcpy((void *)(&deactivateStorage), (void *)lfodata, sizeof(LFOStorage));
+        deactivateStorage = *lfodata;
         memcpy((void *)tpd, (void *)tp, n_scene_params * sizeof(pdata));
 
         auto desiredRate = log2(1.f / totalEnvTime);
@@ -493,7 +493,7 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
         {
             hasFullWave = true;
             waveIsAmpWave = true;
-            memcpy((void *)(&deactivateStorage), (void *)lfodata, sizeof(LFOStorage));
+            deactivateStorage = *lfodata;
             memcpy((void *)tpd, (void *)tp, n_scene_params * sizeof(pdata));
 
             deactivateStorage.magnitude.val.f = 1.f;

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -821,7 +821,7 @@ Surge::FxClipboard::Clipboard FxMenu::fxClipboard;
 void FxMenu::copyFX()
 {
     Surge::FxClipboard::copyFx(storage, fx, fxClipboard);
-    memcpy((void *)fxbuffer, (void *)fx, sizeof(FxStorage));
+    *fxbuffer = *fx;
 }
 
 void FxMenu::pasteFX()


### PR DESCRIPTION
…, for parameters in SurgeSynthesizer.

Starting with just this file, rather than a full replacement, to ensure that everything is good with the outcome here before I change everything else.

The generated assembly code before called memcpy. Afterwards it seems to inline the copy constructor and assignment operator, using registers to move the data. I know gcc can fall back to memcpy for trivial classes, so I believe it's choosing not to do that here.