### PR TITLE
Make surge-testrunner fail if resources not positioned

### DIFF
--- a/src/surge-testrunner/UnitTests.cpp
+++ b/src/surge-testrunner/UnitTests.cpp
@@ -9,6 +9,31 @@
 
 int runAllTests(int argc, char **argv)
 {
+    try
+    {
+        std::string tfn = "resources/test-data/wav/Wavetable.wav";
+        auto p = fs::path{tfn};
+        if (!fs::exists(p))
+        {
+            std::cout << "Can't find file '" << tfn << "'.\n"
+                      << "\n"
+                      << "This means several tests will fail. Currently the\n"
+                      << "test runner assumes you run with CWD as root of the\n"
+                      << "surge repo so that the above local reference loads.\n\n"
+                      << "To fix this, run the test runner from surge or \n"
+                      << "set the variable SURGE_TEST_WITH_FILE_ERRORS and tests\n"
+                      << "will continue." << std::endl;
+
+            if (!getenv("SURGE_TEST_WITH_FILE_ERRORS"))
+                return 62;
+        }
+    }
+    catch (const fs::filesystem_error &e)
+    {
+        std::cerr << "FileSystem Error " << e.what() << std::endl;
+        return 172;
+    }
+
     auto surge = Surge::Headless::createSurge(44100);
     std::cout << "Created surge with " << surge->storage.datapath << " & "
               << surge->storage.userDataPath << std::endl;


### PR DESCRIPTION
Current surge-testrunner has some tests which assume the runner is run from CWD=root of surge (so "resources/" is a good local reference). We should probably fix that one day maybe

But for now make it error out if a candidate test file isn't there but since you can select single tests and they work, also give an env for workaround.