### PR TITLE
Use clang-format-12 for code-quality-pipeline-checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ endforeach()
 add_custom_command(TARGET code-quality-pipeline-checks
   POST_BUILD
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  COMMAND ${CMAKE_COMMAND} -E echo About to check clang-format
-  COMMAND git ls-files -- ${CLANG_FORMAT_GLOBS} | xargs clang-format --dry-run --Werror
+  COMMAND ${CMAKE_COMMAND} -E echo About to check clang-format using clang-format-12
+  COMMAND git ls-files -- ${CLANG_FORMAT_GLOBS} | xargs clang-format-12 --dry-run --Werror
   )
 # }}}

--- a/src/common/dsp/oscillators/AliasOscillator.cpp
+++ b/src/common/dsp/oscillators/AliasOscillator.cpp
@@ -261,12 +261,9 @@ void AliasOscillator::process_block_internal(const float pitch, const float drif
 
     const bool ramp_unmasked_after_threshold = (bool)oscdata->p[ao_mask].deform_type;
 
-    // clang-format off
-    // I don't know why the pipeline behaves differently?
     const uint8_t threshold =
         (uint8_t)((float)bit_mask *
                   clamp01(localcopy[oscdata->p[ao_threshold].param_id_in_scene].f));
-    // clang-format on
 
     const double two32 = 4294967296.0;
 


### PR DESCRIPTION
- like we thought it would
- message what we use