### PR TITLE
Replace memcpy with std::copy and assignment operators where safe

### DIFF
--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -340,13 +340,6 @@ struct ModulationDisplayInfoWindowStrings
 
 class SurgeStorage;
 
-/*
-** WARNING!
-**
-** Parameter is copied with memcpy
-** Therefore, don't have complex types as members!
-*/
-
 class Parameter
 {
   public:
@@ -600,4 +593,5 @@ class Parameter
 };
 
 // I don't make this a member since param needs to be copyable with memcpy.
+// TODO: Don't need to worry about that anymore.
 extern std::atomic<bool> parameterNameUpdated;

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1326,8 +1326,7 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
                     getPatch().scene[scene].osc[entry].wavetable_display_name, 256);
         }
 
-        memcpy(&clipboard_extraconfig[0], &getPatch().scene[scene].osc[entry].extraConfig,
-               sizeof(OscillatorStorage::ExtraConfigurationData));
+        clipboard_extraconfig[0] = getPatch().scene[scene].osc[entry].extraConfig;
     }
 
     if (type & cp_lfo)
@@ -1338,8 +1337,7 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
 
         if (getPatch().scene[scene].lfo[entry].shape.val.i == lt_stepseq)
         {
-            memcpy(&clipboard_stepsequences[0], &getPatch().stepsequences[scene][entry],
-                   sizeof(StepSequencerStorage));
+            clipboard_stepsequences[0] = getPatch().stepsequences[scene][entry];
         }
 
         if (getPatch().scene[scene].lfo[entry].shape.val.i == lt_mseg)
@@ -1367,8 +1365,7 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
 
         for (int i = 0; i < n_lfos; i++)
         {
-            memcpy(&clipboard_stepsequences[i], &getPatch().stepsequences[scene][i],
-                   sizeof(StepSequencerStorage));
+            clipboard_stepsequences[i] = getPatch().stepsequences[scene][i];
             clipboard_msegs[i] = getPatch().msegs[scene][i];
             clipboard_formulae[i] = getPatch().formulamods[scene][i];
 
@@ -1384,8 +1381,7 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
             clipboard_wt[i].Copy(&getPatch().scene[scene].osc[i].wt);
             strncpy(clipboard_wt_names[i], getPatch().scene[scene].osc[i].wavetable_display_name,
                     256);
-            memcpy(&clipboard_extraconfig[i], &getPatch().scene[scene].osc[i].extraConfig,
-                   sizeof(OscillatorStorage::ExtraConfigurationData));
+            clipboard_extraconfig[i] = getPatch().scene[scene].osc[i].extraConfig;
         }
 
         clipboard_primode = getPatch().scene[scene].monoVoicePriorityMode;
@@ -1549,8 +1545,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry, modsources ms
         start = 1;
         getPatch().update_controls(false, &getPatch().scene[scene].osc[entry]);
 
-        memcpy(&getPatch().scene[scene].osc[entry].extraConfig, &clipboard_extraconfig[0],
-               sizeof(OscillatorStorage::ExtraConfigurationData));
+        getPatch().scene[scene].osc[entry].extraConfig = clipboard_extraconfig[0];
     }
 
     if (type & cp_lfo)
@@ -1566,8 +1561,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry, modsources ms
 
         for (int i = 0; i < n_lfos; i++)
         {
-            memcpy(&getPatch().stepsequences[scene][i], &clipboard_stepsequences[i],
-                   sizeof(StepSequencerStorage));
+            getPatch().stepsequences[scene][i] = clipboard_stepsequences[i];
             getPatch().msegs[scene][i] = clipboard_msegs[i];
             getPatch().formulamods[scene][i] = clipboard_formulae[i];
 
@@ -1580,8 +1574,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry, modsources ms
 
         for (int i = 0; i < n_oscs; i++)
         {
-            memcpy(&getPatch().scene[scene].osc[i].extraConfig, &clipboard_extraconfig[i],
-                   sizeof(OscillatorStorage::ExtraConfigurationData));
+            getPatch().scene[scene].osc[i].extraConfig = clipboard_extraconfig[i];
             getPatch().scene[scene].osc[i].wt.Copy(&clipboard_wt[i]);
             strncpy(getPatch().scene[scene].osc[i].wavetable_display_name, clipboard_wt_names[i],
                     256);
@@ -1694,8 +1687,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry, modsources ms
         {
             if (getPatch().scene[scene].lfo[entry].shape.val.i == lt_stepseq)
             {
-                memcpy(&getPatch().stepsequences[scene][entry], &clipboard_stepsequences[0],
-                       sizeof(StepSequencerStorage));
+                getPatch().stepsequences[scene][entry] = clipboard_stepsequences[0];
             }
 
             if (getPatch().scene[scene].lfo[entry].shape.val.i == lt_mseg)

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -13,6 +13,7 @@ const int max_wtable_samples = 2097152;
 #pragma pack(push, 1)
 struct wt_header
 {
+    // This struct can only contain scalar data that can be memcpy'd.
     char tag[4];
     unsigned int n_samples;
     unsigned short n_tables;

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -13,7 +13,8 @@ const int max_wtable_samples = 2097152;
 #pragma pack(push, 1)
 struct wt_header
 {
-    // This struct can only contain scalar data that can be memcpy'd.
+    // This struct can only contain scalar data that can be memcpy'd. It's read directly from data
+    // on the disk.
     char tag[4];
     unsigned int n_samples;
     unsigned short n_tables;

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -20,6 +20,7 @@
 #include "SurgeGUIUtils.h"
 #include "SurgeJUCEHelpers.h"
 #include "RuntimeFont.h"
+#include <algorithm>
 #include <chrono>
 #include "widgets/MenuCustomComponents.h"
 #include "AccessibleHelpers.h"
@@ -467,7 +468,7 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
     {
         hasFullWave = true;
         deactivateStorage = *lfodata;
-        memcpy((void *)tpd, (void *)tp, n_scene_params * sizeof(pdata));
+        std::copy(std::begin(tp), std::end(tp), std::begin(tpd), n_scene_params);
 
         auto desiredRate = log2(1.f / totalEnvTime);
         if (lfodata->shape.val.i == lt_mseg)
@@ -494,7 +495,7 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
             hasFullWave = true;
             waveIsAmpWave = true;
             deactivateStorage = *lfodata;
-            memcpy((void *)tpd, (void *)tp, n_scene_params * sizeof(pdata));
+            std::copy(std::begin(tp), std::end(tp), std::begin(tpd));
 
             deactivateStorage.magnitude.val.f = 1.f;
             tpd[lfodata->magnitude.param_id_in_scene].f = 1.f;

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -468,7 +468,7 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
     {
         hasFullWave = true;
         deactivateStorage = *lfodata;
-        std::copy(std::begin(tp), std::end(tp), std::begin(tpd), n_scene_params);
+        std::copy(std::begin(tp), std::end(tp), std::begin(tpd));
 
         auto desiredRate = log2(1.f / totalEnvTime);
         if (lfodata->shape.val.i == lt_mseg)


### PR DESCRIPTION
This is all the memcpy that can reasonably be replaced without going through and refactoring uses of C-style arrays and news into C++11-and-up constructs. That seems like a reasonable exercise, but one for the future.