### PR TITLE
Correct SIMDE CMake definition

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ else()
 endif()
 
 add_library(simde INTERFACE)
-target_include_directories(simde INTERFACE ${CMAKE_SOURCE_DIR}/libs/simde)
+target_include_directories(simde INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/../libs/simde)
 add_library(surge::simde ALIAS simde)
 
 add_library(surge-juce INTERFACE)


### PR DESCRIPTION
the definition of SIMDE we used worked only if you were building surge as top level, not as subordinate module, as described in https://github.com/surge-synthesizer/surge-rack/pull/731