### PR TITLE
Storage Configuration API

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1048,7 +1048,25 @@ class alignas(16) SurgeStorage
     // second of data, assuming the sample rate is 48k.
     sst::cpputils::StereoRingBuffer<float, 8192> audioOut;
 
-    SurgeStorage(std::string suppliedDataPath = "");
+    struct SurgeStorageConfig
+    {
+        std::string suppliedDataPath{""};
+        bool createUserDirectory{true};
+        fs::path extraThirdPartyWavetablesPath{};
+
+        static SurgeStorageConfig fromDataPath(const std::string &s)
+        {
+            auto r = SurgeStorageConfig();
+            r.suppliedDataPath = s;
+            return r;
+        }
+    };
+    SurgeStorage(const SurgeStorageConfig &);
+    SurgeStorage(std::string suppliedDataPath = "")
+        : SurgeStorage(SurgeStorageConfig::fromDataPath(suppliedDataPath))
+    {
+    }
+
     static std::string skipPatchLoadDataPathSentinel;
 
     // In Surge XT, SurgeStorage can now keep a cache of errors it reports to the user
@@ -1140,11 +1158,12 @@ class alignas(16) SurgeStorage
     void createUserDirectory();
 
     void refresh_wtlist();
-    void refresh_wtlistAddDir(bool userDir, std::string subdir);
+    void refresh_wtlistAddDir(bool userDir, const std::string &subdir);
+    void refresh_wtlistFrom(bool isUser, const fs::path &from, const std::string &subdir);
     void refresh_patchlist();
     void refreshPatchlistAddDir(bool userDir, std::string subdir);
 
-    void refreshPatchOrWTListAddDir(bool userDir, std::string subdir,
+    void refreshPatchOrWTListAddDir(bool userDir, const fs::path &fromPath, std::string subdir,
                                     std::function<bool(std::string)> filterOp,
                                     std::vector<Patch> &items,
                                     std::vector<PatchCategory> &categories);
@@ -1199,6 +1218,7 @@ class alignas(16) SurgeStorage
     fs::path userWavetablesExportPath;
     fs::path userSkinsPath;
     fs::path userMidiMappingsPath;
+    fs::path extraThirdPartyWavetablesPath; // used by rack
 
     std::map<std::string, TiXmlDocument> userMidiMappingsXMLByName;
     void rescanUserMidiMappings();


### PR DESCRIPTION
As we get more clients of SurgeStorage (tests, rack, etc..) a single constructor API is becoming a bit limiting, so make a structure API point on construction which defaults to the SurgeSynth style

WHile implementing add

1. dont-make-user-dir option and
2. extra-thirdparty-wavetables option