### PR TITLE
Fix FM ratio display bug due to mistake in updating to C++ format

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -3500,7 +3500,7 @@ std::string Parameter::get_display(bool external, float ef) const
             txt = character_names[limit_range(i, 0, (int)n_character_modes - 1)];
             break;
         case ct_fmratio_int:
-            txt = fmt::format("C : %d", i);
+            txt = fmt::format("C : {:d}", i);
             break;
         case ct_phaser_stages:
             if (i == 1)


### PR DESCRIPTION
The old code used C-style snprintf "%d", looks like one was missed in the conversion to C++ format strings.

According to `ag "format.*%d"` it's the only occurrence of this in the source code.