### PR TITLE
An optional off-by-default Twist LPG Fix

### DIFF
--- a/src/common/dsp/oscillators/TwistOscillator.cpp
+++ b/src/common/dsp/oscillators/TwistOscillator.cpp
@@ -387,8 +387,17 @@ void TwistOscillator::process_block_internal(float pitch, float drift, bool ster
 
     bool lpgIsOn = !oscdata->p[twist_lpg_response].deactivated;
 
-    constexpr int max_subblock = 4;
-    int subblock = (lpgIsOn || FM) ? 1 : max_subblock;
+    // The LPG in surge 1.1 is wrong because it doesn't use the correct vlock
+    // size. This code allows you to optionally correct that while retaining legacy.
+    // See #6760 for more.
+    constexpr int max_subblock = 12; // This is the internal block size PLAITS uses
+
+    // This setting is *incorrect* but retains legacy surge XT 1.1 behavior
+    int subblock = (lpgIsOn || FM) ? 1 : 4; // retain surge legacy
+
+    // This setting allows us to correct it in VCV Rack.
+    if (lpgIsOn && useCorrectLPGBlockSize)
+        subblock = 12;
 #if SAMPLERATE_SRC
     float src_in[subblock][2];
     float src_out[BLOCK_SIZE_OS][2];

--- a/src/common/dsp/oscillators/TwistOscillator.h
+++ b/src/common/dsp/oscillators/TwistOscillator.h
@@ -90,6 +90,8 @@ class TwistOscillator : public Oscillator
     float fmlagbuffer[BLOCK_SIZE_OS << 1];
     int fmwp, fmrp;
 
+    bool useCorrectLPGBlockSize{false}; // See #6760
+
 #if SAMPLERATE_LANCZOS
     std::unique_ptr<LanczosResampler> lancRes;
 #endif


### PR DESCRIPTION
See issue #6760 and https://github.com/surge-synthesizer/surge-rack/issues/766

The Twist LPG implementation used an incorrect block size so decayed too quickly. There's probably a correct patch to plaits to not decay with size 12 (around line 208 of voice.cc) but for now make it correctable optionally so we can correct it in rack.