### PR TITLE
Skip VST3 Menus in Reason

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -469,6 +469,10 @@ void SurgeSynthEditor::endMacroEdit(long macroNum)
 
 juce::PopupMenu SurgeSynthEditor::hostMenuFor(Parameter *p)
 {
+    // See issue 6752
+    if (juce::PluginHostType().isReason())
+        return {};
+
     auto par = processor.paramsByID[processor.surge->idForParameter(p)];
 
     if (auto *c = getHostContext())
@@ -480,6 +484,10 @@ juce::PopupMenu SurgeSynthEditor::hostMenuFor(Parameter *p)
 
 juce::PopupMenu SurgeSynthEditor::hostMenuForMacro(int macro)
 {
+    // See issue 6752
+    if (juce::PluginHostType().isReason())
+        return {};
+
     auto par = processor.macrosById[macro];
 
     if (auto *c = getHostContext())


### PR DESCRIPTION
Reason 12 / MacOS 13 VST3 menus seem to crash so skip that feature. Addresses #6752