### PR TITLE
Act as ODDSound MTS Main ('Master')

### DIFF
--- a/libs/oddsound-mts/CMakeLists.txt
+++ b/libs/oddsound-mts/CMakeLists.txt
@@ -2,8 +2,9 @@ project(oddsound-mts VERSION 0.0.0 LANGUAGES CXX)
 
 add_library(${PROJECT_NAME}
       MTS-ESP/Client/libMTSClient.cpp
+      MTS-ESP/Master/libMTSMaster.cpp
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC MTS-ESP/Client)
+target_include_directories(${PROJECT_NAME} PUBLIC MTS-ESP/Client MTS-ESP/Master)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
 add_library(surge::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1800,6 +1800,23 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             }
         }
 
+        auto mts_main =
+            TINYXML_SAFE_TO_ELEMENT(nonparamconfig->FirstChild("oddsound_mts_active_as_main"));
+        if (mts_main)
+        {
+            int tv;
+
+            if (tam->QueryIntAttribute("v", &tv) == TIXML_SUCCESS)
+            {
+                if (tv)
+                {
+#ifndef SURGE_SKIP_ODDSOUND_MTS
+                    storage->connect_as_oddsound_main();
+#endif
+                }
+            }
+        }
+
         auto *hcs = TINYXML_SAFE_TO_ELEMENT(nonparamconfig->FirstChild("hardclipmodes"));
 
         if (hcs)
@@ -3046,7 +3063,7 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
 
     // Revision 16 adds the TAM
     TiXmlElement tam("tuningApplicationMode");
-    if (storage->oddsound_mts_active)
+    if (storage->oddsound_mts_active_as_client)
     {
         tam.SetAttribute("v", (int)(storage->patchStoredTuningApplicationMode));
     }
@@ -3055,6 +3072,11 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         tam.SetAttribute("v", (int)(storage->tuningApplicationMode));
     }
     nonparamconfig.InsertEndChild(tam);
+
+    // Revision 21 adds MTS as main
+    TiXmlElement oam("oddsound_mts_active_as_main");
+    oam.SetAttribute("v", (int)(storage->oddsound_mts_active_as_main));
+    nonparamconfig.InsertEndChild(oam);
 
     patch.InsertEndChild(nonparamconfig);
 

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -378,7 +378,7 @@ void SurgeSynthesizer::playNote(char channel, char key, char velocity, char detu
     }
 
 #ifndef SURGE_SKIP_ODDSOUND_MTS
-    if (storage.oddsound_mts_client && storage.oddsound_mts_active)
+    if (storage.oddsound_mts_client && storage.oddsound_mts_active_as_client)
     {
         if (MTS_ShouldFilterNote(storage.oddsound_mts_client, key, channel))
         {
@@ -4104,10 +4104,10 @@ void SurgeSynthesizer::processControl()
         storage.oddsound_mts_on_check = (storage.oddsound_mts_on_check + 1) & (1024 - 1);
         if (storage.oddsound_mts_on_check == 0)
         {
-            bool prior = storage.oddsound_mts_active;
+            bool prior = storage.oddsound_mts_active_as_client;
             storage.setOddsoundMTSActiveTo(MTS_HasMaster(storage.oddsound_mts_client));
 
-            if (prior != storage.oddsound_mts_active)
+            if (prior != storage.oddsound_mts_active_as_client)
             {
                 refresh_editor = true;
             }

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -51,7 +51,7 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
     auto res = key + /* mainChannelState->pitchBendInSemitones + */ mpeBend + detune;
 
 #ifndef SURGE_SKIP_ODDSOUND_MTS
-    if (storage->oddsound_mts_client && storage->oddsound_mts_active)
+    if (storage->oddsound_mts_client && storage->oddsound_mts_active_as_client)
     {
         if (storage->oddsoundRetuneMode == SurgeStorage::RETUNE_CONSTANT ||
             key != keyRetuningForKey)
@@ -80,7 +80,7 @@ float SurgeVoice::channelKeyEquvialent(float key, int channel, bool isMpeEnabled
                                        SurgeStorage *storage, bool remapKeyForTuning)
 {
     float res = key;
-    if (storage->mapChannelToOctave && !storage->oddsound_mts_active && !isMpeEnabled)
+    if (storage->mapChannelToOctave && !storage->oddsound_mts_active_as_client && !isMpeEnabled)
     {
         if (remapKeyForTuning)
         {
@@ -390,7 +390,7 @@ void SurgeVoice::legato(int key, int velocity, char detune)
 
 void SurgeVoice::retriggerPortaIfKeyChanged()
 {
-    if (!storage->oddsound_mts_active &&
+    if (!storage->oddsound_mts_active_as_client &&
         (storage->isStandardTuning || storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL))
     {
         if (floor(state.pkey + 0.5) != state.priorpkey)
@@ -406,7 +406,7 @@ void SurgeVoice::retriggerPortaIfKeyChanged()
         };
 
 #ifndef SURGE_SKIP_ODDSOUND_MTS
-        if (storage->oddsound_mts_client && storage->oddsound_mts_active)
+        if (storage->oddsound_mts_client && storage->oddsound_mts_active_as_client)
         {
             v4k = [this](int k) {
                 return log2f(MTS_NoteToFrequency(storage->oddsound_mts_client, k, state.channel) /
@@ -1485,7 +1485,7 @@ void SurgeVoice::resetPortamentoFrom(int key, int channel)
     {
         float lk = key;
 #ifndef SURGE_SKIP_ODDSOUND_MTS
-        if (storage->oddsound_mts_client && storage->oddsound_mts_active)
+        if (storage->oddsound_mts_client && storage->oddsound_mts_active_as_client)
         {
             lk += MTS_RetuningInSemitones(storage->oddsound_mts_client, lk, channel);
             state.portasrc_key = lk;

--- a/src/common/dsp/oscillators/TwistOscillator.cpp
+++ b/src/common/dsp/oscillators/TwistOscillator.cpp
@@ -306,7 +306,7 @@ TwistOscillator::TwistOscillator(SurgeStorage *storage, OscillatorStorage *oscda
 float TwistOscillator::tuningAwarePitch(float pitch)
 {
     if (storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL &&
-        !(storage->oddsound_mts_client && storage->oddsound_mts_active) &&
+        !(storage->oddsound_mts_client && storage->oddsound_mts_active_as_client) &&
         !(storage->isStandardTuning))
     {
         auto idx = (int)floor(pitch);

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2323,7 +2323,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         case ct_freq_audible_very_low_minval:
                         {
                             auto hasmts = synth->storage.oddsound_mts_client &&
-                                          synth->storage.oddsound_mts_active;
+                                          synth->storage.oddsound_mts_active_as_client;
 
                             std::string tuningmode = hasmts ? "MTS" : "SCL/KBM";
 


### PR DESCRIPTION
This allows you to have a single surge instance act as an oddsound MTS-ESP Master (which we call Main) component. In this mode, the tunign editor features stay active but are broadcast to all other MTS-ESP clients on your system if the master is initializable.