### PR TITLE
Stereo Only output advertised

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT BUILD_TESTING)
   option(BUILD_TESTING "" OFF)
 endif()
 
-project(Surge VERSION 1.1.0 LANGUAGES C CXX ASM)
+project(Surge VERSION 1.1.2 LANGUAGES C CXX ASM)
 
 # Banner {{{
 message(STATUS "It's Surge XT, folks! Version is ${PROJECT_VERSION}")

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -200,8 +200,7 @@ bool SurgeSynthProcessor::isBusesLayoutSupported(const BusesLayout &layouts) con
     auto mocs = layouts.getMainOutputChannelSet();
     auto mics = layouts.getMainInputChannelSet();
 
-    auto outputValid = (mocs == juce::AudioChannelSet::stereo()) ||
-                       (mocs == juce::AudioChannelSet::mono()) || (mocs.isDisabled());
+    auto outputValid = (mocs == juce::AudioChannelSet::stereo()) || (mocs.isDisabled());
     auto inputValid = (mics == juce::AudioChannelSet::stereo()) ||
                       (mics == juce::AudioChannelSet::mono()) || (mics.isDisabled());
 


### PR DESCRIPTION
Surge requires stereo output. For some reason our JUCE bus constraint didn't say that and you could therefore load crashing configurations in logic. Correct.

Also bump the cmakelists project version.