### PR TITLE
Add a 'Announce State' Accessible option

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -474,6 +474,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     std::deque<std::pair<std::string, int>> accAnnounceStrings;
     void enqueueAccessibleAnnouncement(const std::string &s);
+    void announceGuiState();
     void setAccessibilityInformationByParameter(juce::Component *c, Parameter *p,
                                                 const std::string &action);
 

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -76,6 +76,8 @@ enum KeyboardActions
     OPEN_MANUAL,
     TOGGLE_ABOUT,
 
+    ANNOUNCE_STATE,
+
     n_kbdActions
 };
 
@@ -169,6 +171,8 @@ inline std::string keyboardActionName(KeyboardActions a)
         return "OPEN_MANUAL";
     case TOGGLE_ABOUT:
         return "TOGGLE_ABOUT";
+    case ANNOUNCE_STATE:
+        return "ANNOUNCE_STATE";
 
     case n_kbdActions:
         jassert(false);
@@ -315,6 +319,9 @@ inline std::string keyboardActionDescription(KeyboardActions a)
     case TOGGLE_ABOUT:
         desc = "About Surge XT";
         skipOSCase = true;
+        break;
+    case ANNOUNCE_STATE:
+        desc = "Announce Editor State with Accessible API";
         break;
 
     default:


### PR DESCRIPTION
If you annoucne state (default alt-0) then you get a readout of the state of your UI (scene, selected osc and modulator, selected fx, patch name).

Also MTS Main -> MTS Source in the menu

Closes #6591