### PR TITLE
Invalidate all params etc... on patch change

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3824,6 +3824,7 @@ void loadPatchInBackgroundThread(SurgeSynthesizer *sy)
     }
 
     synth->storage.getPatch().isDirty = false;
+    synth->patchChanged = true;
     synth->halt_engine = false;
 
     // Now we want to null out the patchLoadThread since everything is done

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -58,6 +58,7 @@ class alignas(16) SurgeSynthesizer
         send alignas(16)[n_send_slots][n_scenes];
 
     std::atomic<bool> audio_processing_active;
+    std::atomic<bool> patchChanged{false};
 
     // methods
   public:

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -409,6 +409,13 @@ void SurgeSynthProcessor::processBlockPostFunction()
             updateHostDisplay(
                 juce::AudioProcessorListener::ChangeDetails().withParameterInfoChanged(true));
         }
+        if (std::atomic_exchange(&surge->patchChanged, false))
+        {
+            updateHostDisplay(juce::AudioProcessorListener::ChangeDetails()
+                                  .withParameterInfoChanged(true)
+                                  .withProgramChanged(true)
+                                  .withNonParameterStateChanged(true));
+        }
     }
 }
 


### PR DESCRIPTION
A patch change can change the name or value of any param. So when it happens send the maximal updateHostDispolay (excluding latency). Trigger this with a new patchChanged atomic on the synth which we set to true at the end of the off-thread load. Results in bitwig showing all correct param changes on patch change in vst3 and presumably other compliant hosts would do same.

Closes #6607