### PR TITLE
Implement CLAP_NOTE_CHOKE properly

### DIFF
--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -72,6 +72,7 @@ class alignas(16) SurgeSynthesizer
     virtual ~SurgeSynthesizer();
     void playNote(char channel, char key, char velocity, char detune, int32_t host_noteid = -1);
     void releaseNote(char channel, char key, char velocity, int32_t host_noteid = -1);
+    void chokeNote(char channel, char key, char velocity, int32_t host_noteid = -1);
     void releaseNotePostHoldCheck(int scene, char channel, char key, char velocity,
                                   int32_t host_noteid = -1);
     void pitchBend(char channel, int value);

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -619,13 +619,25 @@ void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)
 
         {
             // We need to remember to update the virtual keyboard
-            auto m = juce::MidiMessage::noteOn(nevt->channel, nevt->key, (float)nevt->velocity);
+            auto m = juce::MidiMessage::noteOn(nevt->channel + 1, nevt->key, (float)nevt->velocity);
             juce::ScopedValueSetter<bool> midiAdd(isAddingFromMidi, true);
             midiKeyboardState.processNextMidiEvent(m);
         }
     }
     break;
     case CLAP_EVENT_NOTE_CHOKE:
+    {
+        auto nevt = reinterpret_cast<const clap_event_note *>(evt);
+        surge->chokeNote(nevt->channel, nevt->key, 127 * nevt->velocity, nevt->note_id);
+
+        {
+            // We need to remember to update the virtual keyboard
+            auto m = juce::MidiMessage::noteOff(nevt->channel + 1, nevt->key);
+            juce::ScopedValueSetter<bool> midiAdd(isAddingFromMidi, true);
+            midiKeyboardState.processNextMidiEvent(m);
+        }
+    }
+    break;
     case CLAP_EVENT_NOTE_OFF:
     {
         auto nevt = reinterpret_cast<const clap_event_note *>(evt);
@@ -633,7 +645,7 @@ void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)
 
         {
             // We need to remember to update the virtual keyboard
-            auto m = juce::MidiMessage::noteOff(nevt->channel, nevt->key);
+            auto m = juce::MidiMessage::noteOff(nevt->channel + 1, nevt->key);
             juce::ScopedValueSetter<bool> midiAdd(isAddingFromMidi, true);
             midiKeyboardState.processNextMidiEvent(m);
         }


### PR DESCRIPTION
Implement choke as

1. Do a release in case the note isn't released; then
2. Find the voice and do an uber-release

This seems to work great in the bitwig drum machine. When we have more choke clients we may need to revisit it.

Closes #6332