### PR TITLE
Implement Stereo or Mono noise in Wide mode

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -339,6 +339,7 @@ bool Parameter::has_deformoptions() const
     case ct_alias_mask:
     case ct_tape_drive:
     case ct_dly_fb_clippingmodes:
+    case ct_noise_color:
         return true;
     default:
         break;
@@ -374,6 +375,7 @@ bool Parameter::is_bipolar() const
     case ct_percent_bipolar_pan:
     case ct_percent_bipolar_stringbal:
     case ct_percent_bipolar_w_dynamic_unipolar_formatting:
+    case ct_noise_color:
     case ct_twist_aux_mix:
     case ct_freq_shift:
     case ct_osc_feedback_negative:
@@ -998,6 +1000,7 @@ void Parameter::set_type(int ctrltype)
     case ct_percent_bipolar_stringbal:
     case ct_percent_bipolar_w_dynamic_unipolar_formatting:
     case ct_twist_aux_mix:
+    case ct_noise_color:
         val_min.f = -1;
         val_max.f = 1;
         valtype = vt_float;
@@ -1294,6 +1297,7 @@ void Parameter::set_type(int ctrltype)
     case ct_percent_oscdrift:
     case ct_percent200:
     case ct_percent_bipolar:
+    case ct_noise_color:
     case ct_percent_bipolar_with_string_filter_hook:
     case ct_lfodeform:
     case ct_rotarydrive:
@@ -1638,6 +1642,7 @@ void Parameter::bound_value(bool force_integer)
         case ct_percent_bipolar_stringbal:
         case ct_percent_bipolar_w_dynamic_unipolar_formatting:
         case ct_twist_aux_mix:
+        case ct_noise_color:
         case ct_rotarydrive:
         case ct_osc_feedback:
         case ct_osc_feedback_negative:
@@ -3987,6 +3992,7 @@ bool Parameter::can_setvalue_from_string() const
     case ct_percent_bipolar_stringbal:
     case ct_percent_bipolar_w_dynamic_unipolar_formatting:
     case ct_twist_aux_mix:
+    case ct_noise_color:
     case ct_pitch_semi7bp:
     case ct_pitch_semi7bp_absolutable:
     case ct_pitch:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -50,6 +50,7 @@ enum ctrltypes
     ct_percent_bipolar_with_string_filter_hook,
     ct_percent_bipolar_w_dynamic_unipolar_formatting,
     ct_percent_with_extend_to_bipolar,
+    ct_noise_color,
     ct_twist_aux_mix,
     ct_pitch_octave,
     ct_pitch_semi7bp,

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -172,9 +172,11 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
                                             ct_percent_oscdrift, Surge::Skin::Scene::drift, sc_id,
                                             cg_GLOBAL, 0, true));
 
-        a->push_back(scene[sc].noise_colour.assign(
-            p_id.next(), id_s++, "noisecol", "Noise Color", ct_percent_bipolar,
-            Surge::Skin::Scene::noise_color, sc_id, cg_GLOBAL, 0, true, sceasy));
+        a->push_back(scene[sc].noise_colour.assign(p_id.next(), id_s++, "noisecol", "Noise Color",
+                                                   ct_noise_color, Surge::Skin::Scene::noise_color,
+                                                   sc_id, cg_GLOBAL, 0, true, sceasy));
+        scene[sc].noise_colour.deform_type = NoiseColorChannels::STEREO;
+
         a->push_back(scene[sc].keytrack_root.assign(
             p_id.next(), id_s++, "ktrkroot", "Keytrack Root Key", ct_midikey,
             Surge::Skin::Scene::keytrack_root, sc_id, cg_GLOBAL, 0, false));
@@ -1516,7 +1518,14 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             {
                 if (param_ptr[i]->has_deformoptions())
                 {
-                    param_ptr[i]->deform_type = type_1;
+                    if (param_ptr[i]->ctrltype == ct_noise_color)
+                    {
+                        param_ptr[i]->deform_type = NoiseColorChannels::STEREO;
+                    }
+                    else
+                    {
+                        param_ptr[i]->deform_type = type_1;
+                    }
                 }
             }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -172,6 +172,12 @@ enum deform_type
     n_deform_types,
 };
 
+enum NoiseColorChannels
+{
+    STEREO = 0,
+    MONO = 1
+};
+
 enum lfo_trigger_mode
 {
     lm_freerun = 0,

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1039,6 +1039,7 @@ bool SurgeVoice::process_block(QuadFilterChainState &Q, int Qe)
     if (noise)
     {
         float noisecol = limit_range(localcopy[scene->noise_colour.param_id_in_scene].f, -1.f, 1.f);
+        auto is_stereo_noise = scene->noise_colour.deform_type == NoiseColorChannels::STEREO;
         for (int i = 0; i < BLOCK_SIZE_OS; i += 2)
         {
             ((float *)tblock)[i] =
@@ -1046,9 +1047,17 @@ bool SurgeVoice::process_block(QuadFilterChainState &Q, int Qe)
             ((float *)tblock)[i + 1] = ((float *)tblock)[i];
             if (is_wide)
             {
-                ((float *)tblockR)[i] = correlated_noise_o2mk2_storagerng(
-                    noisegenR[0], noisegenR[1], noisecol, storage);
-                ((float *)tblockR)[i + 1] = ((float *)tblockR)[i];
+                if (is_stereo_noise)
+                {
+                    ((float *)tblockR)[i] = correlated_noise_o2mk2_storagerng(
+                        noisegenR[0], noisegenR[1], noisecol, storage);
+                    ((float *)tblockR)[i + 1] = ((float *)tblockR)[i];
+                }
+                else
+                {
+                    ((float *)tblockR)[i] = ((float *)tblock)[i];
+                    ((float *)tblockR)[i + 1] = ((float *)tblock)[i + 1];
+                }
             }
         }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -7608,8 +7608,8 @@ void SurgeGUIEditor::announceGuiState()
                   .lfo[modsource_editor[current_scene] - ms_lfo1]
                   .shape.val.i;
 
-    oss << "SurgeXT. Patch '" << s->getPatch().name << "'. Scene "
-        << (current_scene == 0 ? "A" : "B") << ". "
+    oss << "Patch '" << s->getPatch().name << "'. Scene " << (current_scene == 0 ? "A" : "B")
+        << ". "
         << " Oscillator " << (current_osc[current_scene] + 1) << " " << osc_type_names[ot] << "."
         << " Modulator " << modulatorName(modsource_editor[current_scene], false) << " "
         << lt_names[ms] << ". " << fxslot_names[current_fx] << " " << fx_type_names[ft] << "."

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2298,6 +2298,27 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         break;
                     }
+                    case ct_noise_color:
+                    {
+                        contextMenu.addSeparator();
+                        auto dt = p->deform_type;
+                        contextMenu.addItem(
+                            "Mono", true, dt == NoiseColorChannels::MONO, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
+
+                                p->deform_type = NoiseColorChannels::MONO,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                        contextMenu.addItem(
+                            "Stereo", true, dt == NoiseColorChannels::STEREO, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
+
+                                p->deform_type = NoiseColorChannels::STEREO,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                    }
                     default:
                     {
                         break;


### PR DESCRIPTION
in Wide mode noise can either be mono or stereo based on the deform on the noise colour (on the RMB menu).
Make a type, handle streaming with it missing, etc... you know the drill.

Closes #6494