### PR TITLE
Add SurgeImage::asJuceImage

### DIFF
--- a/src/surge-xt/gui/SurgeImage.cpp
+++ b/src/surge-xt/gui/SurgeImage.cpp
@@ -145,3 +145,15 @@ juce::AffineTransform SurgeImage::scaleAdjustmentTransform() const
 
     return res;
 }
+
+juce::Image SurgeImage::asJuceImage(float scaleBy)
+{
+    auto d = internalDrawableResolved();
+    if (!d)
+        return {};
+
+    juce::Image res(juce::Image::ARGB, d->getWidth() * scaleBy, d->getHeight() * scaleBy, true);
+    juce::Graphics g(res);
+    d->draw(g, 1.f, juce::AffineTransform::scale(scaleBy));
+    return res;
+}

--- a/src/surge-xt/gui/SurgeImage.h
+++ b/src/surge-xt/gui/SurgeImage.h
@@ -72,6 +72,8 @@ class SurgeImage
      */
     juce::Drawable *getDrawableButUseWithCaution() { return internalDrawableResolved(); }
 
+    juce::Image asJuceImage(float scaleBy = 1.0);
+
   private:
     juce::Drawable *internalDrawableResolved();
     juce::AffineTransform scaleAdjustmentTransform() const;

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -460,6 +460,9 @@ void OverlayWrapper::doTearOut(const juce::Point<int> &showAt)
     dw->supressMoveUpdates = true;
     dw->setContentNonOwned(this, false);
     dw->setSkin(skin, associatedBitmapStore);
+    // This doesn't work but i think that's because we drop the icon in our DW L&F
+    // It does, however, create a renderable image
+    // dw->setIcon(associatedBitmapStore->getImage(IDB_SURGE_ICON)->asJuceImage());
 
     auto brd = dw->getContentComponentBorder();
 


### PR DESCRIPTION
which does the obvious create and draw thing in case you need a juce::Image. Add a commented out approach to using tht to set the icon on a tearout which doesn't show the icon but makes the image just fine.

Closes #6786