### PR TITLE
Allow Alt-,. to jump from patch selector

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -7329,6 +7329,11 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
 
                 auto cg = (int)fc->getProperties().getWithDefault("ControlGroup", -1);
 
+                // special case - allow jump off the patch selector
+                if (dynamic_cast<Surge::Widgets::PatchSelector *>(fc))
+                {
+                    cg = dir < 0 ? 10000000 : 0;
+                }
                 if (cg < 0)
                 {
                     return false;


### PR DESCRIPTION
The patch selector isn't in a CG so you would get 'stuck' there; this at least allows you to jump off it with these key bindings

CLoses #6685