### PR TITLE
Step Sequencer RMB / Edit Part 1

### DIFF
--- a/resources/surge-shared/paramdocumentation.xml
+++ b/resources/surge-shared/paramdocumentation.xml
@@ -18,6 +18,7 @@
   <special id="patch-navigation" help_url="#navigation"/>
   <special id="save-dialog" help_url="#the-save-dialog"/>
   <special id="wavetables" help_url="#wavetable"/>
+  <special id="step-sequencer" help_url="#step-sequencer"/>
   <special id="mseg-editor" help_url="#multi-segment-envelope-generator"/>
   <special id="formula-editor" help_url="#formula"/>
   <special id="mod-list" help_url="#modulation-list"/>

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -378,6 +378,7 @@ template <typename T> struct OverlayAsAccessibleSlider : public juce::Component
     std::function<void(T *, int, bool, bool)> onJogValue = [](T *, int, bool, bool) {
         jassert(false);
     };
+    std::function<void(T *)> onMenuKey = [](T *) {};
     // called with 1 0 -1 for max default min
     std::function<void(T *, int)> onMinMaxDef = [](T *, int) {};
 
@@ -547,6 +548,12 @@ template <typename T> bool OverlayAsAccessibleSlider<T>::keyPressed(const juce::
         onMinMaxDef(under, 0);
         if (ah)
             ah->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
+        return true;
+    }
+
+    if (action == OpenMenu)
+    {
+        onMenuKey(under);
         return true;
     }
     return false;

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.h
@@ -116,6 +116,9 @@ struct LFOAndStepDisplay : public juce::Component,
                         const juce::MouseWheelDetails &wheel) override;
     void mouseExit(const juce::MouseEvent &event) override;
 
+    void showStepRMB(const juce::MouseEvent &);
+    void showStepRMB(int step);
+
     void endHover() override
     {
         if (stuckHover)


### PR DESCRIPTION
This opens a menu on the RMB gesture on the step sequencer and preserves the right drag with a timer; it links to documentation properly and formats the item. The only thing we need to do now is to pop upen the edit box and figure out what else we want on this menu. Neither of those are easy so checkpointing along the way.

Menu pops from both mouse and accessible gestures.

Addesses #6516

foo