### PR TITLE
Expose mpeEnabled flag in surgepy

### DIFF
--- a/src/surge-python/surgepy.cpp
+++ b/src/surge-python/surgepy.cpp
@@ -1006,7 +1006,8 @@ PYBIND11_MODULE(surgepy, m)
              "Load an KBM mapping file and apply tuning to this instance")
         .def("remapToStandardKeyboard",
              &SurgeSynthesizerWithPythonExtensions::remapToStandardKeyboard,
-             "Return to standard C centered keyboard mapping");
+             "Return to standard C centered keyboard mapping")
+        .def_readwrite("mpeEnabled", &SurgeSynthesizerWithPythonExtensions::mpeEnabled);
 
     py::class_<SurgePyControlGroup>(m, "SurgeControlGroup")
         .def("getId", &SurgePyControlGroup::getControlGroupId)

--- a/src/surge-python/tests/test_surgepy.py
+++ b/src/surge-python/tests/test_surgepy.py
@@ -25,3 +25,20 @@ def test_render_note():
     s.playNote(0, 60, 127, 0)
     s.processMultiBlock(buf)
     assert not np.all(buf == 0.0)
+
+
+def test_default_mpeEnabled():
+    """
+    Test that mpeEnabled flag is False by default.
+    """
+    s = surgepy.createSurge(44100)
+    assert s.mpeEnabled is False
+
+
+def test_set_mpeEnabled():
+    """
+    Test that setting mpeEnabled really changes its value.
+    """
+    s = surgepy.createSurge(44100)
+    s.mpeEnabled = True
+    assert s.mpeEnabled is True


### PR DESCRIPTION
- Use pybind11's [def_readwrite](https://pybind11.readthedocs.io/en/stable/classes.html#instance-and-static-fields) to expose the SurgeSynthesizer mpeEnabled flag in surgepy.
- Add Python tests for mpeEnabled in surgepy.