### PR TITLE
Expose tuningApplicationMode in surgepy

### DIFF
--- a/src/surge-python/surgepy.cpp
+++ b/src/surge-python/surgepy.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "SurgeSynthesizer.h"
+#include "SurgeStorage.h"
 #include "version.h"
 #include "filesystem/import.h"
 
@@ -858,6 +859,16 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
     void remapToStandardKeyboard() { storage.remapToConcertCKeyboard(); }
 
     void retuneToStandardScale() { storage.retuneTo12TETScale(); }
+
+    void setTuningApplicationMode(SurgeStorage::TuningApplicationMode m)
+    {
+        storage.tuningApplicationMode = m;
+    }
+
+    SurgeStorage::TuningApplicationMode getTuningApplicationMode() const
+    {
+        return storage.tuningApplicationMode;
+    }
 };
 
 SurgeSynthesizer *createSurge(float sr)
@@ -1007,7 +1018,10 @@ PYBIND11_MODULE(surgepy, m)
         .def("remapToStandardKeyboard",
              &SurgeSynthesizerWithPythonExtensions::remapToStandardKeyboard,
              "Return to standard C centered keyboard mapping")
-        .def_readwrite("mpeEnabled", &SurgeSynthesizerWithPythonExtensions::mpeEnabled);
+        .def_readwrite("mpeEnabled", &SurgeSynthesizerWithPythonExtensions::mpeEnabled)
+        .def_property("tuningApplicationMode",
+                      &SurgeSynthesizerWithPythonExtensions::getTuningApplicationMode,
+                      &SurgeSynthesizerWithPythonExtensions::setTuningApplicationMode);
 
     py::class_<SurgePyControlGroup>(m, "SurgeControlGroup")
         .def("getId", &SurgePyControlGroup::getControlGroupId)
@@ -1218,4 +1232,8 @@ PYBIND11_MODULE(surgepy, m)
         C(FilterType::fut_resonancewarp_ap);
         C(FilterType::fut_tripole);
     }
+
+    py::enum_<SurgeStorage::TuningApplicationMode>(m, "TuningApplicationMode")
+        .value("RETUNE_ALL", SurgeStorage::TuningApplicationMode::RETUNE_ALL)
+        .value("RETUNE_MIDI_ONLY", SurgeStorage::TuningApplicationMode::RETUNE_MIDI_ONLY);
 }

--- a/src/surge-python/tests/test_surgepy.py
+++ b/src/surge-python/tests/test_surgepy.py
@@ -42,3 +42,14 @@ def test_set_mpeEnabled():
     s = surgepy.createSurge(44100)
     s.mpeEnabled = True
     assert s.mpeEnabled is True
+
+
+def test_default_tuningApplicationMode():
+    s = surgepy.createSurge(44100)
+    assert s.tuningApplicationMode == surgepy.TuningApplicationMode.RETUNE_MIDI_ONLY
+
+
+def test_set_tuningApplicationMode():
+    s = surgepy.createSurge(44100)
+    s.tuningApplicationMode = surgepy.TuningApplicationMode.RETUNE_ALL
+    assert s.tuningApplicationMode == surgepy.TuningApplicationMode.RETUNE_ALL


### PR DESCRIPTION
Add `SurgeStorage::TuningApplicationMode` enum to surgepy using pybind11's enum_. Expose `tuningApplicationMode` in surgepy with pybind11's def_property.

In Python `tuningApplicationMode` can now be accessed as
```
    >>> import surgepy
    >>> s = surgepy.createSurge(44100)
    >>> s.tuningApplicationMode
    <TuningApplicationMode.RETUNE_MIDI_ONLY: 1>
```
and set as
```
    >>> s.tuningApplicationMode = surgepy.TuningApplicationMode.RETUNE_ALL
```