### PR TITLE
LFO Raw / Output scaling

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -607,6 +607,12 @@ struct LFOStorage
     Parameter rate, shape, start_phase, magnitude, deform;
     Parameter trigmode, unipolar;
     Parameter delay, hold, attack, decay, sustain, release;
+
+    enum LFOExtraOutputAmplitude
+    {
+        UNSCALED,
+        SCALED
+    } lfoExtraAmplitude{UNSCALED};
 };
 
 struct FxStorage

--- a/src/common/dsp/modulators/LFOModulationSource.cpp
+++ b/src/common/dsp/modulators/LFOModulationSource.cpp
@@ -1255,6 +1255,12 @@ void LFOModulationSource::process_block()
     output_multi[1] = io2;
     output_multi[2] = outputEnvVal + useenv0; // env_val;
 
+    if (lfo->lfoExtraAmplitude == LFOStorage::SCALED)
+    {
+        output_multi[1] *= magnf;
+        output_multi[2] *= magnf;
+    }
+
     if (s == lt_envelope)
     {
         // Additional start mode corrections required

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -406,6 +406,30 @@ void ModulationSourceButton::buildHamburgerMenu(juce::PopupMenu &menu,
 
             idx++;
         }
+
+        if (modsource >= ms_lfo1 && modsource <= ms_slfo6)
+        {
+            auto &lf =
+                sge->getStorage()->getPatch().scene[sge->current_scene].lfo[modsource - ms_lfo1];
+
+            auto sh = lf.shape.val.i;
+            if (sh != lt_formula)
+            {
+                menu.addSeparator();
+                bool sc = lf.lfoExtraAmplitude == LFOStorage::SCALED;
+                menu.addItem(Surge::GUI::toOSCase("Scale Raw / EG By Amplitude"), true, sc,
+                             [sge, modsource] {
+                                 auto &lf = sge->getStorage()
+                                                ->getPatch()
+                                                .scene[sge->current_scene]
+                                                .lfo[modsource - ms_lfo1];
+                                 if (lf.lfoExtraAmplitude == LFOStorage::SCALED)
+                                     lf.lfoExtraAmplitude = LFOStorage::UNSCALED;
+                                 else
+                                     lf.lfoExtraAmplitude = LFOStorage::SCALED;
+                             });
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Allow users to toggle raw outputs scaled by amplitude on an LFO-by-LFO basis in the hamburger menu.

Closes #6674