### PR TITLE
Default tearouts to pinned in plugins; separate pref

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -249,6 +249,28 @@ std::string defaultKeyToString(DefaultKey k)
         r = "oscilloscopeOverlayTearOutAlwaysOnTop";
         break;
 
+    case TuningOverlayTearOutAlwaysOnTop_Plugin:
+        r = "tuningOverlayTearOutAlwaysOnTop_Plugin";
+        break;
+    case ModlistOverlayTearOutAlwaysOnTop_Plugin:
+        r = "modlistOverlayTearOutAlwaysOnTop_Plugin";
+        break;
+    case MSEGOverlayTearOutAlwaysOnTop_Plugin:
+        r = "msegOverlayTearOutAlwaysOnTop_Plugin";
+        break;
+    case FormulaOverlayTearOutAlwaysOnTop_Plugin:
+        r = "formulaOverlayTearOutAlwaysOnTop_Plugin";
+        break;
+    case WSAnalysisOverlayTearOutAlwaysOnTop_Plugin:
+        r = "wsAnalysisOverlayTearOutAlwaysOnTop_Plugin";
+        break;
+    case FilterAnalysisOverlayTearOutAlwaysOnTop_Plugin:
+        r = "filterAnalysisOverlayTearOutAlwaysOnTop_Plugin";
+        break;
+    case OscilloscopeOverlayTearOutAlwaysOnTop_Plugin:
+        r = "oscilloscopeOverlayTearOutAlwaysOnTop_Plugin";
+        break;
+
     case ModListValueDisplay:
         r = "modListValueDisplay";
         break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -123,6 +123,14 @@ enum DefaultKey
     FilterAnalysisOverlayTearOutAlwaysOnTop,
     OscilloscopeOverlayTearOutAlwaysOnTop,
 
+    TuningOverlayTearOutAlwaysOnTop_Plugin,
+    ModlistOverlayTearOutAlwaysOnTop_Plugin,
+    MSEGOverlayTearOutAlwaysOnTop_Plugin,
+    FormulaOverlayTearOutAlwaysOnTop_Plugin,
+    WSAnalysisOverlayTearOutAlwaysOnTop_Plugin,
+    FilterAnalysisOverlayTearOutAlwaysOnTop_Plugin,
+    OscilloscopeOverlayTearOutAlwaysOnTop_Plugin,
+
     // Surge XT Effects specific defaults
     FXUnitAssumeFixedBlock,
     FXUnitDefaultZoom,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -293,16 +293,6 @@ class DroppedUserDataHandler
 };
 
 Surge::GUI::ModulationGrid *Surge::GUI::ModulationGrid::grid = nullptr;
-/*
- * See the comment in SurgeGUIUtils.cpp
- */
-namespace Surge
-{
-namespace GUI
-{
-extern void setIsStandalone(bool b);
-}
-} // namespace Surge
 
 SurgeGUIEditor::SurgeGUIEditor(SurgeSynthEditor *jEd, SurgeSynthesizer *synth)
 {

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -153,7 +153,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
 
         jassert(false); // Make a key for me please!
 
-        pt->setCanTearOut({true, Surge::Storage::nKeys, Surge::Storage::nKeys});
+        pt->setCanTearOut(
+            {true, Surge::Storage::nKeys, Surge::Storage::nKeys, Surge::Storage::nKeys});
 
         return pt;
     }
@@ -209,7 +210,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
 
         mse->setEnclosingParentTitle(title);
         mse->setCanTearOut({true, Surge::Storage::MSEGOverlayLocationTearOut,
-                            Surge::Storage::MSEGOverlayTearOutAlwaysOnTop});
+                            Surge::Storage::MSEGOverlayTearOutAlwaysOnTop,
+                            Surge::Storage::MSEGOverlayTearOutAlwaysOnTop_Plugin});
         mse->setCanTearOutResize({true, Surge::Storage::MSEGOverlaySizeTearOut});
         mse->setMinimumSize(600, 250);
         locationGet(mse.get(), Surge::Skin::Connector::NonParameterConnection::MSEG_EDITOR_WINDOW,
@@ -259,7 +261,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         fme->setSkin(currentSkin, bitmapStore);
         fme->setEnclosingParentTitle(title);
         fme->setCanTearOut({true, Surge::Storage::FormulaOverlayLocationTearOut,
-                            Surge::Storage::FormulaOverlayTearOutAlwaysOnTop});
+                            Surge::Storage::FormulaOverlayTearOutAlwaysOnTop,
+                            Surge::Storage::FormulaOverlayTearOutAlwaysOnTop_Plugin});
         fme->setCanTearOutResize({true, Surge::Storage::FormulaOverlaySizeTearOut});
         fme->setMinimumSize(500, 250);
         locationGet(fme.get(),
@@ -284,7 +287,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         te->setTuning(synth->storage.currentTuning);
         te->setEnclosingParentTitle("Tuning Editor");
         te->setCanTearOut({true, Surge::Storage::TuningOverlayLocationTearOut,
-                           Surge::Storage::TuningOverlayTearOutAlwaysOnTop});
+                           Surge::Storage::TuningOverlayTearOutAlwaysOnTop,
+                           Surge::Storage::TuningOverlayTearOutAlwaysOnTop_Plugin});
         te->setCanTearOutResize({true, Surge::Storage::TuningOverlaySizeTearOut});
         te->setMinimumSize(730, 400);
         locationGet(te.get(), Surge::Skin::Connector::NonParameterConnection::TUNING_EDITOR_WINDOW,
@@ -325,7 +329,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         wsa->setEnclosingParentTitle("Waveshaper Analysis");
         wsa->setWSType(synth->storage.getPatch().scene[current_scene].wsunit.type.val.i);
         wsa->setCanTearOut({true, Surge::Storage::WSAnalysisOverlayLocationTearOut,
-                            Surge::Storage::WSAnalysisOverlayTearOutAlwaysOnTop});
+                            Surge::Storage::WSAnalysisOverlayTearOutAlwaysOnTop,
+                            Surge::Storage::WSAnalysisOverlayTearOutAlwaysOnTop_Plugin});
         wsa->setCanTearOutResize({true, Surge::Storage::WSAnalysisOverlaySizeTearOut});
         wsa->setMinimumSize(300, 160);
 
@@ -343,7 +348,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         fa->setSkin(currentSkin, bitmapStore);
         fa->setEnclosingParentTitle("Filter Analysis");
         fa->setCanTearOut({true, Surge::Storage::FilterAnalysisOverlayLocationTearOut,
-                           Surge::Storage::FilterAnalysisOverlayTearOutAlwaysOnTop});
+                           Surge::Storage::FilterAnalysisOverlayTearOutAlwaysOnTop,
+                           Surge::Storage::FilterAnalysisOverlayTearOutAlwaysOnTop_Plugin});
         fa->setCanTearOutResize({true, Surge::Storage::FilterAnalysisOverlaySizeTearOut});
         fa->setMinimumSize(300, 200);
 
@@ -361,7 +367,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         scope->setSkin(currentSkin, bitmapStore);
         scope->setEnclosingParentTitle("Oscilloscope");
         scope->setCanTearOut({true, Surge::Storage::OscilloscopeOverlayLocationTearOut,
-                              Surge::Storage::OscilloscopeOverlayTearOutAlwaysOnTop});
+                              Surge::Storage::OscilloscopeOverlayTearOutAlwaysOnTop,
+                              Surge::Storage::OscilloscopeOverlayTearOutAlwaysOnTop_Plugin});
         scope->setCanTearOutResize({true, Surge::Storage::OscilloscopeOverlaySizeTearOut});
         scope->setMinimumSize(500, 300);
 
@@ -373,7 +380,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         auto me = std::make_unique<Surge::Overlays::ModulationEditor>(this, this->synth);
         me->setEnclosingParentTitle("Modulation List");
         me->setCanTearOut({true, Surge::Storage::ModlistOverlayLocationTearOut,
-                           Surge::Storage::ModlistOverlayTearOutAlwaysOnTop});
+                           Surge::Storage::ModlistOverlayTearOutAlwaysOnTop,
+                           Surge::Storage::ModlistOverlayTearOutAlwaysOnTop_Plugin});
         me->setCanTearOutResize({true, Surge::Storage::ModlistOverlaySizeTearOut});
         me->setMinimumSize(600, 300);
         me->setSkin(currentSkin, bitmapStore);

--- a/src/surge-xt/gui/SurgeGUIUtils.cpp
+++ b/src/surge-xt/gui/SurgeGUIUtils.cpp
@@ -35,6 +35,7 @@ bool isTouchMode(SurgeStorage *storage)
  */
 static bool isStandalone{false};
 void setIsStandalone(bool b) { isStandalone = b; }
+bool getIsStandalone() { return isStandalone; }
 
 bool allowKeyboardEdits(SurgeStorage *storage)
 {

--- a/src/surge-xt/gui/SurgeGUIUtils.h
+++ b/src/surge-xt/gui/SurgeGUIUtils.h
@@ -20,5 +20,10 @@ void constrainPointOnLineWithinRectangle(const juce::Rectangle<float> rect,
 
 void openFileOrFolder(const std::string &f);
 inline void openFileOrFolder(const fs::path &f) { openFileOrFolder(path_to_string(f)); }
+
+// Are we standalone exe vs a plugin (clap, vst, au, etc...)
+void setIsStandalone(bool);
+bool getIsStandalone();
+
 } // namespace GUI
 } // namespace Surge

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -50,16 +50,13 @@ struct OverlayComponent : juce::Component
      */
     virtual void shownInParent() {}
 
-    std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> canTearOut{
-        false, Surge::Storage::nKeys, Surge::Storage::nKeys};
-    void setCanTearOut(std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> t)
-    {
-        canTearOut = t;
-    }
-    std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> getCanTearOut()
-    {
-        return canTearOut;
-    }
+    typedef std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey,
+                       Surge::Storage::DefaultKey>
+        tearoutTuple_t;
+    tearoutTuple_t canTearOut{false, Surge::Storage::nKeys, Surge::Storage::nKeys,
+                              Surge::Storage::nKeys};
+    void setCanTearOut(tearoutTuple_t t) { canTearOut = t; }
+    tearoutTuple_t getCanTearOut() { return canTearOut; }
     virtual void onTearOutChanged(bool isTornOut) {}
 
     std::pair<bool, Surge::Storage::DefaultKey> canTearOutResize{false, Surge::Storage::nKeys};

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -260,9 +260,16 @@ struct TearOutWindow : public juce::DocumentWindow, public Surge::GUI::SkinConsu
     {
         isPinned = !isPinned;
 
-        Surge::Storage::updateUserDefaultValue(wrapping->storage,
-                                               std::get<2>(wrapping->canTearOutData), isPinned);
-
+        if (Surge::GUI::getIsStandalone())
+        {
+            Surge::Storage::updateUserDefaultValue(wrapping->storage,
+                                                   std::get<2>(wrapping->canTearOutData), isPinned);
+        }
+        else
+        {
+            Surge::Storage::updateUserDefaultValue(wrapping->storage,
+                                                   std::get<3>(wrapping->canTearOutData), isPinned);
+        }
         setAlwaysOnTop(isPinned);
         repaint();
     }

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -20,6 +20,7 @@
 #include "UserDefaults.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
+#include "SurgeGUIUtils.h"
 
 class SurgeGUIEditor;
 class SurgeImage;
@@ -77,19 +78,24 @@ struct OverlayWrapper : public juce::Component,
     SurgeImage *icon{nullptr};
     void setIcon(SurgeImage *d) { icon = d; }
 
-    std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> canTearOutData{
-        false, Surge::Storage::nKeys, Surge::Storage::nKeys};
+    // this is can, size key, standalone pin key, plugin pin key
+    typedef std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey,
+                       Surge::Storage::DefaultKey>
+        tearoutTuple_t;
+    tearoutTuple_t canTearOutData{false, Surge::Storage::nKeys, Surge::Storage::nKeys,
+                                  Surge::Storage::nKeys};
     bool canTearOut, isAlwaysOnTop;
-    void setCanTearOut(std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> t)
+    // this tuple is can: the sie key,
+    void setCanTearOut(tearoutTuple_t t)
     {
         canTearOutData = t;
         canTearOut = std::get<0>(t);
-        isAlwaysOnTop = Surge::Storage::getUserDefaultValue(storage, std::get<2>(t), false);
+        if (Surge::GUI::getIsStandalone())
+            isAlwaysOnTop = Surge::Storage::getUserDefaultValue(storage, std::get<2>(t), false);
+        else
+            isAlwaysOnTop = Surge::Storage::getUserDefaultValue(storage, std::get<3>(t), true);
     }
-    std::tuple<bool, Surge::Storage::DefaultKey, Surge::Storage::DefaultKey> getCanTearOut()
-    {
-        return canTearOutData;
-    }
+    tearoutTuple_t getCanTearOut() { return canTearOutData; }
 
     std::pair<bool, Surge::Storage::DefaultKey> canTearOutResizePair{false, Surge::Storage::nKeys};
     bool canTearOutResize;


### PR DESCRIPTION
This defaults tearout windows to pin on top in plugin contexts which solves problems in reaper, logic, live and more. To avoid confusion with the standalone we also separate the user default parameters by plugin and standalone, making this a really big diff for a very small change (basically changing the default of alwaysOnTop in a plugin only)

Closes #6633