### PR TITLE
Improve slider rename when arrowing through menu sliders

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6861,6 +6861,7 @@ void SurgeGUIEditor::setAccessibilityInformationByTitleAndAction(juce::Component
                                                                  const std::string &title,
                                                                  const std::string &action)
 {
+    auto currT = c->getTitle().toStdString();
 #if MAC
     c->setDescription(title);
     c->setTitle(title);
@@ -6868,6 +6869,14 @@ void SurgeGUIEditor::setAccessibilityInformationByTitleAndAction(juce::Component
     c->setDescription(action);
     c->setTitle(title);
 #endif
+
+    if (currT != title)
+    {
+        if (auto h = c->getAccessibilityHandler())
+        {
+            h->notifyAccessibilityEvent(juce::AccessibilityEvent::titleChanged);
+        }
+    }
 }
 
 std::string SurgeGUIEditor::modulatorIndexExtension(int scene, int ms, int index, bool shortV)

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.cpp
@@ -377,8 +377,23 @@ bool MenuForDiscreteParams::keyPressed(const juce::KeyPress &key)
     setValue(nextValueInOrder(value, -dir));
     notifyValueChanged();
     notifyEndEdit();
+
+    rebuildOnFocus = true;
     repaint();
     return true;
+}
+
+void MenuForDiscreteParams::focusLost(juce::Component::FocusChangeType cause)
+{
+    endHover();
+    if (rebuildOnFocus)
+    {
+        auto sge = firstListenerOfType<SurgeGUIEditor>();
+        if (sge)
+        {
+            sge->queue_refresh = true;
+        }
+    }
 }
 
 } // namespace Widgets

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
@@ -143,12 +143,14 @@ struct MenuForDiscreteParams : public juce::Component,
 
     bool keyPressed(const juce::KeyPress &key) override;
 
+    bool rebuildOnFocus = false;
     void focusGained(juce::Component::FocusChangeType cause) override
     {
+        rebuildOnFocus = false;
         startHover(getBounds().getBottomLeft().toFloat());
     }
 
-    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
+    void focusLost(juce::Component::FocusChangeType cause) override;
 
     juce::Point<int> mouseDownOrigin;
     bool isDraggingGlyph{false};

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -1891,6 +1891,11 @@ void OscillatorWaveformDisplay::showCustomEditor()
         customEditorAccOverlay->setTitle("Close Custom Editor");
         customEditorAccOverlay->setDescription("Close Custom Editor");
     }
+
+    if (auto h = getAccessibilityHandler())
+    {
+        h->notifyAccessibilityEvent(juce::AccessibilityEvent::structureChanged);
+    }
 }
 
 void OscillatorWaveformDisplay::hideCustomEditor()
@@ -1904,6 +1909,11 @@ void OscillatorWaveformDisplay::hideCustomEditor()
 
     customEditorAccOverlay->setTitle("Open Custom Editor");
     customEditorAccOverlay->setDescription("Open Custom Editor");
+
+    if (auto h = getAccessibilityHandler())
+    {
+        h->notifyAccessibilityEvent(juce::AccessibilityEvent::structureChanged);
+    }
 
     repaint();
 }


### PR DESCRIPTION
Discrete (menu) sliders rebuild on menu change but not arrow so do that. But rebuilding on every arrow is annoying in VO so di it at the end.

Also invalidate a few other places

Addresses #6822