### PR TITLE
Build wheels for surgepy with cibuildwheel

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -310,10 +310,16 @@ if(APPLE)
     )
 elseif(UNIX)
   target_compile_definitions(${PROJECT_NAME} PUBLIC LINUX=1)
-  target_link_libraries(${PROJECT_NAME} PRIVATE
-    pthread
-    -Wl,--no-undefined
-    )
+  if(SKBUILD)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      pthread
+      )
+  else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      pthread
+      -Wl,--no-undefined
+      )
+  endif()
   if(CMAKE_SYSTEM_NAME MATCHES "BSD")
     target_link_libraries(${PROJECT_NAME} PRIVATE execinfo)
   endif()

--- a/src/surge-python/CMakeLists.txt
+++ b/src/surge-python/CMakeLists.txt
@@ -12,11 +12,19 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 
 if(UNIX AND NOT APPLE)
   find_package(Threads REQUIRED)
-  target_link_libraries(${PROJECT_NAME}
-    PRIVATE
-    Threads::Threads
-    ${PYTHON_LIBRARIES}
-    )
+
+  if(SKBUILD)
+    target_link_libraries(${PROJECT_NAME}
+      PRIVATE
+      Threads::Threads
+      )
+  else()
+    target_link_libraries(${PROJECT_NAME}
+      PRIVATE
+      Threads::Threads
+      ${PYTHON_LIBRARIES}
+      )
+  endif()
 
   if(CMAKE_SYSTEM_NAME MATCHES "BSD")
     target_link_libraries(${PROJECT_NAME} PRIVATE execinfo)

--- a/src/surge-python/pyproject.toml
+++ b/src/surge-python/pyproject.toml
@@ -11,3 +11,16 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.cibuildwheel]
+container-engine = "podman"
+build-verbosity = 3
+build = [
+    "cp37-manylinux_x86_64",
+    "cp38-manylinux_x86_64",
+    "cp39-manylinux_x86_64",
+    "cp310-manylinux_x86_64",
+    "cp311-manylinux_x86_64",
+]
+test-requires = "pytest"
+test-command = "pytest {project}/src/surge-python/"

--- a/src/surge-python/setup.py
+++ b/src/surge-python/setup.py
@@ -26,6 +26,13 @@ setup(
     install_requires=["numpy"],
     packages=["surgepy"],
     cmake_source_dir="../..",
-    cmake_args=["-DSURGE_BUILD_PYTHON_BINDINGS=TRUE"],
+    cmake_args=[
+        "-DSURGE_BUILD_PYTHON_BINDINGS=TRUE",
+        "-DSURGE_SKIP_JUCE_FOR_RACK=TRUE",
+        "-DSURGE_SKIP_ODDSOUND_MTS=TRUE",
+        "-DSURGE_SKIP_VST3=TRUE",
+        "-DSURGE_SKIP_ALSA=TRUE",
+        "-DSURGE_SKIP_STANDALONE=TRUE",
+    ],
     cmake_process_manifest_hook=just_surgepy,
 )


### PR DESCRIPTION
Use cibuildwheel to build wheels (compiled binary Python packages) for surgepy. Wheels can be built locally by running
```
    $ pipx run cibuildwheel --platform linux src/surge-python/
```
in the surge repo (if pipx and podman are installed). More info on cibuildwheel [here](https://cibuildwheel.readthedocs.io/en/stable/).

Also do not link surgepy with the system libpython when building the surgepy Python package. This allows using the built wheels with multiple Python interpreters. The pybind11 docs recommend not linking against libpython for this reason; more info [here](https://pybind11.readthedocs.io/en/stable/compiling.html#building-manually).

No CI changes here, just changes to make cibuildwheel runnable locally.