### PR TITLE
Don't double-scan 3rd parth

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -943,8 +943,12 @@ void SurgeStorage::refresh_wtlist()
     refresh_wtlistAddDir(false, "wavetables");
 
     firstThirdPartyWTCategory = wt_category.size();
-    refresh_wtlistAddDir(false, "wavetables_3rdparty");
-    if (!extraThirdPartyWavetablesPath.empty())
+    if (extraThirdPartyWavetablesPath.empty() ||
+        !fs::is_directory(extraThirdPartyWavetablesPath / "wavetables_3rdparty"))
+    {
+        refresh_wtlistAddDir(false, "wavetables_3rdparty");
+    }
+    else
     {
         refresh_wtlistFrom(false, extraThirdPartyWavetablesPath, "wavetables_3rdparty");
     }


### PR DESCRIPTION
If the extra third party dir is specified and it contains the waveetables third party don't even try to scan them from the default dir (which would double scan them in 2.0.3 vs 2.1.1 in rack)