### PR TITLE
Refactoring of the spectrum class of oscilloscope

### DIFF
--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -752,6 +752,7 @@ Oscilloscope::SpectrumParameters::SpectrumParameters(SurgeGUIEditor *e, SurgeSto
     noise_floor_.setUnit(" dB");
     max_db_.setRange(-50, 0);
     max_db_.setUnit(" dB");
+#if 0
     addAndMakeVisible(noise_floor_);
     addAndMakeVisible(max_db_);
     // The toggle button.
@@ -763,6 +764,7 @@ Oscilloscope::SpectrumParameters::SpectrumParameters(SurgeGUIEditor *e, SurgeSto
     freeze_.setWantsKeyboardFocus(false);
     freeze_.onToggle = std::bind(toggleParam, std::ref(params_.freeze));
     addAndMakeVisible(freeze_);
+#endif
 }
 
 std::optional<SpectrumDisplay::Parameters> Oscilloscope::SpectrumParameters::getParamsIfDirty()


### PR DESCRIPTION
This has been sort of messy since we added the actual oscilloscope part of this. This moves the spectrum display to its own class like the oscilloscope is, and adds its own parameters and parameter display. They aren't displayed yet since they don't yet do anything.