### PR TITLE
Add initialize patch keybinding (unbound by default)

### DIFF
--- a/src/common/DebugHelpers.cpp
+++ b/src/common/DebugHelpers.cpp
@@ -30,8 +30,8 @@ bool Surge::Debug::openConsole()
         AllocConsole();
         freopen_s(&confp, "CONOUT$", "w", stdout);
         std::cout << "SURGE DEBUG CONSOLE\n\n"
-                  << "This is where we show stdout from Surge, for debugging purposes. If you "
-                     "close this window, Surge will crash!\n"
+                  << "This is where we show stdout from Surge XT, for debugging purposes. If you "
+                     "close this window, Surge XT will crash!\n"
                   << "Version: " << Build::FullVersionStr << ", built on " << Build::BuildDate
                   << " at " << Build::BuildTime << "\n\n"
                   << std::endl;

--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -158,7 +158,7 @@ Component Label =
     Component("Internal Label")
         .withProperty(Component::TEXT, {"text"}, {"Arbitrary text to be displayed on the label."})
         .withProperty(Component::CONTROL_TEXT, {"control_text"},
-                      {"Text tied to a particular Surge parameter. Use skin component connector "
+                      {"Text tied to a particular Surge XT parameter. Use skin component connector "
                        "name as a value. Overrules arbitrary text set with 'text' property"})
         .withProperty(Component::TEXT_ALIGN, {"text_align"}, {"Valid values: left, center, right"})
         .withProperty(Component::FONT_SIZE, {"font_size"}, {"Font size in points, integer only"})

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -71,9 +71,9 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     else if (samplerate < 12000 || samplerate > 48000 * 32)
     {
         std::ostringstream oss;
-        oss << "Warning: SurgeStorage constructed with invalid samplerate :" << samplerate
-            << " - resetting to 48000 until Audio System tells us otherwise" << std::endl;
-        reportError(oss.str(), "SampleRate Corrputed on Startup");
+        oss << "Warning: SurgeStorage constructed with invalid samplerate: " << samplerate
+            << " - resetting to 48000 until audio system tells us otherwise" << std::endl;
+        reportError(oss.str(), "Sample Rate Corrupted on Startup");
         setSamplerate(48000);
     }
     else
@@ -1179,7 +1179,7 @@ void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *os
     {
         std::ostringstream oss;
         oss << "Unable to load file with extension " << extension
-            << "! Surge only supports .wav and .wt wavetable files!";
+            << "! Surge XT only supports .wav and .wt wavetable files!";
         reportError(oss.str(), "Error");
     }
 
@@ -1245,7 +1245,7 @@ bool SurgeStorage::load_wt_wt(string filename, Wavetable *wt)
             << max_wtable_size << " samples per frame.\n"
             << "In some cases, Surge XT detects this situation inconsistently, which can lead to a "
                "potentially volatile state\n."
-            << "It is recommended to restart Surge and not load "
+            << "It is recommended to restart Surge XT and not load "
                "the problematic wavetable again.\n\n"
             << " If you would like, please attach the wavetable which caused this error to a new "
                "GitHub issue at "
@@ -1297,7 +1297,7 @@ bool SurgeStorage::load_wt_wt_mem(const char *data, size_t dataSize, Wavetable *
             << max_wtable_size << " samples per frame.\n"
             << "In some cases, Surge XT detects this situation inconsistently, which can lead to a "
                "potentially volatile state\n."
-            << "It is recommended to restart Surge and not load "
+            << "It is recommended to restart Surge XT and not load "
                "the problematic wavetable again.\n\n"
             << " If you would like, please attach the wavetable which caused this error to a new "
                "GitHub issue at "

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -254,7 +254,7 @@ bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, cons
         //   'cjs3'. ";
         //}
         oss << "This error usually occurs when you attempt to load an .fxp that belongs to another "
-               "plugin into Surge.";
+               "plugin into Surge XT.";
         storage.reportError(oss.str(), "Unknown FXP File");
         return false;
     }

--- a/src/surge-python/surgepy.cpp
+++ b/src/surge-python/surgepy.cpp
@@ -889,10 +889,10 @@ PYBIND11_MODULE(_surgepy, m)
 PYBIND11_MODULE(surgepy, m)
 #endif
 {
-    m.doc() = "Python bindings for Surge Synthesizer";
-    m.def("createSurge", &createSurge, "Create a surge instance", py::arg("sampleRate"));
+    m.doc() = "Python bindings for Surge XT Synthesizer";
+    m.def("createSurge", &createSurge, "Create a Surge XT instance", py::arg("sampleRate"));
     m.def(
-        "getVersion", []() { return Surge::Build::FullVersionStr; }, "Get the version of Surge");
+        "getVersion", []() { return Surge::Build::FullVersionStr; }, "Get the version of Surge XT");
     py::class_<SurgeSynthesizer::ID>(m, "SurgeSynthesizer_ID")
         .def(py::init<>())
         .def("getSynthSideId", &SurgeSynthesizer::ID::getSynthSideId)
@@ -920,24 +920,24 @@ PYBIND11_MODULE(surgepy, m)
         .def("createSynthSideId", &SurgeSynthesizerWithPythonExtensions::createSynthSideId)
 
         .def("getParameterName", &SurgeSynthesizerWithPythonExtensions::getParameterName_py,
-             "Given a parameter, return its name as displayed by the Synth.")
+             "Given a parameter, return its name as displayed by the synth.")
 
         .def("playNote", &SurgeSynthesizerWithPythonExtensions::playNoteWithInts,
-             "Trigger a note on this Surge instance.", py::arg("channel"), py::arg("midiNote"),
+             "Trigger a note on this Surge XT instance.", py::arg("channel"), py::arg("midiNote"),
              py::arg("velocity"), py::arg("detune") = 0)
         .def("releaseNote", &SurgeSynthesizerWithPythonExtensions::releaseNoteWithInts,
-             "Release a note on this Surge instance.", py::arg("channel"), py::arg("midiNote"),
+             "Release a note on this Surge XT instance.", py::arg("channel"), py::arg("midiNote"),
              py::arg("releaseVelocity") = 0)
         .def("pitchBend", &SurgeSynthesizerWithPythonExtensions::pitchBendWithInts,
              "Set the pitch bend value on channel ch", py::arg("channel"), py::arg("bend"))
         .def("allNotesOff", &SurgeSynthesizer::allNotesOff, "Turn off all playing notes")
         .def("polyAftertouch", &SurgeSynthesizerWithPythonExtensions::polyAftertouchWithInts,
-             "Send the poly aftertouch midi message", py::arg("channel"), py::arg("key"),
+             "Send the poly aftertouch MIDI message", py::arg("channel"), py::arg("key"),
              py::arg("value"))
         .def("channelAftertouch", &SurgeSynthesizerWithPythonExtensions::channelAftertouchWithInts,
-             "Send the channel aftertouch midi message", py::arg("channel"), py::arg("value"))
+             "Send the channel aftertouch MIDI message", py::arg("channel"), py::arg("value"))
         .def("channelController", &SurgeSynthesizerWithPythonExtensions::channelControllerWithInts,
-             "Set midi controller on channel to value", py::arg("channel"), py::arg("cc"),
+             "Set MIDI controller on channel to value", py::arg("channel"), py::arg("cc"),
              py::arg("value"))
 
         .def("getParamMin", &SurgeSynthesizerWithPythonExtensions::getParamMin,
@@ -947,9 +947,9 @@ PYBIND11_MODULE(surgepy, m)
         .def("getParamDef", &SurgeSynthesizerWithPythonExtensions::getParamDef,
              "Parameter default value, as a float")
         .def("getParamVal", &SurgeSynthesizerWithPythonExtensions::getParamVal,
-             "Parameter current value in this Surge instance, as a float")
+             "Parameter current value in this Surge XT instance, as a float")
         .def("getParamValType", &SurgeSynthesizerWithPythonExtensions::getParamValType,
-             "Parameter type. float, int or bool are supported")
+             "Parameter types float, int or bool are supported")
 
         .def("getParamDisplay", &SurgeSynthesizerWithPythonExtensions::getParamDisplay,
              "Parameter value display (stringified and formatted)")
@@ -960,12 +960,12 @@ PYBIND11_MODULE(surgepy, m)
              "Set a parameter value", py::arg("param"), py::arg("toThis"))
 
         .def("loadPatch", &SurgeSynthesizerWithPythonExtensions::loadPatchPy,
-             "Load a Surge .fxp patch from the file system.", py::arg("path"))
+             "Load a Surge XT .fxp patch from the file system.", py::arg("path"))
         .def("savePatch", &SurgeSynthesizerWithPythonExtensions::savePatchPy,
-             "Save the current state of Surge to an .fxp file.", py::arg("path"))
+             "Save the current state of Surge XT to an .fxp file.", py::arg("path"))
 
         .def("getModSource", &SurgeSynthesizerWithPythonExtensions::getModSource,
-             "Given a constant from surge.constants.ms_* provide a modulator object",
+             "Given a constant from surge.constants.ms_*, provide a modulator object",
              py::arg("modId"))
         .def("setModDepth01", &SurgeSynthesizerWithPythonExtensions::setModulationPy,
              "Set a modulation to a given depth", py::arg("targetParameter"),
@@ -985,25 +985,25 @@ PYBIND11_MODULE(surgepy, m)
              "Is the given modulation source bipolar?", py::arg("modulationSource"))
 
         .def("getAllModRoutings", &SurgeSynthesizerWithPythonExtensions::getAllModRoutings,
-             "Get the entire modulation matrix for this instance")
+             "Get the entire modulation matrix for this instance.")
 
         .def("process", &SurgeSynthesizer::process,
-             "Run surge for one block and update the internal output buffer.")
+             "Run Surge XT for one block and update the internal output buffer.")
         .def("getOutput", &SurgeSynthesizerWithPythonExtensions::getOutput,
-             "Retrieve the internal output buffer as a 2xBLOCK_SIZE numpy array.")
+             "Retrieve the internal output buffer as a 2 * BLOCK_SIZE numpy array.")
 
         .def("createMultiBlock", &SurgeSynthesizerWithPythonExtensions::createMultiBlock,
-             "Create a numpy array suitable to hold up to b blocks of Surge processing in "
+             "Create a numpy array suitable to hold up to b blocks of Surge XT processing in "
              "processMultiBlock",
              py::arg("blockCapacity"))
         .def("processMultiBlock", &SurgeSynthesizerWithPythonExtensions::processMultiBlock,
-             "Run the surge engine for multiple blocks, updating the value in the numpy array. "
+             "Run the Surge XT engine for multiple blocks, updating the value in the numpy array. "
              "Either populate the\n"
              "entire array, or starting at startBlock position in the output, populate nBlocks.",
              py::arg("val"), py::arg("startBlock") = 0, py::arg("nBlocks") = -1)
 
         .def("getPatch", &SurgeSynthesizerWithPythonExtensions::getPatchAsPy,
-             "Get a python dictionary with the Surge parameters laid out in the logical patch "
+             "Get a Python dictionary with the Surge XT parameters laid out in the logical patch "
              "format")
 
         .def("loadSCLFile", &SurgeSynthesizerWithPythonExtensions::loadSCLFile,
@@ -1014,10 +1014,10 @@ PYBIND11_MODULE(surgepy, m)
         .def("retuneToStandardScale", &SurgeSynthesizerWithPythonExtensions::retuneToStandardScale,
              "Return this instance to 12-TET Scale")
         .def("loadKBMFile", &SurgeSynthesizerWithPythonExtensions::loadKBMFile,
-             "Load an KBM mapping file and apply tuning to this instance")
+             "Load a KBM mapping file and apply tuning to this instance")
         .def("remapToStandardKeyboard",
              &SurgeSynthesizerWithPythonExtensions::remapToStandardKeyboard,
-             "Return to standard C centered keyboard mapping")
+             "Return to standard C-centered keyboard mapping")
         .def_readwrite("mpeEnabled", &SurgeSynthesizerWithPythonExtensions::mpeEnabled)
         .def_property("tuningApplicationMode",
                       &SurgeSynthesizerWithPythonExtensions::getTuningApplicationMode,
@@ -1059,7 +1059,8 @@ PYBIND11_MODULE(surgepy, m)
             return oss.str();
         });
 
-    py::module m_const = m.def_submodule("constants", "Constants which are used to navigate Surge");
+    py::module m_const =
+        m.def_submodule("constants", "Constants which are used to navigate Surge XT");
 
 #define C(x) m_const.attr(#x) = py::int_((int)(x));
     C(cg_GLOBAL);

--- a/src/surge-testrunner/HeadlessNonTestFunctions.cpp
+++ b/src/surge-testrunner/HeadlessNonTestFunctions.cpp
@@ -516,7 +516,7 @@ void filterAnalyzer(int ft, int sft, std::ostream &os)
 [[noreturn]] void performancePlay(const std::string &patchName, int mode)
 {
     auto surge = Surge::Headless::createSurge(48000);
-    std::cout << "Performance Mode with surge at 48k\n"
+    std::cout << "Performance Mode with Surge XT at 48k\n"
               << "-- Ctrl-C to exit\n"
               << "-- patchName = " << patchName << "\n"
               << "-- mode = " << mode << std::endl;

--- a/src/surge-testrunner/UnitTests.cpp
+++ b/src/surge-testrunner/UnitTests.cpp
@@ -20,7 +20,7 @@ int runAllTests(int argc, char **argv)
                       << "This means several tests will fail. Currently the\n"
                       << "test runner assumes you run with CWD as root of the\n"
                       << "surge repo so that the above local reference loads.\n\n"
-                      << "To fix this, run the test runner from surge or \n"
+                      << "To fix this, run the test runner from Surge XT or \n"
                       << "set the variable SURGE_TEST_WITH_FILE_ERRORS and tests\n"
                       << "will continue." << std::endl;
 
@@ -30,12 +30,12 @@ int runAllTests(int argc, char **argv)
     }
     catch (const fs::filesystem_error &e)
     {
-        std::cerr << "FileSystem Error " << e.what() << std::endl;
+        std::cerr << "Filesystem Error " << e.what() << std::endl;
         return 172;
     }
 
     auto surge = Surge::Headless::createSurge(44100);
-    std::cout << "Created surge with " << surge->storage.datapath << " & "
+    std::cout << "Created Surge XT with " << surge->storage.datapath << " & "
               << surge->storage.userDataPath << std::endl;
     std::cout << "WT/Patch = " << surge->storage.wt_list.size() << " & "
               << surge->storage.patch_list.size() << std::endl;

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -906,10 +906,10 @@ end)FN");
     }
 }
 
-TEST_CASE("Two Surges", "[formula]")
+TEST_CASE("Two Surge XTs", "[formula]")
 {
     // this attempts but fails to reproduce 5753 but i left it here anyway
-    SECTION("Two Surges on Tutorial 3")
+    SECTION("Two Surge XTs on Tutorial 3")
     {
         auto s1 = Surge::Test::surgeOnSine();
         auto s2 = Surge::Test::surgeOnSine();

--- a/src/surge-testrunner/UnitTestsTUN.cpp
+++ b/src/surge-testrunner/UnitTestsTUN.cpp
@@ -14,7 +14,7 @@
 
 using namespace Surge::Test;
 
-TEST_CASE("Retune Surge to .scl files", "[tun]")
+TEST_CASE("Retune Surge XT to .scl files", "[tun]")
 {
     auto surge = Surge::Headless::createSurge(44100);
     surge->storage.tuningApplicationMode = SurgeStorage::RETUNE_ALL;

--- a/src/surge-testrunner/main.cpp
+++ b/src/surge-testrunner/main.cpp
@@ -15,7 +15,7 @@
  */
 int main(int argc, char **argv)
 {
-    std::cout << "# surge-headless: " << Surge::Build::FullVersionStr
+    std::cout << "# surge-xt-headless: " << Surge::Build::FullVersionStr
               << " built: " << Surge::Build::BuildDate << " " << Surge::Build::BuildTime << "\n";
 
     if (argc > 2 && strcmp(argv[1], "--non-test") == 0)

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -38,7 +38,7 @@ SurgeSynthProcessor::SurgeSynthProcessor()
 
 #if BUILD_IS_DEBUG
     std::ostringstream oss;
-    oss << "SurgeXT " << wrapperTypeString << "\n"
+    oss << "Surge XT " << wrapperTypeString << "\n"
         << "  - Version      : " << Surge::Build::FullVersionStr << " with JUCE " << std::hex
         << JUCE_VERSION << std::dec << "\n"
         << "  - Build Info   : " << Surge::Build::BuildDate << " " << Surge::Build::BuildTime
@@ -747,7 +747,7 @@ void SurgeSynthProcessor::process_clap_event(const clap_event_header_t *evt)
     case CLAP_EVENT_NOTE_END:
     default:
     {
-        DBG("Unknown CLAP Message type in Surge Direct " << (int)(evt->type));
+        DBG("Unknown CLAP Message type in Surge XT Direct " << (int)(evt->type));
         // In theory I should never get this.
         // jassertfalse
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -672,7 +672,7 @@ void SurgeGUIEditor::idle()
                 oss << "Loading patch " << synth->patchid_queue
                     << " has not occurred after 200 idle cycles. This means that the audio system"
                     << " is delayed while loading many patches in a row. The audio system has to be"
-                    << " running in order to load Surge patches. If the audio system is working,"
+                    << " running in order to load Surge XT patches. If the audio system is working,"
                        " you can probably ignore this message and continue once Surge XT catches "
                        "up.";
 
@@ -2261,7 +2261,8 @@ bool SurgeGUIEditor::open(void *parent)
         auto db = Surge::GUI::SkinDB::get();
 
         std::ostringstream oss;
-        oss << "Unable to load current skin! Reverting the skin to Surge Classic.\n\nSkin Error:\n"
+        oss << "Unable to load current skin! Reverting the skin to Surge XT Classic.\n\nSkin "
+               "Error:\n"
             << db->getAndResetErrorString();
 
         auto msg = std::string(oss.str());
@@ -2889,7 +2890,7 @@ void SurgeGUIEditor::showTooLargeZoomError(double width, double height, float zf
     }
     else
     {
-        msg << "Surge chose the largest fitting zoom level of " << zf << "%.";
+        msg << "Surge XT chose the largest fitting zoom level of " << zf << "%.";
     }
     synth->storage.reportError(msg.str(), "Zoom Level Adjusted");
 #endif
@@ -2972,16 +2973,16 @@ void SurgeGUIEditor::showSettingsMenu(const juce::Point<int> &where,
         juce::URL(fmt::format("{}skin-library", stringWebsite)).launchInDefaultBrowser();
     });
 
-    Surge::GUI::addMenuWithShortcut(settingsMenu, Surge::GUI::toOSCase("Surge Manual..."),
+    Surge::GUI::addMenuWithShortcut(settingsMenu, Surge::GUI::toOSCase("Surge XT Manual..."),
                                     showShortcutDescription("F1"),
                                     []() { juce::URL(stringManual).launchInDefaultBrowser(); });
 
-    settingsMenu.addItem(Surge::GUI::toOSCase("Surge Website..."),
+    settingsMenu.addItem(Surge::GUI::toOSCase("Surge XT Website..."),
                          []() { juce::URL(stringWebsite).launchInDefaultBrowser(); });
 
     settingsMenu.addSeparator();
 
-    Surge::GUI::addMenuWithShortcut(settingsMenu, "About Surge", showShortcutDescription("F12"),
+    Surge::GUI::addMenuWithShortcut(settingsMenu, "About Surge XT", showShortcutDescription("F12"),
                                     [this]() { this->showAboutScreen(); });
 
     settingsMenu.showMenuAsync(popupMenuOptions(where),
@@ -5202,7 +5203,7 @@ void SurgeGUIEditor::setupSkinFromEntry(const Surge::GUI::SkinDB::Entry &entry)
     {
         std::ostringstream oss;
         oss << "Unable to load " << entry.root << entry.name
-            << " skin! Reverting the skin to Surge Classic.\n\nSkin Error:\n"
+            << " skin! Reverting the skin to Surge XT Classic.\n\nSkin Error:\n"
             << db->getAndResetErrorString();
 
         auto msg = std::string(oss.str());
@@ -7248,6 +7249,9 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
             case Surge::GUI::FAVORITE_PATCH:
                 setPatchAsFavorite(synth->storage.getPatch().name, !isPatchFavorite());
                 patchSelector->setIsFavorite(isPatchFavorite());
+                return true;
+            case Surge::GUI::INITIALIZE_PATCH:
+                patchSelector->loadInitPatch();
                 return true;
 
             case Surge::GUI::PREV_PATCH:

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -31,6 +31,7 @@ enum KeyboardActions
     SAVE_PATCH,
     FIND_PATCH,
     FAVORITE_PATCH,
+    INITIALIZE_PATCH,
 
     PREV_PATCH,
     NEXT_PATCH,
@@ -96,6 +97,8 @@ inline std::string keyboardActionName(KeyboardActions a)
         return "FIND_PATCH";
     case FAVORITE_PATCH:
         return "FAVORITE_PATCH";
+    case INITIALIZE_PATCH:
+        return "INITIALIZE_PATCH";
 
     case PREV_PATCH:
         return "PREV_PATCH";
@@ -206,6 +209,9 @@ inline std::string keyboardActionDescription(KeyboardActions a)
         break;
     case FAVORITE_PATCH:
         desc = "Mark Patch as Favorite";
+        break;
+    case INITIALIZE_PATCH:
+        desc = "Initialize Patch";
         break;
 
     case PREV_PATCH:

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -383,7 +383,7 @@ void SurgeGUIEditor::refreshSkin()
     {
         auto db = Surge::GUI::SkinDB::get();
         std::string msg =
-            "Unable to load skin! Reverting the skin to Surge Classic.\n\nSkin error:\n" +
+            "Unable to load skin! Reverting the skin to Surge Classic XT.\n\nSkin error:\n" +
             db->getAndResetErrorString();
         currentSkin = db->defaultSkin(&(synth->storage));
         currentSkin->reloadSkin(bitmapStore);

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -575,27 +575,9 @@ void PatchSelector::showClassicMenu(bool single_category)
     contextMenu.addColumnBreak();
     Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "FUNCTIONS");
 
-    auto initAction = [this]() {
-        int i = 0;
-
-        bool lookingForFactory = (storage->initPatchCategoryType == "Factory");
-        for (auto p : storage->patch_list)
-        {
-            if (p.name == storage->initPatchName &&
-                storage->patch_category[p.category].name == storage->initPatchCategory &&
-                storage->patch_category[p.category].isFactory == lookingForFactory)
-            {
-                loadPatch(i);
-                break;
-            }
-
-            ++i;
-        }
-    };
-
     auto sge = firstListenerOfType<SurgeGUIEditor>();
 
-    contextMenu.addItem(Surge::GUI::toOSCase("Initialize Patch"), initAction);
+    contextMenu.addItem(Surge::GUI::toOSCase("Initialize Patch"), [this]() { loadInitPatch(); });
 
     contextMenu.addItem(Surge::GUI::toOSCase("Set Current Patch as Default"), [this]() {
         Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::InitialPatchName,
@@ -679,14 +661,13 @@ void PatchSelector::showClassicMenu(bool single_category)
                     });
             });
 
-            contextMenu.addItem(Surge::GUI::toOSCase("Delete Patch"), [this, initAction]() {
-                auto cb = juce::ModalCallbackFunction::create([this, initAction](int okcs) {
+            contextMenu.addItem(Surge::GUI::toOSCase("Delete Patch"), [this]() {
+                auto cb = juce::ModalCallbackFunction::create([this](int okcs) {
                     if (okcs)
                     {
                         fs::remove(storage->patch_list[current_patch].path);
                         storage->refresh_patchlist();
                         storage->initializePatchDb(true);
-                        initAction();
                     }
                 });
 
@@ -1106,6 +1087,25 @@ void PatchSelector::loadPatch(int id)
 
         enqueue_sel_id = id;
         notifyValueChanged();
+    }
+}
+
+void PatchSelector::loadInitPatch()
+{
+    int i = 0;
+    bool lookingForFactory = (storage->initPatchCategoryType == "Factory");
+
+    for (auto p : storage->patch_list)
+    {
+        if (p.name == storage->initPatchName &&
+            storage->patch_category[p.category].name == storage->initPatchCategory &&
+            storage->patch_category[p.category].isFactory == lookingForFactory)
+        {
+            loadPatch(i);
+            break;
+        }
+
+        ++i;
     }
 }
 

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -143,6 +143,7 @@ struct PatchSelector : public juce::Component,
     void paint(juce::Graphics &g) override;
 
     void loadPatch(int id);
+    void loadInitPatch();
     int sel_id = 0, enqueue_sel_id = 0;
 
     int getCurrentPatchId() const;


### PR DESCRIPTION
Also run through the codebase and replace any user-facing mention of Surge to Surge XT.

Also make it so that when we delete a patch, we don't load an init patch. Because why not leave the current state, maybe deletion was accidental etc.

Closes #6794 