### PR TITLE
Accesibility Quantized Arrow Keys with Command

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1820,11 +1820,15 @@ void Parameter::bound_value(bool force_integer)
         case ct_countedset_percent_extendable:
         {
             CountedSetUserData *cs = reinterpret_cast<CountedSetUserData *>(user_data);
-            auto count = cs->getCountedSetSize();
-            // OK so now val.f is between 0 and 1. So
-            auto fraccount = val.f * (count - extend_range);
-            auto intcount = (int)fraccount;
-            val.f = limit_range(1.0 * intcount / (count - extend_range) + 0.000001, 0., 1.);
+            if (cs)
+            {
+                auto count = cs->getCountedSetSize();
+                // OK so now val.f is between 0 and 1. So
+                auto fraccount = val.f * (count - extend_range);
+                auto intcount = (int)fraccount;
+                val.f = limit_range(1.0 * intcount / std::max(1, (count - extend_range)) + 0.000001,
+                                    0., 1.);
+            }
             break;
         }
         case ct_alias_mask:

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -436,7 +436,7 @@ accessibleEditActionInternal(const juce::KeyPress &key)
     {
         if (key.getModifiers().isShiftDown())
             return {Decrease, Fine};
-        if (key.getModifiers().isCtrlDown())
+        if (key.getModifiers().isCommandDown())
             return {Decrease, Quantized};
         return {Decrease, NoModifier};
     }
@@ -445,7 +445,7 @@ accessibleEditActionInternal(const juce::KeyPress &key)
     {
         if (key.getModifiers().isShiftDown())
             return {Increase, Fine};
-        if (key.getModifiers().isCtrlDown())
+        if (key.getModifiers().isCommandDown())
             return {Increase, Quantized};
         return {Increase, NoModifier};
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -5714,6 +5714,7 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
         hs->setIsSemitone(style & kSemitone);
         hs->setIsLightStyle(style & kWhite);
         hs->setIsMiniVertical(style & kMini);
+        hs->parameterType = (ctrltypes)p->ctrltype;
 
         hs->setBounds(skinCtrl->x, skinCtrl->y + p->posy_offset * yofs, styleW, styleH);
         hs->setTag(tag);

--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -806,8 +806,36 @@ bool ModulatableSlider::keyPressed(const juce::KeyPress &key)
         dv *= 0.1;
         break;
     case Quantized:
-        // the value set handler handles this, oddly
+    {
+        /* the value set handler handles this, oddly. But we
+         * can fake it. This code should all go in XT2 of course.
+         * I apologize for this code but it adds a super useful
+         * accessibility function without rewriting the whole shebang.
+         * This basically does a linear search across the parameter bind
+         * to find the next step.
+         */
+        if (parameterType != ct_none)
+        {
+            Parameter pp;
+            pp.ctrltype = parameterType;
+            pp.valtype = vt_float;
+            pp.set_type(parameterType);
+            auto v = getValue();
+            auto sv = 0.005 * (action == Increase ? 1 : -1);
+            pp.set_value_f01(v, true);
+            auto fv = pp.val.f;
+            while (v <= 1.f && v >= 0.f)
+            {
+                v += sv;
+                pp.set_value_f01(v, true);
+                if (pp.val.f != fv)
+                    break;
+            }
+            value = v;
+            dv = 0;
+        }
         break;
+    }
     }
 
     if (isEditingModulation)

--- a/src/surge-xt/gui/widgets/ModulatableSlider.h
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.h
@@ -57,6 +57,8 @@ struct ModulatableSlider : public juce::Component,
     static MoveRateState sliderMoveRateState;
     static TouchscreenMode touchscreenMode;
 
+    ctrltypes parameterType{ct_none};
+
     /**
      * The slider is 'light' backgrounded (which matters in the classic skin only)
      * @param b


### PR DESCRIPTION
1. Make 'Command' the Quantized key consistently in ally and mouse
2. Actually respond to it in the modulatable slider, albeit with a pretty hacky way (see the comment there)
3. Fix a problem with size-one wavetables and quantized drags

Closes #6593