### PR TITLE
Alias Editor Accesibility Tweaks

### DIFF
--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -98,7 +98,7 @@ OscillatorWaveformDisplay::OscillatorWaveformDisplay()
     ol = std::make_unique<OverlayAsAccessibleButton<OscillatorWaveformDisplay>>(
         this, customEditor ? "Close Custom Editor" : "Open Custom Editor",
         juce::AccessibilityRole::button);
-
+    ol->setWantsKeyboardFocus(true);
     addChildComponent(*ol);
 
     ol->onPress = [this](OscillatorWaveformDisplay *d) {
@@ -114,6 +114,21 @@ OscillatorWaveformDisplay::OscillatorWaveformDisplay()
             d->customEditorAccOverlay->setDescription("Open Custom Editor");
             d->customEditorAccOverlay->setTitle("Open Custom Editor");
         }
+    };
+    ol->onReturnKey = [this](OscillatorWaveformDisplay *d) {
+        if (customEditor)
+        {
+            hideCustomEditor();
+            d->customEditorAccOverlay->setDescription("Close Custom Editor");
+            d->customEditorAccOverlay->setTitle("Close Custom Editor");
+        }
+        else
+        {
+            showCustomEditor();
+            d->customEditorAccOverlay->setDescription("Open Custom Editor");
+            d->customEditorAccOverlay->setTitle("Open Custom Editor");
+        }
+        return true;
     };
 
     customEditorAccOverlay = std::move(ol);
@@ -403,7 +418,13 @@ void OscillatorWaveformDisplay::resized()
     menuOverlays[2]->setBounds(rightJog.toNearestInt());
     waveTableName = wtr.withTrimmedRight(wtbheight).withTrimmedLeft(wtbheight);
     menuOverlays[0]->setBounds(waveTableName.toNearestInt());
-    customEditorAccOverlay->setBounds(wtl.toNearestInt());
+
+    customEditorBox = getLocalBounds()
+                          .withTop(getHeight() - wtbheight)
+                          .withRight(60)
+                          .withTrimmedBottom(1)
+                          .toFloat();
+    customEditorAccOverlay->setBounds(customEditorBox.toNearestInt());
 }
 
 void OscillatorWaveformDisplay::repaintIfIdIsInRange(int id)
@@ -1577,6 +1598,11 @@ struct AliasAdditiveEditor : public juce::Component,
                 oscdata->extraConfig.data[i] = limitpm1(val);
                 storage->getPatch().isDirty = true;
                 repaint();
+            };
+
+            q->onMenuKey = [this](auto *t) {
+                parent->createAliasOptionsMenu();
+                return true;
             };
 
             addAndMakeVisible(*q);

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
@@ -23,6 +23,7 @@
 
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "Oscillator.h"
+#include "AccessibleHelpers.h"
 
 class SurgeStorage;
 class SurgeGUIEditor;


### PR DESCRIPTION
1. The CustomEdit has the right "size" so it works in tab traversal
2. The Menu/Right Bracket callbacks all work
3. Enter on CustomEdit butto activated

Closes #6822