### PR TITLE
FX Mode handles block mod buffers better

### DIFF
--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -186,6 +186,20 @@ void SurgefxAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         resetFxParams(true);
     }
 
+    auto sampl = buffer.getNumSamples();
+    if (nonLatentBlockMode && ((sampl & ~(BLOCK_SIZE-1)) != sampl))
+    {
+        nonLatentBlockMode = false;
+        input_position = 0;
+        output_position = 0;
+        memset(output_buffer, 0, sizeof(output_buffer));
+        memset(input_buffer, 0, sizeof(input_buffer));
+        memset(sidechain_buffer, 0, sizeof(sidechain_buffer));
+
+        setLatencySamples(BLOCK_SIZE);
+        updateHostDisplay(ChangeDetails().withLatencyChanged(true));
+    }
+
     auto mainInput = getBusBuffer(buffer, true, 0);
 
     int inChanL = 0;

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -187,7 +187,7 @@ void SurgefxAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     }
 
     auto sampl = buffer.getNumSamples();
-    if (nonLatentBlockMode && ((sampl & ~(BLOCK_SIZE-1)) != sampl))
+    if (nonLatentBlockMode && ((sampl & ~(BLOCK_SIZE - 1)) != sampl))
     {
         nonLatentBlockMode = false;
         input_position = 0;

--- a/src/surge-fx/SurgeFXProcessor.h
+++ b/src/surge-fx/SurgeFXProcessor.h
@@ -38,6 +38,7 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
     int output_position{-1};
 
     bool nonLatentBlockMode{true};
+
     //==============================================================================
     void prepareToPlay(double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;


### PR DESCRIPTION
In the event we are in non-latent mode and our buffer is not a multiple of block size, then

1: reset the inputs and outputs
2: Enter latent mode
3: set latency and
4: inform the host of a latency change

Addresses #6638 but some testing before we close it would be super.