### PR TITLE
Don't set overlay wrapper to opaque background

### DIFF
--- a/src/common/SkinColors.cpp
+++ b/src/common/SkinColors.cpp
@@ -380,7 +380,7 @@ const Surge::Skin::Color Border("waveshaper.preview.border", 0xFFFFFF),
 
 namespace Overlay
 {
-const Surge::Skin::Color Background("editor.overlay.background", 0xCC000000);
+const Surge::Skin::Color Background("editor.overlay.background", 0xD9000000);
 }
 
 namespace PatchBrowser

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -39,7 +39,6 @@ OverlayWrapper::OverlayWrapper()
     addChildComponent(*tearOutButton);
 
     setAccessible(true);
-    setOpaque(true);
     setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
 }
 

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -55,7 +55,7 @@ struct PatchStoreDialogCategoryProvider : public Surge::Widgets::TypeAheadDataPr
                     if (it != c.name.end())
                     {
                         // De-duplicate if factory and user are both there.
-                        // Replies on fact that factory comes before yser in order.
+                        // Replies on fact that factory comes before user in order.
                         if (alreadySeen.find(c.name) != alreadySeen.end())
                         {
                             auto didx = alreadySeen[c.name];


### PR DESCRIPTION
Gives full control to the skin color `editor.overlay.background` regarding opacity