### PR TITLE
Truncated WT Files no longer add noise

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1229,7 +1229,19 @@ bool SurgeStorage::load_wt_wt(string filename, Wavetable *wt)
 
     const std::unique_ptr<char[]> data{new char[ds]};
     read = f.sgetn(data.get(), ds);
-    // FIXME - error if read != ds
+
+    if (read != ds)
+    {
+        /* Somehow the file is corrupt. We have a few options
+         * including throw an error here but I think
+         * the best thing to do is just zero pad. In the
+         * factory set, the 'OneShot/Pulse' wavetable
+         * has this problem as a future test case.
+         */
+        auto dpad = data.get() + read;
+        auto drest = ds - read;
+        memset(dpad, 0, drest);
+    }
 
     waveTableDataMutex.lock();
     bool wasBuilt = wt->BuildWT(data.get(), wh, false);


### PR DESCRIPTION
Truncated WT files would silently fill the end of the buffer with noise. This was actually a problem for oneshot/Pulse which advertises 3 tables but has 2. Clearly some old semantic where this would have worked is either ignore the last or fill with zero, so replace the fixme which was sitting here with a fill-with-zero. This will also fix
https://github.com/surge-synthesizer/surge-rack/issues/843 when all merged through.