### PR TITLE
Update Mod Source Scene on Scene Paste

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1841,6 +1841,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry, modsources ms
                 ModulationRouting m;
                 m.source_id = clipboard_modulation_voice[i].source_id;
                 m.source_index = clipboard_modulation_voice[i].source_index;
+                m.source_scene = scene; /* clipboard_modulation_global[i].source_scene; */
                 m.depth = clipboard_modulation_voice[i].depth;
                 m.destination_id = clipboard_modulation_voice[i].destination_id;
                 pushBackOrOverride(getPatch().scene[scene].modulation_voice, m);
@@ -1852,6 +1853,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry, modsources ms
                 ModulationRouting m;
                 m.source_id = clipboard_modulation_scene[i].source_id;
                 m.source_index = clipboard_modulation_scene[i].source_index;
+                m.source_scene = scene; /* clipboard_modulation_global[i].source_scene; */
                 m.depth = clipboard_modulation_scene[i].depth;
                 m.destination_id = clipboard_modulation_scene[i].destination_id;
                 pushBackOrOverride(getPatch().scene[scene].modulation_scene, m);


### PR DESCRIPTION
The modulation source scene isn't really used at a voice level except by the UI and is restored correctly after streaming, but still should be correctly set by scene paste as it is by any other paste, which also fixes a ui-paste-bug

Closes #6875