### PR TITLE
Initial oscilloscope UI tweaks

### DIFF
--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -463,5 +463,6 @@
         <control ui_identifier="modlist.window" x="146" y="57" h="512"/>
         <control ui_identifier="filter.filter_analysis.window" x="298" y="261" h="211"/>
         <control ui_identifier="filter.waveshaper_analysis.window" x="449" y="238"/>
+        <control ui_identifier="oscilloscope.window" y="57" w="748"/>
     </controls>
 </surge-skin>

--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -600,7 +600,7 @@ Connector mod_list =
 Connector filter_analysis = Connector("filter.filter_analysis.window", 300, 263, 450, 212,
                                       Components::Custom, Connector::FILTER_ANALYSIS_WINDOW);
 
-Connector oscilloscope = Connector("oscilloscope.window", 300, 263, 450, 212, Components::Custom,
+Connector oscilloscope = Connector("oscilloscope.window", 0, 58, 750, 365, Components::Custom,
                                    Connector::OSCILLOSCOPE_WINDOW);
 
 Connector ws_analysis = Connector("filter.waveshaper_analysis.window", 450, 237, 300, 160,

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -206,7 +206,6 @@ void WaveformDisplay::process(std::vector<float> data)
     int triggerLimit =
         static_cast<int>(std::pow(10.f, params_.trigger_limit * 4.f)); // 0=>1, 1=>10000
     float triggerSpeed = std::pow(10.f, 2.5f * params_.trigger_speed - 5.f);
-    printf("%.5f\n", triggerSpeed);
     float counterSpeed = params_.counterSpeed();
     float R = 1.f - 250.f / static_cast<float>(storage_->samplerate);
 
@@ -500,7 +499,7 @@ void SpectrumDisplay::updateScopeData(internal::FftScopeType::iterator begin,
     std::lock_guard l(data_lock_);
 
     // Decay existing data, and move new data in if it's larger.
-    const float decay = (1.f - (params_.decay_rate * 0.9f));
+    const float decay = 1.f - sqrt(params_.decay_rate);
 
     std::transform(begin, end, incoming_scope_data_.begin(), incoming_scope_data_.begin(),
                    [decay](const float fn, const float f) { return std::max(f * decay, fn); });
@@ -1359,7 +1358,7 @@ void Oscilloscope::Background::paintWaveformBackground(juce::Graphics &g)
         std::string minus = "-";
         std::string plus = "+";
         std::stringstream gain;
-        const unsigned prec = waveform_params_.gain() > 1.f ? 2 : 0;
+        const unsigned int prec = waveform_params_.gain() > 1.f ? 2 : 0;
 
         gain << std::fixed << std::setprecision(prec) << 1.f / waveform_params_.gain();
 
@@ -1391,8 +1390,8 @@ void Oscilloscope::Background::paintWaveformBackground(juce::Graphics &g)
 
         // Split the grid into multiple sections, starting from 0 and ending at wherever the counter
         // speed says we should end at.
-        const unsigned numLines = 11;
-        const unsigned numSections = numLines - 1;
+        const unsigned int numLines = 11;
+        const unsigned int numSections = numLines - 1;
         float counterSpeedInverse = 1.f / waveform_params_.counterSpeed();
         float sampleRateInverse = 1.f / static_cast<float>(storage_->samplerate);
         float endpoint = counterSpeedInverse * sampleRateInverse * static_cast<float>(width);

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -64,12 +64,12 @@ class WaveformDisplay : public juce::Component, public Surge::GUI::SkinConsuming
 
     struct Parameters
     {
-        float trigger_speed = 0.5f;              // internal trigger speed, knob
+        float trigger_speed = 0.5f;              // internal trigger speed, slider
         TriggerType trigger_type = kTriggerFree; // trigger type, selection
         float trigger_level = 0.5f;              // trigger level, slider
-        float trigger_limit = 0.5f;              // retrigger threshold, knob
-        float time_window = 0.75f;               // X-range, knob
-        float amp_window = 0.5f;                 // Y-range, knob
+        float trigger_limit = 0.5f;              // retrigger threshold, slider
+        float time_window = 0.5f;                // X-range, slider
+        float amp_window = 0.5f;                 // Y-range, slider
         bool freeze = false;                     // freeze display, on/off
         bool dc_kill = false;                    // kill DC, on/off
         bool sync_draw = false;                  // sync redraw, on/off
@@ -138,7 +138,7 @@ class SpectrumDisplay : public juce::Component, public Surge::GUI::SkinConsuming
 {
   public:
     static constexpr float lowFreq = 10;
-    static constexpr float highFreq = 24000;
+    static constexpr float highFreq = 25000;
 
     struct Parameters
     {
@@ -312,7 +312,7 @@ class Oscilloscope : public OverlayComponent,
     };
 
     // Height of parameter window, in pixels.
-    static constexpr const int paramsHeight = 78;
+    static constexpr const int paramsHeight = 80;
 
     void calculateSpectrumData();
     void changeScopeType(ScopeMode type);


### PR DESCRIPTION
Biggified the whole thing
Various text label tweaks, some parameter range and value display tweaks
Retrigger Threshold didn't gray out when Free/Internal modes were selected
Use MSEG Panel skin color for parameter area background
Larger font used for sliders, like in the rest of the GUI