### PR TITLE
Start work on Input with non-block-size blocks

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -393,6 +393,10 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
 
     int32_t non_clap_noteid{1};
 
+    // For non-block-size uniform blocks we need to lag input
+    float inputLatentBuffer alignas(16)[2][BLOCK_SIZE];
+    bool inputIsLatent{false};
+
   public:
     std::unique_ptr<Surge::GUI::UndoManager> undoManager;
 


### PR DESCRIPTION
Input with block-size-not-multiple-of-BLOCK_SIZE blocks would distort in all platforms. This begins to fix it for the VST3 and AU with the VST3 being most important, since FL does this all the time.

What we do here is: if a block is handed to us with a non-multiple of BLOCK_SIZE we just start lagging the input. We don't turn on latent processing in the synth, we don't do it in the CLAP, and we don't show a user error. Clearly this requires more thought but it will stop randomly distorted and crashing behavior, at least, in the case where you don't have uniform blocks.

Addresses #6524