### PR TITLE
Add an errorType enum; use it to report latency shift.

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2580,7 +2580,8 @@ bool SurgeStorage::isStandardTuningAndHasNoToggle()
 
 void SurgeStorage::resetTuningToggle() { isToggledToCache = false; }
 
-void SurgeStorage::reportError(const std::string &msg, const std::string &title, const ErrorType errorType)
+void SurgeStorage::reportError(const std::string &msg, const std::string &title,
+                               const ErrorType errorType)
 {
     std::cout << "Surge Error [" << title << "]\n" << msg << std::endl;
     if (errorListeners.empty())

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2580,17 +2580,17 @@ bool SurgeStorage::isStandardTuningAndHasNoToggle()
 
 void SurgeStorage::resetTuningToggle() { isToggledToCache = false; }
 
-void SurgeStorage::reportError(const std::string &msg, const std::string &title)
+void SurgeStorage::reportError(const std::string &msg, const std::string &title, const ErrorType errorType)
 {
     std::cout << "Surge Error [" << title << "]\n" << msg << std::endl;
     if (errorListeners.empty())
     {
         std::lock_guard<std::mutex> g(preListenerErrorMutex);
-        preListenerErrors.emplace_back(msg, title);
+        preListenerErrors.emplace_back(msg, title, errorType);
     }
 
     for (auto l : errorListeners)
-        l->onSurgeError(msg, title);
+        l->onSurgeError(msg, title, errorType);
 }
 
 float SurgeStorage::remapKeyInMidiOnlyMode(float res)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1098,7 +1098,8 @@ class alignas(16) SurgeStorage
     {
         // This can be called from any thread, beware! But it is called only
         // when an error occursm so if you want to be sloppy and just lock, that's OK
-        virtual void onSurgeError(const std::string &msg, const std::string &title, const ErrorType &errorType) = 0;
+        virtual void onSurgeError(const std::string &msg, const std::string &title,
+                                  const ErrorType &errorType) = 0;
     };
     std::unordered_set<ErrorListener *> errorListeners;
     // this mutex is ONLY locked in the error path and when registering a listener

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1087,24 +1087,30 @@ class alignas(16) SurgeStorage
     static std::string skipPatchLoadDataPathSentinel;
 
     // In Surge XT, SurgeStorage can now keep a cache of errors it reports to the user
-    void reportError(const std::string &msg, const std::string &title);
+    enum ErrorType
+    {
+        GENERAL_ERROR = 1,
+        AUDIO_CONFIGURATION = 2,
+    };
+    void reportError(const std::string &msg, const std::string &title,
+                     const ErrorType errorType = GENERAL_ERROR);
     struct ErrorListener
     {
         // This can be called from any thread, beware! But it is called only
         // when an error occursm so if you want to be sloppy and just lock, that's OK
-        virtual void onSurgeError(const std::string &msg, const std::string &title) = 0;
+        virtual void onSurgeError(const std::string &msg, const std::string &title, const ErrorType &errorType) = 0;
     };
     std::unordered_set<ErrorListener *> errorListeners;
     // this mutex is ONLY locked in the error path and when registering a listener
     // (from the UI thread)
     std::mutex preListenerErrorMutex;
-    std::vector<std::pair<std::string, std::string>> preListenerErrors;
+    std::vector<std::tuple<std::string, std::string, ErrorType>> preListenerErrors;
     void addErrorListener(ErrorListener *l)
     {
         errorListeners.insert(l);
         std::lock_guard<std::mutex> g(preListenerErrorMutex);
         for (auto p : preListenerErrors)
-            l->onSurgeError(p.first, p.second);
+            l->onSurgeError(std::get<0>(p), std::get<1>(p), std::get<2>(p));
         preListenerErrors.clear();
     }
     void removeErrorListener(ErrorListener *l) { errorListeners.erase(l); }

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -288,10 +288,9 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     auto sc = buffer.getNumSamples();
     if ((sc & ~(BLOCK_SIZE - 1)) != sc)
     {
-        // TODO: We should probably show a user warning of some form here.
-        // surge->reportError would work but doesn't have a "dont show again" option
-        // so that requires some code. For now this will just lag input by 32 samples
-        // to make sure we at least don't distort, which improves things for 1.2
+        surge->storage.reportError("Audio Block is not a multiple of BLOCK_SIZE. Input will be latent.",
+                                   "Latent Input",
+                                   SurgeStorage::AUDIO_CONFIGURATION);
         inputIsLatent = true;
     }
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -288,9 +288,9 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     auto sc = buffer.getNumSamples();
     if ((sc & ~(BLOCK_SIZE - 1)) != sc)
     {
-        surge->storage.reportError("Audio Block is not a multiple of BLOCK_SIZE. Input will be latent.",
-                                   "Latent Input",
-                                   SurgeStorage::AUDIO_CONFIGURATION);
+        surge->storage.reportError(
+            "Audio Block is not a multiple of BLOCK_SIZE. Input will be latent.", "Latent Input",
+            SurgeStorage::AUDIO_CONFIGURATION);
         inputIsLatent = true;
     }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6858,7 +6858,8 @@ void SurgeGUIEditor::hideMidiLearnOverlay()
     }
 }
 
-void SurgeGUIEditor::onSurgeError(const string &msg, const string &title, const SurgeStorage::ErrorType &et)
+void SurgeGUIEditor::onSurgeError(const string &msg, const string &title,
+                                  const SurgeStorage::ErrorType &et)
 {
     std::lock_guard<std::mutex> g(errorItemsMutex);
     errorItems.emplace_back(msg, title);

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6858,7 +6858,7 @@ void SurgeGUIEditor::hideMidiLearnOverlay()
     }
 }
 
-void SurgeGUIEditor::onSurgeError(const string &msg, const string &title)
+void SurgeGUIEditor::onSurgeError(const string &msg, const string &title, const SurgeStorage::ErrorType &et)
 {
     std::lock_guard<std::mutex> g(errorItemsMutex);
     errorItems.emplace_back(msg, title);

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -119,7 +119,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::atomic<int> errorItemCount{0};
     std::vector<std::pair<std::string, std::string>> errorItems;
     std::mutex errorItemsMutex;
-    void onSurgeError(const std::string &msg, const std::string &title, const SurgeStorage::ErrorType &type) override;
+    void onSurgeError(const std::string &msg, const std::string &title,
+                      const SurgeStorage::ErrorType &type) override;
 
     static int start_paramtag_value;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -119,7 +119,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::atomic<int> errorItemCount{0};
     std::vector<std::pair<std::string, std::string>> errorItems;
     std::mutex errorItemsMutex;
-    void onSurgeError(const std::string &msg, const std::string &title) override;
+    void onSurgeError(const std::string &msg, const std::string &title, const SurgeStorage::ErrorType &type) override;
 
     static int start_paramtag_value;
 


### PR DESCRIPTION
1. Add a SurgeStorage::ErrorType enum which goes with reportError and defaults to GENERAL_ERROR
2. Call reportError with AUDIO_CONFIGURATION from the new resize
3. When we get that in SurgeGUIEditor, do nothing. Oh well! Maybe later we will do something.

Addresses #6524