### PR TITLE
Prompt with dont-prompt-again for audio error

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -308,6 +308,10 @@ std::string defaultKeyToString(DefaultKey k)
         r = "ignoreMidiProgramChange";
         break;
 
+    case DontShowAudioErrorsAgain:
+        r = "dontShowAudioErrorsAgain";
+        break;
+
     case nKeys:
         break;
     }

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -137,6 +137,8 @@ enum DefaultKey
 
     IgnoreMIDIProgramChange,
 
+    DontShowAudioErrorsAgain,
+
     nKeys
 };
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -286,13 +286,15 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     }
 
     auto sc = buffer.getNumSamples();
-    if (!inputIsLatent && (sc & ~(BLOCK_SIZE - 1)) != sc))
-        {
-            surge->storage.reportError(
-                "Audio Block is not a multiple of BLOCK_SIZE. Input will be latent.",
-                "Latent Input", SurgeStorage::AUDIO_CONFIGURATION);
-            inputIsLatent = true;
-        }
+    if (!inputIsLatent && (sc & ~(BLOCK_SIZE - 1)) != sc)
+    {
+        surge->storage.reportError(
+            "Audio Block is not a multiple of BLOCK_SIZE. This means if you use Audio Input"
+            " it will be delayed by BLOCK_SIZE. You can usually avoid this by having your DAW have"
+            " regular sized buffers.",
+            "Activating Latent Input", SurgeStorage::AUDIO_CONFIGURATION);
+        inputIsLatent = true;
+    }
 
     for (int i = 0; i < buffer.getNumSamples(); i++)
     {

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -286,13 +286,13 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     }
 
     auto sc = buffer.getNumSamples();
-    if ((sc & ~(BLOCK_SIZE - 1)) != sc)
-    {
-        surge->storage.reportError(
-            "Audio Block is not a multiple of BLOCK_SIZE. Input will be latent.", "Latent Input",
-            SurgeStorage::AUDIO_CONFIGURATION);
-        inputIsLatent = true;
-    }
+    if (!inputIsLatent && (sc & ~(BLOCK_SIZE - 1)) != sc))
+        {
+            surge->storage.reportError(
+                "Audio Block is not a multiple of BLOCK_SIZE. Input will be latent.",
+                "Latent Input", SurgeStorage::AUDIO_CONFIGURATION);
+            inputIsLatent = true;
+        }
 
     for (int i = 0; i < buffer.getNumSamples(); i++)
     {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -117,7 +117,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::unique_ptr<Surge::Widgets::MainFrame> frame;
 
     std::atomic<int> errorItemCount{0};
-    std::vector<std::pair<std::string, std::string>> errorItems;
+    std::vector<std::tuple<std::string, std::string, SurgeStorage::ErrorType>> errorItems;
     std::mutex errorItemsMutex;
     void onSurgeError(const std::string &msg, const std::string &title,
                       const SurgeStorage::ErrorType &type) override;


### PR DESCRIPTION
1. Only send the error once per session
2. Have the error get dropped/ignored if you dont prompt again by using OK Cancel with Dont in SGE

Closes #6524