### PR TITLE
Warn and avoid Crash with mis-configured busses

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -227,6 +227,32 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     if (mb->getNumberOfChannels() != 2 || !mb->isEnabled())
     {
         // We have to have a stereo output
+        if (!warnedAboutBadConfig)
+        {
+            std::ostringstream msg;
+            msg << "SurgeXT was not configured with a stereo output. \n"
+                << "SurgeXT requires at least a main stereo output but the \n"
+                << "main bus has " << mb->getNumberOfChannels() << " channels "
+                << "and enablement state " << (mb->isEnabled() ? "True" : "False");
+            surge->storage.reportError(msg.str(), "Bus Configuration Error");
+            warnedAboutBadConfig = true;
+        }
+        return;
+    }
+
+    if (buffer.getNumChannels() < 2 && mb->isEnabled())
+    {
+        if (!warnedAboutBadConfig)
+        {
+            std::ostringstream msg;
+            msg << "SurgeXT did not receive a stereo processing buffer. \n"
+                << "SurgeXT requires at least a main stereo output but the \n"
+                << "provided buffer has " << buffer.getNumChannels() << " channels\n"
+                << "and is enabled. This seems to happen with bluetooth headsets\n"
+                << "in JUCE on macOS when you use the headset as an input and output.";
+            surge->storage.reportError(msg.str(), "Bus Configuration Error");
+            warnedAboutBadConfig = true;
+        }
         return;
     }
 

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -397,6 +397,9 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     float inputLatentBuffer alignas(16)[2][BLOCK_SIZE];
     bool inputIsLatent{false};
 
+    // Have we warned about bad configurations
+    bool warnedAboutBadConfig{false};
+
   public:
     std::unique_ptr<Surge::GUI::UndoManager> undoManager;
 


### PR DESCRIPTION
Bluetooth headsets on Mac with JUCE 6 seem to send us an invalid config even though we have marked it invalid in isBusLayoutsSupported when we use the headset as both input and output. This previously crashed but now gives a relatively clear error message when mis-configured.

Closes #6885