### PR TITLE
Surge FX AW display absent audio

### DIFF
--- a/src/surge-fx/SurgeFXEditor.cpp
+++ b/src/surge-fx/SurgeFXEditor.cpp
@@ -129,6 +129,7 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
         fxParamSliders[i].setChangeNotificationOnlyOnRelease(false);
         fxParamSliders[i].setEnabled(processor.getParamEnabled(i));
         fxParamSliders[i].onValueChange = [i, this]() {
+            this->processor.prepareParametersAbsentAudio();
             this->processor.setFXParamValue01(i, this->fxParamSliders[i].getValue());
             fxParamDisplay[i].setDisplay(
                 processor.getParamValueFromFloat(i, this->fxParamSliders[i].getValue()));
@@ -209,6 +210,7 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
         fxAbsoluted[i].setTitle("Parameter " + std::to_string(i) + " Absoluted");
         addAndMakeVisibleRecordOrder(&(fxAbsoluted[i]));
 
+        processor.prepareParametersAbsentAudio();
         fxParamDisplay[i].setGroup(processor.getParamGroup(i).c_str());
         fxParamDisplay[i].setName(processor.getParamName(i).c_str());
         fxParamDisplay[i].setDisplay(processor.getParamValue(i));
@@ -252,6 +254,7 @@ SurgefxAudioProcessorEditor::~SurgefxAudioProcessorEditor()
 
 void SurgefxAudioProcessorEditor::resetLabels()
 {
+    processor.prepareParametersAbsentAudio();
     auto st = [](auto &thing, const std::string &title) {
         thing.setTitle(title);
         if (auto *handler = thing.getAccessibilityHandler())

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -158,6 +158,7 @@ bool SurgefxAudioProcessor::isBusesLayoutSupported(const BusesLayout &layouts) c
 void SurgefxAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
                                          juce::MidiBuffer &midiMessages)
 {
+    audioRunning = true;
     if (resettingFx || !surge_effect)
         return;
 
@@ -682,6 +683,23 @@ void SurgefxAudioProcessor::setupStorageRanges(Parameter *start, Parameter *endI
     storage_id_end = max_id + 1;
 }
 
+void SurgefxAudioProcessor::prepareParametersAbsentAudio()
+{
+    if (!audioRunning)
+    {
+        if (getEffectType() == fxt_airwindows)
+        {
+            /*
+             * Airwindows needs to set up its internal state with a process
+             * See #6897
+             */
+            float dL alignas(16)[BLOCK_SIZE], dR alignas(16)[BLOCK_SIZE];
+            memset(dL, 0, sizeof(dL));
+            memset(dR, 0, sizeof(dR));
+            surge_effect->process_ringout(dL, dR);
+        }
+    }
+}
 //==============================================================================
 // This creates new instances of the plugin..
 juce::AudioProcessor *JUCE_CALLTYPE createPluginFilter() { return new SurgefxAudioProcessor(); }

--- a/src/surge-fx/SurgeFXProcessor.h
+++ b/src/surge-fx/SurgeFXProcessor.h
@@ -321,6 +321,7 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
     std::atomic<bool> isUserEditing[n_fx_params + 1];
     std::atomic<bool> wasParamFeatureChanged[n_fx_params];
     std::function<void()> paramChangeListener;
+
     float lastBPM = -1;
     bool supressParameterUpdates = false;
     struct SupressGuard
@@ -349,7 +350,10 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
     void copyGlobaldataSubset(int start, int end);
     void setupStorageRanges(Parameter *start, Parameter *endIncluding);
 
+    std::atomic<bool> audioRunning{false};
+
   public:
+    void prepareParametersAbsentAudio();
     void setParameterByString(int i, const std::string &s);
     float getParameterValueForString(int i, const std::string &s);
     bool canSetParameterByString(int i);


### PR DESCRIPTION
Absent an audio bus the AW parameters wouldn't show up properly so detect the no-audio case and work around it just for AW.

Closes #6897
Closes https://github.com/surge-synthesizer/surge-fx/issues/45