### PR TITLE
Add RMB context menu to main output level meter

### DIFF
--- a/resources/surge-shared/paramdocumentation.xml
+++ b/resources/surge-shared/paramdocumentation.xml
@@ -33,6 +33,7 @@
   <special id="waveshaper-analysis" help_url="#waveshaper"/>
   <special id="alias-shape" help_url="#shape"/>
   <special id="action-history" help_url="#action-history"/>
+  <special id="level-meter" help_url="#level-meter"/>
 
   <!-- Params for CG 0 -->
   <param id="filter.balance" help_url="#filter-controls"/>

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1899,6 +1899,8 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
             vu[0]->setBounds(skinCtrl->getRect());
             vu[0]->setSkin(currentSkin, bitmapStore);
+            vu[0]->setTag(tag_main_vu_meter);
+            vu[0]->addListener(this);
             vu[0]->setType(Surge::ParamConfig::vut_vu_stereo);
             vu[0]->setStorage(&(synth->storage));
 
@@ -4054,18 +4056,6 @@ juce::PopupMenu SurgeGUIEditor::makeValueDisplaysMenu(const juce::Point<int> &wh
 
     dispDefMenu.addSeparator();
 
-    bool cpumeter = Surge::Storage::getUserDefaultValue(&(this->synth->storage),
-                                                        Surge::Storage::ShowCPUUsage, false);
-
-    dispDefMenu.addItem(Surge::GUI::toOSCase("Show CPU Usage in VU Meter"), true, cpumeter,
-                        [this, cpumeter]() {
-                            Surge::Storage::updateUserDefaultValue(
-                                &(this->synth->storage), Surge::Storage::ShowCPUUsage, !cpumeter);
-                            this->frame->repaint();
-                        });
-
-    dispDefMenu.addSeparator();
-
     // Middle C submenu
     auto middleCSubMenu = juce::PopupMenu();
 
@@ -4093,6 +4083,15 @@ juce::PopupMenu SurgeGUIEditor::makeValueDisplaysMenu(const juce::Point<int> &wh
     dispDefMenu.addSubMenu("Middle C", middleCSubMenu);
 
     return dispDefMenu;
+}
+
+void SurgeGUIEditor::makeScopeEntry(juce::PopupMenu &menu)
+{
+    bool showOscilloscope = isAnyOverlayPresent(OSCILLOSCOPE);
+
+    Surge::GUI::addMenuWithShortcut(menu, Surge::GUI::toOSCase("Oscilloscope..."),
+                                    showShortcutDescription("Alt + O", u8"\U00002325O"), true,
+                                    showOscilloscope, [this]() { toggleOverlay(OSCILLOSCOPE); });
 }
 
 juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
@@ -4197,15 +4196,11 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
 
     bool showVirtualKeyboard = getShowVirtualKeyboard();
 
-    Surge::GUI::addMenuWithShortcut(wfMenu, Surge::GUI::toOSCase("Show Virtual Keyboard"),
+    Surge::GUI::addMenuWithShortcut(wfMenu, Surge::GUI::toOSCase("Virtual Keyboard"),
                                     showShortcutDescription("Alt + K", u8"\U00002325K"), true,
                                     showVirtualKeyboard, [this]() { toggleVirtualKeyboard(); });
 
-    bool showOscilloscope = isAnyOverlayPresent(OSCILLOSCOPE);
-
-    Surge::GUI::addMenuWithShortcut(wfMenu, Surge::GUI::toOSCase("Open Oscilloscope"),
-                                    showShortcutDescription("Alt + O", u8"\U00002325O"), true,
-                                    showOscilloscope, [this]() { toggleOverlay(OSCILLOSCOPE); });
+    makeScopeEntry(wfMenu);
 
     return wfMenu;
 }

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -801,6 +801,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     juce::PopupMenu makeLfoMenu(const juce::Point<int> &rect);
     juce::PopupMenu makeMonoModeOptionsMenu(const juce::Point<int> &rect, bool updateDefaults);
 
+    void makeScopeEntry(juce::PopupMenu &menu);
+
     void setRecommendedAccessibility();
 
   public:

--- a/src/surge-xt/gui/SurgeGUIEditorTags.h
+++ b/src/surge-xt/gui/SurgeGUIEditorTags.h
@@ -19,30 +19,46 @@
 enum SurgeGUIEditorTags
 {
     tag_scene_select = 1,
+
     tag_osc_select,
     tag_osc_menu,
+
     tag_fx_select,
     tag_fx_menu,
+
     tag_patchname,
+
     tag_mp_category,
     tag_mp_patch,
+
     tag_mp_jogwaveshape,
+
     tag_analyzewaveshape,
     tag_analyzefilters,
+
     tag_store,
+
     tag_mod_source0,
     tag_mod_source_end = tag_mod_source0 + n_modsources,
+
     tag_settingsmenu,
+
     tag_mp_jogfx,
+
     tag_value_typein,
+
     tag_status_mpe,
     tag_status_zoom,
     tag_status_tune,
+
     tag_action_undo,
     tag_action_redo,
 
     tag_mseg_edit,
     tag_lfo_menu,
+
+    tag_main_vu_meter,
+
     start_paramtags,
 };
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -465,7 +465,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
     // In these cases just move along with success. RMB does nothing on these switches
     if (tag == tag_mp_jogwaveshape || tag == tag_mp_jogfx || tag == tag_mp_category ||
-        tag == tag_mp_patch || tag == tag_store || tag == tag_action_undo || tag == tag_action_redo)
+        tag == tag_mp_patch || tag == tag_store || tag == tag_action_undo ||
+        tag == tag_action_redo || tag == tag_main_vu_meter)
     {
         juce::PopupMenu contextMenu;
         std::string hu, txt;
@@ -497,6 +498,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             hu = helpURLForSpecial("save-dialog");
             txt = "Patch Save";
             break;
+        case tag_main_vu_meter:
+            hu = helpURLForSpecial("level-meter");
+            txt = "Level Meter";
+            break;
         default:
             break;
         }
@@ -508,6 +513,23 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
         auto hment = tcomp->getTitle();
 
         contextMenu.addCustomItem(-1, std::move(tcomp), nullptr, hment);
+
+        if (tag == tag_main_vu_meter)
+        {
+            contextMenu.addSeparator();
+
+            makeScopeEntry(contextMenu);
+
+            bool cpumeter = Surge::Storage::getUserDefaultValue(
+                &(synth->storage), Surge::Storage::ShowCPUUsage, false);
+
+            contextMenu.addItem(Surge::GUI::toOSCase("Show CPU Usage"), true, cpumeter,
+                                [this, cpumeter]() {
+                                    Surge::Storage::updateUserDefaultValue(
+                                        &(synth->storage), Surge::Storage::ShowCPUUsage, !cpumeter);
+                                    frame->repaint();
+                                });
+        }
 
 #ifdef DEBUG
         if (tag == tag_action_undo || tag == tag_action_redo)

--- a/src/surge-xt/gui/widgets/VuMeter.cpp
+++ b/src/surge-xt/gui/widgets/VuMeter.cpp
@@ -27,10 +27,25 @@ VuMeter::VuMeter() : juce::Component(), WidgetBaseMixin<VuMeter>(this)
 {
     setAccessible(false);
     setWantsKeyboardFocus(false);
-    setInterceptsMouseClicks(false, false);
 }
 
 VuMeter::~VuMeter() = default;
+
+void VuMeter::mouseDown(const juce::MouseEvent &event)
+{
+    if (forwardedMainFrameMouseDowns(event))
+    {
+        return;
+    }
+
+    if (event.mods.isPopupMenu())
+    {
+        notifyControlModifierClicked(event.mods);
+        return;
+    }
+
+    mouseDownLongHold(event);
+}
 
 void VuMeter::paint(juce::Graphics &g)
 {

--- a/src/surge-xt/gui/widgets/VuMeter.h
+++ b/src/surge-xt/gui/widgets/VuMeter.h
@@ -26,7 +26,9 @@ namespace Surge
 {
 namespace Widgets
 {
-struct VuMeter : public juce::Component, public WidgetBaseMixin<VuMeter>
+struct VuMeter : public juce::Component,
+                 public WidgetBaseMixin<VuMeter>,
+                 public LongHoldMixin<VuMeter>
 {
     VuMeter();
     ~VuMeter();
@@ -49,6 +51,8 @@ struct VuMeter : public juce::Component, public WidgetBaseMixin<VuMeter>
     void setType(Surge::ParamConfig::VUType t) { vu_type = t; };
 
     void paint(juce::Graphics &g) override;
+
+    void mouseDown(const juce::MouseEvent &event) override;
 
     bool isAudioActive{true};
     void setIsAudioActive(bool isIn)


### PR DESCRIPTION
Contains oscilloscope and CPU usage toggles
Remove CPU usage toggle from main menu
Manual will need to have a section called Level Meter (with #level-meter anchor) -> @Andreya-Autumn just FYI!