### PR TITLE
Scope transform aware for control layout

### DIFF
--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -639,8 +639,12 @@ void Oscilloscope::resized()
     spectrum_.setBounds(scopeRect);
     waveform_.setBounds(scopeRect);
 
-    spectrum_parameters_.setBounds(0, h - paramsHeight, w, h);
-    waveform_parameters_.setBounds(0, h - paramsHeight, w, h);
+    juce::Rectangle<int> r;
+    auto ph = juce::Rectangle<int>(0, paramsHeight).transformedBy(getTransform());
+    auto phh = ph.getHeight();
+    r = juce::Rectangle<int>(0, h - phh, w, h);
+    spectrum_parameters_.setBounds(r.transformedBy(getTransform().inverted()));
+    waveform_parameters_.setBounds(r.transformedBy(getTransform().inverted()));
 }
 
 Oscilloscope::WaveformParameters::WaveformParameters(SurgeGUIEditor *e, SurgeStorage *s,


### PR DESCRIPTION
The layout of controls didn't position the parameters in a height which was tranformed. Closes #6913