### PR TITLE
MSEG Constant Segments trigger properly

### DIFF
--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -263,6 +263,7 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
     {
         if (lv0 == lv1)
         {
+            es->timeAlongSegment = timeAlongSegment;
             return lv0;
         }
 


### PR DESCRIPTION
MSEG Constant segments have an optimization to skip most of the calculation which is great. But it avoices updating an internal state about triggers meaning a segment would fire a trigger on every sample if exactly constant. Update the evaluation time state to make sure we know we are beyond the trigger.

Closes #6915