### PR TITLE
Add help text menus for scope, add credits for scope code to About page

### DIFF
--- a/resources/surge-shared/paramdocumentation.xml
+++ b/resources/surge-shared/paramdocumentation.xml
@@ -34,6 +34,7 @@
   <special id="alias-shape" help_url="#shape"/>
   <special id="action-history" help_url="#action-history"/>
   <special id="level-meter" help_url="#level-meter"/>
+  <special id="oscilloscope" help_url="#oscilloscope"/>
 
   <!-- Params for CG 0 -->
   <param id="filter.balance" help_url="#filter-controls"/>

--- a/src/surge-xt/gui/overlays/AboutScreen.cpp
+++ b/src/surge-xt/gui/overlays/AboutScreen.cpp
@@ -408,6 +408,12 @@ void AboutScreen::resized()
             "by Émilie Gillet, licensed under MIT license",
             600);
 
+        yp += lblvs;
+
+        addLabel("Oscilloscope code based on s(m)exoscope by Bram @ Smartelectronix, licensed "
+                 "under GNU GPL v3 license",
+                 600);
+
         auto img = associatedBitmapStore->getImage(IDB_ABOUT_LOGOS);
         auto idxes = {0, 4, 3, 6, 1, 2, 5};
 

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -548,6 +548,7 @@ Oscilloscope::Oscilloscope(SurgeGUIEditor *e, SurgeStorage *s)
     left_chan_button_.setDescription("Enable input from left channel.");
     left_chan_button_.setWantsKeyboardFocus(false);
     left_chan_button_.setTag(tag_input_l);
+    left_chan_button_.addListener(this);
     right_chan_button_.setStorage(storage_);
     right_chan_button_.setToggleState(true);
     right_chan_button_.onToggle = onToggle;
@@ -557,6 +558,7 @@ Oscilloscope::Oscilloscope(SurgeGUIEditor *e, SurgeStorage *s)
     right_chan_button_.setDescription("Enable input from right channel.");
     right_chan_button_.setWantsKeyboardFocus(false);
     right_chan_button_.setTag(tag_input_r);
+    right_chan_button_.addListener(this);
     scope_mode_button_.setStorage(storage_);
     scope_mode_button_.setRows(1);
     scope_mode_button_.setColumns(2);
@@ -564,14 +566,16 @@ Oscilloscope::Oscilloscope(SurgeGUIEditor *e, SurgeStorage *s)
     scope_mode_button_.setWantsKeyboardFocus(false);
     scope_mode_button_.setValue(0.f);
     scope_mode_button_.setTag(tag_scope_mode);
+    scope_mode_button_.addListener(this);
     spectrum_parameters_.setOpaque(true);
     waveform_parameters_.setOpaque(true);
     addAndMakeVisible(background_);
     addAndMakeVisible(left_chan_button_);
     addAndMakeVisible(right_chan_button_);
     addAndMakeVisible(scope_mode_button_);
-    addAndMakeVisible(spectrum_);
-    addAndMakeVisible(spectrum_parameters_);
+
+    addChildComponent(spectrum_);
+    addChildComponent(spectrum_parameters_);
     addChildComponent(waveform_);
     addChildComponent(waveform_parameters_);
 
@@ -782,6 +786,13 @@ Oscilloscope::WaveformParameters::WaveformParameters(SurgeGUIEditor *e, SurgeSto
     time_window_.setTag(tag_wf_time_scaling);
     amp_window_.setTag(tag_wf_amp_scaling);
 
+    // TODO: why doesn't this work?
+    /*     trigger_speed_.addListener(parent_);
+        trigger_level_.addListener(parent_);
+        trigger_limit_.addListener(parent_);
+        time_window_.addListener(parent_);
+        amp_window_.addListener(parent_); */
+
     auto updateParameter = [this](float &param, float &backer, float value) {
         std::lock_guard l(params_lock_);
         params_changed_ = true;
@@ -895,6 +906,10 @@ Oscilloscope::WaveformParameters::WaveformParameters(SurgeGUIEditor *e, SurgeSto
     freeze_.setTag(tag_wf_freeze);
     dc_kill_.setTag(tag_wf_dc_block);
     sync_draw_.setTag(tag_wf_sync);
+
+    /*     freeze_.addListener(this);
+        dc_kill_.addListener(this);
+        sync_draw_.addListener(this); */
 
     freeze_.onToggle = std::bind(toggleParam, std::ref(params_.freeze), nullptr);
     dc_kill_.onToggle = std::bind(toggleParam, std::ref(params_.dc_kill), &state->dc_kill);
@@ -1017,6 +1032,10 @@ Oscilloscope::SpectrumParameters::SpectrumParameters(SurgeGUIEditor *e, SurgeSto
     max_db_.setTag(tag_sp_max_level);
     decay_rate_.setTag(tag_sp_decay_rate);
 
+    /*     noise_floor_.addListener(this);
+        max_db_.addListener(this);
+        decay_rate_.addListener(this); */
+
     auto updateParameter = [this](float &param, float &backer, float value) {
         std::lock_guard l(params_lock_);
         params_changed_ = true;
@@ -1048,6 +1067,7 @@ Oscilloscope::SpectrumParameters::SpectrumParameters(SurgeGUIEditor *e, SurgeSto
 
     freeze_.setWantsKeyboardFocus(false);
     freeze_.setTag(tag_sp_freeze);
+    // freeze_.addListener(this);
     freeze_.onToggle = std::bind(toggleParam, std::ref(params_.freeze));
 
     addAndMakeVisible(freeze_);

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -284,7 +284,7 @@ class Oscilloscope : public OverlayComponent,
                                public Surge::GUI::IComponentTagValue::Listener
     {
       public:
-        SpectrumParameters(SurgeGUIEditor *e, SurgeStorage *s, juce::Component *parent);
+        SpectrumParameters(SurgeGUIEditor *e, SurgeStorage *s, Oscilloscope *parent);
 
         std::optional<SpectrumDisplay::Parameters> getParamsIfDirty();
 
@@ -292,12 +292,23 @@ class Oscilloscope : public OverlayComponent,
         void paint(juce::Graphics &g) override;
         void resized() override;
         void valueChanged(GUI::IComponentTagValue *p) override{};
+        int32_t controlModifierClicked(Surge::GUI::IComponentTagValue *pControl,
+                                       const juce::ModifierKeys &button,
+                                       bool isDoubleClickEvent) override
+        {
+            if (parent_)
+            {
+                return parent_->controlModifierClicked(pControl, button, isDoubleClickEvent);
+            }
+
+            return 0;
+        }
 
       private:
         SurgeGUIEditor *editor_;
         SurgeStorage *storage_;
-        juce::Component
-            *parent_; // Saved here so we can provide it to the children at construction time.
+        // Saved here so we can provide it to the children at construction time.
+        Oscilloscope *parent_;
         SpectrumDisplay::Parameters params_;
         bool params_changed_;
         std::mutex params_lock_;
@@ -313,7 +324,7 @@ class Oscilloscope : public OverlayComponent,
                                public Surge::GUI::IComponentTagValue::Listener
     {
       public:
-        WaveformParameters(SurgeGUIEditor *e, SurgeStorage *s, juce::Component *parent);
+        WaveformParameters(SurgeGUIEditor *e, SurgeStorage *s, Oscilloscope *parent);
 
         std::optional<WaveformDisplay::Parameters> getParamsIfDirty();
 
@@ -321,12 +332,23 @@ class Oscilloscope : public OverlayComponent,
         void paint(juce::Graphics &g) override;
         void resized() override;
         void valueChanged(GUI::IComponentTagValue *p) override{};
+        int32_t controlModifierClicked(Surge::GUI::IComponentTagValue *pControl,
+                                       const juce::ModifierKeys &button,
+                                       bool isDoubleClickEvent) override
+        {
+            if (parent_)
+            {
+                return parent_->controlModifierClicked(pControl, button, isDoubleClickEvent);
+            }
+
+            return 0;
+        }
 
       private:
         SurgeGUIEditor *editor_;
         SurgeStorage *storage_;
-        juce::Component
-            *parent_; // Saved here so we can provide it to the children at construction time.
+        // Saved here so we can provide it to the children at construction time.
+        Oscilloscope *parent_;
         WaveformDisplay::Parameters params_;
         bool params_changed_;
         std::mutex params_lock_;

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -194,6 +194,7 @@ class SpectrumDisplay : public juce::Component, public Surge::GUI::SkinConsuming
 
 class Oscilloscope : public OverlayComponent,
                      public Surge::GUI::SkinConsumingComponent,
+                     public Surge::GUI::IComponentTagValue::Listener,
                      public Surge::GUI::Hoverable
 {
   public:
@@ -206,7 +207,38 @@ class Oscilloscope : public OverlayComponent,
     void updateDrawing();
     void visibilityChanged() override;
 
+    void valueChanged(GUI::IComponentTagValue *p) override{};
+    int32_t controlModifierClicked(Surge::GUI::IComponentTagValue *pControl,
+                                   const juce::ModifierKeys &button,
+                                   bool isDoubleClickEvent) override;
+
   private:
+    enum ControlTags
+    {
+        tag_scope_mode = 567898765, // Just to push outside any ID range
+
+        tag_input_l,
+        tag_input_r,
+
+        tag_wf_dc_block,
+        tag_wf_freeze,
+        tag_wf_sync,
+
+        tag_wf_time_scaling,
+        tag_wf_amp_scaling,
+
+        tag_wf_trigger_mode,
+        tag_wf_trigger_level,
+        tag_wf_retrigger_threshold,
+        tag_wf_int_trigger_freq,
+
+        tag_sp_freeze,
+
+        tag_sp_min_level,
+        tag_sp_max_level,
+        tag_sp_decay_rate,
+    };
+
     enum ChannelSelect
     {
         LEFT = 1,

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -279,7 +279,9 @@ class Oscilloscope : public OverlayComponent,
         WaveformDisplay::Parameters waveform_params_;
     };
 
-    class SpectrumParameters : public juce::Component, public Surge::GUI::SkinConsumingComponent
+    class SpectrumParameters : public juce::Component,
+                               public Surge::GUI::SkinConsumingComponent,
+                               public Surge::GUI::IComponentTagValue::Listener
     {
       public:
         SpectrumParameters(SurgeGUIEditor *e, SurgeStorage *s, juce::Component *parent);
@@ -289,6 +291,7 @@ class Oscilloscope : public OverlayComponent,
         void onSkinChanged() override;
         void paint(juce::Graphics &g) override;
         void resized() override;
+        void valueChanged(GUI::IComponentTagValue *p) override{};
 
       private:
         SurgeGUIEditor *editor_;
@@ -305,7 +308,9 @@ class Oscilloscope : public OverlayComponent,
         Surge::Widgets::SelfDrawToggleButton freeze_;
     };
 
-    class WaveformParameters : public juce::Component, public Surge::GUI::SkinConsumingComponent
+    class WaveformParameters : public juce::Component,
+                               public Surge::GUI::SkinConsumingComponent,
+                               public Surge::GUI::IComponentTagValue::Listener
     {
       public:
         WaveformParameters(SurgeGUIEditor *e, SurgeStorage *s, juce::Component *parent);
@@ -315,6 +320,7 @@ class Oscilloscope : public OverlayComponent,
         void onSkinChanged() override;
         void paint(juce::Graphics &g) override;
         void resized() override;
+        void valueChanged(GUI::IComponentTagValue *p) override{};
 
       private:
         SurgeGUIEditor *editor_;


### PR DESCRIPTION
Also scope multibuttons are now draggable. Further minor UI layout tweaks. Minor parameter name changes.

TODO: Context menu entries for Trigger Mode and Oscilloscope Mode change the value but don't execute the callback that is set in setOnUpdate(). Not sure why.