### PR TITLE
LFO parameter sliders blinking 

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -3155,19 +3155,19 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                     else
                         mod_editor = false;
                     queue_refresh = true;
-                    refresh_mod();
+                    needsModUpdate = true;
                     break;
                 case 1:
                     modsource = newsource;
                     modsource_index = newindex;
                     mod_editor = true;
-                    refresh_mod();
+                    needsModUpdate = true;
                     break;
                 case 2:
                     modsource = newsource;
                     modsource_index = newindex;
                     mod_editor = false;
-                    refresh_mod();
+                    needsModUpdate = true;
                     break;
                 };
             }


### PR DESCRIPTION
When we click on another modulation source button, we change `modsource_editor[i] = newsource` and `queue_refresh = true;`. Doing that we cause recreating all sliders. But we also repaint some components that cause repainting the sliders of the modulation source and we have that blinking. To prevent that, I set `needsModUpdate = true;` instead of calling `refresh_mod()` so that 'refresh_mod()' would only cause one repainting. 
Issue: https://github.com/surge-synthesizer/surge/issues/6889