### PR TITLE
Don't send the Audio Latency message to stdout

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2580,9 +2580,12 @@ bool SurgeStorage::isStandardTuningAndHasNoToggle()
 void SurgeStorage::resetTuningToggle() { isToggledToCache = false; }
 
 void SurgeStorage::reportError(const std::string &msg, const std::string &title,
-                               const ErrorType errorType)
+                               const ErrorType errorType, bool reportToStdout)
 {
-    std::cout << "Surge Error [" << title << "]\n" << msg << std::endl;
+    if (reportToStdout)
+    {
+        std::cout << "Surge Error [" << title << "]\n" << msg << std::endl;
+    }
     if (errorListeners.empty())
     {
         std::lock_guard<std::mutex> g(preListenerErrorMutex);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1113,7 +1113,7 @@ class alignas(16) SurgeStorage
         AUDIO_CONFIGURATION = 2,
     };
     void reportError(const std::string &msg, const std::string &title,
-                     const ErrorType errorType = GENERAL_ERROR);
+                     const ErrorType errorType = GENERAL_ERROR, bool reportToStdout = true);
     struct ErrorListener
     {
         // This can be called from any thread, beware! But it is called only

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -318,7 +318,7 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
             "Audio Block is not a multiple of BLOCK_SIZE. This means if you use Audio Input"
             " it will be delayed by BLOCK_SIZE. You can usually avoid this by having your DAW have"
             " regular sized buffers.",
-            "Activating Latent Input", SurgeStorage::AUDIO_CONFIGURATION);
+            "Activating Latent Input", SurgeStorage::AUDIO_CONFIGURATION, false);
         inputIsLatent = true;
     }
 


### PR DESCRIPTION
Generally we send errors to stdout but the audio latency is more an informational so add an option to not stdout things from reportError and set it true in the processor when we turn on latency. The dialog will still pop up with a don't warn again in the UI once you open it though.