### PR TITLE
Improve Nightly build and CodeQual times

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ include(cmake/stage-extra-content.cmake)
 add_custom_target(code-quality-pipeline-checks)
 
 # Check 1: The extra content is properly specified.
-add_dependencies(code-quality-pipeline-checks download-extra-content)
+# add_dependencies(code-quality-pipeline-checks download-extra-content)
 
 # Clang Format checks
 set(CLANG_FORMAT_DIRS src)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,22 +12,19 @@ pr:
 
 jobs:
   - job: BuildCodeQuality
-    strategy:
-        lin:
-          imageName: 'ubuntu-20.04'
-        pool:
-          vmImage: $(imageName)
+    pool:
+      vmImage: 'ubuntu-20.04'
 
-        steps:
-          - checkout: self
-            fetchDepth: 1
-            # submodules: recursive # can't do submodules here b'cuz depth=1 fails with Github
+    steps:
+      - checkout: self
+        fetchDepth: 1
+        # submodules: recursive # can't do submodules here b'cuz depth=1 fails with Github
 
-          - bash: |
-              git submodule update --init --recursive
-              cmake -Bignore/cq -DSURGE_SKIP_JUCE_FOR_RACK=TRUE -DCMAKE_BUILD_TYPE=Debug -DSURGE_SKIP_LUA=TRUE
-              cmake --build ignore/cq --target code-quality-pipeline-checks
-            displayName: Do Codequal
+      - bash: |
+          git submodule update --init --recursive
+          cmake -Bignore/cq -DSURGE_SKIP_JUCE_FOR_RACK=TRUE -DCMAKE_BUILD_TYPE=Debug -DSURGE_SKIP_LUA=TRUE
+          cmake --build ignore/cq --target code-quality-pipeline-checks
+        displayName: Do Codequal
 
 
   - job: BuildForPR

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,27 @@ pr:
   - xt-alpha
 
 jobs:
-  - job: Build
+  - job: BuildCodeQuality
+    strategy:
+        lin:
+          imageName: 'ubuntu-20.04'
+        pool:
+          vmImage: $(imageName)
+
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            # submodules: recursive # can't do submodules here b'cuz depth=1 fails with Github
+
+          - bash: |
+              git submodule update --init --recursive
+              cmake -Bignore/cq -DSURGE_SKIP_JUCE_FOR_RACK=TRUE -DCMAKE_BUILD_TYPE=Debug -DSURGE_SKIP_LUA=TRUE
+              cmake --build ignore/cq --target code-quality-pipeline-checks
+            displayName: Do Codequal
+
+
+  - job: BuildForPR
+    condition: eq(variables['Build.Reason'], 'PullRequest')
     variables:
       defaultTargets: "surge-xt_Packaged surge-fx_Packaged"
     strategy:
@@ -56,13 +76,6 @@ jobs:
           cmakeArguments: "-A x64 -DCMAKE_BUILD_TYPE=Release"
           cmakeConfig: "Release"
           cmakeTarget: "surge-testrunner"
-        linux-codequality:
-          imageName: 'ubuntu-20.04'
-          isLinux: True
-          aptGetExtras: ""
-          cmakeArguments: "-GNinja -DCMAKE_BUILD_TYPE=Debug"
-          cmakeTarget: "code-quality-pipeline-checks"
-          cmakeConfig: "Debug"
         linux-juce-python-targets:
           imageName: 'ubuntu-22.04'
           isLinux: True
@@ -204,8 +217,8 @@ jobs:
         displayName: macOS - run unit tests
 
   - job: NotifyReleases
-    dependsOn: Build
-    condition: succeeded()
+    dependsOn: BuildCodeQuality
+    condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
     pool:
       vmImage: 'ubuntu-20.04'
 


### PR DESCRIPTION
Split the zure pipeline so

1. PR has a faster code qual and
2. Pushes to main don't do a full build before notifying release

Closes #6957