### PR TITLE
Reorder PatchDB operations on rename

### DIFF
--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -22,14 +22,17 @@
 
 #include "PatchDB.h"
 
-#include "sqlite3.h"
-#include "SurgeStorage.h"
 #include <sstream>
 #include <iterator>
-#include "DebugHelpers.h"
 #include <chrono>
+#include <functional>
+
+#include "sqlite3.h"
+#include "SurgeStorage.h"
+#include "DebugHelpers.h"
 
 #include "sst/basic-blocks/mechanics/endian-ops.h"
+
 namespace mech = sst::basic_blocks::mechanics;
 
 #define TRACE_DB 0
@@ -99,7 +102,7 @@ struct Statement
     {
         auto rc = sqlite3_prepare_v2(h, statement.c_str(), -1, &s, nullptr);
         if (rc != SQLITE_OK)
-            throw Exception(h);
+            throw Exception(rc, "Unable to prepare statement [" + statement + "]");
         prepared = true;
     }
     ~Statement()
@@ -311,6 +314,17 @@ CREATE TABLE IF NOT EXISTS Favorites (
         std::string msg;
         EnQDebugMsg(const std::string &msg) : msg(msg) {}
         void go(WriterWorker &w) override { w.addDebug(msg); }
+    };
+
+    struct EnQLambda : public EnQAble
+    {
+        std::function<void()> op{nullptr};
+        EnQLambda(std::function<void()> iop) : op(iop) {}
+        void go(WriterWorker &w) override
+        {
+            if (op)
+                op();
+        }
     };
 
     struct EnQFavorite : public EnQAble
@@ -1159,6 +1173,11 @@ void PatchDB::addDebugMessage(const std::string &debug)
     worker->enqueueWorkItem(new WriterWorker::EnQDebugMsg(debug));
 }
 
+void PatchDB::doAfterCurrentQueueDrained(std::function<void()> op)
+{
+    worker->enqueueWorkItem(new WriterWorker::EnQLambda(op));
+}
+
 std::vector<std::pair<std::string, int>> PatchDB::readAllFeatures()
 {
 
@@ -1422,6 +1441,19 @@ int PatchDB::numberOfJobsOutstanding()
 {
     std::lock_guard<std::mutex> guard(worker->qLock);
     return worker->pathQ.size();
+}
+
+int PatchDB::waitForJobsOutstandingComplete(int maxWaitInMS)
+{
+    int maxIts = maxWaitInMS / 10;
+    int njo = 0;
+    while ((njo = numberOfJobsOutstanding()) > 0 && maxIts > 0)
+    {
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(10ms);
+        maxIts--;
+    }
+    return numberOfJobsOutstanding();
 }
 
 std::string PatchDB::sqlWhereClauseFor(const std::unique_ptr<PatchDBQueryParser::Token> &t)

--- a/src/common/PatchDB.h
+++ b/src/common/PatchDB.h
@@ -30,6 +30,7 @@
 #include "filesystem/import.h"
 #include <iostream>
 #include <vector>
+#include <functional>
 
 class SurgeStorage;
 
@@ -117,8 +118,18 @@ struct PatchDB
     void addDebugMessage(const std::string &debug);
     void setUserFavorite(const std::string &path, bool isIt);
     void erasePatchByID(int id);
+    void doAfterCurrentQueueDrained(std::function<void()> op);
 
+    /*
+     * Returns a moment-in-time snapshot of number of jobs in the processing queue
+     */
     int numberOfJobsOutstanding();
+    /*
+     * Waits for the processing queue to drain. Obviously don't call this from the processing
+     * queue. The max timeout in ms is the longest wait and at the end it returns the
+     * number of jobs outstanding.
+     */
+    int waitForJobsOutstandingComplete(int maxWaitInMS);
 
     // Query APIs
     std::vector<std::pair<std::string, int>> readAllFeatures();

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -682,9 +682,21 @@ void PatchSelector::showClassicMenu(bool single_category)
                         psd->setEnclosingParentTitle("Rename Patch");
                         const auto priorPath = storage->patch_list[current_patch].path;
                         psd->onOK = [this, priorPath]() {
-                            fs::remove(priorPath);
-                            storage->refresh_patchlist();
-                            storage->initializePatchDb(true);
+                            /*
+                             * OK so the database doesn't like deleting files while it is indexing.
+                             * We should fix this (#6793) but for now put the delete action at the
+                             * end of the db processing thread. BUT that will run on the patchdb
+                             * thread so bounce it from here to there and then back here.
+                             */
+                            auto nextStep = [this, priorPath]() {
+                                auto doDelete = [this, priorPath]() {
+                                    fs::remove(priorPath);
+                                    storage->refresh_patchlist();
+                                    storage->initializePatchDb(true);
+                                };
+                                juce::MessageManager::getInstance()->callAsync(doDelete);
+                            };
+                            storage->patchDB->doAfterCurrentQueueDrained(nextStep);
                         };
                     });
             });


### PR DESCRIPTION
The patcdb rename would look like save / delete / update but the save had a patch db update in it of course. So the delete on unix would delete underneath the patch importer and the importer is not robust under that condition (#6973). Fixing that is hard, so rather than fix that today open an issue for it and instead have the rename look like save+update / drain queue / delete+update and then no more lock.

Closes #6959