### PR TITLE
Renamed pretty much all OSC param names

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -164,7 +164,7 @@ void Parameter::set_name(const char *n)
 }
 
 Parameter *Parameter::assign(ParameterIDCounter::promise_t idp, int pid, const char *name,
-                             const char *dispname, int ctrltype,
+                             const char *dispname, const std::string &altOSCname, int ctrltype,
 
                              const Surge::Skin::Connector &c,
 
@@ -172,14 +172,17 @@ Parameter *Parameter::assign(ParameterIDCounter::promise_t idp, int pid, const c
                              bool modulateable, int ctrlstyle, bool defaultDeactivation)
 {
     assert(c.payload);
-    auto r =
-        assign(idp, pid, name, dispname, ctrltype, c.payload->id, c.payload->posx, c.payload->posy,
-               scene, ctrlgroup, ctrlgroup_entry, modulateable, ctrlstyle, defaultDeactivation);
+    auto r = assign(idp, pid, name, dispname, altOSCname, ctrltype, c.payload->id, c.payload->posx,
+                    c.payload->posy, scene, ctrlgroup, ctrlgroup_entry, modulateable, ctrlstyle,
+                    defaultDeactivation);
+
     r->hasSkinConnector = true;
+
     return r;
 }
+
 Parameter *Parameter::assign(ParameterIDCounter::promise_t idp, int pid, const char *name,
-                             const char *dispname, int ctrltype,
+                             const char *dispname, const std::string &altOSCname, int ctrltype,
 
                              std::string ui_identifier, int posx, int posy, int scene,
                              ControlGroup ctrlgroup, int ctrlgroup_entry, bool modulateable,
@@ -196,27 +199,35 @@ Parameter *Parameter::assign(ParameterIDCounter::promise_t idp, int pid, const c
     this->scene = scene;
     this->ctrlstyle = ctrlstyle;
     this->storage = nullptr;
-    strxcpy(this->ui_identifier, ui_identifier.c_str(), NAMECHARS);
 
+    char prefix[TXT_SIZE + 1] = {};
+
+    strxcpy(this->ui_identifier, ui_identifier.c_str(), NAMECHARS);
     strxcpy(this->name, name, NAMECHARS);
     set_name(dispname);
-    char prefix[TXT_SIZE + 1] = {};
+
     get_prefix(prefix, ctrlgroup, ctrlgroup_entry, scene);
     snprintf(name_storage, NAMECHARS, "%s%s", prefix, name);
+
+    this->oscName = "/param/" + (altOSCname.empty() ? this->name_storage : altOSCname);
+
     posy_offset = 0;
-    if (scene)
-        per_voice_processing = true;
-    else
-        per_voice_processing = false;
-    clear_flags();
-    this->deactivated = defaultDeactivation;
+    per_voice_processing = scene ? true : false;
     midictrl = -1;
 
+    clear_flags();
+
+    this->deactivated = defaultDeactivation;
+
     set_type(ctrltype);
+
     if (valtype == vt_float)
+    {
         val.f = val_default.f;
+    }
 
     bound_value();
+
     return this;
 }
 
@@ -5118,19 +5129,6 @@ float Parameter::calculate_modulation_value_from_string(const std::string &s, st
     valid = false;
 
     return 0.0;
-}
-
-void Parameter::setOSCName(std::string s)
-{
-    oscName = std::move(s);
-    hasOSCName = true;
-}
-
-std::string Parameter::getOSCName()
-{
-    if (!hasOSCName)
-        return get_storage_name();
-    return oscName;
 }
 
 std::atomic<bool> parameterNameUpdated(false);

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -164,7 +164,7 @@ void Parameter::set_name(const char *n)
 }
 
 Parameter *Parameter::assign(ParameterIDCounter::promise_t idp, int pid, const char *name,
-                             const char *dispname, const std::string &altOSCname, int ctrltype,
+                             const char *dispname, const std::string_view altOSCname, int ctrltype,
 
                              const Surge::Skin::Connector &c,
 
@@ -182,7 +182,7 @@ Parameter *Parameter::assign(ParameterIDCounter::promise_t idp, int pid, const c
 }
 
 Parameter *Parameter::assign(ParameterIDCounter::promise_t idp, int pid, const char *name,
-                             const char *dispname, const std::string &altOSCname, int ctrltype,
+                             const char *dispname, const std::string_view altOSCname, int ctrltype,
 
                              std::string ui_identifier, int posx, int posy, int scene,
                              ControlGroup ctrlgroup, int ctrlgroup_entry, bool modulateable,
@@ -209,7 +209,8 @@ Parameter *Parameter::assign(ParameterIDCounter::promise_t idp, int pid, const c
     get_prefix(prefix, ctrlgroup, ctrlgroup_entry, scene);
     snprintf(name_storage, NAMECHARS, "%s%s", prefix, name);
 
-    this->oscName = "/param/" + (altOSCname.empty() ? this->name_storage : altOSCname);
+    this->oscName =
+        fmt::format("/param/{}", (altOSCname.empty() ? this->name_storage : altOSCname));
 
     posy_offset = 0;
     per_voice_processing = scene ? true : false;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -358,7 +358,7 @@ class Parameter
 
   private:
     Parameter *assign(ParameterIDCounter::promise_t id, int pid, const char *name,
-                      const char *dispname, int ctrltype,
+                      const char *dispname, const std::string &altOSCname, int ctrltype,
 
                       std::string ui_identifier, int posx, int posy,
 
@@ -368,13 +368,14 @@ class Parameter
 
   public:
     Parameter *assign(ParameterIDCounter::promise_t id, int pid, const char *name,
-                      const char *dispname, int ctrltype,
+                      const char *dispname, const std::string &altOSCname, int ctrltype,
 
                       const Surge::Skin::Connector &c,
 
                       int scene = 0, ControlGroup ctrlgroup = cg_GLOBAL, int ctrlgroup_entry = 0,
                       bool modulateable = true, int ctrlstyle = cs_off,
                       bool defaultDeactivation = true);
+
     virtual ~Parameter();
 
     bool can_temposync() const;
@@ -476,11 +477,8 @@ class Parameter
     void create_fullname(const char *dn, char *fn, ControlGroup ctrlgroup, int ctrlgroup_entry,
                          const char *lfoPrefixOverride = nullptr) const;
 
-    // Optional OSC name
-    std::string getOSCName();
-    void setOSCName(std::string s);
-    bool hasOSCName{false};
     std::string oscName;
+    std::string get_osc_name() { return oscName; }
 
     pdata val{}, val_default{}, val_min{}, val_max{};
 

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -358,7 +358,7 @@ class Parameter
 
   private:
     Parameter *assign(ParameterIDCounter::promise_t id, int pid, const char *name,
-                      const char *dispname, const std::string &altOSCname, int ctrltype,
+                      const char *dispname, const std::string_view altOSCname, int ctrltype,
 
                       std::string ui_identifier, int posx, int posy,
 
@@ -368,7 +368,7 @@ class Parameter
 
   public:
     Parameter *assign(ParameterIDCounter::promise_t id, int pid, const char *name,
-                      const char *dispname, const std::string &altOSCname, int ctrltype,
+                      const char *dispname, const std::string_view altOSCname, int ctrltype,
 
                       const Surge::Skin::Connector &c,
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -53,43 +53,48 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
     patchptr = nullptr;
 
     ParameterIDCounter p_id;
+
     {
         param_ptr.push_back(fx[fxslot_send1].return_level.assign(
-            p_id.next(), 0, "volume_FX1", "Send FX 1 Return", ct_amplitude,
+            p_id.next(), 0, "volume_FX1", "Send FX 1 Return", "fx/send/1/return", ct_amplitude,
             Surge::Skin::Global::fx1_return, 0, cg_GLOBAL, 0, true, kHorizontal));
         param_ptr.push_back(fx[fxslot_send2].return_level.assign(
-            p_id.next(), 0, "volume_FX2", "Send FX 2 Return", ct_amplitude,
+            p_id.next(), 0, "volume_FX2", "Send FX 2 Return", "fx/send/2/return", ct_amplitude,
             Surge::Skin::Global::fx2_return, 0, cg_GLOBAL, 0, true, kHorizontal));
         param_ptr.push_back(fx[fxslot_send3].return_level.assign(
-            p_id.next(), 0, "volume_FX3", "Send FX 3 Return", ct_amplitude,
+            p_id.next(), 0, "volume_FX3", "Send FX 3 Return", "fx/send/3/return", ct_amplitude,
             Surge::Skin::Global::fx3_return, 0, cg_GLOBAL, 0, true, kHorizontal));
         param_ptr.push_back(fx[fxslot_send4].return_level.assign(
-            p_id.next(), 0, "volume_FX4", "Send FX 4 Return", ct_amplitude,
+            p_id.next(), 0, "volume_FX4", "Send FX 4 Return", "fx/send/4/return", ct_amplitude,
             Surge::Skin::Global::fx4_return, 0, cg_GLOBAL, 0, true, kHorizontal));
-        param_ptr.push_back(volume.assign(
-            p_id.next(), 0, "volume", "Global Volume", ct_decibel_attenuation_clipper,
-            Surge::Skin::Global::master_volume, 0, cg_GLOBAL, 0, true, kHorizontal | kEasy));
+
+        param_ptr.push_back(volume.assign(p_id.next(), 0, "volume", "Global Volume",
+                                          "global/volume", ct_decibel_attenuation_clipper,
+                                          Surge::Skin::Global::master_volume, 0, cg_GLOBAL, 0, true,
+                                          kHorizontal | kEasy));
     }
-    param_ptr.push_back(scene_active.assign(p_id.next(), 0, "scene_active", "Active Scene",
-                                            ct_scenesel, Surge::Skin::Global::active_scene, 0,
-                                            cg_GLOBAL, 0, false, kHorizontal));
-    param_ptr.push_back(scenemode.assign(p_id.next(), 0, "scenemode", "Scene Mode", ct_scenemode,
-                                         Surge::Skin::Global::scene_mode, 0, cg_GLOBAL, 0, false,
-                                         kHorizontal | kNoPopup));
 
-    param_ptr.push_back(splitpoint.assign(p_id.next(), 0, "splitkey", "Split Point",
-                                          ct_midikey_or_channel, Surge::Skin::Scene::splitpoint, 0,
-                                          cg_GLOBAL, 0, false, kHorizontal | kNoPopup));
+    param_ptr.push_back(scene_active.assign(
+        p_id.next(), 0, "scene_active", "Active Scene", "global/active_scene", ct_scenesel,
+        Surge::Skin::Global::active_scene, 0, cg_GLOBAL, 0, false, kHorizontal));
+    param_ptr.push_back(scenemode.assign(
+        p_id.next(), 0, "scenemode", "Scene Mode", "global/scene_mode", ct_scenemode,
+        Surge::Skin::Global::scene_mode, 0, cg_GLOBAL, 0, false, kHorizontal | kNoPopup));
 
-    param_ptr.push_back(fx_disable.assign(p_id.next(), 0, "fx_disable", "FX Disable", ct_none,
+    param_ptr.push_back(splitpoint.assign(
+        p_id.next(), 0, "splitkey", "Split Point", "global/split_point", ct_midikey_or_channel,
+        Surge::Skin::Scene::splitpoint, 0, cg_GLOBAL, 0, false, kHorizontal | kNoPopup));
+
+    param_ptr.push_back(fx_disable.assign(p_id.next(), 0, "fx_disable", "FX Disable",
+                                          "hidden/fx_disable", ct_none,
                                           Surge::Skin::Global::fx_disable, 0, cg_GLOBAL, 0, false));
 
-    param_ptr.push_back(polylimit.assign(p_id.next(), 0, "polylimit", "Polyphony Limit",
-                                         ct_polylimit, Surge::Skin::Scene::polylimit, 0, cg_GLOBAL,
-                                         0, false, kHorizontal | kNoPopup));
-    param_ptr.push_back(fx_bypass.assign(p_id.next(), 0, "fx_bypass", "FX Chain Bypass",
-                                         ct_fxbypass, Surge::Skin::Global::fx_bypass, 0, cg_GLOBAL,
-                                         0, false, kHorizontal | kNoPopup));
+    param_ptr.push_back(polylimit.assign(
+        p_id.next(), 0, "polylimit", "Polyphony Limit", "global/polyphony_limit", ct_polylimit,
+        Surge::Skin::Scene::polylimit, 0, cg_GLOBAL, 0, false, kHorizontal | kNoPopup));
+    param_ptr.push_back(fx_bypass.assign(
+        p_id.next(), 0, "fx_bypass", "FX Chain Bypass", "fx/chain_bypass", ct_fxbypass,
+        Surge::Skin::Global::fx_bypass, 0, cg_GLOBAL, 0, false, kHorizontal | kNoPopup));
 
     polylimit.val.i = DEFAULT_POLYLIMIT;
     splitpoint.val.i = 60;
@@ -97,9 +102,9 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
 
     for (int fx = 0; fx < n_fx_slots; fx++)
     {
-        param_ptr.push_back(this->fx[fx].type.assign(p_id.next(), 0, "type", "FX Type", ct_fxtype,
-                                                     Surge::Skin::FX::fx_type, 0, cg_FX, fx, false,
-                                                     kHorizontal));
+        param_ptr.push_back(this->fx[fx].type.assign(
+            p_id.next(), 0, "type", "FX Type", fmt::format("{}/type", fxslot_shortoscname[fx]),
+            ct_fxtype, Surge::Skin::FX::fx_type, 0, cg_FX, fx, false, kHorizontal));
         for (int p = 0; p < n_fx_params; p++)
         {
             auto conn = Surge::Skin::Connector::connectorByID("fx.param_" + std::to_string(p + 1));
@@ -109,9 +114,10 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
             snprintf(label, LABEL_SIZE, "p%i", p);
             char dawlabel[LABEL_SIZE];
             snprintf(dawlabel, LABEL_SIZE, "Param %i", p + 1);
-            param_ptr.push_back(
-                this->fx[fx].p[p].assign(p_id.next(), 0, label, dawlabel, ct_none, conn, 0, cg_FX,
-                                         fx, true, kHorizontal | kHide | ((fx == 0) ? kEasy : 0)));
+            param_ptr.push_back(this->fx[fx].p[p].assign(
+                p_id.next(), 0, label, dawlabel,
+                fmt::format("{}/param{}", fxslot_shortoscname[fx], p + 1), ct_none, conn, 0, cg_FX,
+                fx, true, kHorizontal | kHide | ((fx == 0) ? kEasy : 0)));
         }
     }
 
@@ -120,10 +126,8 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
 
     for (int sc = 0; sc < n_scenes; sc++)
     {
-        int sceasy =
-            (sc == 0)
-                ? kEasy
-                : 0; // only consider parameters in the first scene as non-expertmode parameters
+        // only consider parameters in the first scene as non-expertmode parameters
+        int sceasy = (sc == 0) ? kEasy : 0;
         int id_s = 0;
         vector<Parameter *> *a;
         a = &param_ptr;
@@ -133,14 +137,20 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
         scene_start_promise[sc] = p_id.tail;
 
         a->push_back(scene[sc].octave.assign(p_id.next(), id_s++, "octave", "Octave",
-                                             ct_pitch_octave, Surge::Skin::Scene::octave, sc_id,
-                                             cg_GLOBAL, 0, false, kHorizontal | kNoPopup));
-        a->push_back(scene[sc].pitch.assign(p_id.next(), id_s++, "pitch", "Pitch", ct_pitch_semi7bp,
+                                             fmt::format("{:c}/octave", 'a' + sc), ct_pitch_octave,
+                                             Surge::Skin::Scene::octave, sc_id, cg_GLOBAL, 0, false,
+                                             kHorizontal | kNoPopup));
+
+        a->push_back(scene[sc].pitch.assign(p_id.next(), id_s++, "pitch", "Pitch",
+                                            fmt::format("{:c}/pitch", 'a' + sc), ct_pitch_semi7bp,
                                             Surge::Skin::Scene::pitch, sc_id, cg_GLOBAL, 0, true,
                                             kSemitone | sceasy));
+
         a->push_back(scene[sc].portamento.assign(p_id.next(), id_s++, "portamento", "Portamento",
+                                                 fmt::format("{:c}/portamento", 'a' + sc),
                                                  ct_portatime, Surge::Skin::Scene::portatime, sc_id,
                                                  cg_GLOBAL, 0, true, sceasy));
+
         for (int osc = 0; osc < n_oscs; osc++)
         {
             // Initialize the display name here
@@ -149,226 +159,334 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
             scene[sc].osc[osc].wavetable_formula_nframes = 10;
             scene[sc].osc[osc].wavetable_formula_res_base = 5;
 
-            a->push_back(scene[sc].osc[osc].type.assign(p_id.next(), id_s++, "type", "Type",
-                                                        ct_osctype, Surge::Skin::Osc::osc_type,
-                                                        sc_id, cg_OSC, osc, false));
-            a->push_back(scene[sc].osc[osc].octave.assign(p_id.next(), id_s++, "octave", "Octave",
-                                                          ct_pitch_octave, Surge::Skin::Osc::octave,
-                                                          sc_id, cg_OSC, osc, false, kNoPopup));
+            a->push_back(scene[sc].osc[osc].type.assign(
+                p_id.next(), id_s++, "type", "Type",
+                fmt::format("{:c}/osc/{}/type", 'a' + sc, osc + 1), ct_osctype,
+                Surge::Skin::Osc::osc_type, sc_id, cg_OSC, osc, false));
+
+            a->push_back(scene[sc].osc[osc].octave.assign(
+                p_id.next(), id_s++, "octave", "Octave",
+                fmt::format("{:c}/osc/{}/octave", 'a' + sc, osc + 1), ct_pitch_octave,
+                Surge::Skin::Osc::octave, sc_id, cg_OSC, osc, false, kNoPopup));
+
             a->push_back(scene[sc].osc[osc].pitch.assign(
-                p_id.next(), id_s++, "pitch", "Pitch", ct_pitch_semi7bp_absolutable,
+                p_id.next(), id_s++, "pitch", "Pitch",
+                fmt::format("{:c}/osc/{}/pitch", 'a' + sc, osc + 1), ct_pitch_semi7bp_absolutable,
                 Surge::Skin::Osc::pitch, sc_id, cg_OSC, osc, true, kSemitone | sceasy));
+
             for (int i = 0; i < n_osc_params; i++)
             {
                 char label[LABEL_SIZE];
                 snprintf(label, LABEL_SIZE, "param%i", i);
                 a->push_back(scene[sc].osc[osc].p[i].assign(
-                    p_id.next(), id_s++, label, "-", ct_none,
+                    p_id.next(), id_s++, label, "-",
+                    fmt::format("{:c}/osc/{}/param{}", 'a' + sc, osc + 1, i + 1), ct_none,
                     Surge::Skin::Connector::connectorByID("osc.param_" + std::to_string(i + 1)),
                     sc_id, cg_OSC, osc, true, ((i < 6) ? sceasy : 0)));
             }
+
             a->push_back(scene[sc].osc[osc].keytrack.assign(
-                p_id.next(), id_s++, "keytrack", "Keytrack", ct_bool_keytrack,
+                p_id.next(), id_s++, "keytrack", "Keytrack",
+                fmt::format("{:c}/osc/{}/keytrack", 'a' + sc, osc + 1), ct_bool_keytrack,
                 Surge::Skin::Osc::keytrack, sc_id, cg_OSC, osc, false));
+
             a->push_back(scene[sc].osc[osc].retrigger.assign(
-                p_id.next(), id_s++, "retrigger", "Retrigger", ct_bool_retrigger,
+                p_id.next(), id_s++, "retrigger", "Retrigger",
+                fmt::format("{:c}/osc/{}/retrigger", 'a' + sc, osc + 1), ct_bool_retrigger,
                 Surge::Skin::Osc::retrigger, sc_id, cg_OSC, osc, false));
         }
-        a->push_back(scene[sc].polymode.assign(p_id.next(), id_s++, "polymode", "Play Mode",
-                                               ct_polymode, Surge::Skin::Scene::playmode, sc_id,
-                                               cg_GLOBAL, 0, false, kNoPopup));
+
+        a->push_back(scene[sc].polymode.assign(
+            p_id.next(), id_s++, "polymode", "Play Mode", fmt::format("{:c}/play_mode", 'a' + sc),
+            ct_polymode, Surge::Skin::Scene::playmode, sc_id, cg_GLOBAL, 0, false, kNoPopup));
+
         a->push_back(scene[sc].fm_switch.assign(p_id.next(), id_s++, "fm_switch", "FM Routing",
+                                                fmt::format("{:c}/osc/fm_routing", 'a' + sc),
                                                 ct_fmconfig, Surge::Skin::Scene::fmrouting, sc_id,
                                                 cg_GLOBAL, 0, false));
-        a->push_back(scene[sc].fm_depth.assign(p_id.next(), id_s++, "fm_depth", "FM Depth",
-                                               ct_decibel_fmdepth, Surge::Skin::Scene::fmdepth,
-                                               sc_id, cg_GLOBAL, 0, true, sceasy));
 
-        a->push_back(scene[sc].drift.assign(p_id.next(), id_s++, "drift", "Osc Drift",
-                                            ct_percent_oscdrift, Surge::Skin::Scene::drift, sc_id,
-                                            cg_GLOBAL, 0, true));
+        a->push_back(scene[sc].fm_depth.assign(
+            p_id.next(), id_s++, "fm_depth", "FM Depth", fmt::format("{:c}/osc/fm_depth", 'a' + sc),
+            ct_decibel_fmdepth, Surge::Skin::Scene::fmdepth, sc_id, cg_GLOBAL, 0, true, sceasy));
+
+        a->push_back(scene[sc].drift.assign(
+            p_id.next(), id_s++, "drift", "Osc Drift", fmt::format("{:c}/osc/drift", 'a' + sc),
+            ct_percent_oscdrift, Surge::Skin::Scene::drift, sc_id, cg_GLOBAL, 0, true));
 
         a->push_back(scene[sc].noise_colour.assign(p_id.next(), id_s++, "noisecol", "Noise Color",
+                                                   fmt::format("{:c}/mixer/noise/color", 'a' + sc),
                                                    ct_noise_color, Surge::Skin::Scene::noise_color,
                                                    sc_id, cg_GLOBAL, 0, true, sceasy));
         scene[sc].noise_colour.deform_type = NoiseColorChannels::STEREO;
 
         a->push_back(scene[sc].keytrack_root.assign(
-            p_id.next(), id_s++, "ktrkroot", "Keytrack Root Key", ct_midikey,
+            p_id.next(), id_s++, "ktrkroot", "Keytrack Root Key",
+            fmt::format("{:c}/filter/keytrack_root", 'a' + sc), ct_midikey,
             Surge::Skin::Scene::keytrack_root, sc_id, cg_GLOBAL, 0, false));
-        // ct_midikey
-        // drift,keytrack_root
 
-        a->push_back(scene[sc].volume.assign(p_id.next(), id_s++, "volume", "Volume",
-                                             ct_amplitude_clipper, Surge::Skin::Scene::volume,
-                                             sc_id, cg_GLOBAL, 0, true, sceasy));
-        a->push_back(scene[sc].pan.assign(p_id.next(), id_s++, "pan", "Pan", ct_percent_bipolar_pan,
-                                          Surge::Skin::Scene::pan, sc_id, cg_GLOBAL, 0, true,
-                                          sceasy));
-        a->push_back(scene[sc].width.assign(p_id.next(), id_s++, "pan2", "Width",
-                                            ct_percent_bipolar, Surge::Skin::Scene::width, sc_id,
-                                            cg_GLOBAL, 0, true, sceasy));
+        a->push_back(scene[sc].volume.assign(
+            p_id.next(), id_s++, "volume", "Volume", fmt::format("{:c}/amp/volume", 'a' + sc),
+            ct_amplitude_clipper, Surge::Skin::Scene::volume, sc_id, cg_GLOBAL, 0, true, sceasy));
+
+        a->push_back(scene[sc].pan.assign(
+            p_id.next(), id_s++, "pan", "Pan", fmt::format("{:c}/amp/pan", 'a' + sc),
+            ct_percent_bipolar_pan, Surge::Skin::Scene::pan, sc_id, cg_GLOBAL, 0, true, sceasy));
+
+        a->push_back(scene[sc].width.assign(
+            p_id.next(), id_s++, "pan2", "Width", fmt::format("{:c}/amp/width", 'a' + sc),
+            ct_percent_bipolar, Surge::Skin::Scene::width, sc_id, cg_GLOBAL, 0, true, sceasy));
+
         a->push_back(scene[sc].send_level[0].assign(
-            p_id.next(), id_s++, "send_fx_1", "Send FX 1 Level", ct_sendlevel,
-            Surge::Skin::Scene::send_fx_1, sc_id, cg_GLOBAL, 0, true, sceasy));
+            p_id.next(), id_s++, "send_fx_1", "Send FX 1 Level",
+            fmt::format("{:c}/send/1/level", 'a' + sc), ct_sendlevel, Surge::Skin::Scene::send_fx_1,
+            sc_id, cg_GLOBAL, 0, true, sceasy));
+
         a->push_back(scene[sc].send_level[1].assign(
-            p_id.next(), id_s++, "send_fx_2", "Send FX 2 Level", ct_sendlevel,
-            Surge::Skin::Scene::send_fx_2, sc_id, cg_GLOBAL, 0, true, sceasy));
+            p_id.next(), id_s++, "send_fx_2", "Send FX 2 Level",
+            fmt::format("{:c}/send/2/level", 'a' + sc), ct_sendlevel, Surge::Skin::Scene::send_fx_2,
+            sc_id, cg_GLOBAL, 0, true, sceasy));
+
         a->push_back(scene[sc].send_level[2].assign(
-            p_id.next(), id_s++, "send_fx_3", "Send FX 3 Level", ct_sendlevel,
-            Surge::Skin::Scene::send_fx_3, sc_id, cg_GLOBAL, 0, true, sceasy));
+            p_id.next(), id_s++, "send_fx_3", "Send FX 3 Level",
+            fmt::format("{:c}/send/3/level", 'a' + sc), ct_sendlevel, Surge::Skin::Scene::send_fx_3,
+            sc_id, cg_GLOBAL, 0, true, sceasy));
+
         a->push_back(scene[sc].send_level[3].assign(
-            p_id.next(), id_s++, "send_fx_4", "Send FX 4 Level", ct_sendlevel,
-            Surge::Skin::Scene::send_fx_4, sc_id, cg_GLOBAL, 0, true, sceasy));
-        a->push_back(scene[sc].level_o1.assign(p_id.next(), id_s++, "level_o1", "Osc 1 Level",
+            p_id.next(), id_s++, "send_fx_4", "Send FX 4 Level",
+            fmt::format("{:c}/send/4/level", 'a' + sc), ct_sendlevel, Surge::Skin::Scene::send_fx_4,
+            sc_id, cg_GLOBAL, 0, true, sceasy));
+
+        a->push_back(scene[sc].level_o1.assign(p_id.next(), id_s++, "level_o1", "Osc 1 Volume",
+                                               fmt::format("{:c}/mixer/osc1/volume", 'a' + sc),
                                                ct_amplitude, Surge::Skin::Mixer::level_o1, sc_id,
                                                cg_MIX, 0, true, sceasy));
+
         a->push_back(scene[sc].mute_o1.assign(p_id.next(), id_s++, "mute_o1", "Osc 1 Mute",
+                                              fmt::format("{:c}/mixer/osc1/mute", 'a' + sc),
                                               ct_bool_mute, Surge::Skin::Mixer::mute_o1, sc_id,
                                               cg_MIX, 0, false));
+
         a->push_back(scene[sc].solo_o1.assign(p_id.next(), id_s++, "solo_o1", "Osc 1 Solo",
+                                              fmt::format("{:c}/mixer/osc1/solo", 'a' + sc),
                                               ct_bool_solo, Surge::Skin::Mixer::solo_o1, sc_id,
                                               cg_MIX, 0, false, kMeta));
+
         a->push_back(scene[sc].route_o1.assign(p_id.next(), id_s++, "route_o1", "Osc 1 Route",
+                                               fmt::format("{:c}/mixer/osc1/route", 'a' + sc),
                                                ct_oscroute, Surge::Skin::Mixer::route_o1, sc_id,
                                                cg_MIX, 0, false));
-        a->push_back(scene[sc].level_o2.assign(p_id.next(), id_s++, "level_o2", "Osc 2 Level",
+
+        a->push_back(scene[sc].level_o2.assign(p_id.next(), id_s++, "level_o2", "Osc 2 Volume",
+                                               fmt::format("{:c}/mixer/osc2/volume", 'a' + sc),
                                                ct_amplitude, Surge::Skin::Mixer::level_o2, sc_id,
                                                cg_MIX, 0, true, sceasy));
+
         a->push_back(scene[sc].mute_o2.assign(p_id.next(), id_s++, "mute_o2", "Osc 2 Mute",
+                                              fmt::format("{:c}/mixer/osc2/mute", 'a' + sc),
                                               ct_bool_mute, Surge::Skin::Mixer::mute_o2, sc_id,
                                               cg_MIX, 0, false));
+
         a->push_back(scene[sc].solo_o2.assign(p_id.next(), id_s++, "solo_o2", "Osc 2 Solo",
+                                              fmt::format("{:c}/mixer/osc2/solo", 'a' + sc),
                                               ct_bool_solo, Surge::Skin::Mixer::solo_o2, sc_id,
                                               cg_MIX, 0, false, kMeta));
+
         a->push_back(scene[sc].route_o2.assign(p_id.next(), id_s++, "route_o2", "Osc 2 Route",
+                                               fmt::format("{:c}/mixer/osc2/route", 'a' + sc),
                                                ct_oscroute, Surge::Skin::Mixer::route_o2, sc_id,
                                                cg_MIX, 0, false));
-        a->push_back(scene[sc].level_o3.assign(p_id.next(), id_s++, "level_o3", "Osc 3 Level",
+
+        a->push_back(scene[sc].level_o3.assign(p_id.next(), id_s++, "level_o3", "Osc 3 Volume",
+                                               fmt::format("{:c}/mixer/osc3/volume", 'a' + sc),
                                                ct_amplitude, Surge::Skin::Mixer::level_o3, sc_id,
                                                cg_MIX, 0, true, sceasy));
+
         a->push_back(scene[sc].mute_o3.assign(p_id.next(), id_s++, "mute_o3", "Osc 3 Mute",
+                                              fmt::format("{:c}/mixer/osc3/mute", 'a' + sc),
                                               ct_bool_mute, Surge::Skin::Mixer::mute_o3, sc_id,
                                               cg_MIX, 0, false));
+
         a->push_back(scene[sc].solo_o3.assign(p_id.next(), id_s++, "solo_o3", "Osc 3 Solo",
+                                              fmt::format("{:c}/mixer/osc3/solo", 'a' + sc),
                                               ct_bool_solo, Surge::Skin::Mixer::solo_o3, sc_id,
                                               cg_MIX, 0, false, kMeta));
+
         a->push_back(scene[sc].route_o3.assign(p_id.next(), id_s++, "route_o3", "Osc 3 Route",
+                                               fmt::format("{:c}/mixer/osc3/route", 'a' + sc),
                                                ct_oscroute, Surge::Skin::Mixer::route_o3, sc_id,
                                                cg_MIX, 0, false));
+
         a->push_back(scene[sc].level_ring_12.assign(
-            p_id.next(), id_s++, "level_ring12", "Ring Modulation 1x2 Level", ct_amplitude_ringmod,
+            p_id.next(), id_s++, "level_ring12", "Ring Modulation 1x2 Volume",
+            fmt::format("{:c}/mixer/rm1x2/volume", 'a' + sc), ct_amplitude_ringmod,
             Surge::Skin::Mixer::level_ring12, sc_id, cg_MIX, 0, true, sceasy));
+
         a->push_back(scene[sc].mute_ring_12.assign(
-            p_id.next(), id_s++, "mute_ring12", "Ring Modulation 1x2 Mute", ct_bool_mute,
+            p_id.next(), id_s++, "mute_ring12", "Ring Modulation 1x2 Mute",
+            fmt::format("{:c}/mixer/rm1x2/mute", 'a' + sc), ct_bool_mute,
             Surge::Skin::Mixer::mute_ring12, sc_id, cg_MIX, 0, false));
+
         a->push_back(scene[sc].solo_ring_12.assign(
-            p_id.next(), id_s++, "solo_ring12", "Ring Modulation 1x2 Solo", ct_bool_solo,
+            p_id.next(), id_s++, "solo_ring12", "Ring Modulation 1x2 Solo",
+            fmt::format("{:c}/mixer/rm1x2/solo", 'a' + sc), ct_bool_solo,
             Surge::Skin::Mixer::solo_ring12, sc_id, cg_MIX, 0, false, kMeta));
+
         a->push_back(scene[sc].route_ring_12.assign(
-            p_id.next(), id_s++, "route_ring12", "Ring Modulation 1x2 Route", ct_oscroute,
+            p_id.next(), id_s++, "route_ring12", "Ring Modulation 1x2 Route",
+            fmt::format("{:c}/mixer/rm1x2/route", 'a' + sc), ct_oscroute,
             Surge::Skin::Mixer::route_ring12, sc_id, cg_MIX, 0, false));
+
         a->push_back(scene[sc].level_ring_23.assign(
-            p_id.next(), id_s++, "level_ring23", "Ring Modulation 2x3 Level", ct_amplitude_ringmod,
+            p_id.next(), id_s++, "level_ring23", "Ring Modulation 2x3 Volume",
+            fmt::format("{:c}/mixer/rm2x3/volume", 'a' + sc), ct_amplitude_ringmod,
             Surge::Skin::Mixer::level_ring23, sc_id, cg_MIX, 0, true, sceasy));
+
         a->push_back(scene[sc].mute_ring_23.assign(
-            p_id.next(), id_s++, "mute_ring23", "Ring Modulation 2x3 Mute", ct_bool_mute,
+            p_id.next(), id_s++, "mute_ring23", "Ring Modulation 2x3 Mute",
+            fmt::format("{:c}/mixer/rm2x3/mute", 'a' + sc), ct_bool_mute,
             Surge::Skin::Mixer::mute_ring23, sc_id, cg_MIX, 0, false));
+
         a->push_back(scene[sc].solo_ring_23.assign(
-            p_id.next(), id_s++, "solo_ring23", "Ring Modulation 2x3 Solo", ct_bool_solo,
+            p_id.next(), id_s++, "solo_ring23", "Ring Modulation 2x3 Solo",
+            fmt::format("{:c}/mixer/rm2x3/solo", 'a' + sc), ct_bool_solo,
             Surge::Skin::Mixer::solo_ring23, sc_id, cg_MIX, 0, false, kMeta));
+
         a->push_back(scene[sc].route_ring_23.assign(
-            p_id.next(), id_s++, "route_ring23", "Ring Modulation 2x3 Route", ct_oscroute,
+            p_id.next(), id_s++, "route_ring23", "Ring Modulation 2x3 Route",
+            fmt::format("{:c}/mixer/rm2x3/route", 'a' + sc), ct_oscroute,
             Surge::Skin::Mixer::route_ring23, sc_id, cg_MIX, 0, false));
-        a->push_back(scene[sc].level_noise.assign(p_id.next(), id_s++, "level_noise", "Noise Level",
-                                                  ct_amplitude, Surge::Skin::Mixer::level_noise,
-                                                  sc_id, cg_MIX, 0, true, sceasy));
+
+        a->push_back(scene[sc].level_noise.assign(
+            p_id.next(), id_s++, "level_noise", "Noise Volume",
+            fmt::format("{:c}/mixer/noise/volume", 'a' + sc), ct_amplitude,
+            Surge::Skin::Mixer::level_noise, sc_id, cg_MIX, 0, true, sceasy));
+
         a->push_back(scene[sc].mute_noise.assign(p_id.next(), id_s++, "mute_noise", "Noise Mute",
+                                                 fmt::format("{:c}/mixer/noise/mute", 'a' + sc),
                                                  ct_bool_mute, Surge::Skin::Mixer::mute_noise,
                                                  sc_id, cg_MIX, 0, false));
+
         a->push_back(scene[sc].solo_noise.assign(p_id.next(), id_s++, "solo_noise", "Noise Solo",
+                                                 fmt::format("{:c}/mixer/noise/solo", 'a' + sc),
                                                  ct_bool_solo, Surge::Skin::Mixer::solo_noise,
                                                  sc_id, cg_MIX, 0, false, kMeta));
+
         a->push_back(scene[sc].route_noise.assign(p_id.next(), id_s++, "route_noise", "Noise Route",
+                                                  fmt::format("{:c}/mixer/noise/route", 'a' + sc),
                                                   ct_oscroute, Surge::Skin::Mixer::route_noise,
                                                   sc_id, cg_MIX, 0, false));
+
         a->push_back(scene[sc].level_pfg.assign(p_id.next(), id_s++, "level_pfg", "Pre-Filter Gain",
+                                                fmt::format("{:c}/mixer/prefilter_gain", 'a' + sc),
                                                 ct_decibel, Surge::Skin::Mixer::level_prefiltergain,
                                                 sc_id, cg_MIX, 0, true, sceasy));
 
         int pbx = 164, pby = 112;
+
         a->push_back(scene[sc].pbrange_up.assign(
-            p_id.next(), id_s++, "pbrange_up", "Pitch Bend Up Range", ct_pbdepth,
-            Surge::Skin::Scene::pbrange_up, sc_id, cg_GLOBAL, 0, true, kNoPopup));
+            p_id.next(), id_s++, "pbrange_up", "Pitch Bend Up Range",
+            fmt::format("{:c}/pitchbend_up", 'a' + sc), ct_pbdepth, Surge::Skin::Scene::pbrange_up,
+            sc_id, cg_GLOBAL, 0, true, kNoPopup));
+
         a->push_back(scene[sc].pbrange_dn.assign(
-            p_id.next(), id_s++, "pbrange_dn", "Pitch Bend Down Range", ct_pbdepth,
+            p_id.next(), id_s++, "pbrange_dn", "Pitch Bend Down Range",
+            fmt::format("{:c}/pitchbend_down", 'a' + sc), ct_pbdepth,
             Surge::Skin::Scene::pbrange_dn, sc_id, cg_GLOBAL, 0, true, kNoPopup));
+
         scene[sc].pbrange_up.set_extend_range(false);
         scene[sc].pbrange_dn.set_extend_range(false);
 
-        a->push_back(scene[sc].vca_level.assign(p_id.next(), id_s++, "vca_level", "VCA Gain",
-                                                ct_decibel, Surge::Skin::Scene::gain, sc_id,
-                                                cg_GLOBAL, 0, true, sceasy));
+        a->push_back(scene[sc].vca_level.assign(
+            p_id.next(), id_s++, "vca_level", "VCA Gain", fmt::format("{:c}/amp/gain", 'a' + sc),
+            ct_decibel, Surge::Skin::Scene::gain, sc_id, cg_GLOBAL, 0, true, sceasy));
+
         a->push_back(scene[sc].vca_velsense.assign(
-            p_id.next(), id_s++, "vca_velsense", "Velocity > VCA Gain", ct_decibel_attenuation,
+            p_id.next(), id_s++, "vca_velsense", "Velocity > VCA Gain",
+            fmt::format("{:c}/amp/vel_to_gain", 'a' + sc), ct_decibel_attenuation,
             Surge::Skin::Scene::vel_sensitivity, sc_id, cg_GLOBAL, 0, false));
 
         a->push_back(scene[sc].feedback.assign(p_id.next(), id_s++, "feedback", "Feedback",
+                                               fmt::format("{:c}/filter/feedback", 'a' + sc),
                                                ct_osc_feedback_negative,
                                                Surge::Skin::Filter::feedback, sc_id, cg_GLOBAL, 0,
                                                true, kHorizontal | kWhite | sceasy));
+
         a->push_back(scene[sc].filterblock_configuration.assign(
-            p_id.next(), id_s++, "fb_config", "Filter Configuration", ct_fbconfig,
-            Surge::Skin::Filter::config, sc_id, cg_GLOBAL, 0, false));
+            p_id.next(), id_s++, "fb_config", "Filter Configuration",
+            fmt::format("{:c}/filter/config", 'a' + sc), ct_fbconfig, Surge::Skin::Filter::config,
+            sc_id, cg_GLOBAL, 0, false));
+
         a->push_back(scene[sc].filter_balance.assign(
-            p_id.next(), id_s++, "f_balance", "Filter Balance", ct_percent_bipolar,
+            p_id.next(), id_s++, "f_balance", "Filter Balance",
+            fmt::format("{:c}/filter/balance", 'a' + sc), ct_percent_bipolar,
             Surge::Skin::Filter::balance, sc_id, cg_GLOBAL, 0, true, sceasy));
 
-        a->push_back(scene[sc].lowcut.assign(p_id.next(), id_s++, "lowcut", "Highpass", ct_freq_hpf,
-                                             Surge::Skin::Filter::highpass, sc_id, cg_GLOBAL, 0,
-                                             true, sceasy));
+        a->push_back(scene[sc].lowcut.assign(
+            p_id.next(), id_s++, "lowcut", "Highpass", fmt::format("{:c}/highpass", 'a' + sc),
+            ct_freq_hpf, Surge::Skin::Filter::highpass, sc_id, cg_GLOBAL, 0, true, sceasy));
 
         a->push_back(scene[sc].wsunit.type.assign(p_id.next(), id_s++, "ws_type", "Waveshaper Type",
+                                                  fmt::format("{:c}/waveshaper/type", 'a' + sc),
                                                   ct_wstype, Surge::Skin::Filter::waveshaper_type,
                                                   sc_id, cg_GLOBAL, 0, false, kNoPopup));
+
         a->push_back(scene[sc].wsunit.drive.assign(
-            p_id.next(), id_s++, "ws_drive", "Waveshaper Drive", ct_decibel_narrow_short_extendable,
+            p_id.next(), id_s++, "ws_drive", "Waveshaper Drive",
+            fmt::format("{:c}/waveshaper/drive", 'a' + sc), ct_decibel_narrow_short_extendable,
             Surge::Skin::Filter::waveshaper_drive, sc_id, cg_GLOBAL, 0, true, sceasy));
 
         for (int f = 0; f < n_filterunits_per_scene; f++)
         {
             a->push_back(scene[sc].filterunit[f].type.assign(
-                p_id.next(), id_s++, "type", "Type", ct_filtertype,
+                p_id.next(), id_s++, "type", "Type",
+                fmt::format("{:c}/filter/{}/type", 'a' + sc, f + 1), ct_filtertype,
                 Surge::Skin::Connector::connectorByID("filter.type_" + std::to_string(f + 1)),
                 sc_id, cg_FILTER, f, false));
+
             a->push_back(scene[sc].filterunit[f].subtype.assign(
-                p_id.next(), id_s++, "subtype", "Subtype", ct_filtersubtype,
+                p_id.next(), id_s++, "subtype", "Subtype",
+                fmt::format("{:c}/filter/{}/subtype", 'a' + sc, f + 1), ct_filtersubtype,
                 Surge::Skin::Connector::connectorByID("filter.subtype_" + std::to_string(f + 1)),
                 sc_id, cg_FILTER, f, false));
+
             a->push_back(scene[sc].filterunit[f].cutoff.assign(
-                p_id.next(), id_s++, "cutoff", "Cutoff", ct_freq_audible_with_tunability,
+                p_id.next(), id_s++, "cutoff", "Cutoff",
+                fmt::format("{:c}/filter/{}/cutoff", 'a' + sc, f + 1),
+                ct_freq_audible_with_tunability,
                 Surge::Skin::Connector::connectorByID("filter.cutoff_" + std::to_string(f + 1)),
                 sc_id, cg_FILTER, f, true, sceasy));
+
             if (f == 1)
+            {
                 a->push_back(scene[sc].f2_cutoff_is_offset.assign(
                     p_id.next(), id_s++, "f2_cf_is_offset", "Filter 2 Offset Mode",
-                    ct_bool_relative_switch, Surge::Skin::Filter::f2_offset_mode, sc_id, cg_GLOBAL,
-                    0, false, kMeta));
+                    fmt::format("{:c}/filter/2/offset_mode", 'a' + sc), ct_bool_relative_switch,
+                    Surge::Skin::Filter::f2_offset_mode, sc_id, cg_GLOBAL, 0, false, kMeta));
+            }
+
             a->push_back(scene[sc].filterunit[f].resonance.assign(
-                p_id.next(), id_s++, "resonance", "Resonance", ct_percent,
+                p_id.next(), id_s++, "resonance", "Resonance",
+                fmt::format("{:c}/filter/{}/resonance", 'a' + sc, f + 1), ct_percent,
                 Surge::Skin::Connector::connectorByID("filter.resonance_" + std::to_string(f + 1)),
                 sc_id, cg_FILTER, f, true, kHorizontal | sceasy));
+
             if (f == 1)
+            {
                 a->push_back(scene[sc].f2_link_resonance.assign(
-                    p_id.next(), id_s++, "f2_link_resonance", "Link Resonance", ct_bool_link_switch,
+                    p_id.next(), id_s++, "f2_link_resonance", "Link Resonance",
+                    fmt::format("{:c}/filter/2/link_resonance", 'a' + sc), ct_bool_link_switch,
                     Surge::Skin::Filter::f2_link_resonance, sc_id, cg_GLOBAL, 0, false, kMeta));
+            }
 
             a->push_back(scene[sc].filterunit[f].envmod.assign(
-                p_id.next(), id_s++, "envmod", "FEG Mod Amount", ct_freq_mod,
+                p_id.next(), id_s++, "envmod", "FEG Mod Amount",
+                fmt::format("{:c}/filter/{}/feg_amount", 'a' + sc, f + 1), ct_freq_mod,
                 Surge::Skin::Connector::connectorByID("filter.envmod_" + std::to_string(f + 1)),
                 sc_id, cg_FILTER, f, true, sceasy));
+
             a->push_back(scene[sc].filterunit[f].keytrack.assign(
-                p_id.next(), id_s++, "keytrack", "Keytrack", ct_percent_bipolar,
+                p_id.next(), id_s++, "keytrack", "Keytrack",
+                fmt::format("{:c}/filter/{}/keytrack", 'a' + sc, f + 1), ct_percent_bipolar,
                 Surge::Skin::Connector::connectorByID("filter.keytrack_" + std::to_string(f + 1)),
                 sc_id, cg_FILTER, f, true));
         }
@@ -376,9 +494,8 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
         // scene[sc].filterunit[0].type.val.i = 1;
         for (int e = 0; e < 2; e++) // 2 = we have two envelopes, filter and amplifier
         {
-            std::string envs = "aeg.";
-            if (e == 1)
-                envs = "feg.";
+            std::string et = (e == 1) ? "aeg" : "feg";
+            std::string envs = fmt::format("{}.", et);
 
             /*
              * Since the connectors are in a namespace and here we have a loop over two
@@ -390,27 +507,41 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
             };
 
             a->push_back(scene[sc].adsr[e].a.assign(p_id.next(), id_s++, "attack", "Attack",
+                                                    fmt::format("{:c}/{}/attack", 'a' + sc, et),
                                                     ct_envtime, getCon("attack"), sc_id, cg_ENV, e,
                                                     true, kVertical | kWhite | sceasy));
+
             a->push_back(scene[sc].adsr[e].a_s.assign(
-                p_id.next(), id_s++, "attack_shape", "Attack Shape", ct_envshape_attack,
+                p_id.next(), id_s++, "attack_shape", "Attack Shape",
+                fmt::format("{:c}/{}/attack_shape", 'a' + sc, et), ct_envshape_attack,
                 getCon("attack_shape"), sc_id, cg_ENV, e, false, kNoPopup));
-            a->push_back(scene[sc].adsr[e].d.assign(p_id.next(), id_s++, "decay", "Decay",
-                                                    ct_envtime, getCon("decay"), sc_id, cg_ENV, e,
-                                                    true, kVertical | kWhite | sceasy));
+
+            a->push_back(scene[sc].adsr[e].d.assign(
+                p_id.next(), id_s++, "decay", "Decay", fmt::format("{:c}/{}/decay", 'a' + sc, et),
+                ct_envtime, getCon("decay"), sc_id, cg_ENV, e, true, kVertical | kWhite | sceasy));
+
             a->push_back(scene[sc].adsr[e].d_s.assign(
-                p_id.next(), id_s++, "decay_shape", "Decay Shape", ct_envshape,
+                p_id.next(), id_s++, "decay_shape", "Decay Shape",
+                fmt::format("{:c}/{}/decay_shape", 'a' + sc, et), ct_envshape,
                 getCon("decay_shape"), sc_id, cg_ENV, e, false, kNoPopup));
+
             a->push_back(scene[sc].adsr[e].s.assign(p_id.next(), id_s++, "sustain", "Sustain",
+                                                    fmt::format("{:c}/{}/sustain", 'a' + sc, et),
                                                     ct_percent, getCon("sustain"), sc_id, cg_ENV, e,
                                                     true, kVertical | kWhite | sceasy));
+
             a->push_back(scene[sc].adsr[e].r.assign(p_id.next(), id_s++, "release", "Release",
+                                                    fmt::format("{:c}/{}/release", 'a' + sc, et),
                                                     ct_envtime, getCon("release"), sc_id, cg_ENV, e,
                                                     true, kVertical | kWhite | sceasy));
+
             a->push_back(scene[sc].adsr[e].r_s.assign(
-                p_id.next(), id_s++, "release_shape", "Release Shape", ct_envshape,
+                p_id.next(), id_s++, "release_shape", "Release Shape",
+                fmt::format("{:c}/{}/release_shape", 'a' + sc, et), ct_envshape,
                 getCon("release_shape"), sc_id, cg_ENV, e, false, kNoPopup));
+
             a->push_back(scene[sc].adsr[e].mode.assign(p_id.next(), id_s++, "mode", "Envelope Mode",
+                                                       fmt::format("{:c}/{}/mode", 'a' + sc, et),
                                                        ct_envmode, getCon("mode"), sc_id, cg_ENV, e,
                                                        false, kNoPopup));
         }
@@ -418,68 +549,92 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
         for (int l = 0; l < n_lfos; l++)
         {
             char label[LABEL_SIZE];
+            const int lid = (l % n_lfos_voice) + 1;
+            std::string lt = (l < n_lfos_voice) ? "vlfo" : "slfo";
 
             snprintf(label, LABEL_SIZE, "lfo%i_shape", l);
-            a->push_back(scene[sc].lfo[l].shape.assign(p_id.next(), id_s++, label, "Type",
-                                                       ct_lfotype, Surge::Skin::LFO::shape, sc_id,
-                                                       cg_LFO, ms_lfo1 + l));
+            a->push_back(scene[sc].lfo[l].shape.assign(
+                p_id.next(), id_s++, label, "Type",
+                fmt::format("{:c}/{}{}/type", 'a' + sc, lt, lid), ct_lfotype,
+                Surge::Skin::LFO::shape, sc_id, cg_LFO, ms_lfo1 + l));
 
             snprintf(label, LABEL_SIZE, "lfo%i_rate", l);
             a->push_back(scene[sc].lfo[l].rate.assign(
-                p_id.next(), id_s++, label, "Rate", ct_lforate_deactivatable,
+                p_id.next(), id_s++, label, "Rate",
+                fmt::format("{:c}/{}{}/rate", 'a' + sc, lt, lid), ct_lforate_deactivatable,
                 Surge::Skin::LFO::rate, sc_id, cg_LFO, ms_lfo1 + l, true, sceasy, false));
+
             snprintf(label, LABEL_SIZE, "lfo%i_phase", l);
             a->push_back(scene[sc].lfo[l].start_phase.assign(
-                p_id.next(), id_s++, label, "Phase / Shuffle", ct_lfophaseshuffle,
+                p_id.next(), id_s++, label, "Phase / Shuffle",
+                fmt::format("{:c}/{}{}/phase", 'a' + sc, lt, lid), ct_lfophaseshuffle,
                 Surge::Skin::LFO::phase, sc_id, cg_LFO, ms_lfo1 + l, true));
+
             snprintf(label, LABEL_SIZE, "lfo%i_magnitude", l);
             a->push_back(scene[sc].lfo[l].magnitude.assign(
-                p_id.next(), id_s++, label, "Amplitude", ct_lfoamplitude,
+                p_id.next(), id_s++, label, "Amplitude",
+                fmt::format("{:c}/{}{}/amplitude", 'a' + sc, lt, lid), ct_lfoamplitude,
                 Surge::Skin::LFO::amplitude, sc_id, cg_LFO, ms_lfo1 + l, true, sceasy));
+
             snprintf(label, LABEL_SIZE, "lfo%i_deform", l);
-            a->push_back(scene[sc].lfo[l].deform.assign(p_id.next(), id_s++, label, "Deform",
-                                                        ct_lfodeform, Surge::Skin::LFO::deform,
-                                                        sc_id, cg_LFO, ms_lfo1 + l, true));
+            a->push_back(scene[sc].lfo[l].deform.assign(
+                p_id.next(), id_s++, label, "Deform",
+                fmt::format("{:c}/{}{}/deform", 'a' + sc, lt, lid), ct_lfodeform,
+                Surge::Skin::LFO::deform, sc_id, cg_LFO, ms_lfo1 + l, true));
 
             snprintf(label, LABEL_SIZE, "lfo%i_trigmode", l);
             a->push_back(scene[sc].lfo[l].trigmode.assign(
-                p_id.next(), id_s++, label, "Trigger Mode", ct_lfotrigmode,
+                p_id.next(), id_s++, label, "Trigger Mode",
+                fmt::format("{:c}/{}{}/trigger_mode", 'a' + sc, lt, lid), ct_lfotrigmode,
                 Surge::Skin::LFO::trigger_mode, sc_id, cg_LFO, ms_lfo1 + l, false, kNoPopup));
+
             snprintf(label, LABEL_SIZE, "lfo%i_unipolar", l);
             a->push_back(scene[sc].lfo[l].unipolar.assign(
-                p_id.next(), id_s++, label, "Unipolar", ct_bool_unipolar,
+                p_id.next(), id_s++, label, "Unipolar",
+                fmt::format("{:c}/{}{}/unipolar", 'a' + sc, lt, lid), ct_bool_unipolar,
                 Surge::Skin::LFO::unipolar, sc_id, cg_LFO, ms_lfo1 + l, false));
 
             snprintf(label, LABEL_SIZE, "lfo%i_delay", l);
             a->push_back(scene[sc].lfo[l].delay.assign(
-                p_id.next(), id_s++, label, "Delay", ct_envtime_deactivatable,
+                p_id.next(), id_s++, label, "Delay",
+                fmt::format("{:c}/{}{}/eg/delay", 'a' + sc, lt, lid), ct_envtime_deactivatable,
                 Surge::Skin::LFO::delay, sc_id, cg_LFO, ms_lfo1 + l, true, kMini));
+
             snprintf(label, LABEL_SIZE, "lfo%i_attack", l);
-            a->push_back(scene[sc].lfo[l].attack.assign(p_id.next(), id_s++, label, "Attack",
-                                                        ct_envtime, Surge::Skin::LFO::attack, sc_id,
-                                                        cg_LFO, ms_lfo1 + l, true, kMini));
+            a->push_back(scene[sc].lfo[l].attack.assign(
+                p_id.next(), id_s++, label, "Attack",
+                fmt::format("{:c}/{}{}/eg/attack", 'a' + sc, lt, lid), ct_envtime,
+                Surge::Skin::LFO::attack, sc_id, cg_LFO, ms_lfo1 + l, true, kMini));
+
             snprintf(label, LABEL_SIZE, "lfo%i_hold", l);
-            a->push_back(scene[sc].lfo[l].hold.assign(p_id.next(), id_s++, label, "Hold",
-                                                      ct_envtime, Surge::Skin::LFO::hold, sc_id,
-                                                      cg_LFO, ms_lfo1 + l, true, kMini));
+            a->push_back(scene[sc].lfo[l].hold.assign(
+                p_id.next(), id_s++, label, "Hold",
+                fmt::format("{:c}/{}{}/eg/hold", 'a' + sc, lt, lid), ct_envtime,
+                Surge::Skin::LFO::hold, sc_id, cg_LFO, ms_lfo1 + l, true, kMini));
+
             snprintf(label, LABEL_SIZE, "lfo%i_decay", l);
-            a->push_back(scene[sc].lfo[l].decay.assign(p_id.next(), id_s++, label, "Decay",
-                                                       ct_envtime, Surge::Skin::LFO::decay, sc_id,
-                                                       cg_LFO, ms_lfo1 + l, true, kMini));
+            a->push_back(scene[sc].lfo[l].decay.assign(
+                p_id.next(), id_s++, label, "Decay",
+                fmt::format("{:c}/{}{}/eg/decay", 'a' + sc, lt, lid), ct_envtime,
+                Surge::Skin::LFO::decay, sc_id, cg_LFO, ms_lfo1 + l, true, kMini));
+
             snprintf(label, LABEL_SIZE, "lfo%i_sustain", l);
-            a->push_back(scene[sc].lfo[l].sustain.assign(p_id.next(), id_s++, label, "Sustain",
-                                                         ct_percent, Surge::Skin::LFO::sustain,
-                                                         sc_id, cg_LFO, ms_lfo1 + l, true, kMini));
+            a->push_back(scene[sc].lfo[l].sustain.assign(
+                p_id.next(), id_s++, label, "Sustain",
+                fmt::format("{:c}/{}{}/eg/sustain", 'a' + sc, lt, lid), ct_percent,
+                Surge::Skin::LFO::sustain, sc_id, cg_LFO, ms_lfo1 + l, true, kMini));
+
             snprintf(label, LABEL_SIZE, "lfo%i_release", l);
             a->push_back(scene[sc].lfo[l].release.assign(
-                p_id.next(), id_s++, label, "Release", ct_envtime_lfodecay,
+                p_id.next(), id_s++, label, "Release",
+                fmt::format("{:c}/{}{}/eg/release", 'a' + sc, lt, lid), ct_envtime_lfodecay,
                 Surge::Skin::LFO::release, sc_id, cg_LFO, ms_lfo1 + l, true, kMini));
         }
     }
 
-    param_ptr.push_back(character.assign(p_id.next(), 0, "character", "Character", ct_character,
-                                         Surge::Skin::Global::character, 0, cg_GLOBAL, 0, false,
-                                         kNoPopup));
+    param_ptr.push_back(
+        character.assign(p_id.next(), 0, "character", "Character", "global/character", ct_character,
+                         Surge::Skin::Global::character, 0, cg_GLOBAL, 0, false, kNoPopup));
 
     // Resolve the promise chain
     p_id.resolve();
@@ -642,71 +797,18 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
             {
                 Surge::MSEG::createInitVoiceMSEG(ms);
             }
+
             Surge::MSEG::rebuildCache(ms);
 
             auto *fs = &(formulamods[s][m]);
             Surge::Formula::createInitFormula(fs);
         }
 
-    // Build table of param_ptr -- storage name
-    for (auto *p : param_ptr)
-        param_ptr_by_storagename[p->get_storage_name()] = p;
-
-    /* ---- Set any OSC names here  ---- */
-    /* Example of how to set an OSC name:
-    parameterFromStorageName("scene_active")->setOSCName("active_scene");
-    */
-
     // Build table of param_ptr -- osc name
     for (auto *p : param_ptr)
     {
-        if (p->hasOSCName)
-        {
-            param_ptr_by_oscname[p->getOSCName()] = p;
-        }
+        param_ptr_by_oscname[p->get_osc_name()] = p;
     }
-
-#if 0
-   // DEBUG CODE WHICH WILL DIE
-   std::map<std::string, int> idToParam;
-   for( auto p : param_ptr )
-   {
-      auto uiid = p->ui_identifier;
-      if( idToParam.find( uiid ) == idToParam.end() )
-      {
-         idToParam[uiid] = p->id;
-      }
-   }
-   auto pns = std::string();
-   std::ostringstream hdr, body;
-   auto hdrpre = std::string();
-   for( auto ni : idToParam )
-   {
-      auto n = ni.first;
-      auto dp = n.find( "." );
-      auto ns = n.substr( 0, dp );
-      auto la = n.substr( dp + 1 );
-      auto p = param_ptr[ni.second];
-      if( ns != pns )
-      {
-         if( pns != "" )
-         {
-            hdr << ";\n   }\n"; body << "   }\n";
-         }
-         pns = ns;
-         hdr << "   namespace " << ns << " {\n";
-         body << "  namespace " << ns << " {\n";
-         hdrpre = "      extern Surge::Skin::Connector ";
-      }
-      hdr << hdrpre << la;
-      hdrpre = ", ";
-      body << "      Connector " << la << "( \"" << p->ui_identifier << "\", " << p->posx << ", " << p->posy << ", Connector::SLIDER );\n";
-      //std::cout << ns << "/" << la << " " << p->posx << " " << p->posy  << std::endl;
-   }
-   hdr << ";\n   }\n"; body << "   }\n";
-
-   std::cout << hdr.str() << "\n" << body.str() << std::endl;
-#endif
 }
 
 void SurgePatch::init_default_values()
@@ -714,6 +816,7 @@ void SurgePatch::init_default_values()
     // reset all parameters to their default value (could be zero, then zeroes never would have to
     // be saved in xml) will make it all more predictable
     int n = param_ptr.size();
+
     for (int i = 0; i < n; i++)
     {
         if ((i != volume.id) && (i != fx_bypass.id) && (i != polylimit.id))
@@ -739,6 +842,7 @@ void SurgePatch::init_default_values()
             osc.queue_type = -1;
             osc.keytrack.val.b = true;
             osc.retrigger.val.b = false;
+
             /*
              * init-default-values is called at load_raw. load_raw will
              * replace any wavetables *but* if it doesn't have a wt osc that
@@ -753,10 +857,14 @@ void SurgePatch::init_default_values()
                 osc.wt.queue_id = 0;
             }
             else
+            {
                 osc.wt.queue_id = -1;
+            }
+
             osc.wt.queue_filename = "";
             osc.wt.current_filename = "";
         }
+
         scene[sc].fm_depth.val.f = -24.f;
         scene[sc].portamento.val.f = scene[sc].portamento.val_min.f;
         scene[sc].keytrack_root.val.i = 60;
@@ -1255,31 +1363,22 @@ unsigned int SurgePatch::save_patch(void **data)
     return psize;
 }
 
-Parameter *SurgePatch::parameterFromStorageName(std::string stName)
-{
-    auto it = param_ptr_by_storagename.find(stName);
-    if (it != std::end(param_ptr_by_storagename))
-    {
-        return it->second;
-    }
-    else
-    {
-        return nullptr;
-    }
-}
 Parameter *SurgePatch::parameterFromOSCName(std::string oscName)
 {
     auto ot = param_ptr_by_oscname.find(oscName);
+
     if (ot != std::end(param_ptr_by_oscname))
+    {
         return ot->second;
-    return parameterFromStorageName(oscName);
+    }
+
+    return nullptr;
 }
 
 float convert_v11_reso_to_v12_2P(float reso)
 {
     float Qinv =
         (1.0f - 0.99f * limit_range((float)(1.f - (1.f - reso) * (1.f - reso)), 0.0f, 1.0f));
-    // return 1.0f - sqrt(1.0f - Qinv / 1.05f);
     return 1.f - sqrt(1.f - ((1.0f - Qinv) / 1.05f));
 }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -67,6 +67,8 @@ const int n_osc_params = 7;
 const int n_egs = 2;
 const int n_fx_params = 12;
 const int n_fx_slots = 16;
+const int n_fx_chains = 4;
+const int n_fx_per_chain = 4;
 const int n_send_slots = 4;
 const int FIRipol_M = 256;
 const int FIRipol_M_bits = 8;
@@ -190,16 +192,16 @@ enum NoiseColorChannels
 enum RingModMode
 {
     rmm_ring = 0,
-    rmm_cxor43_0 = 1,
-    rmm_cxor43_1 = 2,
-    rmm_cxor43_2 = 3,
-    rmm_cxor43_3 = 4,
-    rmm_cxor43_4 = 5,
-    rmm_cxor93_0 = 6,
-    rmm_cxor93_1 = 7,
-    rmm_cxor93_2 = 8,
-    rmm_cxor93_3 = 9,
-    rmm_cxor93_4 = 10
+    rmm_cxor43_0,
+    rmm_cxor43_1,
+    rmm_cxor43_2,
+    rmm_cxor43_3,
+    rmm_cxor43_4,
+    rmm_cxor93_0,
+    rmm_cxor93_1,
+    rmm_cxor93_2,
+    rmm_cxor93_3,
+    rmm_cxor93_4
 };
 
 enum lfo_trigger_mode
@@ -282,7 +284,7 @@ inline bool uses_wavetabledata(int i)
 
 enum fxslot_positions
 {
-    fxslot_ains1,
+    fxslot_ains1 = 0,
     fxslot_ains2,
     fxslot_bins1,
     fxslot_bins2,
@@ -298,6 +300,22 @@ enum fxslot_positions
     fxslot_send4,
     fxslot_global3,
     fxslot_global4
+};
+
+// clang-format off
+static int constexpr fxslot_order[n_fx_slots] = 
+    {fxslot_ains1,   fxslot_ains2,   fxslot_ains3,   fxslot_ains4,
+     fxslot_bins1,   fxslot_bins2,   fxslot_bins3,   fxslot_bins4,
+     fxslot_send1,   fxslot_send2,   fxslot_send3,   fxslot_send4,
+     fxslot_global1, fxslot_global2, fxslot_global3, fxslot_global4};
+// clang-format on
+
+enum fxchains
+{
+    fxc_scenea = 0,
+    fxc_sceneb,
+    fxc_send,
+    fxc_global,
 };
 
 const char fxslot_names[n_fx_slots][NAMECHARS] = {
@@ -329,6 +347,10 @@ const char fxslot_longnames[n_fx_slots][NAMECHARS] = {
 const char fxslot_shortnames[n_fx_slots][8] = {
     "FX A1", "FX A2", "FX B1", "FX B2", "FX S1", "FX S2", "FX G1", "FX G2",
     "FX A3", "FX A4", "FX B3", "FX B4", "FX S3", "FX S4", "FX G3", "FX G4",
+};
+const std::string fxslot_shortoscname[n_fx_slots] = {
+    "fx/a/1", "fx/a/2", "fx/b/1", "fx/b/2", "fx/send/1", "fx/send/2", "fx/global/1", "fx/global/2",
+    "fx/a/3", "fx/a/4", "fx/b/3", "fx/b/4", "fx/send/3", "fx/send/4", "fx/global/3", "fx/global/4",
 };
 
 enum fx_type
@@ -955,7 +977,6 @@ class SurgePatch
 
     void load_patch(const void *data, int size, bool preset);
     unsigned int save_patch(void **data);
-    Parameter *parameterFromStorageName(std::string stName);
     Parameter *parameterFromOSCName(std::string stName);
 
     // data
@@ -963,7 +984,6 @@ class SurgePatch
     FxStorage fx[n_fx_slots];
     int scene_start[n_scenes], scene_size;
 
-    std::unordered_map<std::string, Parameter *> param_ptr_by_storagename;
     std::unordered_map<std::string, Parameter *> param_ptr_by_oscname;
 
     // streaming name for splitpoint is splitkey (due to legacy)

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -854,47 +854,47 @@ inline void all_ring_modes_block(float *__restrict src1_l, float *__restrict src
     {
         switch (mode)
         {
-        case RingModMode::rmm_ring:
+        case rmm_ring:
             mech::mul_block<BLOCK_SIZE_OS>(src1_l, src2_l, dst_l);
             mech::mul_block<BLOCK_SIZE_OS>(src1_r, src2_r, dst_r);
             break;
-        case RingModMode::rmm_cxor43_0:
+        case rmm_cxor43_0:
             cxor43_0_block(src1_l, src2_l, dst_l, nquads);
             cxor43_0_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case RingModMode::rmm_cxor43_1:
+        case rmm_cxor43_1:
             cxor43_1_block(src1_l, src2_l, dst_l, nquads);
             cxor43_1_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case RingModMode::rmm_cxor43_2:
+        case rmm_cxor43_2:
             cxor43_2_block(src1_l, src2_l, dst_l, nquads);
             cxor43_2_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case RingModMode::rmm_cxor43_3:
+        case rmm_cxor43_3:
             cxor43_3_block(src1_l, src2_l, dst_l, nquads);
             cxor43_3_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case RingModMode::rmm_cxor43_4:
+        case rmm_cxor43_4:
             cxor43_4_block(src1_l, src2_l, dst_l, nquads);
             cxor43_4_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case RingModMode::rmm_cxor93_0:
+        case rmm_cxor93_0:
             cxor93_0_block(src1_l, src2_l, dst_l, nquads);
             cxor93_0_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case RingModMode::rmm_cxor93_1:
+        case rmm_cxor93_1:
             cxor93_1_block(src1_l, src2_l, dst_l, nquads);
             cxor93_1_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case RingModMode::rmm_cxor93_2:
+        case rmm_cxor93_2:
             cxor93_2_block(src1_l, src2_l, dst_l, nquads);
             cxor93_2_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case RingModMode::rmm_cxor93_3:
+        case rmm_cxor93_3:
             cxor93_3_block(src1_l, src2_l, dst_l, nquads);
             cxor93_3_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case RingModMode::rmm_cxor93_4:
+        case rmm_cxor93_4:
             cxor93_4_block(src1_l, src2_l, dst_l, nquads);
             cxor93_4_block(src1_r, src2_r, dst_r, nquads);
             break;
@@ -905,37 +905,37 @@ inline void all_ring_modes_block(float *__restrict src1_l, float *__restrict src
     {
         switch (mode)
         {
-        case RingModMode::rmm_ring:
+        case rmm_ring:
             mech::mul_block<BLOCK_SIZE_OS>(src1_l, src2_l, dst_l);
             break;
-        case RingModMode::rmm_cxor43_0:
+        case rmm_cxor43_0:
             cxor43_0_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case RingModMode::rmm_cxor43_1:
+        case rmm_cxor43_1:
             cxor43_1_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case RingModMode::rmm_cxor43_2:
+        case rmm_cxor43_2:
             cxor43_2_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case RingModMode::rmm_cxor43_3:
+        case rmm_cxor43_3:
             cxor43_3_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case RingModMode::rmm_cxor43_4:
+        case rmm_cxor43_4:
             cxor43_4_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case RingModMode::rmm_cxor93_0:
+        case rmm_cxor93_0:
             cxor93_0_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case RingModMode::rmm_cxor93_1:
+        case rmm_cxor93_1:
             cxor93_1_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case RingModMode::rmm_cxor93_2:
+        case rmm_cxor93_2:
             cxor93_2_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case RingModMode::rmm_cxor93_3:
+        case rmm_cxor93_3:
             cxor93_3_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case RingModMode::rmm_cxor93_4:
+        case rmm_cxor93_4:
             cxor93_4_block(src1_l, src2_l, dst_l, nquads);
             break;
         }

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -854,47 +854,47 @@ inline void all_ring_modes_block(float *__restrict src1_l, float *__restrict src
     {
         switch (mode)
         {
-        case rmm_ring:
+        case RingModMode::rmm_ring:
             mech::mul_block<BLOCK_SIZE_OS>(src1_l, src2_l, dst_l);
             mech::mul_block<BLOCK_SIZE_OS>(src1_r, src2_r, dst_r);
             break;
-        case rmm_cxor43_0:
+        case RingModMode::rmm_cxor43_0:
             cxor43_0_block(src1_l, src2_l, dst_l, nquads);
             cxor43_0_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case rmm_cxor43_1:
+        case RingModMode::rmm_cxor43_1:
             cxor43_1_block(src1_l, src2_l, dst_l, nquads);
             cxor43_1_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case rmm_cxor43_2:
+        case RingModMode::rmm_cxor43_2:
             cxor43_2_block(src1_l, src2_l, dst_l, nquads);
             cxor43_2_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case rmm_cxor43_3:
+        case RingModMode::rmm_cxor43_3:
             cxor43_3_block(src1_l, src2_l, dst_l, nquads);
             cxor43_3_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case rmm_cxor43_4:
+        case RingModMode::rmm_cxor43_4:
             cxor43_4_block(src1_l, src2_l, dst_l, nquads);
             cxor43_4_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case rmm_cxor93_0:
+        case RingModMode::rmm_cxor93_0:
             cxor93_0_block(src1_l, src2_l, dst_l, nquads);
             cxor93_0_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case rmm_cxor93_1:
+        case RingModMode::rmm_cxor93_1:
             cxor93_1_block(src1_l, src2_l, dst_l, nquads);
             cxor93_1_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case rmm_cxor93_2:
+        case RingModMode::rmm_cxor93_2:
             cxor93_2_block(src1_l, src2_l, dst_l, nquads);
             cxor93_2_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case rmm_cxor93_3:
+        case RingModMode::rmm_cxor93_3:
             cxor93_3_block(src1_l, src2_l, dst_l, nquads);
             cxor93_3_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case rmm_cxor93_4:
+        case RingModMode::rmm_cxor93_4:
             cxor93_4_block(src1_l, src2_l, dst_l, nquads);
             cxor93_4_block(src1_r, src2_r, dst_r, nquads);
             break;
@@ -905,37 +905,37 @@ inline void all_ring_modes_block(float *__restrict src1_l, float *__restrict src
     {
         switch (mode)
         {
-        case rmm_ring:
+        case RingModMode::rmm_ring:
             mech::mul_block<BLOCK_SIZE_OS>(src1_l, src2_l, dst_l);
             break;
-        case rmm_cxor43_0:
+        case RingModMode::rmm_cxor43_0:
             cxor43_0_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case rmm_cxor43_1:
+        case RingModMode::rmm_cxor43_1:
             cxor43_1_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case rmm_cxor43_2:
+        case RingModMode::rmm_cxor43_2:
             cxor43_2_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case rmm_cxor43_3:
+        case RingModMode::rmm_cxor43_3:
             cxor43_3_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case rmm_cxor43_4:
+        case RingModMode::rmm_cxor43_4:
             cxor43_4_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case rmm_cxor93_0:
+        case RingModMode::rmm_cxor93_0:
             cxor93_0_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case rmm_cxor93_1:
+        case RingModMode::rmm_cxor93_1:
             cxor93_1_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case rmm_cxor93_2:
+        case RingModMode::rmm_cxor93_2:
             cxor93_2_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case rmm_cxor93_3:
+        case RingModMode::rmm_cxor93_3:
             cxor93_3_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case rmm_cxor93_4:
+        case RingModMode::rmm_cxor93_4:
             cxor93_4_block(src1_l, src2_l, dst_l, nquads);
             break;
         }

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -310,14 +310,6 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void enqueueFXChainClear(int fxchain);
     void swapFX(int source, int target, SurgeSynthesizer::FXReorderMode m);
 
-    // clang-format off
-    static int constexpr fxslot_order[n_fx_slots] = 
-        {fxslot_ains1,   fxslot_ains2,   fxslot_ains3,   fxslot_ains4,
-         fxslot_bins1,   fxslot_bins2,   fxslot_bins3,   fxslot_bins4,
-         fxslot_send1,   fxslot_send2,   fxslot_send3,   fxslot_send4,
-         fxslot_global1, fxslot_global2, fxslot_global3, fxslot_global4};
-    // clang-format on
-
     /*
     ** Callbacks from the Status Panel. If this gets to be too many perhaps make these an interface?
     */

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -516,31 +516,43 @@ th {
 span {
     margin-left: 16px;
 }
+
+code {
+    color: #dc3918;
+    font-size: 16px;
+    padding: 1px 0px;
+}
 </style>
   </head>
   <body style="margin: 0pt; background: #CDCED4;">
     <div style="border-bottom: 1px solid #123463; background: #ff9000; padding: 2pt;">
       <div style="font-size: 20pt; font-family: Lato; padding: 2pt; color:#123463;">
-        Surge XT parameters addressable by OSC
+        Surge XT Open Sound Control (OSC) Specification
       </div>
     </div>
 
     <div style="margin:10pt; padding: 5pt; border: 1px solid #123463; background: #fafbff;">
       <div style="font-size: 12pt; font-family: Lato; color: #123463;">
-        Construct OSC messages for Surge XT using the exact (case sensitive)
-        entry listed in the 'Address' column in the tables below.</br>
-        The form of the message should be <b>/param/&ltaddress&gt value</b>,
-        where 'value' is either
+        Construct OSC messages using the exact (case sensitive)
+        entry listed in the <b>Address</b> column in the tables below.</br>
+        The form of the message should be <code>/&ltsection&gt/&ltaddress&gt &ltvalue&gt</code>,
+        where <code>section</code> can currently be either <code>tuning</code> or <code>param</code>, and <code>value</code> can be:
+
         <ul>
-            <li>a floating point value between 0.0 and 1.0</li>
+            <li>a floating point value between <b>0.0</b> and <b>1.0</b></li>
             <li>an integer value</li>
-            <li>0 or 1 (boolean)</li>
-            <li>contextual: either an in integer or a float, depending on the context</li>
+            <li>a boolean value, <b>0</b> (false) or <b>1</b> (true)</li>
+            <li>contextual: either an in integer or a float, depending on the context (loaded oscillator or effect type)</li>
         </ul>
-        Where an address is listed as beginning with <b>'*'</b>, replace the <b>'*'</b> with either <b>'a'</b> or <b>'b'</b>,
-        depending on which scene you wish to address. E.g., 'a_drift' or 'b_drift'.
-        <p>Examples: <span><b>/param/volume 0.63</b></span>
-        <span><b>/param/polylimit 12</b></span><span><b>/param/a_mute_noise 0</b></span></p>
+
+        Where an address contains an asterisk <b>(*)</b>, replace the asterisk with either <b>a</b> or <b>b</b>,
+        depending on which scene you wish to address - e.g. <code>/a/drift</code> or <code>/b/drift</code>.
+
+        <p>Examples:
+            <span><code>/param/mixer/osc1/level 0.63</code></span>
+            <span><code>/param/global/polyphony_limit 12</code></span>
+            <span><code>/param/a_mute_noise 0</code></span>
+        </p>
       </div>
     </div>
 
@@ -554,14 +566,16 @@ span {
 
     for (auto *p : synth->storage.getPatch().param_ptr)
     {
-        st_str = p->getOSCName();
-        if (st_str[1] == '_')
+        st_str = p->get_osc_name();
+
+        if (st_str[6] == '/' && st_str[8] == '/')
         {
-            if (st_str[0] == 'b')
+            if (st_str[7] == 'b')
                 continue; // 'b_...' entries not added to vector
-            else if (st_str[0] == 'a')
+
+            else if (st_str[7] == 'a')
             {
-                st_str[0] = '*';
+                st_str[7] = '*';
             }
         }
         sortvector.push_back(oscParamInfo{p, st_str, p->get_full_name(), p->ctrlgroup});

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2376,104 +2376,92 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
                             contextMenu, "COMBINATOR MODE");
 
+                        contextMenu.addItem("Ring Modulation", true, dt == rmm_ring, [this, p]() {
+                            undoManager()->pushParameterChange(p->id, p, p->val);
+
+                            p->deform_type = rmm_ring, synth->storage.getPatch().isDirty = true;
+                            frame->repaint();
+                        });
                         contextMenu.addItem(
-                            "Ringmod (classic)", true, dt == RingModMode::rmm_ring, [this, p]() {
+                            "CXOR: cx4,3-bc-ba-bc-ba (0)", true, dt == rmm_cxor43_0, [this, p]() {
                                 undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                p->deform_type = RingModMode::rmm_ring,
+                                p->deform_type = rmm_cxor43_0,
                                 synth->storage.getPatch().isDirty = true;
                                 frame->repaint();
                             });
-                        contextMenu.addItem("CXOR: cx4,3-bc-ba-bc-ba (0)", true,
-                                            dt == RingModMode::rmm_cxor43_0, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
+                        contextMenu.addItem(
+                            "CXOR: cx4,3-bc-ba-ba-bc (1)", true, dt == rmm_cxor43_1, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                                p->deform_type = RingModMode::rmm_cxor43_0,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
-                        contextMenu.addItem("CXOR: cx4,3-bc-ba-ba-bc (1)", true,
-                                            dt == RingModMode::rmm_cxor43_1, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
+                                p->deform_type = rmm_cxor43_1,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                        contextMenu.addItem(
+                            "CXOR: cx4,3-bc-ba-aa-bc (2)", true, dt == rmm_cxor43_2, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                                p->deform_type = RingModMode::rmm_cxor43_1,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
-                        contextMenu.addItem("CXOR: cx4,3-bc-ba-aa-bc (2)", true,
-                                            dt == RingModMode::rmm_cxor43_2, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
+                                p->deform_type = rmm_cxor43_2,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                        contextMenu.addItem(
+                            "CXOR: cx4,3-bc-cc-ba-bc (3)", true, dt == rmm_cxor43_3, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                                p->deform_type = RingModMode::rmm_cxor43_2,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
-                        contextMenu.addItem("CXOR: cx4,3-bc-cc-ba-bc (3)", true,
-                                            dt == RingModMode::rmm_cxor43_3, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
+                                p->deform_type = rmm_cxor43_3,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                        contextMenu.addItem(
+                            "CXOR: cx4,3-bc-bc-ba-bc (4)", true, dt == rmm_cxor43_4, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                                p->deform_type = RingModMode::rmm_cxor43_3,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
-                        contextMenu.addItem("CXOR: cx4,3-bc-bc-ba-bc (4)", true,
-                                            dt == RingModMode::rmm_cxor43_4, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
+                                p->deform_type = rmm_cxor43_4,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                        contextMenu.addItem(
+                            "CXOR: cx9,3-cb-ab-cb-ab (0)", true, dt == rmm_cxor93_0, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                                p->deform_type = RingModMode::rmm_cxor43_4,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
-                        contextMenu.addItem("CXOR: cx9,3-cb-ab-cb-ab (0)", true,
-                                            dt == RingModMode::rmm_cxor93_0, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
+                                p->deform_type = rmm_cxor93_0,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                        contextMenu.addItem(
+                            "CXOR: cx9,3-bb-cc-bb-aa (1)", true, dt == rmm_cxor93_1, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                                p->deform_type = RingModMode::rmm_cxor93_0,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
-                        contextMenu.addItem("CXOR: cx9,3-bb-cc-bb-aa (1)", true,
-                                            dt == RingModMode::rmm_cxor93_1, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
+                                p->deform_type = rmm_cxor93_1,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                        contextMenu.addItem(
+                            "CXOR: cx9,3-cb-ba-aa-bb (2)", true, dt == rmm_cxor93_2, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                                p->deform_type = RingModMode::rmm_cxor93_1,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
-                        contextMenu.addItem("CXOR: cx9,3-cb-ba-aa-bb (2)", true,
-                                            dt == RingModMode::rmm_cxor93_2, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
+                                p->deform_type = rmm_cxor93_2,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                        contextMenu.addItem(
+                            "CXOR: cx9,3-cb-bb-aa-bb (3)", true, dt == rmm_cxor93_3, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                                p->deform_type = RingModMode::rmm_cxor93_2,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
-                        contextMenu.addItem("CXOR: cx9,3-cb-bb-aa-bb (3)", true,
-                                            dt == RingModMode::rmm_cxor93_3, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
+                                p->deform_type = rmm_cxor93_3,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
+                        contextMenu.addItem(
+                            "CXOR: cx9,3-cb-ab-ab-cc (4)", true, dt == rmm_cxor93_4, [this, p]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
 
-                                                p->deform_type = RingModMode::rmm_cxor93_3,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
-                        contextMenu.addItem("CXOR: cx9,3-cb-ab-ab-cc (4)", true,
-                                            dt == RingModMode::rmm_cxor93_4, [this, p]() {
-                                                undoManager()->pushParameterChange(p->id, p,
-                                                                                   p->val);
-
-                                                p->deform_type = RingModMode::rmm_cxor93_4,
-                                                synth->storage.getPatch().isDirty = true;
-                                                frame->repaint();
-                                            });
+                                p->deform_type = rmm_cxor93_4,
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
                     }
                     default:
                     {
@@ -2989,7 +2977,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
             {
                 contextMenu.addSeparator();
 
-                auto oscName = p->getOSCName();
+                auto oscName = p->get_osc_name();
 
                 auto i =
                     juce::PopupMenu::Item(fmt::format("OSC: {}", oscName))

--- a/src/surge-xt/gui/widgets/EffectChooser.cpp
+++ b/src/surge-xt/gui/widgets/EffectChooser.cpp
@@ -55,7 +55,7 @@ EffectChooser::EffectChooser() : juce::Component(), WidgetBaseMixin<EffectChoose
     {
         for (int i = 0; i < n_fx_slots; ++i)
         {
-            fxIndexToDisplayPosition[SurgeGUIEditor::fxslot_order[i]] = i;
+            fxIndexToDisplayPosition[fxslot_order[i]] = i;
         }
     }
     setRepaintsOnMouseActivity(true);
@@ -65,7 +65,7 @@ EffectChooser::EffectChooser() : juce::Component(), WidgetBaseMixin<EffectChoose
     for (int i = 0; i < n_fx_slots; ++i)
     {
         fxTypes[i] = fxt_off;
-        auto mapi = SurgeGUIEditor::fxslot_order[i];
+        auto mapi = fxslot_order[i];
         auto q =
             std::make_unique<OverlayAsAccessibleButton<EffectChooser>>(this, fxslot_names[mapi]);
         q->setBounds(getEffectRectangle(mapi));
@@ -185,7 +185,7 @@ void EffectChooser::resized()
     int i = 0;
     for (const auto &q : slotAccOverlays)
     {
-        q->setBounds(getEffectRectangle(SurgeGUIEditor::fxslot_order[i]));
+        q->setBounds(getEffectRectangle(fxslot_order[i]));
         i++;
     }
 }

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -440,7 +440,7 @@ void OscillatorMenu::populate()
         {
             menu.addSeparator();
 
-            auto oscName = storage->getPatch().scene[sc].osc[osc].type.getOSCName();
+            auto oscName = storage->getPatch().scene[sc].osc[osc].type.get_osc_name();
 
             auto i =
                 juce::PopupMenu::Item(fmt::format("OSC: {}", oscName))
@@ -858,7 +858,7 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
         {
             menu.addSeparator();
 
-            auto oscName = storage->getPatch().fx[sge->current_fx].type.getOSCName();
+            auto oscName = storage->getPatch().fx[sge->current_fx].type.get_osc_name();
 
             auto i =
                 juce::PopupMenu::Item(fmt::format("OSC: {}", oscName))


### PR DESCRIPTION
Sideeffect: Renamed Level parameter in mixer to Volume to be consistent with scene output and global volume params.

Also removed setOSCName() method and hasOSCName member, as a consequence. The way things are implemented here completely obsoleted this method.