### PR TITLE
Ignore playhead if it exists in standalone

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -490,7 +490,7 @@ void SurgeSynthProcessor::processBlockPlayhead()
 {
     auto playhead = getPlayHead();
 
-    if (playhead)
+    if (playhead && !(wrapperType == wrapperType_Standalone))
     {
         juce::AudioPlayHead::CurrentPositionInfo cp;
         playhead->getCurrentPosition(cp);


### PR DESCRIPTION
This makes any tempo syncable stuff work in standalone, and makes the Tempo field in VKB also work as expected.