### PR TITLE
Change the Audio Input Latency error

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1166,7 +1166,7 @@ class alignas(16) SurgeStorage
     enum ErrorType
     {
         GENERAL_ERROR = 1,
-        AUDIO_CONFIGURATION = 2,
+        AUDIO_INPUT_LATENCY_WARNING = 2,
     };
     void reportError(const std::string &msg, const std::string &title,
                      const ErrorType errorType = GENERAL_ERROR, bool reportToStdout = true);

--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -228,6 +228,8 @@ SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
     // add the bottom right corner resizer only for VST2
     setResizable(true, processor.wrapperType == juce::AudioProcessor::wrapperType_VST);
 
+    sge->audioLatencyNotified = processor.inputIsLatent;
+
     sge->open(nullptr);
 
     idleTimer = std::make_unique<IdleTimer>(this);

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -383,7 +383,7 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
                         "This can be avoided by setting the DAW to use fixed buffer sizes, if "
                         "possible.",
                         fmt::arg("sz", BLOCK_SIZE)),
-            "Audio Input Latency Activated", SurgeStorage::AUDIO_CONFIGURATION, false);
+            "Audio Input Latency Activated", SurgeStorage::AUDIO_INPUT_LATENCY_WARNING, false);
         inputIsLatent = true;
     }
 

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -430,8 +430,11 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
 
     // For non-block-size uniform blocks we need to lag input
     float inputLatentBuffer alignas(16)[2][BLOCK_SIZE];
+
+  public:
     bool inputIsLatent{false};
 
+  private:
     // Have we warned about bad configurations
     bool warnedAboutBadConfig{false};
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -565,10 +565,12 @@ void SurgeGUIEditor::idle()
 
         for (const auto &[msg, title, code] : cp)
         {
-            if (code == SurgeStorage::AUDIO_CONFIGURATION)
+            if (code == SurgeStorage::AUDIO_INPUT_LATENCY_WARNING)
             {
-                promptForOKCancelWithDontAskAgain(
-                    title, msg, Surge::Storage::DefaultKey::DontShowAudioErrorsAgain, []() {});
+                // promptForOKCancelWithDontAskAgain(
+                //     title, msg, Surge::Storage::DefaultKey::DontShowAudioErrorsAgain, []() {});
+                audioLatencyNotified = true;
+                frame->repaint();
             }
             else
             {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -130,6 +130,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void onSurgeError(const std::string &msg, const std::string &title,
                       const SurgeStorage::ErrorType &type) override;
 
+    std::atomic<bool> audioLatencyNotified{false};
+
     static int start_paramtag_value;
 
     void idle();

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -383,6 +383,15 @@ void OscillatorWaveformDisplay::paint(juce::Graphics &g)
     {
         drawEditorBox(g, customEditorActionLabel(customEditor == nullptr));
     }
+
+    if (sge && sge->audioLatencyNotified)
+    {
+        g.setColour(skin->getColor(Colors::Osc::Display::Wave));
+        g.setFont(skin->fontManager->getLatoAtSize(7));
+        auto lmsg = fmt::format("Input Delay: {} Samples", BLOCK_SIZE);
+        g.drawText(lmsg.c_str(), getLocalBounds().reduced(2, 2).translated(0, 10),
+                   juce::Justification::topLeft);
+    }
 }
 
 std::string OscillatorWaveformDisplay::getCurrentWavetableName()

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
@@ -71,7 +71,7 @@ struct OscillatorWaveformDisplay : public juce::Component,
 
     bool isMuted{false};
 
-    SurgeGUIEditor *sge;
+    SurgeGUIEditor *sge{nullptr};
     void setSurgeGUIEditor(SurgeGUIEditor *s) { sge = s; }
 
     void onOscillatorTypeChanged();


### PR DESCRIPTION
The Audio input latency message shipped with Surge 1.2.0 fired way too often to be useful to users, especially users who never use the feature. This retains the behavior (uneven blocks are latent and complete) but instead marks it on the input of audio in when latent.