### PR TITLE
Create a new option for overlays to not initial-grab keyboard focus.

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -441,6 +441,7 @@ void SurgeGUIEditor::showOverlay(OverlayTags olt,
     auto t = ol->getEnclosingParentTitle();
     auto r = ol->getEnclosingParentPosition();
     auto c = ol->getHasIndependentClose();
+    bool wantsInitialKeyboardFocus = ol->wantsInitialKeyboardFocus();
 
     std::function<void()> onClose = []() {};
     bool isModal = false;
@@ -510,7 +511,10 @@ void SurgeGUIEditor::showOverlay(OverlayTags olt,
         }
     }
 
-    getOverlayIfOpen(olt)->grabKeyboardFocus();
+    if (wantsInitialKeyboardFocus)
+    {
+        getOverlayIfOpen(olt)->grabKeyboardFocus();
+    }
 }
 
 void SurgeGUIEditor::closeOverlay(OverlayTags olt)

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -1243,6 +1243,8 @@ void Oscilloscope::visibilityChanged()
     }
 }
 
+bool Oscilloscope::wantsInitialKeyboardFocus() { return false; }
+
 // Lock for member variables must be held by the caller.
 void Oscilloscope::calculateSpectrumData()
 {

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -214,6 +214,7 @@ class Oscilloscope : public OverlayComponent,
     void resized() override;
     void updateDrawing();
     void visibilityChanged() override;
+    bool wantsInitialKeyboardFocus() override;
 
     void valueChanged(GUI::IComponentTagValue *p) override{};
     int32_t controlModifierClicked(Surge::GUI::IComponentTagValue *pControl,

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -51,6 +51,9 @@ struct OverlayComponent : juce::Component
     virtual bool shouldRepaintOnParamChange(const SurgePatch &, Parameter *p) { return true; }
     virtual void forceDataRefresh() {}
 
+    // For A11Y: should the overlay be granted keyboard focus as soon as it appears.
+    virtual bool wantsInitialKeyboardFocus() { return true; }
+
     /*
      * This is called when a parent wrapper finally decides to show me, which will
      * be after I am added visibly to a hidden element. Basically use it to grab focus.


### PR DESCRIPTION
Exempt the oscilloscope from initial-grab keyboard focus.

Fixes #6927 