### PR TITLE
Supress the Input Latency on OSC other than AudioIn

### DIFF
--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -384,7 +384,8 @@ void OscillatorWaveformDisplay::paint(juce::Graphics &g)
         drawEditorBox(g, customEditorActionLabel(customEditor == nullptr));
     }
 
-    if (sge && sge->audioLatencyNotified)
+    // Display the latency message in audio input.
+    if (sge && sge->audioLatencyNotified && oscdata->type.val.i == ot_audioinput)
     {
         g.setColour(skin->getColor(Colors::Osc::Display::Wave));
         g.setFont(skin->fontManager->getLatoAtSize(7));


### PR DESCRIPTION
Which should have been in 1.2.1. Sigh.