### PR TITLE
fix: include correct headers for gcc 13

### DIFF
--- a/src/common/SkinColors.h
+++ b/src/common/SkinColors.h
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 /*
  * For a discussion of why this is in src/common rather than src/common/gui


### PR DESCRIPTION
Due to changes in upstream [gcc][0], surge no longer builds from source (a.k.a. FTBFS).

This patch adds the required headers throughout the project, thankfully it is only one location!

[0]: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes