### PR TITLE
Use custom alert window for deleting user patches (#5663)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ Jarkko Sakkinen <jarkko.sakkinen@iki.fi>
 Jeremy Sagan <info@sagantech.biz>
 Chad Scarborough <github:ChadScarborough>
 Sebastian Schwarzhuber <https://github.com/cannero>
+Tejas Singh <https://github.com/tejas1993>
 Jeff Smith <whydoubt@gmail.com>
 Jon Spruyt <http://jonspru.yt>
 Phil Stone <https://github.com/pkstone/>

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -111,6 +111,8 @@ target_sources(${PROJECT_NAME} PRIVATE
   gui/overlays/MSEGEditor.h
   gui/overlays/MiniEdit.cpp
   gui/overlays/MiniEdit.h
+  gui/overlays/Alert.cpp
+  gui/overlays/Alert.h
   gui/overlays/ModulationEditor.cpp
   gui/overlays/ModulationEditor.h
   gui/overlays/Oscilloscope.cpp

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -43,6 +43,7 @@
 
 #include "overlays/AboutScreen.h"
 #include "overlays/MiniEdit.h"
+#include "overlays/Alert.h"
 #include "overlays/MSEGEditor.h"
 #include "overlays/LuaEditors.h"
 #include "overlays/ModulationEditor.h"
@@ -5516,6 +5517,22 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
     miniEdit->toFront(true);
     miniEdit->setFocusReturnTarget(returnFocusTo);
     miniEdit->grabFocus();
+}
+
+
+void SurgeGUIEditor::alertWindow(const std::string &title, const std::string &prompt,
+                                std::function<void()> onOk)
+{
+    alert = std::make_unique<Surge::Overlays::Alert>();
+    alert->setSkin(currentSkin, bitmapStore);
+    alert->setDescription(title);
+    alert->setWindowTitle(title);
+    addAndMakeVisibleWithTracking(frame.get(), *alert);
+    alert->setLabel(prompt);
+    alert->onOk = std::move(onOk);
+    alert->setBounds(0, 0, getWindowSizeX(), getWindowSizeY());
+    alert->setVisible(true);
+    alert->toFront(true);
 }
 
 bool SurgeGUIEditor::modSourceButtonDraggedOver(Surge::Widgets::ModulationSourceButton *msb,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -5519,9 +5519,8 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
     miniEdit->grabFocus();
 }
 
-
-void SurgeGUIEditor::alertWindow(const std::string &title, const std::string &prompt,
-                                std::function<void()> onOk)
+void SurgeGUIEditor::alertOKCancel(const std::string &title, const std::string &prompt,
+                                   std::function<void()> onOk)
 {
     alert = std::make_unique<Surge::Overlays::Alert>();
     alert->setSkin(currentSkin, bitmapStore);

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -828,8 +828,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool getUseKeyboardShortcuts();
     void setUseKeyboardShortcuts(bool b);
     void toggleUseKeyboardShortcuts();
-    void alertWindow(const std::string &title, const std::string &prompt,
-                std::function<void()> onOk);
+    void alertOKCancel(const std::string &title, const std::string &prompt,
+                       std::function<void()> onOk);
 
     std::unique_ptr<Surge::Overlays::Alert> alert;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -85,6 +85,7 @@ namespace Overlays
 struct AboutScreen;
 struct TypeinParamEditor;
 struct MiniEdit;
+struct Alert;
 
 struct OverlayWrapper;
 struct PatchStoreDialog;
@@ -827,6 +828,10 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool getUseKeyboardShortcuts();
     void setUseKeyboardShortcuts(bool b);
     void toggleUseKeyboardShortcuts();
+    void alertWindow(const std::string &title, const std::string &prompt,
+                std::function<void()> onOk);
+
+    std::unique_ptr<Surge::Overlays::Alert> alert;
 
     std::unique_ptr<juce::AlertWindow> okcWithToggleAlertWindow;
     std::unique_ptr<juce::ToggleButton> okcWithToggleToggleButton;

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -48,7 +48,7 @@ Alert::~Alert() {}
 
 juce::Rectangle<int> Alert::getDisplayRegion()
 {
-    return juce::Rectangle<int>(0, 0, 360, 90).withCentre(getBounds().getCentre());
+    return juce::Rectangle<int>(0, 0, 360, 95).withCentre(getBounds().getCentre());
 }
 
 void Alert::paint(juce::Graphics &g)
@@ -89,8 +89,7 @@ void Alert::paint(juce::Graphics &g)
     g.fillRect(bodyRect);
     g.setColour(skin->getColor(Colors::Dialog::Label::Text));
     g.setFont(skin->fontManager->getLatoAtSize(9));
-    g.drawFittedText(label, bodyRect.withTrimmedLeft(2).withTrimmedRight(2),
-                     juce::Justification::centredTop, 4);
+    g.drawFittedText(label, bodyRect.reduced(6), juce::Justification::centredTop, 4);
 
     g.setColour(skin->getColor(Colors::Dialog::Border));
     g.drawRect(fullRect.expanded(1), 2);

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -1,0 +1,121 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#include "Alert.h"
+#include "widgets/SurgeTextButton.h"
+#include "SurgeImageStore.h"
+#include "RuntimeFont.h"
+#include "SurgeImage.h"
+
+namespace Surge
+{
+namespace Overlays
+{
+Alert::Alert()
+{
+
+    okButton = std::make_unique<Surge::Widgets::SurgeTextButton>("alertOk");
+    okButton->setButtonText("OK");
+    okButton->addListener(this);
+    addAndMakeVisible(*okButton);
+
+    cancelButton = std::make_unique<Surge::Widgets::SurgeTextButton>("alertCancel");
+    cancelButton->setButtonText("Cancel");
+    cancelButton->addListener(this);
+    addAndMakeVisible(*cancelButton);
+}
+
+Alert::~Alert() {}
+
+juce::Rectangle<int> Alert::getDisplayRegion()
+{
+    return juce::Rectangle<int>(0, 0, 360, 90).withCentre(getBounds().getCentre());
+}
+
+void Alert::paint(juce::Graphics &g)
+{
+    if (!skin || !associatedBitmapStore)
+    {
+        g.fillAll(juce::Colours::red);
+        return;
+    }
+
+    g.fillAll(skin->getColor(Colors::Overlay::Background));
+
+    auto fullRect = getDisplayRegion();
+
+    auto tbRect = fullRect.withHeight(18);
+
+    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Background));
+    g.fillRect(tbRect);
+    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Text));
+    g.setFont(skin->fontManager->getLatoAtSize(10, juce::Font::bold));
+    g.drawText(title, tbRect, juce::Justification::centred);
+
+    auto icon = associatedBitmapStore->getImage(IDB_SURGE_ICON);
+
+    if (icon)
+    {
+        const auto iconSize = 14;
+#if MAC
+        icon->drawAt(g, fullRect.getRight() - iconSize + 2, fullRect.getY() + 1, 1);
+#else
+        icon->drawAt(g, fullRect.getX() + 2, fullRect.getY() + 1, 1);
+#endif
+    }
+
+    auto bodyRect = fullRect.withTrimmedTop(18);
+
+    g.setColour(skin->getColor(Colors::Dialog::Background));
+    g.fillRect(bodyRect);
+    g.setColour(skin->getColor(Colors::Dialog::Label::Text));
+    g.setFont(skin->fontManager->getLatoAtSize(9));
+    g.drawFittedText(label, bodyRect.withTrimmedLeft(2).withTrimmedRight(2),
+                     juce::Justification::centredTop, 4);
+
+    g.setColour(skin->getColor(Colors::Dialog::Border));
+    g.drawRect(fullRect.expanded(1), 2);
+
+    auto buttonRowRect = fullRect.withHeight(17).translated(0, 72);
+
+    okButton->setBounds(buttonRowRect.withWidth(50).translated(80, 0));
+    cancelButton->setBounds(buttonRowRect.withWidth(50).translated(230, 0));
+}
+
+void Alert::onSkinChanged()
+{
+    okButton->setSkin(skin, associatedBitmapStore);
+    cancelButton->setSkin(skin, associatedBitmapStore);
+
+    repaint();
+}
+
+void Alert::buttonClicked(juce::Button *button)
+{
+    if (button == okButton.get())
+    {
+        onOk();
+    }
+    setVisible(false);
+}
+} // namespace Overlays
+} // namespace Surge

--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -1,0 +1,62 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+#include "SkinSupport.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
+
+namespace Surge
+{
+
+namespace Widgets
+{
+struct SurgeTextButton;
+}
+
+namespace Overlays
+{
+
+struct Alert : public juce::Component,
+               public Surge::GUI::SkinConsumingComponent,
+               public juce::Button::Listener
+{
+
+    Alert();
+    ~Alert();
+
+    std::string title, label;
+    std::unique_ptr<Surge::Widgets::SurgeTextButton> okButton;
+    std::unique_ptr<Surge::Widgets::SurgeTextButton> cancelButton;
+    void setWindowTitle(const std::string &t)
+    {
+        title = t;
+        setTitle(title);
+    }
+    void setLabel(const std::string &t) { label = t; }
+    std::function<void()> onOk;
+    void paint(juce::Graphics &g) override;
+    void onSkinChanged() override;
+    void buttonClicked(juce::Button *button) override;
+    juce::Rectangle<int> getDisplayRegion();
+};
+
+} // namespace Overlays
+} // namespace Surge

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -701,22 +701,18 @@ void PatchSelector::showClassicMenu(bool single_category)
                     });
             });
 
-            contextMenu.addItem(Surge::GUI::toOSCase("Delete Patch"), [this]() {
-                auto cb = juce::ModalCallbackFunction::create([this](int okcs) {
-                    if (okcs)
-                    {
-                        fs::remove(storage->patch_list[current_patch].path);
-                        storage->refresh_patchlist();
-                        storage->initializePatchDb(true);
-                    }
-                });
+            contextMenu.addItem(Surge::GUI::toOSCase("Delete Patch"), [this, sge]() {
 
-                juce::AlertWindow::showOkCancelBox(
-                    juce::AlertWindow::NoIcon, "Delete Patch",
-                    std::string("Do you really want to delete\n") +
+                auto onOk = [this] () {
+                    fs::remove(storage->patch_list[current_patch].path);
+                    storage->refresh_patchlist();
+                    storage->initializePatchDb(true);
+                    isUser = false;
+                };
+
+                sge->alertWindow("Delete Patch", std::string("Do you really want to delete\n") +
                         storage->patch_list[current_patch].path.u8string() +
-                        "?\n\nThis cannot be undone!",
-                    "Yes", "No", nullptr, cb);
+                        "?\n\nThis cannot be undone!", onOk);
             });
         }
 

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -1378,14 +1378,14 @@ class PatchSelectorAH : public juce::AccessibilityHandler
 {
   public:
     explicit PatchSelectorAH(PatchSelector *sel)
-        : selector(sel),
-          juce::AccessibilityHandler(*sel, juce::AccessibilityRole::label,
-                                     juce::AccessibilityActions()
-                                         .addAction(juce::AccessibilityActionType::press,
-                                                    [sel] { sel->showClassicMenu(); })
-                                         .addAction(juce::AccessibilityActionType::showMenu,
-                                                    [sel] { sel->showClassicMenu(); }),
-                                     {std::make_unique<PatchSelectorValueInterface>(sel)})
+        : selector(sel), juce::AccessibilityHandler(
+                             *sel, juce::AccessibilityRole::label,
+                             juce::AccessibilityActions()
+                                 .addAction(juce::AccessibilityActionType::press,
+                                            [sel] { sel->showClassicMenu(); })
+                                 .addAction(juce::AccessibilityActionType::showMenu,
+                                            [sel] { sel->showClassicMenu(); }),
+                             {std::make_unique<PatchSelectorValueInterface>(sel)})
     {
     }
 


### PR DESCRIPTION
Following up from discord, as a first step for https://github.com/surge-synthesizer/surge/issues/5663 . I figured we could start with a single use case and migrate the rest after.  I used MiniEdit as a guide for Alert. 

Since it's my first pull request for surge, let me know if there's any process I haven't followed. Attached screenshot of the alert box.

Testing: 
User testing by creating/deleting patches multiple times. Checked functionality for both Okay and Cancel. 

![Surge Delete Patch Alert](https://github.com/surge-synthesizer/surge/assets/5881947/dcbb5bdf-e10a-4ecc-8c5a-8536587d78c1)
