### PR TITLE
Adjust positioning of OK/Cancel buttons for consistency

### DIFF
--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -62,7 +62,7 @@ void Alert::paint(juce::Graphics &g)
     g.fillAll(skin->getColor(Colors::Overlay::Background));
 
     auto fullRect = getDisplayRegion();
-
+    auto dialogCenter = fullRect.getWidth() / 2;
     auto tbRect = fullRect.withHeight(18);
 
     g.setColour(skin->getColor(Colors::Dialog::Titlebar::Background));
@@ -93,11 +93,21 @@ void Alert::paint(juce::Graphics &g)
 
     g.setColour(skin->getColor(Colors::Dialog::Border));
     g.drawRect(fullRect.expanded(1), 2);
+}
 
-    auto buttonRowRect = fullRect.withHeight(17).translated(0, 72);
+void Alert::resized()
+{
+    auto margin = 2, btnHeight = 17, btnWidth = 50;
 
-    okButton->setBounds(buttonRowRect.withWidth(50).translated(80, 0));
-    cancelButton->setBounds(buttonRowRect.withWidth(50).translated(230, 0));
+    auto fullRect = getDisplayRegion();
+    auto dialogCenter = fullRect.getWidth() / 2;
+
+    auto buttonRow = fullRect.withHeight(btnHeight).translated(0, 70);
+    auto okRect = buttonRow.withTrimmedLeft(dialogCenter - btnWidth - margin).withWidth(btnWidth);
+    auto canRect = buttonRow.withTrimmedLeft(dialogCenter + margin).withWidth(btnWidth);
+
+    okButton->setBounds(okRect);
+    cancelButton->setBounds(canRect);
 }
 
 void Alert::onSkinChanged()

--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -53,6 +53,7 @@ struct Alert : public juce::Component,
     void setLabel(const std::string &t) { label = t; }
     std::function<void()> onOk;
     void paint(juce::Graphics &g) override;
+    void resized() override;
     void onSkinChanged() override;
     void buttonClicked(juce::Button *button) override;
     juce::Rectangle<int> getDisplayRegion();

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -325,10 +325,12 @@ void PatchStoreDialog::resized()
     auto h = 25;
     auto commH = getHeight() - (6 + showTagsField) * h + 8;
     auto xSplit = 70;
+    auto buttonHeight = 17;
     auto buttonWidth = 50;
     auto margin = 4;
     auto margin2 = 2;
     auto r = getLocalBounds().withHeight(h);
+    auto dialogCenter = getLocalBounds().getWidth() / 2;
     auto ce = r.withTrimmedLeft(xSplit)
                   .withTrimmedRight(margin2 * 3)
                   .reduced(margin)
@@ -364,15 +366,18 @@ void PatchStoreDialog::resized()
     commentEd->setBounds(q);
     ce = ce.translated(0, commH);
 
-    auto be = ce.withWidth(buttonWidth).withRightX(ce.getRight()).translated(0, margin2 * 3);
-    cancelButton->setBounds(be);
-    be = be.translated(-buttonWidth - margin, 0);
+    auto buttonRow = getLocalBounds().withHeight(buttonHeight).withY(ce.getY() + (margin2 * 3));
+
+    auto be =
+        buttonRow.withTrimmedLeft(dialogCenter - buttonWidth - margin2).withWidth(buttonWidth);
     okButton->setBounds(be);
+    be = buttonRow.withTrimmedLeft(dialogCenter + margin2).withWidth(buttonWidth);
+    cancelButton->setBounds(be);
 
     if (okOverButton->isVisible())
     {
-        be = be.translated(-buttonWidth - (margin * 2), 0);
-        okOverButton->setBounds(be.withLeft(be.getX() - buttonWidth));
+        be = ce.withWidth(buttonWidth * 2).withRightX(ce.getRight()).translated(0, margin2 * 3);
+        okOverButton->setBounds(be);
     }
 
     auto cl = r.withRight(xSplit).reduced(2).translated(0, margin2 * 3);


### PR DESCRIPTION
Small continuation of #7037, bringing OK/Cancel buttons in Alert dialog closer together to match MiniEdit. Center OK/Cancel buttons in Save Patch dialog, too.