### PR TITLE
Migrate no icon alerts in SurgeGUIEditor and add OverlayUtils for drawing windows

### DIFF
--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -113,6 +113,8 @@ target_sources(${PROJECT_NAME} PRIVATE
   gui/overlays/MiniEdit.h
   gui/overlays/Alert.cpp
   gui/overlays/Alert.h
+  gui/overlays/OverlayUtils.h
+  gui/overlays/OverlayUtils.cpp
   gui/overlays/ModulationEditor.cpp
   gui/overlays/ModulationEditor.h
   gui/overlays/Oscilloscope.cpp

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -5520,7 +5520,7 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
 }
 
 void SurgeGUIEditor::alertOKCancel(const std::string &title, const std::string &prompt,
-                                   std::function<void()> onOk)
+                                   std::function<void()> onOk, AlertButtonStyle buttonStyle)
 {
     alert = std::make_unique<Surge::Overlays::Alert>();
     alert->setSkin(currentSkin, bitmapStore);
@@ -5528,6 +5528,14 @@ void SurgeGUIEditor::alertOKCancel(const std::string &title, const std::string &
     alert->setWindowTitle(title);
     addAndMakeVisibleWithTracking(frame.get(), *alert);
     alert->setLabel(prompt);
+    if (buttonStyle == AlertButtonStyle::YES_NO)
+    {
+        alert->setButtonText("Yes", "No");
+    }
+    else
+    {
+        alert->setButtonText("OK", "Cancel");
+    }
     alert->onOk = std::move(onOk);
     alert->setBounds(0, 0, getWindowSizeX(), getWindowSizeY());
     alert->setVisible(true);
@@ -6686,7 +6694,7 @@ bool SurgeGUIEditor::onDrop(const std::string &fname)
                 std::cout << "Could not find the skin after loading!" << std::endl;
             }
         };
-        alertOKCancel("Install Skin", oss.str(), cb);
+        alertOKCancel("Install Skin", oss.str(), cb, AlertButtonStyle::YES_NO);
     }
     else if (fExt == ".zip")
     {
@@ -6785,7 +6793,7 @@ bool SurgeGUIEditor::onDrop(const std::string &fname)
             }
         };
 
-        alertOKCancel("Install from ZIP archive", oss.str(), cb);
+        alertOKCancel("Install from ZIP archive", oss.str(), cb, AlertButtonStyle::YES_NO);
     }
     return true;
 }

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -828,8 +828,14 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool getUseKeyboardShortcuts();
     void setUseKeyboardShortcuts(bool b);
     void toggleUseKeyboardShortcuts();
+
+    enum AlertButtonStyle
+    {
+        OK_CANCEL,
+        YES_NO
+    };
     void alertOKCancel(const std::string &title, const std::string &prompt,
-                       std::function<void()> onOk);
+                       std::function<void()> onOk, AlertButtonStyle buttonStyle = OK_CANCEL);
 
     std::unique_ptr<Surge::Overlays::Alert> alert;
 

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -33,14 +33,11 @@ namespace Overlays
 {
 Alert::Alert()
 {
-
     okButton = std::make_unique<Surge::Widgets::SurgeTextButton>("alertOk");
-    okButton->setButtonText("OK");
     okButton->addListener(this);
     addAndMakeVisible(*okButton);
 
     cancelButton = std::make_unique<Surge::Widgets::SurgeTextButton>("alertCancel");
-    cancelButton->setButtonText("Cancel");
     cancelButton->addListener(this);
     addAndMakeVisible(*cancelButton);
 }

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -25,6 +25,7 @@
 #include "SurgeImageStore.h"
 #include "RuntimeFont.h"
 #include "SurgeImage.h"
+#include "OverlayUtils.h"
 
 namespace Surge
 {
@@ -53,46 +54,12 @@ juce::Rectangle<int> Alert::getDisplayRegion()
 
 void Alert::paint(juce::Graphics &g)
 {
-    if (!skin || !associatedBitmapStore)
-    {
-        g.fillAll(juce::Colours::red);
-        return;
-    }
-
-    g.fillAll(skin->getColor(Colors::Overlay::Background));
-
     auto fullRect = getDisplayRegion();
-    auto dialogCenter = fullRect.getWidth() / 2;
-    auto tbRect = fullRect.withHeight(18);
-
-    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Background));
-    g.fillRect(tbRect);
-    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Text));
-    g.setFont(skin->fontManager->getLatoAtSize(10, juce::Font::bold));
-    g.drawText(title, tbRect, juce::Justification::centred);
-
-    auto icon = associatedBitmapStore->getImage(IDB_SURGE_ICON);
-
-    if (icon)
-    {
-        const auto iconSize = 14;
-#if MAC
-        icon->drawAt(g, fullRect.getRight() - iconSize + 2, fullRect.getY() + 1, 1);
-#else
-        icon->drawAt(g, fullRect.getX() + 2, fullRect.getY() + 1, 1);
-#endif
-    }
-
-    auto bodyRect = fullRect.withTrimmedTop(18);
-
-    g.setColour(skin->getColor(Colors::Dialog::Background));
-    g.fillRect(bodyRect);
+    paintOverlayWindow(g, skin, associatedBitmapStore, fullRect, title);
     g.setColour(skin->getColor(Colors::Dialog::Label::Text));
     g.setFont(skin->fontManager->getLatoAtSize(9));
-    g.drawFittedText(label, bodyRect.reduced(6), juce::Justification::centredTop, 4);
-
-    g.setColour(skin->getColor(Colors::Dialog::Border));
-    g.drawRect(fullRect.expanded(1), 2);
+    g.drawFittedText(label, fullRect.withTrimmedTop(18).reduced(6), juce::Justification::centredTop,
+                     4);
 }
 
 void Alert::resized()

--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -20,16 +20,11 @@
  * https://github.com/surge-synthesizer/surge
  */
 #include "SkinSupport.h"
-
+#include "widgets/SurgeTextButton.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 
 namespace Surge
 {
-
-namespace Widgets
-{
-struct SurgeTextButton;
-}
 
 namespace Overlays
 {
@@ -51,6 +46,11 @@ struct Alert : public juce::Component,
         setTitle(title);
     }
     void setLabel(const std::string &t) { label = t; }
+    void setButtonText(const juce::String &okText, const juce::String &cancelText)
+    {
+        okButton->setButtonText(okText);
+        cancelButton->setButtonText(cancelText);
+    }
     std::function<void()> onOk;
     void paint(juce::Graphics &g) override;
     void resized() override;

--- a/src/surge-xt/gui/overlays/MiniEdit.cpp
+++ b/src/surge-xt/gui/overlays/MiniEdit.cpp
@@ -28,6 +28,7 @@
 #include "SurgeGUIEditor.h"
 #include "widgets/SurgeTextButton.h"
 #include "AccessibleHelpers.h"
+#include "OverlayUtils.h"
 
 namespace Surge
 {
@@ -68,51 +69,10 @@ juce::Rectangle<int> MiniEdit::getDisplayRegion()
 
 void MiniEdit::paint(juce::Graphics &g)
 {
-    if (!skin || !associatedBitmapStore)
-    {
-        // This is a software error obvs
-        g.fillAll(juce::Colours::red);
-        return;
-    }
-
-    g.fillAll(skin->getColor(Colors::Overlay::Background));
-
     auto fullRect = getDisplayRegion();
-
-    auto tbRect = fullRect.withHeight(18);
-
-    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Background));
-    g.fillRect(tbRect);
-    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Text));
-    g.setFont(skin->fontManager->getLatoAtSize(10, juce::Font::bold));
-    g.drawText(title, tbRect, juce::Justification::centred);
-
-    auto icon = associatedBitmapStore->getImage(IDB_SURGE_ICON);
-
-    if (icon)
-    {
-        const auto iconSize = 14;
-#if MAC
-        icon->drawAt(g, fullRect.getRight() - iconSize + 2, fullRect.getY() + 1, 1);
-#else
-        icon->drawAt(g, fullRect.getX() + 2, fullRect.getY() + 1, 1);
-#endif
-    }
-
-    auto bodyRect = fullRect.withTrimmedTop(18);
-
-    g.setColour(skin->getColor(Colors::Dialog::Background));
-    g.fillRect(bodyRect);
-
-    g.setColour(skin->getColor(Colors::Dialog::Label::Text));
-    g.setFont(skin->fontManager->getLatoAtSize(9));
-
-    auto labelRect = bodyRect.withHeight(20).reduced(6, 0);
-
+    paintOverlayWindow(g, skin, associatedBitmapStore, fullRect, title);
+    auto labelRect = fullRect.withTrimmedTop(18).withHeight(20).reduced(6, 0);
     g.drawText(label, labelRect, juce::Justification::centredLeft);
-
-    g.setColour(skin->getColor(Colors::Dialog::Border));
-    g.drawRect(fullRect.expanded(1), 2);
 }
 
 void MiniEdit::onSkinChanged()

--- a/src/surge-xt/gui/overlays/OverlayUtils.cpp
+++ b/src/surge-xt/gui/overlays/OverlayUtils.cpp
@@ -1,0 +1,76 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#include "OverlayUtils.h"
+#include "widgets/SurgeTextButton.h"
+#include "SurgeImageStore.h"
+#include "RuntimeFont.h"
+#include "SurgeImage.h"
+
+namespace Surge
+{
+namespace Overlays
+{
+
+void paintOverlayWindow(juce::Graphics &g, std::shared_ptr<GUI::Skin> skin,
+                        std::shared_ptr<SurgeImageStore> associatedBitmapStore,
+                        juce::Rectangle<int> displayRegion, std::string title)
+{
+
+    if (!skin || !associatedBitmapStore)
+    {
+        g.fillAll(juce::Colours::red);
+        return;
+    }
+
+    g.fillAll(skin->getColor(Colors::Overlay::Background));
+    auto tbRect = displayRegion.withHeight(18);
+
+    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Background));
+    g.fillRect(tbRect);
+    g.setColour(skin->getColor(Colors::Dialog::Titlebar::Text));
+    g.setFont(skin->fontManager->getLatoAtSize(10, juce::Font::bold));
+    g.drawText(title, tbRect, juce::Justification::centred);
+
+    auto icon = associatedBitmapStore->getImage(IDB_SURGE_ICON);
+
+    if (icon)
+    {
+        const auto iconSize = 14;
+#if MAC
+        icon->drawAt(g, displayRegion.getRight() - iconSize + 2, displayRegion.getY() + 1, 1);
+#else
+        icon->drawAt(g, displayRegion.getX() + 2, displayRegion.getY() + 1, 1);
+#endif
+    }
+
+    auto bodyRect = displayRegion.withTrimmedTop(18);
+
+    g.setColour(skin->getColor(Colors::Dialog::Background));
+    g.fillRect(bodyRect);
+
+    g.setColour(skin->getColor(Colors::Dialog::Border));
+    g.drawRect(displayRegion.expanded(1), 2);
+}
+
+} // namespace Overlays
+} // namespace Surge

--- a/src/surge-xt/gui/overlays/OverlayUtils.h
+++ b/src/surge-xt/gui/overlays/OverlayUtils.h
@@ -1,0 +1,37 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#include "SkinSupport.h"
+#include "juce_gui_basics/juce_gui_basics.h"
+
+namespace Surge
+{
+
+namespace Overlays
+{
+
+void paintOverlayWindow(juce::Graphics &g, std::shared_ptr<GUI::Skin> skin,
+                        std::shared_ptr<SurgeImageStore> associatedBitmapStore,
+                        juce::Rectangle<int> displayRegion, std::string title);
+
+}
+} // namespace Surge

--- a/src/surge-xt/gui/overlays/OverlayUtils.h
+++ b/src/surge-xt/gui/overlays/OverlayUtils.h
@@ -20,6 +20,9 @@
  * https://github.com/surge-synthesizer/surge
  */
 
+#ifndef SURGE_SRC_SURGE_XT_GUI_OVERLAYS_OVERLAYUTILS_H
+#define SURGE_SRC_SURGE_XT_GUI_OVERLAYS_OVERLAYUTILS_H
+
 #include "SkinSupport.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -35,3 +38,5 @@ void paintOverlayWindow(juce::Graphics &g, std::shared_ptr<GUI::Skin> skin,
 
 }
 } // namespace Surge
+
+#endif


### PR DESCRIPTION
Following up on https://github.com/surge-synthesizer/surge/pull/7037 
Moving a couple more alertOkCancels to the custom overlay and adding utility for the code to draw the window as discussed in the above pull request. Having the Alert and MiniEdit overlays use this - though subsequently other overlays may use this as well. My preference for the implementation of this is as a utility method, but I'm happy to add an abstraction layer instead if you prefer. We could also add more common code for buttons etc to this in the next PRs.

Questions:

1. Thoughts on standardizing between "Ok"/"Cancel" and "Yes"/"No" for these? This PR uses only the former - if we want to definitely allow both, I'll update this PR. 
2. Could you point me to how to test all the changes for this? I love this synth but I am new to it so I've never used the functionality this PR edits. 

Additionally - I'll be travelling starting tomorrow mid-day Seattle/US time and will be back Monday. So it will be difficult for me to contribute during this time. Next week however, I should be able to continue work on this and look at some of the short circuit work pointed to in discord. 