### PR TITLE
More explicit PI32 bail out; tweak README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,26 @@ endif()
 
 # }}}
 
+# Fail on 32 bit except on windows {{{
+if (${CMAKE_SIZEOF_VOID_P} EQUAL 4)
+  if (WIN32)
+    message(STATUS "Windows 32 bit build is lightly tested")
+  else()
+    # If you hit this error and want to try and do a 32 bit build on your Linux variant
+    # most likely you will need to conditionally ifdef out the Spring Reverb and a few
+    # things. We would happily merge that conditional compilation. The straztegy is basically
+    # add a 'is 32 bit linux' compile flag to surge common, use that to make the SpringReverb
+    # a nullptr in Effects.cpp and skipped code in the C++, test. etc... The branch where you
+    # can add this flag is where we add the -msse2 flag in the GNU/CLang branch below, to get
+    # started
+    message(WARNING "32 Bit Builds are only available on Windows.")
+    message(WARNING "If you are building on an r-pi, install a 64 bit OS.")
+    message(WARNING "If you want to help fix this, see the comment in CMakeLists.txt.")
+    message(FATAL_ERROR "Stopping compilation")
+  endif()
+endif()
+# }}}
+
 # Global compiler/linker settings {{{
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -193,11 +193,13 @@ To build a fat binary on a Mac, simply add the following CMake argument to your 
 ### Building for Raspberry Pi
 
 SurgeXT builds natively on a RaspberryPI on 64 bit operating systems. Install your compiler
-toolchain and run the standard cmake commands.
+toolchain and run the standard cmake commands. SurgeXT will *not* build on 32 bit raspberry pi
+systems, giving an error in the Spring Reverb and elsewhere in DSP code. If you would like to work
+on fixing this, see the comment in CMakeLists.txt or drop on our discord or github.
 
-As of June 2023, though, the gcc in some raspbian distributions has a bug which generates a
+As of June 2023, though, the gcc in some distributions has an apparent bug which generates a
 specious warning which we promote to an error. We found Surge compiles cleanly with
-`gcc (Debian 10.2.1-6) 10.2.1 20210110` but not with `gcc version 10.2.1 20210110 (Raspbian 10.2.1-6+rpi1)`.
+`gcc (Debian 10.2.1-6) 10.2.1 20210110` but not with others.
 Surge also compiles with clang 11. The error in question takes the form
 
 ```


### PR DESCRIPTION
If you are on 32 bit and not on windows, fatal error in the CMake