### PR TITLE
Various parameter and naming adjustments for Bonsai

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,55 +1,55 @@
-[submodule "libs/tuning-library"]
-	path = libs/tuning-library
-	url = https://github.com/surge-synthesizer/tuning-library
-[submodule "libs/simde"]
-	path = libs/simde
-	url = https://github.com/simd-everywhere/simde
-[submodule "libs/pybind11"]
-	path = libs/pybind11
-	url = https://github.com/pybind/pybind11
+[submodule "libs/clap-juce-extensions"]
+	path = libs/clap-juce-extensions
+	url = https://github.com/free-audio/clap-juce-extensions
 [submodule "libs/eurorack/eurorack"]
 	path = libs/eurorack/eurorack
 	url = https://github.com/surge-synthesizer/eurorack.git
-[submodule "libs/oddsound-mts/MTS-ESP"]
-	path = libs/oddsound-mts/MTS-ESP
-	url = https://github.com/ODDSound/MTS-ESP
-[submodule "libs/libsamplerate"]
-	path = libs/libsamplerate
-	url = https://github.com/libsndfile/libsamplerate.git
-[submodule "libs/JUCE"]
-	path = libs/JUCE
-	url = https://github.com/surge-synthesizer/JUCE
-[submodule "libs/LuaJitLib/LuaJIT"]
-	path = libs/LuaJitLib/LuaJIT
-	url = https://github.com/LuaJIT/LuaJIT.git
 [submodule "libs/fmt"]
 	path = libs/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "libs/JUCE"]
+	path = libs/JUCE
+	url = https://github.com/surge-synthesizer/JUCE
+[submodule "libs/libsamplerate"]
+	path = libs/libsamplerate
+	url = https://github.com/libsndfile/libsamplerate.git
+[submodule "libs/LuaJitLib/LuaJIT"]
+	path = libs/LuaJitLib/LuaJIT
+	url = https://github.com/LuaJIT/LuaJIT.git
+[submodule "libs/simde"]
+	path = libs/simde
+	url = https://github.com/simd-everywhere/simde
+[submodule "libs/tuning-library"]
+	path = libs/tuning-library
+	url = https://github.com/surge-synthesizer/tuning-library
+[submodule "libs/oddsound-mts/MTS-ESP"]
+	path = libs/oddsound-mts/MTS-ESP
+	url = https://github.com/ODDSound/MTS-ESP
 [submodule "libs/PEGTL"]
 	path = libs/PEGTL
 	url = https://github.com/taocpp/PEGTL.git
 	branch = 2.x
-[submodule "libs/sst/sst-plugininfra"]
-	path = libs/sst/sst-plugininfra
-	url = https://github.com/surge-synthesizer/sst-plugininfra
-[submodule "libs/sst/sst-cpputils"]
-	path = libs/sst/sst-cpputils
-	url = https://github.com/surge-synthesizer/sst-cpputils
-[submodule "libs/clap-juce-extensions"]
-	path = libs/clap-juce-extensions
-	url = https://github.com/free-audio/clap-juce-extensions
-[submodule "libs/sst/sst-filters"]
-	path = libs/sst/sst-filters
-	url = https://github.com/surge-synthesizer/sst-filters
-[submodule "libs/sst/sst-waveshapers"]
-	path = libs/sst/sst-waveshapers
-	url = https://github.com/surge-synthesizer/sst-waveshapers
 [submodule "libs/pffft"]
 	path = libs/pffft
 	url = https://github.com/surge-synthesizer/pffft.git
+[submodule "libs/pybind11"]
+	path = libs/pybind11
+	url = https://github.com/pybind/pybind11
 [submodule "libs/sst/sst-basic-blocks"]
 	path = libs/sst/sst-basic-blocks
 	url = https://github.com/surge-synthesizer/sst-basic-blocks.git
+[submodule "libs/sst/sst-cpputils"]
+	path = libs/sst/sst-cpputils
+	url = https://github.com/surge-synthesizer/sst-cpputils
 [submodule "libs/sst/sst-effects"]
 	path = libs/sst/sst-effects
 	url = https://github.com/surge-synthesizer/sst-effects
+[submodule "libs/sst/sst-filters"]
+	path = libs/sst/sst-filters
+	url = https://github.com/surge-synthesizer/sst-filters
+[submodule "libs/sst/sst-plugininfra"]
+	path = libs/sst/sst-plugininfra
+	url = https://github.com/surge-synthesizer/sst-plugininfra
+[submodule "libs/sst/sst-waveshapers"]
+	path = libs/sst/sst-waveshapers
+	url = https://github.com/surge-synthesizer/sst-waveshapers

--- a/resources/surge-shared/configuration.xml
+++ b/resources/surge-shared/configuration.xml
@@ -54,6 +54,9 @@
               p7="0.75" p8="0.793701" p9="1" p10="0" p11="1"/>
 </type>
 <sectionheader label="DISTORTION"/>
+<type i="28" name="Bonsai">
+    <snapshot name="Init" p0="0" p1="-6" p2="¸0.25" p3="0" p4="0" p5="0.5" p6="0.5" p7="-0" p8="0.25" p9="0" p10="1"/>
+</type>
 <type i="18" name="CHOW">
     <snapshot name="Init" p0="-24" p1="10" p3="1"/>
 </type>
@@ -72,9 +75,6 @@
 <type i="25" name="Waveshaper">
     <snapshot name="Init" p0="-60" p0_deactivated="1" p1="70" p1_deactivated="1" p2="0" p3="0" p4="0" p5="-60" p6="70"
               p7="0" p8="1"/>
-</type>
-<type i="28" name="Bonsai">
-    <snapshot name="Init" p0="0" p1="-6" p2="1" p3="0" p4="0" p5="0.5" p6="0.5" p7="-6" p8="0.25" p9="0" p10="1"/>
 </type>
 <sectionheader label="MANGLING"/>
 <type i="21" name="Combulator">

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -294,7 +294,6 @@ bool Parameter::can_extend_range() const
     case ct_countedset_percent_extendable:
     case ct_dly_fb_clippingmodes:
     case ct_bonsai_bass_boost:
-    case ct_bonsai_noise_gain:
 
     // Extendable integers are really rare and special.
     // If you add one, you may want to chat with us on Discord!
@@ -413,7 +412,6 @@ bool Parameter::is_bipolar() const
     case ct_modern_trimix:
     case ct_oscspread_bipolar:
     case ct_bonsai_bass_boost:
-    case ct_bonsai_noise_gain:
         res = true;
         break;
     case ct_lfoamplitude:
@@ -1308,13 +1306,6 @@ void Parameter::set_type(int ctrltype)
         val_default.f = 0.f;
         break;
 
-    case ct_bonsai_bass_distortion:
-        valtype = vt_float;
-        val_min.f = 0.0f;
-        val_max.f = 3.0f;
-        val_default.f = 1.0f;
-        break;
-
     case ct_bonsai_sat_filter:
         valtype = vt_int;
         val_min.i = 0;
@@ -1327,13 +1318,6 @@ void Parameter::set_type(int ctrltype)
         val_min.i = 0;
         val_default.i = 1;
         val_max.i = 3;
-        break;
-
-    case ct_bonsai_noise_gain:
-        valtype = vt_float;
-        val_min.f = -24.0f;
-        val_max.f = 12.0f;
-        val_default.f = 0.f;
         break;
 
     case ct_bonsai_noise_mode:
@@ -1549,8 +1533,8 @@ void Parameter::set_type(int ctrltype)
     case ct_decibel_narrow_deactivatable:
     case ct_decibel_extra_narrow_deactivatable:
     case ct_bonsai_bass_boost:
-    case ct_bonsai_noise_gain:
         displayType = LinearWithScale;
+        displayInfo.extendFactor = 3;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "dB");
         break;
 
@@ -1746,7 +1730,6 @@ void Parameter::bound_value(bool force_integer)
         case ct_reson_res_extendable:
         case ct_modern_trimix:
         case ct_tape_drive:
-        case ct_bonsai_bass_distortion:
         {
             val.f = floor(val.f * 100) / 100.0;
             break;
@@ -1838,7 +1821,6 @@ void Parameter::bound_value(bool force_integer)
         case ct_decibel_narrow_deactivatable:
         case ct_decibel_extra_narrow_deactivatable:
         case ct_bonsai_bass_boost:
-        case ct_bonsai_noise_gain:
         {
             val.f = floor(val.f);
             break;
@@ -2219,7 +2201,6 @@ float Parameter::get_extended(float f) const
         return 12.f * f;
     case ct_decibel_extendable:
     case ct_bonsai_bass_boost:
-    case ct_bonsai_noise_gain:
         return 3.f * f;
     case ct_decibel_narrow_extendable:
         return 5.f * f;
@@ -4334,8 +4315,6 @@ bool Parameter::can_setvalue_from_string() const
     case ct_tape_speed:
     case ct_spring_decay:
     case ct_bonsai_bass_boost:
-    case ct_bonsai_bass_distortion:
-    case ct_bonsai_noise_gain:
     {
         return true;
     }

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -204,11 +204,9 @@ enum ctrltypes
     ct_spring_decay,
     ct_amplitude_ringmod,
     ct_bonsai_bass_boost,
-    ct_bonsai_bass_distortion,
     ct_bonsai_sat_filter,
     ct_bonsai_sat_mode,
     ct_bonsai_noise_mode,
-    ct_bonsai_noise_gain,
 
     num_ctrltypes,
 };

--- a/src/common/dsp/effects/BonsaiEffect.cpp
+++ b/src/common/dsp/effects/BonsaiEffect.cpp
@@ -33,11 +33,11 @@ const char *BonsaiEffect::group_label(int id)
     case 1:
         return "Bass Boost";
     case 2:
-        return "Tape(ish) Sat";
+        return "Saturation";
     case 3:
         return "Noise";
     case 4:
-        return "Misc";
+        return "Output";
     }
     return 0;
 }
@@ -69,7 +69,7 @@ void BonsaiEffect::init_ctrltypes()
     fxdata->p[b_bass_boost].set_type(ct_bonsai_bass_boost);
     fxdata->p[b_bass_boost].posy_offset = 3;
 
-    fxdata->p[b_bass_distort].set_type(ct_bonsai_bass_distortion);
+    fxdata->p[b_bass_distort].set_type(ct_percent);
     fxdata->p[b_bass_distort].posy_offset = 3;
 
     fxdata->p[b_tape_bias_mode].set_type(ct_bonsai_sat_filter);
@@ -84,7 +84,7 @@ void BonsaiEffect::init_ctrltypes()
     fxdata->p[b_noise_sensitivity].set_type(ct_percent);
     fxdata->p[b_noise_sensitivity].posy_offset = 7;
 
-    fxdata->p[b_noise_gain].set_type(ct_bonsai_noise_gain);
+    fxdata->p[b_noise_gain].set_type(ct_decibel_narrow);
     fxdata->p[b_noise_gain].posy_offset = 7;
 
     fxdata->p[b_dull].set_type(ct_percent);


### PR DESCRIPTION
Bass Distort is now in 0-100%
Bias Filter modes now don't mention "type x"
Dist Mode is now called Type with nice user-friendly names
Noise Gain is not asymmeteric nor extendable anymore
Input and output gain are both just named Gain to comply to other Surge effects
Removed two custom ctypes and replaced them with existing ones instead
Moved Bonsai to the first place in the Distortion effect group in the menu