### PR TITLE
Fix a problem in FX about param position assumption

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -670,10 +670,18 @@ struct FxStorage
     // Just a heads up: if you change this, please go look at reorderFx in SurgeSynthesizer too!
     FxStorage(fxslot_positions slot) : fxslot(slot) {}
     FxStorage() = delete;
-    fxslot_positions fxslot;
+
+    // Note that some clients assume that &(FxStorage) == &(FxStorage->type) and the
+    // param range is from &FXStorage -> &FXStorage->p[end]. This used to be true but
+    // is too limiting an assumption. We are fixing those clients now (rack still
+    // left to do) but if you add members please add them to the *end* of the param stack
+    // until we get em all
     Parameter type;
     Parameter return_level;
     Parameter p[n_fx_params];
+
+    // like this one!
+    fxslot_positions fxslot;
 };
 
 struct SurgeSceneStorage

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -54,7 +54,7 @@ SurgefxAudioProcessor::SurgefxAudioProcessor()
     audio_thread_surge_effect.reset();
     resetFxType(effectNum, false);
     fxstorage->return_level.id = -1;
-    setupStorageRanges((Parameter *)fxstorage, &(fxstorage->p[n_fx_params - 1]));
+    setupStorageRanges(&(fxstorage->type), &(fxstorage->p[n_fx_params - 1]));
 
     for (int i = 0; i < n_fx_params; ++i)
     {


### PR DESCRIPTION
The FX unit assumed &FxStorage == &FxStorage->type in one spot, which it had since epoch, but with the addition of a member at the top of the class, that assumption broke, and blammeroonie.

So do three things

1. Fix that assumption in SurgeFXProcessor
2. Move the new member to the end of the class just in case. Like we need to clean up the rack client which may do the same. And
3. Add a big honkin comment explaning this

Closes #7052