### PR TITLE
OSC improvements: patch loading, OSC output (path of loaded patch)

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1255,6 +1255,7 @@ class alignas(16) SurgeStorage
     float cpu_falloff;
 
     bool oscListenerRunning{false};
+    bool oscSending{false};
 
     bool getOverrideDataHome(std::string &value);
     void createUserDirectory();

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3945,11 +3945,15 @@ void loadPatchInBackgroundThread(SurgeSynthesizer *sy)
     {
         Patch p = synth->storage.patch_list[synth->patchid];
         pathstr = path_to_string(p.path);
+        // Trim extension
+        pathstr = pathstr.substr(0, pathstr.find_last_of("."));
         for (auto &it : synth->patchLoadedListeners)
             (it.second)(pathstr);
     }
     if (had_patchid_file)
     {
+        // Trim extension
+        pathstr = pathstr.substr(0, pathstr.find_last_of("."));
         for (auto &it : synth->patchLoadedListeners)
             (it.second)(pathstr);
     }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3940,18 +3940,18 @@ void loadPatchInBackgroundThread(SurgeSynthesizer *sy)
     synth->patchChanged = true;
     synth->halt_engine = false;
 
-    // Notify the patch load listener(s)
+    // Notify the 'patch loaded' listener(s)
     if (patchid >= 0)
     {
         Patch p = synth->storage.patch_list[synth->patchid];
         pathstr = path_to_string(p.path);
-        for (auto &listener : synth->patchLoadedListeners)
-            (listener)(pathstr);
+        for (auto &it : synth->patchLoadedListeners)
+            (it.second)(pathstr);
     }
     if (had_patchid_file)
     {
-        for (auto &listener : synth->patchLoadedListeners)
-            (listener)(pathstr);
+        for (auto &it : synth->patchLoadedListeners)
+            (it.second)(pathstr);
     }
 
     // Now we want to null out the patchLoadThread since everything is done

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4270,6 +4270,7 @@ void SurgeSynthesizer::process()
 
         if (masterfade < 0.0001f)
         {
+            std::cout << "patchid: " << patch_loaded << std::endl;
             std::lock_guard<std::mutex> mg(patchLoadSpawnMutex);
             // spawn patch-loading thread
             allNotesOff();

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3945,12 +3945,12 @@ void loadPatchInBackgroundThread(SurgeSynthesizer *sy)
     {
         Patch p = synth->storage.patch_list[synth->patchid];
         for (auto &it : synth->patchLoadedListeners)
-            (it.second)(p.path.replace_extension(string_to_path("")));
+            (it.second)(p.path.replace_extension());
     }
     if (had_patchid_file)
     {
         for (auto &it : synth->patchLoadedListeners)
-            (it.second)(ppath.replace_extension(string_to_path("")));
+            (it.second)(ppath.replace_extension());
     }
 
     // Now we want to null out the patchLoadThread since everything is done

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3945,12 +3945,12 @@ void loadPatchInBackgroundThread(SurgeSynthesizer *sy)
     {
         Patch p = synth->storage.patch_list[synth->patchid];
         for (auto &it : synth->patchLoadedListeners)
-            (it.second)(p.path.replace_extension(""));
+            (it.second)(p.path.replace_extension(string_to_path("")));
     }
     if (had_patchid_file)
     {
         for (auto &it : synth->patchLoadedListeners)
-            (it.second)(ppath.replace_extension(""));
+            (it.second)(ppath.replace_extension(string_to_path("")));
     }
 
     // Now we want to null out the patchLoadThread since everything is done

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -388,9 +388,8 @@ class alignas(16) SurgeSynthesizer
 
     // ----  'patch loaded' listener(s) ----
     // Listeners are notified whenever a patch changes, with the path of the new patch.
-    // Listeners should run on their own thread; for example, the OSC patchLoadedListener
-    // runs on a juce::MessageManager thread.
-    // (See SurgeSynthProcessor::initOSCOut() and SurgeSynthProcessor::stopOSCOUt() for example).
+    // Listeners should do any significant work on their own thread; for example, the OSC
+    // patchLoadedListener calls OSCSender::send(), which runs on a juce::MessageManager thread.
     //
     // Be sure to delete any added listeners in the desctructor of the class that added them.
     std::unordered_map<std::string, std::function<void(std::string)>> patchLoadedListeners;

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -387,12 +387,12 @@ class alignas(16) SurgeSynthesizer
     unsigned int saveRaw(void **data);
 
     // ----  'patch loaded' listener(s) ----
-    // Listeners are notified whenever a patch changes, with the path of the new patch
+    // Listeners are notified whenever a patch changes, with the path of the new patch.
     // Listeners should run on their own thread; for example, the OSC patchLoadedListener
     // runs on a juce::MessageManager thread.
-    // (See SurgeSynthProcessor::initOSCOut() and stopOSCOUt())
-    // Be sure to delete the listener in the desctructor of the class that orignally called
-    // 'addPatchLoadListener()'
+    // (See SurgeSynthProcessor::initOSCOut() and SurgeSynthProcessor::stopOSCOUt() for example).
+    //
+    // Be sure to delete any added listeners in the desctructor of the class that added them.
     std::unordered_map<std::string, std::function<void(std::string)>> patchLoadedListeners;
     void addPatchLoadedListener(std::string key, std::function<void(std::string)> const &l)
     {

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -392,7 +392,7 @@ class alignas(16) SurgeSynthesizer
     // patchLoadedListener calls OSCSender::send(), which runs on a juce::MessageManager thread.
     //
     // Be sure to delete any added listeners in the desctructor of the class that added them.
-    std::unordered_map<std::string, std::function<void(std::string)>> patchLoadedListeners;
+    std::unordered_map<std::string, std::function<void(const fs::path &)>> patchLoadedListeners;
     void addPatchLoadedListener(std::string key, std::function<void(const fs::path &)> const &l)
     {
         patchLoadedListeners.insert({key, l});

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -393,7 +393,7 @@ class alignas(16) SurgeSynthesizer
     //
     // Be sure to delete any added listeners in the desctructor of the class that added them.
     std::unordered_map<std::string, std::function<void(std::string)>> patchLoadedListeners;
-    void addPatchLoadedListener(std::string key, std::function<void(std::string)> const &l)
+    void addPatchLoadedListener(std::string key, std::function<void(const fs::path &)> const &l)
     {
         patchLoadedListeners.insert({key, l});
     }

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -333,12 +333,20 @@ std::string defaultKeyToString(DefaultKey k)
         r = "dontShowAudioErrorsAgain";
         break;
 
-    case OSCPort:
-        r = "openSoundControlPort";
+    case OSCPortIn:
+        r = "openSoundControlPortIn";
         break;
 
-    case StartOSC:
-        r = "startOSC";
+    case OSCPortOut:
+        r = "openSoundControlPortOut";
+        break;
+
+    case StartOSCIn:
+        r = "startOSCIn";
+        break;
+
+    case StartOSCOut:
+        r = "startOSCOut";
         break;
 
     case nKeys:

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -162,8 +162,10 @@ enum DefaultKey
     DontShowAudioErrorsAgain,
 
     // OSC (Open Sound Control)
-    StartOSC,
-    OSCPort,
+    StartOSCIn,
+    StartOSCOut,
+    OSCPortIn,
+    OSCPortOut,
 
     nKeys
 };

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -93,5 +93,6 @@ const int N_INPUTS = 2;
 
 const int DEFAULT_POLYLIMIT = 16;
 
-const int DEFAULT_OSC_PORT = 53280;
+const int DEFAULT_OSC_PORT_IN = 53280;
+const int DEFAULT_OSC_PORT_OUT = 53281;
 #endif // SURGE_SRC_COMMON_GLOBALS_H

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -169,6 +169,8 @@ target_sources(${PROJECT_NAME} PRIVATE
 
   osc/OSCListener.cpp
   osc/OSCListener.h
+  osc/OSCSender.cpp
+  osc/OSCSender.h
   )
 
 if(NOT EXISTS ${SURGE_JUCE_PATH}/modules/juce_gui_basics/accessibility/juce_AccessibilityHandler.h)

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -156,7 +156,6 @@ SurgeSynthProcessor::SurgeSynthProcessor()
     bool startOSCOutNow =
         Surge::Storage::getUserDefaultValue(&(surge->storage), Surge::Storage::StartOSCOut, false);
     if (startOSCOutNow)
-    // TODO: is this only working if OSC is enabled to auto-start? FIX IF SO!
     {
         int defaultOSCOutPort = Surge::Storage::getUserDefaultValue(
             &(surge->storage), Surge::Storage::OSCPortOut, DEFAULT_OSC_PORT_OUT);

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -264,7 +264,7 @@ bool SurgeSynthProcessor::changeOSCInPort(int new_port)
 
 bool SurgeSynthProcessor::initOSCOut(int port)
 {
-    auto state = oscSender.init(port);
+    auto state = oscSender.init(surge, port);
     surge->storage.oscSending = state;
 
     return state;

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -160,7 +160,20 @@ SurgeSynthProcessor::SurgeSynthProcessor()
         int defaultOSCOutPort = Surge::Storage::getUserDefaultValue(
             &(surge->storage), Surge::Storage::OSCPortOut, DEFAULT_OSC_PORT_OUT);
         bool success = initOSCOut(defaultOSCOutPort);
-        if (!success)
+        if (success)
+        {
+            // Add listener for patch changes
+            surge->addPatchLoadedListener([this](auto &s) { this->patch_load_to_OSC(s); });
+            /*
+            surge->addPatchLoadedListener([wed = juce::Component::SafePointer(this)]() {
+                juce::MessageManager::getInstance()->callAsync([wed]() {
+                    if (wed)
+                        wed->patch_load_to_OSC(s);
+                });
+            });
+            */
+        }
+        else
         {
             std::ostringstream msg;
             msg << "Surge XT was unable to connect to UDP port " << defaultOSCOutPort
@@ -170,6 +183,7 @@ SurgeSynthProcessor::SurgeSynthProcessor()
             return;
         }
     }
+
 #endif
 }
 
@@ -280,6 +294,12 @@ bool SurgeSynthProcessor::changeOSCOutPort(int new_port)
     }
 
     return initOSCOut(new_port);
+}
+
+// Called as 'patch loaded' listener:
+void SurgeSynthProcessor::patch_load_to_OSC(std::string &patchstr)
+{
+    std::cout << "Patch loaded: " << patchstr << std::endl;
 }
 
 //==============================================================================

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -273,6 +273,8 @@ bool SurgeSynthProcessor::initOSCOut(int port)
     if (state)
     {
         // Add listener for patch changes, to send new path to OSC output
+        // Listener will run on the juce::MessageManager thread so as to
+        // not tie up the patch loading thread.
         surge->addPatchLoadedListener("OSC_OUT", [ssp = this](auto s) {
             juce::MessageManager::getInstance()->callAsync([ssp, s]() {
                 if (ssp)
@@ -292,7 +294,7 @@ void SurgeSynthProcessor::stopOSCOut()
 
 bool SurgeSynthProcessor::changeOSCOutPort(int new_port) { return initOSCOut(new_port); }
 
-// Called as 'patch loaded' listener:
+// Called as 'patch loaded' listener; runs on the juce::MessageManager thread
 void SurgeSynthProcessor::patch_load_to_OSC(std::string fullPathStr)
 {
     if (surge->storage.oscSending && !fullPathStr.empty())

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -273,14 +273,10 @@ bool SurgeSynthProcessor::initOSCOut(int port)
     if (state)
     {
         // Add listener for patch changes, to send new path to OSC output
-        // Listener will run on the juce::MessageManager thread so as to
+        // This will run on the juce::MessageManager thread so as to
         // not tie up the patch loading thread.
-        surge->addPatchLoadedListener("OSC_OUT", [ssp = this](auto s) {
-            juce::MessageManager::getInstance()->callAsync([ssp, s]() {
-                if (ssp)
-                    ssp->patch_load_to_OSC(s);
-            });
-        });
+        surge->addPatchLoadedListener("OSC_OUT",
+                                      [ssp = this](auto s) { ssp->patch_load_to_OSC(s); });
     }
 
     return state;

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -163,15 +163,14 @@ SurgeSynthProcessor::SurgeSynthProcessor()
         if (success)
         {
             // Add listener for patch changes
-            surge->addPatchLoadedListener([this](auto &s) { this->patch_load_to_OSC(s); });
-            /*
-            surge->addPatchLoadedListener([wed = juce::Component::SafePointer(this)]() {
-                juce::MessageManager::getInstance()->callAsync([wed]() {
-                    if (wed)
-                        wed->patch_load_to_OSC(s);
+            // surge->addPatchLoadedListener([this](auto &s) { this->patch_load_to_OSC(s); });
+
+            surge->addPatchLoadedListener([ssp = this](auto &s) {
+                juce::MessageManager::getInstance()->callAsync([ssp, &s]() {
+                    if (ssp)
+                        ssp->patch_load_to_OSC(s);
                 });
             });
-            */
         }
         else
         {
@@ -285,16 +284,7 @@ bool SurgeSynthProcessor::initOSCOut(int port)
     return state;
 }
 
-bool SurgeSynthProcessor::changeOSCOutPort(int new_port)
-{
-    if (oscSender.sendingOSC)
-    {
-        surge->storage.oscSending = false;
-        oscSender.disconnect();
-    }
-
-    return initOSCOut(new_port);
-}
+bool SurgeSynthProcessor::changeOSCOutPort(int new_port) { return initOSCOut(new_port); }
 
 // Called as 'patch loaded' listener:
 void SurgeSynthProcessor::patch_load_to_OSC(std::string &patchstr)

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -137,17 +137,18 @@ SurgeSynthProcessor::SurgeSynthProcessor()
 
 #if SURGE_HAS_OSC
     // OSC (Open Sound Control)
-    bool startOSCNow =
-        Surge::Storage::getUserDefaultValue(&(surge->storage), Surge::Storage::StartOSC, false);
-    if (startOSCNow)
+    bool startOSCInNow =
+        Surge::Storage::getUserDefaultValue(&(surge->storage), Surge::Storage::StartOSCIn, false);
+    if (startOSCInNow)
     {
-        int defaultOSCPort = Surge::Storage::getUserDefaultValue(
-            &(surge->storage), Surge::Storage::OSCPort, DEFAULT_OSC_PORT);
-        bool success = initOSC(defaultOSCPort);
+        int defaultOSCPortIn = Surge::Storage::getUserDefaultValue(
+            &(surge->storage), Surge::Storage::OSCPortIn, DEFAULT_OSC_PORT_IN);
+        bool success = initOSC(defaultOSCPortIn);
         if (!success)
         {
             std::ostringstream msg;
-            msg << "Surge XT was unable to connect to port " << defaultOSCPort << ".\n"
+            msg << "Surge XT was unable to connect to UDP port " << defaultOSCPortIn
+                << " for OSC input.\n"
                 << "It may be in use by another application.";
             surge->storage.reportError(msg.str(), "OSC Initialization Error");
         }

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -606,7 +606,7 @@ void SurgeSynthProcessor::processBlockOSC()
     for (const auto &om : messages)
     {
         float pval = om.val;
-        if (om.type == oscMsg::PARAMETER)
+        if (om.type == oscParamMsg::PARAMETER) // currently the only type
         {
             if (om.param->valtype == vt_int)
                 pval = Parameter::intScaledToFloat(pval, om.param->val_max.i, om.param->val_min.i);

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -167,6 +167,7 @@ SurgeSynthProcessor::SurgeSynthProcessor()
                 << " for OSC output.\n"
                 << "It may be in use by another application.";
             surge->storage.reportError(msg.str(), "OSC Output Initialization Error");
+            return;
         }
     }
 #endif

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -290,11 +290,12 @@ void SurgeSynthProcessor::stopOSCOut()
 bool SurgeSynthProcessor::changeOSCOutPort(int new_port) { return initOSCOut(new_port); }
 
 // Called as 'patch loaded' listener; runs on the juce::MessageManager thread
-void SurgeSynthProcessor::patch_load_to_OSC(std::string fullPathStr)
+void SurgeSynthProcessor::patch_load_to_OSC(fs::path fullPath)
 {
-    if (surge->storage.oscSending && !fullPathStr.empty())
+    std::string pathStr = path_to_string(fullPath);
+    if (surge->storage.oscSending && !pathStr.empty())
     {
-        oscSender.send("/patch", fullPathStr);
+        oscSender.send("/patch", pathStr);
     }
 }
 //==============================================================================

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -395,6 +395,8 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     bool changeOSCInPort(int newport);
     bool changeOSCOutPort(int newport);
 
+    void patch_load_to_OSC(std::string &patchstr);
+
 #if HAS_CLAP_JUCE_EXTENSIONS
     bool isInputMain(int index) override { return false; }
     bool supportsDirectProcess() override { return true; }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -335,25 +335,32 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
 
     //==============================================================================
     // Open Sound Control
-    struct oscMsg
+    struct oscParamMsg
     {
         enum Type
         {
-            PARAMETER,
-            SET_TUNING
+            PARAMETER // the only type that uses these messages, for now
         } type{PARAMETER};
         Parameter *param;
         float val{0.0};
         std::string str;
 
-        oscMsg() {}
-        oscMsg(Parameter *p, float v) : type(PARAMETER), param(p), val(v) {}
+        oscParamMsg() {}
+        oscParamMsg(Parameter *p, float v) : type(PARAMETER), param(p), val(v) {}
     };
 
-    sst::cpputils::SimpleRingBuffer<oscMsg, 4096> oscRingBuf;
+    sst::cpputils::SimpleRingBuffer<oscParamMsg, 4096> oscRingBuf;
 
     Surge::OSC::OSCListener oscListener;
     Surge::OSC::OSCSender oscSender;
+
+    bool initOSCIn(int port);
+    bool initOSCOut(int port);
+    bool changeOSCInPort(int newport);
+    bool changeOSCOutPort(int newport);
+    void stopOSCOut();
+
+    void patch_load_to_OSC(std::string patchstr);
 
     //==============================================================================
     const juce::String getName() const override;
@@ -389,14 +396,6 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     void reset() override;
 
     bool getPluginHasMainInput() const override { return false; }
-
-    bool initOSCIn(int port);
-    bool initOSCOut(int port);
-    bool changeOSCInPort(int newport);
-    bool changeOSCOutPort(int newport);
-    void stopOSCOut();
-
-    void patch_load_to_OSC(std::string patchstr);
 
 #if HAS_CLAP_JUCE_EXTENSIONS
     bool isInputMain(int index) override { return false; }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -28,6 +28,7 @@
 #include "util/LockFreeStack.h"
 
 #include "osc/OSCListener.h"
+#include "osc/OSCSender.h"
 
 #include "juce_audio_processors/juce_audio_processors.h"
 
@@ -352,6 +353,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     sst::cpputils::SimpleRingBuffer<oscMsg, 4096> oscRingBuf;
 
     Surge::OSC::OSCListener oscListener;
+    Surge::OSC::OSCSender oscSender;
 
     //==============================================================================
     const juce::String getName() const override;
@@ -388,8 +390,10 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
 
     bool getPluginHasMainInput() const override { return false; }
 
-    bool initOSC(int port);
-    bool changeOSCPort(int newport);
+    bool initOSCIn(int port);
+    bool initOSCOut(int port);
+    bool changeOSCInPort(int newport);
+    bool changeOSCOutPort(int newport);
 
 #if HAS_CLAP_JUCE_EXTENSIONS
     bool isInputMain(int index) override { return false; }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -394,8 +394,9 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     bool initOSCOut(int port);
     bool changeOSCInPort(int newport);
     bool changeOSCOutPort(int newport);
+    void stopOSCOut();
 
-    void patch_load_to_OSC(std::string &patchstr);
+    void patch_load_to_OSC(std::string patchstr);
 
 #if HAS_CLAP_JUCE_EXTENSIONS
     bool isInputMain(int index) override { return false; }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -360,7 +360,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     bool changeOSCOutPort(int newport);
     void stopOSCOut();
 
-    void patch_load_to_OSC(std::string patchstr);
+    void patch_load_to_OSC(fs::path);
 
     //==============================================================================
     const juce::String getName() const override;

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4866,9 +4866,8 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
         oscSubMenu.addItem(Surge::GUI::toOSCase("Reset OSC Output Port to " +
                                                 std::to_string(DEFAULT_OSC_PORT_OUT)),
                            [this]() {
-                               /*
                                bool success =
-                               juceEditor->processor.changeOSCInPort(DEFAULT_OSC_PORT_OUT);
+                                   juceEditor->processor.changeOSCOutPort(DEFAULT_OSC_PORT_OUT);
 
                                if (!success)
                                {
@@ -4880,7 +4879,6 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
                                        &(synth->storage), Surge::Storage::OSCPortOut,
                                DEFAULT_OSC_PORT_OUT);
                                }
-                               */
                            });
     }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4755,134 +4755,7 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
 {
     auto oscSubMenu = juce::PopupMenu();
     int iportnum = juceEditor->processor.oscListener.portnum;
-    int oportnum = 0;
-
-    oscSubMenu.addItem(Surge::GUI::toOSCase("Change OSC Input Port..."), [this, iportnum]() {
-        const auto c{std::to_string(iportnum)};
-
-        promptForMiniEdit(
-            c, "Enter a new value:", "OSC Input Port Number", juce::Point<int>(10, 10),
-            [this](const std::string &c) {
-                int newPort = Surge::Storage::getUserDefaultValue(
-                    &(synth->storage), Surge::Storage::OSCPortIn, DEFAULT_OSC_PORT_IN);
-
-                try
-                {
-                    newPort = std::stoi(c);
-                }
-                catch (...)
-                {
-                    std::ostringstream msg;
-                    msg << "Entered value is not a number. Please try again.";
-                    synth->storage.reportError(msg.str(), "Input Error");
-                    return;
-                }
-
-                if (newPort > 65535 || newPort < 1)
-                {
-                    std::ostringstream msg;
-                    msg << "Port number must be between 1 and 65535!";
-                    synth->storage.reportError(msg.str(), "Port Number Out Of Range");
-                    return;
-                }
-
-                bool success = juceEditor->processor.changeOSCInPort(newPort);
-                if (!success)
-                {
-                    SurgeGUIEditor::initOSCError(newPort);
-                }
-                else
-                {
-                    Surge::Storage::updateUserDefaultValue(&(synth->storage),
-                                                           Surge::Storage::OSCPortIn, newPort);
-                }
-            },
-            mainMenu);
-    });
-    oscSubMenu.addItem(Surge::GUI::toOSCase("Change OSC Output Port..."), [this, oportnum]() {
-        const auto c{std::to_string(oportnum)};
-
-        promptForMiniEdit(
-            c, "Enter a new value:", "OSC Output Port Number", juce::Point<int>(10, 10),
-            [this](const std::string &c) {
-                int newPort = Surge::Storage::getUserDefaultValue(
-                    &(synth->storage), Surge::Storage::OSCPortIn, DEFAULT_OSC_PORT_OUT);
-
-                try
-                {
-                    newPort = std::stoi(c);
-                }
-                catch (...)
-                {
-                    std::ostringstream msg;
-                    msg << "Entered value is not a number. Please try again.";
-                    synth->storage.reportError(msg.str(), "Input Error");
-                    return;
-                }
-
-                if (newPort > 65535 || newPort < 1)
-                {
-                    std::ostringstream msg;
-                    msg << "Port number must be between 1 and 65535!";
-                    synth->storage.reportError(msg.str(), "Port Number Out Of Range");
-                    return;
-                }
-
-                bool success = juceEditor->processor.changeOSCInPort(newPort);
-                if (!success)
-                {
-                    SurgeGUIEditor::initOSCError(newPort);
-                }
-                else
-                {
-                    Surge::Storage::updateUserDefaultValue(&(synth->storage),
-                                                           Surge::Storage::OSCPortOut, newPort);
-                }
-            },
-            mainMenu);
-    });
-
-    if (iportnum != DEFAULT_OSC_PORT_IN)
-    {
-        oscSubMenu.addItem(
-            Surge::GUI::toOSCase("Reset OSC Input Port to " + std::to_string(DEFAULT_OSC_PORT_IN)),
-            [this]() {
-                bool success = juceEditor->processor.changeOSCInPort(DEFAULT_OSC_PORT_IN);
-
-                if (!success)
-                {
-                    SurgeGUIEditor::initOSCError(DEFAULT_OSC_PORT_IN);
-                }
-                else
-                {
-                    Surge::Storage::updateUserDefaultValue(
-                        &(synth->storage), Surge::Storage::OSCPortIn, DEFAULT_OSC_PORT_IN);
-                }
-            });
-    }
-
-    if (oportnum != DEFAULT_OSC_PORT_OUT)
-    {
-        oscSubMenu.addItem(Surge::GUI::toOSCase("Reset OSC Output Port to " +
-                                                std::to_string(DEFAULT_OSC_PORT_OUT)),
-                           [this]() {
-                               bool success =
-                                   juceEditor->processor.changeOSCOutPort(DEFAULT_OSC_PORT_OUT);
-
-                               if (!success)
-                               {
-                                   SurgeGUIEditor::initOSCError(DEFAULT_OSC_PORT_OUT);
-                               }
-                               else
-                               {
-                                   Surge::Storage::updateUserDefaultValue(
-                                       &(synth->storage), Surge::Storage::OSCPortOut,
-                               DEFAULT_OSC_PORT_OUT);
-                               }
-                           });
-    }
-
-    oscSubMenu.addSeparator();
+    int oportnum = juceEditor->processor.oscSender.portnum;
 
     if (synth->storage.oscListenerRunning)
     {
@@ -4941,6 +4814,135 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
                            Surge::Storage::updateUserDefaultValue(
                                &(synth->storage), Surge::Storage::StartOSCOut, !outIsChecked);
                        });
+
+    oscSubMenu.addSeparator();
+
+    oscSubMenu.addItem(Surge::GUI::toOSCase("Change OSC Input Port..."), [this, iportnum]() {
+        const auto c{std::to_string(iportnum)};
+
+        promptForMiniEdit(
+            c, "Enter a new value:", "OSC Input Port Number", juce::Point<int>(10, 10),
+            [this](const std::string &c) {
+                int newPort = Surge::Storage::getUserDefaultValue(
+                    &(synth->storage), Surge::Storage::OSCPortIn, DEFAULT_OSC_PORT_IN);
+
+                try
+                {
+                    newPort = std::stoi(c);
+                }
+                catch (...)
+                {
+                    std::ostringstream msg;
+                    msg << "Entered value is not a number. Please try again.";
+                    synth->storage.reportError(msg.str(), "Input Error");
+                    return;
+                }
+
+                if (newPort > 65535 || newPort < 1)
+                {
+                    std::ostringstream msg;
+                    msg << "Port number must be between 1 and 65535!";
+                    synth->storage.reportError(msg.str(), "Port Number Out Of Range");
+                    return;
+                }
+
+                bool success = juceEditor->processor.changeOSCInPort(newPort);
+                if (!success)
+                {
+                    SurgeGUIEditor::initOSCError(newPort);
+                }
+                else
+                {
+                    Surge::Storage::updateUserDefaultValue(&(synth->storage),
+                                                           Surge::Storage::OSCPortIn, newPort);
+                }
+            },
+            mainMenu);
+    });
+
+    if (iportnum != DEFAULT_OSC_PORT_IN)
+    {
+        oscSubMenu.addItem(
+            Surge::GUI::toOSCase("Reset OSC Input Port to " + std::to_string(DEFAULT_OSC_PORT_IN)),
+            [this]() {
+                bool success = juceEditor->processor.changeOSCInPort(DEFAULT_OSC_PORT_IN);
+
+                if (!success)
+                {
+                    SurgeGUIEditor::initOSCError(DEFAULT_OSC_PORT_IN);
+                }
+                else
+                {
+                    Surge::Storage::updateUserDefaultValue(
+                        &(synth->storage), Surge::Storage::OSCPortIn, DEFAULT_OSC_PORT_IN);
+                }
+            });
+    }
+
+    oscSubMenu.addSeparator();
+
+    oscSubMenu.addItem(Surge::GUI::toOSCase("Change OSC Output Port..."), [this, oportnum]() {
+        const auto c{std::to_string(oportnum)};
+
+        promptForMiniEdit(
+            c, "Enter a new value:", "OSC Output Port Number", juce::Point<int>(10, 10),
+            [this](const std::string &c) {
+                int newPort = Surge::Storage::getUserDefaultValue(
+                    &(synth->storage), Surge::Storage::OSCPortOut, DEFAULT_OSC_PORT_OUT);
+
+                try
+                {
+                    newPort = std::stoi(c);
+                }
+                catch (...)
+                {
+                    std::ostringstream msg;
+                    msg << "Entered value is not a number. Please try again.";
+                    synth->storage.reportError(msg.str(), "Input Error");
+                    return;
+                }
+
+                if (newPort > 65535 || newPort < 1)
+                {
+                    std::ostringstream msg;
+                    msg << "Port number must be between 1 and 65535!";
+                    synth->storage.reportError(msg.str(), "Port Number Out Of Range");
+                    return;
+                }
+
+                bool success = juceEditor->processor.changeOSCOutPort(newPort);
+                if (!success)
+                {
+                    SurgeGUIEditor::initOSCError(newPort);
+                }
+                else
+                {
+                    Surge::Storage::updateUserDefaultValue(&(synth->storage),
+                                                           Surge::Storage::OSCPortOut, newPort);
+                }
+            },
+            mainMenu);
+    });
+
+    if (oportnum != DEFAULT_OSC_PORT_OUT)
+    {
+        oscSubMenu.addItem(
+            Surge::GUI::toOSCase("Reset OSC Output Port to " +
+                                 std::to_string(DEFAULT_OSC_PORT_OUT)),
+            [this]() {
+                bool success = juceEditor->processor.changeOSCOutPort(DEFAULT_OSC_PORT_OUT);
+
+                if (!success)
+                {
+                    SurgeGUIEditor::initOSCError(DEFAULT_OSC_PORT_OUT);
+                }
+                else
+                {
+                    Surge::Storage::updateUserDefaultValue(
+                        &(synth->storage), Surge::Storage::OSCPortOut, DEFAULT_OSC_PORT_OUT);
+                }
+            });
+    }
 
     oscSubMenu.addSeparator();
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4817,48 +4817,50 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
 
     oscSubMenu.addSeparator();
 
-    oscSubMenu.addItem(Surge::GUI::toOSCase("Change OSC Input Port..."), [this, iportnum]() {
-        const auto c{std::to_string(iportnum)};
+    oscSubMenu.addItem(
+        Surge::GUI::toOSCase("Change OSC Input Port (" + std::to_string(iportnum) + ")..."),
+        [this, iportnum]() {
+            const auto c{std::to_string(iportnum)};
 
-        promptForMiniEdit(
-            c, "Enter a new value:", "OSC Input Port Number", juce::Point<int>(10, 10),
-            [this](const std::string &c) {
-                int newPort = Surge::Storage::getUserDefaultValue(
-                    &(synth->storage), Surge::Storage::OSCPortIn, DEFAULT_OSC_PORT_IN);
+            promptForMiniEdit(
+                c, "Enter a new value:", "OSC Input Port Number", juce::Point<int>(10, 10),
+                [this](const std::string &c) {
+                    int newPort = Surge::Storage::getUserDefaultValue(
+                        &(synth->storage), Surge::Storage::OSCPortIn, DEFAULT_OSC_PORT_IN);
 
-                try
-                {
-                    newPort = std::stoi(c);
-                }
-                catch (...)
-                {
-                    std::ostringstream msg;
-                    msg << "Entered value is not a number. Please try again.";
-                    synth->storage.reportError(msg.str(), "Input Error");
-                    return;
-                }
+                    try
+                    {
+                        newPort = std::stoi(c);
+                    }
+                    catch (...)
+                    {
+                        std::ostringstream msg;
+                        msg << "Entered value is not a number. Please try again.";
+                        synth->storage.reportError(msg.str(), "Input Error");
+                        return;
+                    }
 
-                if (newPort > 65535 || newPort < 1)
-                {
-                    std::ostringstream msg;
-                    msg << "Port number must be between 1 and 65535!";
-                    synth->storage.reportError(msg.str(), "Port Number Out Of Range");
-                    return;
-                }
+                    if (newPort > 65535 || newPort < 1)
+                    {
+                        std::ostringstream msg;
+                        msg << "Port number must be between 1 and 65535!";
+                        synth->storage.reportError(msg.str(), "Port Number Out Of Range");
+                        return;
+                    }
 
-                bool success = juceEditor->processor.changeOSCInPort(newPort);
-                if (!success)
-                {
-                    SurgeGUIEditor::initOSCError(newPort);
-                }
-                else
-                {
-                    Surge::Storage::updateUserDefaultValue(&(synth->storage),
-                                                           Surge::Storage::OSCPortIn, newPort);
-                }
-            },
-            mainMenu);
-    });
+                    bool success = juceEditor->processor.changeOSCInPort(newPort);
+                    if (!success)
+                    {
+                        SurgeGUIEditor::initOSCError(newPort);
+                    }
+                    else
+                    {
+                        Surge::Storage::updateUserDefaultValue(&(synth->storage),
+                                                               Surge::Storage::OSCPortIn, newPort);
+                    }
+                },
+                mainMenu);
+        });
 
     if (iportnum != DEFAULT_OSC_PORT_IN)
     {
@@ -4881,48 +4883,50 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
 
     oscSubMenu.addSeparator();
 
-    oscSubMenu.addItem(Surge::GUI::toOSCase("Change OSC Output Port..."), [this, oportnum]() {
-        const auto c{std::to_string(oportnum)};
+    oscSubMenu.addItem(
+        Surge::GUI::toOSCase("Change OSC Output Port (" + std::to_string(oportnum) + ")..."),
+        [this, oportnum]() {
+            const auto c{std::to_string(oportnum)};
 
-        promptForMiniEdit(
-            c, "Enter a new value:", "OSC Output Port Number", juce::Point<int>(10, 10),
-            [this](const std::string &c) {
-                int newPort = Surge::Storage::getUserDefaultValue(
-                    &(synth->storage), Surge::Storage::OSCPortOut, DEFAULT_OSC_PORT_OUT);
+            promptForMiniEdit(
+                c, "Enter a new value:", "OSC Output Port Number", juce::Point<int>(10, 10),
+                [this](const std::string &c) {
+                    int newPort = Surge::Storage::getUserDefaultValue(
+                        &(synth->storage), Surge::Storage::OSCPortOut, DEFAULT_OSC_PORT_OUT);
 
-                try
-                {
-                    newPort = std::stoi(c);
-                }
-                catch (...)
-                {
-                    std::ostringstream msg;
-                    msg << "Entered value is not a number. Please try again.";
-                    synth->storage.reportError(msg.str(), "Input Error");
-                    return;
-                }
+                    try
+                    {
+                        newPort = std::stoi(c);
+                    }
+                    catch (...)
+                    {
+                        std::ostringstream msg;
+                        msg << "Entered value is not a number. Please try again.";
+                        synth->storage.reportError(msg.str(), "Input Error");
+                        return;
+                    }
 
-                if (newPort > 65535 || newPort < 1)
-                {
-                    std::ostringstream msg;
-                    msg << "Port number must be between 1 and 65535!";
-                    synth->storage.reportError(msg.str(), "Port Number Out Of Range");
-                    return;
-                }
+                    if (newPort > 65535 || newPort < 1)
+                    {
+                        std::ostringstream msg;
+                        msg << "Port number must be between 1 and 65535!";
+                        synth->storage.reportError(msg.str(), "Port Number Out Of Range");
+                        return;
+                    }
 
-                bool success = juceEditor->processor.changeOSCOutPort(newPort);
-                if (!success)
-                {
-                    SurgeGUIEditor::initOSCError(newPort);
-                }
-                else
-                {
-                    Surge::Storage::updateUserDefaultValue(&(synth->storage),
-                                                           Surge::Storage::OSCPortOut, newPort);
-                }
-            },
-            mainMenu);
-    });
+                    bool success = juceEditor->processor.changeOSCOutPort(newPort);
+                    if (!success)
+                    {
+                        SurgeGUIEditor::initOSCError(newPort);
+                    }
+                    else
+                    {
+                        Surge::Storage::updateUserDefaultValue(&(synth->storage),
+                                                               Surge::Storage::OSCPortOut, newPort);
+                    }
+                },
+                mainMenu);
+        });
 
     if (oportnum != DEFAULT_OSC_PORT_OUT)
     {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4791,7 +4791,7 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
     if (synth->storage.oscSending)
     {
         oscSubMenu.addItem(Surge::GUI::toOSCase("Stop OSC Output"),
-                           [this]() { juceEditor->processor.oscSender.stopSending(); });
+                           [this]() { juceEditor->processor.stopOSCOut(); });
     }
     else
     {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4786,7 +4786,7 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
                     return;
                 }
 
-                bool success = juceEditor->processor.changeOSCPort(newPort);
+                bool success = juceEditor->processor.changeOSCInPort(newPort);
                 if (!success)
                 {
                     SurgeGUIEditor::initOSCError(newPort);
@@ -4828,7 +4828,7 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
                     return;
                 }
 
-                bool success = juceEditor->processor.changeOSCPort(newPort);
+                bool success = juceEditor->processor.changeOSCInPort(newPort);
                 if (!success)
                 {
                     SurgeGUIEditor::initOSCError(newPort);
@@ -4847,7 +4847,7 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
         oscSubMenu.addItem(
             Surge::GUI::toOSCase("Reset OSC Input Port to " + std::to_string(DEFAULT_OSC_PORT_IN)),
             [this]() {
-                bool success = juceEditor->processor.changeOSCPort(DEFAULT_OSC_PORT_IN);
+                bool success = juceEditor->processor.changeOSCInPort(DEFAULT_OSC_PORT_IN);
 
                 if (!success)
                 {
@@ -4868,7 +4868,7 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
                            [this]() {
                                /*
                                bool success =
-                               juceEditor->processor.changeOSCPort(DEFAULT_OSC_PORT_OUT);
+                               juceEditor->processor.changeOSCInPort(DEFAULT_OSC_PORT_OUT);
 
                                if (!success)
                                {
@@ -4896,7 +4896,7 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
         oscSubMenu.addItem(Surge::GUI::toOSCase("Start OSC Listener"), [this]() {
             int defaultOSCPortIn = Surge::Storage::getUserDefaultValue(
                 &(this->synth->storage), Surge::Storage::OSCPortIn, DEFAULT_OSC_PORT_IN);
-            bool success = juceEditor->processor.initOSC(defaultOSCPortIn);
+            bool success = juceEditor->processor.initOSCIn(defaultOSCPortIn);
 
             if (!success)
             {
@@ -4916,17 +4916,17 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
 
     oscSubMenu.addSeparator();
 
-    if (synth->storage.oscListenerRunning) // TODO: fix this!
+    if (synth->storage.oscSending)
     {
         oscSubMenu.addItem(Surge::GUI::toOSCase("Stop OSC Output"),
-                           [this]() { juceEditor->processor.oscListener.stopListening(); });
+                           [this]() { juceEditor->processor.oscSender.stopSending(); });
     }
     else
     {
         oscSubMenu.addItem(Surge::GUI::toOSCase("Start OSC Output"), [this]() {
             int defaultOSCPortOut = Surge::Storage::getUserDefaultValue(
                 &(this->synth->storage), Surge::Storage::OSCPortOut, DEFAULT_OSC_PORT_OUT);
-            // bool success = juceEditor->processor.initOSC(defaultOSCPortOut);
+            bool success = juceEditor->processor.initOSCOut(defaultOSCPortOut);
 
             // if (!success)
             //{

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -588,28 +588,7 @@ code {
                     <tr>
                         <td>/patch</td>
                         <td>new patch</td>
-                        <td class="center">file path (absolute)</td>
-                    </tr>
-                </table>
-            </div>
-            <!-- Show tuning change output -->
-            <div class="tablewrap fr cr">
-                <div class="heading"><h3>Tuning Change:</h3></div>
-                <table style="border: 2px solid black;">
-                    <tr>
-                        <th>Address</th>
-                        <th>Description</th>
-                        <th>Sent Values</th>
-                    </tr>
-                    <tr>
-                        <td>/tuning/scl</td>
-                        <td>new scl tuning</td>
-                        <td class="center">file path (absolute)</td>
-                    </tr>
-                    <tr>
-                        <td>/tuning/kbm</td>
-                        <td>new kbm mapping</td>
-                        <td class="center">file path (absolute)</td>
+                        <td class="center">file path (absolute, no extension)</td>
                     </tr>
                 </table>
             </div>
@@ -665,12 +644,7 @@ code {
                     <tr>
                         <td>/patch</td>
                         <td>load patch</td>
-                        <td class="center">file path (absolute or relative)</td>
-                    </tr>
-                    <tr>
-                        <td>/patch/path</td>
-                        <td>patch path</td>
-                        <td class="center">absolute path</td>
+                        <td class="center">file path (absolute, no extension)</td>
                     </tr>
                     <tr>
                         <td>/patch/incr</td>

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -489,6 +489,10 @@ div.heading {
     width: 100%;
 }
 
+h2 {
+    text-align: center;
+}
+
 h3 {
     margin: 0 0 8px 0;
 }
@@ -502,6 +506,8 @@ div.outer {
 
 div.frame {
     max-width: 1300px;
+    border: 1px solid #aaa;
+    overflow: hidden;
 }
 
 div.tablewrap {
@@ -564,122 +570,164 @@ code {
       </div>
     </div>
 
-    <div style="margin:10pt; padding: 5pt; border: 1px solid #123463; background: #fafbff;">
-      <div style="line-height: 1.5; font-size: 12pt; font-family: Lato; color: #123463;">
-        Construct OSC messages using the exact (case sensitive)
-        entry listed in the <b>Address</b> column in the tables below.</br>
-        The form of the message should be <code>/&ltaddress&gt &ltvalue&gt</code>,
-        where <code>address</code> can currently begin with either <code>tuning</code>, <code>settings</code>, or <code>param</code>,</br> and <code>value</code> can be:
-
-        <ul>
-            <li>a floating point value between <b>0.0</b> and <b>1.0</b></li>
-            <li>an integer value</li>
-            <li>a boolean value, <b>0</b> (false) or <b>1</b> (true)</li>
-            <li>a file path (absolute, or relative to the default path)
-            <li>contextual: either an in integer or a float, depending on the context (loaded oscillator or effect type)</li>
-        </ul>
-
-        Where an address contains an asterisk <b>(*)</b>, replace the asterisk with either <b>a</b> or <b>b</b>,
-        depending on which scene you wish to address - e.g. <code>/a/drift</code> or <code>/b/drift</code>.
-
-        <p>Examples:
-            <div style="margin: -6px 0 2px 0; line-height: 1.75">
-                <span><code>/param/b/amp/gain 0.63</code></span>
-                <span><code>/param/global/polyphony_limit 12</code></span>
-                <span><code>/param/a/mixer/noise/mute 0</code></span>
+    <div style="margin:10pt; padding: 5pt; border: 1px solid #123463; background: #fafbff; overflow:hidden">
+              <div class="outer">
+        <div class="frame">
+            <h2>OSC Output</h2>
+            <!-- Show patch change output -->
+            <div class="tablewrap fl cl">
+                <div class="heading"><h3>Patch Change:</h3></div>
+                <table style="border: 2px solid black;">
+                    <tr>
+                        <th>Address</th>
+                        <th>Description</th>
+                        <th>Sent Values</th>
+                    </tr>
+                    <tr>
+                        <td>/patch</td>
+                        <td>new patch</td>
+                        <td class="center">file path (absolute)</td>
+                    </tr>
+                </table>
             </div>
-            <div style="margin: 4px 0 0 0; line-height: 1.75">
-                <span><code>/tuning/scl ptolemy</code></span>
-                <span><code>/tuning/scl /Users/jane/scala_tunings/ptolemy.scl</code></span>
-                <span><code>/settings/path/scl /Users/jane/scala_tunings</code></span>
+            <!-- Show tuning change output -->
+            <div class="tablewrap fr cr">
+                <div class="heading"><h3>Tuning Change:</h3></div>
+                <table style="border: 2px solid black;">
+                    <tr>
+                        <th>Address</th>
+                        <th>Description</th>
+                        <th>Sent Values</th>
+                    </tr>
+                    <tr>
+                        <td>/tuning/scl</td>
+                        <td>new scl tuning</td>
+                        <td class="center">file path (absolute)</td>
+                    </tr>
+                    <tr>
+                        <td>/tuning/kbm</td>
+                        <td>new kbm mapping</td>
+                        <td class="center">file path (absolute)</td>
+                    </tr>
+                </table>
             </div>
-        </p>
-      </div>
+        </div>
     </div>
 
-    <div style="margin:10pt; padding: 5pt; border: 1px solid #123463; background: #fafbff; overflow:hidden">
-      <div class="outer"><div class="frame">
+    <div class="outer">
+        <div class="frame">
+            <h2>OSC Input</h2>
+            <div style="margin:10pt; padding: 5pt 12pt; background: #fafbff;">
+            <div style="font-size: 12pt; font-family: Lato;">
+                Construct OSC messages using the exact (case sensitive)
+                entry listed in the <b>Address</b> column in the tables below.</br>
+                The form of the message should be <code>/&ltaddress&gt &ltvalue&gt</code>,
+                where <code>address</code> can currently begin with either <code>tuning</code>,
+                <code>settings</code>, or <code>param</code>, and <code>value</code> can be:
+
+                <ul>
+                    <li>a floating point value between <b>0.0</b> and <b>1.0</b></li>
+                    <li>an integer value</li>
+                    <li>a boolean value, <b>0</b> (false) or <b>1</b> (true)</li>
+                    <li>a file path (absolute, or relative to the default path)
+                    <li>contextual: either an in integer or a float, depending on the context (loaded oscillator or effect type)</li>
+                </ul>
+
+                Where an address contains an asterisk <b>(*)</b>, replace the asterisk with either <b>a</b> or <b>b</b>,
+                depending on which scene you wish to address - e.g. <code>/a/drift</code> or <code>/b/drift</code>.
+
+                <p>Examples:
+                    <div style="margin: -6px 0 2px 0; line-height: 1.75">
+                        <span><code>/param/b/amp/gain 0.63</code></span>
+                        <span><code>/param/global/polyphony_limit 12</code></span>
+                        <span><code>/param/a/mixer/noise/mute 0</code></span>
+                    </div>
+                    <div style="margin: 4px 0 0 0; line-height: 1.75">
+                        <span><code>/tuning/scl ptolemy</code></span>
+                        <span><code>/tuning/scl /Users/jane/scala_tunings/ptolemy.scl</code></span>
+                        <span><code>/settings/path/scl /Users/jane/scala_tunings</code></span>
+                    </div>
+                </p>
+            </div>
+            </div>
+
+            <!-- Show patch selection -->
+            <div class="tablewrap fl cl">
+                <div class="heading"><h3>Patches:</h3></div>
+                <table style="border: 2px solid black;">
+                    <tr>
+                        <th>Address</th>
+                        <th>Description</th>
+                        <th>Appropriate Values</th>
+                    </tr>
+                    <tr>
+                        <td>/patch</td>
+                        <td>load patch</td>
+                        <td class="center">file path (absolute or relative)</td>
+                    </tr>
+                    <tr>
+                        <td>/patch/path</td>
+                        <td>patch path</td>
+                        <td class="center">absolute path</td>
+                    </tr>
+                    <tr>
+                        <td>/patch/incr</td>
+                        <td>increment patch</td>
+                        <td class="center">(none)</td>
+                    </tr>
+                    <tr>
+                        <td>/patch/decr</td>
+                        <td>decrement patch</td>
+                        <td class="center">(none)</td>
+                    </tr>
+                    <tr>
+                        <td>/patch/incr_category</td>
+                        <td>increment category</td>
+                        <td class="center">(none)</td>
+                    </tr>
+                    <tr>
+                        <td>/patch/decr_category</td>
+                        <td>decrement category</td>
+                        <td class="center">(none)</td>
+                    </tr>
+                </table>
+            </div>
+
+            <!-- Show tuning controls -->
+            <div class="tablewrap fr cr">
+                <div class="heading"><h3>Tuning:</h3></div>
+                <table style="border: 2px solid black;">
+                    <tr>
+                        <th>Address</th>
+                        <th>Description</th>
+                        <th>Appropriate Values</th>
+                    </tr>
+                    <tr>
+                        <td>/tuning/scl</td>
+                        <td> .scl tuning file</td>
+                        <td class="center">file path (absolute or relative)*</td>
+                    </tr>
+                    <tr>
+                        <td>/tuning/kbm</td>
+                        <td>.kbm mapping file</td>
+                        <td class="center">file path (absolute or relative)*</td>
+                    </tr>
+                        <tr>
+                        <td>/tuning/path/scl</td>
+                        <td>.scl file default path</td>
+                        <td class="center">file path (absolute only)</td>
+                    </tr>
+                    <tr>
+                        <td>/tuning/path/kbm</td>
+                        <td>.kbm file default path</td>
+                        <td class="center">file path (absolute only)</td>
+                    </tr>
+                        <tr>
+                        <td class="center" colspan="3">*use value = '_reset' to reset path to factory default</td>
+                    </tr>
+                </table>
+            </div>
     )HTML";
-
-    // Show patch selection
-    htmls << R"HTML(
-        <div class="tablewrap fl cl">
-        <div class="heading"><h3>Patches:</h3></div>
-            <table style="border: 2px solid black;">
-                <tr>
-                    <th>Address</th>
-                    <th>Description</th>
-                    <th>Appropriate Values</th>
-                </tr>
-                <tr>
-                    <td>/patch</td>
-                    <td>load patch</td>
-                    <td class="center">file path (absolute or relative)</td>
-                </tr>
-            </table>
-            </div>
-        )HTML";
-
-    // Show tuning controls
-    htmls << R"HTML(
-        <div class="tablewrap fl cl">
-        <div class="heading"><h3>Tuning:</h3></div>
-            <table style="border: 2px solid black;">
-                <tr>
-                    <th>Address</th>
-                    <th>Description</th>
-                    <th>Appropriate Values</th>
-                </tr>
-                <tr>
-                    <td>/tuning/scl</td>
-                    <td> .scl tuning file</td>
-                    <td class="center">file path (absolute or relative)</td>
-                </tr>
-                <tr>
-                    <td>/tuning/kbm</td>
-                    <td>.kbm mapping file</td>
-                    <td class="center">file path (absolute or relative)</td>
-                </tr>
-            </table>
-            </div>
-        )HTML";
-
-    // Show settings
-    htmls << R"HTML(
-        <div class="tablewrap fr cr">
-        <div class="heading"><h3>Settings:</h3></div>
-            <table style="border: 2px solid black;">
-                <tr>
-                    <th>Address</th>
-                    <th>Description</th>
-                    <th>Appropriate Values</th>
-                </tr>
-                <tr>
-                    <td>/settings/path/scl</td>
-                    <td>.scl file default path</td>
-                    <td class="center">file path (absolute only)</td>
-                </tr>
-                <tr>
-                    <td>/settings/path/kbm</td>
-                    <td>.kbm file default path</td>
-                    <td class="center">file path (absolute only)</td>
-                </tr>
-                <tr>
-                    <td>/settings/path/patch_group</td>
-                    <td>patch group</td>
-                    <td class="center"></td>
-                </tr>
-                <tr>
-                    <td>/settings/path/patch_category</td>
-                    <td>patch category</td>
-                    <td class="center"></td>
-                </tr>
-                <tr>
-                    <td class="center" colspan="3">(use value = '_reset' to reset path to factory default)</td>
-                </tr>
-            </table>
-            </div>
-        )HTML";
 
     std::vector<oscParamInfo> sortvector;
     std::string st_str;

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -603,8 +603,8 @@ code {
                 Construct OSC messages using the exact (case sensitive)
                 entry listed in the <b>Address</b> column in the tables below.</br>
                 The form of the message should be <code>/&ltaddress&gt &ltvalue&gt</code>,
-                where <code>address</code> can currently begin with either <code>tuning</code>,
-                <code>settings</code>, or <code>param</code>, and <code>value</code> can be:
+                where <code>address</code> can currently begin with either <code>tuning</code>
+                or <code>param</code>, and <code>value</code> can be:
 
                 <ul>
                     <li>a floating point value between <b>0.0</b> and <b>1.0</b></li>
@@ -625,8 +625,8 @@ code {
                     </div>
                     <div style="margin: 4px 0 0 0; line-height: 1.75">
                         <span><code>/tuning/scl ptolemy</code></span>
-                        <span><code>/tuning/scl /Users/jane/scala_tunings/ptolemy.scl</code></span>
-                        <span><code>/settings/path/scl /Users/jane/scala_tunings</code></span>
+                        <span><code>/tuning/scl /Users/jane/scala_tunings/ptolemy</code></span>
+                        <span><code>/tuning/path/scl /Users/jane/scala_tunings</code></span>
                     </div>
                 </p>
             </div>
@@ -703,8 +703,8 @@ code {
                         <td>.kbm file default path</td>
                         <td class="center">file path (absolute only)</td>
                     </tr>
-                        <tr>
-                        <td class="center" colspan="3">*use value = '_reset' to reset path to factory default</td>
+                    <tr>
+                        <td class="center" colspan="3">* no extension; use value = '_reset' to reset path to factory default</td>
                     </tr>
                 </table>
             </div>

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -502,6 +502,8 @@ div.outer {
     margin: 0 0 10pt 0;
     font-family: Lato;
     color: #123463;
+    display: flex;
+    justify-content: center;
 }
 
 div.frame {

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -601,6 +601,25 @@ code {
       <div class="outer"><div class="frame">
     )HTML";
 
+    // Show patch selection
+    htmls << R"HTML(
+        <div class="tablewrap fl cl">
+        <div class="heading"><h3>Patches:</h3></div>
+            <table style="border: 2px solid black;">
+                <tr>
+                    <th>Address</th>
+                    <th>Description</th>
+                    <th>Appropriate Values</th>
+                </tr>
+                <tr>
+                    <td>/patch</td>
+                    <td>load patch</td>
+                    <td class="center">file path (absolute or relative)</td>
+                </tr>
+            </table>
+            </div>
+        )HTML";
+
     // Show tuning controls
     htmls << R"HTML(
         <div class="tablewrap fl cl">
@@ -644,6 +663,16 @@ code {
                     <td>/settings/path/kbm</td>
                     <td>.kbm file default path</td>
                     <td class="center">file path (absolute only)</td>
+                </tr>
+                <tr>
+                    <td>/settings/path/patch_group</td>
+                    <td>patch group</td>
+                    <td class="center"></td>
+                </tr>
+                <tr>
+                    <td>/settings/path/patch_category</td>
+                    <td>patch category</td>
+                    <td class="center"></td>
                 </tr>
                 <tr>
                     <td class="center" colspan="3">(use value = '_reset' to reset path to factory default)</td>

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -692,6 +692,11 @@ code {
                         <td>decrement category</td>
                         <td class="center">(none)</td>
                     </tr>
+                    <tr>
+                        <td>/patch/random</td>
+                        <td>choose random patch</td>
+                        <td class="center">(none)</td>
+                    </tr>
                 </table>
             </div>
 

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -587,8 +587,8 @@ code {
                     </tr>
                     <tr>
                         <td>/patch</td>
-                        <td>new patch</td>
-                        <td class="center">file path (absolute, no extension)</td>
+                        <td>patch changed</td>
+                        <td class="center">new file path (absolute, no extension)</td>
                     </tr>
                 </table>
             </div>

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -47,7 +47,6 @@
 #include "fmt/core.h"
 #include "SurgeJUCEHelpers.h"
 #include "AccessibleHelpers.h"
-#include "SurgeJUCEHelpers.h"
 
 /*
  * It is an arbitrary number that we set as an ID for patch menu items.

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -654,6 +654,7 @@ void PatchSelector::showClassicMenu(bool single_category)
                     auto res = c.getResult();
                     auto rString = res.getFullPathName().toStdString();
 
+                    std::cout << "queuePatchFileLoad: " << rString << std::endl;
                     sge->queuePatchFileLoad(rString);
 
                     auto dir =

--- a/src/surge-xt/osc/OSCListener.cpp
+++ b/src/surge-xt/osc/OSCListener.cpp
@@ -131,7 +131,7 @@ void OSCListener::oscMessageReceived(const juce::OSCMessage &message)
     }
     else if (address1 == "patch")
     {
-        std::string dataStr = getWholeString(message);
+        std::string dataStr = getWholeString(message) + ".fxp";
         {
             std::lock_guard<std::mutex> mg(synth->patchLoadSpawnMutex);
             strncpy(synth->patchid_file, dataStr.c_str(), FILENAME_MAX);

--- a/src/surge-xt/osc/OSCListener.cpp
+++ b/src/surge-xt/osc/OSCListener.cpp
@@ -153,7 +153,7 @@ void OSCListener::oscMessageReceived(const juce::OSCMessage &message)
             if ((dataStr != "_reset") && (!fs::exists(dataStr)))
             {
                 std::ostringstream msg;
-                msg << "An OSC '.../path/...' message was received with a path which "
+                msg << "An OSC 'tuning/path/...' message was received with a path which "
                        "does not exist: the default path will not change.";
                 synth->storage.reportError(msg.str(), "Path does not exist.");
                 return;

--- a/src/surge-xt/osc/OSCListener.cpp
+++ b/src/surge-xt/osc/OSCListener.cpp
@@ -43,21 +43,13 @@ OSCListener::~OSCListener()
 bool OSCListener::init(SurgeSynthProcessor *ssp, const std::unique_ptr<SurgeSynthesizer> &surge,
                        int port)
 {
-    if (!connect(port))
-    {
-#ifdef DEBUG
-        std::cout << "Error: could not connect to UDP port " << std::to_string(port) << std::endl;
-#endif
-        return false;
-    }
-    else
+    synth = surge.get();
+    if (connect(port))
     {
         addListener(this);
         listening = true;
         portnum = port;
-        synth = surge.get();
         sspPtr = ssp;
-
         synth->storage.oscListenerRunning = true;
 
 #ifdef DEBUG
@@ -65,6 +57,7 @@ bool OSCListener::init(SurgeSynthProcessor *ssp, const std::unique_ptr<SurgeSynt
 #endif
         return true;
     }
+    return false;
 }
 
 void OSCListener::stopListening()

--- a/src/surge-xt/osc/OSCListener.cpp
+++ b/src/surge-xt/osc/OSCListener.cpp
@@ -221,6 +221,7 @@ void OSCListener::oscMessageReceived(const juce::OSCMessage &message)
             else
             {
                 def_path = path;
+                def_path += ".scl";
             }
 #ifdef DEBUG
             std::cout << "scl_path: " << def_path << std::endl;
@@ -241,6 +242,7 @@ void OSCListener::oscMessageReceived(const juce::OSCMessage &message)
             else
             {
                 def_path = path;
+                def_path += ".kbm";
             }
             synth->storage.loadMappingFromKBM(def_path);
         }

--- a/src/surge-xt/osc/OSCListener.cpp
+++ b/src/surge-xt/osc/OSCListener.cpp
@@ -136,6 +136,27 @@ void OSCListener::oscMessageReceived(const juce::OSCMessage &message)
         std::cout << "Parameter full name:" << p->get_full_name() << std::endl;
 #endif
     }
+    else if (address1 == "patch")
+    {
+        /*
+        auto res = c.getResult();
+        auto rString = res.getFullPathName().toStdString();
+
+        {
+            std::lock_guard<std::mutex> mg(synth->patchLoadSpawnMutex);
+            strncpy(synth->patchid_file, file.c_str(), FILENAME_MAX);
+            synth->has_patchid_file = true;
+        }
+        synth->processAudioThreadOpsWhenAudioEngineUnavailable();
+
+        auto dir = string_to_path(res.getParentDirectory().getFullPathName().toStdString());
+
+        if (dir != patchPath)
+        {
+            Surge::Storage::updateUserDefaultPath(storage, Surge::Storage::LastPatchPath, dir);
+        }
+        */
+    }
     else if (address1 == "settings")
     {
         std::getline(split, address2, '/');

--- a/src/surge-xt/osc/OSCListener.h
+++ b/src/surge-xt/osc/OSCListener.h
@@ -60,7 +60,7 @@ class OSCListener : public juce::OSCReceiver,
     void oscMessageReceived(const juce::OSCMessage &message) override;
     void oscBundleReceived(const juce::OSCBundle &bundle) override;
 
-    int portnum = 0;
+    int portnum = DEFAULT_OSC_PORT_IN;
     bool listening = false;
 
   private:

--- a/src/surge-xt/osc/OSCSender.cpp
+++ b/src/surge-xt/osc/OSCSender.cpp
@@ -37,7 +37,7 @@ OSCSender::~OSCSender() { juceOSCSender.disconnect(); }
 bool OSCSender::init(const std::unique_ptr<SurgeSynthesizer> &surge, int port)
 {
     synth = surge.get();
-    // specify here where to send OSC messages to: host URL and UDP port number
+    // Send OSC messages to localhost:UDP port number:
     if (!juceOSCSender.connect("127.0.0.1", port))
     {
 #ifdef DEBUG

--- a/src/surge-xt/osc/OSCSender.cpp
+++ b/src/surge-xt/osc/OSCSender.cpp
@@ -1,0 +1,75 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#include "OSCSender.h"
+#include <sstream>
+#include <vector>
+#include <string>
+
+namespace Surge
+{
+namespace OSC
+{
+
+OSCSender::OSCSender() {}
+
+OSCSender::~OSCSender() { juceOSCSender.disconnect(); }
+
+bool OSCSender::init(int port)
+{
+    // specify here where to send OSC messages to: host URL and UDP port number
+    if (!juceOSCSender.connect("127.0.0.1", port))
+    {
+#ifdef DEBUG
+        std::cout << "Surge OSCSender: failed to connect to UDP port " << port << "." << std::endl;
+#endif
+        return false;
+    }
+    sendingOSC = true;
+#ifdef DEBUG
+    std::cout << "SurgeOSC: Sending OSC on port " << port << "." << std::endl;
+#endif
+    return true;
+}
+
+void OSCSender::stopSending()
+{
+    if (!sendingOSC)
+        return;
+
+    sendingOSC = false;
+#ifdef DEBUG
+    std::cout << "SurgeOSC: Stopped sending OSC." << std::endl;
+#endif
+}
+
+/*
+    {
+        // create and send an OSC message with an address and a float value:
+        if (!juceOSCSender.send("/juce/rotaryknob", (float)rotaryKnob.getValue()))
+            showConnectionErrorMessage("Error: could not send OSC message.");
+    };
+
+*/
+
+} // namespace OSC
+} // namespace Surge

--- a/src/surge-xt/osc/OSCSender.cpp
+++ b/src/surge-xt/osc/OSCSender.cpp
@@ -79,14 +79,5 @@ void OSCSender::stopSending()
 #endif
 }
 
-/*
-    {
-        // create and send an OSC message with an address and a float value:
-        if (!juceOSCSender.send("/juce/rotaryknob", (float)rotaryKnob.getValue()))
-            showConnectionErrorMessage("Error: could not send OSC message.");
-    };
-
-*/
-
 } // namespace OSC
 } // namespace Surge

--- a/src/surge-xt/osc/OSCSender.cpp
+++ b/src/surge-xt/osc/OSCSender.cpp
@@ -55,6 +55,13 @@ bool OSCSender::init(const std::unique_ptr<SurgeSynthesizer> &surge, int port)
     return true;
 }
 
+void OSCSender::send(std::string addr, std::string msg)
+{
+    if (sendingOSC)
+        if (!juceOSCSender.send(juce::OSCMessage(juce::String(addr), juce::String(msg))))
+            std::cout << "Error: could not send OSC message.";
+}
+
 void OSCSender::stopSending()
 {
     if (!sendingOSC)

--- a/src/surge-xt/osc/OSCSender.cpp
+++ b/src/surge-xt/osc/OSCSender.cpp
@@ -34,8 +34,9 @@ OSCSender::OSCSender() {}
 
 OSCSender::~OSCSender() { juceOSCSender.disconnect(); }
 
-bool OSCSender::init(int port)
+bool OSCSender::init(const std::unique_ptr<SurgeSynthesizer> &surge, int port)
 {
+    synth = surge.get();
     // specify here where to send OSC messages to: host URL and UDP port number
     if (!juceOSCSender.connect("127.0.0.1", port))
     {
@@ -45,6 +46,9 @@ bool OSCSender::init(int port)
         return false;
     }
     sendingOSC = true;
+    portnum = port;
+    synth->storage.oscSending = true;
+
 #ifdef DEBUG
     std::cout << "SurgeOSC: Sending OSC on port " << port << "." << std::endl;
 #endif
@@ -57,6 +61,7 @@ void OSCSender::stopSending()
         return;
 
     sendingOSC = false;
+    synth->storage.oscSending = false;
 #ifdef DEBUG
     std::cout << "SurgeOSC: Stopped sending OSC." << std::endl;
 #endif

--- a/src/surge-xt/osc/OSCSender.cpp
+++ b/src/surge-xt/osc/OSCSender.cpp
@@ -58,8 +58,13 @@ bool OSCSender::init(const std::unique_ptr<SurgeSynthesizer> &surge, int port)
 void OSCSender::send(std::string addr, std::string msg)
 {
     if (sendingOSC)
-        if (!juceOSCSender.send(juce::OSCMessage(juce::String(addr), juce::String(msg))))
-            std::cout << "Error: could not send OSC message.";
+    {
+        // Runs on the juce messenger thread
+        juce::MessageManager::getInstance()->callAsync([this, msg, addr]() {
+            if (!this->juceOSCSender.send(juce::OSCMessage(juce::String(addr), juce::String(msg))))
+                std::cout << "Error: could not send OSC message.";
+        });
+    }
 }
 
 void OSCSender::stopSending()

--- a/src/surge-xt/osc/OSCSender.h
+++ b/src/surge-xt/osc/OSCSender.h
@@ -51,6 +51,7 @@ class OSCSender : public juce::OSCSender
     ~OSCSender();
 
     bool init(const std::unique_ptr<SurgeSynthesizer> &surge, int port);
+    void send(std::string addr, std::string msg);
     void stopSending();
 
     // void oscMessageReceived(const juce::OSCMessage &message) override;

--- a/src/surge-xt/osc/OSCSender.h
+++ b/src/surge-xt/osc/OSCSender.h
@@ -37,6 +37,7 @@
 */
 
 #include "juce_osc/juce_osc.h"
+#include "SurgeSynthesizer.h"
 
 namespace Surge
 {
@@ -49,17 +50,18 @@ class OSCSender : public juce::OSCSender
     OSCSender();
     ~OSCSender();
 
-    bool init(int port);
+    bool init(const std::unique_ptr<SurgeSynthesizer> &surge, int port);
     void stopSending();
 
     // void oscMessageReceived(const juce::OSCMessage &message) override;
     // void oscBundleReceived(const juce::OSCBundle &bundle) override;
 
-    int portnum = 0;
+    int portnum = DEFAULT_OSC_PORT_OUT;
     bool sendingOSC = false;
 
   private:
     juce::OSCSender juceOSCSender;
+    SurgeSynthesizer *synth{nullptr};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OSCSender)
 };

--- a/src/surge-xt/osc/OSCSender.h
+++ b/src/surge-xt/osc/OSCSender.h
@@ -44,7 +44,7 @@ namespace Surge
 namespace OSC
 {
 
-class OSCSender : public juce::OSCSender
+class OSCSender
 {
   public:
     OSCSender();
@@ -53,9 +53,6 @@ class OSCSender : public juce::OSCSender
     bool init(const std::unique_ptr<SurgeSynthesizer> &surge, int port);
     void send(std::string addr, std::string msg);
     void stopSending();
-
-    // void oscMessageReceived(const juce::OSCMessage &message) override;
-    // void oscBundleReceived(const juce::OSCBundle &bundle) override;
 
     int portnum = DEFAULT_OSC_PORT_OUT;
     bool sendingOSC = false;

--- a/src/surge-xt/osc/OSCSender.h
+++ b/src/surge-xt/osc/OSCSender.h
@@ -1,0 +1,69 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+#ifndef SURGE_SRC_SURGE_XT_OSC_OSCSENDER_H
+#define SURGE_SRC_SURGE_XT_OSC_OSCSENDER_H
+/*
+** Surge Synthesizer is Free and Open Source Software
+**
+** Surge is made available under the Gnu General Public License, v3.0
+** https://www.gnu.org/licenses/gpl-3.0.en.html
+**
+** Copyright 2004-2020 by various individuals as described by the Git transaction log
+**
+** All source at: https://github.com/surge-synthesizer/surge.git
+**
+** Surge was a commercial product from 2004-2018, with Copyright and ownership
+** in that period held by Claes Johanson at Vember Audio. Claes made Surge
+** open source in September 2018.
+*/
+
+#include "juce_osc/juce_osc.h"
+
+namespace Surge
+{
+namespace OSC
+{
+
+class OSCSender : public juce::OSCSender
+{
+  public:
+    OSCSender();
+    ~OSCSender();
+
+    bool init(int port);
+    void stopSending();
+
+    // void oscMessageReceived(const juce::OSCMessage &message) override;
+    // void oscBundleReceived(const juce::OSCBundle &bundle) override;
+
+    int portnum = 0;
+    bool sendingOSC = false;
+
+  private:
+    juce::OSCSender juceOSCSender;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OSCSender)
+};
+
+} // namespace OSC
+} // namespace Surge
+#endif // SURGE_SRC_SURGE_XT_OSC_OSCSENDER_H


### PR DESCRIPTION
Enhancements to OSC:

Patch changing via OSC is working, including full path specification, patch incr/decr, category incr/decr, and random patch change.

OSC output has been added. The first (and only, so far) message reports the path for patch changes.

All patch and tuning file paths have been made consistent in excluding file extension from OSC messages. They are added contextually in OSCListener.