### PR TITLE
Allow only .wav and .wt files in Load Wavetable dialog

### DIFF
--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -1022,8 +1022,8 @@ void OscillatorWaveformDisplay::loadWavetableFromFile()
         return;
     }
 
-    sge->fileChooser = std::make_unique<juce::FileChooser>("Select Wavetable to Load",
-                                                           juce::File(path_to_string(wtPath)));
+    sge->fileChooser = std::make_unique<juce::FileChooser>(
+        "Select Wavetable to Load", juce::File(path_to_string(wtPath)), "*.wav, *.wt");
     sge->fileChooser->launchAsync(
         juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
         [this, wtPath](const juce::FileChooser &c) {


### PR DESCRIPTION
Fixes #3300