### PR TITLE
Migrate alerts with toggle buttons to surge ui

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3660,23 +3660,13 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
     {
         if (MTS_HasIPC())
         {
-            tuningSubMenu.addItem("Reinitialize MTS Library and IPC", true, false, []() {
-                auto cb = juce::ModalCallbackFunction::create([](int okcs) {
-                    if (okcs)
-                    {
-                        MTS_Reinitialize();
-                    }
-                });
-
+            tuningSubMenu.addItem("Reinitialize MTS Library and IPC", true, false, [this]() {
                 std::string msg =
                     "Reinitializing MTS will disconnect all clients, including "
                     "this one, and will generally require you to restart your DAW session, "
                     "but it will clear up after particularly nasty crashes or IPC issues. "
                     "Are you sure you want to do this?";
-
-                juce::AlertWindow::showOkCancelBox(juce::AlertWindow::NoIcon,
-                                                   "Reinitialize MTS-ESP", msg, "Yes", "No",
-                                                   nullptr, cb);
+                alertYesNo("Reinitialize MTS-ESP", msg, MTS_Reinitialize);
             });
         }
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -845,10 +845,6 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     std::unique_ptr<Surge::Overlays::Alert> alert;
 
-    std::unique_ptr<juce::AlertWindow> okcWithToggleAlertWindow;
-    std::unique_ptr<juce::ToggleButton> okcWithToggleToggleButton;
-    std::function<void()> okcWithToggleCallback;
-
     enum AskAgainStates
     {
         DUNNO = 1,

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -474,3 +474,25 @@ void SurgeJUCELookAndFeel::drawPopupMenuSectionHeaderWithOptions(Graphics &graph
 {
     LookAndFeel_V2::drawPopupMenuSectionHeaderWithOptions(graphics, area, sectionName, options);
 }
+
+void SurgeJUCELookAndFeel::drawToggleButton(Graphics &g, ToggleButton &button,
+                                            bool shouldDrawButtonAsHighlighted,
+                                            bool shouldDrawButtonAsDown)
+{
+    auto tickWidth = jmin(15.0f, (float)button.getHeight() * 0.75f) * 1.2f;
+
+    drawTickBox(g, button, 2.0f, ((float)button.getHeight() - tickWidth) * 0.5f, tickWidth,
+                tickWidth, button.getToggleState(), button.isEnabled(),
+                shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+
+    g.setColour(button.findColour(ToggleButton::textColourId));
+    g.setFont(skin->fontManager->getLatoAtSize(9));
+
+    if (!button.isEnabled())
+        g.setOpacity(0.5f);
+
+    g.drawFittedText(
+        button.getButtonText(),
+        button.getLocalBounds().withTrimmedLeft(roundToInt(tickWidth) + 10).withTrimmedRight(2),
+        Justification::centredLeft, 10);
+}

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -132,6 +132,10 @@ void SurgeJUCELookAndFeel::onSkinChanged()
               skin->getColor(Colors::VirtualKeyboard::OctaveJog::Background));
     setColour(MidiKeyboardComponent::upDownButtonArrowColourId,
               skin->getColor(Colors::VirtualKeyboard::OctaveJog::Arrow));
+
+    setColour(ToggleButton::textColourId, skin->getColor(Colors::Dialog::Label::Text));
+    setColour(ToggleButton::tickColourId, skin->getColor(Colors::Dialog::Checkbox::Tick));
+    setColour(ToggleButton::tickDisabledColourId, skin->getColor(Colors::Dialog::Checkbox::Border));
 }
 
 void SurgeJUCELookAndFeel::drawLabel(Graphics &graphics, Label &label)

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.h
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.h
@@ -61,6 +61,9 @@ class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4, public Surge::GUI::Ski
 
     void drawCornerResizer(juce::Graphics &g, int w, int h, bool, bool) override{};
 
+    void drawToggleButton(juce::Graphics &g, juce::ToggleButton &b,
+                          bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) override;
+
     enum SurgeColourIds
     {
         componentBgStart = 0x3700001,

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -69,13 +69,6 @@ void Alert::paint(juce::Graphics &g)
     g.setFont(skin->fontManager->getLatoAtSize(9));
     g.drawFittedText(label, fullRect.withTrimmedTop(18).reduced(6), juce::Justification::centredTop,
                      4);
-
-    toggleButton->setColour(juce::ToggleButton::textColourId,
-                            skin->getColor(Colors::Dialog::Label::Text));
-    toggleButton->setColour(juce::ToggleButton::tickColourId,
-                            skin->getColor(Colors::Dialog::Checkbox::Tick));
-    toggleButton->setColour(juce::ToggleButton::tickDisabledColourId,
-                            skin->getColor(Colors::Dialog::Checkbox::Border));
 }
 
 void Alert::resized()

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -44,34 +44,58 @@ Alert::Alert()
 
 Alert::~Alert() {}
 
+void Alert::addToggleButtonAndSetText(const std::string &t)
+{
+    toggleButton = std::make_unique<juce::ToggleButton>(t);
+    addAndMakeVisible(*toggleButton);
+}
+
 juce::Rectangle<int> Alert::getDisplayRegion()
 {
+    if (toggleButton)
+    {
+        return juce::Rectangle<int>(0, 0, 360, 111).withCentre(getBounds().getCentre());
+    }
     return juce::Rectangle<int>(0, 0, 360, 95).withCentre(getBounds().getCentre());
 }
 
 void Alert::paint(juce::Graphics &g)
 {
     auto fullRect = getDisplayRegion();
+
     paintOverlayWindow(g, skin, associatedBitmapStore, fullRect, title);
+
     g.setColour(skin->getColor(Colors::Dialog::Label::Text));
     g.setFont(skin->fontManager->getLatoAtSize(9));
     g.drawFittedText(label, fullRect.withTrimmedTop(18).reduced(6), juce::Justification::centredTop,
                      4);
+
+    toggleButton->setColour(juce::ToggleButton::textColourId,
+                            skin->getColor(Colors::Dialog::Label::Text));
+    toggleButton->setColour(juce::ToggleButton::tickColourId,
+                            skin->getColor(Colors::Dialog::Checkbox::Tick));
+    toggleButton->setColour(juce::ToggleButton::tickDisabledColourId,
+                            skin->getColor(Colors::Dialog::Checkbox::Border));
 }
 
 void Alert::resized()
 {
-    auto margin = 2, btnHeight = 17, btnWidth = 50;
+    auto margin = 2, btnHeight = 17, btnWidth = 50, buttonVertTranslate = toggleButton ? 86 : 70;
 
     auto fullRect = getDisplayRegion();
     auto dialogCenter = fullRect.getWidth() / 2;
 
-    auto buttonRow = fullRect.withHeight(btnHeight).translated(0, 70);
+    auto buttonRow = fullRect.withHeight(btnHeight).translated(0, buttonVertTranslate);
     auto okRect = buttonRow.withTrimmedLeft(dialogCenter - btnWidth - margin).withWidth(btnWidth);
     auto canRect = buttonRow.withTrimmedLeft(dialogCenter + margin).withWidth(btnWidth);
 
     okButton->setBounds(okRect);
     cancelButton->setBounds(canRect);
+
+    if (toggleButton)
+    {
+        toggleButton->setBounds(fullRect.withHeight(16).translated(10, 70));
+    }
 }
 
 void Alert::onSkinChanged()
@@ -84,14 +108,29 @@ void Alert::onSkinChanged()
 
 void Alert::buttonClicked(juce::Button *button)
 {
-    if (button == okButton.get())
+    if (!toggleButton)
     {
-        onOk();
+        if (button == okButton.get())
+        {
+            onOk();
+        }
+        else if (button == cancelButton.get() && onCancel)
+        {
+            onCancel();
+        }
     }
-    else if (button == cancelButton.get() && onCancel)
+    else
     {
-        onCancel();
+        if (button == okButton.get())
+        {
+            onOkForToggleState(toggleButton->getToggleState());
+        }
+        else if (button == cancelButton.get() && onCancelForToggleState)
+        {
+            onCancelForToggleState(toggleButton->getToggleState());
+        }
     }
+
     setVisible(false);
 }
 } // namespace Overlays

--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -40,6 +40,7 @@ struct Alert : public juce::Component,
     std::string title, label;
     std::unique_ptr<Surge::Widgets::SurgeTextButton> okButton;
     std::unique_ptr<Surge::Widgets::SurgeTextButton> cancelButton;
+    std::unique_ptr<juce::ToggleButton> toggleButton;
     void setWindowTitle(const std::string &t)
     {
         title = t;
@@ -51,8 +52,11 @@ struct Alert : public juce::Component,
         okButton->setButtonText(okText);
         cancelButton->setButtonText(cancelText);
     }
+    void addToggleButtonAndSetText(const std::string &t);
     std::function<void()> onOk;
     std::function<void()> onCancel;
+    std::function<void(bool)> onOkForToggleState;
+    std::function<void(bool)> onCancelForToggleState;
     void paint(juce::Graphics &g) override;
     void resized() override;
     void onSkinChanged() override;


### PR DESCRIPTION
[Issue](https://github.com/surge-synthesizer/surge/issues/5663)
Looked up some JUCE forums, they said that the appropriate way to do this was to edit the LookAndFeel. Happy to implement this in a different way too of course! 
![Alert With Toggle unticked](https://github.com/surge-synthesizer/surge/assets/5881947/bfe32fec-a880-4de6-a9ef-ec129d4a47bc)
![alert with toggle ticked](https://github.com/surge-synthesizer/surge/assets/5881947/bbdcc76d-66d7-4149-8d2f-78112652fbd5)
