### PR TITLE
Fix Modulation Display with sst-effects fx

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2386,6 +2386,8 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
                 iw->valminus = res->valDown;
                 iw->dvalplus = res->changeUp;
                 iw->dvalminus = res->changeDown;
+
+                strncpy(txt, res->singleLineModulationSummary.c_str(), TXT_SIZE - 1);
                 return;
             }
         }


### PR DESCRIPTION
1. Actually fill out the short description used when not in expanded infowindow mode (duh)
2. With correct data (that's nice!)
3. And also fix some places where the info window is wrong

Closes #7066