### PR TITLE
Migrate message boxes to new UI

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3660,23 +3660,13 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
     {
         if (MTS_HasIPC())
         {
-            tuningSubMenu.addItem("Reinitialize MTS Library and IPC", true, false, []() {
-                auto cb = juce::ModalCallbackFunction::create([](int okcs) {
-                    if (okcs)
-                    {
-                        MTS_Reinitialize();
-                    }
-                });
-
+            tuningSubMenu.addItem("Reinitialize MTS Library and IPC", true, false, [this]() {
                 std::string msg =
                     "Reinitializing MTS will disconnect all clients, including "
                     "this one, and will generally require you to restart your DAW session, "
                     "but it will clear up after particularly nasty crashes or IPC issues. "
                     "Are you sure you want to do this?";
-
-                juce::AlertWindow::showOkCancelBox(juce::AlertWindow::NoIcon,
-                                                   "Reinitialize MTS-ESP", msg, "Yes", "No",
-                                                   nullptr, cb);
+                alertYesNo("Reinitialize MTS-ESP", msg, MTS_Reinitialize);
             });
         }
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -5647,7 +5647,7 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
 
 void SurgeGUIEditor::alertBox(const std::string &title, const std::string &prompt,
                               std::function<void()> onOk, std::function<void()> onCancel,
-                              Surge::Overlays::AlertButtonStyle buttonStyle)
+                              AlertButtonStyle buttonStyle)
 {
     alert = std::make_unique<Surge::Overlays::Alert>();
     alert->setSkin(currentSkin, bitmapStore);
@@ -5655,28 +5655,31 @@ void SurgeGUIEditor::alertBox(const std::string &title, const std::string &promp
     alert->setWindowTitle(title);
     addAndMakeVisibleWithTracking(frame.get(), *alert);
     alert->setLabel(prompt);
-    alert->setButtonStyle(buttonStyle);
+
+    switch (buttonStyle)
+    {
+    case AlertButtonStyle::OK_CANCEL:
+    {
+        alert->setOkCancelButtonTexts("OK", "Cancel");
+        break;
+    }
+    case AlertButtonStyle::YES_NO:
+    {
+        alert->setOkCancelButtonTexts("Yes", "No");
+        break;
+    }
+    case AlertButtonStyle::OK:
+    {
+        alert->setSingleButtonText("OK");
+        break;
+    }
+    }
+
     alert->onOk = std::move(onOk);
     alert->onCancel = std::move(onCancel);
     alert->setBounds(0, 0, getWindowSizeX(), getWindowSizeY());
     alert->setVisible(true);
     alert->toFront(true);
-}
-
-void SurgeGUIEditor::alertOKCancel(const std::string &title, const std::string &prompt,
-                                   std::function<void()> onOk, std::function<void()> onCancel)
-{
-    alertBox(title, prompt, onOk, onCancel, Surge::Overlays::AlertButtonStyle::OK_CANCEL);
-}
-
-void SurgeGUIEditor::alertYesNo(const std::string &title, const std::string &prompt,
-                                std::function<void()> onOk, std::function<void()> onCancel)
-{
-    alertBox(title, prompt, onOk, onCancel, Surge::Overlays::AlertButtonStyle::YES_NO);
-}
-void SurgeGUIEditor::messageBox(const std::string &title, const std::string &prompt)
-{
-    alertBox(title, prompt, nullptr, nullptr, Surge::Overlays::AlertButtonStyle::OK);
 }
 
 bool SurgeGUIEditor::modSourceButtonDraggedOver(Surge::Widgets::ModulationSourceButton *msb,
@@ -8333,7 +8336,7 @@ bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(
     addAndMakeVisibleWithTracking(frame.get(), *alert);
     alert->setLabel(msg);
     alert->addToggleButtonAndSetText(ynMessage);
-    alert->setButtonStyle(Surge::Overlays::AlertButtonStyle::OK_CANCEL);
+    alert->setOkCancelButtonTexts("OK", "Cancel");
     alert->onOkForToggleState = [this, dontAskAgainKey, okCallback](bool dontAskAgain) {
         if (dontAskAgain)
         {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -570,7 +570,7 @@ void SurgeGUIEditor::idle()
             }
             else
             {
-                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::NoIcon, title, msg);
+                messageBox(title, msg);
             }
         }
     }
@@ -5645,9 +5645,9 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
     miniEdit->grabFocus();
 }
 
-void SurgeGUIEditor::alertOKCancel(const std::string &title, const std::string &prompt,
-                                   std::function<void()> onOk, std::function<void()> onCancel,
-                                   AlertButtonStyle buttonStyle)
+void SurgeGUIEditor::alertBox(const std::string &title, const std::string &prompt,
+                              std::function<void()> onOk, std::function<void()> onCancel,
+                              Surge::Overlays::AlertButtonStyle buttonStyle)
 {
     alert = std::make_unique<Surge::Overlays::Alert>();
     alert->setSkin(currentSkin, bitmapStore);
@@ -5655,19 +5655,28 @@ void SurgeGUIEditor::alertOKCancel(const std::string &title, const std::string &
     alert->setWindowTitle(title);
     addAndMakeVisibleWithTracking(frame.get(), *alert);
     alert->setLabel(prompt);
-    if (buttonStyle == AlertButtonStyle::YES_NO)
-    {
-        alert->setButtonText("Yes", "No");
-    }
-    else
-    {
-        alert->setButtonText("OK", "Cancel");
-    }
+    alert->setButtonStyle(buttonStyle);
     alert->onOk = std::move(onOk);
     alert->onCancel = std::move(onCancel);
     alert->setBounds(0, 0, getWindowSizeX(), getWindowSizeY());
     alert->setVisible(true);
     alert->toFront(true);
+}
+
+void SurgeGUIEditor::alertOKCancel(const std::string &title, const std::string &prompt,
+                                   std::function<void()> onOk, std::function<void()> onCancel)
+{
+    alertBox(title, prompt, onOk, onCancel, Surge::Overlays::AlertButtonStyle::OK_CANCEL);
+}
+
+void SurgeGUIEditor::alertYesNo(const std::string &title, const std::string &prompt,
+                                std::function<void()> onOk, std::function<void()> onCancel)
+{
+    alertBox(title, prompt, onOk, onCancel, Surge::Overlays::AlertButtonStyle::YES_NO);
+}
+void SurgeGUIEditor::messageBox(const std::string &title, const std::string &prompt)
+{
+    alertBox(title, prompt, nullptr, nullptr, Surge::Overlays::AlertButtonStyle::OK);
 }
 
 bool SurgeGUIEditor::modSourceButtonDraggedOver(Surge::Widgets::ModulationSourceButton *msb,
@@ -8324,7 +8333,7 @@ bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(
     addAndMakeVisibleWithTracking(frame.get(), *alert);
     alert->setLabel(msg);
     alert->addToggleButtonAndSetText(ynMessage);
-    alert->setButtonText("OK", "Cancel");
+    alert->setButtonStyle(Surge::Overlays::AlertButtonStyle::OK_CANCEL);
     alert->onOkForToggleState = [this, dontAskAgainKey, okCallback](bool dontAskAgain) {
         if (dontAskAgain)
         {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -86,7 +86,6 @@ struct AboutScreen;
 struct TypeinParamEditor;
 struct MiniEdit;
 struct Alert;
-enum AlertButtonStyle;
 struct OverlayWrapper;
 struct PatchStoreDialog;
 } // namespace Overlays
@@ -829,14 +828,30 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void setUseKeyboardShortcuts(bool b);
     void toggleUseKeyboardShortcuts();
 
+    enum AlertButtonStyle
+    {
+        OK_CANCEL,
+        YES_NO,
+        OK
+    };
+
     void alertBox(const std::string &title, const std::string &prompt, std::function<void()> onOk,
-                  std::function<void()> onCancel, Surge::Overlays::AlertButtonStyle buttonStyle);
+                  std::function<void()> onCancel, AlertButtonStyle buttonStyle);
 
     void alertOKCancel(const std::string &title, const std::string &prompt,
-                       std::function<void()> onOk, std::function<void()> onCancel = nullptr);
+                       std::function<void()> onOk, std::function<void()> onCancel = nullptr)
+    {
+        alertBox(title, prompt, onOk, onCancel, AlertButtonStyle::OK_CANCEL);
+    }
     void alertYesNo(const std::string &title, const std::string &prompt, std::function<void()> onOk,
-                    std::function<void()> onCancel = nullptr);
-    void messageBox(const std::string &title, const std::string &prompt);
+                    std::function<void()> onCancel = nullptr)
+    {
+        alertBox(title, prompt, onOk, onCancel, AlertButtonStyle::YES_NO);
+    }
+    void messageBox(const std::string &title, const std::string &prompt)
+    {
+        alertBox(title, prompt, nullptr, nullptr, AlertButtonStyle::OK);
+    }
 
     std::unique_ptr<Surge::Overlays::Alert> alert;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -86,7 +86,7 @@ struct AboutScreen;
 struct TypeinParamEditor;
 struct MiniEdit;
 struct Alert;
-
+enum AlertButtonStyle;
 struct OverlayWrapper;
 struct PatchStoreDialog;
 } // namespace Overlays
@@ -829,19 +829,14 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void setUseKeyboardShortcuts(bool b);
     void toggleUseKeyboardShortcuts();
 
-    enum AlertButtonStyle
-    {
-        OK_CANCEL,
-        YES_NO
-    };
+    void alertBox(const std::string &title, const std::string &prompt, std::function<void()> onOk,
+                  std::function<void()> onCancel, Surge::Overlays::AlertButtonStyle buttonStyle);
+
     void alertOKCancel(const std::string &title, const std::string &prompt,
-                       std::function<void()> onOk, std::function<void()> onCancel = nullptr,
-                       AlertButtonStyle buttonStyle = OK_CANCEL);
+                       std::function<void()> onOk, std::function<void()> onCancel = nullptr);
     void alertYesNo(const std::string &title, const std::string &prompt, std::function<void()> onOk,
-                    std::function<void()> onCancel = nullptr)
-    {
-        alertOKCancel(title, prompt, onOk, onCancel, YES_NO);
-    }
+                    std::function<void()> onCancel = nullptr);
+    void messageBox(const std::string &title, const std::string &prompt);
 
     std::unique_ptr<Surge::Overlays::Alert> alert;
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -845,10 +845,6 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     std::unique_ptr<Surge::Overlays::Alert> alert;
 
-    std::unique_ptr<juce::AlertWindow> okcWithToggleAlertWindow;
-    std::unique_ptr<juce::ToggleButton> okcWithToggleToggleButton;
-    std::function<void()> okcWithToggleCallback;
-
     enum AskAgainStates
     {
         DUNNO = 1,

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -474,3 +474,25 @@ void SurgeJUCELookAndFeel::drawPopupMenuSectionHeaderWithOptions(Graphics &graph
 {
     LookAndFeel_V2::drawPopupMenuSectionHeaderWithOptions(graphics, area, sectionName, options);
 }
+
+void SurgeJUCELookAndFeel::drawToggleButton(Graphics &g, ToggleButton &button,
+                                            bool shouldDrawButtonAsHighlighted,
+                                            bool shouldDrawButtonAsDown)
+{
+    auto tickWidth = jmin(15.0f, (float)button.getHeight() * 0.75f) * 1.2f;
+
+    drawTickBox(g, button, 2.0f, ((float)button.getHeight() - tickWidth) * 0.5f, tickWidth,
+                tickWidth, button.getToggleState(), button.isEnabled(),
+                shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+
+    g.setColour(button.findColour(ToggleButton::textColourId));
+    g.setFont(skin->fontManager->getLatoAtSize(9));
+
+    if (!button.isEnabled())
+        g.setOpacity(0.5f);
+
+    g.drawFittedText(
+        button.getButtonText(),
+        button.getLocalBounds().withTrimmedLeft(roundToInt(tickWidth) + 10).withTrimmedRight(2),
+        Justification::centredLeft, 10);
+}

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -132,6 +132,10 @@ void SurgeJUCELookAndFeel::onSkinChanged()
               skin->getColor(Colors::VirtualKeyboard::OctaveJog::Background));
     setColour(MidiKeyboardComponent::upDownButtonArrowColourId,
               skin->getColor(Colors::VirtualKeyboard::OctaveJog::Arrow));
+
+    setColour(ToggleButton::textColourId, skin->getColor(Colors::Dialog::Label::Text));
+    setColour(ToggleButton::tickColourId, skin->getColor(Colors::Dialog::Checkbox::Tick));
+    setColour(ToggleButton::tickDisabledColourId, skin->getColor(Colors::Dialog::Checkbox::Border));
 }
 
 void SurgeJUCELookAndFeel::drawLabel(Graphics &graphics, Label &label)

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.h
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.h
@@ -61,6 +61,9 @@ class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4, public Surge::GUI::Ski
 
     void drawCornerResizer(juce::Graphics &g, int w, int h, bool, bool) override{};
 
+    void drawToggleButton(juce::Graphics &g, juce::ToggleButton &b,
+                          bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) override;
+
     enum SurgeColourIds
     {
         componentBgStart = 0x3700001,

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -79,7 +79,7 @@ void Alert::resized()
     auto dialogCenter = fullRect.getWidth() / 2;
     auto buttonRow = fullRect.withHeight(btnHeight).translated(0, buttonVertTranslate);
 
-    if (style == AlertButtonStyle::OK)
+    if (singleButton)
     {
         auto okRect = buttonRow.withTrimmedLeft(dialogCenter - btnWidth / 2).withWidth(btnWidth);
         okButton->setBounds(okRect);
@@ -106,31 +106,6 @@ void Alert::onSkinChanged()
     cancelButton->setSkin(skin, associatedBitmapStore);
 
     repaint();
-}
-
-void Alert::setButtonStyle(AlertButtonStyle s)
-{
-    style = s;
-    switch (style)
-    {
-    case AlertButtonStyle::OK_CANCEL:
-    {
-        okButton->setButtonText("OK");
-        cancelButton->setButtonText("Cancel");
-        break;
-    }
-    case AlertButtonStyle::YES_NO:
-    {
-        okButton->setButtonText("Yes");
-        cancelButton->setButtonText("No");
-        break;
-    }
-    case AlertButtonStyle::OK:
-    {
-        okButton->setButtonText("OK");
-        break;
-    }
-    }
 }
 
 void Alert::buttonClicked(juce::Button *button)

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -77,13 +77,22 @@ void Alert::resized()
 
     auto fullRect = getDisplayRegion();
     auto dialogCenter = fullRect.getWidth() / 2;
-
     auto buttonRow = fullRect.withHeight(btnHeight).translated(0, buttonVertTranslate);
-    auto okRect = buttonRow.withTrimmedLeft(dialogCenter - btnWidth - margin).withWidth(btnWidth);
-    auto canRect = buttonRow.withTrimmedLeft(dialogCenter + margin).withWidth(btnWidth);
 
-    okButton->setBounds(okRect);
-    cancelButton->setBounds(canRect);
+    if (style == AlertButtonStyle::OK)
+    {
+        auto okRect = buttonRow.withTrimmedLeft(dialogCenter - btnWidth / 2).withWidth(btnWidth);
+        okButton->setBounds(okRect);
+    }
+    else
+    {
+        auto okRect =
+            buttonRow.withTrimmedLeft(dialogCenter - btnWidth - margin).withWidth(btnWidth);
+        auto canRect = buttonRow.withTrimmedLeft(dialogCenter + margin).withWidth(btnWidth);
+
+        okButton->setBounds(okRect);
+        cancelButton->setBounds(canRect);
+    }
 
     if (toggleButton)
     {
@@ -99,11 +108,36 @@ void Alert::onSkinChanged()
     repaint();
 }
 
+void Alert::setButtonStyle(AlertButtonStyle s)
+{
+    style = s;
+    switch (style)
+    {
+    case AlertButtonStyle::OK_CANCEL:
+    {
+        okButton->setButtonText("OK");
+        cancelButton->setButtonText("Cancel");
+        break;
+    }
+    case AlertButtonStyle::YES_NO:
+    {
+        okButton->setButtonText("Yes");
+        cancelButton->setButtonText("No");
+        break;
+    }
+    case AlertButtonStyle::OK:
+    {
+        okButton->setButtonText("OK");
+        break;
+    }
+    }
+}
+
 void Alert::buttonClicked(juce::Button *button)
 {
     if (!toggleButton)
     {
-        if (button == okButton.get())
+        if (button == okButton.get() && onOk)
         {
             onOk();
         }
@@ -114,7 +148,7 @@ void Alert::buttonClicked(juce::Button *button)
     }
     else
     {
-        if (button == okButton.get())
+        if (button == okButton.get() && onOkForToggleState)
         {
             onOkForToggleState(toggleButton->getToggleState());
         }

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -69,13 +69,6 @@ void Alert::paint(juce::Graphics &g)
     g.setFont(skin->fontManager->getLatoAtSize(9));
     g.drawFittedText(label, fullRect.withTrimmedTop(18).reduced(6), juce::Justification::centredTop,
                      4);
-
-    toggleButton->setColour(juce::ToggleButton::textColourId,
-                            skin->getColor(Colors::Dialog::Label::Text));
-    toggleButton->setColour(juce::ToggleButton::tickColourId,
-                            skin->getColor(Colors::Dialog::Checkbox::Tick));
-    toggleButton->setColour(juce::ToggleButton::tickDisabledColourId,
-                            skin->getColor(Colors::Dialog::Checkbox::Border));
 }
 
 void Alert::resized()

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -44,34 +44,58 @@ Alert::Alert()
 
 Alert::~Alert() {}
 
+void Alert::addToggleButtonAndSetText(const std::string &t)
+{
+    toggleButton = std::make_unique<juce::ToggleButton>(t);
+    addAndMakeVisible(*toggleButton);
+}
+
 juce::Rectangle<int> Alert::getDisplayRegion()
 {
+    if (toggleButton)
+    {
+        return juce::Rectangle<int>(0, 0, 360, 111).withCentre(getBounds().getCentre());
+    }
     return juce::Rectangle<int>(0, 0, 360, 95).withCentre(getBounds().getCentre());
 }
 
 void Alert::paint(juce::Graphics &g)
 {
     auto fullRect = getDisplayRegion();
+
     paintOverlayWindow(g, skin, associatedBitmapStore, fullRect, title);
+
     g.setColour(skin->getColor(Colors::Dialog::Label::Text));
     g.setFont(skin->fontManager->getLatoAtSize(9));
     g.drawFittedText(label, fullRect.withTrimmedTop(18).reduced(6), juce::Justification::centredTop,
                      4);
+
+    toggleButton->setColour(juce::ToggleButton::textColourId,
+                            skin->getColor(Colors::Dialog::Label::Text));
+    toggleButton->setColour(juce::ToggleButton::tickColourId,
+                            skin->getColor(Colors::Dialog::Checkbox::Tick));
+    toggleButton->setColour(juce::ToggleButton::tickDisabledColourId,
+                            skin->getColor(Colors::Dialog::Checkbox::Border));
 }
 
 void Alert::resized()
 {
-    auto margin = 2, btnHeight = 17, btnWidth = 50;
+    auto margin = 2, btnHeight = 17, btnWidth = 50, buttonVertTranslate = toggleButton ? 86 : 70;
 
     auto fullRect = getDisplayRegion();
     auto dialogCenter = fullRect.getWidth() / 2;
 
-    auto buttonRow = fullRect.withHeight(btnHeight).translated(0, 70);
+    auto buttonRow = fullRect.withHeight(btnHeight).translated(0, buttonVertTranslate);
     auto okRect = buttonRow.withTrimmedLeft(dialogCenter - btnWidth - margin).withWidth(btnWidth);
     auto canRect = buttonRow.withTrimmedLeft(dialogCenter + margin).withWidth(btnWidth);
 
     okButton->setBounds(okRect);
     cancelButton->setBounds(canRect);
+
+    if (toggleButton)
+    {
+        toggleButton->setBounds(fullRect.withHeight(16).translated(10, 70));
+    }
 }
 
 void Alert::onSkinChanged()
@@ -84,14 +108,29 @@ void Alert::onSkinChanged()
 
 void Alert::buttonClicked(juce::Button *button)
 {
-    if (button == okButton.get())
+    if (!toggleButton)
     {
-        onOk();
+        if (button == okButton.get())
+        {
+            onOk();
+        }
+        else if (button == cancelButton.get() && onCancel)
+        {
+            onCancel();
+        }
     }
-    else if (button == cancelButton.get() && onCancel)
+    else
     {
-        onCancel();
+        if (button == okButton.get())
+        {
+            onOkForToggleState(toggleButton->getToggleState());
+        }
+        else if (button == cancelButton.get() && onCancelForToggleState)
+        {
+            onCancelForToggleState(toggleButton->getToggleState());
+        }
     }
+
     setVisible(false);
 }
 } // namespace Overlays

--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -29,6 +29,13 @@ namespace Surge
 namespace Overlays
 {
 
+enum AlertButtonStyle
+{
+    OK_CANCEL,
+    YES_NO,
+    OK
+};
+
 struct Alert : public juce::Component,
                public Surge::GUI::SkinConsumingComponent,
                public juce::Button::Listener
@@ -41,17 +48,14 @@ struct Alert : public juce::Component,
     std::unique_ptr<Surge::Widgets::SurgeTextButton> okButton;
     std::unique_ptr<Surge::Widgets::SurgeTextButton> cancelButton;
     std::unique_ptr<juce::ToggleButton> toggleButton;
+    AlertButtonStyle style;
     void setWindowTitle(const std::string &t)
     {
         title = t;
         setTitle(title);
     }
     void setLabel(const std::string &t) { label = t; }
-    void setButtonText(const juce::String &okText, const juce::String &cancelText)
-    {
-        okButton->setButtonText(okText);
-        cancelButton->setButtonText(cancelText);
-    }
+    void setButtonStyle(AlertButtonStyle s);
     void addToggleButtonAndSetText(const std::string &t);
     std::function<void()> onOk;
     std::function<void()> onCancel;

--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -29,13 +29,6 @@ namespace Surge
 namespace Overlays
 {
 
-enum AlertButtonStyle
-{
-    OK_CANCEL,
-    YES_NO,
-    OK
-};
-
 struct Alert : public juce::Component,
                public Surge::GUI::SkinConsumingComponent,
                public juce::Button::Listener
@@ -48,14 +41,23 @@ struct Alert : public juce::Component,
     std::unique_ptr<Surge::Widgets::SurgeTextButton> okButton;
     std::unique_ptr<Surge::Widgets::SurgeTextButton> cancelButton;
     std::unique_ptr<juce::ToggleButton> toggleButton;
-    AlertButtonStyle style;
+    bool singleButton = false;
     void setWindowTitle(const std::string &t)
     {
         title = t;
         setTitle(title);
     }
     void setLabel(const std::string &t) { label = t; }
-    void setButtonStyle(AlertButtonStyle s);
+    void setSingleButtonText(const std::string ok)
+    {
+        okButton->setButtonText(ok);
+        singleButton = true;
+    }
+    void setOkCancelButtonTexts(const std::string &ok, const std::string &cancel)
+    {
+        okButton->setButtonText(ok);
+        cancelButton->setButtonText(cancel);
+    }
     void addToggleButtonAndSetText(const std::string &t);
     std::function<void()> onOk;
     std::function<void()> onCancel;

--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -40,6 +40,7 @@ struct Alert : public juce::Component,
     std::string title, label;
     std::unique_ptr<Surge::Widgets::SurgeTextButton> okButton;
     std::unique_ptr<Surge::Widgets::SurgeTextButton> cancelButton;
+    std::unique_ptr<juce::ToggleButton> toggleButton;
     void setWindowTitle(const std::string &t)
     {
         title = t;
@@ -51,8 +52,11 @@ struct Alert : public juce::Component,
         okButton->setButtonText(okText);
         cancelButton->setButtonText(cancelText);
     }
+    void addToggleButtonAndSetText(const std::string &t);
     std::function<void()> onOk;
     std::function<void()> onCancel;
+    std::function<void(bool)> onOkForToggleState;
+    std::function<void(bool)> onCancelForToggleState;
     void paint(juce::Graphics &g) override;
     void resized() override;
     void onSkinChanged() override;

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -653,9 +653,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
 
         if (!fn.empty())
         {
-            std::string message = "Wavetable was successfully exported to\n" + fn + "!";
-            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::NoIcon, "Wavetable Export",
-                                                   message);
+            sge->messageBox("Wavetable Export",
+                            "Wavetable was successfully exported to\n" + fn + "!");
         }
     };
 


### PR DESCRIPTION
Closes #5663.

Previous: 
![Current message box](https://github.com/surge-synthesizer/surge/assets/5881947/22927a1c-84e1-49fa-860d-1f196220c8dc)

New: 
![message box new](https://github.com/surge-synthesizer/surge/assets/5881947/8b5c8923-2a62-460e-8c9d-a85bacbb7fda)

Question: Unless I'm missing something, exactly one message box remains: https://github.com/surge-synthesizer/surge/blob/21baada63f332f62b32df3ac2c794b3250e221b8/src/surge-fx/SurgeFXEditor.cpp#L598 
Since it's in surge-fx, I'll have to link the surge-xt project in the surge-fx makefile to use the work we've done so far? That seems like overkill for this, is there something I'm missing? 
