### PR TITLE
Adjust sstfx friend declaration to match struct vs class

### DIFF
--- a/src/common/dsp/Effect.h
+++ b/src/common/dsp/Effect.h
@@ -110,7 +110,7 @@ class alignas(16) Effect
     float *pd_float[n_fx_params];
     int *pd_int[n_fx_params];
 
-    friend class surge::sstfx::SurgeFXConfig;
+    friend struct surge::sstfx::SurgeFXConfig;
 
   protected:
     SurgeStorage *storage;


### PR DESCRIPTION
This tossed an ABI warning in the rack build correctly. Declare as struct, friend as struct.