### PR TITLE
FX Swap in Undo; Swap to Self crash resolved

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4944,7 +4944,8 @@ void SurgeSynthesizer::changeModulatorSmoothing(Modulator::SmoothingMode m)
 
 void SurgeSynthesizer::reorderFx(int source, int target, FXReorderMode m)
 {
-    if (source < 0 || source >= n_fx_slots || target < 0 || target >= n_fx_slots)
+    if (source < 0 || source >= n_fx_slots || target < 0 || target >= n_fx_slots ||
+        source == target)
     {
         return;
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6971,10 +6971,13 @@ void SurgeGUIEditor::enqueueFXChainClear(int fxchain)
 
 void SurgeGUIEditor::swapFX(int source, int target, SurgeSynthesizer::FXReorderMode m)
 {
-    if (source < 0 || source >= n_fx_slots || target < 0 || target >= n_fx_slots)
+    if (source < 0 || source >= n_fx_slots || target < 0 || target >= n_fx_slots ||
+        source == target)
     {
         return;
     }
+
+    undoManager()->pushPatch();
 
     auto t = fxPresetName[target];
 


### PR DESCRIPTION
1. FX Swap didn't particpate in Undo. It does now (with a full patch stream which is the best we can do)

2. FX Swap when dropped on itself would swap with self, with sometimes catastrophic mistakes. Put a source==target guard in along with the other source and target range checks. Closes #7085