### PR TITLE
Menu Bold Fonts use the Bold Typeface

### DIFF
--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -352,6 +352,13 @@ juce::Font SurgeJUCELookAndFeel::getPopupMenuFont()
     return skin->fontManager->getLatoAtSize(15);
     // return juce::LookAndFeel_V4::getPopupMenuFont();
 }
+
+juce::Font SurgeJUCELookAndFeel::getPopupMenuBoldFont()
+{
+    // return juce::Font("Comic Sans MS", 15, juce::Font::plain);
+    return skin->fontManager->getLatoAtSize(15, juce::Font::bold);
+}
+
 // overridden here just to make the shortcut text same size as normal menu entry text
 void SurgeJUCELookAndFeel::drawPopupMenuItem(Graphics &g, const Rectangle<int> &area,
                                              const bool isSeparator, const bool isActive,

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.h
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.h
@@ -47,6 +47,7 @@ class SurgeJUCELookAndFeel : public juce::LookAndFeel_V4, public Surge::GUI::Ski
     SurgeStorage *storage{nullptr};
 
     juce::Font getPopupMenuFont() override;
+    juce::Font getPopupMenuBoldFont();
     void drawPopupMenuBackgroundWithOptions(juce::Graphics &g, int w, int h,
                                             const juce::PopupMenu::Options &o) override;
     void drawPopupMenuItem(juce::Graphics &g, const juce::Rectangle<int> &area,

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -24,6 +24,7 @@
 #include "SurgeImageStore.h"
 #include "SurgeImage.h"
 #include "UserDefaults.h"
+#include "SurgeJUCELookAndFeel.h"
 #include <fmt/format.h>
 #include <StringOps.h>
 
@@ -89,7 +90,11 @@ void MenuTitleHelpComponent::getIdealSize(int &idealWidth, int &idealHeight)
 
     if (isBoldened)
     {
-        font = getLookAndFeel().getPopupMenuFont().boldened();
+        auto sjlf = dynamic_cast<SurgeJUCELookAndFeel *>(&getLookAndFeel());
+        if (sjlf)
+            font = sjlf->getPopupMenuBoldFont();
+        else
+            font = getLookAndFeel().getPopupMenuFont().boldened();
     }
 
     idealHeight =
@@ -129,7 +134,11 @@ void MenuTitleHelpComponent::paint(juce::Graphics &g)
 
     if (isBoldened)
     {
-        g.setFont(getLookAndFeel().getPopupMenuFont().boldened());
+        auto sjlf = dynamic_cast<SurgeJUCELookAndFeel *>(&getLookAndFeel());
+        if (sjlf)
+            g.setFont(sjlf->getPopupMenuBoldFont());
+        else
+            g.setFont(getLookAndFeel().getPopupMenuFont().boldened());
     }
 
     if (isItemHighlighted())
@@ -236,7 +245,11 @@ void MenuCenteredBoldLabel::paint(juce::Graphics &g)
     auto r = getLocalBounds();
     auto ft = getLookAndFeel().getPopupMenuFont();
 
-    ft = ft.withHeight(ft.getHeight() - 1).boldened();
+    auto sjlf = dynamic_cast<SurgeJUCELookAndFeel *>(&getLookAndFeel());
+    if (sjlf)
+        ft = sjlf->getPopupMenuBoldFont().withHeight(ft.getHeight() - 1);
+    else
+        ft = ft.withHeight(ft.getHeight() - 1).boldened();
 
     g.setFont(ft);
     g.setColour(getLookAndFeel().findColour(juce::PopupMenu::ColourIds::textColourId));


### PR DESCRIPTION
Bold fonts in menus used `getPopupMenuFont().bolden()` which in some cases on macOS renders improperly for our TTF font but we aren't sure why. We already ship the LatoBold font TTF with surge, so instead add a `getPopupMenuFontBold` API point which uses that TTF and adjust calling code to use that rather than font.bolden

My theory is this will address #7021 but lets leave it open until we get confirmation from a user.