### PR TITLE
Alert has its own Focus Traverser

### DIFF
--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -69,6 +69,16 @@ struct Alert : public juce::Component,
     std::unique_ptr<MultiLineSkinLabel> labelComponent;
 
     void visibilityChanged() override;
+
+    /*
+     * Alerts should use default focus order not the wonky tag first and
+     * then description and so on order for the main frame (which is laying out controls
+     * in a differently structured way).
+     */
+    std::unique_ptr<juce::ComponentTraverser> createKeyboardFocusTraverser() override
+    {
+        return std::make_unique<juce::KeyboardFocusTraverser>();
+    }
 };
 
 } // namespace Overlays


### PR DESCRIPTION
Alert doesnt' subclass Overlay. That's fine but as a result it participates in main window focus. Change it so it has its own keyboard traverser.

This mostly solves the 'wander into other ui' problems but I still get the patch browser in my keyboard list so its not complete. Merge to make nightlies better for ally users tho

Addresses #7089