### PR TITLE
CLAP moved CMake min from 20 -> 21; track that

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,8 +21,8 @@ if (NOT SURGE_SKIP_JUCE_FOR_RACK)
   add_subdirectory(${SURGE_JUCE_PATH} ${CMAKE_BINARY_DIR}/JUCE EXCLUDE_FROM_ALL)
 endif()
 
-if(${CMAKE_VERSION} VERSION_LESS 3.20)
-  message(WARNING "CMake version less than 3.20. Skipping clap builds. Please "
+if(${CMAKE_VERSION} VERSION_LESS 3.21)
+  message(WARNING "CMake version less than 3.21. Skipping clap builds. Please "
     "consider using a newer version of CMake")
   set(SURGE_BUILD_CLAP FALSE)
 else()


### PR DESCRIPTION
but since surge requires 20, track it by excluding clap