### PR TITLE
Make MTS-ESP Disconnected State sticky in dawExtraState

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2922,6 +2922,14 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 dawExtraState.isDirty = ival;
             }
 
+            p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("disconnectFromOddSoundMTS"));
+            dawExtraState.disconnectFromOddSoundMTS = false;
+
+            if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
+            {
+                dawExtraState.disconnectFromOddSoundMTS = ival;
+            }
+
             p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("mpePitchBendRange"));
 
             if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
@@ -3656,6 +3664,10 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         TiXmlElement isDi("isDirty");
         isDi.SetAttribute("v", dawExtraState.isDirty ? 1 : 0);
         dawExtraXML.InsertEndChild(isDi);
+
+        TiXmlElement odS("disconnectFromOddSoundMTS");
+        odS.SetAttribute("v", dawExtraState.disconnectFromOddSoundMTS ? 1 : 0);
+        dawExtraXML.InsertEndChild(odS);
 
         TiXmlElement mpm("monoPedalMode");
         mpm.SetAttribute("v", dawExtraState.monoPedalMode);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -961,6 +961,8 @@ struct DAWExtraStateStorage
     int oddsoundRetuneMode = 0;
 
     bool isDirty{false};
+
+    bool disconnectFromOddSoundMTS{false};
 };
 
 struct PatchTuningStorage

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4197,12 +4197,26 @@ void SurgeSynthesizer::processControl()
         storage.oddsound_mts_on_check = (storage.oddsound_mts_on_check + 1) & (1024 - 1);
         if (storage.oddsound_mts_on_check == 0)
         {
-            bool prior = storage.oddsound_mts_active_as_client;
-            storage.setOddsoundMTSActiveTo(MTS_HasMaster(storage.oddsound_mts_client));
-
-            if (prior != storage.oddsound_mts_active_as_client)
+            if (storage.getPatch().dawExtraState.disconnectFromOddSoundMTS)
             {
-                refresh_editor = true;
+                if (storage.oddsound_mts_active_as_client)
+                {
+                    auto q = storage.oddsound_mts_client;
+                    storage.oddsound_mts_active_as_client = false;
+                    storage.oddsound_mts_client = nullptr;
+                    MTS_DeregisterClient(q);
+                    refresh_editor = true;
+                }
+            }
+            else
+            {
+                bool prior = storage.oddsound_mts_active_as_client;
+                storage.setOddsoundMTSActiveTo(MTS_HasMaster(storage.oddsound_mts_client));
+
+                if (prior != storage.oddsound_mts_active_as_client)
+                {
+                    refresh_editor = true;
+                }
             }
         }
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3674,21 +3674,25 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
     if (tsMode && !this->synth->storage.oddsound_mts_client &&
         !getStorage()->oddsound_mts_active_as_main)
     {
-        tuningSubMenu.addItem(Surge::GUI::toOSCase("Reconnect as Client to MTS-ESP"), [this]() {
-            this->synth->storage.initialize_oddsound();
-            this->synth->refresh_editor = true;
-        });
+        tuningSubMenu.addItem(
+            Surge::GUI::toOSCase("Reconnect Instance as MTS-ESP Client"), [this]() {
+                this->synth->storage.initialize_oddsound();
+                this->synth->refresh_editor = true;
+                this->synth->storage.getPatch().dawExtraState.disconnectFromOddSoundMTS = false;
+            });
     }
 
     if (this->synth->storage.oddsound_mts_active_as_client &&
         this->synth->storage.oddsound_mts_client)
     {
-        tuningSubMenu.addItem(Surge::GUI::toOSCase("Disconnect as Client from MTS-ESP"), [this]() {
-            auto q = this->synth->storage.oddsound_mts_client;
-            this->synth->storage.oddsound_mts_active_as_client = false;
-            this->synth->storage.oddsound_mts_client = nullptr;
-            MTS_DeregisterClient(q);
-        });
+        tuningSubMenu.addItem(
+            Surge::GUI::toOSCase("Disconnect Instance as MTS-ESP Client"), [this]() {
+                auto q = this->synth->storage.oddsound_mts_client;
+                this->synth->storage.oddsound_mts_active_as_client = false;
+                this->synth->storage.oddsound_mts_client = nullptr;
+                this->synth->storage.getPatch().dawExtraState.disconnectFromOddSoundMTS = true;
+                MTS_DeregisterClient(q);
+            });
 
         tuningSubMenu.addSeparator();
 


### PR DESCRIPTION
Add the Disconnected state to the dawExtraState so you can do a mix of connected and disconnected in a single reaper session

Addreses #7040