### PR TITLE
shared_ptr<float[N]> workaround

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2831,13 +2831,14 @@ Surge::Storage::ScenesOutputData::ScenesOutputData()
     {
         for (int j = 0; j < N_OUTPUTS; j++)
         {
-            std::shared_ptr<float[BLOCK_SIZE]> block{new float[BLOCK_SIZE]{}};
+            std::shared_ptr<float> block(new float[BLOCK_SIZE], [](float *p) { delete[] p; });
+            memset(block.get(), 0, BLOCK_SIZE * sizeof(float));
             sceneData[i][j] = block;
         }
     }
 }
-const std::shared_ptr<float[BLOCK_SIZE]> &
-Surge::Storage::ScenesOutputData::getSceneData(int scene, int channel) const
+const std::shared_ptr<float> &Surge::Storage::ScenesOutputData::getSceneData(int scene,
+                                                                             int channel) const
 {
     assert(scene < n_scenes && scene >= 0);
     assert(channel < N_OUTPUTS && channel >= 0);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1135,12 +1135,11 @@ namespace Storage
 {
 struct ScenesOutputData
 {
-    std::shared_ptr<float[BLOCK_SIZE]> sceneData[n_scenes][N_OUTPUTS]{{nullptr, nullptr},
-                                                                      {nullptr, nullptr}};
+    std::shared_ptr<float> sceneData[n_scenes][N_OUTPUTS]{{nullptr, nullptr}, {nullptr, nullptr}};
 
   public:
     ScenesOutputData();
-    const std::shared_ptr<float[BLOCK_SIZE]> &getSceneData(int scene, int channel) const;
+    const std::shared_ptr<float> &getSceneData(int scene, int channel) const;
     void provideSceneData(int scene, int channel, float *data);
     bool thereAreClients(int scene) const;
 };

--- a/src/common/dsp/effects/AudioInputEffect.h
+++ b/src/common/dsp/effects/AudioInputEffect.h
@@ -52,7 +52,7 @@ class AudioInputEffect : public Effect
     int group_label_ypos(int id) override;
 
   private:
-    std::shared_ptr<float[BLOCK_SIZE]> sceneDataPtr[N_OUTPUTS]{nullptr, nullptr};
+    std::shared_ptr<float> sceneDataPtr[N_OUTPUTS]{nullptr, nullptr};
     effect_slot_type getSlotType(fxslot_positions p);
     void applySlidersControls(float *buffer[], const float &channel, const float &pan,
                               const float &levelDb);

--- a/src/surge-testrunner/UnitTestsFX.cpp
+++ b/src/surge-testrunner/UnitTestsFX.cpp
@@ -433,13 +433,13 @@ TEST_CASE("Scenes Output Data", "[fx]")
             float data[32]{1.0f};
             scenesOutputData.provideSceneData(0, 0, data);
             scenesOutputData.provideSceneData(0, 1, data);
-            REQUIRE(scenesOutputData.getSceneData(0, 0)[0] == 1.0f);
-            REQUIRE(scenesOutputData.getSceneData(0, 1)[0] == 1.0f);
+            REQUIRE(scenesOutputData.getSceneData(0, 0).get()[0] == 1.0f);
+            REQUIRE(scenesOutputData.getSceneData(0, 1).get()[0] == 1.0f);
 
             scenesOutputData.provideSceneData(1, 0, data);
             scenesOutputData.provideSceneData(1, 1, data);
-            REQUIRE(scenesOutputData.getSceneData(1, 0)[0] == 0.0f);
-            REQUIRE(scenesOutputData.getSceneData(1, 1)[0] == 0.0f);
+            REQUIRE(scenesOutputData.getSceneData(1, 0).get()[0] == 0.0f);
+            REQUIRE(scenesOutputData.getSceneData(1, 1).get()[0] == 0.0f);
         }
         REQUIRE(!scenesOutputData.thereAreClients(0));
         REQUIRE(!scenesOutputData.thereAreClients(1));


### PR DESCRIPTION
C++17 allows a `shared_ptr<float[N]>` but earlier doesn't. Thats fine we are C++17 but rack compiles with such an old version of the OSX SDK that it doesn't have the appropriat econstructor in place. We could do a bunch of ifdefs to fix this but instead, just make the type `shared_ptr<float>` in this case and adjust the constructor to have a custom [] deallocator.

Addresses #7116
Addresses https://github.com/surge-synthesizer/surge-rack/issues/904