### PR TITLE
CLI OpenSoundControl works

### DIFF
--- a/src/surge-xt/cli/cli-main.cpp
+++ b/src/surge-xt/cli/cli-main.cpp
@@ -126,6 +126,8 @@ struct SurgePlayback : juce::MidiInputCallback, juce::AudioIODeviceCallback
                                      int numSamples,
                                      const juce::AudioIODeviceCallbackContext &context) override
     {
+        proc->processBlockOSC();
+
         for (int i = 0; i < numSamples; ++i)
         {
             if (pos >= BLOCK_SIZE)


### PR DESCRIPTION
The CLI has a separate process loop so it needs to make sure to call processBlockOSC().