### PR TITLE
Osc noteid fix

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -599,186 +599,195 @@ code {
         <div class="outer">
             <div class="frame">
                 <div style="margin:10pt; padding: 5pt 12pt; background: #fafbff;">
-                <div style="font-size: 12pt; font-family: Lato;">
-                    <p>
-                    Surge XT supports external OSC control of most parameters, including patch and tuning changes. Where appropriate and feasible,
-                    Surge parameters/changes are reported to OSC out, either when they occur, or in the special case of <b>/send_all_parameters</b>
-                    (see below), on request. Notes may also be triggered via OSC, either by frequency or by MIDI note number.
-                    </p>
-                    <p>
-                        OSC messages are constructed using the exact (case sensitive)
-                        entry listed in the <b>Address</b> column in the tables below.</br>
-                        The form of the message should be <code>/&ltaddress&gt &ltvalue&gt</code>,
-                        where <code>address</code> is one of the ones listed below, and <code>value</code> can be*:
+                    <div style="font-size: 12pt; font-family: Lato;">
+                        <p>
+                        Surge XT supports external OSC control of most parameters, including patch and tuning changes. Where appropriate and feasible,
+                        Surge parameters/changes are reported to OSC out, either when they occur, or in the special case of <b>/send_all_parameters</b>
+                        (see below), on request. Notes may also be triggered via OSC, either by frequency or by MIDI note number.
+                        </p>
+                        <p>
+                            OSC messages are constructed using the exact (case sensitive)
+                            entry listed in the <b>Address</b> column in the tables below.</br>
+                            The form of the message should be <code>/&ltaddress&gt &ltvalue&gt</code>,
+                            where <code>address</code> is one of the ones listed below, and <code>value</code> can be*:
 
-                        <ul>
-                            <li>a floating point value between <b>0.0</b> and <b>1.0</b> (note: use '.' as the decimal mark, never ',').</li>
-                            <li>an integer value</li>
-                            <li>a boolean value, <b>0</b> (false) or <b>1</b> (true)</li>
-                            <li>a file path (absolute, or relative to the default path)
-                            <li>contextual: either an in integer or a float, depending on the context (loaded oscillator or effect type)</li>
-                        </ul>
+                            <ul>
+                                <li>a floating point value between <b>0.0</b> and <b>1.0</b> (note: use '.' as the decimal mark, never ',').</li>
+                                <li>an integer value</li>
+                                <li>a boolean value, <b>0</b> (false) or <b>1</b> (true)</li>
+                                <li>a file path (absolute, or relative to the default path)
+                                <li>contextual: either an in integer or a float, depending on the context (loaded oscillator or effect type)</li>
+                            </ul>
 
-                        Where an address contains an asterisk <b>(*)</b>, replace the asterisk with either <b>a</b> or <b>b</b>,
-                        depending on which scene you wish to address - e.g. <code>/a/drift</code> or <code>/b/drift</code>.
-                    <p>
-                    <p style="border: 1px solid black; padding: 4px;" >
-                        <b>*Important note: all numeric values must be sent over OSC as floating point numbers</b>
-                        (even if they are listed as integer or boolean type --
-                        the 'appropriate values' describe how the data is used by Surge XT,
-                        not how messages are to be formatted for OSC).
-                    </p>
-                    <p>Examples:
-                        <div style="margin: -6px 0 2px 0; line-height: 1.75">
-                            <span><code>/mnote 68 120</code></span>
-                            <span><code>/fnote 440.0 120</code></span>
-                            <span><code>/mnote 68 0</code></span>
-                            <span><code>/fnote 440.0 0</code></span>
-                            <span><code>/mnote/rel 68 45</code></span>
-                            <span><code>/fnote/rel 440.0 45</code></span>
-                        </div>
-                        <div style="margin: 4px 0 0 0; line-height: 1.75">
-                            <span><code>/patch/load /Library/Application Support/Surge XT/patches_factory/Plucks/Clean</code></span>
-                            <span><code>/patch/save</code></span>
-                            <span><code>/patch/incr</code></span>
-                        </div>
-                        <div style="margin: 4px 0 0 0; line-height: 1.75">
-                            <span><code>/tuning/scl ptolemy</code></span>
-                            <span><code>/tuning/scl /Users/jane/scala_tunings/ptolemy</code></span>
-                            <span><code>/tuning/path/scl /Users/jane/scala_tunings</code></span>
-                        </div>
-                        <div style="margin: 4px 0 0 0; line-height: 1.75">
-                            <span><code>/param/b/amp/gain 0.63</code></span>
-                            <span><code>/param/global/polyphony_limit 12</code></span>
-                            <span><code>/param/a/mixer/noise/mute 0</code></span>
-                        </div>
-                    </p>
-                    <p style="margin-top: 28px;">
-                        All OSC messages described below work in <b>both</b> directions, unless marked with "<b>†</b>". For these, only
-                        the incoming OSC message is supported; there is no corresponding OSC out message.
-                    </p>
-                    <p style="margin-bottom: 0px;">
-                        Errors are reported (when feasible) to "/error". Monitor that address to see them.
-                    </p>
+                            Where an address contains an asterisk <b>(*)</b>, replace the asterisk with either <b>a</b> or <b>b</b>,
+                            depending on which scene you wish to address - e.g. <code>/a/drift</code> or <code>/b/drift</code>.
+                        <p>
+                        <p style="border: 1px solid black; padding: 4px;" >
+                            <b>*Important note: all numeric values must be sent over OSC as floating point numbers</b>
+                            (even if they are listed as integer or boolean type --
+                            the 'appropriate values' describe how the data is used by Surge XT,
+                            not how messages are to be formatted for OSC).
+                        </p>
+                        <p>Examples:
+                            <div style="margin: -6px 0 2px 0; line-height: 1.75">
+                                <span><code>/mnote 68 120</code></span>
+                                <span><code>/fnote 440.0 120</code></span>
+                                <span><code>/mnote 68 0</code></span>
+                                <span><code>/fnote 440.0 0</code></span>
+                                <span><code>/mnote/rel 68 45</code></span>
+                                <span><code>/fnote/rel 440.0 45</code></span>
+                            </div>
+                            <div style="margin: 4px 0 0 0; line-height: 1.75">
+                                <span><code>/patch/load /Library/Application Support/Surge XT/patches_factory/Plucks/Clean</code></span>
+                                <span><code>/patch/save</code></span>
+                                <span><code>/patch/incr</code></span>
+                            </div>
+                            <div style="margin: 4px 0 0 0; line-height: 1.75">
+                                <span><code>/tuning/scl ptolemy</code></span>
+                                <span><code>/tuning/scl /Users/jane/scala_tunings/ptolemy</code></span>
+                                <span><code>/tuning/path/scl /Users/jane/scala_tunings</code></span>
+                            </div>
+                            <div style="margin: 4px 0 0 0; line-height: 1.75">
+                                <span><code>/param/b/amp/gain 0.63</code></span>
+                                <span><code>/param/global/polyphony_limit 12</code></span>
+                                <span><code>/param/a/mixer/noise/mute 0</code></span>
+                            </div>
+                        </p>
+                        <p style="margin-top: 28px;">
+                            All OSC messages described below work in <b>both</b> directions, unless marked with "<b>†</b>". For these, only
+                            the incoming OSC message is supported; there is no corresponding OSC out message.
+                        </p>
+                        <p style="margin-bottom: 0px;">
+                            Errors are reported (when feasible) to "/error". Monitor that address to see them.
+                        </p>
+                    </div>
                 </div>
-            </div>
 
-            <div class="tablewrap fr cr">
-                <div class="heading"><h3>Patches:</h3></div>
+                <div class="tablewrap" style="width: 1000px; margin: 8px auto;">
+                    <div class="heading">
+                         <h3>Notes:</h3>
+                    </div>
                     <table style="border: 2px solid black;">
-                        <tr>
-                            <th>Address</th>
-                            <th>Description</th>
-                            <th>Appropriate Values</th>
-                        </tr>
-                        <tr>
-                            <td class="nw">/patch/load</td>
-                            <td class="nw">load patch</td>
-                            <td>file path (absolute, no extension)</td>
-                        </tr>
-                        <tr>
-                            <td class="nw">/patch/save</td>
-                            <td class="nw">save patch</td>
-                            <td><b>† </b>none: overwrites current patch OR
-                                file path (absolute, no extension, overwrites if file exists)
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="nw">/patch/incr</td>
-                            <td class="nw">increment patch</td>
-                            <td><b>† </b>(none)</td>
-                        </tr>
-                        <tr>
-                            <td class="nw">/patch/decr</td>
-                            <td class="nw">decrement patch</td>
-                            <td><b>† </b>(none)</td>
-                        </tr>
-                        <tr>
-                            <td class="nw">/patch/incr_category</td>
-                            <td class="nw">increment category</td>
-                            <td><b>† </b>(none)</td>
-                        </tr>
-                        <tr>
-                            <td class="nw">/patch/decr_category</td>
-                            <td class="nw">decrement category</td>
-                            <td><b>† </b>(none)</td>
-                        </tr>
-                        <tr>
-                            <td class="nw">/patch/random</td>
-                            <td class="nw">choose random patch</td>
-                            <td><b>† </b>(none)</td>
-                        </tr>
+                         <tr>
+                              <th>Address</th>
+                              <th>Description</th>
+                              <th>Appropriate Values</th>
+                         </tr>
+                         <tr>
+                              <td>/mnote</td>
+                              <td>MIDI note</td>
+                              <td><b>† </b>note number, velocity (integers 0-127)*</td>
+                         </tr>
+                         <tr>
+                              <td>/fnote ‡</td>
+                              <td>frequency note</td>
+                              <td><b>† </b>frequency (float), velocity (integer 0-127)*</td>
+                         </tr>
+                         <tr>
+                              <td>/mnote/rel</td>
+                              <td>MIDI note release</td>
+                              <td><b>† </b>note number, release velocity (integers 0-127)</td>
+                         </tr>
+                         <tr>
+                              <td>/fnote/rel</td>
+                              <td>frequency note release</td>
+                              <td><b>† </b>frequency (float), release velocity (integer 0-127)</td>
+                         </tr>
+                         <tr>
+                              <td class="center" colspan="3">* velocity 0 releases note; use the .../rel messages to
+                                   release notes with velocity<br>
+                                   ‡ When using '/fnote', Surge XT <em>must</em> be set to standard tuning for proper
+                                   results.</td>
+                         </tr>
                     </table>
-                </div>
+               </div>
 
-                <div class="tablewrap fl cl">
-                    <div class="heading"><h3>Notes:</h3></div>
+               <div class="tablewrap fl cl">
+                    <div class="heading">
+                         <h3>Patches:</h3>
+                    </div>
                     <table style="border: 2px solid black;">
-                        <tr>
-                            <th>Address</th>
-                            <th>Description</th>
-                            <th>Appropriate Values</th>
-                        </tr>
-                        <tr>
-                            <td>/mnote</td>
-                            <td>MIDI note</td>
-                            <td><b>† </b>note number, velocity (integers 0-127)*</td>
-                        </tr> 
-                        <tr>
-                            <td>/fnote ‡</td>
-                            <td>frequency note</td>
-                            <td><b>† </b>frequency (float), velocity (integer 0-127)*</td>
-                        </tr>
-                        <tr>
-                            <td>/mnote/rel</td>
-                            <td>MIDI note release</td>
-                            <td><b>† </b>note number, release velocity (integers 0-127)</td>
-                        </tr> 
-                        <tr>
-                            <td>/fnote/rel</td>
-                            <td>frequency note release</td>
-                            <td><b>† </b>frequency (float), release velocity (integer 0-127)</td>
-                        </tr>
-                        <tr>
-                            <td class="center" colspan="3">* velocity 0 releases note; use the .../rel messages to release notes with velocity<br>
-                            ‡ When using '/fnote', Surge XT <em>must</em> be set to standard tuning for proper results.</td>
-                        </tr>
+                         <tr>
+                              <th>Address</th>
+                              <th>Description</th>
+                              <th>Appropriate Values</th>
+                         </tr>
+                         <tr>
+                              <td class="nw">/patch/load</td>
+                              <td class="nw">load patch</td>
+                              <td>file path (absolute, no extension)</td>
+                         </tr>
+                         <tr>
+                              <td class="nw">/patch/save</td>
+                              <td class="nw">save patch</td>
+                              <td><b>† </b>none: overwrites current patch OR
+                                   file path (absolute, no extension, overwrites if file exists)
+                              </td>
+                         </tr>
+                         <tr>
+                              <td class="nw">/patch/incr</td>
+                              <td class="nw">increment patch</td>
+                              <td><b>† </b>(none)</td>
+                         </tr>
+                         <tr>
+                              <td class="nw">/patch/decr</td>
+                              <td class="nw">decrement patch</td>
+                              <td><b>† </b>(none)</td>
+                         </tr>
+                         <tr>
+                              <td class="nw">/patch/incr_category</td>
+                              <td class="nw">increment category</td>
+                              <td><b>† </b>(none)</td>
+                         </tr>
+                         <tr>
+                              <td class="nw">/patch/decr_category</td>
+                              <td class="nw">decrement category</td>
+                              <td><b>† </b>(none)</td>
+                         </tr>
+                         <tr>
+                              <td class="nw">/patch/random</td>
+                              <td class="nw">choose random patch</td>
+                              <td><b>† </b>(none)</td>
+                         </tr>
                     </table>
-                </div>
+               </div>
 
-                <div class="tablewrap fl cl">
-                    <div class="heading"><h3>Tuning:</h3></div>
+               <div class="tablewrap fr cr">
+                    <div class="heading">
+                         <h3>Tuning:</h3>
+                    </div>
                     <table style="border: 2px solid black;">
-                        <tr>
-                            <th>Address</th>
-                            <th>Description</th>
-                            <th>Appropriate Values</th>
-                        </tr>
-                        <tr>
-                            <td>/tuning/scl</td>
-                            <td> .scl tuning file</td>
-                            <td><b>† </b>file path (absolute or relative)*</td>
-                        </tr>
-                        <tr>
-                            <td>/tuning/kbm</td>
-                            <td>.kbm mapping file</td>
-                            <td><b>† </b>file path (absolute or relative)*</td>
-                        </tr>
-                        <tr>
-                            <td>/tuning/path/scl</td>
-                            <td>.scl file default path</td>
-                            <td><b>† </b>file path (absolute only)</td>
-                        </tr>
-                        <tr>
-                            <td>/tuning/path/kbm</td>
-                            <td>.kbm file default path</td>
-                            <td><b>† </b>file path (absolute only)</td>
-                        </tr>
-                        <tr>
-                            <td class="center" colspan="3">* no extension; use value = '_reset' to reset path to factory default</td>
-                        </tr>
+                         <tr>
+                              <th>Address</th>
+                              <th>Description</th>
+                              <th>Appropriate Values</th>
+                         </tr>
+                         <tr>
+                              <td>/tuning/scl</td>
+                              <td> .scl tuning file</td>
+                              <td><b>† </b>file path (absolute or relative)*</td>
+                         </tr>
+                         <tr>
+                              <td>/tuning/kbm</td>
+                              <td>.kbm mapping file</td>
+                              <td><b>† </b>file path (absolute or relative)*</td>
+                         </tr>
+                         <tr>
+                              <td>/tuning/path/scl</td>
+                              <td>.scl file default path</td>
+                              <td><b>† </b>file path (absolute only)</td>
+                         </tr>
+                         <tr>
+                              <td>/tuning/path/kbm</td>
+                              <td>.kbm file default path</td>
+                              <td><b>† </b>file path (absolute only)</td>
+                         </tr>
+                         <tr>
+                              <td class="center" colspan="3">* no extension; use value = '_reset' to reset path to
+                                   factory default</td>
+                         </tr>
                     </table>
-                </div>
+               </div>
 
                 <div style="clear: both;"></div>
 

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -735,36 +735,36 @@ code {
                               <td>file path (absolute, no extension)</td>
                          </tr>
                          <tr>
-                              <td class="nw">/patch/save</td>
+                              <td class="nw"><b>† </b>/patch/save</td>
                               <td class="nw">save patch</td>
-                              <td><b>† </b>none: overwrites current patch OR
+                              <td>none: overwrites current patch OR
                                    file path (absolute, no extension, overwrites if file exists)
                               </td>
                          </tr>
                          <tr>
-                              <td class="nw">/patch/incr</td>
+                              <td class="nw"><b>† </b>/patch/incr</td>
                               <td class="nw">increment patch</td>
-                              <td><b>† </b>(none)</td>
+                              <td>(none)</td>
                          </tr>
                          <tr>
-                              <td class="nw">/patch/decr</td>
+                              <td class="nw"><b>† </b>/patch/decr</td>
                               <td class="nw">decrement patch</td>
-                              <td><b>† </b>(none)</td>
+                              <td>(none)</td>
                          </tr>
                          <tr>
-                              <td class="nw">/patch/incr_category</td>
+                              <td class="nw"><b>† </b>/patch/incr_category</td>
                               <td class="nw">increment category</td>
-                              <td><b>† </b>(none)</td>
+                              <td>(none)</td>
                          </tr>
                          <tr>
-                              <td class="nw">/patch/decr_category</td>
+                              <td class="nw"><b>† </b>/patch/decr_category</td>
                               <td class="nw">decrement category</td>
-                              <td><b>† </b>(none)</td>
+                              <td>(none)</td>
                          </tr>
                          <tr>
-                              <td class="nw">/patch/random</td>
+                              <td class="nw"><b>† </b>/patch/random</td>
                               <td class="nw">choose random patch</td>
-                              <td><b>† </b>(none)</td>
+                              <td>(none)</td>
                          </tr>
                     </table>
                </div>
@@ -780,24 +780,24 @@ code {
                               <th>Appropriate Values</th>
                          </tr>
                          <tr>
-                              <td>/tuning/scl</td>
+                              <td><b>† </b>/tuning/scl</td>
                               <td> .scl tuning file</td>
-                              <td><b>† </b>file path (absolute or relative)*</td>
+                              <td>file path (absolute or relative)*</td>
                          </tr>
                          <tr>
-                              <td>/tuning/kbm</td>
+                              <td><b>† </b>/tuning/kbm</td>
                               <td>.kbm mapping file</td>
-                              <td><b>† </b>file path (absolute or relative)*</td>
+                              <td>file path (absolute or relative)*</td>
                          </tr>
                          <tr>
-                              <td>/tuning/path/scl</td>
+                              <td><b>† </b>/tuning/path/scl</td>
                               <td>.scl file default path</td>
-                              <td><b>† </b>file path (absolute only)</td>
+                              <td>file path (absolute only)</td>
                          </tr>
                          <tr>
-                              <td>/tuning/path/kbm</td>
+                              <td><b>† </b>/tuning/path/kbm</td>
                               <td>.kbm file default path</td>
-                              <td><b>† </b>file path (absolute only)</td>
+                              <td>file path (absolute only)</td>
                          </tr>
                          <tr>
                               <td class="center" colspan="3">* no extension; use value = '_reset' to reset path to

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -682,7 +682,7 @@ code {
                          </tr>
                          <tr>
                               <td><b>† </b>/mnote</td>
-                              <td>MIDI note</td>
+                              <td>MIDI-style note</td>
                               <td>note number (0-127)</td>
                               <td>velocity (0 - 127)*</td>
                               <td>noteID (optional, 0 - maxint)§
@@ -696,7 +696,7 @@ code {
                          </tr>
                          <tr>
                               <td><b>† </b>/mnote/rel</td>
-                              <td>MIDI note release</td>
+                              <td>MIDI-style note release</td>
                               <td>note number (0-127)</td>
                               <td>release velocity (0 - 127)</td>
                               <td>noteID (optional, 0 - maxint)§

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -576,6 +576,11 @@ ul {
    -moz-box-sizing: border-box;
 }
 
+p.tight {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
 td.nw {
     white-space: nowrap;
 }
@@ -671,33 +676,45 @@ code {
                          <tr>
                               <th>Address</th>
                               <th>Description</th>
-                              <th>Appropriate Values</th>
+                              <th>Arg. 1</th>
+                              <th>Arg. 2</th>
+                              <th>Arg. 3</th>
                          </tr>
                          <tr>
-                              <td>/mnote</td>
+                              <td><b>† </b>/mnote</td>
                               <td>MIDI note</td>
-                              <td><b>† </b>note number, velocity (integers 0-127)*</td>
+                              <td>note number (0-127)</td>
+                              <td>velocity (0 - 127)*</td>
+                              <td>noteID (optional, 0 - maxint)§
                          </tr>
                          <tr>
-                              <td>/fnote ‡</td>
+                              <td><b>† </b>/fnote ‡</td>
                               <td>frequency note</td>
-                              <td><b>† </b>frequency (float), velocity (integer 0-127)*</td>
+                              <td>frequency (8.176 - 12543.853)</td>
+                              <td>velocity (0 - 127)*</td>
+                              <td>noteID (optional, 0 - maxint)§
                          </tr>
                          <tr>
-                              <td>/mnote/rel</td>
+                              <td><b>† </b>/mnote/rel</td>
                               <td>MIDI note release</td>
-                              <td><b>† </b>note number, release velocity (integers 0-127)</td>
+                              <td>note number (0-127)</td>
+                              <td>release velocity (0 - 127)</td>
+                              <td>noteID (optional, 0 - maxint)§
                          </tr>
                          <tr>
-                              <td>/fnote/rel</td>
+                              <td><b>† </b>/fnote/rel</td>
                               <td>frequency note release</td>
-                              <td><b>† </b>frequency (float), release velocity (integer 0-127)</td>
+                              <td>frequency (8.176 - 12543.853)</td>
+                              <td>release velocity (0 - 127)</td>
+                              <td>noteID (optional, 0 - maxint)§
                          </tr>
                          <tr>
-                              <td class="center" colspan="3">* velocity 0 releases note; use the .../rel messages to
-                                   release notes with velocity<br>
-                                   ‡ When using '/fnote', Surge XT <em>must</em> be set to standard tuning for proper
-                                   results.</td>
+                            <td colspan="5">
+                                <p class="tight">* Velocity of 0 releases note; use the '.../rel' messages to release notes with velocity.</p>
+                                <p class="tight">‡ When using '/fnote', Surge XT <em>must</em> be set to standard tuning for proper results. </p>
+                                <p class="tight">§ NoteID can be supplied for more control over the lifecycle of notes (and for future note modulation).
+                                   If it is not supplied, one will be derived from the note or frequency.</p>
+                            </td>
                          </tr>
                     </table>
                </div>

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -118,18 +118,33 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     if (address1 == "fnote")
     // Play a note at the given frequency and velocity
     {
+        int32_t noteID = 0;
         std::getline(split, address2, '/'); // check for '/rel'
 
-        if (!message[0].isFloat32())
+        if (message.size() < 2 || message.size() > 3)
         {
-            sendError("Invalid data type for frequency (must be a float).");
+            sendDataCountError("fnote", "2 or 3");
             return;
         }
-
+        if (!message[0].isFloat32())
+        {
+            sendNotFloatError("fnote", "frequency");
+            return;
+        }
         if (!message[1].isFloat32())
         {
-            sendError("Invalid data type for velocity (must be an float between 0 - 127).");
+            sendNotFloatError("fnote", "velocity");
             return;
+        }
+        if (message.size() == 3)
+        // note id supplied
+        {
+            if (!message[0].isFloat32())
+            {
+                sendNotFloatError("fnote", "noteID");
+                return;
+            }
+            noteID = message[3].getFloat32();
         }
 
         float frequency = message[0].getFloat32();
@@ -152,8 +167,10 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         }
         bool noteon = (address2 != "rel") && (velocity != 0);
 
-        // Make a noteID from frequency, and send packet to audio thread
-        int32_t noteID = (unsigned &)frequency;
+        // Make a noteID from frequency if not supplied
+        if (noteID == 0)
+            noteID = int(frequency * 10000);
+        // queue packet to audio thread
         sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(
             frequency, static_cast<char>(velocity), noteon, noteID));
     }
@@ -161,6 +178,14 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     else if (address1 == "mnote")
     // OSC equivalent of MIDI note
     {
+        int32_t noteID = 0;
+
+        if (message.size() < 2 || message.size() > 3)
+        {
+            sendDataCountError("mnote", "2 or 3");
+            return;
+        }
+
         std::getline(split, address2, '/'); // check for '/rel'
 
         if (!message[0].isFloat32() || !message[1].isFloat32())
@@ -169,6 +194,18 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                       "float between 0 - 127).");
             return;
         }
+
+        if (message.size() == 3)
+        // note id supplied
+        {
+            if (!message[0].isFloat32())
+            {
+                sendNotFloatError("mnote", "noteID");
+                return;
+            }
+            noteID = message[3].getFloat32();
+        }
+
         int note = static_cast<int>(message[0].getFloat32());
         int velocity = static_cast<int>(message[1].getFloat32());
 
@@ -185,15 +222,22 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         }
 
         bool noteon = (address2 != "rel") && (velocity != 0);
+        if (noteID == 0)
+            noteID = int(note);
 
         // Send packet to audio thread
-        sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(static_cast<char>(note),
-                                                                static_cast<char>(velocity), noteon,
-                                                                static_cast<int32_t>(note)));
+        sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(
+            static_cast<char>(note), static_cast<char>(velocity), noteon, noteID));
     }
 
     else if (address1 == "param")
     {
+        if (message.size() != 1)
+        {
+            sendDataCountError("param", "1");
+            return;
+        }
+
         auto *p = synth->storage.getPatch().parameterFromOSCName(addr);
         if (p == NULL)
         {
@@ -219,6 +263,12 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
 
     else if (address1 == "patch")
     {
+        if (message.size() != 1)
+        {
+            sendDataCountError("patch", "1");
+            return;
+        }
+
         std::getline(split, address2, '/');
         if (address2 == "load")
         {
@@ -269,6 +319,12 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
 
     else if (address1 == "tuning")
     {
+        if (message.size() != 1)
+        {
+            sendDataCountError("tuning", "1");
+            return;
+        }
+
         fs::path path = getWholeString(message);
         fs::path def_path;
 
@@ -419,6 +475,19 @@ void OpenSoundControl::sendError(std::string errorMsg)
         OpenSoundControl::send("/error", errorMsg);
     else
         std::cout << "OSC Error: " << errorMsg << std::endl;
+}
+
+void OpenSoundControl::sendNotFloatError(std::string addr, std::string msg)
+{
+    OpenSoundControl::sendError(
+        "/" + addr + " data value '" + msg +
+        "' is not expressed as a float. All data must be sent as OSC floats.");
+}
+
+void OpenSoundControl::sendDataCountError(std::string addr, std::string count)
+{
+    OpenSoundControl::sendError("Wrong number of data items supplied for /" + addr + "; expected " +
+                                count + ".");
 }
 
 // Loop through all params, send them to OSC Out

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -249,7 +249,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         if (!message[0].isFloat32())
         {
             // Not a valid data value
-            sendError("Invalid param data type (not float).");
+            sendNotFloatError("param", "");
             return;
         }
 

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -139,12 +139,12 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         if (message.size() == 3)
         // note id supplied
         {
-            if (!message[0].isFloat32())
+            if (!message[2].isFloat32())
             {
                 sendNotFloatError("fnote", "noteID");
                 return;
             }
-            noteID = message[3].getFloat32();
+            noteID = static_cast<int>(message[2].getFloat32());
         }
 
         float frequency = message[0].getFloat32();
@@ -170,6 +170,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         // Make a noteID from frequency if not supplied
         if (noteID == 0)
             noteID = int(frequency * 10000);
+
         // queue packet to audio thread
         sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(
             frequency, static_cast<char>(velocity), noteon, noteID));
@@ -198,12 +199,12 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         if (message.size() == 3)
         // note id supplied
         {
-            if (!message[0].isFloat32())
+            if (!message[2].isFloat32())
             {
                 sendNotFloatError("mnote", "noteID");
                 return;
             }
-            noteID = message[3].getFloat32();
+            noteID = message[2].getFloat32();
         }
 
         int note = static_cast<int>(message[0].getFloat32());

--- a/src/surge-xt/osc/OpenSoundControl.h
+++ b/src/surge-xt/osc/OpenSoundControl.h
@@ -77,6 +77,8 @@ class OpenSoundControl : public juce::OSCReceiver,
     std::string getWholeString(const juce::OSCMessage &message);
     juce::OSCSender juceOSCSender;
     void sendError(std::string errorMsg);
+    void sendNotFloatError(std::string addr, std::string msg);
+    void sendDataCountError(std::string addr, std::string count);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OpenSoundControl)
 };


### PR DESCRIPTION
Added capability of user-supplied noteIDs, to support finer-grained modulation of notes (future enhancement). If you can, please check the OSC spec. HTML page (accessed from the OSC Settings menu), as much had to be changed to accommodate the complexity of Note options.