### PR TITLE
Add Vintage FM feedback mode to FM2 and FM3 osc types

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -368,6 +368,7 @@ bool Parameter::has_deformoptions() const
     case ct_noise_color:
     case ct_amplitude_ringmod:
     case ct_bonsai_bass_boost:
+    case ct_osc_feedback_negative:
         return true;
     default:
         break;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -124,7 +124,11 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 // 19 -> 20 (XT 1.1 release)   added voice envelope mode, but super late so don't break 19
 // 20 -> 21 (XT 1.2 nightlies) added absolutable mode for Combulator Offset 1/2 (to match the behavior of Center parameter)
 //                             added oddsound_as_mts_main
-// 21 -> 22 (XT 1.3 nighlies)  added new ring modulator modes in the mixer, add bonsai distortion effect, changed MIDI mapping behavior, deactivatable scenes
+// 21 -> 22 (XT 1.3 nighlies)  added new ring modulator modes in the mixer
+//                             added bonsai distortion effect
+//                             changed MIDI mapping behavior
+//                             added capability to deactivate scenes
+//                             added Vintage FM feedback mode to FM2, FM3 and Sine oscillator types
 // clang-format on
 
 const int ff_revision = 22;

--- a/src/common/dsp/oscillators/FM2Oscillator.h
+++ b/src/common/dsp/oscillators/FM2Oscillator.h
@@ -52,15 +52,21 @@ class FM2Oscillator : public Oscillator
     virtual ~FM2Oscillator();
     virtual void init_ctrltypes() override;
     virtual void init_default_values() override;
-    double phase, lastoutput;
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
+
+    template <int mode, bool stereo, bool FM>
+    void process_block_internal(float pitch, float drift, float FMdepth);
+
+    double phase, oldout1, oldout2;
 
     using quadr_osc = sst::basic_blocks::dsp::SurgeQuadrOsc<float>;
+
     quadr_osc RM1, RM2;
     Surge::Oscillator::DriftLFO driftLFO;
     float fb_val;
+    int fb_mode;
     lag<double> FMdepth, RelModDepth1, RelModDepth2, FeedbackDepth, PhaseOffset;
-    virtual void handleStreamingMismatches(int streamingRevision,
-                                           int currentSynthStreamingRevision) override;
 };
 
 #endif // SURGE_SRC_COMMON_DSP_OSCILLATORS_FM2OSCILLATOR_H

--- a/src/common/dsp/oscillators/FM3Oscillator.h
+++ b/src/common/dsp/oscillators/FM3Oscillator.h
@@ -52,12 +52,18 @@ class FM3Oscillator : public Oscillator
     virtual ~FM3Oscillator();
     virtual void init_ctrltypes() override;
     virtual void init_default_values() override;
-    double phase, lastoutput;
+
+    template <int mode, bool stereo, bool FM>
+    void process_block_internal(float pitch, float drift, float FMdepth);
+
+    double phase, oldout1, oldout2;
 
     using quadr_osc = sst::basic_blocks::dsp::SurgeQuadrOsc<float>;
+
     quadr_osc RM1, RM2, AM;
     Surge::Oscillator::DriftLFO driftLFO;
     float fb_val;
+    int fb_mode;
     lag<double> FMdepth, AbsModDepth, RelModDepth1, RelModDepth2, FeedbackDepth;
     virtual void handleStreamingMismatches(int streamingRevision,
                                            int currentSynthStreamingRevision) override;

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2477,6 +2477,30 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         break;
                     }
+                    case ct_osc_feedback_negative:
+                    {
+                        contextMenu.addSeparator();
+                        auto dt = p->deform_type;
+
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                            contextMenu, "FEEDBACK TYPE");
+
+                        contextMenu.addItem("Surge", true, dt == 0, [this, p]() {
+                            undoManager()->pushParameterChange(p->id, p, p->val);
+                            p->deform_type = 0;
+                            synth->storage.getPatch().isDirty = true;
+                            frame->repaint();
+                        });
+                        contextMenu.addItem("Vintage FM", true, dt == 1, [this, p]() {
+                            undoManager()->pushParameterChange(p->id, p, p->val);
+                            p->deform_type = 1;
+                            synth->storage.getPatch().isDirty = true;
+                            frame->repaint();
+                        });
+                        contextMenu.addSeparator();
+
+                        break;
+                    }
                     default:
                     {
                         break;


### PR DESCRIPTION
This leaves Sine oscillator to complete the trifecta.