### PR TITLE
Improve fullscreen mode

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -29,6 +29,7 @@
 #include "RuntimeFont.h"
 #include "AccessibleHelpers.h"
 #include <version.h>
+#include "gui/widgets/MainFrame.h"
 
 struct VKeyboardWheel : public juce::Component
 {
@@ -338,6 +339,13 @@ void SurgeSynthEditor::reapplySurgeComponentColours()
 
 void SurgeSynthEditor::resized()
 {
+    drawExtendedControls = sge->getShowVirtualKeyboard();
+
+    auto w = getWidth();
+    auto h =
+        getHeight() -
+        (drawExtendedControls ? 0.01 * sge->getZoomFactor() * extraYSpaceForVirtualKeyboard : 0);
+
     if (Surge::GUI::getIsStandalone())
     {
         juce::Component *comp = this;
@@ -348,8 +356,22 @@ void SurgeSynthEditor::resized()
             {
                 if (cdw->isFullScreen())
                 {
-                    std::cout << __FILE__ << ":" << __LINE__ << " Deal with Full Screen zoom"
-                              << std::endl;
+                    // target width
+                    auto tw = sge->getWindowSizeX() * sge->getZoomFactor() * 0.01f;
+                    auto th = (sge->getWindowSizeY() +
+                               (drawExtendedControls ? extraYSpaceForVirtualKeyboard : 0)) *
+                              sge->getZoomFactor() * 0.01f;
+
+                    auto b = getLocalBounds();
+                    auto pw = (b.getWidth() - tw) / 2.0;
+                    auto ph = (b.getHeight() - th) / 2.0;
+
+                    // turn off aspect ratio
+                    if (getConstrainer())
+                        getConstrainer()->setFixedAspectRatio(0.f);
+
+                    sge->moveTopLeftTo(pw, ph);
+                    return;
                 }
                 comp = nullptr;
             }
@@ -358,14 +380,11 @@ void SurgeSynthEditor::resized()
                 comp = comp->getParentComponent();
             }
         }
+
+        sge->moveTopLeftTo(0, 0);
     }
 
-    drawExtendedControls = sge->getShowVirtualKeyboard();
-
-    auto w = getWidth();
-    auto h =
-        getHeight() -
-        (drawExtendedControls ? 0.01 * sge->getZoomFactor() * extraYSpaceForVirtualKeyboard : 0);
+    auto b = getLocalBounds();
     auto wR = 1.0 * w / sge->getWindowSizeX();
     auto hR = 1.0 * h / sge->getWindowSizeY();
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2895,6 +2895,27 @@ bool SurgeGUIEditor::doesZoomFitToScreen(float zf, float &correctedZf)
     }
 }
 
+void SurgeGUIEditor::moveTopLeftTo(float tx, float ty)
+{
+    /* This pushes every item so that it co-alighns with frame at tx, ty */
+    if (frame && frame->isVisible())
+    {
+        auto b = frame->getBounds();
+        auto bx = b.getX();
+        auto by = b.getY();
+        auto dx = tx - bx;
+        auto dy = ty - by;
+
+        for (auto c : juceEditor->getChildren())
+        {
+            auto q = c->getBounds();
+            auto nx = q.getX() + dx;
+            auto ny = q.getY() + dy;
+            c->setTopLeftPosition(nx, ny);
+        }
+    }
+}
+
 void SurgeGUIEditor::resizeWindow(float zf) { setZoomFactor(zf, true); }
 
 void SurgeGUIEditor::setZoomFactor(float zf) { setZoomFactor(zf, false); }
@@ -3849,8 +3870,6 @@ juce::PopupMenu SurgeGUIEditor::makeZoomMenu(const juce::Point<int> &where, bool
                                             [this, w = juce::Component::SafePointer(cdw)]() {
                                                 if (w)
                                                 {
-                                                    std::cout << __FILE__ << ":" << __LINE__
-                                                              << " Exit Full Screen" << std::endl;
                                                     w->setFullScreen(false);
                                                 }
                                             });
@@ -3861,8 +3880,6 @@ juce::PopupMenu SurgeGUIEditor::makeZoomMenu(const juce::Point<int> &where, bool
                                             [w = juce::Component::SafePointer(cdw)]() {
                                                 if (w)
                                                 {
-                                                    std::cout << __FILE__ << ":" << __LINE__
-                                                              << " Enter Full Screen" << std::endl;
                                                     w->setFullScreen(true);
                                                 }
                                             });

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -305,6 +305,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void setZoomFactor(float zf);
     void setZoomFactor(float zf, bool resizeWindow);
     void resizeWindow(float zf);
+    void moveTopLeftTo(float tx, float ty);
     bool doesZoomFitToScreen(float zf,
                              float &correctedZf); // returns true if it fits; false if not; sets
                                                   // correctedZF to right size in either case


### PR DESCRIPTION
Addresses #7104

basically

1. don't do internal zoom and constraints in full screen
2. center the components in the full screen
3. but don't zoom to largest in full screen yet. just center in screen