### PR TITLE
Add a Tuning Visualizer for MTS-ESP Mode

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1244,6 +1244,15 @@ void SurgeGUIEditor::idle()
 
         scanJuceSkinComponents = false;
     }
+
+    if (synth->storage.oddsound_mts_active_as_client)
+    {
+        auto w = getOverlayWrapperIfOpen(TUNING_EDITOR);
+        if (w && (slowIdleCounter % 30 == 0))
+        {
+            w->repaint();
+        }
+    }
 }
 
 void SurgeGUIEditor::toggle_mod_editing()
@@ -3373,6 +3382,13 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
 
         tuningSubMenu.addItem(Surge::GUI::toOSCase("Current Tuning: ") + mtsScale, false, false,
                               []() {});
+
+        std::string openname = isAnyOverlayPresent(TUNING_EDITOR) ? "Close " : "Open ";
+
+        Surge::GUI::addMenuWithShortcut(tuningSubMenu,
+                                        Surge::GUI::toOSCase(openname + "Tuning Visualizer..."),
+                                        showShortcutDescription("Alt + T", u8"\U00002325T"),
+                                        [this]() { this->toggleOverlay(TUNING_EDITOR); });
 
         tuningSubMenu.addSeparator();
     }

--- a/src/surge-xt/gui/overlays/TuningOverlays.h
+++ b/src/surge-xt/gui/overlays/TuningOverlays.h
@@ -113,6 +113,9 @@ struct TuningOverlay : public OverlayComponent,
     Tunings::Tuning tuning;
     SurgeStorage *storage{nullptr};
 
+    bool mtsMode{false};
+    void setMTSMode(bool isMTSOn);
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TuningOverlay);
 };
 } // namespace Overlays


### PR DESCRIPTION
In MTS-ESP mode you can use a subset of the tuning editor so rename it tuning visualizer in that mode and show the true keys and the keyboard display

Closes #7146