### PR TITLE
MIDI Program Change Support

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1355,6 +1355,7 @@ class alignas(16) SurgeStorage
     int firstUserCategory;
     std::vector<int> patchOrdering;
     std::vector<int> patchCategoryOrdering;
+    std::array<std::array<int, 128>, 128> patchIdToMidiBankAndProgram;
 
     // The in-memory wavetable database
     std::vector<Patch> wt_list;
@@ -1372,6 +1373,7 @@ class alignas(16) SurgeStorage
     fs::path userDefaultFilePath;
     fs::path userDataPath;
     fs::path userPatchesPath;
+    fs::path userPatchesMidiProgramChangePath;
     fs::path userWavetablesPath;
     fs::path userModulatorSettingsPath;
     fs::path userFXPath;
@@ -1379,6 +1381,8 @@ class alignas(16) SurgeStorage
     fs::path userSkinsPath;
     fs::path userMidiMappingsPath;
     fs::path extraThirdPartyWavetablesPath; // used by rack
+
+    std::string midiProgramChangePatchesSubdir{"MIDI Programs"};
 
     std::map<std::string, TiXmlDocument> userMidiMappingsXMLByName;
     void rescanUserMidiMappings();

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1929,8 +1929,10 @@ void SurgeSynthesizer::programChange(char channel, int value)
         return;
 
     PCH = value;
-    // load_patch((CC0<<7) + PCH);
-    patchid_queue = (CC0 << 7) + PCH;
+
+    auto pid = storage.patchIdToMidiBankAndProgram[CC0][PCH];
+    if (pid >= 0)
+        patchid_queue = pid;
 }
 
 void SurgeSynthesizer::updateDisplay()


### PR DESCRIPTION
Addresses #576

I might even go as so far as to say we are done with #576 with this commit but I'm sure there will be comments and changes still. So here's how it works

1. We add a new directory %USER%/Patches/MIDI Programs
2. We add a new data structure `patchIdToMidiBankAndProgram[128][128]` which for a bank and program is used for a patch id
3. We populate it as follows

   a. If `MIDI Programs` has top level patches those become bank 0 b. If `MIDI Programs` has directories, those fill in order. So a just-directories MIDI programs has bank 0 as the first directory and a mix and match has bank 0 as the raw top level and bank 1 as the first directory c. If there's still banks to be filled we fill them one at a time from factor. So if you have 6 directories in MIDI Programs, bank 7 will become 'Basses' (the first factory)

By 'fill' we mean traverse the category in alphabetical order and set the patches as programs, up to 128

Banks with < 128 patches don't respond to PCH for the empty slots Categories with > 128 patches only map the first 128