### PR TITLE
SelfDrawnButton solo mode had incorrect hover colors

### DIFF
--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -629,10 +629,10 @@ void MultiSwitchSelfDraw::paint(juce::Graphics &g)
             {
                 if (solo)
                 {
-                    g.setColour(skin->getColor(royalMode ? clr::HoverFill : clr::HoverOnFill));
+                    g.setColour(skin->getColor(clr::HoverFill));
                     g.fillRoundedRectangle(fc.toFloat(), cornerIn);
 
-                    fg = skin->getColor(royalMode ? clr::Text : clr::HoverOnText);
+                    fg = skin->getColor(royalMode ? clr::Text : clr::TextHover);
                 }
                 else
                 {


### PR DESCRIPTION
This corrects it so the scope is consistent with the mseg in classic, dark, and royal all

Closes #7173