### PR TITLE
Extend COMB size by 2x; Make extension cmake option

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -391,6 +391,12 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
   JUCE_STANDALONE_APPLICATION=0
   )
 
+if (SST_FILTERS_COMB_EXTENSION_FACTOR)
+  message(STATUS "Overriding comb extension factor to ${SST_FILTERS_COMB_EXTENSION_FACTOR}")
+  target_compile_definitions(${PROJECT_NAME} PUBLIC
+          SST_FILTERS_COMB_EXTENSION_FACTOR=${SST_FILTERS_COMB_EXTENSION_FACTOR})
+endif()
+
 target_include_directories(${PROJECT_NAME} PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
   dsp


### PR DESCRIPTION
1. The comb size is 2x larger allowing lower resonant physical modelling with the comb
2. Since this uses more memory, allow a build time flag to turn it off.  -DSST_FILTERS_COMB_EXTENSION_FACTOR=1 will revert to 1.2; =4 will give you even more modelling. =3 will crash and burn horribly. Pick a power of 2 if you use this!

Closes #7172