### PR TITLE
Turn off Midi PC Factory Backfill

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -790,17 +790,21 @@ void SurgeStorage::refresh_patchlist()
         }
     }
 
-    if (currBank < 128)
-    {
-        for (auto c : patchCategoryOrdering)
-        {
-            loadCategoryIntoBank(c, currBank);
-
-            currBank++;
-            if (currBank >= 128)
-                break;
-        }
-    }
+    /*
+     * Our initial implementation loaded factory banks
+     * in order into unused upper banks. We decided we don't want
+     * this but if you do, you do something like this:
+     * if (currBank < 128)
+     * {
+     *    for (auto c : patchCategoryOrdering)
+     *   {
+     *       loadCategoryIntoBank(c, currBank);
+     *       currBank++;
+     *       if (currBank >= 128)
+     *           break;
+     *   }
+     * }
+     */
 }
 
 void SurgeStorage::refreshPatchlistAddDir(bool userDir, string subdir)

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1922,12 +1922,6 @@ void SurgeSynthesizer::polyAftertouch(char channel, int key, int value)
 
 void SurgeSynthesizer::programChange(char channel, int value)
 {
-    auto ignorePC = Surge::Storage::getUserDefaultValue(
-        &(storage), Surge::Storage::IgnoreMIDIProgramChange, false);
-
-    if (ignorePC)
-        return;
-
     PCH = value;
 
     auto pid = storage.patchIdToMidiBankAndProgram[CC0][PCH];

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -333,7 +333,7 @@ std::string defaultKeyToString(DefaultKey k)
         r = "focusModEditorAfterAddModulationFrom";
         break;
 
-    case IgnoreMIDIProgramChange:
+    case IgnoreMIDIProgramChange_Deprecated:
         r = "ignoreMidiProgramChange";
         break;
 

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -161,7 +161,7 @@ enum DefaultKey
     FXUnitAssumeFixedBlock,
     FXUnitDefaultZoom,
 
-    IgnoreMIDIProgramChange,
+    IgnoreMIDIProgramChange_Deprecated, // better PC support means skip this
 
     DontShowAudioErrorsAgain,
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4757,17 +4757,6 @@ juce::PopupMenu SurgeGUIEditor::makeMidiMenu(const juce::Point<int> &where)
         });
 
     midiSubMenu.addSeparator();
-    bool igMID = Surge::Storage::getUserDefaultValue(
-        &(this->synth->storage), Surge::Storage::IgnoreMIDIProgramChange, false);
-
-    midiSubMenu.addItem("Ignore MIDI Program Change" + Surge::GUI::toOSCase(" Messages"), true,
-                        igMID, [this, igMID]() {
-                            Surge::Storage::updateUserDefaultValue(
-                                &(this->synth->storage), Surge::Storage::IgnoreMIDIProgramChange,
-                                !igMID);
-                        });
-
-    midiSubMenu.addSeparator();
 
     auto chanSubMenu = juce::PopupMenu();
 

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -498,7 +498,7 @@ void PatchSelector::showClassicMenu(bool single_category)
     bool has_3rdparty = false;
     int last_category = current_category;
     auto patch_cat_size = storage->patch_category.size();
-    int tutorialCat = -1;
+    int tutorialCat = -1, midiPCCat = -1;
 
     if (single_category)
     {
@@ -587,6 +587,11 @@ void PatchSelector::showClassicMenu(bool single_category)
             {
                 tutorialCat = c;
             }
+            else if (!storage->patch_category[c].isFactory &&
+                     storage->patch_category[c].name == storage->midiProgramChangePatchesSubdir)
+            {
+                midiPCCat = c;
+            }
             else
             {
                 populatePatchMenuForCategory(c, contextMenu, single_category, main_e, true);
@@ -597,6 +602,13 @@ void PatchSelector::showClassicMenu(bool single_category)
         {
             optionallyAddFavorites(contextMenu, true);
         }
+    }
+
+    if (midiPCCat >= 0 &&
+        storage->patch_category[midiPCCat].numberOfPatchesInCategoryAndChildren > 0)
+    {
+        contextMenu.addSeparator();
+        populatePatchMenuForCategory(midiPCCat, contextMenu, single_category, main_e, true);
     }
 
     contextMenu.addColumnBreak();


### PR DESCRIPTION
We initially made the unused banks fill in order
with Factory. We decided this was probably too volatile so just turned it off.

Doing so means in most cases midi program change does nothing so also remove the menu item for ignore midi program change.

Closes #576