### PR TITLE
Deactivate misleading tuning typeins in Tune-After mode

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -5320,7 +5320,7 @@ bool Parameter::supports_tuning_value_from_string(const std::string &s, std::str
     }
     if (storage->tuningApplicationMode == SurgeStorage::TuningApplicationMode::RETUNE_ALL)
     {
-        errMsg = "No tuning type-ins in tune-after mode";
+        errMsg = "No ratio type-ins in tune-after mode";
         return false;
     }
 

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -5320,7 +5320,7 @@ bool Parameter::supports_tuning_value_from_string(const std::string &s, std::str
     }
     if (storage->tuningApplicationMode == SurgeStorage::TuningApplicationMode::RETUNE_ALL)
     {
-        errMsg = "No tuning typesin in tune-after mode";
+        errMsg = "No tuning type-ins in tune-after mode";
         return false;
     }
 

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -4497,6 +4497,9 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
         {
             if (extend_range && s.find("/") != std::string::npos)
             {
+                if (!supports_tuning_value_from_string(s, errMsg))
+                    return false;
+
                 try
                 {
                     auto a = Tunings::toneFromString(s);
@@ -4627,6 +4630,9 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
             // Check for a fraction
             if (s.find("/") != std::string::npos)
             {
+                if (!supports_tuning_value_from_string(s, errMsg))
+                    return false;
+
                 try
                 {
                     auto a = Tunings::toneFromString(s);
@@ -4919,6 +4925,9 @@ float Parameter::calculate_modulation_value_from_string(const std::string &s, st
             // Check for a fraction
             if (s.find("/") != std::string::npos)
             {
+                if (!supports_tuning_value_from_string(s, errMsg))
+                    return false;
+
                 try
                 {
                     auto a = Tunings::toneFromString(s);
@@ -5022,6 +5031,9 @@ float Parameter::calculate_modulation_value_from_string(const std::string &s, st
 
             if (s[0] == 'T' || s[0] == 't')
             {
+                if (!supports_tuning_value_from_string(s, errMsg))
+                    return false;
+
                 try
                 {
                     auto a = Tunings::toneFromString(s.c_str() + 1);
@@ -5297,6 +5309,22 @@ float Parameter::calculate_modulation_value_from_string(const std::string &s, st
     valid = false;
 
     return 0.0;
+}
+
+bool Parameter::supports_tuning_value_from_string(const std::string &s, std::string &errMsg)
+{
+    if (!storage)
+    {
+        // Well that's odd! But let it go.
+        return true;
+    }
+    if (storage->tuningApplicationMode == SurgeStorage::TuningApplicationMode::RETUNE_ALL)
+    {
+        errMsg = "No tuning typesin in tune-after mode";
+        return false;
+    }
+
+    return true;
 }
 
 std::atomic<bool> parameterNameUpdated(false);

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -462,6 +462,7 @@ class Parameter
     void set_value_f01(float v, bool force_integer = false);
     bool set_value_from_string(const std::string &s, std::string &errMsg);
     bool set_value_from_string_onto(const std::string &s, pdata &ontoThis, std::string &errMsg);
+    bool supports_tuning_value_from_string(const std::string &s, std::string &errMsg);
     void set_error_message(std::string &errMsg, const std::string value, const std::string unit,
                            const ErrorMessageMode mode);
     void set_extend_range(bool er);


### PR DESCRIPTION
In Tune-After mode the typein "9/8" didn't uniformly give you a 9/8 pitch shift; it gave you that many keys shift. This was rather confusing. Some even called it "borked". So just make a clear error that this typein style is only availabel in tune-at-midi mode

Closes #6977