### PR TITLE
MSEG ControlPOint would nan with identical VValues

### DIFF
--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -607,7 +607,12 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                     {
                         float dv = 0;
                         if (verticalScaleByValues)
-                            dv = -2 * dy / vscale / (0.5 * segdx);
+                        {
+                            if (segdx == 0)
+                                dv = 0;
+                            else
+                                dv = -2 * dy / vscale / (0.5 * segdx);
+                        }
                         else
                             dv = -2 * dy / vscale;
 


### PR DESCRIPTION
For some types where we scale the change in cpv by the values (like linear), a pair of identical points would nan out the CPV

Embassingly this mean tthe default mseg / grab sustain CPV / drag would destroy our mseg.

Addresses #6918 but its not the core problem there