### PR TITLE
Protect against other NaNs in MSEG

### DIFF
--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -34,6 +34,8 @@ namespace MSEG
 
 void rebuildCache(MSEGStorage *ms)
 {
+    forceToConstrainedNormalForm(ms);
+
     if (ms->loop_start > ms->n_activeSegments - 1)
     {
         ms->loop_start = -1;
@@ -1182,8 +1184,28 @@ void resetControlPoint(MSEGStorage *ms, int idx)
 
 void constrainControlPointAt(MSEGStorage *ms, int idx)
 {
+    if (!std::isfinite(ms->segments[idx].cpduration))
+        ms->segments[idx].cpduration = 0.5;
+    if (!std::isfinite(ms->segments[idx].cpv))
+        ms->segments[idx].cpv = 0.0;
+
     ms->segments[idx].cpduration = limit_range(ms->segments[idx].cpduration, 0.f, 1.f);
     ms->segments[idx].cpv = limit_range(ms->segments[idx].cpv, -1.f, 1.f);
+}
+
+void forceToConstrainedNormalForm(MSEGStorage *ms) // removes any nans etc
+{
+    for (auto &seg : ms->segments)
+    {
+        if (!std::isfinite(seg.v0))
+            seg.v0 = 0;
+        if (!std::isfinite(seg.cpv))
+            seg.cpv = 0;
+        if (!std::isfinite(seg.duration))
+            seg.duration = 0.1;
+        if (!std::isfinite(seg.cpduration))
+            seg.cpduration = 0.6;
+    }
 }
 
 void scaleDurations(MSEGStorage *ms, float factor, float maxDuration)

--- a/src/common/dsp/modulators/MSEGModulationHelper.h
+++ b/src/common/dsp/modulators/MSEGModulationHelper.h
@@ -85,6 +85,7 @@ void adjustDurationConstantTotalDuration(MSEGStorage *ms, int idx, float dx, flo
 void resetControlPoint(MSEGStorage *ms, float t);
 void resetControlPoint(MSEGStorage *ms, int idx);
 void constrainControlPointAt(MSEGStorage *ms, int idx);
+void forceToConstrainedNormalForm(MSEGStorage *ms); // removes any nans etc
 
 void scaleDurations(MSEGStorage *ms, float factor, float maxDuration = -1);
 void scaleValues(MSEGStorage *ms, float factor);


### PR DESCRIPTION
The broken preset in #6918 had got a nan in it. We've since fixed a bunch of ways to make nans accidentally in the editor but in case we don't get them all, and since this is ui thread stuff, just always constrain mseg values to std::isfinite

Closes #6918