### PR TITLE
Fix the FX Standalone for Bluetooth headsets

### DIFF
--- a/src/surge-fx/SurgeFXEditor.cpp
+++ b/src/surge-fx/SurgeFXEditor.cpp
@@ -257,10 +257,14 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
     getConstrainer()->setMinimumWidth(baseWidth * 0.75);
     getConstrainer()->setFixedAspectRatio(baseWidth * 1.0 / baseHeight);
     // setResizable(false, false);
+
+    idleTimer = std::make_unique<IdleTimer>(this);
+    idleTimer->startTimer(1000 / 5);
 }
 
 SurgefxAudioProcessorEditor::~SurgefxAudioProcessorEditor()
 {
+    idleTimer->stopTimer();
     setLookAndFeel(nullptr);
     this->processor.setParameterChangeListener([]() {});
 }
@@ -681,4 +685,25 @@ bool SurgefxAudioProcessorEditor::keyPressed(const juce::KeyPress &key)
     }
 
     return false;
+}
+
+void SurgefxAudioProcessorEditor::IdleTimer::timerCallback() { ed->idle(); }
+
+void SurgefxAudioProcessorEditor::idle()
+{
+    if (processor.m_audioValid != priorValid)
+    {
+        priorValid = processor.m_audioValid;
+        if (!processor.m_audioValid)
+        {
+            fxNameLabel->setFont(18);
+            fxNameLabel->setText(processor.m_audioValidMessage,
+                                 juce::NotificationType::dontSendNotification);
+        }
+        else
+        {
+            fxNameLabel->setFont(28);
+            fxNameLabel->setText("Surge XT Effects", juce::NotificationType::dontSendNotification);
+        }
+    }
 }

--- a/src/surge-fx/SurgeFXEditor.h
+++ b/src/surge-fx/SurgeFXEditor.h
@@ -169,6 +169,18 @@ class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor, juce::Asy
 
     bool keyPressed(const juce::KeyPress &key) override;
 
+    // We have a very slow idle (it just checks invalid bus configs)
+    struct IdleTimer : juce::Timer
+    {
+        IdleTimer(SurgefxAudioProcessorEditor *ed) : ed(ed) {}
+        ~IdleTimer() = default;
+        void timerCallback() override;
+        SurgefxAudioProcessorEditor *ed;
+    };
+    void idle();
+    std::unique_ptr<IdleTimer> idleTimer;
+    bool priorValid{true};
+
   public:
     std::vector<juce::Component *> accessibleOrderWeakRefs;
 

--- a/src/surge-fx/SurgeFXProcessor.h
+++ b/src/surge-fx/SurgeFXProcessor.h
@@ -283,6 +283,9 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
     // Members for the FX. If this looks a lot like surge-rack/SurgeFX.hpp that's not a coincidence
     std::unique_ptr<SurgeStorage> storage;
 
+    std::atomic<bool> m_audioValid{true};
+    std::string m_audioValidMessage{};
+
   private:
     template <typename T, typename F> struct FXAudioParameter : public T
     {


### PR DESCRIPTION
Bluetooth headsets give wierd transient bad configurations Make it so we are robust in the standalone FX bank under that, like we did for the standalone synth in 1.2

Closes #7186