### PR TITLE
Handle an uncaught exception from Surge creation better

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.h
+++ b/src/surge-xt/SurgeSynthEditor.h
@@ -29,6 +29,7 @@
 #include "juce_audio_utils/juce_audio_utils.h"
 
 #include <forward_list>
+#include "version.h"
 
 class SurgeGUIEditor;
 class SurgeJUCELookAndFeel;
@@ -139,6 +140,34 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     std::unique_ptr<juce::Drawable> logo;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SurgeSynthEditor)
+};
+
+struct SurgeSynthStartupErrorEditor : juce::AudioProcessorEditor
+{
+    SurgeSynthProcessor &ssp;
+    SurgeSynthStartupErrorEditor(SurgeSynthProcessor &p) : juce::AudioProcessorEditor(p), ssp(p)
+    {
+        setSize(700, 700);
+    }
+    void paint(juce::Graphics &g) override
+    {
+        g.fillAll(juce::Colours::black);
+        g.setColour(juce::Colour(255, 50, 50));
+
+        g.setFont(40);
+        auto lb = getLocalBounds().withHeight(50).translated(0, 100);
+        g.drawText("Fatal Surge Startup Error", lb, juce::Justification::centred);
+
+        g.setColour(juce::Colours::white);
+        g.setFont(20);
+        lb = lb.translated(0, 55).withHeight(120);
+        g.drawFittedText(ssp.fatalErrorMessage, lb, juce::Justification::centred, 5);
+        lb = lb.translated(0, 125);
+        g.drawText(Surge::Build::FullVersionStr, lb, juce::Justification::centred);
+        lb = lb.translated(0, 25);
+        g.drawText("Report on Surge discord or github issue with a screenshot of this screen", lb,
+                   juce::Justification::centred);
+    }
 };
 
 #endif // SURGE_SRC_SURGE_XT_SURGESYNTHEDITOR_H

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -469,6 +469,8 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
   public:
     bool inputIsLatent{false};
 
+    std::string fatalErrorMessage{false};
+
   private:
     // Have we warned about bad configurations
     bool warnedAboutBadConfig{false};


### PR DESCRIPTION
If the creation of the surge instance throws an exception, we catch it and replace the surge internals with a fatal error screen. This may help us debug #7187. Or may not.