### PR TITLE
Modern retrig-from-zero sample offset

### DIFF
--- a/src/common/dsp/oscillators/ModernOscillator.cpp
+++ b/src/common/dsp/oscillators/ModernOscillator.cpp
@@ -141,7 +141,8 @@ void ModernOscillator::init(float pitch, bool is_display, bool nonzero_init_drif
         unisonOffsets[u] = us.detune(u);
         us.attenuatedPanLaw(u, mixL[u], mixR[u]);
 
-        phase[u] = oscdata->retrigger.val.b || is_display ? 0.f : storage->rand_01();
+        phase[u] =
+            oscdata->retrigger.val.b || is_display ? pitch_to_dphase(pitch) : storage->rand_01();
         sphase[u] = phase[u];
         sTurnFrac[u] = 0;
         sprior[u] = 0;


### PR DESCRIPTION
The modern 2-point DPW algorithm uses points at phase, phase-d and phase -2d to calculate. This has the defacto one-sample latency effect (at the oversample sample rate).

This doesn't matter *except* in the retrigger-from-zero case when that shift makes the first output point at the wrong phase.

So in retrigger, intiialize phase to dphase, not to 0, so you can hit the zero point for symmetric waveforms exactly.

Addresses https://github.com/surge-synthesizer/surge-rack/issues/937