### PR TITLE
Revert "Skip VST3 Menus in Reason"

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -610,10 +610,6 @@ void SurgeSynthEditor::endMacroEdit(long macroNum)
 
 juce::PopupMenu SurgeSynthEditor::hostMenuFor(Parameter *p)
 {
-    // See issue 6752
-    if (juce::PluginHostType().isReason())
-        return {};
-
     auto par = processor.paramsByID[processor.surge->idForParameter(p)];
 
     if (auto *c = getHostContext())
@@ -625,10 +621,6 @@ juce::PopupMenu SurgeSynthEditor::hostMenuFor(Parameter *p)
 
 juce::PopupMenu SurgeSynthEditor::hostMenuForMacro(int macro)
 {
-    // See issue 6752
-    if (juce::PluginHostType().isReason())
-        return {};
-
     auto par = processor.macrosById[macro];
 
     if (auto *c = getHostContext())


### PR DESCRIPTION
Reverts surge-synthesizer/surge#6766

Test to see if Reason Studios actually fixed it. Surely they wouldn't lie to us!