### PR TITLE
More "release by note id" work

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -601,6 +601,7 @@ struct MidiKeyState
 {
     int keystate;
     char lastdetune;
+    int32_t lastNoteIdForKey;
     int64_t voiceOrder;
 };
 

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -523,8 +523,8 @@ void SurgeSynthesizer::playNoteByFrequency(float freq, char velocity, int32_t id
     auto k = 12 * log2(freq / 440) + 69;
     auto mk = (int)std::floor(k);
     auto off = k - mk;
-    //std::cout << "playNote freq: " << freq << "  note: " << mk << "  offset: " << off
-    //   << "  vel: " << static_cast<int>(velocity) << " id : " << id << std::endl;
+    // std::cout << "playNote freq: " << freq << "  note: " << mk << "  offset: " << off
+    //    << "  vel: " << static_cast<int>(velocity) << " id : " << id << std::endl;
     playNote(0, mk, velocity, 0, id);
     // and now to fix the tuning
     this->setNoteExpression(SurgeVoice::PITCH, id, mk, 0, off); // since PITCH is in semitones

--- a/src/surge-testrunner/UnitTestsVOICE.cpp
+++ b/src/surge-testrunner/UnitTestsVOICE.cpp
@@ -293,7 +293,7 @@ TEST_CASE("Play and release Frequency and Note ID", "[voice]")
             for (auto &c : cmd)
             {
                 auto [play, keyOrFreq, channel, nid, expected] = c;
-                INFO( "CMD " << play << " " << keyOrFreq << " " << nid);
+                INFO("CMD " << play << " " << keyOrFreq << " " << nid);
                 if (play)
                 {
                     if (byNote)
@@ -316,7 +316,8 @@ TEST_CASE("Play and release Frequency and Note ID", "[voice]")
                     {
                         for (const auto &v : s->voices[sc])
                         {
-                            std::cout << v << " " << v->state.gate << " " << v->state.key << " " << v->host_note_id << std::endl;
+                            std::cout << v << " " << v->state.gate << " " << v->state.key << " "
+                                      << v->host_note_id << std::endl;
                         }
                     }
                 }


### PR DESCRIPTION
oh goodness, mono_fp reuses ids by bringing voices back from the channel state etc.... its just too ugly to even describe but this fixes it.