### PR TITLE
Modern Oscillator Pitch: Lag -> Lipol

### DIFF
--- a/src/common/dsp/oscillators/ModernOscillator.cpp
+++ b/src/common/dsp/oscillators/ModernOscillator.cpp
@@ -125,8 +125,8 @@ void ModernOscillator::init(float pitch, bool is_display, bool nonzero_init_drif
 {
     // we need a tiny little portamento since the derivative is pretty
     // unstable under super big pitch changes
-    pitchlag.setRate(0.5);
-    pitchlag.startValue(pitch);
+    pitchlag.newValue(pitch);
+    pitchlag.instantize();
     pwidth.setRate(0.001); // 4x slower
     sync.setRate(0.001 * BLOCK_SIZE_OS);
 
@@ -171,7 +171,7 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
 
     float ud = oscdata->p[mo_unison_detune].get_extended(
         localcopy[oscdata->p[mo_unison_detune].param_id_in_scene].f);
-    pitchlag.startValue(pitch);
+    pitchlag.newValue(pitch);
     sync.newValue(std::max(0.f, localcopy[oscdata->p[mo_sync].param_id_in_scene].f));
 
     float absOff = 0;

--- a/src/common/dsp/oscillators/ModernOscillator.h
+++ b/src/common/dsp/oscillators/ModernOscillator.h
@@ -75,8 +75,9 @@ class ModernOscillator : public Oscillator
     template <mo_multitypes multitype, bool subOctave, bool FM>
     void process_sblk(float pitch, float drift = 0.f, bool stereo = false, float FMdepth = 0.f);
 
-    lag<double, true> sawmix, trimix, sqrmix, pwidth, sync, dpbase[MAX_UNISON], dspbase[MAX_UNISON],
-        subdpbase, subdpsbase, detune, pitchlag, fmdepth;
+    lag<double, true> sawmix, trimix, sqrmix, pwidth, sync,  detune, fmdepth;
+    lipol<double, true> pitchlag,dpbase[MAX_UNISON], dspbase[MAX_UNISON],
+        subdpbase, subdpsbase;
 
     // character filter
     Surge::Oscillator::CharacterFilter<double> charFilt;

--- a/src/common/dsp/oscillators/ModernOscillator.h
+++ b/src/common/dsp/oscillators/ModernOscillator.h
@@ -75,9 +75,8 @@ class ModernOscillator : public Oscillator
     template <mo_multitypes multitype, bool subOctave, bool FM>
     void process_sblk(float pitch, float drift = 0.f, bool stereo = false, float FMdepth = 0.f);
 
-    lag<double, true> sawmix, trimix, sqrmix, pwidth, sync,  detune, fmdepth;
-    lipol<double, true> pitchlag,dpbase[MAX_UNISON], dspbase[MAX_UNISON],
-        subdpbase, subdpsbase;
+    lag<double, true> sawmix, trimix, sqrmix, pwidth, sync, detune, fmdepth;
+    lipol<double, true> pitchlag, dpbase[MAX_UNISON], dspbase[MAX_UNISON], subdpbase, subdpsbase;
 
     // character filter
     Surge::Oscillator::CharacterFilter<double> charFilt;


### PR DESCRIPTION
addresses #7224

The original version of Modern used the trailing three points for the derivative, but didnt' recaclulate all three at once. This meant it was a bit unstable under extreme pitch changes so we used a lag/lpf on pitch and dphase. We subsequently changed the algorithm to always calculate the trailing three points but never undid that lag, leading to low porta high shift having an audible sweep in modern, as reported in #7224.

This change fixes that and simply block smooths pitch shifts.