### PR TITLE
Slider-Mouse-Unhide error; Flanger temposync fix

### DIFF
--- a/src/surge-xt/gui/widgets/ModulatableSlider.cpp
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.cpp
@@ -550,7 +550,24 @@ void ModulatableSlider::mouseUp(const juce::MouseEvent &event)
         if (editTypeWas == DRAG)
         {
             updateLocationState();
-            auto p = juce::Point<float>(handleCX, handleCY);
+
+            /*
+             * The center calculation is a bit off for mouse restore in horizontal
+             * mode. We could fix it and change all the meaning of the items but
+             * its much easier just to bodge in an offset here for now.
+             */
+            auto ptY = handleCY;
+            auto ptX = handleCX;
+            if (orientation == ParamConfig::kHorizontal)
+            {
+                ptY += handleSize.getHeight() / 2;
+            }
+            else
+            {
+                // Idiosyncratically only the horizontal calculation is wrong
+                // ptX += handleSize.getWidth() / 2;
+            }
+            auto p = juce::Point<float>(ptX, ptY);
             if (isEditingModulation)
                 p = juce::Point<float>(handleMX, handleMY);
             p = localPointToGlobal(p);


### PR DESCRIPTION
The horitonzal slider positioned the mouse subtly
incorrectly when it unhid, placing it at the top of the slider box, which in the tightly packed FX section meant mis-clicks were easy. Closes #7232

Also the temposycn scale on teh flanger rate was wrong, but fix it using the API I just added to do same in Phaser. Closes #7233