### PR TITLE
Revert "Modern Oscillator Pitch: Lag -> Lipol (#7231)"

### DIFF
--- a/src/common/dsp/oscillators/ModernOscillator.cpp
+++ b/src/common/dsp/oscillators/ModernOscillator.cpp
@@ -125,8 +125,8 @@ void ModernOscillator::init(float pitch, bool is_display, bool nonzero_init_drif
 {
     // we need a tiny little portamento since the derivative is pretty
     // unstable under super big pitch changes
-    pitchlag.newValue(pitch);
-    pitchlag.instantize();
+    pitchlag.setRate(0.5);
+    pitchlag.startValue(pitch);
     pwidth.setRate(0.001); // 4x slower
     sync.setRate(0.001 * BLOCK_SIZE_OS);
 
@@ -171,7 +171,7 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
 
     float ud = oscdata->p[mo_unison_detune].get_extended(
         localcopy[oscdata->p[mo_unison_detune].param_id_in_scene].f);
-    pitchlag.newValue(pitch);
+    pitchlag.startValue(pitch);
     sync.newValue(std::max(0.f, localcopy[oscdata->p[mo_sync].param_id_in_scene].f));
 
     float absOff = 0;

--- a/src/common/dsp/oscillators/ModernOscillator.h
+++ b/src/common/dsp/oscillators/ModernOscillator.h
@@ -75,8 +75,8 @@ class ModernOscillator : public Oscillator
     template <mo_multitypes multitype, bool subOctave, bool FM>
     void process_sblk(float pitch, float drift = 0.f, bool stereo = false, float FMdepth = 0.f);
 
-    lag<double, true> sawmix, trimix, sqrmix, pwidth, sync, detune, fmdepth;
-    lipol<double, true> pitchlag, dpbase[MAX_UNISON], dspbase[MAX_UNISON], subdpbase, subdpsbase;
+    lag<double, true> sawmix, trimix, sqrmix, pwidth, sync, dpbase[MAX_UNISON], dspbase[MAX_UNISON],
+        subdpbase, subdpsbase, detune, pitchlag, fmdepth;
 
     // character filter
     Surge::Oscillator::CharacterFilter<double> charFilt;


### PR DESCRIPTION
This reverts commit 0d099b37d404f57e3db64c7897b5cec19c395052.

The change causes pops under extrema which I will outline in the original issue

Related to #7224 