### PR TITLE
Osc work

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -290,6 +290,7 @@ bool SurgeSynthProcessor::initOSCOut(int port)
         surge->addPatchLoadedListener("OSC_OUT",
                                       [ssp = this](auto s) { ssp->patch_load_to_OSC(s); });
     }
+
     // Add a listener for parameter changes
     SurgeSynthProcessor::addParamChangeListener(
         "OSC_OUT", [ssp = this](auto str1, auto str2) { ssp->param_change_to_OSC(str1, str2); });

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -353,10 +353,9 @@ void SurgeSynthProcessor::paramChangeToListeners(Parameter *p, bool isMacro, int
 
             case vt_float:
             {
-                auto nat_value = p->value_to_normalized(p->val.f);
                 std::ostringstream oss;
-                oss << float_to_clocalestr(p->val.f) << " " << float_to_clocalestr(nat_value)
-                    << " n";
+                oss << p->get_display(false, 0.0) << " "
+                    << float_to_clocalestr(p->value_to_normalized(p->val.f)) << " (normalized)";
                 valStr = oss.str();
             }
             break;

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -635,7 +635,7 @@ code {
                             not how messages are to be formatted for OSC).
                         </p>
                         <p style="margin-top: 28px;">
-                             <b>OSC output</b>: All parameter and patch changes made on Surge XT are reported to OSC out.
+                             <b>OSC output</b>: All parameter and patch changes made on Surge XT are reported to OSC out, if OSC output is enabled.
                              Floating point parameters are reported both in their 'natural' range, and normalized (0.0 - 1.0).
                              Errors are reported (when feasible) to "/error".
                         </p>

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -618,7 +618,8 @@ code {
                             where <code>address</code> is one of the ones listed below, and zero or more <code>values</code> can be*:
 
                             <ul>
-                                <li>a floating point value between <b>0.0</b> and <b>1.0</b> (note: use '.' as the decimal mark, never ',').</li>
+                                <li>a floating point value between <b>0.0</b> and <b>1.0</b>, where 0 represents the minimum acceptable
+                                    value for the parameter, and 1 represents the maximum. <br />(note: use '.' as the decimal mark, never ',').</li>
                                 <li>an integer value</li>
                                 <li>a boolean value, <b>0</b> (false) or <b>1</b> (true)</li>
                                 <li>a file path (absolute, or relative to the default path)
@@ -628,6 +629,9 @@ code {
                             Where an address contains an asterisk <b>(*)</b>, replace the asterisk with either <b>a</b> or <b>b</b>,
                             depending on which scene you wish to address - e.g. <code>/a/drift</code> or <code>/b/drift</code>.
                         <p>
+                            If a value is received that is less than the minimum or greater than the maximum acceptable value, it will be clipped
+                            to the associated limit.
+                        </p>
                         <p style="border: 1px solid black; padding: 4px;" >
                             <b>*Important note: all numeric values must be sent over OSC as floating point numbers</b>
                             (even if they are listed as integer or boolean type --
@@ -892,16 +896,13 @@ code {
                 <div style="margin:10pt; padding: 5pt 12pt; background: #fafbff;">
                     <div style="font-size: 12pt; font-family: Lato;">
                         <p>
-                            For /param messages, 'float' values may be expressed in their natural range
-                            (as described below in the 'Appropriate Values' column) or <u>normalized</u> to the range 0.0 to 1.0.
-                            To use normalized values, add 'n' after the data value, as shown in the first example below.
+                            For /param messages, 'float' values must be expressed as 'normalized' in the range 0.0 to 1.0.
                         </p>
                     </div>
                 </div>
 
                 <div style="width: 1130px; margin: 8px auto; line-height: 1.75">
-                    <span><code>/param/b/amp/gain 0.63 n</code></span>
-                    <span><code>/param/b/amp/gain 45.3</code></span>
+                    <span><code>/param/b/amp/gain 0.63</code></span>
                     <span><code>/param/global/polyphony_limit 12</code></span>
                     <span><code>/param/a/mixer/noise/mute 0</code></span>
                 </div>
@@ -1016,8 +1017,11 @@ code {
             {
                 std::stringstream buffer;
                 buffer.precision(1);
-                buffer << std::fixed << "float (" << itr.p->val_min.f << " to " << itr.p->val_max.f
-                       << ")";
+                auto pmin = 0.0;
+                auto pmax = 1.0;
+                // auto pdisp_min = itr.p->get_display(true, 0.0);
+                // auto pdisp_max = itr.p->get_display(true, 1.0);
+                buffer << std::fixed << "float (" << pmin << " to " << pmax << ")";
                 valueType = buffer.str();
                 break;
             }

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -345,6 +345,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     else if (address1 == "param")
     {
         bool normalized = false;
+        /*
         if (message.size() == 2)
         {
             if (!message[1].isString())
@@ -360,7 +361,9 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                 return;
             }
         }
-        else if (message.size() != 1)
+
+        else */
+        if (message.size() != 1)
         {
             sendDataCountError("param", "1");
             return;
@@ -408,8 +411,8 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                 return;
             }
             float val = message[0].getFloat32();
-            if (!normalized)
-                val = getNormValue(p, val);
+            // if (!normalized)
+            //     val = getNormValue(p, val);
             sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(p, val));
         }
 
@@ -692,10 +695,9 @@ void OpenSoundControl::sendAllParams()
 
                 case vt_float:
                 {
-                    auto nat_value = p.value_to_normalized(p.val.f);
                     std::ostringstream oss;
-                    oss << float_to_clocalestr(p.val.f) << " " << float_to_clocalestr(nat_value)
-                        << " n";
+                    oss << p.get_display(false, 0.0) << " "
+                        << float_to_clocalestr(p.value_to_normalized(p.val.f)) << " (normalized)";
                     valStr = oss.str();
                 }
                 break;

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -691,8 +691,14 @@ void OpenSoundControl::sendAllParams()
                     break;
 
                 case vt_float:
-                    valStr = float_to_clocalestr(p.val.f);
-                    break;
+                {
+                    auto nat_value = p.value_to_normalized(p.val.f);
+                    std::ostringstream oss;
+                    oss << float_to_clocalestr(p.val.f) << " " << float_to_clocalestr(nat_value)
+                        << " n";
+                    valStr = oss.str();
+                }
+                break;
 
                 default:
                     break;


### PR DESCRIPTION
Switching back to only accepting normalized (0.0 - 1.0) values for floats received in /param messages. OSC output now reports all param changes in 'display' format *and* normalized.