### PR TITLE
Add a test suite *after* surge-xt

### DIFF
--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -236,3 +236,5 @@ if (APPLE)
 endif()
 
 surge_juce_package(${PROJECT_NAME} "Surge XT")
+
+add_subdirectory(xt-tests)

--- a/src/surge-xt/xt-tests/CMakeLists.txt
+++ b/src/surge-xt/xt-tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+# vi:set sw=2 et:
+project(surge-xt-tests)
+
+add_executable(${PROJECT_NAME}
+        main.cpp
+        XTTestOSC.cpp
+  )
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  surge-xt
+  surge::catch2_v3
+
+  # These are PRIVATE linked by the plugin for appropriate reason
+  # but means we need to copy them here
+        surge-common
+        surge-platform
+        surge-juce
+        juce::juce_graphics
+        juce::juce_audio_utils
+        juce::juce_audio_processors
+        juce::juce_audio_plugin_client
+        juce::juce_osc
+        surge-xt-binary
+        sst-filters-extras
+)
+
+message(STATUS "Using CatchDiscoverTests on ${PROJECT_NAME}" )
+catch_discover_tests(${PROJECT_NAME} WORKING_DIRECTORY ${SURGE_SOURCE_DIR})

--- a/src/surge-xt/xt-tests/CMakeLists.txt
+++ b/src/surge-xt/xt-tests/CMakeLists.txt
@@ -24,5 +24,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
         sst-filters-extras
 )
 
-message(STATUS "Using CatchDiscoverTests on ${PROJECT_NAME}" )
-catch_discover_tests(${PROJECT_NAME} WORKING_DIRECTORY ${SURGE_SOURCE_DIR})
+if (${SURGE_INCLUDE_XT_TESTS_IN_CTEST})
+    message(STATUS "Using CatchDiscoverTests on ${PROJECT_NAME}" )
+    catch_discover_tests(${PROJECT_NAME} WORKING_DIRECTORY ${SURGE_SOURCE_DIR})
+endif()

--- a/src/surge-xt/xt-tests/XTTestOSC.cpp
+++ b/src/surge-xt/xt-tests/XTTestOSC.cpp
@@ -1,0 +1,82 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#include "catch2/catch_amalgamated.hpp"
+#include "SurgeSynthProcessor.h"
+
+TEST_CASE("Can Make an SSP", "[xt-osc]")
+{
+    juce::MessageManager::getInstance();
+    auto s = SurgeSynthProcessor();
+    REQUIRE(s.supportsMPE());
+
+    juce::MessageManager::deleteInstance();
+}
+
+TEST_CASE("Simulate the Audio Thread", "[xt-osc]")
+{
+    auto mm = juce::MessageManager::getInstance();
+
+    auto s = SurgeSynthProcessor();
+    std::atomic<bool> keepGoing{true};
+    std::atomic<int32_t> gatedVoices{0};
+    auto t = std::thread([&s, &keepGoing, &gatedVoices]() {
+        using namespace std::chrono_literals;
+
+        while (keepGoing)
+        {
+            auto a = juce::AudioBuffer<float>(6, 512);
+            auto m = juce::MidiBuffer();
+            s.processBlock(a, m);
+
+            auto gv = 0;
+            auto &srg = s.surge;
+            for (const auto &sv : srg->voices)
+                for (const auto &v : sv)
+                    if (v->state.gate)
+                        gv++;
+
+            gatedVoices = gv;
+            std::this_thread::sleep_for(1ms);
+        }
+    });
+
+    mm->runDispatchLoop();
+
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(100ms);
+    REQUIRE(gatedVoices == 0);
+
+    auto msg = juce::OSCMessage("/mnote", 60.f, 90.f);
+    s.oscHandler.oscMessageReceived(msg);
+    std::this_thread::sleep_for(100ms);
+    REQUIRE(gatedVoices == 1);
+
+    msg = juce::OSCMessage("/mnote", 60.f, 0.f);
+    s.oscHandler.oscMessageReceived(msg);
+    std::this_thread::sleep_for(100ms);
+    REQUIRE(gatedVoices == 0);
+
+    keepGoing = false;
+    t.join();
+    juce::MessageManager::deleteInstance();
+}

--- a/src/surge-xt/xt-tests/main.cpp
+++ b/src/surge-xt/xt-tests/main.cpp
@@ -1,0 +1,34 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#define CATCH_CONFIG_RUNNER
+#include "catch2/catch_amalgamated.hpp"
+
+/*
+ * This is a simple main that either routes around or routes to catch2 main.
+ * If it routes around, it heads into something in HeadlessNonTestFunctions
+ */
+int main(int argc, char **argv)
+{
+    int result = Catch::Session().run(argc, argv);
+    return result;
+}


### PR DESCRIPTION
this allows us to test features in SurgeSynthProcessor not just surge-common. Specifically it lets us test OSC message handling.

There's a lot of stuff here which would be boilerplate if we had a lot of tests. Will leave that to adventurous OSC tester to figure out.