### PR TITLE
Exclude `immintrin.h` on RISC-V

### DIFF
--- a/src/common/dsp/vembertech/portable_intrinsics.h
+++ b/src/common/dsp/vembertech/portable_intrinsics.h
@@ -22,7 +22,7 @@
 #ifndef SURGE_SRC_COMMON_DSP_VEMBERTECH_PORTABLE_INTRINSICS_H
 #define SURGE_SRC_COMMON_DSP_VEMBERTECH_PORTABLE_INTRINSICS_H
 
-#if LINUX && !ARM_NEON
+#if LINUX && !ARM_NEON && !defined(__riscv)
 #include <immintrin.h>
 #endif
 


### PR DESCRIPTION
I am trying to build `surge` on RISC-V, but there is no header `<immintrin.h>` on RISC-V.