### PR TITLE
Deal with macos / juce zip __MACOSX directory stuff

### DIFF
--- a/src/surge-xt/gui/SkinSupport.cpp
+++ b/src/surge-xt/gui/SkinSupport.cpp
@@ -141,8 +141,15 @@ void SkinDB::rescanForSkins(SurgeStorage *storage)
                     {
                         if (fs::is_directory(d))
                         {
-                            alldirs.push_back(d);
-                            workStack.push_back(d);
+                            if (d.path().filename().u8string() == "__MACOSX")
+                            {
+                                // skip this mis-zipped dir. See #7249
+                            }
+                            else
+                            {
+                                alldirs.push_back(d);
+                                workStack.push_back(d);
+                            }
                         }
                     }
                 }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -224,6 +224,19 @@ class DroppedUserDataHandler
                       << std::endl;
             return false;
         }
+
+        // mac zip can create a place for the finder bundle that juce
+        // unzips as opposed to applies. Nuke it. See #7249
+        if (fs::is_directory(uncompressTo / "__MACOSX"))
+        {
+            try
+            {
+                fs::remove_all(uncompressTo / "__MACOSX");
+            }
+            catch (const fs::filesystem_error &)
+            {
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
the __MACOSX directory is special. juce zipfile doesn't treat it as so. Now we do. Basically.

Closes #7249