### PR TITLE
Remove the explicit immintrin include from portable_intrinsics

### DIFF
--- a/src/common/dsp/filters/VectorizedSVFilter.h
+++ b/src/common/dsp/filters/VectorizedSVFilter.h
@@ -22,6 +22,7 @@
 #ifndef SURGE_SRC_COMMON_DSP_FILTERS_VECTORIZEDSVFILTER_H
 #define SURGE_SRC_COMMON_DSP_FILTERS_VECTORIZEDSVFILTER_H
 
+#include "globals.h"
 #include <vembertech/portable_intrinsics.h>
 
 //------------------------------------------------------------------------------------------------

--- a/src/common/dsp/vembertech/portable_intrinsics.h
+++ b/src/common/dsp/vembertech/portable_intrinsics.h
@@ -22,10 +22,6 @@
 #ifndef SURGE_SRC_COMMON_DSP_VEMBERTECH_PORTABLE_INTRINSICS_H
 #define SURGE_SRC_COMMON_DSP_VEMBERTECH_PORTABLE_INTRINSICS_H
 
-#if LINUX && !ARM_NEON
-#include <immintrin.h>
-#endif
-
 #define vFloat __m128
 
 #define vZero _mm_setzero_ps()


### PR DESCRIPTION
portable_intrinsics should really bite the dust but at least now we know it doesn't need this ancient include.