### PR TITLE
Fix surge skins link

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4641,7 +4641,7 @@ juce::PopupMenu SurgeGUIEditor::makeSkinMenu(const juce::Point<int> &where)
                         [this]() { showHTML(skinInspectorHtml()); });
 
     skinSubMenu.addItem(Surge::GUI::toOSCase("Skin Development Guide..."), []() {
-        juce::URL("https://surge-synthesizer.github.io/skin-manual.html").launchInDefaultBrowser();
+        juce::URL("https://surge-synthesizer.github.io/skin-manual/").launchInDefaultBrowser();
     });
 
     return skinSubMenu;


### PR DESCRIPTION
https://surge-synthesizer.github.io/skin-manual.html no longer exists. Changed to https://surge-synthesizer.github.io/skin-manual/