### PR TITLE
Send OSC/Param from FX/OSC menu; Fix lipol for amp/send

### DIFF
--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -64,7 +64,9 @@ class alignas(16) SurgeSynthesizer
 
     // aligned stuff
     SurgeStorage storage alignas(16);
-    lipol_ps FX alignas(16)[n_send_slots], amp alignas(16), amp_mute alignas(16),
+
+    // Each of these operations is post downsample so need to be blocksize not blocksize os.
+    lipol_ps_blocksz FX alignas(16)[n_send_slots], amp alignas(16), amp_mute alignas(16),
         send alignas(16)[n_send_slots][n_scenes];
 
     std::atomic<bool> audio_processing_active;
@@ -131,6 +133,9 @@ class alignas(16) SurgeSynthesizer
     bool loadFx(bool initp, bool force_reload_all);
     void enqueueFXOff(int whichFX);
     bool loadOscalgos();
+    std::atomic<bool> resendOscParam[n_scenes][n_oscs]{};
+    std::atomic<bool> resendFXParam[n_fx_slots]{};
+
     bool load_fx_needed;
 
     /*

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1266,6 +1266,41 @@ void SurgeGUIEditor::idle()
             w->repaint();
         }
     }
+
+    for (int s=0; s<n_scenes; ++s)
+    {
+        for (int o=0; o < n_oscs; ++o)
+        {
+            if (synth->resendOscParam[s][o])
+            {
+                auto &par = synth->storage.getPatch().scene[s].osc[o].type;
+                SurgeSynthesizer::ID eid = synth->idForParameter(&par);
+
+                juceEditor->beginParameterEdit(&par);
+                synth->getParent()->surgeParameterUpdated(eid,
+                                                          par.get_value_f01());
+                synth->resendOscParam[s][o] = false;
+
+                juceEditor->endParameterEdit(&par);
+            }
+        }
+    }
+
+    for (int s=0; s < n_fx_slots; ++s)
+    {
+        if (synth->resendFXParam[s])
+        {
+            auto &par = synth->storage.getPatch().fx[s].type;
+            SurgeSynthesizer::ID eid = synth->idForParameter(&par);
+
+            juceEditor->beginParameterEdit(&par);
+            synth->getParent()->surgeParameterUpdated(eid,
+                                                      par.get_value_f01());
+            synth->resendFXParam[s] = false;
+
+            juceEditor->endParameterEdit(&par);
+        }
+    }
 }
 
 void SurgeGUIEditor::toggle_mod_editing()


### PR DESCRIPTION
1. Oscillator and FX menus now send parameter invalidations and subsequent VST3 latch / OSC outbound
2. Use the right block size for the lipol on the global amplitude and send, which are post downsample