### PR TITLE
Osc work - refactoring/enhancement of 'all notes off' handling

### DIFF
--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -104,6 +104,7 @@ class alignas(16) SurgeSynthesizer
     void channelController(char channel, int cc, int value);
     void programChange(char channel, int value);
     void allNotesOff();
+    void allSoundOff();
     void setSamplerate(float sr);
     void updateHighLowKeys(int scene);
     int getNumInputs() { return N_INPUTS; }

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -466,7 +466,7 @@ class alignas(16) SurgeSynthesizer
   public:
     int CC0, CC32, PCH, patchid;
     float masterfade = 0;
-    bool approachingAllSoundsOff{false};
+    bool approachingAllSoundOff{false};
     // TODO: FIX SCENE ASSUMPTION (for halfbandA/B - use std::array)
     sst::filters::HalfRate::HalfRateFilter halfbandA, halfbandB, halfbandIN;
     std::list<SurgeVoice *> voices[n_scenes];
@@ -527,6 +527,7 @@ class alignas(16) SurgeSynthesizer
     std::list<HoldBufferItem> holdbuffer[n_scenes];
     void purgeHoldbuffer(int scene);
     void purgeDuplicateHeldVoicesInPolyMode(int scehe, int channel, int key);
+    void stopSound();
 
     QuadFilterChainState *FBQ[n_scenes];
 

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -434,7 +434,7 @@ void SurgeSynthesizer::processEnqueuedPatchIfNeeded()
 void SurgeSynthesizer::loadRaw(const void *data, int size, bool preset)
 {
     halt_engine = true;
-    allNotesOff();
+    stopSound();
     for (int s = 0; s < n_scenes; s++)
         for (int i = 0; i < n_customcontrollers; i++)
             storage.getPatch().scene[s].modsources[ms_ctrl1 + i]->reset();

--- a/src/surge-testrunner/UnitTestsDSP.cpp
+++ b/src/surge-testrunner/UnitTestsDSP.cpp
@@ -559,7 +559,7 @@ TEST_CASE( "NaN Patch From Issue #1514", "[dsp]" )
       for( auto &e : events )
          e.atSample += 1000;
 
-      surge->allNotesOff();
+      surge->stopSound();
       for( int i=0; i<100; ++i )
          surge->process();
       

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -452,7 +452,7 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     {
         if (priorCallWasProcessBlockNotBypassed)
         {
-            surge->allNotesOff();
+            surge->allSoundOff();
             bypassCountdown = 8; // let us fade out by doing a halted process
         }
 
@@ -471,7 +471,7 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     {
         // I am just becoming active. There may be lingering notes from when I was
         // deactivated so
-        surge->allNotesOff();
+        surge->allSoundOff();
     }
 
     surge->audio_processing_active = true;
@@ -741,6 +741,12 @@ void SurgeSynthProcessor::processBlockOSC()
         }
         break;
 
+        case SurgeSynthProcessor::KILLALL:
+        {
+            surge->allSoundOff();
+        }
+        break;
+
         case SurgeSynthProcessor::MOD:
         {
             surge->setModDepth01(om.param->id, (modsources)om.ival, om.scene, om.index, om.fval);
@@ -787,7 +793,7 @@ clap_process_status SurgeSynthProcessor::clap_direct_process(const clap_process 
     {
         // I am just becoming active. There may be lingering notes from when I was
         // deactivated so
-        surge->allNotesOff();
+        surge->allSoundOff();
     }
     surge->audio_processing_active = true;
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -452,7 +452,7 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     {
         if (priorCallWasProcessBlockNotBypassed)
         {
-            surge->allSoundOff();
+            surge->stopSound();
             bypassCountdown = 8; // let us fade out by doing a halted process
         }
 
@@ -471,7 +471,7 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     {
         // I am just becoming active. There may be lingering notes from when I was
         // deactivated so
-        surge->allSoundOff();
+        surge->stopSound();
     }
 
     surge->audio_processing_active = true;
@@ -741,7 +741,7 @@ void SurgeSynthProcessor::processBlockOSC()
         }
         break;
 
-        case SurgeSynthProcessor::KILLALL:
+        case SurgeSynthProcessor::ALLSOUNDOFF:
         {
             surge->allSoundOff();
         }
@@ -793,7 +793,7 @@ clap_process_status SurgeSynthProcessor::clap_direct_process(const clap_process 
     {
         // I am just becoming active. There may be lingering notes from when I was
         // deactivated so
-        surge->allSoundOff();
+        surge->stopSound();
     }
     surge->audio_processing_active = true;
 

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -347,7 +347,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         NOTEX_TIMB,
         NOTEX_PRES,
         ALLNOTESOFF,
-        KILLALL,
+        ALLSOUNDOFF,
         MOD
     };
 

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -347,6 +347,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         NOTEX_TIMB,
         NOTEX_PRES,
         ALLNOTESOFF,
+        KILLALL,
         MOD
     };
 

--- a/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorHtmlGenerators.cpp
@@ -700,6 +700,13 @@ code {
                               <td>(none)</td>
                          </tr>
                          <tr>
+                              <td>/allsoundoff</td>
+                              <td>stop all sound NOW</td>
+                              <td>(none)</td>
+                              <td>(none)</td>
+                              <td>(none)</td>
+                         </tr>
+                         <tr>
                             <td colspan="5">
                                 <p class="tight">* Velocity 0 releases the note; use the <span>.../rel</span> messages to release notes with velocity. If noteIDs are
                                     supplied, the note number or frequency value for releases is disregarded.</p>

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -420,7 +420,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
 
     else if (address1 == "allsoundoff")
     {
-        sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::KILLALL));
+        sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::ALLSOUNDOFF));
     }
 
     // Parameters

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -418,6 +418,11 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::ALLNOTESOFF));
     }
 
+    else if (address1 == "allsoundoff")
+    {
+        sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::KILLALL));
+    }
+
     // Parameters
     else if (address1 == "param")
     {


### PR DESCRIPTION
Refactored SurgeSynthesizer::allNotesOff() to SurgeSynthesizer::stopSound().
Extracted code from MIDI all notes off handler to SurgeSynthesizer::allNotesOff().
MIDI all notes off now calls SS::allNotesOff(), as does OSC '/allnotesoff'.
All former internal calls to SS:allNotesOff() now call SS:stopSound;
OSC '/allsoundoff' message now supported, calls same code as MIDI CC 120 (all sound off).