### PR TITLE
Add the FX Group name to the end of Accessible sliders

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3843,6 +3843,45 @@ void SurgeSynthesizer::getParameterName(long index, char *text) const
         snprintf(text, TXT_SIZE, "-");
 }
 
+void SurgeSynthesizer::getParameterNameExtendedByFXGroup(long index, char *text) const
+{
+    if ((index >= 0) && (index < storage.getPatch().param_ptr.size()))
+    {
+        auto par = storage.getPatch().param_ptr[index];
+
+        if (par->ctrlgroup != cg_FX)
+        {
+            getParameterName(index, text);
+            return;
+        }
+
+        std::string fxGroupName{};
+        auto p0 = &storage.getPatch().fx[par->ctrlgroup_entry].p[0];
+        auto df = par - p0;
+        if (df >= 0 && df < n_fx_params)
+        {
+            auto &fxi = fx[par->ctrlgroup_entry];
+            if (fxi)
+            {
+                auto gi = fxi->groupIndexForParamIndex(df);
+                if (gi >= 0)
+                {
+                    auto gn = fxi->group_label(gi);
+                    if (gn)
+                    {
+                        fxGroupName = gn;
+                        fxGroupName = fxGroupName + " - ";
+                    }
+                }
+            }
+        }
+        snprintf(text, TXT_SIZE, "%s %s%s", fxslot_shortnames[par->ctrlgroup_entry],
+                 fxGroupName.c_str(), par->get_name());
+    }
+    else
+        snprintf(text, TXT_SIZE, "-");
+}
+
 void SurgeSynthesizer::getParameterAccessibleName(long index, char *text) const
 {
     if ((index >= 0) && (index < storage.getPatch().param_ptr.size()))

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -258,6 +258,10 @@ class alignas(16) SurgeSynthesizer
     {
         getParameterName(index.getSynthSideId(), text);
     }
+    void getParameterNameExtendedByFXGroup(const ID &index, char *text) const
+    {
+        getParameterNameExtendedByFXGroup(index.getSynthSideId(), text);
+    }
     void getParameterAccessibleName(const ID &index, char *text) const
     {
         getParameterAccessibleName(index.getSynthSideId(), text);
@@ -337,6 +341,7 @@ class alignas(16) SurgeSynthesizer
     void getParameterDisplay(long index, char *text, float x) const;
     void getParameterDisplayAlt(long index, char *text) const;
     void getParameterName(long index, char *text) const;
+    void getParameterNameExtendedByFXGroup(long index, char *text) const;
     void getParameterAccessibleName(long index, char *text) const;
     void getParameterMeta(long index, parametermeta &pm) const;
 

--- a/src/common/dsp/Effect.h
+++ b/src/common/dsp/Effect.h
@@ -67,6 +67,20 @@ class alignas(16) Effect
     {
         return -1;
     } // number of blocks it takes for the effect to 'ring out'
+    int groupIndexForParamIndex(int paramIndex)
+    {
+        int fpos = fxdata->p[paramIndex].posy / 10 + fxdata->p[paramIndex].posy_offset;
+        int res = -1;
+        for (auto j = 0; j < n_fx_params && group_label(j); ++j)
+        {
+            if (group_label(j) && group_label_ypos(j) <= fpos // constants for SurgeGUIEditor. Sigh.
+            )
+            {
+                res = j;
+            }
+        }
+        return res;
+    }
 
     virtual void process(float *dataL, float *dataR) { return; }
     virtual void process_only_control()

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -68,6 +68,7 @@ struct SurgeParamToJuceInfo
         {
             s->getParameterName(s->idForParameter(p), txt);
         }
+
         return juce::String(txt);
     }
 
@@ -249,9 +250,10 @@ struct SurgeMacroToJuceParamAdapter : public SurgeBaseParam
 struct SurgeBypassParameter : public juce::RangedAudioParameter
 {
     explicit SurgeBypassParameter()
-        : value(0.f), range(0.f, 1.f, 0.01f),
-          juce::RangedAudioParameter(juce::ParameterID("surgext-bypass", 1), "Bypass Surge XT",
-                                     juce::AudioProcessorParameterWithIDAttributes())
+        : value(0.f),
+          range(0.f, 1.f, 0.01f), juce::RangedAudioParameter(
+                                      juce::ParameterID("surgext-bypass", 1), "Bypass Surge XT",
+                                      juce::AudioProcessorParameterWithIDAttributes())
     {
         setValueNotifyingHost(getValue());
     }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -58,7 +58,16 @@ struct SurgeParamToJuceInfo
     static juce::String getParameterName(SurgeSynthesizer *s, Parameter *p)
     {
         char txt[TXT_SIZE];
-        s->getParameterName(s->idForParameter(p), txt);
+        // technically this branch is checked inside the extended by fx group but
+        // lets make it explicit here also
+        if (p->ctrlgroup == cg_FX)
+        {
+            s->getParameterNameExtendedByFXGroup(s->idForParameter(p), txt);
+        }
+        else
+        {
+            s->getParameterName(s->idForParameter(p), txt);
+        }
         return juce::String(txt);
     }
 
@@ -240,10 +249,9 @@ struct SurgeMacroToJuceParamAdapter : public SurgeBaseParam
 struct SurgeBypassParameter : public juce::RangedAudioParameter
 {
     explicit SurgeBypassParameter()
-        : value(0.f),
-          range(0.f, 1.f, 0.01f), juce::RangedAudioParameter(
-                                      juce::ParameterID("surgext-bypass", 1), "Bypass Surge XT",
-                                      juce::AudioProcessorParameterWithIDAttributes())
+        : value(0.f), range(0.f, 1.f, 0.01f),
+          juce::RangedAudioParameter(juce::ParameterID("surgext-bypass", 1), "Bypass Surge XT",
+                                     juce::AudioProcessorParameterWithIDAttributes())
     {
         setValueNotifyingHost(getValue());
     }

--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -418,6 +418,18 @@ struct OverlayAsAccessibleContainer : public juce::Component
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OverlayAsAccessibleContainer);
 };
 
+struct HasExtendedAccessibleGroupName
+{
+    virtual ~HasExtendedAccessibleGroupName() = default;
+    std::string extendedAccessibleGroupName{};
+    virtual void setExtendedAccessibleGroupName(const std::string &s)
+    {
+        extendedAccessibleGroupName = s;
+        // We should maybe fire an ally event here but this only happens at construction time
+        // so skip it for now
+    }
+};
+
 enum AccessibleKeyEditAction
 {
     None,

--- a/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
+++ b/src/surge-xt/gui/widgets/MenuForDiscreteParams.h
@@ -27,6 +27,7 @@
 #include "WidgetBaseMixin.h"
 #include "ModulatableControlInterface.h"
 #include "SurgeJUCEHelpers.h"
+#include "AccessibleHelpers.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -47,7 +48,8 @@ namespace Widgets
 struct MenuForDiscreteParams : public juce::Component,
                                public WidgetBaseMixin<MenuForDiscreteParams>,
                                public LongHoldMixin<MenuForDiscreteParams>,
-                               public ModulatableControlInterface
+                               public ModulatableControlInterface,
+                               public HasExtendedAccessibleGroupName
 
 {
     MenuForDiscreteParams();

--- a/src/surge-xt/gui/widgets/ModulatableSlider.h
+++ b/src/surge-xt/gui/widgets/ModulatableSlider.h
@@ -28,6 +28,7 @@
 #include "WidgetBaseMixin.h"
 #include "ModulatableControlInterface.h"
 #include "SurgeJUCEHelpers.h"
+#include "AccessibleHelpers.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -40,7 +41,8 @@ namespace Widgets
 struct ModulatableSlider : public juce::Component,
                            public WidgetBaseMixin<ModulatableSlider>,
                            public LongHoldMixin<ModulatableSlider>,
-                           public ModulatableControlInterface
+                           public ModulatableControlInterface,
+                           public HasExtendedAccessibleGroupName
 {
     ModulatableSlider();
     ~ModulatableSlider();


### PR DESCRIPTION
so rather than getting "channel, mix, channel, mix" you get "channel - Left, Mix - Left, Channel - Right, Mix - Right" etc

The implementation of this is kinda gross, but that's part of the sturcture of the fx. Along the way add a single function go to param index to group index.

Closes #7238