### PR TITLE
Add a config-time for extra user wavetables

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -307,6 +307,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     userModulatorSettingsPath = userDataPath / "Modulator Presets";
     userSkinsPath = userDataPath / "Skins";
     extraThirdPartyWavetablesPath = config.extraThirdPartyWavetablesPath;
+    extraUserWavetablesPath = config.extraUsersWavetablesPath;
 
     if (config.createUserDirectory)
     {
@@ -1024,6 +1025,11 @@ void SurgeStorage::refresh_wtlist()
     }
     firstUserWTCategory = wt_category.size();
     refresh_wtlistAddDir(true, "Wavetables");
+
+    if (!extraUserWavetablesPath.empty())
+    {
+        refresh_wtlistFrom(true, extraUserWavetablesPath, "");
+    }
 
     wtCategoryOrdering = std::vector<int>(wt_category.size());
     std::iota(wtCategoryOrdering.begin(), wtCategoryOrdering.end(), 0);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1201,6 +1201,7 @@ class alignas(16) SurgeStorage
         std::string suppliedDataPath{""};
         bool createUserDirectory{true};
         fs::path extraThirdPartyWavetablesPath{};
+        fs::path extraUsersWavetablesPath{};
         bool scanWavetableAndPatches{true};
 
         static SurgeStorageConfig fromDataPath(const std::string &s)
@@ -1381,6 +1382,7 @@ class alignas(16) SurgeStorage
     fs::path userSkinsPath;
     fs::path userMidiMappingsPath;
     fs::path extraThirdPartyWavetablesPath; // used by rack
+    fs::path extraUserWavetablesPath; // used by rack
 
     std::string midiProgramChangePatchesSubdir{"MIDI Programs"};
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1382,7 +1382,7 @@ class alignas(16) SurgeStorage
     fs::path userSkinsPath;
     fs::path userMidiMappingsPath;
     fs::path extraThirdPartyWavetablesPath; // used by rack
-    fs::path extraUserWavetablesPath; // used by rack
+    fs::path extraUserWavetablesPath;       // used by rack
 
     std::string midiProgramChangePatchesSubdir{"MIDI Programs"};
 


### PR DESCRIPTION
Just like for extra factory, allow user wavetables to be pointed at someplace else by a client. Used by the rack modules per https://github.com/surge-synthesizer/surge-rack/issues/939