### PR TITLE
Copy Paste and Undo on Mono Options

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1546,6 +1546,7 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
         }
 
         clipboard_primode = getPatch().scene[scene].monoVoicePriorityMode;
+        clipboard_envmode = getPatch().scene[scene].monoVoiceEnvelopeMode;
     }
 
     modRoutingMutex.lock();
@@ -1741,6 +1742,7 @@ void SurgeStorage::clipboard_paste(int type, int scene, int entry, modsources ms
         }
 
         getPatch().scene[scene].monoVoicePriorityMode = clipboard_primode;
+        getPatch().scene[scene].monoVoiceEnvelopeMode = clipboard_envmode;
     }
 
     if (type == cp_modulator_target)

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1646,6 +1646,7 @@ class alignas(16) SurgeStorage
     std::array<std::string, n_oscs> clipboard_wt_names;
     char clipboard_modulator_names[n_lfos][max_lfo_indices][CUSTOM_CONTROLLER_LABEL_SIZE + 1];
     MonoVoicePriorityMode clipboard_primode = NOTE_ON_LATEST_RETRIGGER_HIGHEST;
+    MonoVoiceEnvelopeMode clipboard_envmode = RESTART_FROM_ZERO;
 
   public:
     // whether to skip loading, desired while exporting manifests. Only used by LV2 currently.

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -320,6 +320,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void showZoomMenu(const juce::Point<int> &where, Surge::GUI::IComponentTagValue *launchFrom);
     void showLfoMenu(const juce::Point<int> &where, Surge::GUI::IComponentTagValue *launchFrom);
 
+    void addEnvTrigOptions(juce::PopupMenu &, int);
+
     juce::PopupMenu::Options popupMenuOptions(const juce::Point<int> &where);
     juce::PopupMenu::Options popupMenuOptions(const juce::Component *c = nullptr,
                                               bool useComponentBounds = true);

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -72,7 +72,7 @@ std::string decodeControllerID(int id)
     return out;
 }
 
-void addEnvTrigOptions(SurgeSynthesizer *synth, juce::PopupMenu &contextMenu, int current_scene)
+void SurgeGUIEditor::addEnvTrigOptions(juce::PopupMenu &contextMenu, int current_scene)
 {
     std::vector<std::string> labels = {"Reset to Zero", "Continue from Current Level"};
     std::vector<MonoVoiceEnvelopeMode> vals = {RESTART_FROM_ZERO, RESTART_FROM_LATEST};
@@ -88,7 +88,9 @@ void addEnvTrigOptions(SurgeSynthesizer *synth, juce::PopupMenu &contextMenu, in
 
         contextMenu.addItem(
             Surge::GUI::toOSCase(labels[i]), true, isChecked,
-            [synth, current_scene, value, isChecked]() {
+            [this, current_scene, value, isChecked]() {
+                undoManager()->pushPatch();
+
                 synth->storage.getPatch().scene[current_scene].monoVoiceEnvelopeMode = value;
 
                 if (!isChecked)
@@ -1866,6 +1868,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                         contextMenu.addItem(
                                             Surge::GUI::toOSCase(labels[i]), true, isChecked,
                                             [this, isChecked, vals, i]() {
+                                                undoManager()->pushPatch();
                                                 synth->storage.getPatch()
                                                     .scene[current_scene]
                                                     .monoVoicePriorityMode = vals[i];
@@ -1875,7 +1878,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     }
                                 }
 
-                                addEnvTrigOptions(synth, contextMenu, current_scene);
+                                addEnvTrigOptions(contextMenu, current_scene);
 
                                 contextMenu.addSeparator();
 
@@ -1886,7 +1889,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                             if (p->val.i == pm_latch)
                             {
-                                addEnvTrigOptions(synth, contextMenu, current_scene);
+                                addEnvTrigOptions(contextMenu, current_scene);
                             }
                         }
                     }


### PR DESCRIPTION
Mono Envelope Mode and Priority mode copied (envelope) and undid (both) inconsistently. Fix by doing a simple full patch push in this rare case for undo, and by copying in the copy case.

Closes #7299