### PR TITLE
OSC Startup from Various Unstream Cases

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -142,7 +142,6 @@ SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
         std::lock_guard<std::mutex> grd(surgeLookAndFeelSetupMutex);
         if (auto sp = surgeLookAndFeelWeakPointer.lock())
         {
-            std::cout << "Re-using shared pointer" << std::endl;
             surgeLF = sp;
         }
         else

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -250,10 +250,9 @@ struct SurgeMacroToJuceParamAdapter : public SurgeBaseParam
 struct SurgeBypassParameter : public juce::RangedAudioParameter
 {
     explicit SurgeBypassParameter()
-        : value(0.f),
-          range(0.f, 1.f, 0.01f), juce::RangedAudioParameter(
-                                      juce::ParameterID("surgext-bypass", 1), "Bypass Surge XT",
-                                      juce::AudioProcessorParameterWithIDAttributes())
+        : value(0.f), range(0.f, 1.f, 0.01f),
+          juce::RangedAudioParameter(juce::ParameterID("surgext-bypass", 1), "Bypass Surge XT",
+                                     juce::AudioProcessorParameterWithIDAttributes())
     {
         setValueNotifyingHost(getValue());
     }
@@ -393,6 +392,8 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     sst::cpputils::SimpleRingBuffer<oscToAudio, 4096> oscRingBuf;
 
     Surge::OSC::OpenSoundControl oscHandler;
+    std::atomic<bool> oscCheckStartup{false};
+    void tryLazyOscStartupFromStreamedState();
 
     bool initOSCIn(int port);
     bool initOSCOut(int port);

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -250,9 +250,10 @@ struct SurgeMacroToJuceParamAdapter : public SurgeBaseParam
 struct SurgeBypassParameter : public juce::RangedAudioParameter
 {
     explicit SurgeBypassParameter()
-        : value(0.f), range(0.f, 1.f, 0.01f),
-          juce::RangedAudioParameter(juce::ParameterID("surgext-bypass", 1), "Bypass Surge XT",
-                                     juce::AudioProcessorParameterWithIDAttributes())
+        : value(0.f),
+          range(0.f, 1.f, 0.01f), juce::RangedAudioParameter(
+                                      juce::ParameterID("surgext-bypass", 1), "Bypass Surge XT",
+                                      juce::AudioProcessorParameterWithIDAttributes())
     {
         setValueNotifyingHost(getValue());
     }


### PR DESCRIPTION
now the OSC info is in DawExtra we need to start after a load and no earlier so we do that here by handling it in both the set state and prepare to play inbound cases. Works with 2 things in reaper muted or un on macos.

Closes #7293