### PR TITLE
Clamp Max Porta time to 16 seconds

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -636,8 +636,12 @@ void SurgeVoice::update_portamento()
              ((1.f / quantStep) * fabs(state.getPitch(storage) - state.portasrc_key) + 0.00001));
     }
 
+    float portaClamp = 4;
+    // more than 16 second portamento with the modulation is painful. See #7301
+    assert(scene->portamento.val_max.f < portaClamp);
     state.portaphase +=
-        storage->envelope_rate_linear(localcopy[scene->portamento.param_id_in_scene].f) *
+        storage->envelope_rate_linear(
+            std::min(localcopy[scene->portamento.param_id_in_scene].f, portaClamp)) *
         (scene->portamento.temposync ? storage->temposyncratio : 1.f) * const_rate_factor;
 
     if ((state.portaphase < 1) &&


### PR DESCRIPTION
Max porta time was 2 (aka "4 seconds") but was modulatable across the entire range up to about 128 seconds I think. That's the same as stuck. So add an internal clamp which means even in extreme off the end modulation, you cap out at 16 seconds.

Addresses case 2 of #7301