### PR TITLE
Fix slider fx group accesibility

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6093,6 +6093,7 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
         hs->setSkin(currentSkin, bitmapStore, skinCtrl);
         hs->setMoveRate(p->moverate);
 
+        hs->setExtendedAccessibleGroupName(extendedAccessibleGroupName);
         setAccessibilityInformationByParameter(hs.get(), p, "Adjust");
 
         if (p->can_temposync())
@@ -6110,7 +6111,6 @@ SurgeGUIEditor::layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control
         {
             hs->setLabel(p->get_name());
         }
-        hs->setExtendedAccessibleGroupName(extendedAccessibleGroupName);
 
         hs->setBipolarFn([p]() { return p->is_bipolar(); });
         hs->setFontStyle(Surge::GUI::Skin::setFontStyleProperty(


### PR DESCRIPTION
Slider FX group didn't work basically, after I shuffled the code. Fix that by moving the shuffle to the rigth spot. Closes #7323