### PR TITLE
Don't allow .. out of patches

### DIFF
--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -570,7 +570,26 @@ void SurgeSynthesizer::savePatch(bool factoryInPlace, bool skipOverwrite)
             return;
         }
 
+        auto comppath = savepath;
         savepath /= catPath;
+
+        comppath = comppath.lexically_normal();
+        savepath = savepath.lexically_normal();
+
+        // make sure your category isnt "../../../etc/config"
+
+        auto [_, compIt] =
+            std::mismatch(savepath.begin(), savepath.end(), comppath.begin(), comppath.end());
+        if (compIt != comppath.end())
+        {
+            storage.reportError(
+                "Your save path is not a directory below the user patches directory. "
+                "This usually means you are doing something like trying to use too many ../"
+                " in your category name.",
+                "Save Path not below user path");
+            return;
+        }
+
         create_directories(savepath);
     }
     catch (...)


### PR DESCRIPTION
If you add enough .. in your category, you end up outside of the patches directory. Lets do a check to avoid that. But patch subdirs and .. still work. so category of "test/foo/../bar" works just "test/../../../../etc/root" does not

Closes #7326