### PR TITLE
Don't clobber FX param deform type

### DIFF
--- a/src/common/dsp/effects/DelayEffect.cpp
+++ b/src/common/dsp/effects/DelayEffect.cpp
@@ -84,7 +84,6 @@ void DelayEffect::init_ctrltypes()
     fxdata->p[dly_time_right].set_type(ct_envtime_linkable_delay);
     fxdata->p[dly_feedback].set_name("Feedback");
     fxdata->p[dly_feedback].set_type(ct_dly_fb_clippingmodes);
-    fxdata->p[dly_feedback].deform_type = 1;
 
     fxdata->p[dly_crossfeed].set_type(ct_percent);
     fxdata->p[dly_lowcut].set_type(ct_freq_audible_deactivatable_hp);

--- a/src/common/dsp/effects/chowdsp/TapeEffect.cpp
+++ b/src/common/dsp/effects/chowdsp/TapeEffect.cpp
@@ -205,7 +205,6 @@ void TapeEffect::init_ctrltypes()
     fxdata->p[tape_drive].set_type(ct_tape_drive);
     fxdata->p[tape_drive].posy_offset = 1;
     fxdata->p[tape_drive].val_default.f = 0.85f;
-    fxdata->p[tape_drive].deform_type = SolverType::RK4;
     fxdata->p[tape_saturation].set_name("Saturation");
     fxdata->p[tape_saturation].set_type(ct_percent);
     fxdata->p[tape_saturation].posy_offset = 1;


### PR DESCRIPTION
Tape Drive and Delay Feedback deform type value was clobbered on init_ctrltypes()