### PR TITLE
Formula Modulator Esc Key Handling Corrected

### DIFF
--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -860,11 +860,12 @@ void FormulaModulatorEditor::escapeKeyPressed()
                 }
             }
         };
+        auto nocb = [this]() { grabKeyboardFocus(); };
 
         editor->alertYesNo("Close Formula Editor",
                            "Do you really want to close the formula editor? Any "
                            "changes that were not applied will be lost!",
-                           nullptr, cb);
+                           cb, nocb);
     }
     else
     {


### PR DESCRIPTION
If you press esc in formula modulator

1. Yes/No box actually does yes/no properly and
2. If you chose No then escape again right away you get the box

Would be nice to have this on X, which is why this just addresses #7337. The X treatment is trickier.