### PR TITLE
Fix a crash-on-jog when wavetables not available

### DIFF
--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -1099,15 +1099,15 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
                     sge->undoManager()->pushWavetable(scene, oscInScene);
                 id = storage->getAdjacentWaveTable(oscdata->wt.current_id, false);
 
-                if (sge)
-                {
-                    std::string announce = "Loaded wavetable is: ";
-                    announce += storage->wt_list[id].name;
-                    sge->enqueueAccessibleAnnouncement(announce);
-                }
-
                 if (id >= 0)
                 {
+                    if (sge)
+                    {
+                        std::string announce = "Loaded wavetable is: ";
+                        announce += storage->wt_list[id].name;
+                        sge->enqueueAccessibleAnnouncement(announce);
+                    }
+
                     oscdata->wt.queue_id = id;
                 }
             }
@@ -1125,15 +1125,15 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
 
                 id = storage->getAdjacentWaveTable(oscdata->wt.current_id, true);
 
-                if (sge)
-                {
-                    std::string announce = "Loaded wavetable is: ";
-                    announce += storage->wt_list[id].name;
-                    sge->enqueueAccessibleAnnouncement(announce);
-                }
-
                 if (id >= 0)
                 {
+                    if (sge)
+                    {
+                        std::string announce = "Loaded wavetable is: ";
+                        announce += storage->wt_list[id].name;
+                        sge->enqueueAccessibleAnnouncement(announce);
+                    }
+
                     oscdata->wt.queue_id = id;
                 }
             }


### PR DESCRIPTION
If running surge with no wavetalbes, you get one and only one wavetable (sine to saw) from memory so the system works. But the jog buttons still went looking. Specificall, actually, they didn't try and load anything but they did try and accessibily announce the name. So move that announce block into the success block.

Closes #7347