### PR TITLE
Bonsai Sample Rate Changes work

### DIFF
--- a/src/common/dsp/effects/SurgeSSTFXAdapter.h
+++ b/src/common/dsp/effects/SurgeSSTFXAdapter.h
@@ -173,6 +173,8 @@ template <typename T> struct SurgeSSTFXBase : T
 
     int get_ringout_decay() override { return T::getRingoutDecay(); }
 
+    void sampleRateReset() override { T::onSampleRateChanged(); }
+
     const char *get_effectname() override { return T::effectName; }
 
     void init_default_values() override


### PR DESCRIPTION
Bonsai had const construction time SR variables; fix to be at init. The SSTFXAdapter didn't notify effects properly when sample rates changed. Also fix.