### PR TITLE
AudioInput smoothing; part 1

### DIFF
--- a/src/common/dsp/effects/AudioInputEffect.h
+++ b/src/common/dsp/effects/AudioInputEffect.h
@@ -58,8 +58,11 @@ class AudioInputEffect : public Effect
     void process(float *dataL, float *dataR) override;
     const char *group_label(int id) override;
     int group_label_ypos(int id) override;
+    void init() override;
 
   private:
+    lipol_ps_blocksz mix alignas(16), width alignas(16);
+
     std::shared_ptr<float> sceneDataPtr[N_OUTPUTS]{nullptr, nullptr};
     effect_slot_type getSlotType(fxslot_positions p);
     void applySlidersControls(float *buffer[], const float &channel, const float &pan,

--- a/src/surge-testrunner/UnitTestsFX.cpp
+++ b/src/surge-testrunner/UnitTestsFX.cpp
@@ -1064,8 +1064,10 @@ TEST_CASE("Audio Input Effect", "[fx]")
                         surge->storage.getPatch().copy_globaldata(
                             surge->storage.getPatch().globaldata);
 
+                        surge->fx[slot]->init();
                         surge->fx[slot]->process(inParamsGroup.leftEffectInput,
                                                  inParamsGroup.rightEffectInput);
+
                         for (int i = 0; i < 4; ++i)
                         {
                             REQUIRE(inParamsGroup.leftEffectInput[i] ==


### PR DESCRIPTION
Mix and Width are smoothed
Width uses the shared calculation (but still percent units) Move the input connection to init() not ::Ctor