### PR TITLE
Fix MSVC stdext::checked_array_iterator warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ if(MSVC)
     # amke msvc define __cplulsplus properly
     $<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus>
   )
+  add_compile_definitions(_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)
 endif()
 # }}}
 # Source Groups {{{


### PR DESCRIPTION
Fixes fmt errors in MSVC [deprecating stdext::checked_array_iterator](https://github.com/fmtlib/fmt/issues/3540) which causes compile errors in debug mode