### PR TITLE
Improve margins for patch comment tooltip

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1517,7 +1517,7 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
     assert(parameters);
     int n = param_ptr.size();
 
-    // delete volume & fx_bypass if it's a preset. Those settings should stick
+    // delete volume (below streaming version 17) & fx_bypass if it's a preset
     if (is_preset)
     {
         if (revision < 17)
@@ -1536,14 +1536,6 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
         {
             parameters->RemoveChild(tp);
         }
-
-        /*
-         * As of Surge 1.9, store the polylimit
-         *
-         * tp = TINYXML_SAFE_TO_ELEMENT(parameters->FirstChild("polylimit"));
-         * if (tp)
-         *   parameters->RemoveChild(tp);
-         */
     }
 
     TiXmlElement *p;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -117,6 +117,7 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 //                             added (a lot of) new waveshapers
 //                             added two additional FX slots to all FX chains
 //                             added new Conditioner parameter (Side Low Cut)
+//                             read Global Volume from the patch (it was always stored just never read)
 // 17 -> 18 (XT 1.1 nightlies) added clipping options to Delay Feedback parameter (via deform)
 //                             added Tone parameter to Phaser effect
 // 18 -> 19 (XT 1.1 nightlies) added String deform options (interpolation, bipolar Decay params, Stiffness options)

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -8204,11 +8204,11 @@ void SurgeGUIEditor::showPatchCommentTooltip(const std::string &comment)
     {
         auto psb = patchSelector->getBounds();
 
+        patchSelectorComment->positionForComment(psb.getCentre().withY(psb.getBottom()), comment,
+                                                 psb.getWidth());
         patchSelectorComment->setVisible(true);
         patchSelectorComment->getParentComponent()->toFront(true);
         patchSelectorComment->toFront(true);
-        patchSelectorComment->positionForComment(psb.getCentre().withY(psb.getBottom()), comment,
-                                                 psb.getWidth());
     }
 }
 

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -1440,7 +1440,7 @@ void PatchSelectorCommentTooltip::paint(juce::Graphics &g)
     g.fillRect(getLocalBounds().reduced(1));
     g.setColour(skin->getColor(clr::Text));
     g.setFont(skin->fontManager->getLatoAtSize(9));
-    g.drawMultiLineText(comment, 5, g.getCurrentFont().getHeight() + 2, getWidth(),
+    g.drawMultiLineText(comment, 4, g.getCurrentFont().getHeight() + 2, getWidth(),
                         juce::Justification::left);
 }
 
@@ -1457,6 +1457,7 @@ void PatchSelectorCommentTooltip::positionForComment(const juce::Point<int> &cen
 
     auto ft = skin->fontManager->getLatoAtSize(9);
     auto width = 0.f;
+    auto maxWidth = (float)maxTooltipWidth;
 
     while (std::getline(ss, to, '\n'))
     {
@@ -1469,17 +1470,18 @@ void PatchSelectorCommentTooltip::positionForComment(const juce::Point<int> &cen
             w = 1.f;
         }
 
-        auto rows = std::ceil(w / (float)maxTooltipWidth);
+        auto rows = std::ceil(w / maxWidth);
 
         width = std::max(w, width);
         numLines += (int)rows;
     }
 
-    auto height = std::max(numLines * (ft.getHeight() + 2), 30.f);
+    auto height = std::max((numLines * (ft.getHeight() + 2)) + 2, 16.f);
+    auto margin = 10;
 
     auto r = juce::Rectangle<int>()
                  .withCentre(juce::Point(centerPoint.x, centerPoint.y))
-                 .withSizeKeepingCentre(std::min(width, (float)maxTooltipWidth), height)
+                 .withSizeKeepingCentre(std::min(width + margin, maxWidth), height)
                  .translated(0, height / 2);
 
     setBounds(r);


### PR DESCRIPTION
Also document the Global Volume read change (for streaming revisions below 17)