### PR TITLE
Fix the Tune button left click behavior

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -3304,11 +3304,14 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
     }
     if (tag == tag_status_tune)
     {
-        toggleTuning();
         if (synth->storage.isStandardTuningAndHasNoToggle())
         {
             juce::Point<int> where = control->asJuceComponent()->getBounds().getBottomLeft();
             showTuningMenu(where, control);
+        }
+        else
+        {
+            toggleTuning();
         }
 
         return;


### PR DESCRIPTION
The way it was it always created the context menu no matter if you used left or right click. The way it used to work is once you have a tuning loaded, left click just toggles the tuning and you have to right click to get the context menu. If no tuning was loaded both left and right clicks would create the context menu. Now it works like that again.