### PR TITLE
add guards for LV2 headless build

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -253,8 +253,8 @@ SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
     setResizable(true, processor.wrapperType == juce::AudioProcessor::wrapperType_VST);
 
     sge->audioLatencyNotified = processor.inputIsLatent;
-
-    sge->open(nullptr);
+    if (juce::Desktop::getInstance().isHeadless() == false)
+        sge->open(nullptr);
 
     idleTimer = std::make_unique<IdleTimer>(this);
     idleTimer->startTimer(1000 / 60);

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3015,10 +3015,13 @@ void SurgeGUIEditor::setZoomFactor(float zf, bool resizeWindow)
 
 void SurgeGUIEditor::setBitmapZoomFactor(float zf)
 {
-    float dbs = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()->scale;
-    int fullPhysicalZoomFactor = (int)(zf * dbs);
-    if (bitmapStore != nullptr)
-        bitmapStore->setPhysicalZoomFactor(fullPhysicalZoomFactor);
+    if (juce::Desktop::getInstance().isHeadless() == false)
+    {
+        float dbs = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()->scale;
+        int fullPhysicalZoomFactor = (int)(zf * dbs);
+        if (bitmapStore != nullptr)
+            bitmapStore->setPhysicalZoomFactor(fullPhysicalZoomFactor);
+    }
 }
 
 void SurgeGUIEditor::showMinimumZoomError() const
@@ -5284,6 +5287,9 @@ int SurgeGUIEditor::findLargestFittingZoomBetween(
     float baseW, float baseH)
 {
     // Here is a very crude implementation
+    if (juce::Desktop::getInstance().isHeadless() == true)
+        return 1;
+
     int result = zoomHigh;
     auto screenDim = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()->totalArea;
     float sx = screenDim.getWidth() * percentageOfScreenAvailable / 100.0;


### PR DESCRIPTION
Hi,

This should fix the `juce_lv2_helper` segfault when build the LV2 plugin on a headless system.