### PR TITLE
Accepting 'extra' arguments for incoming Parameter OSC msgs

### DIFF
--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -431,9 +431,9 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     {
         float val = 0;
 
-        if ((message.size() != 1) && !querying)
+        if ((message.size() < 1) && !querying)
         {
-            sendDataCountError("param", "1");
+            sendDataCountError("param", "1 or more");
             return;
         }
         else if (!querying)


### PR DESCRIPTION
This is a tweak, which should hopefully aid Geert's experiment with controlling one Surge from another.