### PR TITLE
Fix build with GCC7

### DIFF
--- a/src/common/dsp/effects/AudioInputEffect.cpp
+++ b/src/common/dsp/effects/AudioInputEffect.cpp
@@ -127,7 +127,7 @@ void AudioInputEffect::init_default_values()
 }
 const char *AudioInputEffect::group_label(int id)
 {
-    std::vector group_labels = {{"Audio Input", "Effect Input", "Scene Input", "Output"}};
+    std::vector group_labels = {"Audio Input", "Effect Input", "Scene Input", "Output"};
     effect_slot_type slot_type = getSlotType(fxdata->fxslot);
     if (slot_type == a_insert_slot)
         group_labels[2] = "Scene B Input";


### PR DESCRIPTION
Build was failing with GCC 7

```
/home/runner/work/Cardinal/Cardinal/plugins/surgext/surge/src/common/dsp/effects/AudioInputEffect.cpp: In member function 'virtual const char* AudioInputEffect::group_label(int)':
/home/runner/work/Cardinal/Cardinal/plugins/surgext/surge/src/common/dsp/effects/AudioInputEffect.cpp:130:89: error: class template argument deduction failed:
     std::vector group_labels = {{"Audio Input", "Effect Input", "Scene Input", "Output"}};
                                                                                         ^
/home/runner/work/Cardinal/Cardinal/plugins/surgext/surge/src/common/dsp/effects/AudioInputEffect.cpp:130:89: error: no matching function for call to 'vector(<brace-enclosed initializer list>)'
In file included from /home/runner/mod-workdir/moddwarf/toolchain/aarch64-mod-linux-gnu/include/c++/7.5.0/vector:64:0,
                 from /home/runner/mod-workdir/moddwarf/toolchain/aarch64-mod-linux-gnu/include/c++/7.5.0/functional:61,
                 from /home/runner/work/Cardinal/Cardinal/plugins/surgext/surge/src/common/Parameter.h:29,
                 from /home/runner/work/Cardinal/Cardinal/plugins/surgext/surge/src/common/SurgeStorage.h:26,
                 from /home/runner/work/Cardinal/Cardinal/plugins/surgext/surge/src/common/dsp/Effect.h:27,
                 from /home/runner/work/Cardinal/Cardinal/plugins/surgext/surge/src/common/dsp/effects/AudioInputEffect.h:24,
                 from /home/runner/work/Cardinal/Cardinal/plugins/surgext/surge/src/common/dsp/effects/AudioInputEffect.cpp:23:
/home/runner/mod-workdir/moddwarf/toolchain/aarch64-mod-linux-gnu/include/c++/7.5.0/bits/stl_vector.h:216:11: note: candidate: template<class _Tp, class _Alloc> vector(std::vector<_Tp, _Alloc>)-> std::vector<_Tp, _Alloc>
     class vector : protected _Vector_base<_Tp, _Alloc>
           ^~~~~~
```