### PR TITLE
Integrate Superparasites Clouds Firmware (off by default)

### DIFF
--- a/libs/eurorack/CMakeLists.txt
+++ b/libs/eurorack/CMakeLists.txt
@@ -1,14 +1,36 @@
 project(eurorack VERSION 0.0.0 LANGUAGES CXX)
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME})
+
+option(EURORACK_CLOUDS_IS_CLOUDS "Use the clouds (as opposed to superparasites) firmware for clouds" TRUE)
+
+if (EURORACK_CLOUDS_IS_CLOUDS)
+  target_sources(${PROJECT_NAME} PRIVATE
         eurorack/clouds/dsp/correlator.cc
         eurorack/clouds/dsp/granular_processor.cc
         eurorack/clouds/dsp/mu_law.cc
         eurorack/clouds/dsp/pvoc/frame_transformation.cc
         eurorack/clouds/dsp/pvoc/phase_vocoder.cc
         eurorack/clouds/dsp/pvoc/stft.cc
-        eurorack/clouds/resources.cc
+        eurorack/clouds/resources.cc)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC EURORACK_CLOUDS_IS_CLOUDS=1)
+else()
+  target_sources(${PROJECT_NAME} PRIVATE
+          eurorack/supercell/resources.cc
+          eurorack/supercell/dsp/kammerl_player.cc
+          eurorack/supercell/dsp/pvoc/stft.cc
+          eurorack/supercell/dsp/pvoc/spectral_clouds_transformation.cc
+          eurorack/supercell/dsp/pvoc/phase_vocoder.cc
+          eurorack/supercell/dsp/pvoc/frame_transformation.cc
+          eurorack/supercell/dsp/granular_processor.cc
+          eurorack/supercell/dsp/mu_law.cc
+          eurorack/supercell/dsp/correlator.cc
+)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC EURORACK_CLOUDS_IS_SUPERPARASITES=1)
+endif()
 
+
+target_sources(${PROJECT_NAME} PRIVATE
         eurorack/plaits/dsp/voice.cc
         eurorack/plaits/dsp/speech/lpc_speech_synth_phonemes.cc
         eurorack/plaits/dsp/speech/lpc_speech_synth_controller.cc

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1272,7 +1272,11 @@ void Parameter::set_type(int ctrltype)
     case ct_nimbusmode:
         valtype = vt_int;
         val_min.i = 0;
-        val_max.i = 3; // sin, tri, saw, s&h
+#if EURORACK_CLOUDS_IS_SUPERPARASITES
+        val_max.i = 7;
+#else
+        val_max.i = 3;
+#endif
         val_default.i = 0;
         break;
 
@@ -4049,6 +4053,23 @@ std::string Parameter::get_display(bool external, float ef) const
                 break;
             case 3:
                 txt = "Spectral Madness";
+                break;
+#if EURORACK_CLOUDS_IS_SUPERPARASITES
+            case 4:
+                txt = "Oliverb";
+                break;
+            case 5:
+                txt = "Reonestor";
+                break;
+            case 6:
+                txt = "Kammerl";
+                break;
+            case 7:
+                txt = "Spectral Cloud";
+                break;
+#endif
+            default:
+                txt = "Unknown Model";
                 break;
             }
         }

--- a/src/surge-xt/gui/overlays/AboutScreen.cpp
+++ b/src/surge-xt/gui/overlays/AboutScreen.cpp
@@ -417,6 +417,15 @@ void AboutScreen::resized()
 
         yp += lblvs;
 
+#if EURORACK_CLOUDS_IS_SUPERPARASITES
+        addLabel("Nimbus includes the the integrated superparasites firmware by Patrick Dowling, "
+                 "including"
+                 " mqtthiqs/Parasites and jkammerl/Beat Repeat modes.",
+                 600);
+
+        yp += lblvs;
+#endif
+
         addLabel("Oscilloscope code based on s(m)exoscope by Bram @ Smartelectronix, licensed "
                  "under GNU GPL v3 license",
                  600);


### PR DESCRIPTION
This commit implements the superparasites firmware as an option for clouds. The firmware comes from patrick dowling at https://github.com/patrickdowling/superparasites

In this commit, the firmware is activatable at build time but is still off by default, so the synth is unchanged unless you opt in in libs/eurorack/CMakeLists with the option.

Closes https://github.com/patrickdowling/superparasites/issues/6 Addresses #7359