### PR TITLE
Refresh solo button on OSC Message

### DIFF
--- a/scripts/osc-tests/OSC_test_solo.py
+++ b/scripts/osc-tests/OSC_test_solo.py
@@ -1,0 +1,28 @@
+from osc4py3.as_eventloop import *
+from osc4py3 import oscbuildparse as obp
+from osc4py3.oscmethod import *
+import time
+
+def set_solo(val):
+    print("Setting solo to ", val)
+    msg = obp.OSCMessage("/param/a/mixer/osc1/solo", ",f", [val])
+    osc_send(msg, "oscout")
+    osc_process()
+
+### config
+ip = "127.0.0.1"
+surgeOSCInPort = 53280	#Surge XT default OSC in port
+
+osc_startup()
+osc_udp_client(ip, surgeOSCInPort, "oscout")
+
+for i in range(40):
+    set_solo(False)
+    time.sleep(2)
+    set_solo(True)
+    time.sleep(2)
+
+set_solo(False)
+
+
+osc_terminate()

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -737,6 +737,15 @@ void SurgeSynthProcessor::processBlockOSC()
                 pval = Parameter::intScaledToFloat(pval, om.param->val_max.i, om.param->val_min.i);
             surge->setParameter01(surge->idForParameter(om.param), pval, true);
             surge->storage.getPatch().isDirty = true;
+
+            // Special cases: A few control types require a rebuild and
+            // SGE Value Callbacks would do it as would the VST3 param handler
+            // so put them here for now. Bit of a hack...
+            auto ct = om.param->ctrltype;
+            if (ct == ct_bool_solo || ct == ct_bool_mute || ct == ct_scenesel)
+            {
+                surge->refresh_editor = true;
+            }
         }
         break;
 


### PR DESCRIPTION
The solo button is non-local and so requires a rebuild when it changes. The various mechanisms we have do this but OSC did not. So start a list of param types which when OSC set push a rebuild and add solo, mute, and scenesel all to them.

Closes #7417