### PR TITLE
Modulator retriggers obey "from current"/"piano mode"

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -719,15 +719,28 @@ template <bool first> void SurgeVoice::calc_ctrldata(QuadFilterChainState *Q, in
         }
     }
 
+    auto pm = scene->polymode.val.i;
+
+    bool fromCurrent = (pm == pm_poly && scene->polyVoiceRepeatedKeyMode ==
+                                             PolyVoiceRepeatedKeyMode::ONE_VOICE_PER_KEY) ||
+                       (pm != pm_poly &&
+                        scene->monoVoiceEnvelopeMode == MonoVoiceEnvelopeMode::RESTART_FROM_LATEST);
+
     for (int i = 0; i < n_lfos_voice; ++i)
     {
         if (lfo[i].retrigger_AEG)
         {
-            ((ADSRModulationSource *)modsources[ms_ampeg])->retrigger();
+            auto ms = ((ADSRModulationSource *)modsources[ms_ampeg]);
+            auto val = fromCurrent * ms->get_output(0);
+
+            ms->retriggerFrom(val);
         }
         if (lfo[i].retrigger_FEG)
         {
-            ((ADSRModulationSource *)modsources[ms_filtereg])->retrigger();
+            auto ms = ((ADSRModulationSource *)modsources[ms_filtereg]);
+            auto val = fromCurrent * ms->get_output(0);
+
+            ms->retriggerFrom(val);
         }
     }
 

--- a/src/common/dsp/modulators/ADSRModulationSource.h
+++ b/src/common/dsp/modulators/ADSRModulationSource.h
@@ -79,10 +79,12 @@ class ADSRModulationSource : public ModulationSource
         _discharge = 0.f;
     }
 
-    void retrigger()
+    void retrigger() { retriggerFrom(0.f); }
+
+    void retriggerFrom(float start)
     {
         if (envstate < s_release)
-            attack();
+            attackFrom(start);
     }
 
     virtual void attack() override { attackFrom(0.f); }


### PR DESCRIPTION
In "from current" and "piano mode" envelopes retrigger continously so now the modulators (MSEG, Formula, Step Sequencer) follow that logic also

Closes #7360