### PR TITLE
Fix error in b611a81; Restore sin negative feedback

### DIFF
--- a/src/common/dsp/oscillators/SineOscillator.cpp
+++ b/src/common/dsp/oscillators/SineOscillator.cpp
@@ -628,7 +628,7 @@ void SineOscillator::process_block_internal(float pitch, float drift, float fmde
     fv = limit_range(fv, -1.0e6f, 1.0e6f);
 
     FMdepth.newValue(fv);
-    FB.newValue(abs(fb_val));
+    FB.newValue(fb_val);
 
     float p alignas(16)[MAX_UNISON];
     float sx alignas(16)[MAX_UNISON];
@@ -684,8 +684,8 @@ void SineOscillator::process_block_internal(float pitch, float drift, float fmde
 
         float fmpd = FM ? FMdepth.v * master_osc[k] : 0.f;
         auto fmpds = _mm_set1_ps(fmpd);
-        auto fbv = _mm_set1_ps(FB.v);
-        auto fbnegmask = _mm_cmplt_ps(fbv, _mm_setzero_ps());
+        auto fbv = _mm_set1_ps(std::fabs(FB.v));
+        auto fbnegmask = _mm_cmplt_ps(_mm_set1_ps(FB.v), _mm_setzero_ps());
 
         for (int u = 0; u < n_unison; u += 4)
         {


### PR DESCRIPTION
My fix to remove clicks also removed negative feedback! Anyway this change makes the correct change; linterp feedback postiive to negative and apply the abs on a per-sample basis for feedback transitions.

Addresses #7353