### PR TITLE
Tuning Editor Keyboard can also play notes

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6404,3 +6404,19 @@ void SurgeGUIEditor::enqueueAccessibleAnnouncement(const std::string &s)
         accAnnounceStrings.push_back({s, 3});
     }
 }
+
+void SurgeGUIEditor::playNote(char key, char vel)
+{
+    auto ed = juceEditor;
+    auto &proc = ed->processor;
+
+    proc.midiFromGUI.push(SurgeSynthProcessor::midiR(0, key, vel, true));
+}
+
+void SurgeGUIEditor::releaseNote(char key, char vel)
+{
+    auto ed = juceEditor;
+    auto &proc = ed->processor;
+
+    proc.midiFromGUI.push(SurgeSynthProcessor::midiR(0, key, vel, false));
+}

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -528,6 +528,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void ensureParameterItemIsFocused(Parameter *p);
     void setPatchFromUndo(void *data, size_t datasz);
 
+    void playNote(char key, char vel);
+    void releaseNote(char key, char vel);
+
   private:
     juce::Rectangle<int> positionForModulationGrid(modsources entry);
     juce::Rectangle<int> positionForModOverview();


### PR DESCRIPTION
Forever and a day that keyboard table layout of frequencies has been sitting there, wanting to be pressed to play a note. But in the time we've had it noone thought of it until VincyZed suggested it.

Anyway bit more of a refactor than I thought since the juce tablelistboxmodel thing is very opinionated so needed to factor to a custom component etc... but also usefully adds a ui safe play and release note method to SurgeGUIEditor

Closes #7365