### PR TITLE
Drain the osc ring buf without audio

### DIFF
--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -792,6 +792,18 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
 
         sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(p, modnum, mscene, index, depth));
     }
+    if (!synth->audio_processing_active)
+    {
+        // Audio isn't running so the queue wont be drained.
+        // In this case do the (slightly hacky) drain-on-this-thread
+        // approach. There's a small race condition here in that if
+        // processing restarts while we have a message we are doing
+        // here then maybe we go blammo. That's a super-duper edge
+        // case which i'll mention here but not fix. (The fix is probably
+        // to have an atomic book in processBlock and properly atomic
+        // compare and set it and return if two threads are in process).
+        sspPtr->processBlockOSC();
+    }
 }
 
 bool OpenSoundControl::hasEnding(std::string const &fullString, std::string const &ending)


### PR DESCRIPTION
When audio isn't running the osc ring buf just fills up. Like we do with other things use the audio processing active bool to drain on the osc thread. There's a tiny race condition if you are processing an osc message while you turn on audio but leave that edge-case-of-an-edge-case in a comment

Closes #7445