### PR TITLE
FX Change Mod Clear fixed (broke iwth index introduction)

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2994,7 +2994,11 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
                         {
                             for (int sc = 0; sc < n_scenes; ++sc)
                             {
-                                clearModulation(p->id, (modsources)ms, sc, true);
+                                auto mi = getModulationIndicesBetween(p->id, (modsources)ms, sc);
+                                for (auto m : mi)
+                                {
+                                    clearModulation(p->id, (modsources)ms, sc, m, true);
+                                }
                             }
                         }
                     }
@@ -3022,7 +3026,11 @@ bool SurgeSynthesizer::loadFx(bool initp, bool force_reload_all)
                     {
                         for (int sc = 0; sc < n_scenes; sc++)
                         {
-                            clearModulation(p->id, (modsources)ms, sc, true);
+                            auto mi = getModulationIndicesBetween(p->id, (modsources)ms, sc);
+                            for (auto m : mi)
+                            {
+                                clearModulation(p->id, (modsources)ms, sc, m, true);
+                            }
                         }
                     }
                 }

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -374,7 +374,7 @@ class alignas(16) SurgeSynthesizer
     void muteModulation(long ptag, modsources modsource, int modsourceScene, int index, bool mute);
     bool isModulationMuted(long ptag, modsources modsource, int modsourceScene, int index) const;
     void clearModulation(long ptag, modsources modsource, int modsourceScene, int index,
-                         bool clearEvenIfInvalid = false);
+                         bool clearEvenIfInvalid);
     // clear the modulation routings on the algorithm-specific sliders
     void clear_osc_modulation(int scene, int entry);
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1059,7 +1059,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                                 pushModulationToUndoRedo(md, (modsources)thisms, use_scene, modidx,
                                                          Surge::GUI::UndoManager::UNDO);
-                                synth->clearModulation(md, thisms, use_scene, modidx);
+                                synth->clearModulation(md, thisms, use_scene, modidx, false);
                                 refresh_mod();
 
                                 if (bvf)
@@ -1164,7 +1164,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                                                  idx,
                                                                  Surge::GUI::UndoManager::UNDO);
 
-                                        synth->clearModulation(md, thisms, use_scene, idx);
+                                        synth->clearModulation(md, thisms, use_scene, idx, false);
                                     }
                             }
 
@@ -2740,7 +2740,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                                         ptag, (modsources)ms, sc, modidx,
                                                         Surge::GUI::UndoManager::UNDO);
                                                     synth->clearModulation(ptag, (modsources)ms, sc,
-                                                                           modidx);
+                                                                           modidx, false);
                                                     refresh_mod();
                                                     synth->storage.getPatch().isDirty = true;
                                                     synth->refresh_editor = true;
@@ -3092,7 +3092,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 pushModulationToUndoRedo(ptag, (modsources)thisms, use_scene, modsource_index,
                                          Surge::GUI::UndoManager::UNDO);
 
-                synth->clearModulation(ptag, thisms, use_scene, modsource_index);
+                synth->clearModulation(ptag, thisms, use_scene, modsource_index, false);
                 auto ctrms = dynamic_cast<Surge::Widgets::ModulatableControlInterface *>(control);
                 jassert(ctrms);
 

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -401,7 +401,7 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
                         datum.source_scene, datum.source_index, Surge::GUI::UndoManager::UNDO);
                     me->synth->clearModulation(datum.destination_id + datum.idBase,
                                                (modsources)datum.source_id, datum.source_scene,
-                                               datum.source_index);
+                                               datum.source_index, false);
                     // The rebuild may delete this so defer
                     auto c = contents;
                     juce::Timer::callAfterDelay(1, [c, me]() {


### PR DESCRIPTION
The signature clange of clearModulation led to a mistake due to casting and defaults

Closes #7395