### PR TITLE
Swapping/Moving FX preserves modulation muting

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -5264,8 +5264,11 @@ void SurgeSynthesizer::reorderFx(int source, int target, FXReorderMode m)
             auto depth =
                 getModDepth01(fxsync[source].p[whichForReal].id, (modsources)mv->at(i).source_id,
                               mv->at(i).source_scene, mv->at(i).source_index);
+            auto mut = isModulationMuted(fxsync[source].p[whichForReal].id,
+                                         (modsources)mv->at(i).source_id, mv->at(i).source_scene,
+                                         mv->at(i).source_index);
             fxmodsync[target].push_back({mv->at(i).source_id, mv->at(i).source_scene,
-                                         mv->at(i).source_index, whichForReal, depth});
+                                         mv->at(i).source_index, whichForReal, depth, mut});
         }
 
         if (m == FXReorderMode::SWAP)
@@ -5287,8 +5290,11 @@ void SurgeSynthesizer::reorderFx(int source, int target, FXReorderMode m)
                 auto depth = getModDepth01(fxsync[target].p[whichForReal].id,
                                            (modsources)mv->at(i).source_id, mv->at(i).source_scene,
                                            mv->at(i).source_index);
+                auto mut = isModulationMuted(fxsync[target].p[whichForReal].id,
+                                             (modsources)mv->at(i).source_id,
+                                             mv->at(i).source_scene, mv->at(i).source_index);
                 fxmodsync[source].push_back({mv->at(i).source_id, mv->at(i).source_scene,
-                                             mv->at(i).source_index, whichForReal, depth});
+                                             mv->at(i).source_index, whichForReal, depth, mut});
             }
         }
 


### PR DESCRIPTION
Moving an FX keeps the modulation intact but when coding the swap/undo last night I realized that the move didn't keep mute intact. This fixes that bug.