### PR TITLE
Only run the Docker PR on PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
         displayName: Do Codequal
 
   - job: BuildLinuxDocker
+    condition: eq(variables['Build.Reason'], 'PullRequest')
     pool:
       vmImage: 'ubuntu-20.04'
 


### PR DESCRIPTION
This restores the quick-to-nightly behavior of code-qual splitwq