### PR TITLE
Fix MSEG draw error on when tick 0 < 0.1

### DIFF
--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -1336,10 +1336,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             if (pxa < drawArea.getX() || pxa > drawArea.getRight())
                 continue;
 
-            if (t > 0.1)
-            {
-                g.drawLine(pxa, drawArea.getY(), pxa, drawArea.getBottom() + ticklen, linewidth);
-            }
+            g.drawLine(pxa, drawArea.getY(), pxa, drawArea.getBottom() + ticklen, linewidth);
         }
 
         updateVTicks();


### PR DESCRIPTION
For some reason we only drew ticks abouve 0.1 in the MSEG canvas. No comment, no reason, nothign breaks if we remove it but having it there causes #7453

So don't do that.

Closes #7453