### PR TITLE
Upstream OBS Patches to 1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
       -Wno-free-nonheap-object # https://github.com/surge-synthesizer/surge/issues/4251
       -Wno-return-local-addr # squelch sqlite3 error: function may return address of local variable
       -Wno-error=restrict # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
+      -Wno-date-time
     )
   endif()
 endif()

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -243,4 +243,6 @@ endif()
 
 surge_juce_package(${PROJECT_NAME} "Surge XT")
 
-add_subdirectory(xt-tests)
+if (${SURGE_BUILD_TESTRUNNER})
+  add_subdirectory(xt-tests)
+endif()


### PR DESCRIPTION
This diff upstreams three patches used to make OBS build across various unixen

1. Add -Wno-date-time to gcc (supress-errors.patch)
2. Add cstdint to cpufeatures (include-cstdint.patch)
3. Make the xt tests optional under SURGE_BUILD_TESTRUNNER (will allow us to retire disable-tests.patch if we add -DSURGE_BUILD_TESTRUNNER=FALSE to the build command)