### PR TITLE
Avoid crash on loop handle draw on MSEG node delete

### DIFF
--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -799,13 +799,12 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         auto tpx = timeToPx();
         float maxt = drawDuration();
 
-        int ls = (ms->loop_start >= 0 ? ms->loop_start : 0);
-        int le = (ms->loop_end >= 0 ? ms->loop_end : ms->n_activeSegments - 1);
-
         // draw loop area
         if (ms->loopMode != MSEGStorage::ONESHOT && ms->editMode != MSEGStorage::LFO)
         {
-            // std::cout << "LS/LS are " << ls << "/" << le << std::endl;
+            int ls = (ms->loop_start >= 0 ? ms->loop_start : 0);
+            int le = (ms->loop_end >= 0 ? ms->loop_end : ms->n_activeSegments - 1);
+
             float pxs = limit_range((float)tpx(ms->segmentStart[ls]), (float)haxisArea.getX(),
                                     (float)haxisArea.getRight());
             float pxe = limit_range((float)tpx(ms->segmentEnd[le]), (float)haxisArea.getX(),

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -799,11 +799,13 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         auto tpx = timeToPx();
         float maxt = drawDuration();
 
+        int ls = (ms->loop_start >= 0 ? ms->loop_start : 0);
+        int le = (ms->loop_end >= 0 ? ms->loop_end : ms->n_activeSegments - 1);
+
         // draw loop area
         if (ms->loopMode != MSEGStorage::ONESHOT && ms->editMode != MSEGStorage::LFO)
         {
-            int ls = (ms->loop_start >= 0 ? ms->loop_start : 0);
-            int le = (ms->loop_end >= 0 ? ms->loop_end : ms->n_activeSegments - 1);
+            // std::cout << "LS/LS are " << ls << "/" << le << std::endl;
             float pxs = limit_range((float)tpx(ms->segmentStart[ls]), (float)haxisArea.getX(),
                                     (float)haxisArea.getRight());
             float pxe = limit_range((float)tpx(ms->segmentEnd[le]), (float)haxisArea.getX(),
@@ -822,15 +824,14 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             auto mcolor = skin->getColor(Colors::MSEGEditor::Loop::Marker);
 
             // draw loop markers
-            if (loopDragTime < 0 || !loopDragIsStart)
+            if ((loopDragTime < 0 || !loopDragIsStart) && (ls >= 0 && ls < ms->segmentStart.size()))
             {
-                drawLoopDragMarker(g, mcolor, hotzone::LOOP_START,
-                                   ms->segmentStart[ms->loop_start]);
+                drawLoopDragMarker(g, mcolor, hotzone::LOOP_START, ms->segmentStart[ls]);
             }
 
-            if (loopDragTime < 0 || loopDragIsStart)
+            if ((loopDragTime < 0 || loopDragIsStart) && (le >= 0 && le < ms->segmentStart.size()))
             {
-                drawLoopDragMarker(g, mcolor, hotzone::LOOP_END, ms->segmentEnd[ms->loop_end]);
+                drawLoopDragMarker(g, mcolor, hotzone::LOOP_END, ms->segmentEnd[le]);
             }
 
             // loop marker when dragged


### PR DESCRIPTION
A case where you deleted a loop node marker which reset the loop would result in a draw error since we didn't consistently use the constraineed loop endpoints to indedx the segments. This caused a crash in some situations.

Closes #7401