### PR TITLE
Add an Overlay PreClose Chickenbox; Update Formula to use

### DIFF
--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -847,8 +847,10 @@ void FormulaModulatorEditor::showPreludeCode()
 
 void FormulaModulatorEditor::escapeKeyPressed()
 {
-    if (controlArea->applyS->isEnabled())
+    auto pcm = getPreCloseChickenBoxMessage();
+    if (pcm.has_value())
     {
+        auto pcp = *pcm;
         auto cb = [this]() {
             auto c = getParentComponent();
             while (c)
@@ -862,10 +864,7 @@ void FormulaModulatorEditor::escapeKeyPressed()
         };
         auto nocb = [this]() { grabKeyboardFocus(); };
 
-        editor->alertYesNo("Close Formula Editor",
-                           "Do you really want to close the formula editor? Any "
-                           "changes that were not applied will be lost!",
-                           cb, nocb);
+        editor->alertYesNo(pcp.first, pcp.second, cb, nocb);
     }
     else
     {
@@ -880,6 +879,18 @@ void FormulaModulatorEditor::escapeKeyPressed()
         }
     }
     return;
+}
+
+std::optional<std::pair<std::string, std::string>>
+FormulaModulatorEditor::getPreCloseChickenBoxMessage()
+{
+    if (controlArea->applyS->isEnabled())
+    {
+        return std::make_pair("Close Formula Editor",
+                              "Do you really want to close the formula editor? Any "
+                              "changes that were not applied will be lost!");
+    }
+    return std::nullopt;
 }
 
 struct WavetablePreviewComponent : juce::Component

--- a/src/surge-xt/gui/overlays/LuaEditors.h
+++ b/src/surge-xt/gui/overlays/LuaEditors.h
@@ -118,6 +118,8 @@ struct FormulaModulatorEditor : public CodeEditorContainerWithApply, public Refr
         return false;
     }
 
+    std::optional<std::pair<std::string, std::string>> getPreCloseChickenBoxMessage() override;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FormulaModulatorEditor);
 };
 

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -25,6 +25,8 @@
 
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "UserDefaults.h"
+#include <optional>
+#include <utility>
 
 class Parameter;
 class SurgePatch;
@@ -87,6 +89,16 @@ struct OverlayComponent : juce::Component
     bool getCanMoveAround() { return canMoveAround.first; }
     juce::Point<int> defaultLocation;
     Surge::Storage::DefaultKey getMoveAroundKey() { return canMoveAround.second; }
+
+    /*
+     * If you want to chicken box the close, return a message from here. The pair
+     * is the OK/Cancel title and message, respectively. If you are ok to close,
+     * return std::nullopt, which is the default behavior.
+     */
+    virtual std::optional<std::pair<std::string, std::string>> getPreCloseChickenBoxMessage()
+    {
+        return std::nullopt;
+    }
 };
 } // namespace Overlays
 } // namespace Surge

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -728,5 +728,27 @@ void OverlayWrapper::onSkinChanged()
     repaint();
 }
 
+void OverlayWrapper::onClose()
+{
+    auto pc = getPrimaryChildAsOverlayComponent();
+    if (pc && pc->getPreCloseChickenBoxMessage().has_value())
+    {
+        auto pcm = *(pc->getPreCloseChickenBoxMessage());
+        editor->alertYesNo(
+            pcm.first, pcm.second,
+            [this]() {
+                closeOverlay();
+                if (isTornOut())
+                    tearOutParent.reset(nullptr);
+            },
+            [pc]() { pc->grabKeyboardFocus(); });
+    }
+    else
+    {
+        closeOverlay();
+        if (isTornOut())
+            tearOutParent.reset(nullptr);
+    }
+}
 } // namespace Overlays
 } // namespace Surge

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -126,12 +126,8 @@ struct OverlayWrapper : public juce::Component,
     bool showCloseButton{true};
     void setShowCloseButton(bool b) { showCloseButton = b; }
 
-    void onClose()
-    {
-        closeOverlay();
-        if (isTornOut())
-            tearOutParent.reset(nullptr);
-    }
+    void onClose();
+
     std::function<void()> closeOverlay = []() {};
     void setCloseOverlay(std::function<void()> f) { closeOverlay = std::move(f); }
 


### PR DESCRIPTION
1. Overlay component get std::optional getPreCloseChickenBoxMessage which if it returns a value pops a chicken box in the surge gui when you press 'x' on the overlay
2. Implement it for FormulaEditor so that 'x' and 'esc' do the same thing

Closes #7337