### PR TITLE
Filter Analysis doesn't grab Kbd Focus on open

### DIFF
--- a/src/surge-xt/gui/overlays/FilterAnalysis.h
+++ b/src/surge-xt/gui/overlays/FilterAnalysis.h
@@ -92,6 +92,8 @@ struct FilterAnalysis : public OverlayComponent, Surge::GUI::SkinConsumingCompon
     int whichFilter{0};
     void selectFilter(int which);
 
+    bool wantsInitialKeyboardFocus() const override { return false; }
+
     std::unique_ptr<Surge::Widgets::SelfDrawToggleButton> f1Button, f2Button;
     std::unique_ptr<FilterAnalysisEvaluator> evaluator;
     bool shouldRepaintOnParamChange(const SurgePatch &patch, Parameter *p) override;

--- a/src/surge-xt/gui/overlays/Oscilloscope.cpp
+++ b/src/surge-xt/gui/overlays/Oscilloscope.cpp
@@ -1243,8 +1243,6 @@ void Oscilloscope::visibilityChanged()
     }
 }
 
-bool Oscilloscope::wantsInitialKeyboardFocus() { return false; }
-
 // Lock for member variables must be held by the caller.
 void Oscilloscope::calculateSpectrumData()
 {

--- a/src/surge-xt/gui/overlays/Oscilloscope.h
+++ b/src/surge-xt/gui/overlays/Oscilloscope.h
@@ -214,7 +214,7 @@ class Oscilloscope : public OverlayComponent,
     void resized() override;
     void updateDrawing();
     void visibilityChanged() override;
-    bool wantsInitialKeyboardFocus() override;
+    bool wantsInitialKeyboardFocus() const override { return false; }
 
     void valueChanged(GUI::IComponentTagValue *p) override{};
     int32_t controlModifierClicked(Surge::GUI::IComponentTagValue *pControl,

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -54,7 +54,7 @@ struct OverlayComponent : juce::Component
     virtual void forceDataRefresh() {}
 
     // For A11Y: should the overlay be granted keyboard focus as soon as it appears.
-    virtual bool wantsInitialKeyboardFocus() { return true; }
+    virtual bool wantsInitialKeyboardFocus() const { return true; }
 
     /*
      * This is called when a parent wrapper finally decides to show me, which will


### PR DESCRIPTION
This avoids a hover-paint on the filter 1 button when its neither selected nor hovered. Since this is a non-accessible UI this is basically what we want anyway.

Also make wantsInitialKeyboardFocus false.

Closes #7361