### PR TITLE
Clap 1.2.0; Preset Discovery; Improved PatchDB Scan Times

### DIFF
--- a/src/common/PatchFileHeaderStructs.h
+++ b/src/common/PatchFileHeaderStructs.h
@@ -1,0 +1,56 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#ifndef SURGE_SRC_COMMON_FXPHEADERSTRUCTS_H
+#define SURGE_SRC_COMMON_FXPHEADERSTRUCTS_H
+
+namespace sst::io
+{
+
+#pragma pack(push, 1)
+struct fxChunkSetCustom
+{
+    int chunkMagic; // 'CcnK'
+    int byteSize;   // of this chunk, excl. magic + byteSize
+
+    int fxMagic; // 'FPCh'
+    int version;
+    int fxID; // fx unique id
+    int fxVersion;
+
+    int numPrograms;
+    char prgName[28];
+
+    int chunkSize;
+    // char chunk[8]; // variable
+};
+
+struct patch_header
+{
+    char tag[4];
+    // TODO: FIX SCENE AND OSC COUNT ASSUMPTION for wtsize
+    // (but also since it's used in streaming, do it with care!)
+    unsigned int xmlsize, wtsize[2][3];
+};
+#pragma pack(pop)
+} // namespace sst::io
+#endif // SURGE_FXPHEADERSTRUCTS_H

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -38,6 +38,8 @@
 #include "UnitConversions.h"
 
 #include "sst/basic-blocks/mechanics/endian-ops.h"
+#include "PatchFileHeaderStructs.h"
+
 namespace mech = sst::basic_blocks::mechanics;
 
 using namespace std;
@@ -1102,16 +1104,6 @@ void SurgePatch::update_controls(
     }
 }
 
-#pragma pack(push, 1)
-struct patch_header
-{
-    char tag[4];
-    // TODO: FIX SCENE AND OSC COUNT ASSUMPTION for wtsize
-    // (but also since it's used in streaming, do it with care!)
-    unsigned int xmlsize, wtsize[2][3];
-};
-#pragma pack(pop)
-
 // BASE 64 SUPPORT, THANKS TO:
 // https://renenyffenegger.ch/notes/development/Base64/Encoding-and-decoding-base-64-with-cpp
 static const std::string base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -1208,6 +1200,8 @@ std::string base64_decode(std::string const &encoded_string)
 
 void SurgePatch::load_patch(const void *data, int datasize, bool preset)
 {
+    using namespace sst::io;
+
     if (datasize <= 4)
         return;
     assert(datasize);
@@ -1288,6 +1282,8 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
 
 unsigned int SurgePatch::save_patch(void **data)
 {
+    using namespace sst::io;
+
     size_t psize = 0;
     // void **xmldata = new void*();
     void *xmldata = 0;

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -32,30 +32,11 @@
 #include "SurgeMemoryPools.h"
 
 #include "sst/basic-blocks/mechanics/endian-ops.h"
+#include "PatchFileHeaderStructs.h"
+
 namespace mech = sst::basic_blocks::mechanics;
 
 using namespace std;
-
-// seems to be missing from VST2.3, so it's copied from the VST list instead
-//--------------------------------------------------------------------
-// For Preset (Program) (.fxp) with chunk (magic = 'FPCh')
-//--------------------------------------------------------------------
-struct fxChunkSetCustom
-{
-    int chunkMagic; // 'CcnK'
-    int byteSize;   // of this chunk, excl. magic + byteSize
-
-    int fxMagic; // 'FPCh'
-    int version;
-    int fxID; // fx unique id
-    int fxVersion;
-
-    int numPrograms;
-    char prgName[28];
-
-    int chunkSize;
-    // char chunk[8]; // variable
-};
 
 void SurgeSynthesizer::jogPatch(bool increment, bool insideCategory)
 {
@@ -228,6 +209,8 @@ void SurgeSynthesizer::loadPatch(int id)
 bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, const char *patchName,
                                        bool forceIsPreset)
 {
+    using namespace sst::io;
+
     std::filebuf f;
     if (!f.open(string_to_path(fxpPath), std::ios::binary | std::ios::in))
         return false;
@@ -627,6 +610,8 @@ void SurgeSynthesizer::savePatch(bool factoryInPlace, bool skipOverwrite)
 
 void SurgeSynthesizer::savePatchToPath(fs::path filename, bool refreshPatchList)
 {
+    using namespace sst::io;
+
     std::ofstream f(filename, std::ios::out | std::ios::binary);
 
     if (!f)

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -61,7 +61,7 @@ if(SURGE_BUILD_CLAP)
   clap_juce_extensions_plugin(TARGET surge-xt
     CLAP_ID "org.surge-synth-team.surge-xt"
 
-    # CLAP_SUPPORTS_CUSTOM_FACTORY 1
+    CLAP_SUPPORTS_CUSTOM_FACTORY 1
     CLAP_FEATURES "instrument" "synthesizer" "hybrid" "free and open source")
 endif()
 
@@ -74,6 +74,8 @@ target_sources(${PROJECT_NAME} PRIVATE
   SurgeSynthEditor.h
   SurgeSynthProcessor.cpp
   SurgeSynthProcessor.h
+
+  SurgeCLAPPresetDiscovery.cpp
 
   util/LockFreeStack.h
 

--- a/src/surge-xt/SurgeCLAPPresetDiscovery.cpp
+++ b/src/surge-xt/SurgeCLAPPresetDiscovery.cpp
@@ -1,0 +1,247 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#if HAS_CLAP_JUCE_EXTENSIONS
+
+#include <iostream>
+#include <memory>
+#include <cstring>
+#include <fstream>
+#include <vector>
+
+#include <clap/clap.h>
+
+#include "SurgeStorage.h"
+
+#include "sst/basic-blocks/mechanics/endian-ops.h"
+#include "PatchFileHeaderStructs.h"
+
+namespace sst::surge_xt::preset_discovery
+{
+#define PSOUT std::cout << "[preset] " << __LINE__ << " " << __func__ << " "
+
+static const clap_preset_discovery_provider_descriptor desc{
+    CLAP_VERSION, "org.surge-synth-team.surge-xt.preset-indexer", "Surge XT Presets",
+    "Surge Synth Team"};
+
+struct PresetProvider
+{
+    const clap_preset_discovery_indexer *indexer{nullptr};
+    std::unique_ptr<SurgeStorage> storage;
+
+    PresetProvider(const clap_preset_discovery_indexer *idx) : indexer(idx)
+    {
+        provider.desc = &desc;
+        provider.provider_data = this;
+        provider.init = [](auto a) {
+            auto p = reinterpret_cast<PresetProvider *>(a->provider_data);
+            return p->init();
+        };
+        provider.destroy = [](auto a) {
+            auto p = reinterpret_cast<PresetProvider *>(a->provider_data);
+            delete p;
+        };
+        provider.get_metadata = [](auto a, auto k, const auto *l, auto *m) {
+            auto p = reinterpret_cast<PresetProvider *>(a->provider_data);
+            return p->get_metadata(k, l, m);
+        };
+        provider.get_extension = [](auto a, auto b) {
+            auto p = reinterpret_cast<PresetProvider *>(a->provider_data);
+            return p->get_extension(b);
+        };
+    }
+
+    ~PresetProvider() {}
+
+    bool init()
+    {
+        SurgeStorage::SurgeStorageConfig config;
+        config.createUserDirectory = false;
+
+        storage = std::make_unique<SurgeStorage>(config);
+
+        auto res = true;
+        auto fxp = clap_preset_discovery_filetype{"Surge XT Patch", "", "fxp"};
+        res = res && indexer->declare_filetype(indexer, &fxp);
+
+        if (fs::is_directory(storage->datapath / "patches_factory"))
+        {
+            char floc[PATH_MAX];
+            strncpy(floc, (storage->datapath / "patches_factory").u8string().c_str(), PATH_MAX - 1);
+            auto factory = clap_preset_discovery_location{
+                CLAP_PRESET_DISCOVERY_IS_FACTORY_CONTENT, "Surge XT Factory Presets",
+                CLAP_PRESET_DISCOVERY_LOCATION_FILE, floc};
+            res = res && indexer->declare_location(indexer, &factory);
+        }
+
+        if (fs::is_directory(storage->datapath / "patches_3rdparty"))
+        {
+            char tploc[PATH_MAX];
+            strncpy(tploc, (storage->datapath / "patches_3rdparty").u8string().c_str(),
+                    PATH_MAX - 1);
+            auto third_party = clap_preset_discovery_location{
+                CLAP_PRESET_DISCOVERY_IS_FACTORY_CONTENT, "Surge XT Third Party Presets",
+                CLAP_PRESET_DISCOVERY_LOCATION_FILE, tploc};
+            res = res && indexer->declare_location(indexer, &third_party);
+        }
+
+        if (fs::is_directory(storage->userPatchesPath))
+        {
+            char uloc[PATH_MAX];
+            strncpy(uloc, storage->userPatchesPath.u8string().c_str(), PATH_MAX - 1);
+
+            auto userpatch = clap_preset_discovery_location{
+                CLAP_PRESET_DISCOVERY_IS_USER_CONTENT, "Surge XT User Presets",
+                CLAP_PRESET_DISCOVERY_LOCATION_FILE, uloc};
+            res = res && indexer->declare_location(indexer, &userpatch);
+        }
+        return res;
+    }
+
+    bool get_metadata(uint32_t location_kind, const char *location,
+                      const clap_preset_discovery_metadata_receiver_t *rcv)
+    {
+
+        namespace mech = sst::basic_blocks::mechanics;
+
+        auto bail = [rcv, location](const std::string &s) {
+            std::string l{location};
+            std::string ms = l + ": " + s;
+            rcv->on_error(rcv, 0, ms.c_str());
+            return false;
+        };
+        /*
+         * This is our FXP cracker, customized for this extraction
+         */
+        auto p = fs::path{location};
+        std::ifstream stream(p, std::ios::in | std::ios::binary);
+        if (!stream.is_open())
+            return bail("Unable to open file");
+
+        std::vector<char> fxChunk;
+        fxChunk.resize(sizeof(sst::io::fxChunkSetCustom));
+        stream.read(fxChunk.data(), fxChunk.size());
+        if (!stream)
+            return bail("Cannot read chunk header");
+
+        auto *fxp = (sst::io::fxChunkSetCustom *)(fxChunk.data());
+        if ((mech::endian_read_int32BE(fxp->chunkMagic) != 'CcnK') ||
+            (mech::endian_read_int32BE(fxp->fxMagic) != 'FPCh') ||
+            (mech::endian_read_int32BE(fxp->fxID) != 'cjs3'))
+        {
+            return bail("This is not a Surge FXP file");
+        }
+
+        std::vector<char> patchHeaderChunk;
+        patchHeaderChunk.resize(sizeof(sst::io::patch_header));
+        stream.read(patchHeaderChunk.data(), patchHeaderChunk.size());
+        if (!stream)
+            return bail("Unable to read patch header");
+        auto *ph = (sst::io::patch_header *)(patchHeaderChunk.data());
+        auto xmlSz = mech::endian_read_int32LE(ph->xmlsize);
+
+        if (!memcpy(ph->tag, "sub3", 4) || xmlSz < 0 || xmlSz > 1024 * 1024 * 1024)
+        {
+            return bail("Not a Surge XML containing FXP");
+        }
+
+        std::vector<char> xmlData;
+        xmlData.resize(xmlSz);
+        stream.read(xmlData.data(), xmlData.size());
+        if (!stream)
+            return bail("Unable to read XML data");
+
+        TiXmlDocument doc;
+        doc.Parse(xmlData.data(), nullptr, TIXML_ENCODING_LEGACY);
+        if (doc.Error())
+        {
+            return bail(doc.ErrorDesc());
+        }
+
+        auto patch = TINYXML_SAFE_TO_ELEMENT(doc.FirstChild("patch"));
+        if (!patch)
+            return bail("XML does not contain a patch");
+        auto meta = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("meta"));
+        if (!meta)
+            return bail("XML does not contain a meta tag");
+
+        if (!meta->Attribute("name"))
+            return bail("XML meta does not contain a name");
+
+        auto res = rcv->begin_preset(rcv, meta->Attribute("name"), "");
+        if (!res)
+            return bail("Cannot begin preset");
+
+        clap_universal_plugin_id_t clp{"clap", "org.surge-synth-team.surge-xt"};
+        rcv->add_plugin_id(rcv, &clp);
+
+        if (meta->Attribute("author"))
+            rcv->add_creator(rcv, meta->Attribute("author"));
+
+        if (meta->Attribute("comment"))
+            rcv->set_description(rcv, meta->Attribute("comment"));
+
+        if (meta->Attribute("license"))
+            rcv->add_extra_info(rcv, "license", meta->Attribute("license"));
+
+        if (meta->Attribute("category"))
+            rcv->add_extra_info(rcv, "category", meta->Attribute("category"));
+
+        return true;
+    }
+
+    const void *get_extension(const char *eid) { return nullptr; }
+
+    struct clap_preset_discovery_provider provider;
+};
+
+uint32_t pd_count(const struct clap_preset_discovery_factory *factory) { return 1; }
+
+const clap_preset_discovery_provider_descriptor_t *
+pd_get_descriptor(const struct clap_preset_discovery_factory *factory, uint32_t index)
+{
+    return &desc;
+}
+
+const clap_preset_discovery_provider_t *
+pd_create(const struct clap_preset_discovery_factory *factory,
+          const clap_preset_discovery_indexer_t *indexer, const char *provider_id)
+{
+    if (strcmp(provider_id, desc.id) == 0)
+    {
+        auto res = new PresetProvider(indexer);
+        return &res->provider;
+    }
+    return nullptr;
+}
+
+static const struct clap_preset_discovery_factory surgePresetDiscoveryFactory
+{
+    pd_count, pd_get_descriptor, pd_create
+};
+} // namespace sst::surge_xt::preset_discovery
+
+const void *getSurgePresetDiscoveryFactory()
+{
+    return &sst::surge_xt::preset_discovery::surgePresetDiscoveryFactory;
+}
+#endif

--- a/src/surge-xt/SurgeCLAPPresetDiscovery.cpp
+++ b/src/surge-xt/SurgeCLAPPresetDiscovery.cpp
@@ -31,6 +31,7 @@
 #include <clap/clap.h>
 
 #include "SurgeStorage.h"
+#include "SurgeSynthProcessor.h"
 
 #include "sst/basic-blocks/mechanics/endian-ops.h"
 #include "PatchFileHeaderStructs.h"
@@ -242,7 +243,7 @@ static const struct clap_preset_discovery_factory surgePresetDiscoveryFactory
 };
 } // namespace sst::surge_xt::preset_discovery
 
-const void *getSurgePresetDiscoveryFactory()
+const void *SurgeSynthProcessor::getSurgePresetDiscoveryFactory()
 {
     return &sst::surge_xt::preset_discovery::surgePresetDiscoveryFactory;
 }

--- a/src/surge-xt/SurgeCLAPPresetDiscovery.cpp
+++ b/src/surge-xt/SurgeCLAPPresetDiscovery.cpp
@@ -83,10 +83,12 @@ struct PresetProvider
         auto fxp = clap_preset_discovery_filetype{"Surge XT Patch", "", "fxp"};
         res = res && indexer->declare_filetype(indexer, &fxp);
 
+        // PATH_MAX is unreliably available
+        static constexpr int pathSize{8192};
         if (fs::is_directory(storage->datapath / "patches_factory"))
         {
-            char floc[PATH_MAX];
-            strncpy(floc, (storage->datapath / "patches_factory").u8string().c_str(), PATH_MAX - 1);
+            char floc[pathSize];
+            strncpy(floc, (storage->datapath / "patches_factory").u8string().c_str(), pathSize - 1);
             auto factory = clap_preset_discovery_location{
                 CLAP_PRESET_DISCOVERY_IS_FACTORY_CONTENT, "Surge XT Factory Presets",
                 CLAP_PRESET_DISCOVERY_LOCATION_FILE, floc};
@@ -95,9 +97,9 @@ struct PresetProvider
 
         if (fs::is_directory(storage->datapath / "patches_3rdparty"))
         {
-            char tploc[PATH_MAX];
+            char tploc[pathSize];
             strncpy(tploc, (storage->datapath / "patches_3rdparty").u8string().c_str(),
-                    PATH_MAX - 1);
+                    pathSize - 1);
             auto third_party = clap_preset_discovery_location{
                 CLAP_PRESET_DISCOVERY_IS_FACTORY_CONTENT, "Surge XT Third Party Presets",
                 CLAP_PRESET_DISCOVERY_LOCATION_FILE, tploc};
@@ -106,8 +108,8 @@ struct PresetProvider
 
         if (fs::is_directory(storage->userPatchesPath))
         {
-            char uloc[PATH_MAX];
-            strncpy(uloc, storage->userPatchesPath.u8string().c_str(), PATH_MAX - 1);
+            char uloc[pathSize];
+            strncpy(uloc, storage->userPatchesPath.u8string().c_str(), pathSize - 1);
 
             auto userpatch = clap_preset_discovery_location{
                 CLAP_PRESET_DISCOVERY_IS_USER_CONTENT, "Surge XT User Presets",

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -1450,7 +1450,7 @@ bool SurgeSynthProcessor::presetLoadFromLocation(uint32_t location_kind, const c
     return true;
 }
 
-const void * JUCE_CALLTYPE clapJuceExtensionCustomFactory(const char *f)
+const void *JUCE_CALLTYPE clapJuceExtensionCustomFactory(const char *f)
 {
     if (strcmp(f, CLAP_PRESET_DISCOVERY_FACTORY_ID) == 0 ||
         strcmp(f, CLAP_PRESET_DISCOVERY_FACTORY_ID_COMPAT) == 0)

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -1450,13 +1450,12 @@ bool SurgeSynthProcessor::presetLoadFromLocation(uint32_t location_kind, const c
     return true;
 }
 
-extern void *getSurgePresetDiscoveryFactory();
-const void *clapJuceExtensionCustomFactory(const char *f)
+const void * JUCE_CALLTYPE clapJuceExtensionCustomFactory(const char *f)
 {
     if (strcmp(f, CLAP_PRESET_DISCOVERY_FACTORY_ID) == 0 ||
         strcmp(f, CLAP_PRESET_DISCOVERY_FACTORY_ID_COMPAT) == 0)
     {
-        return getSurgePresetDiscoveryFactory();
+        return SurgeSynthProcessor::getSurgePresetDiscoveryFactory();
     }
 
     return nullptr;

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -1430,6 +1430,37 @@ bool SurgeSynthProcessor::remoteControlsPageFill(
     }
     return true;
 }
+
+#endif
+
+#if HAS_CLAP_JUCE_EXTENSIONS
+
+bool SurgeSynthProcessor::presetLoadFromLocation(uint32_t location_kind, const char *location,
+                                                 const char * /*load_key*/) noexcept
+{
+    if (location_kind != CLAP_PRESET_DISCOVERY_LOCATION_FILE)
+        return false;
+
+    {
+        std::lock_guard<std::mutex> mg(surge->patchLoadSpawnMutex);
+        strncpy(surge->patchid_file, location, sizeof(surge->patchid_file));
+        surge->has_patchid_file = true;
+    }
+    surge->processAudioThreadOpsWhenAudioEngineUnavailable();
+    return true;
+}
+
+extern void *getSurgePresetDiscoveryFactory();
+const void *clapJuceExtensionCustomFactory(const char *f)
+{
+    if (strcmp(f, CLAP_PRESET_DISCOVERY_FACTORY_ID) == 0 ||
+        strcmp(f, CLAP_PRESET_DISCOVERY_FACTORY_ID_COMPAT) == 0)
+    {
+        return getSurgePresetDiscoveryFactory();
+    }
+
+    return nullptr;
+}
 #endif
 
 //==============================================================================

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -531,7 +531,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
 };
 
 #if HAS_CLAP_JUCE_EXTENSIONS
-extern const void * JUCE_CALLTYPE clapJuceExtensionCustomFactory(const char *);
+extern const void *JUCE_CALLTYPE clapJuceExtensionCustomFactory(const char *);
 #endif
 
 #endif // SURGE_SRC_SURGE_XT_SURGESYNTHPROCESSOR_H

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -522,12 +522,16 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
   public:
     std::unique_ptr<Surge::GUI::UndoManager> undoManager;
 
+#if HAS_CLAP_JUCE_EXTENSIONS
+    static const void *getSurgePresetDiscoveryFactory();
+#endif
+
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SurgeSynthProcessor)
 };
 
 #if HAS_CLAP_JUCE_EXTENSIONS
-extern const void *clapJuceExtensionCustomFactory(const char *);
+extern const void * JUCE_CALLTYPE clapJuceExtensionCustomFactory(const char *);
 #endif
 
 #endif // SURGE_SRC_SURGE_XT_SURGESYNTHPROCESSOR_H

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -489,6 +489,10 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
                            uint32_t & /*pageID*/, juce::String & /*pageName*/,
                            std::array<juce::AudioProcessorParameter *, CLAP_REMOTE_CONTROLS_COUNT>
                                & /*params*/) noexcept override;
+
+    bool supportsPresetLoad() const noexcept override { return true; }
+    bool presetLoadFromLocation(uint32_t /*location_kind*/, const char * /*location*/,
+                                const char * /*load_key*/) noexcept override;
 #endif
 
   private:
@@ -521,5 +525,9 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SurgeSynthProcessor)
 };
+
+#if HAS_CLAP_JUCE_EXTENSIONS
+extern const void *clapJuceExtensionCustomFactory(const char *);
+#endif
 
 #endif // SURGE_SRC_SURGE_XT_SURGESYNTHPROCESSOR_H


### PR DESCRIPTION
- Move to clap 1.2.0 for clap-juce-extensions and so on
- As a result, implement the now non-draft preset-discovery API so surge exposes presets to bitwig, MTS, etc...
- And implement the non-draft preset-load API so bitwig, MTS etc can force surge to load
- Add an optimization i found in preset discovery to the patch db scanner also, reducing SQlite rebuild time

Closes #7269