### PR TITLE
Add an OSC Settings Window which doesn't work yet

### DIFF
--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -139,6 +139,7 @@ target_sources(${PROJECT_NAME} PRIVATE
   gui/overlays/TypeinParamEditor.h
   gui/overlays/WaveShaperAnalysis.cpp
   gui/overlays/WaveShaperAnalysis.h
+  gui/overlays/OpenSoundControlSettings.cpp
   gui/widgets/EffectChooser.cpp
   gui/widgets/EffectChooser.h
   gui/widgets/EffectLabel.h

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -395,6 +395,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         OSCILLOSCOPE,
         KEYBINDINGS_EDITOR,
         ACTION_HISTORY,
+        OPEN_SOUND_CONTROL_SETTINGS,
 
         n_overlay_tags,
     };

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -1718,6 +1718,10 @@ juce::PopupMenu SurgeGUIEditor::makeOSCMenu(const juce::Point<int> &where)
     auto des = &(synth->storage.getPatch().dawExtraState);
     auto oscSubMenu = juce::PopupMenu();
 
+    oscSubMenu.addItem("Show OSC Settings Screen",
+                       [this]() { showOverlay(OPEN_SOUND_CONTROL_SETTINGS); });
+    oscSubMenu.addSeparator();
+
     if (storage->oscListenerRunning || storage->oscSending)
     {
         oscSubMenu.addItem(Surge::GUI::toOSCase("Stop OSC Connections"), [this]() {

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -32,6 +32,7 @@
 #include "overlays/Oscilloscope.h"
 #include "overlays/OverlayWrapper.h"
 #include "overlays/KeyBindingsOverlay.h"
+#include "overlays/OpenSoundControlSettings.h"
 #include "widgets/MainFrame.h"
 #include "widgets/WaveShaperSelector.h"
 #include "UserDefaults.h"
@@ -283,6 +284,24 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
     {
         return makeStorePatchDialog();
     }
+
+    case OPEN_SOUND_CONTROL_SETTINGS:
+    {
+        auto te = std::make_unique<Surge::Overlays::OpenSoundControlSettings>();
+
+        te->setStorage(&(this->synth->storage));
+        te->setSurgeGUIEditor(this);
+        te->setSkin(currentSkin, bitmapStore);
+        te->setEnclosingParentTitle("Open Sound Control Settings");
+
+        auto posRect =
+            juce::Rectangle<int>(0, 0, 500, 230).withCentre(frame->getBounds().getCentre());
+
+        te->setEnclosingParentPosition(posRect);
+
+        return te;
+    }
+    break;
 
     case TUNING_EDITOR:
     {

--- a/src/surge-xt/gui/overlays/OpenSoundControlSettings.cpp
+++ b/src/surge-xt/gui/overlays/OpenSoundControlSettings.cpp
@@ -1,0 +1,318 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#include "OpenSoundControlSettings.h"
+#include "RuntimeFont.h"
+#include "SurgeGUIEditor.h"
+#include "SurgeGUIUtils.h"
+#include "widgets/TypeAheadTextEditor.h"
+#include "widgets/SurgeTextButton.h"
+#include "AccessibleHelpers.h"
+
+namespace Surge
+{
+namespace Overlays
+{
+
+OpenSoundControlSettings::OpenSoundControlSettings()
+{
+    setAccessible(true);
+    setWantsKeyboardFocus(true);
+
+    auto makeEd = [this](const std::string &n) {
+        auto ed = std::make_unique<juce::TextEditor>(n);
+        ed->setJustification(juce::Justification::centredLeft);
+        ed->setWantsKeyboardFocus(true);
+        Surge::Widgets::fixupJuceTextEditorAccessibility(*ed);
+        ed->setTitle(n);
+        ed->setSelectAllWhenFocused(true);
+        ed->setWantsKeyboardFocus(true);
+        addAndMakeVisible(*ed);
+        return std::move(ed);
+    };
+
+    inPort = makeEd("In Port");
+    inPort->addListener(this);
+    addAndMakeVisible(*inPort);
+
+    inPortL = std::make_unique<juce::Label>("In Port", "In Port");
+    addAndMakeVisible(*inPortL);
+
+    inPortReset = std::make_unique<Widgets::SurgeTextButton>("Reset In Port");
+    inPortReset->addListener(this);
+    addAndMakeVisible(*inPortReset);
+
+    outPort = makeEd("Out Port");
+    outPort->setText("456 fixme");
+    outPort->addListener(this);
+    addAndMakeVisible(*outPort);
+
+    outPortL = std::make_unique<juce::Label>("Out Port", "Out Port");
+    addAndMakeVisible(*outPortL);
+
+    outPortReset = std::make_unique<Widgets::SurgeTextButton>("Reset Out Port");
+    outPortReset->addListener(this);
+    addAndMakeVisible(*outPortReset);
+
+    outIP = makeEd("Out IP");
+    outIP->setText("780 fixme");
+    outIP->addListener(this);
+    addAndMakeVisible(*outIP);
+
+    outIPL = std::make_unique<juce::Label>("Out IP", "Out IP");
+    addAndMakeVisible(*outIPL);
+
+    outIPReset = std::make_unique<Widgets::SurgeTextButton>("Reset IP");
+    outIPReset->addListener(this);
+    addAndMakeVisible(*outIPReset);
+
+    enableIn = std::make_unique<juce::ToggleButton>("Enable OSC In");
+    enableIn->addListener(this);
+    addAndMakeVisible(*enableIn);
+
+    enableOut = std::make_unique<juce::ToggleButton>("Enable OSC Out");
+    enableOut->addListener(this);
+    addAndMakeVisible(*enableOut);
+
+    showSpec = std::make_unique<Widgets::SurgeTextButton>("Show Open Sound Control Spec");
+    showSpec->addListener(this);
+    addAndMakeVisible(*showSpec);
+
+    OSCHeader = std::make_unique<juce::Label>("OSC Header", "Open Sound Control Settings");
+    OSCHeader->setJustificationType(juce::Justification::centredTop);
+    addAndMakeVisible(*OSCHeader);
+}
+
+OpenSoundControlSettings::~OpenSoundControlSettings() = default;
+
+void OpenSoundControlSettings::setStorage(SurgeStorage *s) { storage = s; }
+
+void OpenSoundControlSettings::paint(juce::Graphics &g)
+{
+    g.fillAll(skin->getColor(Colors::Dialog::Background));
+}
+
+void OpenSoundControlSettings::setSurgeGUIEditor(SurgeGUIEditor *e)
+{
+    editor = e;
+    setValuesFromEditor();
+}
+
+void OpenSoundControlSettings::shownInParent()
+{
+    if (inPort && inPort->isShowing())
+    {
+        inPort->grabKeyboardFocus();
+    }
+}
+
+void OpenSoundControlSettings::onSkinChanged()
+{
+    auto resetColors = [this](const auto &typein) {
+        typein->setFont(skin->getFont(Fonts::PatchStore::TextEntry));
+        typein->setColour(juce::TextEditor::backgroundColourId,
+                          skin->getColor(Colors::Dialog::Entry::Background));
+        typein->setColour(juce::TextEditor::textColourId,
+                          skin->getColor(Colors::Dialog::Entry::Text));
+        typein->setColour(juce::TextEditor::highlightedTextColourId,
+                          skin->getColor(Colors::Dialog::Entry::Text));
+        typein->setColour(juce::TextEditor::highlightColourId,
+                          skin->getColor(Colors::Dialog::Entry::Focus));
+        typein->setColour(juce::TextEditor::outlineColourId,
+                          skin->getColor(Colors::Dialog::Entry::Border));
+        typein->setColour(juce::TextEditor::focusedOutlineColourId,
+                          skin->getColor(Colors::Dialog::Entry::Border));
+
+        typein->applyColourToAllText(skin->getColor(Colors::Dialog::Entry::Text));
+    };
+
+    auto resetLabel = [this](const auto &label) {
+        label->setFont(skin->getFont(Fonts::PatchStore::Label));
+        label->setColour(juce::Label::textColourId, skin->getColor(Colors::Dialog::Label::Text));
+        label->setJustificationType(juce::Justification::centred);
+    };
+
+    resetColors(inPort);
+    resetColors(outPort);
+    resetColors(outIP);
+
+    resetLabel(inPortL);
+    resetLabel(outPortL);
+    resetLabel(outIPL);
+    resetLabel(OSCHeader);
+    OSCHeader->setFont(OSCHeader->getFont().withHeight(30));
+
+    enableIn->setColour(juce::ToggleButton::tickDisabledColourId,
+                        skin->getColor(Colors::Dialog::Checkbox::Border));
+    enableIn->setColour(juce::ToggleButton::tickColourId,
+                        skin->getColor(Colors::Dialog::Checkbox::Tick));
+
+    enableOut->setColour(juce::ToggleButton::tickDisabledColourId,
+                         skin->getColor(Colors::Dialog::Checkbox::Border));
+    enableOut->setColour(juce::ToggleButton::tickColourId,
+                         skin->getColor(Colors::Dialog::Checkbox::Tick));
+
+    inPortReset->setSkin(skin, associatedBitmapStore);
+    outPortReset->setSkin(skin, associatedBitmapStore);
+    outIPReset->setSkin(skin, associatedBitmapStore);
+    showSpec->setSkin(skin, associatedBitmapStore);
+}
+
+void OpenSoundControlSettings::resized()
+{
+
+    // overall size set in SurgeGUIEditorOverlays.cpp when created
+    auto uheight = 25;
+    auto ushift = 28;
+    auto col = getLocalBounds().withTrimmedTop(50).reduced(20, 0);
+    col = col.withWidth(col.getWidth() / 3);
+
+    OSCHeader->setBounds(getLocalBounds().withHeight(30).translated(0, 3));
+
+    {
+        auto lcol = col.withHeight(uheight).reduced(5, 0);
+        enableIn->setBounds(lcol);
+        lcol = lcol.translated(0, ushift);
+        inPortL->setBounds(lcol);
+        lcol = lcol.translated(0, ushift);
+        inPort->setBounds(lcol);
+        inPort->setIndents(4, (inPort->getHeight() - inPort->getTextHeight()) / 2);
+
+        lcol = lcol.translated(0, ushift);
+        inPortReset->setBounds(lcol);
+    }
+
+    col = col.translated(col.getWidth(), 0);
+    {
+        auto lcol = col.withHeight(uheight).reduced(5, 0);
+        enableOut->setBounds(lcol);
+        lcol = lcol.translated(0, ushift);
+        outPortL->setBounds(lcol);
+        lcol = lcol.translated(0, ushift);
+        outPort->setBounds(lcol);
+        outPort->setIndents(4, (outPort->getHeight() - outPort->getTextHeight()) / 2);
+
+        lcol = lcol.translated(0, ushift);
+        outPortReset->setBounds(lcol);
+    }
+
+    col = col.translated(col.getWidth(), 0);
+    {
+        auto lcol = col.withHeight(uheight).reduced(5, 0);
+        lcol = lcol.translated(0, ushift);
+        outIPL->setBounds(lcol);
+        lcol = lcol.translated(0, ushift);
+        outIP->setBounds(lcol);
+        outIP->setIndents(4, (outIP->getHeight() - outIP->getTextHeight()) / 2);
+
+        lcol = lcol.translated(0, ushift);
+        outIPReset->setBounds(lcol);
+    }
+
+    auto spec = getLocalBounds().withHeight(uheight).translated(0, 6 * ushift).reduced(40, 0);
+    showSpec->setBounds(spec);
+}
+
+void OpenSoundControlSettings::setValuesFromEditor()
+{
+    if (!editor)
+        return;
+
+    enableIn->setToggleState(editor->synth->storage.oscListenerRunning, juce::dontSendNotification);
+    enableOut->setToggleState(editor->synth->storage.oscSending, juce::dontSendNotification);
+
+    inPort->setText(std::to_string(editor->synth->storage.oscPortIn), juce::dontSendNotification);
+    outPort->setText(std::to_string(editor->synth->storage.oscPortOut), juce::dontSendNotification);
+    outIP->setText(editor->synth->storage.oscOutIP, juce::dontSendNotification);
+}
+
+#define LOG_CALLBACK std::cout << "OpenSoundControlSettings.cpp:" << __LINE__ << " "
+
+void OpenSoundControlSettings::buttonClicked(juce::Button *button)
+{
+    if (!editor)
+        return;
+
+    if (!storage)
+        return;
+
+    auto synth = editor->synth;
+
+    if (button == enableIn.get())
+    {
+        LOG_CALLBACK << "enableIn is now " << (enableIn->getToggleState() ? "on" : "off")
+                     << std::endl;
+    }
+    if (button == enableOut.get())
+    {
+        LOG_CALLBACK << "enableOut is now " << (enableOut->getToggleState() ? "on" : "off")
+                     << std::endl;
+    }
+
+    if (button == inPortReset.get())
+    {
+        LOG_CALLBACK << "Reset IN Port" << std::endl;
+        // probably want to do something like set it up then setValuesFromEditor() after you do here
+    }
+    if (button == outPortReset.get())
+    {
+        LOG_CALLBACK << "Reset Out Port" << std::endl;
+    }
+    if (button == outIPReset.get())
+    {
+        LOG_CALLBACK << "Reset Out IP" << std::endl;
+    }
+
+    if (button == showSpec.get())
+    {
+        LOG_CALLBACK << "Show Spec" << std::endl;
+    }
+}
+
+void OpenSoundControlSettings::textEditorTextChanged(juce::TextEditor &ed)
+{
+    if (!editor)
+        return;
+
+    if (!storage)
+        return;
+
+    auto synth = editor->synth;
+
+    if (&ed == inPort.get())
+    {
+        LOG_CALLBACK << "inPort changed to '" << inPort->getText() << "'" << std::endl;
+    }
+
+    if (&ed == outPort.get())
+    {
+        LOG_CALLBACK << "outPort changed to '" << outPort->getText() << "'" << std::endl;
+    }
+
+    if (&ed == outIP.get())
+    {
+        LOG_CALLBACK << "outIP changed to '" << outIP->getText() << "'" << std::endl;
+    }
+}
+
+} // namespace Overlays
+} // namespace Surge

--- a/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
+++ b/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
@@ -1,0 +1,81 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#ifndef SURGE_SRC_SURGE_XT_GUI_OVERLAYS_OpenSoundControlSettings_H
+#define SURGE_SRC_SURGE_XT_GUI_OVERLAYS_OpenSoundControlSettings_H
+
+#include "SkinSupport.h"
+#include "SurgeStorage.h"
+
+#include "juce_gui_basics/juce_gui_basics.h"
+#include "OverlayComponent.h"
+
+class SurgeGUIEditor;
+class SurgeStorage;
+
+namespace Surge
+{
+namespace Widgets
+{
+struct SurgeTextButton;
+}
+namespace Overlays
+{
+struct OpenSoundControlSettings : public OverlayComponent,
+                                  public Surge::GUI::SkinConsumingComponent,
+                                  public juce::Button::Listener,
+                                  public juce::TextEditor::Listener
+{
+    OpenSoundControlSettings();
+    ~OpenSoundControlSettings();
+    void paint(juce::Graphics &g) override;
+    void resized() override;
+    void shownInParent() override;
+
+    SurgeGUIEditor *editor{nullptr};
+    void setSurgeGUIEditor(SurgeGUIEditor *e);
+
+    SurgeStorage *storage{nullptr};
+    void setStorage(SurgeStorage *s);
+
+    void onSkinChanged() override;
+    void buttonClicked(juce::Button *button) override;
+    void textEditorTextChanged(juce::TextEditor &) override;
+
+    std::unique_ptr<juce::TextEditor> inPort, outPort, outIP;
+    std::unique_ptr<juce::Label> inPortL, outPortL, outIPL;
+    std::unique_ptr<Widgets::SurgeTextButton> inPortReset, outPortReset, outIPReset;
+
+    std::unique_ptr<Widgets::SurgeTextButton> showSpec;
+    std::unique_ptr<juce::Label> OSCHeader;
+
+    std::unique_ptr<juce::ToggleButton> enableOut, enableIn;
+
+    std::unique_ptr<juce::Label> headerLabel;
+
+    void setValuesFromEditor();
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OpenSoundControlSettings);
+};
+} // namespace Overlays
+} // namespace Surge
+#endif // SURGE_XT_OpenSoundControlSettings_H

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -273,6 +273,8 @@ void PatchStoreDialog::onSkinChanged()
                           skin->getColor(Colors::Dialog::Entry::Border));
         typein->setColour(juce::TextEditor::focusedOutlineColourId,
                           skin->getColor(Colors::Dialog::Entry::Border));
+
+        typein->applyColourToAllText(skin->getColor(Colors::Dialog::Entry::Text));
     };
 
     auto resetLabel = [this](const auto &label) {


### PR DESCRIPTION
1. Add an OSC Settings Window per the spec in #7472
2. Make each of the edits and callbacks print with a line number
3. Add some hints as to what they shoudl do
4. Make sure when you open you read; support skins. etc...