### PR TITLE
Don't build Lua tests if Lua not available

### DIFF
--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -39,6 +39,8 @@
 
 #include "lua/LuaSources.h"
 
+#if HAS_LUA
+
 TEST_CASE("Lua Hello World", "[lua]")
 {
     SECTION("Hello World")
@@ -968,3 +970,5 @@ TEST_CASE("Two Surge XTs", "[formula]")
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Building Surge without Lua using `-DSURGE_SKIP_LUA=ON` results in an error because [UnitTestsLUA.cpp](https://github.com/surge-synthesizer/surge/blob/1ddf4df83c642d9da4b16a5d6483732e502275ad/src/surge-testrunner/UnitTestsLUA.cpp) is still compiled and tries to use Lua. Following other files like [LuaSupport.cpp](https://github.com/surge-synthesizer/surge/blob/1ddf4df83c642d9da4b16a5d6483732e502275ad/src/common/LuaSupport.cpp#L49), this PR adds a preprocessor guard to check for `HAS_LUA` first.