### PR TITLE
Clean up surge voice dstructor path; fixes windows leak

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -133,7 +133,20 @@ float SurgeVoice::channelKeyEquvialent(float key, int channel, bool isMpeEnabled
     return res;
 }
 
-SurgeVoice::SurgeVoice() {}
+// This is super useful for debugging placement new issues. Please leave it here until
+// we stabilize 1.3.1 at least
+// #define VOICE_LIFETIME_DEBUG 1
+#ifdef VOICE_LIFETIME_DEBUG
+int voiceCDCount{0};
+#endif
+
+SurgeVoice::SurgeVoice()
+{
+#ifdef VOICE_LIFETIME_DEBUG
+    voiceCDCount++;
+    std::cout << "Calling SurgeVoice CTOR NoArg " << voiceCDCount << std::endl;
+#endif
+}
 
 SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *params, int key,
                        int velocity, int channel, int scene_id, float detune,
@@ -143,6 +156,10 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
                        float fegStart)
 //: fb(storage,oscene)
 {
+#ifdef VOICE_LIFETIME_DEBUG
+    voiceCDCount++;
+    std::cout << "Calling SurgeVoice CTOR FullArg " << voiceCDCount << std::endl;
+#endif
     // assign pointers
     this->storage = storage;
     this->scene = oscene;
@@ -362,7 +379,13 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
     switch_toggled();
 }
 
-SurgeVoice::~SurgeVoice() {}
+SurgeVoice::~SurgeVoice()
+{
+#ifdef VOICE_LIFETIME_DEBUG
+    voiceCDCount--;
+    std::cout << "Calling SurgeVoice DTOR " << voiceCDCount << std::endl;
+#endif
+}
 
 void SurgeVoice::legato(int key, int velocity, char detune)
 {

--- a/src/common/dsp/modulators/FormulaModulationHelper.cpp
+++ b/src/common/dsp/modulators/FormulaModulationHelper.cpp
@@ -385,7 +385,7 @@ end
     s.tempo = 120;
 
     if (s.raisedError)
-        std::cout << "ERROR: " << s.error << std::endl;
+        std::cout << "ERROR: " << *(s.error) << std::endl;
 #endif
 
     return true;

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -27,6 +27,7 @@
 #include "StringOps.h"
 #include "LuaSupport.h"
 #include <variant>
+#include <memory>
 
 class SurgeVoice;
 
@@ -70,17 +71,20 @@ struct EvaluatorState
     // patch features
     float macrovalues[n_customcontrollers];
 
-    std::string error;
+    std::unique_ptr<std::string> error;
     bool raisedError = false;
     void adderror(const std::string &msg)
     {
-        error += msg;
+        if (!error)
+            error = std::make_unique<std::string>();
+
+        *error += msg;
         raisedError = true;
     }
 
     int activeoutputs;
 
-    lua_State *L; // This is assigned by prepareForEvaluation to be one per thread
+    lua_State *L{nullptr}; // This is assigned by prepareForEvaluation to be one per thread
 };
 
 void setupStorage(SurgeStorage *s);

--- a/src/common/dsp/modulators/LFOModulationSource.cpp
+++ b/src/common/dsp/modulators/LFOModulationSource.cpp
@@ -1228,8 +1228,8 @@ void LFOModulationSource::process_block()
 
         if (formulastate.raisedError)
         {
-            auto em = formulastate.error;
-            formulastate.error = "";
+            auto em = *formulastate.error;
+            formulastate.error.reset();
             formulastate.raisedError = false;
             storage->reportError(em, "Formula Evaluator Error");
             std::cout << "ERROR: " << em << std::endl;


### PR DESCRIPTION
~SurgeVoice was not getting called reliably for voices which were created anew. On windows, since the forumla evaluator contains a std::string and msft allocates that even for empty, that lead to a small per voice leak.

This fixes the issue in two ways

1. It makes sure that the placement new constructor and destructor calls match. Especially since the voice storage is now in a std::array so it is destroyed at exit and constructed at startup, we add two calls to ~SurgeVoice and one to ::SurgeVoice()
2. That string shouldn't be a member anyway. Its only on the lua error path where things are already breaking various realtime rules. So make it a unique ptr and alloc it explicitly only if needed and reset it once consumed

Addresses #7478