### PR TITLE
Changed disabled button appearance. OSC spec tweak.

### DIFF
--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -405,7 +405,7 @@
 
                     <div style="clear: both;"></div>
 
-                    <div style="width: 1130px; margin: 0 0 32px 10px; line-height: 1.75">
+                    <div style="width: 1130px; margin: 0 0 16px 10px; line-height: 1.75">
                          <span><code>/patch/load /Library/Application Support/Surge XT/patches_factory/Plucks/Clean</code></span>
                          <span><code>/patch/save</code></span>
                          <span><code>/patch/incr</code></span>

--- a/src/surge-xt/gui/widgets/SurgeTextButton.cpp
+++ b/src/surge-xt/gui/widgets/SurgeTextButton.cpp
@@ -57,7 +57,7 @@ void SurgeTextButton::paint(juce::Graphics &g)
 
     if (!isEn)
     {
-        // fg = juce::Colour(skin->getColor(clr::DeactivatedText));
+        fg = fg.withAlpha(0.5f);
     }
     else if (isPr)
     {


### PR DESCRIPTION
Disabled buttons now have  0.5 alpha, so that they look 'grayed out'.