### PR TITLE
Additional OSC port input error checking

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -288,11 +288,12 @@ void SurgeSynthProcessor::initOSCError(int port, std::string outIP)
     msg << "Surge XT was unable to connect to OSC port " << port;
     if (!outIP.empty())
     {
-        msg << "; at IP Address " << outIP;
+        msg << " at IP Address " << outIP;
     }
 
-    msg << "\n"
-        << "Either it is not a valid port, or it may be in use by another application.";
+    msg << ".\n"
+        << "Either it is not a valid port, or it is already used by Surge XT or another "
+           "application.";
 
     surge->storage.reportError(msg.str(), "OSC Initialization Error");
 };

--- a/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
+++ b/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
@@ -78,6 +78,7 @@ struct OpenSoundControlSettings : public OverlayComponent,
 
     int validPort(std::string portStr, std::string type);
     bool validateIPString(std::string ipStr);
+    void validateInputs(juce::TextEditor &);
 
     std::unique_ptr<juce::TextEditor> inPort, outPort, outIP;
     std::unique_ptr<juce::Label> inL, outL, outIPL;

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -95,7 +95,7 @@ void OpenSoundControl::tryOSCStartup()
 
 bool OpenSoundControl::initOSCIn(int port)
 {
-    if (port < 1)
+    if (port < 1 || port == oportnum)
     {
         return false;
     }
@@ -872,7 +872,7 @@ void OpenSoundControl::oscBundleReceived(const juce::OSCBundle &bundle)
 
 bool OpenSoundControl::initOSCOut(int port, std::string ipaddr)
 {
-    if (port < 1)
+    if (port < 1 || port == iportnum)
     {
         return false;
     }


### PR DESCRIPTION
Disallow OSC in and out ports to be the same.
Only allow numbers (and numbers+dot for IP) in text input fields. Refactor input validation happening on text editor focus lost into a separate method and use it when pressing Enter in text input fields, as well