### PR TITLE
Optionally have Overlays not persist on Create/Destroy

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6133,7 +6133,7 @@ void SurgeGUIEditor::populateDawExtraState(SurgeSynthesizer *synth)
     {
         auto olw = getOverlayWrapperIfOpen(ol.first);
 
-        if (olw)
+        if (olw && olw->getRetainOpenStateOnEditorRecreate())
         {
             DAWExtraStateStorage::EditorState::OverlayState os;
 

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -613,6 +613,7 @@ Surge::Overlays::OverlayWrapper *SurgeGUIEditor::addJuceEditorOverlay(
     {
         ol->setCanTearOut(olc->getCanTearOut());
         ol->setCanTearOutResize(olc->getCanTearOutResize());
+        ol->setRetainOpenStateOnEditorRecreate(olc->getRetainOpenStateOnEditorRecreate());
     }
 
     ol->addAndTakeOwnership(std::move(c));

--- a/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
+++ b/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
@@ -91,6 +91,8 @@ struct OpenSoundControlSettings : public OverlayComponent,
 
     void setValuesFromEditor();
 
+    bool getRetainOpenStateOnEditorRecreate() override { return false; }
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OpenSoundControlSettings);
 };
 } // namespace Overlays

--- a/src/surge-xt/gui/overlays/OverlayComponent.h
+++ b/src/surge-xt/gui/overlays/OverlayComponent.h
@@ -91,6 +91,12 @@ struct OverlayComponent : juce::Component
     Surge::Storage::DefaultKey getMoveAroundKey() { return canMoveAround.second; }
 
     /*
+     * Use this as 'true' for 'transient' dialogs like settings which
+     * shouldn't persist across editor sessions
+     */
+    virtual bool getRetainOpenStateOnEditorRecreate() { return true; }
+
+    /*
      * If you want to chicken box the close, return a message from here. The pair
      * is the OK/Cancel title and message, respectively. If you are ok to close,
      * return std::nullopt, which is the default behavior.

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -126,6 +126,10 @@ struct OverlayWrapper : public juce::Component,
     bool showCloseButton{true};
     void setShowCloseButton(bool b) { showCloseButton = b; }
 
+    bool retainOnRecreate{true};
+    bool getRetainOpenStateOnEditorRecreate() { return retainOnRecreate; }
+    void setRetainOpenStateOnEditorRecreate(bool b) { retainOnRecreate = b; }
+
     void onClose();
 
     std::function<void()> closeOverlay = []() {};


### PR DESCRIPTION
And use this for the OSC settings dialog, which is more transient than the other overlays.

Closes #7498