### PR TITLE
Alert OK/Cancel box responds to enter/esc at top level

### DIFF
--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -176,7 +176,26 @@ void Alert::buttonClicked(juce::Button *button)
 void Alert::visibilityChanged()
 {
     if (isVisible())
+    {
         grabKeyboardFocus();
+    }
+}
+
+bool Alert::keyPressed(const juce::KeyPress &press)
+{
+    if (press == juce::KeyPress::escapeKey)
+    {
+        buttonClicked(cancelButton.get());
+        return true;
+    }
+
+    if (press == juce::KeyPress::returnKey)
+    {
+        buttonClicked(okButton.get());
+        return true;
+    }
+
+    return false;
 }
 
 void Alert::setWindowTitle(const std::string &t)

--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -76,6 +76,8 @@ struct Alert : public Surge::Overlays::OverlayComponent,
 
     void visibilityChanged() override;
 
+    bool keyPressed(const juce::KeyPress &press) override;
+
     /*
      * Alerts should use default focus order not the wonky tag first and
      * then description and so on order for the main frame (which is laying out controls


### PR DESCRIPTION
So you don't have to tab to the buttons to activate them

Closes #7495