### PR TITLE
Store Last Loaded Path in DES

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2952,6 +2952,12 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 dawExtraState.isDirty = ival;
             }
 
+            p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("lastLoadedPath"));
+            if (p && p->Attribute("v"))
+            {
+                dawExtraState.lastLoadedPatch = fs::path{p->Attribute("v")};
+            }
+
             p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("disconnectFromOddSoundMTS"));
             dawExtraState.disconnectFromOddSoundMTS = false;
 
@@ -3714,6 +3720,10 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         TiXmlElement isDi("isDirty");
         isDi.SetAttribute("v", dawExtraState.isDirty ? 1 : 0);
         dawExtraXML.InsertEndChild(isDi);
+
+        TiXmlElement llP("lastLoadedPath");
+        llP.SetAttribute("v", dawExtraState.lastLoadedPatch.u8string().c_str());
+        dawExtraXML.InsertEndChild(llP);
 
         TiXmlElement odS("disconnectFromOddSoundMTS");
         odS.SetAttribute("v", dawExtraState.disconnectFromOddSoundMTS ? 1 : 0);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -984,6 +984,8 @@ struct DAWExtraStateStorage
     std::string oscIPAddrOut{DEFAULT_OSC_IPADDR_OUT};
     bool oscStartIn{false};
     bool oscStartOut{false};
+
+    fs::path lastLoadedPatch{};
 };
 
 struct PatchTuningStorage

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4104,18 +4104,16 @@ void loadPatchInBackgroundThread(SurgeSynthesizer *sy)
     if (patchid >= 0)
     {
         Patch p = synth->storage.patch_list[synth->patchid];
-        synth->storage.lastLoadedPatch = p.path.replace_extension();
+        synth->storage.lastLoadedPatch = p.path;
         for (auto &it : synth->patchLoadedListeners)
-            (it.second)(p.path.replace_extension());
+            (it.second)(p.path);
     }
     if (had_patchid_file)
     {
-        synth->storage.lastLoadedPatch = ppath.replace_extension();
+        synth->storage.lastLoadedPatch = ppath;
         for (auto &it : synth->patchLoadedListeners)
-            (it.second)(ppath.replace_extension());
+            (it.second)(ppath);
     }
-
-    synth->storage.lastLoadedPatch = ppath;
 
     // Now we want to null out the patchLoadThread since everything is done
     auto myThread = std::move(synth->patchLoadThread);
@@ -4137,7 +4135,7 @@ void SurgeSynthesizer::processAudioThreadOpsWhenAudioEngineUnavailable(bool dang
         {
             loadPatch(patchid_queue);
             Patch p = storage.patch_list[patchid_queue];
-            storage.lastLoadedPatch = p.path.replace_extension();
+            storage.lastLoadedPatch = p.path;
             patchid_queue = -1;
         }
 
@@ -4160,12 +4158,12 @@ void SurgeSynthesizer::processAudioThreadOpsWhenAudioEngineUnavailable(bool dang
             {
                 loadPatch(ptid);
                 Patch patch = storage.patch_list[ptid];
-                storage.lastLoadedPatch = patch.path.replace_extension();
+                storage.lastLoadedPatch = patch.path;
             }
             else
             {
                 loadPatchByPath(patchid_file, -1, s.c_str());
-                storage.lastLoadedPatch = p.replace_extension();
+                storage.lastLoadedPatch = p;
             }
             patchid_file[0] = 0;
         }
@@ -4991,6 +4989,8 @@ void SurgeSynthesizer::populateDawExtraState()
 
     des.monoPedalMode = storage.monoPedalMode;
     des.oddsoundRetuneMode = storage.oddsoundRetuneMode;
+
+    des.lastLoadedPatch = storage.lastLoadedPatch;
 }
 
 void SurgeSynthesizer::loadFromDawExtraState()
@@ -5103,6 +5103,8 @@ void SurgeSynthesizer::loadFromDawExtraState()
             storage.controllers_chan[i] = des.customcontrol_chan_map[i];
         }
     }
+
+    storage.lastLoadedPatch = des.lastLoadedPatch;
 }
 
 void SurgeSynthesizer::swapMetaControllers(int c1, int c2)

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -556,7 +556,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     {
         if (querying)
         {
-            std::string patchpath = synth->storage.lastLoadedPatch.u8string();
+            std::string patchpath = synth->storage.lastLoadedPatch.replace_extension().u8string();
 
             if (!patchpath.empty())
             {
@@ -888,7 +888,8 @@ bool OpenSoundControl::initOSCOut(int port, std::string ipaddr)
     // Add listener for patch changes, to send new path to OSC output
     // This will run on the juce::MessageManager thread so as to
     // not tie up the patch loading thread.
-    synth->addPatchLoadedListener("OSC_OUT", [ssp = sspPtr](auto s) { ssp->patch_load_to_OSC(s); });
+    synth->addPatchLoadedListener(
+        "OSC_OUT", [ssp = sspPtr](auto s) { ssp->patch_load_to_OSC(s.replace_extension()); });
 
     // Add a listener for parameter changes
     sspPtr->addParamChangeListener("OSC_OUT",


### PR DESCRIPTION
This allows it to always be correct on restore from a DAW session etc... in all cases, including drag and drop and restore from DAW buffer stream.

Closes #7489