### PR TITLE
Add help button to OSC Settings dialog

### DIFF
--- a/resources/surge-shared/paramdocumentation.xml
+++ b/resources/surge-shared/paramdocumentation.xml
@@ -35,6 +35,7 @@
   <special id="action-history" help_url="#action-history"/>
   <special id="level-meter" help_url="#level-meter"/>
   <special id="oscilloscope" help_url="#oscilloscope"/>
+  <special id="opensound-settings" help_url="#osc-settings"/>
 
   <!-- Params for CG 0 -->
   <param id="filter.balance" help_url="#filter-controls"/>

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -296,7 +296,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         te->setEnclosingParentTitle("Open Sound Control Settings");
 
         auto posRect =
-            juce::Rectangle<int>(0, 0, 320, 140).withCentre(frame->getBounds().getCentre());
+            juce::Rectangle<int>(0, 0, 300, 140).withCentre(frame->getBounds().getCentre());
 
         te->setEnclosingParentPosition(posRect);
 

--- a/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
+++ b/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
@@ -82,12 +82,9 @@ struct OpenSoundControlSettings : public OverlayComponent,
 
     std::unique_ptr<juce::TextEditor> inPort, outPort, outIP;
     std::unique_ptr<juce::Label> inL, outL, outIPL;
-    std::unique_ptr<Widgets::SurgeTextButton> inPortReset, outPortReset, outIPReset, apply, ok,
-        cancel;
-
+    std::unique_ptr<Widgets::SurgeTextButton> inPortReset, outPortReset, outIPReset, help, apply,
+        ok, cancel;
     std::unique_ptr<juce::ToggleButton> enableOut, enableIn;
-
-    std::unique_ptr<juce::Label> headerLabel;
 
     void setValuesFromEditor();
 

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -145,6 +145,7 @@ PatchStoreDialog::PatchStoreDialog()
         auto ed = std::make_unique<juce::TextEditor>(n);
         ed->setJustification(juce::Justification::centredLeft);
         ed->setWantsKeyboardFocus(true);
+        ed->addListener(this);
         Surge::Widgets::fixupJuceTextEditorAccessibility(*ed);
         ed->setTitle(n);
         addAndMakeVisible(*ed);
@@ -170,6 +171,7 @@ PatchStoreDialog::PatchStoreDialog()
 
     ta->setJustification(juce::Justification::centredLeft);
     ta->setSelectAllWhenFocused(true);
+    ta->addListener(this);
     ta->setToElementZeroOnReturn = true;
 
     catEd = std::move(ta);
@@ -255,6 +257,16 @@ void PatchStoreDialog::shownInParent()
     {
         nameEd->grabKeyboardFocus();
     }
+}
+
+void PatchStoreDialog::textEditorFocusLost(juce::TextEditor &ed)
+{
+    if (!editor || !storage)
+    {
+        return;
+    }
+
+    ed.setHighlightedRegion(juce::Range(-1, -1));
 }
 
 void PatchStoreDialog::onSkinChanged()

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.h
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.h
@@ -44,7 +44,8 @@ struct PatchStoreDialogCategoryProvider;
 
 struct PatchStoreDialog : public OverlayComponent,
                           public Surge::GUI::SkinConsumingComponent,
-                          public juce::Button::Listener
+                          public juce::Button::Listener,
+                          public juce::TextEditor::Listener
 {
     PatchStoreDialog();
     ~PatchStoreDialog();
@@ -88,6 +89,7 @@ struct PatchStoreDialog : public OverlayComponent,
     void setStoreTuningInPatch(const bool value);
 
     void onSkinChanged() override;
+    void textEditorFocusLost(juce::TextEditor &) override;
     void buttonClicked(juce::Button *button) override;
     std::unique_ptr<juce::TextEditor> nameEd, authorEd, catEd, licenseEd, tagEd, commentEd;
     std::unique_ptr<juce::Label> nameEdL, authorEdL, catEdL, licenseEdL, tagEdL, commentEdL;

--- a/src/surge-xt/gui/overlays/TuningOverlays.cpp
+++ b/src/surge-xt/gui/overlays/TuningOverlays.cpp
@@ -578,6 +578,7 @@ class RadialScaleGraph : public juce::Component,
                     te->setText(std::to_string(i), juce::NotificationType::dontSendNotification);
                     te->setEnabled(i != 0);
                     te->addListener(this);
+                    te->setSelectAllWhenFocused(true);
 
                     te->onEscapeKey = [this]() { giveAwayKeyboardFocus(); };
                     toneInterior->addAndMakeVisible(*te);
@@ -711,6 +712,7 @@ class RadialScaleGraph : public juce::Component,
 
   private:
     void textEditorReturnKeyPressed(juce::TextEditor &editor) override;
+    void textEditorFocusLost(juce::TextEditor &editor) override;
 
   public:
     virtual void paint(juce::Graphics &g) override;
@@ -2214,6 +2216,11 @@ void RadialScaleGraph::textEditorReturnKeyPressed(juce::TextEditor &editor)
     }
 }
 
+void RadialScaleGraph::textEditorFocusLost(juce::TextEditor &editor)
+{
+    editor.setHighlightedRegion(juce::Range(-1, -1));
+}
+
 struct SCLKBMDisplay : public juce::Component,
                        Surge::GUI::SkinConsumingComponent,
                        juce::TextEditor::Listener,
@@ -2254,12 +2261,16 @@ struct SCLKBMDisplay : public juce::Component,
         teProps(evenDivOf);
         evenDivOf->setText("2", juce::dontSendNotification);
         addAndMakeVisible(*evenDivOf);
+        evenDivOf->addListener(this);
+        evenDivOf->setSelectAllWhenFocused(true);
 
         evenDivIntoL = newL("into");
         evenDivInto = std::make_unique<juce::TextEditor>();
         teProps(evenDivInto);
         evenDivInto->setText("12", juce::dontSendNotification);
         addAndMakeVisible(*evenDivInto);
+        evenDivInto->addListener(this);
+        evenDivInto->setSelectAllWhenFocused(true);
 
         evenDivStepsL = newL("steps");
 
@@ -2311,18 +2322,24 @@ struct SCLKBMDisplay : public juce::Component,
         teProps(kbmStart);
         kbmStart->setText("60", juce::dontSendNotification);
         addAndMakeVisible(*kbmStart);
+        kbmStart->addListener(this);
+        kbmStart->setSelectAllWhenFocused(true);
 
         kbmConstantL = newL("Constant:");
         kbmConstant = std::make_unique<juce::TextEditor>();
         teProps(kbmConstant);
         kbmConstant->setText("69", juce::dontSendNotification);
         addAndMakeVisible(*kbmConstant);
+        kbmConstant->addListener(this);
+        kbmConstant->setSelectAllWhenFocused(true);
 
         kbmFreqL = newL("Freq:");
         kbmFreq = std::make_unique<juce::TextEditor>();
         teProps(kbmFreq);
         kbmFreq->setText("440", juce::dontSendNotification);
         addAndMakeVisible(*kbmFreq);
+        kbmFreq->addListener(this);
+        kbmFreq->setSelectAllWhenFocused(true);
 
         kbmGo = std::make_unique<Surge::Widgets::SelfDrawButton>("Generate");
         kbmGo->setStorage(overlay->storage);
@@ -2555,6 +2572,10 @@ struct SCLKBMDisplay : public juce::Component,
     }
 
     void textEditorTextChanged(juce::TextEditor &editor) override { setApplyEnabled(true); }
+    void textEditorFocusLost(juce::TextEditor &editor) override
+    {
+        editor.setHighlightedRegion(juce::Range(-1, -1));
+    }
 
     void onSkinChanged() override
     {
@@ -2602,7 +2623,7 @@ struct SCLKBMDisplay : public juce::Component,
                          skin->getColor(qclr::ToneLabelText));
             r->applyColourToAllText(skin->getColor(qclr::ToneLabelText), true);
 
-            // Work around a buglet that the text editor applies fonts ontly to newly inserted
+            // Work around a buglet that the text editor applies fonts only to newly inserted
             // text after setFont
             auto t = r->getText();
             r->setText("--", juce::dontSendNotification);


### PR DESCRIPTION
Also make it so that juce::TextEditors in OSC Settings, Patch Store dialog and Tuning Editor get their selection removed on losing focus, which removes the vestigial 50% opaque selection rect that is annoying. This still needs to be done for Category typeahead in Patch Store dialog, because it's a different widget.