### PR TITLE
Do the same select trick on TypeAhead

### DIFF
--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -457,6 +457,8 @@ void TypeAhead::focusLost(juce::Component::FocusChangeType type)
     {
         l->typeaheadCanceled();
     }
+
+    setHighlightedRegion(juce::Range(-1, -1));
 }
 } // namespace Widgets
 } // namespace Surge


### PR DESCRIPTION
to avoid the remnant highlighted when not focused in the juce text editor which is somewhat annoysome