### PR TITLE
Implementing sampleRateReset() for BBDEnsembleEffect

### DIFF
--- a/src/common/dsp/effects/BBDEnsembleEffect.h
+++ b/src/common/dsp/effects/BBDEnsembleEffect.h
@@ -74,6 +74,7 @@ class BBDEnsembleEffect : public Effect
     virtual ~BBDEnsembleEffect();
     virtual const char *get_effectname() override { return "Ensemble"; }
     virtual void init() override;
+    virtual void sampleRateReset() override;
     virtual void process(float *dataL, float *dataR) override;
     virtual void suspend() override;
     void setvars(bool init);


### PR DESCRIPTION
Resolves #7519.

Re-initializes everything in the effect that is sample-rate dependent. I wasn't noticing the bug originally when testing in Bitwig, since Bitwig was re-instantiating the entire plugin when the sample rate changed.

@Andreya-Autumn if you have a chance to test this branch, that would be very helpful!

@baconpaul thanks for the clue about `sampleRateReset()`.