### PR TITLE
Global (so SLFO -> Effect) modulators use index correctly

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4361,11 +4361,14 @@ void SurgeSynthesizer::processControl()
     for (int i = 0; i < n; i++)
     {
         int src_id = storage.getPatch().modulation_global[i].source_id;
+        int src_index = storage.getPatch().modulation_global[i].source_index;
         int dst_id = storage.getPatch().modulation_global[i].destination_id;
         float depth = storage.getPatch().modulation_global[i].depth;
         int source_scene = storage.getPatch().modulation_global[i].source_scene;
+
         storage.getPatch().globaldata[dst_id].f +=
-            depth * storage.getPatch().scene[source_scene].modsources[src_id]->get_output(0) *
+            depth *
+            storage.getPatch().scene[source_scene].modsources[src_id]->get_output(src_index) *
             (1 - storage.getPatch().modulation_global[i].muted);
     }
 


### PR DESCRIPTION
Global (SLFO->Effect for instance) modulations ignored the source index in the routing table, always picking index 0. This meant, for instance, an indexed formula modulator couldn't modulate an effect reliably (it always picked output 0) and also things like env/wav would not work on regular lfos. Also fix edge case with formula to mseg overlay swap Fix an edge-case crash in Formula Modulator Debugger on MSEG Swap