### PR TITLE
Set tuning radial 'stretch' lower bound to 100cents

### DIFF
--- a/src/surge-xt/gui/overlays/TuningOverlays.cpp
+++ b/src/surge-xt/gui/overlays/TuningOverlays.cpp
@@ -3028,6 +3028,13 @@ void TuningOverlay::onScaleRescaled(double scaleBy)
     double sFactor = (tCents + 1) / tCents - 1;
 
     double scale = (1.0 + sFactor * scaleBy);
+    // smallest compression is 20 cents
+    static constexpr float smallestRepInterval{100};
+    if (tCents <= smallestRepInterval && scaleBy < 0)
+    {
+        scale = smallestRepInterval / tCents;
+    }
+
     for (auto &t : storage->currentScale.tones)
     {
         t.type = Tunings::Tone::kToneCents;


### PR DESCRIPTION
you can't dial-stretch the repetition interval for the entire scale below 100cents using the spinny knob, which used to be unbounded and would explode you.

Closes #7530