### PR TITLE
Send MTS-ESP Master Tunings without UI

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2530,6 +2530,15 @@ bool SurgeStorage::resetToCurrentScaleAndMapping()
         table_note_omega[1][i] =
             (float)cos(2 * M_PI * min(0.5, 440 * table_pitch[i] * dsamplerate_os_inv));
     }
+
+    if (oddsound_mts_active_as_main && !uiThreadChecksTunings)
+    {
+        for (int i = 0; i < 128; ++i)
+        {
+            MTS_SetNoteTuning(currentTuning.frequencyForMidiNote(i), i);
+        }
+        MTS_SetScaleName(currentTuning.scale.description.c_str());
+    }
     tuningUpdates++;
     return true;
 }
@@ -2826,6 +2835,15 @@ void SurgeStorage::connect_as_oddsound_main()
                     "MTS-ESP Source Initialization Error");
     }
     lastSentTuningUpdate = -1;
+
+    if (!uiThreadChecksTunings && oddsound_mts_active_as_main)
+    {
+        for (int i = 0; i < 128; ++i)
+        {
+            MTS_SetNoteTuning(currentTuning.frequencyForMidiNote(i), i);
+        }
+        MTS_SetScaleName(currentTuning.scale.description.c_str());
+    }
 }
 void SurgeStorage::disconnect_as_oddsound_main()
 {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1596,6 +1596,7 @@ class alignas(16) SurgeStorage
     void disconnect_as_oddsound_main();
     uint64_t lastSentTuningUpdate{0}; // since tuning update starts at 2
     void send_tuning_update();
+    std::atomic<bool> uiThreadChecksTunings{false};
 #endif
     MTSClient *oddsound_mts_client = nullptr;
     std::atomic<bool> oddsound_mts_active_as_client{false};

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -455,6 +455,8 @@ SurgeGUIEditor::SurgeGUIEditor(SurgeSynthEditor *jEd, SurgeSynthesizer *synth)
     }
 
     juceEditor->processor.undoManager->resetEditor(this);
+
+    synth->storage.uiThreadChecksTunings = true;
 }
 
 SurgeGUIEditor::~SurgeGUIEditor()
@@ -467,6 +469,7 @@ SurgeGUIEditor::~SurgeGUIEditor()
     populateDawExtraState(synth); // If I must die, leave my state for future generations
     synth->storage.getPatch().dawExtraState.isPopulated = isPop;
     synth->storage.removeErrorListener(this);
+    synth->storage.uiThreadChecksTunings = false;
 }
 
 void SurgeGUIEditor::forceLFODisplayRebuild() { lfoDisplay->repaint(); }


### PR DESCRIPTION
An oversight, we only refreshed tunings if the surge UI was open. This meant saved sessions where the UI didn't open would not provide scales properly.

Addresses #7523. Would like confirmatino before we close that though.