### PR TITLE
Add an option (-DSURGE_SKIP_WERROR=True) to skip -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   add_compile_options(
     -Wno-multichar
     # Targeting Windows with GCC/Clang is experimental
-    $<$<NOT:$<BOOL:${WIN32}>>:-Werror>
+    $<$<NOT:$<OR:$<BOOL:${WIN32}>,$<BOOL:${SURGE_SKIP_WERROR}>>>:-Werror>
 
     # PE/COFF doesn't support visibility
     $<$<NOT:$<BOOL:${WIN32}>>:-fvisibility=hidden>


### PR DESCRIPTION
Some build environments have compilers, toolchains, or other oddities which mean -Werror doesn't work. Rather than have those distros patch, add a cmake option which we don't set in CI but you can at home!

Closes #7509