### PR TITLE
Step Sequencer Typein returns focus to step

### DIFF
--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -2649,6 +2649,7 @@ void LFOAndStepDisplay::showStepTypein(int i)
                                "");
     stepEditor->setSkin(skin, associatedBitmapStore);
     stepEditor->setEditableText(fmt::format("{:.{}f} %", ss->steps[i] * 100.f, decimals));
+    stepEditor->setReturnFocusTarget(stepSliderOverlays[i].get());
 
     auto topOfControl = getY();
     auto pb = getBounds();


### PR DESCRIPTION
When doing a step sequencer edit as text focus thingy the focus would return to top of sequencer, which wasn't useful. Set a return target and make it the step which launched the edit.

Closes #7521