### PR TITLE
Invert cli log level logic

### DIFF
--- a/src/surge-xt/cli/cli-main.cpp
+++ b/src/surge-xt/cli/cli-main.cpp
@@ -63,7 +63,7 @@ enum LogLevels
 int logLevel{BASIC};
 #define LOG(lev, x)                                                                                \
     {                                                                                              \
-        if (lev >= logLevel)                                                                       \
+        if (logLevel >= lev)                                                                       \
         {                                                                                          \
             std::cout << logTimestamp() << " - " << x << std::endl;                                \
         }                                                                                          \


### PR DESCRIPTION
It is normally expected the incoming log level, via parameter or configuration, to dictate how the current the set of log msgs are to be shown. If cli in invoked with VERBOSE or TRACE level, all msgs up to that level are shown. Otherwise, if it is said to be BASIC, only msgs with such level should be displayed.