### PR TITLE
Currently used tempo is saved to patch

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2655,7 +2655,7 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
     {
         if (tos->QueryDoubleAttribute("v", &d) != TIXML_SUCCESS)
         {
-            d = 1.0;
+            d = 120.0;
         }
     }
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2642,6 +2642,32 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
         }
     }
 
+    bool userPrefOverrideTempoOnPatchLoad = Surge::Storage::getUserDefaultValue(
+        storage, Surge::Storage::OverrideTempoOnPatchLoad, true);
+
+    TiXmlElement *tos = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("tempoOnSave"));
+
+    if (revision < 23)
+    {
+        d = -1.0;
+    }
+    else
+    {
+        if (tos->QueryDoubleAttribute("v", &d) != TIXML_SUCCESS)
+        {
+            d = 1.0;
+        }
+    }
+
+    if (userPrefOverrideTempoOnPatchLoad)
+    {
+        storage->unstreamedTempo = (float)d;
+    }
+    else
+    {
+        storage->unstreamedTempo = -1.f;
+    }
+
     dawExtraState.isPopulated = false;
     TiXmlElement *de = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("dawExtraState"));
 
@@ -3571,7 +3597,7 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
     }
 
     {
-        TiXmlElement compat("compatability");
+        TiXmlElement compat("compatability"); // TODO: Fix typo for XT2, LOL!
 
         TiXmlElement comb("correctlyTunedCombFilter");
         comb.SetAttribute("v", correctlyTuneCombFilter ? 1 : 0);
@@ -3595,6 +3621,10 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
 
         patch.InsertEndChild(pt);
     }
+
+    TiXmlElement tempoOnSave("tempoOnSave");
+    tempoOnSave.SetDoubleAttribute("v", storage->temposyncratio * 120.0);
+    patch.InsertEndChild(tempoOnSave);
 
     TiXmlElement dawExtraXML("dawExtraState");
     dawExtraXML.SetAttribute("populated", dawExtraState.isPopulated ? 1 : 0);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -126,14 +126,15 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 // 20 -> 21 (XT 1.2 nightlies) added absolutable mode for Combulator Offset 1/2 (to match the behavior of Center parameter)
 //                             added oddsound_as_mts_main
 // 21 -> 22 (XT 1.3 nighlies)  added new ring modulator modes in the mixer
-//                             added bonsai distortion effect
+//                             added Bonsai distortion effect
 //                             changed MIDI mapping behavior
 //                             added capability to deactivate scenes
 //                             added Vintage FM feedback mode to FM2, FM3 and Sine oscillator types
 //                             added extend mode to Delay Crossfeed and Mod Depth parameters
+// 22 -> 23 (XT 1.3.2 release) added storing of Tempo parameter to the patch (will be loaded in Standalone only if option enabled)
 // clang-format on
 
-const int ff_revision = 22;
+const int ff_revision = 23;
 
 const int n_scene_params = 273;
 const int n_global_params = 11 + n_fx_slots * (n_fx_params + 1); // each param plus a type
@@ -1317,6 +1318,7 @@ class alignas(16) SurgeStorage
 
     float vu_falloff;
     float temposyncratio, temposyncratio_inv; // 1.f is 120 BPM
+    float unstreamedTempo{120.f};             // this one is in actual BPM
     double songpos;
     void init_tables();
     float nyquist_pitch;

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -460,7 +460,7 @@ class alignas(16) SurgeSynthesizer
 
     //==============================================================================
     // synth -> editor variables
-    bool refresh_editor, patch_loaded;
+    bool refresh_editor, refresh_vkb, patch_loaded;
     int learn_param_from_cc, learn_macro_from_cc, learn_param_from_note;
     int refresh_ctrl_queue[8];
     int refresh_parameter_queue[8];

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -121,6 +121,9 @@ std::string defaultKeyToString(DefaultKey k)
     case OverrideMappingOnPatchLoad:
         r = "overrideMappingOnPatchLoad";
         break;
+    case OverrideTempoOnPatchLoad:
+        r = "overrideTempoOnPatchLoad";
+        break;
     case DefaultPatchAuthor:
         r = "defaultPatchAuthor";
         break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -73,6 +73,7 @@ enum DefaultKey
 
     OverrideTuningOnPatchLoad,
     OverrideMappingOnPatchLoad,
+    OverrideTempoOnPatchLoad,
 
     RememberTabPositionsPerScene,
     RestoreMSEGSnapFromPatch,

--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -328,7 +328,11 @@ void SurgeSynthEditor::paint(juce::Graphics &g)
 #endif
 }
 
-void SurgeSynthEditor::idle() { sge->idle(); }
+void SurgeSynthEditor::idle()
+{
+    sge->idle();
+    tempoTypein->setText(std::to_string((int)(processor.surge->storage.temposyncratio * 120)));
+}
 
 void SurgeSynthEditor::reapplySurgeComponentColours()
 {

--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -211,6 +211,7 @@ SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
         float newT = std::atof(tempoTypein->getText().toRawUTF8());
 
         processor.standaloneTempo = newT;
+        processor.surge->storage.unstreamedTempo = newT;
         tempoTypein->giveAwayKeyboardFocus();
     };
 
@@ -331,7 +332,19 @@ void SurgeSynthEditor::paint(juce::Graphics &g)
 void SurgeSynthEditor::idle()
 {
     sge->idle();
-    tempoTypein->setText(std::to_string((int)(processor.surge->storage.temposyncratio * 120)));
+
+    if (processor.surge->refresh_vkb)
+    {
+        const int curTypeinBPM = std::atoi(tempoTypein->getText().toStdString().c_str());
+        const int curBPM = std::round(processor.surge->time_data.tempo);
+
+        if (curTypeinBPM != curBPM)
+        {
+            tempoTypein->setText(fmt::format("{}", curBPM));
+        }
+
+        processor.surge->refresh_vkb = false;
+    }
 }
 
 void SurgeSynthEditor::reapplySurgeComponentColours()

--- a/src/surge-xt/SurgeSynthEditor.h
+++ b/src/surge-xt/SurgeSynthEditor.h
@@ -156,7 +156,7 @@ struct SurgeSynthStartupErrorEditor : juce::AudioProcessorEditor
 
         g.setFont(40);
         auto lb = getLocalBounds().withHeight(50).translated(0, 100);
-        g.drawText("Fatal Surge Startup Error", lb, juce::Justification::centred);
+        g.drawText("Fatal Surge XT Startup Error", lb, juce::Justification::centred);
 
         g.setColour(juce::Colours::white);
         g.setFont(20);
@@ -165,8 +165,9 @@ struct SurgeSynthStartupErrorEditor : juce::AudioProcessorEditor
         lb = lb.translated(0, 125);
         g.drawText(Surge::Build::FullVersionStr, lb, juce::Justification::centred);
         lb = lb.translated(0, 25);
-        g.drawText("Report on Surge discord or github issue with a screenshot of this screen", lb,
-                   juce::Justification::centred);
+        g.drawText(
+            "Report issue on Surge Synth Team Discord or GitHub with a screenshot of this screen",
+            lb, juce::Justification::centred);
     }
 };
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -690,6 +690,7 @@ void SurgeSynthProcessor::processBlockPlayhead()
             {
                 standaloneTempo = surge->storage.unstreamedTempo;
                 surge->refresh_editor = true;
+                surge->refresh_vkb = true;
             }
         }
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -682,6 +682,17 @@ void SurgeSynthProcessor::processBlockPlayhead()
     }
     else
     {
+        // only if we want to change tempo on patch load
+        if (surge->storage.unstreamedTempo > -1.f)
+        {
+            // and only if it's different from current one
+            if (surge->storage.unstreamedTempo != standaloneTempo)
+            {
+                standaloneTempo = surge->storage.unstreamedTempo;
+                surge->refresh_editor = true;
+            }
+        }
+
         surge->time_data.tempo = standaloneTempo;
         surge->time_data.timeSigNumerator = 4;
         surge->time_data.timeSigDenominator = 4;
@@ -1264,7 +1275,7 @@ void SurgeSynthProcessor::getStateInformation(juce::MemoryBlock &destData)
         sse->populateForStreaming(surge.get());
     }
 
-    void *data = nullptr; // surgeInstance owns this on return
+    void *data = nullptr; // Surge instance owns this on return
     unsigned int stateSize = surge->saveRaw(&data);
     destData.setSize(stateSize);
     destData.copyFrom(data, 0, stateSize);

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -1033,6 +1033,30 @@ juce::PopupMenu SurgeGUIEditor::makePatchDefaultsMenu(const juce::Point<int> &wh
 
     patchDefMenu.addSeparator();
 
+    if (Surge::GUI::getIsStandalone())
+    {
+        auto tempoOnLoadMenu = juce::PopupMenu();
+
+        bool overrideTempoOnLoad = Surge::Storage::getUserDefaultValue(
+            &(synth->storage), Surge::Storage::OverrideTempoOnPatchLoad, true);
+
+        tempoOnLoadMenu.addItem(Surge::GUI::toOSCase("Keep Current Tempo"), true,
+                                !overrideTempoOnLoad, [this, overrideTempoOnLoad]() {
+                                    Surge::Storage::updateUserDefaultValue(
+                                        &(this->synth->storage),
+                                        Surge::Storage::OverrideTempoOnPatchLoad, false);
+                                });
+
+        tempoOnLoadMenu.addItem(Surge::GUI::toOSCase("Override With Embedded Tempo if Available"),
+                                true, overrideTempoOnLoad, [this, overrideTempoOnLoad]() {
+                                    Surge::Storage::updateUserDefaultValue(
+                                        &(this->synth->storage),
+                                        Surge::Storage::OverrideTempoOnPatchLoad, true);
+                                });
+
+        patchDefMenu.addSubMenu(Surge::GUI::toOSCase("Tempo on Patch Load"), tempoOnLoadMenu);
+    }
+
     auto tuningOnLoadMenu = juce::PopupMenu();
 
     bool overrideTuningOnLoad = Surge::Storage::getUserDefaultValue(


### PR DESCRIPTION
It is only loaded in standalone, and only if the "Tempo on patch load" option is set to override. This option only shows in standalone, too.

Closes #7529