### PR TITLE
Fix category name generation when splitting folders with more than 256 patches

### DIFF
--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -1204,7 +1204,7 @@ bool PatchSelector::populatePatchMenuForCategory(int c, juce::PopupMenu &context
 
         if (n_subc > 1)
         {
-            name = menuName.c_str() + (subc + 1);
+            name = fmt::format("{} {}", menuName, subc + 1).c_str();
         }
         else
         {


### PR DESCRIPTION
Closes #7548