### PR TITLE
Fix a Symlink Scannign error

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -750,10 +750,18 @@ void SurgeStorage::refresh_patchlist()
     }
     for (auto &p : patch_list)
     {
-        auto qtime = fs::last_write_time(p.path);
-        p.lastModTime =
-            std::chrono::duration_cast<std::chrono::seconds>(qtime.time_since_epoch()).count();
-
+        try
+        {
+            auto qtime = fs::last_write_time(p.path);
+            p.lastModTime =
+                std::chrono::duration_cast<std::chrono::seconds>(qtime.time_since_epoch()).count();
+        }
+        catch (const fs::filesystem_error &e)
+        {
+            std::cout << "Error : unable to stat " << p.path.u8string() << " '" << e.what() << "'"
+                      << std::endl;
+            p.lastModTime = 0;
+        }
         auto ps = p.path.u8string();
         auto pf = pathToTrunc(ps);
 

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -519,7 +519,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
   public:
     bool inputIsLatent{false};
 
-    std::string fatalErrorMessage{false};
+    std::string fatalErrorMessage{};
 
   private:
     // Have we warned about bad configurations


### PR DESCRIPTION
If a patch was a symlink to a missing patch, the modtime scan at startup to rebuild the patch db would throw an uncaught filesystem exception. Catch it and compensate.

Closes #7547