### PR TITLE
Different recovery path for hosed %DOCUMENTS%

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -201,6 +201,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     }
 
     userDataPath = sst::plugininfra::paths::bestDocumentsFolderPathFor("Surge XT");
+
 #elif LINUX
     if (!hasSuppliedDataPath)
     {
@@ -280,7 +281,19 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
 
     if (userDataPath.empty())
     {
-        userDataPath = sst::plugininfra::paths::bestDocumentsFolderPathFor(sxt);
+        try
+        {
+            userDataPath = sst::plugininfra::paths::bestDocumentsFolderPathFor(sxt);
+        }
+        catch (const std::runtime_error &e)
+        {
+            userDataPath = fs : path{"/documents/not/available"};
+            reportError(
+                std::string() + "Surge is unable to find the %DOCUMENTS% directory. " +
+                    "Your system is misconfigured and several features including saving patches, " +
+                    "the search database and preferences will not work. " + e.what(),
+                "Unable to determine %DOCUMENTS%");
+        }
     }
 #endif
 

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -287,7 +287,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
         }
         catch (const std::runtime_error &e)
         {
-            userDataPath = fs : path{"/documents/not/available"};
+            userDataPath = fs::path{"/documents/not/available"};
             reportError(
                 std::string() + "Surge is unable to find the %DOCUMENTS% directory. " +
                     "Your system is misconfigured and several features including saving patches, " +

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -23,6 +23,8 @@
 #ifndef SURGE_SRC_SURGE_XT_GUI_SURGEGUIEDITOR_H
 #define SURGE_SRC_SURGE_XT_GUI_SURGEGUIEDITOR_H
 
+#include <deque>
+
 #include "globals.h"
 
 #include "SurgeGUICallbackInterfaces.h"
@@ -125,7 +127,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::unique_ptr<Surge::Widgets::MainFrame> frame;
 
     std::atomic<int> errorItemCount{0};
-    std::vector<std::tuple<std::string, std::string, SurgeStorage::ErrorType>> errorItems;
+    std::deque<std::tuple<std::string, std::string, SurgeStorage::ErrorType>> errorItems;
     std::mutex errorItemsMutex;
     void onSurgeError(const std::string &msg, const std::string &title,
                       const SurgeStorage::ErrorType &type) override;
@@ -785,6 +787,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     float blinktimer = 0;
     bool blinkstate = false;
     int firstIdleCountdown = 0;
+    int firstErrorIdleCountdown{30};
     int sendStructureChangeIn = -1;
 
     juce::PopupMenu makeSmoothMenu(const juce::Point<int> &where,


### PR DESCRIPTION
Seems OneDrive can hose down %DOCUMENTS% on windows enough that more people were getting the error that the folder cant resolve. This sucks and those systems are misconfigured.

But with these changes we actually can start surge with a clear error that says saving and the like wont work. The synth kinda works also

Addresses #7544 