### PR TITLE
Error handling when you cant open a patch etc

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -771,8 +771,12 @@ void SurgeStorage::refresh_patchlist()
         }
         catch (const fs::filesystem_error &e)
         {
-            std::cout << "Error : unable to stat " << p.path.u8string() << " '" << e.what() << "'"
-                      << std::endl;
+            std::ostringstream erross;
+            erross << "Unable to determine the modification time of '" << p.path.u8string() << ". "
+                   << "This usually means the file can't be opened, or is a broken symlink, or "
+                      "some such. Underlying error: "
+                   << e.what();
+            reportError(erross.str(), "Unable to Read File Time");
             p.lastModTime = 0;
         }
         auto ps = p.path.u8string();
@@ -2948,7 +2952,9 @@ void SurgeStorage::reportError(const std::string &msg, const std::string &title,
     }
 
     for (auto l : errorListeners)
+    {
         l->onSurgeError(msg, title, errorType);
+    }
 }
 
 float SurgeStorage::remapKeyInMidiOnlyMode(float res)

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -213,7 +213,11 @@ bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, cons
 
     std::filebuf f;
     if (!f.open(string_to_path(fxpPath), std::ios::binary | std::ios::in))
+    {
+        storage.reportError(std::string() + "Unable to open file " + std::string(fxpPath),
+                            "Unable to open file");
         return false;
+    }
     fxChunkSetCustom fxp;
     auto read = f.sgetn(reinterpret_cast<char *>(&fxp), sizeof(fxp));
     // FIXME - error if read != chunk size


### PR DESCRIPTION
Symlink scan on startup and fail ot open patch all pop an error. moreover the error mesages protect against getting hidden on rebuilds.

Closes #7547