### PR TITLE
Fix Enter key not working on NumberField widgets

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3447,6 +3447,21 @@ void SurgeGUIEditor::promptForUserValueEntry(Parameter *p, juce::Component *c, i
     typeinParamEditor->grabFocus();
 }
 
+bool SurgeGUIEditor::promptForUserValueEntry(uint32_t tag, juce::Component *c)
+{
+    auto t = tag - start_paramtags;
+
+    if (t < 0 || t >= n_total_params)
+    {
+        return false;
+    }
+
+    auto p = synth->storage.getPatch().param_ptr[t];
+
+    promptForUserValueEntry(p, c);
+    return true;
+}
+
 std::string SurgeGUIEditor::helpURLFor(Parameter *p)
 {
     auto storage = &(synth->storage);

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -901,13 +901,14 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void removeUnusedTrackedComponents();
 
   public:
+    void promptForUserValueEntry(Parameter *p, juce::Component *c, int modsource, int modScene,
+                                 int modindex);
+    bool promptForUserValueEntry(Surge::Widgets::ModulatableControlInterface *mci);
+    bool promptForUserValueEntry(uint32_t tag, juce::Component *c);
     void promptForUserValueEntry(Parameter *p, juce::Component *c)
     {
         promptForUserValueEntry(p, c, -1, -1, -1);
     }
-    void promptForUserValueEntry(Parameter *p, juce::Component *c, int modsource, int modScene,
-                                 int modindex);
-    bool promptForUserValueEntry(Surge::Widgets::ModulatableControlInterface *mci);
 
     /*
     ** Skin support

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -3146,7 +3146,9 @@ int32_t MSEGControlRegion::controlModifierClicked(Surge::GUI::IComponentTagValue
         {
             contextMenu.addSeparator();
 
-            auto handleTypein = [pControl, this](const std::string &s) {
+            auto c = pControl->asJuceComponent();
+
+            auto handleTypein = [c, pControl, this](const std::string &s) {
                 auto i = std::atoi(s.c_str());
 
                 if (i >= 1 && i <= 100)
@@ -3154,11 +3156,9 @@ int32_t MSEGControlRegion::controlModifierClicked(Surge::GUI::IComponentTagValue
                     pControl->setValue(Parameter::intScaledToFloat(i, 100, 1));
                     valueChanged(pControl);
 
-                    auto iv = pControl->asJuceComponent();
-
-                    if (iv)
+                    if (c)
                     {
-                        iv->repaint();
+                        c->repaint();
                     }
 
                     return true;
@@ -3169,7 +3169,7 @@ int32_t MSEGControlRegion::controlModifierClicked(Surge::GUI::IComponentTagValue
             auto val =
                 std::to_string(Parameter::intUnscaledFromFloat(pControl->getValue(), 100, 1));
 
-            auto showTypein = [this, handleTypein, menuName, pControl, val]() {
+            auto showTypein = [this, c, handleTypein, menuName, pControl, val]() {
                 if (!typeinEditor)
                 {
                     typeinEditor =
@@ -3182,9 +3182,10 @@ int32_t MSEGControlRegion::controlModifierClicked(Surge::GUI::IComponentTagValue
                 typeinEditor->setValueLabels("current: " + val, "");
                 typeinEditor->setSkin(skin, associatedBitmapStore);
                 typeinEditor->setEditableText(val);
+                typeinEditor->setReturnFocusTarget(c);
 
-                auto topOfControl = pControl->asJuceComponent()->getParentComponent()->getY();
-                auto pb = pControl->asJuceComponent()->getBounds();
+                auto topOfControl = c->getParentComponent()->getY();
+                auto pb = c->getBounds();
                 auto cx = pb.getCentreX();
 
                 auto r = typeinEditor->getRequiredSize();

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -71,6 +71,7 @@ std::string NumberField::valueToDisplay() const
     }
     return oss.str();
 }
+
 void NumberField::paint(juce::Graphics &g)
 {
     jassert(skin);
@@ -104,6 +105,7 @@ void NumberField::setControlMode(Surge::Skin::Parameters::NumberfieldControlMode
 {
     controlMode = n;
     extended = isExtended;
+
     switch (controlMode)
     {
     case Skin::Parameters::NONE:
@@ -134,6 +136,7 @@ void NumberField::setControlMode(Surge::Skin::Parameters::NumberfieldControlMode
     }
     bounceToInt();
 }
+
 void NumberField::mouseDown(const juce::MouseEvent &event)
 {
     if (forwardedMainFrameMouseDowns(event))
@@ -186,6 +189,7 @@ void NumberField::mouseDrag(const juce::MouseEvent &event)
         lastDistanceChecked = d;
     }
 }
+
 void NumberField::mouseUp(const juce::MouseEvent &event)
 {
     mouseUpLongHold(event);
@@ -230,7 +234,19 @@ bool NumberField::keyPressed(const juce::KeyPress &key)
     auto [action, mod] = Surge::Widgets::accessibleEditAction(key, storage);
 
     if (action == None)
+    {
         return false;
+    }
+
+    if (action == Return)
+    {
+        auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+        if (sge && sge->promptForUserValueEntry(getTag(), this))
+        {
+            return true;
+        }
+    }
 
     if (action == OpenMenu)
     {
@@ -239,9 +255,12 @@ bool NumberField::keyPressed(const juce::KeyPress &key)
     }
 
     if (action != Increase && action != Decrease)
+    {
         return false;
+    }
 
     int amt = 1;
+
     if (action == Decrease)
     {
         amt = -1;
@@ -256,6 +275,7 @@ bool NumberField::keyPressed(const juce::KeyPress &key)
     changeBy(amt);
     notifyEndEdit();
     repaint();
+
     return true;
 }
 


### PR DESCRIPTION
Except the two in MSEG Editor.

But fix focus return from typeins for h/v snap in MSEG Editor.

Addresses #7557