### PR TITLE
Changed the cli midi behaviour

### DIFF
--- a/src/surge-xt/cli/cli-main.cpp
+++ b/src/surge-xt/cli/cli-main.cpp
@@ -211,13 +211,13 @@ void isQuitPressed()
 int main(int argc, char **argv)
 {
     // juce::ConsoleApplication is just such a mess.
-    CLI::App app("surge-xt-CLI : a command line player for surge-xt");
+    CLI::App app("surge-xt-cli - a command line player for Surge XT");
 
     app.set_version_flag("--version", Surge::Build::FullVersionStr);
 
     bool listDevices{false};
     app.add_flag("-l,--list-devices", listDevices,
-                 "List all devices available on this system, then exit");
+                 "List all devices available on this system, then exit.");
 
     std::string audioInterface{};
     app.add_flag("--audio-interface", audioInterface,
@@ -238,26 +238,28 @@ int main(int argc, char **argv)
         ->default_val("-1"); // a value of -1 means we skip loading devices altogether.
 
     int oscInputPort{0};
-    app.add_flag("--osc-in-port", oscInputPort, "Port for OSC Input; unspecified means no OSC.");
+    app.add_flag("--osc-in-port", oscInputPort,
+                 "Port for OSC input. If not specified, OSC will not be used.");
 
     int oscOutputPort{0};
     app.add_flag("--osc-out-port", oscOutputPort,
-                 "Port for OSC Output; unspecified means input only; input required.");
+                 "Port for OSC output. If not specified, OSC input will be used and required.");
 
     std::string oscOutputIPAddr{"127.0.0.1"};
-    app.add_flag("--osc-out-ipaddr", oscOutputIPAddr,
-                 "IP Address for OSC Output; unspecified means '127.0.0.1 (localhost)'.");
+    app.add_flag(
+        "--osc-out-ipaddr", oscOutputIPAddr,
+        "IP Address for OSC output. If not specified, local host will be used (127.0.0.1).");
 
     int sampleRate{0};
     app.add_flag("--sample-rate", sampleRate,
-                 "Sample Rate for Audio Output. Will use system default if blank.");
+                 "Sample rate for audio output. If not specified, system default will be used.");
 
     int bufferSize{0};
     app.add_flag("--buffer-size", bufferSize,
-                 "Buffer Size for Audio Output. Will use system default if blank.");
+                 "Buffer size for audio output. If not specified, system default will be used.");
 
     std::string initPatch{};
-    app.add_flag("--init-patch", initPatch, "Choose this file (by path) as the initial patch.");
+    app.add_flag("--init-patch", initPatch, "Choose this file path as the initial patch.");
 
     CLI11_PARSE(app, argc, argv);
 
@@ -283,7 +285,7 @@ int main(int argc, char **argv)
         }
         else
         {
-            LOG(BASIC, "Failed to load patch:" << initPatch);
+            LOG(BASIC, "Failed to load patch:" << initPatch << "!");
         }
     }
 
@@ -295,7 +297,7 @@ int main(int argc, char **argv)
     {
         if (midiInput >= midiDevices.size())
         {
-            PRINTERR("Invalid MIDI input device number.");
+            PRINTERR("Invalid MIDI input device number!");
             exit(1);
         }
 
@@ -303,7 +305,7 @@ int main(int argc, char **argv)
         auto inp = juce::MidiInput::openDevice(vmini.identifier, engine.get());
         if (!inp)
         {
-            PRINTERR("Unable to open MIDI device " << vmini.name);
+            PRINTERR("Unable to open MIDI device " << vmini.name << "!");
             exit(1);
         }
         midiInputs.push_back(std::move(inp));
@@ -313,20 +315,20 @@ int main(int argc, char **argv)
     // Warn about mixing MIDI input commands
     if (midiInput >= 0 && allMidi)
     {
-        LOG(BASIC, "WARNING: Selecting a single MIDI device overrides --all-midi-inputs.")
+        LOG(BASIC, "WARNING: Selecting a single MIDI device overrides --all-midi-inputs!")
     }
 
     // Requesting all devices always works, even if no devices are found.
     // Explicitly requesting a single MIDI device means we skip this.
     if (allMidi && midiInput < 0)
     {
-        LOG(BASIC, "Binding to all MIDI inputs. Found " << midiDevices.size() << " device(s).");
+        LOG(BASIC, "Binding to all MIDI inputs... Found " << midiDevices.size() << " device << midiDevices.size() > 1 ? "s" : "" << "!");
         for (auto &vmini : midiDevices)
         {
             auto inp = juce::MidiInput::openDevice(vmini.identifier, engine.get());
             if (!inp)
             {
-                PRINTERR("Unable to open MIDI device " << vmini.name);
+                PRINTERR("Unable to open MIDI device " << vmini.name << "!");
                 exit(1);
             }
             midiInputs.push_back(std::move(inp));
@@ -344,15 +346,16 @@ int main(int argc, char **argv)
     {
         types[audioTypeIndex]->scanForDevices();
         audioDeviceIndex = types[audioTypeIndex]->getDefaultDeviceIndex(false);
-        LOG(BASIC, "Audio device is unspecified: Using system default");
+        LOG(BASIC, "Audio device is not specified! Using system default.");
     }
     else
     {
         auto p = audioInterface.find('.');
         if (p == std::string::npos)
         {
-            PRINTERR("Audio Interface Argument must be of form a.b, per --list-devices. You gave "
-                     << audioInterface);
+            PRINTERR(
+                "Audio interface argument must be of form a.b, as per --list-devices. You gave "
+                << audioInterface << ".");
             exit(3);
         }
         else
@@ -364,21 +367,21 @@ int main(int argc, char **argv)
 
             if (da < 0 || da >= types.size())
             {
-                PRINTERR("Audio Type Index must be in range 0..." << types.size() - 1);
+                PRINTERR("Audio type index must be in range 0 ... " << types.size() - 1 << "!");
                 exit(4);
             }
         }
     }
 
     const auto &atype = types[audioTypeIndex];
-    LOG(BASIC, "Audio Driver Type   : [" << atype->getTypeName() << "]")
+    LOG(BASIC, "Audio driver type   : [" << atype->getTypeName() << "]")
 
     atype->scanForDevices(); // This must be called before getting the list of devices
     juce::StringArray deviceNames(atype->getDeviceNames()); // This will now return a list of
 
     if (audioDeviceIndex < 0 || audioDeviceIndex >= deviceNames.size())
     {
-        PRINTERR("Audio Device Index must be in range 0..." << deviceNames.size() - 1);
+        PRINTERR("Audio device index must be in range 0 ... " << deviceNames.size() - 1 << "!");
     }
 
     const auto &dname = deviceNames[audioDeviceIndex];
@@ -387,7 +390,7 @@ int main(int argc, char **argv)
 
     if (!device)
     {
-        PRINTERR("Unable to open audio output " << dname);
+        PRINTERR("Unable to open audio output " << dname << "!");
         exit(2);
     }
     LOG(BASIC, "Audio Output        : [" << device->getName() << "]");
@@ -414,8 +417,8 @@ int main(int argc, char **argv)
                 sampleRate = s;
         if (sampleRate == 0)
         {
-            LOG(BASIC, "Sample Rate " << candSampleRate << " not supported.");
-            LOG(BASIC, "Your audio interface supports these rates:");
+            LOG(BASIC, "Sample rate " << candSampleRate << " is not supported!");
+            LOG(BASIC, "Your audio interface supports these sample rates:");
             for (auto s : sr)
             {
                 LOG(BASIC, "   " << s);
@@ -438,7 +441,7 @@ int main(int argc, char **argv)
                 bufferSize = s;
         if (bufferSize == 0)
         {
-            LOG(BASIC, "Buffer Size " << bufferSize << " not supported.");
+            LOG(BASIC, "Buffer size " << bufferSize << " is not supported!");
             LOG(BASIC, "Your audio interface supports these sizes:");
             for (auto s : bs)
             {
@@ -453,14 +456,14 @@ int main(int argc, char **argv)
         auto p = audioPorts.find(',');
         if (p == std::string::npos)
         {
-            PRINTERR("Audio Ports Argument must be of form L,R. You gave " << audioPorts);
+            PRINTERR("Audio ports argument must be of form L,R. You gave " << audioPorts << ".");
             exit(3);
         }
         else
         {
             auto dl = std::atoi(audioPorts.substr(0, p).c_str());
             auto dr = std::atoi(audioPorts.substr(p + 1).c_str());
-            LOG(BASIC, "Binding to outputs  : L=" << dl << ", R=" << dr << "");
+            LOG(BASIC, "Binding to outputs  : L = " << dl << ", R = " << dr << "");
             outputBitset = (1 << (dl)) + (1 << (dr));
         }
     }
@@ -468,7 +471,7 @@ int main(int argc, char **argv)
     auto res = device->open(0, outputBitset, sampleRate, bufferSize);
     if (!res.isEmpty())
     {
-        PRINTERR("Unable to open audio device: " << res);
+        PRINTERR("Unable to open audio device: " << res << "!");
         exit(3);
     }
 
@@ -482,18 +485,18 @@ int main(int argc, char **argv)
     if (oscInputPort > 0)
     {
         needsMessageLoop = true;
-        LOG(BASIC, "Starting OSC Input on " << oscInputPort);
+        LOG(BASIC, "Starting OSC input on " << oscInputPort);
         engine->proc->initOSCIn(oscInputPort);
         if (oscOutputPort > 0)
         {
-            LOG(BASIC, "Starting OSC Output on " << oscOutputPort);
+            LOG(BASIC, "Starting OSC output on " << oscOutputPort);
             engine->proc->initOSCOut(oscOutputPort, oscOutputIPAddr);
         }
     }
 
     if (needsMessageLoop)
     {
-        LOG(BASIC, "Beginning message loop");
+        LOG(BASIC, "Beginning message loop...");
     }
     else
     {
@@ -523,7 +526,7 @@ int main(int argc, char **argv)
         }
     }
 
-    LOG(BASIC, "Shutting down CLI.");
+    LOG(BASIC, "Shutting down CLI...");
 
     // Handle interrupt and collect these in lambda to close if you bail out
     device->stop();

--- a/src/surge-xt/cli/cli-main.cpp
+++ b/src/surge-xt/cli/cli-main.cpp
@@ -221,42 +221,43 @@ int main(int argc, char **argv)
 
     std::string audioInterface{};
     app.add_flag("--audio-interface", audioInterface,
-                 "Select an audio interface, using index (like '0.2') as shown in list-devices");
+                 "Select an audio interface, using index (like '0.2') as shown in list-devices.");
 
     std::string audioPorts{};
     app.add_flag(
         "--audio-ports", audioPorts,
-        "Select the ports to address in the audio interface. '0,1' means first pair, Zero based.");
+        "Select the ports to address in the audio interface. '0,1' means first pair, zero based.");
+
+    bool allMidi{false};
+    app.add_flag("--all-midi-inputs", allMidi, "Bind all available MIDI inputs to the synth.");
 
     int midiInput{};
     app.add_flag("--midi-input", midiInput,
-                 "Select a single MIDI input using the index from list-devices")
+                 "Select a single MIDI input using the index from list-devices. Overrides "
+                 "--all-midi-inputs.")
         ->default_val("-1"); // a value of -1 means we skip loading devices altogether.
 
-    bool allMidi{false};
-    app.add_flag("--all-midi-inputs", allMidi, "Bind all available MIDI inputs to the synth");
-
     int oscInputPort{0};
-    app.add_flag("--osc-in-port", oscInputPort, "Port for OSC Input; unspecified means no OSC");
+    app.add_flag("--osc-in-port", oscInputPort, "Port for OSC Input; unspecified means no OSC.");
 
     int oscOutputPort{0};
     app.add_flag("--osc-out-port", oscOutputPort,
-                 "Port for OSC Output; unspecified means input only; input required");
+                 "Port for OSC Output; unspecified means input only; input required.");
 
     std::string oscOutputIPAddr{"127.0.0.1"};
     app.add_flag("--osc-out-ipaddr", oscOutputIPAddr,
-                 "IP Address for OSC Output; unspecified means '127.0.0.1 (localhost)'");
+                 "IP Address for OSC Output; unspecified means '127.0.0.1 (localhost)'.");
 
     int sampleRate{0};
     app.add_flag("--sample-rate", sampleRate,
-                 "Sample Rate for Audio Output. Will use system default if blank");
+                 "Sample Rate for Audio Output. Will use system default if blank.");
 
     int bufferSize{0};
     app.add_flag("--buffer-size", bufferSize,
-                 "Buffer Size for Audio Output. Will use system default if blank");
+                 "Buffer Size for Audio Output. Will use system default if blank.");
 
     std::string initPatch{};
-    app.add_flag("--init-patch", initPatch, "Choose this file (by path) as the initial patch");
+    app.add_flag("--init-patch", initPatch, "Choose this file (by path) as the initial patch.");
 
     CLI11_PARSE(app, argc, argv);
 
@@ -310,7 +311,8 @@ int main(int argc, char **argv)
     }
 
     // Requesting all devices always works, even if no devices are found.
-    if (allMidi)
+    // Explicitly requesting a single MIDI device means we skip this.
+    if (allMidi && midiInput < 0)
     {
         LOG(BASIC, "Binding to all MIDI inputs. Found " << midiDevices.size() << " device(s).");
         for (auto &vmini : midiDevices)

--- a/src/surge-xt/cli/cli-main.cpp
+++ b/src/surge-xt/cli/cli-main.cpp
@@ -230,11 +230,11 @@ int main(int argc, char **argv)
 
     int midiInput{};
     app.add_flag("--midi-input", midiInput,
-                 "Select a single midi input using the index from list-devices")
+                 "Select a single MIDI input using the index from list-devices")
         ->default_val("-1"); // a value of -1 means we skip loading devices altogether.
 
     bool allMidi{false};
-    app.add_flag("--all-midi-inputs", allMidi, "Bind all available midi inputs to the synth");
+    app.add_flag("--all-midi-inputs", allMidi, "Bind all available MIDI inputs to the synth");
 
     int oscInputPort{0};
     app.add_flag("--osc-in-port", oscInputPort, "Port for OSC Input; unspecified means no OSC");
@@ -289,12 +289,12 @@ int main(int argc, char **argv)
     auto midiDevices = juce::MidiInput::getAvailableDevices();
     std::vector<std::unique_ptr<juce::MidiInput>> midiInputs;
 
-    // Only try to open a midi device when explicitly requested.
+    // Only try to open a MIDI device when explicitly requested.
     if (midiInput >= 0)
     {
         if (midiInput >= midiDevices.size())
         {
-            PRINTERR("Invalid midi input device number.");
+            PRINTERR("Invalid MIDI input device number.");
             exit(1);
         }
 
@@ -302,27 +302,27 @@ int main(int argc, char **argv)
         auto inp = juce::MidiInput::openDevice(vmini.identifier, engine.get());
         if (!inp)
         {
-            PRINTERR("Unable to open midi device " << vmini.name);
+            PRINTERR("Unable to open MIDI device " << vmini.name);
             exit(1);
         }
         midiInputs.push_back(std::move(inp));
-        LOG(BASIC, "Opened Midi Input   : [" << vmini.name << "] ");
+        LOG(BASIC, "Opened MIDI Input   : [" << vmini.name << "] ");
     }
 
     // Requesting all devices always works, even if no devices are found.
     if (allMidi)
     {
-        LOG(BASIC, "Binding to all midi inputs. Found " << midiDevices.size() << " device(s).");
+        LOG(BASIC, "Binding to all MIDI inputs. Found " << midiDevices.size() << " device(s).");
         for (auto &vmini : midiDevices)
         {
             auto inp = juce::MidiInput::openDevice(vmini.identifier, engine.get());
             if (!inp)
             {
-                PRINTERR("Unable to open midi device " << vmini.name);
+                PRINTERR("Unable to open MIDI device " << vmini.name);
                 exit(1);
             }
             midiInputs.push_back(std::move(inp));
-            LOG(BASIC, "Opened Midi Input   : [" << vmini.name << "] ");
+            LOG(BASIC, "Opened MIDI Input   : [" << vmini.name << "] ");
         }
     }
 

--- a/src/surge-xt/cli/cli-main.cpp
+++ b/src/surge-xt/cli/cli-main.cpp
@@ -322,7 +322,9 @@ int main(int argc, char **argv)
     // Explicitly requesting a single MIDI device means we skip this.
     if (allMidi && midiInput < 0)
     {
-        LOG(BASIC, "Binding to all MIDI inputs... Found " << midiDevices.size() << " device << midiDevices.size() > 1 ? "s" : "" << "!");
+        LOG(BASIC, "Binding to all MIDI inputs... Found " << midiDevices.size() << " device"
+                                                          << (midiDevices.size() == 1 ? "" : "s")
+                                                          << "!");
         for (auto &vmini : midiDevices)
         {
             auto inp = juce::MidiInput::openDevice(vmini.identifier, engine.get());

--- a/src/surge-xt/cli/cli-main.cpp
+++ b/src/surge-xt/cli/cli-main.cpp
@@ -310,6 +310,12 @@ int main(int argc, char **argv)
         LOG(BASIC, "Opened MIDI Input   : [" << vmini.name << "] ");
     }
 
+    // Warn about mixing MIDI input commands
+    if (midiInput >= 0 && allMidi)
+    {
+        LOG(BASIC, "WARNING: Selecting a single MIDI device overrides --all-midi-inputs.")
+    }
+
     // Requesting all devices always works, even if no devices are found.
     // Explicitly requesting a single MIDI device means we skip this.
     if (allMidi && midiInput < 0)


### PR DESCRIPTION
- midi is off by default
- specifying a midi device checks for out of bounds index
- requesting all midi devices adds all available devices, which may be 0. 
 
NB both may be enabled at the same time. If the specified device is not present, that will cause an error despite the all-midi flag.

For some reason I needed to set `->default_val("-1")` to get cli11 to actually use that value as the default.