### PR TITLE
Broaden search over query

### DIFF
--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -837,7 +837,28 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
 
         std::ostringstream searchName;
-        searchName << fs::path(p.path.parent_path().filename() / p.name) << " ";
+        searchName << p.name << " ";
+
+        if (storage)
+        {
+            auto pTmp = p.path.parent_path();
+            std::vector<fs::path> parentFiles;
+            int maxItForSafety{0};
+            while ((pTmp != storage->userPatchesPath) &&
+                   (pTmp != storage->datapath / "patches_factory") &&
+                   (pTmp != storage->datapath / "patches_3rdparty") && !pTmp.empty() &&
+                   (pTmp != pTmp.root_directory()) && maxItForSafety < 10)
+            {
+                parentFiles.push_back(pTmp.filename());
+                pTmp = pTmp.parent_path();
+                maxItForSafety++;
+            }
+
+            for (auto pf : parentFiles)
+            {
+                searchName << pf.u8string() << " ";
+            }
+        }
 
         std::ifstream stream(p.path, std::ios::in | std::ios::binary);
 

--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -854,6 +854,11 @@ CREATE TABLE IF NOT EXISTS Favorites (
                 maxItForSafety++;
             }
 
+            if (pTmp == storage->datapath / "patches_3rdparty")
+            {
+                parentFiles.erase(parentFiles.end() - 1);
+            }
+
             for (auto pf : parentFiles)
             {
                 searchName << pf.u8string() << " ";

--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -837,7 +837,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
 
         std::ostringstream searchName;
-        searchName << p.name << " ";
+        searchName << fs::path(p.path.parent_path().filename() / p.name) << " ";
 
         std::ifstream stream(p.path, std::ios::in | std::ios::binary);
 


### PR DESCRIPTION
Sometimes query criteria is not written on patch name. Thus, It'd be nice to also search on path name, which holds category info, additionally to patch name. Thus is specially useful for users for filtering Keys, Polys and so on.