### PR TITLE
Start and stop the NSEventLoop in the CLI for OSC

### DIFF
--- a/src/surge-xt/cli/CMakeLists.txt
+++ b/src/surge-xt/cli/CMakeLists.txt
@@ -3,6 +3,9 @@ project(surge-xt-cli VERSION ${CMAKE_PROJECT_VERSION})
 add_subdirectory(../../../libs/CLI11 CLI11)
 
 add_executable(${PROJECT_NAME} cli-main.cpp)
+if (APPLE)
+    target_sources(${PROJECT_NAME} PRIVATE cli-mac-helpers.mm)
+endif()
 get_target_property(output_dir surge-xt RUNTIME_OUTPUT_DIRECTORY)
 set_property(TARGET ${PROJECT_NAME} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${output_dir}/CLI)
 target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/src/surge-xt/cli/cli-mac-helpers.mm
+++ b/src/surge-xt/cli/cli-mac-helpers.mm
@@ -1,0 +1,26 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <AppKit/AppKit.h>
+
+void objCShutdown() { [NSApp stop:nil]; }

--- a/src/surge-xt/cli/cli-main.cpp
+++ b/src/surge-xt/cli/cli-main.cpp
@@ -31,6 +31,14 @@
 
 #include "SurgeSynthProcessor.h"
 
+#if JUCE_MAC
+namespace juce
+{
+extern void initialiseNSApplication();
+}
+extern void objCShutdown(); // in cli-mac-helpers.mm
+#endif
+
 // This tells us to keep processing
 std::atomic<bool> continueLoop{true};
 
@@ -513,6 +521,14 @@ int main(int argc, char **argv)
     signal(SIGTERM, ctrlc_callback_handler);
 #endif
 
+#if MAC
+    if (needsMessageLoop)
+    {
+        LOG(BASIC, "Starting NSApp for MAC Loop");
+        juce::initialiseNSApplication();
+    }
+#endif
+
     while (continueLoop)
     {
         if (needsMessageLoop)
@@ -529,6 +545,13 @@ int main(int argc, char **argv)
     }
 
     LOG(BASIC, "Shutting down CLI...");
+#if JUCE_MAC
+    if (needsMessageLoop)
+    {
+        LOG(BASIC, "Shutting down NSApp");
+        objCShutdown();
+    }
+#endif
 
     // Handle interrupt and collect these in lambda to close if you bail out
     device->stop();


### PR DESCRIPTION
OSC uses the NSEvntLoop on MacOS to send messages in some cases. Whereas on linux this is explicitly
driven by a client thread on mac you need to start and stop the system. Use the internals fo the juce mac application to do so, and a custom function to shut down cleanly.