### PR TITLE
Docs over OSC

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ Chad Scarborough <github:ChadScarborough>
 Sebastian Schwarzhuber <https://github.com/cannero>
 Tejas Singh <https://github.com/tejas1993>
 Jeff Smith <whydoubt@gmail.com>
+Geert Smolders <https://www.polyprax.nl>
 Jon Spruyt <http://jonspru.yt>
 Phil Stone <https://github.com/pkstone/>
 Markku Tavasti <tavasti@iki.fi>

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -323,9 +323,9 @@ void SurgeSynthProcessor::param_change_to_OSC(std::string paramPath, bool hasFlo
     if (surge->storage.oscSending && !paramPath.empty())
     {
         juce::OSCMessage om = juce::OSCMessage(juce::OSCAddressPattern(juce::String(paramPath)));
-        om.addString(valStr);
         if (hasFloat)
             om.addFloat32(value);
+        om.addString(valStr);
         oscHandler.send(om, true);
     }
 }

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -912,13 +912,16 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     // Modulation mapping
     else if (address1 == "mod")
     {
-        if (!querying)
+        if (querying && message.size() < 1)
         {
-            if (message.size() < 2)
-            {
-                sendDataCountError("mod", "2");
-                return;
-            }
+            sendError("Modulation query must specify both mod source and mod target.");
+            return;
+        }
+
+        if (!querying && message.size() < 2)
+        {
+            sendDataCountError("mod", "2");
+            return;
         }
 
         bool muteMsg = false;
@@ -982,6 +985,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
             sendError("Bad OSC message format.");
             return;
         }
+
         if (!querying && !message[1].isFloat32())
         {
             sendNotFloatError("mod", "depth");

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -187,6 +187,30 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     std::getline(split, address1, '/');
     bool querying = false;
 
+    // Doc requests
+    if (address1 == "doc")
+    { // remove the '/doc' from the address
+        std::getline(split, address1, '/');
+        addr = addr.substr(4);
+        if (address1 == "all_docs")
+        {
+            OpenSoundControl::sendAllParamDocs();
+            return;
+        }
+
+        auto *p = synth->storage.getPatch().parameterFromOSCName(addr);
+        if (p == NULL)
+        {
+            // Not a valid OSC address
+            sendError("No parameter with OSC address of " + addr);
+        }
+        else
+        {
+            OpenSoundControl::sendParameterDocs(p, true);
+        }
+        return;
+    }
+
     // Queries (for params and modulators)
     if (address1 == "q")
     {
@@ -1112,11 +1136,11 @@ void OpenSoundControl::stopSending(bool updateOSCStartInStorage)
     }
 }
 
-void OpenSoundControl::send(juce::OSCMessage om, bool needsMessengerThread)
+void OpenSoundControl::send(juce::OSCMessage om, bool needsMessageThread)
 {
     if (sendingOSC)
     {
-        if (needsMessengerThread)
+        if (needsMessageThread)
         {
             // Runs on the juce messenger thread
             juce::MessageManager::getInstance()->callAsync([this, om]() {
@@ -1177,6 +1201,32 @@ void OpenSoundControl::sendAllParams()
             {
                 Parameter *p = synth->storage.getPatch().param_ptr[i];
                 sendParameter(p, false);
+            }
+            // Now do the macros
+            for (int i = 0; i < n_customcontrollers; i++)
+            {
+                sendMacro(i, false);
+            }
+            // delete timer;    // This prints the elapsed time
+        });
+    }
+}
+
+// Loop through all params, send them to OSC Out
+void OpenSoundControl::sendAllParamDocs()
+{
+    if (sendingOSC)
+    {
+        // Runs on the juce messenger thread
+        juce::MessageManager::getInstance()->callAsync([this]() {
+            // auto timer = new Surge::Debug::TimeBlock("ParameterDump");
+            std::string valStr;
+            int n = synth->storage.getPatch().param_ptr.size();
+            // Dump all params except for macros
+            for (int i = 0; i < n; i++)
+            {
+                Parameter *p = synth->storage.getPatch().param_ptr[i];
+                sendParameterDocs(p, false);
             }
             // Now do the macros
             for (int i = 0; i < n_customcontrollers; i++)
@@ -1280,7 +1330,7 @@ std::string OpenSoundControl::getModulatorOSCAddr(int modid, int scene, int inde
     return ("/mod/" + muteStr + sceneStr + modName + indexStr);
 }
 
-void OpenSoundControl::sendMacro(long macnum, bool needsMsgThread)
+void OpenSoundControl::sendMacro(long macnum, bool needsMessageThread)
 {
     auto cms = ((ControllerModulationSource *)synth->storage.getPatch()
                     .scene[0]
@@ -1294,7 +1344,7 @@ void OpenSoundControl::sendMacro(long macnum, bool needsMsgThread)
     if (!valStr.empty())
         om.addString(valStr);
 
-    OpenSoundControl::send(om, needsMsgThread);
+    OpenSoundControl::send(om, needsMessageThread);
 }
 
 void OpenSoundControl::sendPath(std::string pathString)
@@ -1334,6 +1384,56 @@ void OpenSoundControl::sendParameter(const Parameter *p, bool needsMessageThread
     om.addFloat32(val01);
     if (!valStr.empty())
         om.addString(valStr);
+    OpenSoundControl::send(om, needsMessageThread);
+}
+
+void OpenSoundControl::sendParameterDocs(const Parameter *p, bool needsMessageThread)
+{
+    // fetch param name/description and set unused params to 'Disabled'
+    // note: unused parameters will still return doc values!
+    std::string paramName = p->get_name();
+    if (paramName.find("Param ") != std::string::npos || paramName == "-")
+        paramName = "Disabled"; // Not a great solution. Maybe turn into a bool.
+
+    // determine value type and set min/max value
+    std::string valMin = "";
+    std::string valMax = "";
+    std::string paramType = "";
+
+    switch (p->valtype)
+    {
+    case vt_int:
+        paramType = "int";
+        valMin = std::to_string(p->val_min.i);
+        valMax = std::to_string(p->val_max.i);
+        break;
+
+    case vt_bool:
+        paramType = "bool";
+        valMin = std::to_string(p->val_min.b);
+        valMax = std::to_string(p->val_max.b);
+        break;
+
+    case vt_float:
+        paramType = "float";
+        valMin = std::to_string(p->val_min.f);
+        valMax = std::to_string(p->val_max.f);
+        break;
+
+    default:
+        paramType = std::to_string(p->valtype);
+        break;
+    }
+
+    // Adding the doc prefix to the address again
+    std::string addr = "/doc" + p->oscName;
+
+    juce::OSCMessage om = juce::OSCMessage(juce::OSCAddressPattern(juce::String(addr)));
+    om.addString(paramName);
+    om.addString(paramType);
+    om.addString(valMin);
+    om.addString(valMax);
+
     OpenSoundControl::send(om, needsMessageThread);
 }
 

--- a/src/surge-xt/osc/OpenSoundControl.h
+++ b/src/surge-xt/osc/OpenSoundControl.h
@@ -72,8 +72,9 @@ class OpenSoundControl : public juce::OSCReceiver,
     void oscMessageReceived(const juce::OSCMessage &message) override;
     void oscBundleReceived(const juce::OSCBundle &bundle) override;
 
-    void send(juce::OSCMessage om, bool needsMessengerThread);
+    void send(juce::OSCMessage om, bool needsMessageThread);
     void sendAllParams();
+    void sendAllParamDocs();
     void sendAllModulators();
     void stopSending(bool updateOSCStartInStorage = true);
 
@@ -100,8 +101,9 @@ class OpenSoundControl : public juce::OSCReceiver,
     void sendNotFloatError(std::string addr, std::string msg);
     void sendDataCountError(std::string addr, std::string count);
     float getNormValue(Parameter *p, float fval);
-    void sendParameter(const Parameter *p, bool needsMsgThread);
-    void sendMacro(long macnum, bool needsMsgThread);
+    void sendParameter(const Parameter *p, bool needsMessageThread);
+    void sendParameterDocs(const Parameter *p, bool needsMessageThread);
+    void sendMacro(long macnum, bool needsMessageThread);
     void sendModulator(ModulationRouting mod, int scene, bool global);
     void sendPath(std::string pathStr);
 


### PR DESCRIPTION
Added functions to send parameter names, value type, min value, max value. This is basic metadata to determine how a parameter should be controlled.

Tiny tweak to 'needsMessageThread' variable name for consistency.

Finally, changed the order of 'echoed' messages for consistency.