### PR TITLE
chane OBS workflow path to home:surge-synth-team

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,7 +1,7 @@
 workflow_nightly:
     steps:
     - trigger_services:
-        project: home:baconpaul:surge 
+        project: home:surge-synth-team
         package: surge-xt-nightly
     filters:
         event: push


### PR DESCRIPTION
Hi,

It also requires to add GH token to the home:surge-synth-team profile.