### PR TITLE
Update CLAP features

### DIFF
--- a/src/surge-fx/CMakeLists.txt
+++ b/src/surge-fx/CMakeLists.txt
@@ -74,6 +74,7 @@ if(SURGE_BUILD_CLAP)
       "audio-effect"
       "filter"
       "phaser"
+      "rotary speaker"
       "equalizer"
       "phase-vocoder"
       "granular"

--- a/src/surge-fx/CMakeLists.txt
+++ b/src/surge-fx/CMakeLists.txt
@@ -70,7 +70,23 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 if(SURGE_BUILD_CLAP)
   clap_juce_extensions_plugin(TARGET surge-fx
     CLAP_ID "org.surge-synth-team.surge-xt-fx"
-    CLAP_FEATURES "effect" "multi-effect" "delay" "rotary speaker" "eq" "reverb" "chorus" "flanger" "distortion" "free and open source")
+    CLAP_FEATURES
+      "audio-effect"
+      "filter"
+      "phaser"
+      "equalizer"
+      "phase-vocoder"
+      "granular"
+      "frequency-shifter"
+      "distortion"
+      "transient-shaper"
+      "flanger"
+      "chorus"
+      "delay"
+      "reverb"
+      "multi-effects"
+      "stereo"
+      "free and open source")
 endif()
 
 surge_juce_package(${PROJECT_NAME} "Surge XT Effects")

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -62,7 +62,7 @@ if(SURGE_BUILD_CLAP)
     CLAP_ID "org.surge-synth-team.surge-xt"
 
     CLAP_SUPPORTS_CUSTOM_FACTORY 1
-    CLAP_FEATURES "instrument" "synthesizer" "hybrid" "free and open source")
+    CLAP_FEATURES "instrument" "synthesizer" "stereo" "free and open source")
 endif()
 
 if(JUCE_ASIO_SUPPORT)


### PR DESCRIPTION
I updated the CLAP features of Surge XT and Surge XT Effects to match the standard plugin features.
This will help hosts categorize the plugins better.

### Changes
- Surge XT:
  - Removed: "hybrid"
  - Added: "stereo"
- Surge XT Effects:
  - Removed: "effect", "multi-effect", "rotary speaker", and "eq"
  - Added: "audio-effect", "filter", "phaser", "equalizer", "phase-vocoder", "granular", "frequency-shifter", "multi-effects", and "stereo"

#### Remaining questions
- I left "free and open source" in, though it doesn't follow CLAP's guidance for non-standard features. Should something be done about this?
- I do not know if Surge is also capable of mono output. If so, the "mono" feature should probably be added.
- There may be some audio effect sub-features I've missed which could be added. Alternatively, maybe it would be better to remove all the sub-features except for "multi-effects"?

Feel free to push changes to this branch if you'd like, or let me know anything that should be changed and I can do it once I get the chance.