### PR TITLE
CLAP feature fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Jacky Ligon <http://jackyligon.com>
 Erik-Jan Maalderink <fonkle@gmx.com>
 Kjetil Matheussen <k.s.matheussen@notam02.no>
 Sean McGoff <https://github.com/SeanMcGoff>
+Dalton Messmer <messmer.dalton@gmail.com>
 Dave Palmer <itsmedavep@gmail.com>
 Adam Raisbeck <sense@i2pi.com>
 Naren Ratan <narenr@fastmail.com>

--- a/src/surge-fx/CMakeLists.txt
+++ b/src/surge-fx/CMakeLists.txt
@@ -76,7 +76,6 @@ if(SURGE_BUILD_CLAP)
       "phaser"
       "rotary speaker"
       "equalizer"
-      "phase-vocoder"
       "granular"
       "frequency-shifter"
       "distortion"


### PR DESCRIPTION
Removed the "phase-vocoder" CLAP feature which was added in #7586, and added myself to AUTHORS.