### PR TITLE
OSC work: added MIDI-style controller OSC-in messages

### DIFF
--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -319,6 +319,26 @@
                          <span><code>/ne/pressure 24566 0.4</code></span>
                     </div>
 
+                    <div class="tablewrap" style="width: 60%; margin: 8px;">
+                         <div class="heading">
+                              <h2>MIDI-type controllers</h2>
+                         </div>
+                         <table style="border: 2px solid black;">
+                              <tr>
+                                   <th>Address</th>
+                                   <th>Description</th>
+                                   <th>Value 1</th>
+                              </tr>
+                              <tr>
+                                   <td>/pbend</td>
+                                   <td>pitch bend</td>
+                                   <td>pitch offset (-1.0 - 1.0)</td>
+                              </tr>
+                         </table>
+                    </div>
+                    <div style="width: 98%; margin: 0 0 32px 10px; line-height: 1.75">
+                         <span><code>/pbend -.085</code></span>
+                    </div>
                     <div class="tablewrap fl cl">
                          <div class="heading">
                               <h2>Patches</h2>

--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -337,13 +337,26 @@
                                    <td>channel (0 - 15)</td>
                                    <td>pitch offset (-1.0 - 1.0)</td>
                                    <td></td>
-                                   </tr>
-                                   <tr>
-                                        <td>/cc</td>
-                                        <td>control change</td>
-                                        <td>channel (0 - 15)</td>
-                                        <td>controller # (0 - 127)</td>
-                                        <td>value (0 - 127)</td>
+                              </tr>
+                              <tr>
+                                   <td>/cc</td>
+                                   <td>control change</td>
+                                   <td>channel (0 - 15)</td>
+                                   <td>controller # (0 - 127)</td>
+                                   <td>value (0 - 127)</td>
+                              </tr>
+                              <tr>
+                                   <td>/chan_at</td>
+                                   <td>channel aftertouch</td>
+                                   <td>channel (0 - 15)</td>
+                                   <td>value (0 - 127)</td>
+                              </tr>
+                              <tr>
+                                   <td>/poly_at</td>
+                                   <td>polyphonic aftertouch</td>
+                                   <td>channel (0 - 15)</td>
+                                   <td>note # (0 - 127)</td>
+                                   <td>value (0 - 127)</td>
                               </tr>
                          </table>
                     </div>
@@ -1087,8 +1100,9 @@
                               <tr>
                                    <td>/param/fx/&lt;s&gt;/&lt;n&gt;/deactivate</td>
                                    <td> (FX slot Deactivate)</td>
-                                   <td>boolean (0 or 1)</td>
+                                   <td>boolean (0 or 1)<br />1 = deactivated</td>
                               </tr>
+
                          </table>
                     </div>
 
@@ -1371,12 +1385,12 @@
                                    <td>boolean (0 or 1)</td>
                               </tr>
                               <tr>
-                                   <td>&lt;parameter address&gt;/deact+</td>
-                                   <td>deactivate</td>
+                                   <td>&lt;parameter address&gt;/enable+</td>
+                                   <td>enable</td>
                                    <td>boolean (0 or 1)</td>
                               </tr>
                               <tr>
-                                   <td>&lt;parameter address&gt;/tsync+</td>
+                                   <td>&lt;parameter address&gt;/tempo_sync+</td>
                                    <td>tempo sync</td>
                                    <td>boolean (0 or 1)</td>
                               </tr>
@@ -1391,7 +1405,7 @@
                                    <td>integer (0 to 3) OR bitmask</td>
                               </tr>
                               <tr>
-                                   <td>/param/&lt;s&gt;/portamento/conrate+</td>
+                                   <td>/param/&lt;s&gt;/portamento/const_rate+</td>
                                    <td>portamento constant rate</td>
                                    <td>boolean (0 or 1)</td>
                               </tr>
@@ -1416,10 +1430,10 @@
                     <div style="clear: both;"></div>
                     
                     <div style="width: 98%; margin: 0 0 32px 10px; line-height: 1.75">
-                         <span><code>/param/a/pitch/extend_x 1</code></span>
-                         <span><code>/param/a/osc/1/pitch/absol_x 1</code></span>
-                         <span><code>/param/a/aeg/attack/tsync_x 0</code></span>
-                         <span><code>/param/a/filter/feedback/deform_x 2</code></span>
+                         <span><code>/param/a/pitch/extend+ 1</code></span>
+                         <span><code>/param/a/osc/1/pitch/absol+ 1</code></span>
+                         <span><code>/param/a/aeg/attack/tempo_sync+ 0</code></span>
+                         <span><code>/param/a/filter/feedback/deform+ 2</code></span>
                     </div>
 
                     <div style="border: 1px solid lightgray;"></div>

--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -362,6 +362,9 @@
                     </div>
                     <div style="width: 98%; margin: 0 0 32px 10px; line-height: 1.75">
                          <span><code>/pbend -.085</code></span>
+                         <span><code>/cc 0 1 88</code></span>
+                         <span><code>/chan_at 0 42</code></span>
+                         <span><code>/poly_at 0 60 42</code></span>
                     </div>
                     <div class="tablewrap fl cl">
                          <div class="heading">
@@ -1431,7 +1434,7 @@
                     
                     <div style="width: 98%; margin: 0 0 32px 10px; line-height: 1.75">
                          <span><code>/param/a/pitch/extend+ 1</code></span>
-                         <span><code>/param/a/osc/1/pitch/absol+ 1</code></span>
+                         <span><code>/param/a/osc/1/pitch/abs+ 1</code></span>
                          <span><code>/param/a/aeg/attack/tempo_sync+ 0</code></span>
                          <span><code>/param/a/filter/feedback/deform+ 2</code></span>
                     </div>

--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -319,7 +319,7 @@
                          <span><code>/ne/pressure 24566 0.4</code></span>
                     </div>
 
-                    <div class="tablewrap" style="width: 60%; margin: 8px;">
+                    <div class="tablewrap" style="width: 70%; margin: 8px;">
                          <div class="heading">
                               <h2>MIDI-type controllers</h2>
                          </div>
@@ -328,11 +328,22 @@
                                    <th>Address</th>
                                    <th>Description</th>
                                    <th>Value 1</th>
+                                   <th>Value 2</th>
+                                   <th>Value 3</th>
                               </tr>
                               <tr>
                                    <td>/pbend</td>
                                    <td>pitch bend</td>
+                                   <td>channel (0 - 15)</td>
                                    <td>pitch offset (-1.0 - 1.0)</td>
+                                   <td></td>
+                                   </tr>
+                                   <tr>
+                                        <td>/cc</td>
+                                        <td>control change</td>
+                                        <td>channel (0 - 15)</td>
+                                        <td>controller # (0 - 127)</td>
+                                        <td>value (0 - 127)</td>
                               </tr>
                          </table>
                     </div>

--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -616,7 +616,8 @@ void SurgeSynthEditor::endMacroEdit(long macroNum)
     par->endChangeGesture();
     // echo change to OSC out
     float newval = par->getValue();
-    processor.paramChangeToListeners(nullptr, true, processor.SCT_MACRO, macroNum, newval, "");
+    processor.paramChangeToListeners(nullptr, true, processor.SCT_MACRO, (float)macroNum, newval,
+                                     .0, "");
 }
 
 #if LINUX

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -776,6 +776,26 @@ void SurgeSynthProcessor::processBlockOSC()
     {
         switch (om.type)
         {
+        case SurgeSynthProcessor::MNOTE:
+        {
+            if (om.on)
+                surge->playNote(0, om.char0, om.char1, 0, om.noteid);
+            else
+                surge->releaseNoteByHostNoteID(om.noteid, om.char1);
+        }
+        break;
+
+        case SurgeSynthProcessor::FREQNOTE:
+        {
+            if (om.on)
+                surge->playNoteByFrequency(om.fval, om.char1, om.noteid);
+            else
+            {
+                surge->releaseNoteByHostNoteID(om.noteid, om.char1);
+            }
+        }
+        break;
+
         case SurgeSynthProcessor::NOTEX_PITCH:
             surge->setNoteExpression(SurgeVoice::PITCH, om.noteid, -1, -1, om.fval);
             break;
@@ -794,6 +814,10 @@ void SurgeSynthProcessor::processBlockOSC()
 
         case SurgeSynthProcessor::NOTEX_TIMB:
             surge->setNoteExpression(SurgeVoice::TIMBRE, om.noteid, -1, -1, om.fval);
+            break;
+
+        case SurgeSynthProcessor::PITCHBEND:
+            surge->pitchBend(om.char0, om.ival);
             break;
 
         case SurgeSynthProcessor::PARAMETER:
@@ -822,26 +846,6 @@ void SurgeSynthProcessor::processBlockOSC()
         case SurgeSynthProcessor::MACRO:
         {
             surge->setMacroParameter01(om.ival, om.fval);
-        }
-        break;
-
-        case SurgeSynthProcessor::MNOTE:
-        {
-            if (om.on)
-                surge->playNote(0, om.mnote, om.vel, 0, om.noteid);
-            else
-                surge->releaseNoteByHostNoteID(om.noteid, om.vel);
-        }
-        break;
-
-        case SurgeSynthProcessor::FREQNOTE:
-        {
-            if (om.on)
-                surge->playNoteByFrequency(om.fval, om.vel, om.noteid);
-            else
-            {
-                surge->releaseNoteByHostNoteID(om.noteid, om.vel);
-            }
         }
         break;
 
@@ -1355,6 +1359,7 @@ void SurgeSynthProcessor::applyMidi(const juce::MidiMessage &m)
     else if (m.isPitchWheel())
     {
         surge->pitchBend(ch, m.getPitchWheelValue() - 8192);
+        std::cout << "pbend ch: " << ch << "  val: " << m.getPitchWheelValue() - 8192 << std::endl;
     }
     else if (m.isController())
     {

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -368,7 +368,8 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         PORTA_CONSTRATE_X,
         PORTA_GLISS_X,
         PORTA_RETRIGGER_X,
-        PORTA_CURVE_X
+        PORTA_CURVE_X,
+        PITCHBEND
     };
 
     struct oscToAudio
@@ -377,12 +378,13 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         Parameter *param;
         float fval{0.0};
         int ival{-1};
-        char mnote{0}, vel{0};
+        char char0{0}, char1{0};
         bool on{false};
         int32_t noteid{-1};
         int scene{0}, index{0};
 
         oscToAudio() {}
+        oscToAudio(oscToAudio_type omtype, char c, int i) : type(omtype), char0(c), ival(i) {}
         oscToAudio(oscToAudio_type omtype) : type(omtype) {}
         oscToAudio(oscToAudio_type omtype, Parameter *p, int i) : type(omtype), param(p), ival(i) {}
         oscToAudio(int mask, int on) : type(FX_DISABLE), ival(mask), on(on) {}
@@ -397,11 +399,11 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         {
         }
         oscToAudio(float freq, char velocity, bool noteon, int32_t nid)
-            : type(FREQNOTE), fval(freq), vel(velocity), on(noteon), noteid(nid)
+            : type(FREQNOTE), fval(freq), char1(velocity), on(noteon), noteid(nid)
         {
         }
         oscToAudio(char note, char velocity, bool noteon, int32_t nid)
-            : type(MNOTE), mnote(note), vel(velocity), on(noteon), noteid(nid)
+            : type(MNOTE), char0(note), char1(velocity), on(noteon), noteid(nid)
         {
         }
         oscToAudio(oscToAudio_type type, int32_t nid, float f) : type(type), noteid(nid), fval(f) {}

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -362,7 +362,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         MOD_MUTE,
         ABSOLUTE_X,
         TEMPOSYNC_X,
-        DEACT_X,
+        ENABLE_X,
         EXTEND_X,
         DEFORM_X,
         PORTA_CONSTRATE_X,
@@ -370,7 +370,9 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         PORTA_RETRIGGER_X,
         PORTA_CURVE_X,
         PITCHBEND,
-        CC
+        CC,
+        CHAN_ATOUCH,
+        POLY_ATOUCH
     };
 
     struct oscToAudio
@@ -436,14 +438,16 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         SCT_EX_TEMPOSYNC,
         SCT_EX_EXTENDRANGE,
         SCT_EX_ABSOLUTE,
-        SCT_EX_DEACTIVATE,
+        SCT_EX_ENABLE,
         SCT_EX_DEFORM,
         SCT_EX_PORTA_CONRATE,
         SCT_EX_PORTA_GLISS,
         SCT_EX_PORTA_RETRIG,
         SCT_EX_PORTA_CURVE,
         SCT_PITCHBEND,
-        SCT_CC
+        SCT_CC,
+        SCT_CHAN_ATOUCH,
+        SCT_POLY_ATOUCH
     };
 
     void paramChangeToListeners(Parameter *p, bool isSpecialCase = false, int specialCaseType = -1,

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2035,6 +2035,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     pl->ctrlgroup == p->ctrlgroup && pl->can_temposync())
                                 {
                                     pl->temposync = setTSTo;
+                                    // output updated value to OSC
+                                    juceEditor->processor.paramChangeToListeners(
+                                        pl, true, juceEditor->processor.SCT_EX_TEMPOSYNC,
+                                        (float)pl->temposync, .0, .0, "");
 
                                     if (setTSTo)
                                     {

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2713,7 +2713,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         // output updated value to OSC
                         juceEditor->processor.paramChangeToListeners(
-                            p, true, juceEditor->processor.SCT_EX_DEACTIVATE, (float)p->deactivated,
+                            p, true, juceEditor->processor.SCT_EX_ENABLE, (float)!p->deactivated,
                             .0, .0, "");
                     });
                 }

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1645,7 +1645,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                                 juceEditor->processor.paramChangeToListeners(
                                                     p, true,
                                                     juceEditor->processor.SCT_EX_EXTENDRANGE,
-                                                    (int)p->extend_range, 0.0, "", 0);
+                                                    (float)p->extend_range, .0, .0, "");
                                             });
                     }
                 }
@@ -1957,8 +1957,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             synth->storage.getPatch().isDirty = true;
                             // output updated value to OSC
                             juceEditor->processor.paramChangeToListeners(
-                                p, true, juceEditor->processor.SCT_EX_TEMPOSYNC, p->temposync, 0.0,
-                                "", 0);
+                                p, true, juceEditor->processor.SCT_EX_TEMPOSYNC,
+                                (float)p->temposync, .0, .0, "");
 
                             if (p->temposync)
                             {
@@ -2092,7 +2092,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                             // output updated value to OSC
                                             juceEditor->processor.paramChangeToListeners(
                                                 p, true, juceEditor->processor.SCT_EX_PORTA_CONRATE,
-                                                p->porta_constrate, 0.0, "", 0);
+                                                (float)p->porta_constrate, .0, .0, "");
                                         });
 
                     isChecked = p->porta_gliss;
@@ -2104,7 +2104,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                             // output updated value to OSC
                                             juceEditor->processor.paramChangeToListeners(
                                                 p, true, juceEditor->processor.SCT_EX_PORTA_GLISS,
-                                                p->porta_gliss, 0.0, "", 0);
+                                                (float)p->porta_gliss, .0, .0, "");
                                         });
 
                     isChecked = p->porta_retrigger;
@@ -2116,7 +2116,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                             // output updated value to OSC
                                             juceEditor->processor.paramChangeToListeners(
                                                 p, true, juceEditor->processor.SCT_EX_PORTA_RETRIG,
-                                                p->porta_retrigger, 0.0, "", 0);
+                                                (float)p->porta_retrigger, .0, .0, "");
                                         });
 
                     Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
@@ -2131,7 +2131,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                             // output updated value to OSC
                                             juceEditor->processor.paramChangeToListeners(
                                                 p, true, juceEditor->processor.SCT_EX_PORTA_CURVE,
-                                                p->porta_curve, 0.0, "", 0);
+                                                (float)p->porta_curve, .0, .0, "");
                                         });
 
                     isChecked = (p->porta_curve == 0);
@@ -2143,7 +2143,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                             // output updated value to OSC
                                             juceEditor->processor.paramChangeToListeners(
                                                 p, true, juceEditor->processor.SCT_EX_PORTA_CURVE,
-                                                p->porta_curve, 0.0, "", 0);
+                                                (float)p->porta_curve, .0, .0, "");
                                         });
 
                     isChecked = (p->porta_curve == 1);
@@ -2155,7 +2155,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                             // output updated value to OSC
                                             juceEditor->processor.paramChangeToListeners(
                                                 p, true, juceEditor->processor.SCT_EX_PORTA_CURVE,
-                                                p->porta_curve, 0.0, "", 0);
+                                                (float)p->porta_curve, .0, .0, "");
                                         });
                 }
 
@@ -2627,7 +2627,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     // output updated value to OSC
                                     juceEditor->processor.paramChangeToListeners(
                                         p, true, juceEditor->processor.SCT_EX_EXTENDRANGE,
-                                        p->extend_range, 0.0, "", 0);
+                                        (float)p->extend_range, .0, .0, "");
                                 });
                         }
                     }
@@ -2667,8 +2667,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         // output updated value to OSC
                         juceEditor->processor.paramChangeToListeners(
-                            p, true, juceEditor->processor.SCT_EX_ABSOLUTE, (int)p->absolute, 0.0,
-                            "", 0);
+                            p, true, juceEditor->processor.SCT_EX_ABSOLUTE, (float)p->absolute, .0,
+                            .0, "");
                     });
                 }
 
@@ -2713,8 +2713,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         // output updated value to OSC
                         juceEditor->processor.paramChangeToListeners(
-                            p, true, juceEditor->processor.SCT_EX_DEACTIVATE, p->deactivated, 0.0,
-                            "", 0);
+                            p, true, juceEditor->processor.SCT_EX_DEACTIVATE, (float)p->deactivated,
+                            .0, .0, "");
                     });
                 }
 
@@ -3289,8 +3289,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 void SurgeGUIEditor::update_deform_type(Parameter *p, int type)
 {
     p->deform_type = type;
-    juceEditor->processor.paramChangeToListeners(p, true, juceEditor->processor.SCT_EX_DEFORM, type,
-                                                 0.0, "", 0);
+    juceEditor->processor.paramChangeToListeners(p, true, juceEditor->processor.SCT_EX_DEFORM,
+                                                 (float)type, .0, .0, "");
 }
 
 void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
@@ -3759,8 +3759,9 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
 
         if (d != cur_bitmask)
         {
-            juceEditor->processor.paramChangeToListeners(
-                nullptr, true, juceEditor->processor.SCT_FX_DEACT, cur_bitmask, 0.0, "", d);
+            juceEditor->processor.paramChangeToListeners(nullptr, true,
+                                                         juceEditor->processor.SCT_FX_DEACT,
+                                                         (float)cur_bitmask, (float)d, .0, "");
         }
 
         synth->storage.getPatch().fx_disable.val.i = d;

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -232,86 +232,8 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         }
     }
 
-    // Note expressions
-    if (address1 == "ne")
-    {
-        if (message.size() != 2)
-        {
-            sendDataCountError("note expression", "2");
-        }
-        if (!message[0].isFloat32())
-        {
-            sendNotFloatError("ne", "value");
-            return;
-        }
-        int noteID = getNoteID(message, 0);
-        if (noteID == -1)
-        {
-            sendError("Note expressions require a valid noteID.");
-            return;
-        }
-        float val = message[1].getFloat32();
-
-        std::getline(split, address2, '/');
-        if (address2 == "volume")
-        {
-            if (val < 0.0 || val > 4.0)
-            {
-                sendError("Note expression (volume) '" + std::to_string(val) +
-                          "' is out of range (0.0 - 4.0).");
-                return;
-            }
-            sspPtr->oscRingBuf.push(
-                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_VOL, noteID, val));
-        }
-        else if (address2 == "pitch")
-        {
-            if (val < -120.0 || val > 120.0)
-            {
-                sendError("Note expression (pitch) '" + std::to_string(val) +
-                          "' is out of range (-120.0 - 120.0).");
-                return;
-            }
-            sspPtr->oscRingBuf.push(
-                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_PITCH, noteID, val));
-        }
-        else if (address2 == "pan")
-        {
-            if (val < 0.0 || val > 1.0)
-            {
-                sendError("Note expression (pan) '" + std::to_string(val) +
-                          "' is out of range (0.0 - 1.0).");
-                return;
-            }
-            sspPtr->oscRingBuf.push(
-                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_PAN, noteID, val));
-        }
-        else if (address2 == "timbre")
-        {
-            if (val < 0.0 || val > 1.0)
-            {
-                sendError("Note expression (timbre) '" + std::to_string(val) +
-                          "' is out of range (0.0 - 1.0).");
-                return;
-            }
-            sspPtr->oscRingBuf.push(
-                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_TIMB, noteID, val));
-        }
-        else if (address2 == "pressure")
-        {
-            if (val < 0.0 || val > 1.0)
-            {
-                sendError("Note expression (pressure) '" + std::to_string(val) +
-                          "' is out of range (0.0 - 1.0).");
-                return;
-            }
-            sspPtr->oscRingBuf.push(
-                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_PRES, noteID, val));
-        }
-    }
-
     // 'Frequency' notes
-    else if (address1 == "fnote")
+    if (address1 == "fnote")
     // Play a note at the given frequency and velocity
     {
         int32_t noteID = 0;
@@ -428,6 +350,105 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         // Send packet to audio thread
         sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(
             static_cast<char>(note), static_cast<char>(velocity), noteon, noteID));
+    }
+
+    else if (address1 == "pbend")
+    {
+        if (message.size() != 2)
+        {
+            sendDataCountError("pitchbend", "2");
+        }
+        if (!message[0].isFloat32() || !message[1].isFloat32())
+        {
+            sendNotFloatError("pbend", "channel or value");
+            return;
+        }
+
+        float bend = message[1].getFloat32();
+        if ((bend >= -1.0) && (bend <= 1.0))
+        {
+            sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(
+                SurgeSynthProcessor::PITCHBEND, static_cast<char>(message[0].getFloat32()),
+                static_cast<int>(bend * 8192)));
+        }
+    }
+
+    // Note expressions
+    else if (address1 == "ne")
+    {
+        if (message.size() != 2)
+        {
+            sendDataCountError("note expression", "2");
+        }
+        if (!message[0].isFloat32())
+        {
+            sendNotFloatError("ne", "value");
+            return;
+        }
+        int noteID = getNoteID(message, 0);
+        if (noteID == -1)
+        {
+            sendError("Note expressions require a valid noteID.");
+            return;
+        }
+        float val = message[1].getFloat32();
+
+        std::getline(split, address2, '/');
+        if (address2 == "volume")
+        {
+            if (val < 0.0 || val > 4.0)
+            {
+                sendError("Note expression (volume) '" + std::to_string(val) +
+                          "' is out of range (0.0 - 4.0).");
+                return;
+            }
+            sspPtr->oscRingBuf.push(
+                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_VOL, noteID, val));
+        }
+        else if (address2 == "pitch")
+        {
+            if (val < -120.0 || val > 120.0)
+            {
+                sendError("Note expression (pitch) '" + std::to_string(val) +
+                          "' is out of range (-120.0 - 120.0).");
+                return;
+            }
+            sspPtr->oscRingBuf.push(
+                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_PITCH, noteID, val));
+        }
+        else if (address2 == "pan")
+        {
+            if (val < 0.0 || val > 1.0)
+            {
+                sendError("Note expression (pan) '" + std::to_string(val) +
+                          "' is out of range (0.0 - 1.0).");
+                return;
+            }
+            sspPtr->oscRingBuf.push(
+                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_PAN, noteID, val));
+        }
+        else if (address2 == "timbre")
+        {
+            if (val < 0.0 || val > 1.0)
+            {
+                sendError("Note expression (timbre) '" + std::to_string(val) +
+                          "' is out of range (0.0 - 1.0).");
+                return;
+            }
+            sspPtr->oscRingBuf.push(
+                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_TIMB, noteID, val));
+        }
+        else if (address2 == "pressure")
+        {
+            if (val < 0.0 || val > 1.0)
+            {
+                sendError("Note expression (pressure) '" + std::to_string(val) +
+                          "' is out of range (0.0 - 1.0).");
+                return;
+            }
+            sspPtr->oscRingBuf.push(
+                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_PRES, noteID, val));
+        }
     }
 
     // All notes off

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -373,75 +373,6 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         }
     }
 
-    else if (address1 == "cc" && !querying)
-    {
-        if (message.size() != 3)
-        {
-            sendDataCountError("cc", "3");
-        }
-        if (!(message[0].isFloat32() && message[1].isFloat32() && message[2].isFloat32()))
-        {
-            sendNotFloatError("cc", "channel, control number, or value");
-            return;
-        }
-        float chan = static_cast<int>(message[0].getFloat32());
-        float cnum = static_cast<int>(message[1].getFloat32());
-        float val = static_cast<int>(message[2].getFloat32());
-
-        if ((chan >= 0.0) && (chan <= 15.) && (cnum >= 0.0) && (cnum <= 127.) && (val >= 0.0) &&
-            (val <= 127.0))
-        {
-            sspPtr->oscRingBuf.push(
-                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::CC, chan, cnum, val));
-        }
-    }
-
-    else if (address1 == "chan_at" && !querying)
-    {
-        if (message.size() != 2)
-        {
-            sendDataCountError("chan_at", "2");
-        }
-        if (!(message[0].isFloat32() && message[1].isFloat32()))
-        {
-            sendNotFloatError("chan_at", "channel or value");
-            return;
-        }
-        float chan = static_cast<int>(message[0].getFloat32());
-        float val = static_cast<int>(message[1].getFloat32());
-
-        if ((chan >= 0.0) && (chan <= 15.) && (val >= 0.0) && (val <= 127.0))
-        {
-            sspPtr->oscRingBuf.push(
-                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::CHAN_ATOUCH, chan, val));
-        }
-    }
-
-    else if (address1 == "poly_at" && !querying)
-    {
-        if (message.size() != 3)
-        {
-            sendDataCountError("poly_at", "3");
-        }
-        if (!(message[0].isFloat32() && message[1].isFloat32() && message[2].isFloat32()))
-        {
-            sendNotFloatError("poly_at", "channel, note number, or value");
-            return;
-        }
-        float chan = static_cast<int>(message[0].getFloat32());
-        float nnum = static_cast<int>(message[1].getFloat32());
-        float val = static_cast<int>(message[2].getFloat32());
-
-        if ((chan >= 0.0) && (chan <= 15.) && (nnum >= 0.0) && (nnum <= 127.) && (val >= 0.0) &&
-            (val <= 127.0))
-        {
-            // std::cout << "Sending poly aftertouch. chan: " << (char)chan
-            //          << "  notenum: " << (char)nnum << "  val: " << (int)val << std::endl;
-            sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(
-                SurgeSynthProcessor::POLY_ATOUCH, (char)chan, (char)nnum, (int)val));
-        }
-    }
-
     // Note expressions
     else if (address1 == "ne" && !querying)
     {
@@ -517,6 +448,74 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
             }
             sspPtr->oscRingBuf.push(
                 SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::NOTEX_PRES, noteID, val));
+        }
+    }
+    else if (address1 == "cc" && !querying)
+    {
+        if (message.size() != 3)
+        {
+            sendDataCountError("cc", "3");
+        }
+        if (!(message[0].isFloat32() && message[1].isFloat32() && message[2].isFloat32()))
+        {
+            sendNotFloatError("cc", "channel, control number, or value");
+            return;
+        }
+        float chan = static_cast<int>(message[0].getFloat32());
+        float cnum = static_cast<int>(message[1].getFloat32());
+        float val = static_cast<int>(message[2].getFloat32());
+
+        if ((chan >= 0.0) && (chan <= 15.) && (cnum >= 0.0) && (cnum <= 127.) && (val >= 0.0) &&
+            (val <= 127.0))
+        {
+            sspPtr->oscRingBuf.push(
+                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::CC, chan, cnum, val));
+        }
+    }
+
+    else if (address1 == "chan_at" && !querying)
+    {
+        if (message.size() != 2)
+        {
+            sendDataCountError("chan_at", "2");
+        }
+        if (!(message[0].isFloat32() && message[1].isFloat32()))
+        {
+            sendNotFloatError("chan_at", "channel or value");
+            return;
+        }
+        float chan = static_cast<int>(message[0].getFloat32());
+        float val = static_cast<int>(message[1].getFloat32());
+
+        if ((chan >= 0.0) && (chan <= 15.) && (val >= 0.0) && (val <= 127.0))
+        {
+            sspPtr->oscRingBuf.push(
+                SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::CHAN_ATOUCH, chan, val));
+        }
+    }
+
+    else if (address1 == "poly_at" && !querying)
+    {
+        if (message.size() != 3)
+        {
+            sendDataCountError("poly_at", "3");
+        }
+        if (!(message[0].isFloat32() && message[1].isFloat32() && message[2].isFloat32()))
+        {
+            sendNotFloatError("poly_at", "channel, note number, or value");
+            return;
+        }
+        float chan = static_cast<int>(message[0].getFloat32());
+        float nnum = static_cast<int>(message[1].getFloat32());
+        float val = static_cast<int>(message[2].getFloat32());
+
+        if ((chan >= 0.0) && (chan <= 15.) && (nnum >= 0.0) && (nnum <= 127.) && (val >= 0.0) &&
+            (val <= 127.0))
+        {
+            // std::cout << "Sending poly aftertouch. chan: " << (char)chan
+            //          << "  notenum: " << (char)nnum << "  val: " << (int)val << std::endl;
+            sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(
+                SurgeSynthProcessor::POLY_ATOUCH, (char)chan, (char)nnum, (int)val));
         }
     }
 

--- a/src/surge-xt/osc/OpenSoundControl.h
+++ b/src/surge-xt/osc/OpenSoundControl.h
@@ -99,7 +99,7 @@ class OpenSoundControl : public juce::OSCReceiver,
     void sendError(std::string errorMsg);
     void sendNotFloatError(std::string addr, std::string msg);
     void sendDataCountError(std::string addr, std::string count);
-    float getNormValue(Parameter *p, float fval);
+    void sendMidiBoundsError(std::string addr);
     void sendParameter(const Parameter *p, bool needsMessageThread, std::string extension = "");
     void sendParameterExtOptions(const Parameter *p, bool needsMessageThread);
     void sendAllParameterInfo(const Parameter *p, bool needsMessageThread);


### PR DESCRIPTION
Added OSC acceptance/processing of '/pbend', '/cc', '/poly_at', and '/chan_at' MIDI-style control inputs.

The parameter change-to-listeners signature was changed to something a bit more organized and versatile as part of this.

NOTE: OSC message naming for two extended parameter attributes has changed since recent nightlies:
'.../tsync+' has been renamed '.../tempo_sync+' and '.../portamento/conrate+' is now '.../portamento/const_rate+'.

In addition, the '.../deact+' extended attribute has been removed. Please use '.../enable+' instead (note the positive logic, i.e. 1 = enable, 0 = disable/deactivate).