### PR TITLE
Osc work: fix for #7592

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1486,6 +1486,7 @@ class alignas(16) SurgeStorage
     std::string oscOutIP{"127.0.0.1"};
     bool oscStartIn{false};
     bool oscStartOut{false};
+    bool echoMIDIctrlToOSC{true}; // This may be made UI- or OSC-switchable in future
 
     static constexpr double MIDI_0_FREQ = Tunings::MIDI_0_FREQ;
     // this value needs to be passed along to FilterCoefficientMaker

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2335,8 +2335,13 @@ void SurgeSynthesizer::channelController(char channel, int cc, int value)
              storage.getPatch().param_ptr[i]->midichan == -1))
         {
             this->setParameterSmoothed(i, fval);
-            int j = 0;
 
+            // Notify audio thread param change listeners (OSC, e.g.)
+            // (which run on juce messenger thread)
+            for (const auto &it : audioThreadParamListeners)
+                (it.second)(storage.getPatch().param_ptr[i]->oscName, fval);
+
+            int j = 0;
             while (j < 7)
             {
                 if ((refresh_ctrl_queue[j] > -1) && (refresh_ctrl_queue[j] != i))

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -459,6 +459,21 @@ class alignas(16) SurgeSynthesizer
     void deletePatchLoadedListener(std::string key) { patchLoadedListeners.erase(key); }
 
     //==============================================================================
+    // Parameter changes coming from within the synth (e.g. from MIDI-learned input)
+    // are communicated to listeners here
+    std::unordered_map<std::string,
+                       std::function<void(const std::string oscname, const float fval)>>
+        audioThreadParamListeners;
+
+    void
+    addAudioParamListener(std::string key,
+                          std::function<void(const std::string oscname, const float fval)> const &l)
+    {
+        audioThreadParamListeners.insert({key, l});
+    }
+    void deleteAudioParamListener(std::string key) { audioThreadParamListeners.erase(key); }
+
+    //==============================================================================
     // synth -> editor variables
     bool refresh_editor, refresh_vkb, patch_loaded;
     int learn_param_from_cc, learn_macro_from_cc, learn_param_from_note;

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -1390,26 +1390,30 @@ void SurgeSynthProcessor::applyMidi(const juce::MidiMessage &m)
     {
         int atval = m.getChannelPressureValue();
         surge->channelAftertouch(ch, atval);
-        paramChangeToListeners(nullptr, true, SCT_CHAN_ATOUCH, (float)ch, (float)atval, .0, "");
+        if (surge->storage.echoMIDIctrlToOSC)
+            paramChangeToListeners(nullptr, true, SCT_CHAN_ATOUCH, (float)ch, (float)atval, .0, "");
     }
     else if (m.isAftertouch())
     {
         int atval = m.getAfterTouchValue();
         surge->polyAftertouch(ch, m.getNoteNumber(), atval);
-        paramChangeToListeners(nullptr, true, SCT_POLY_ATOUCH, (float)ch, (float)m.getNoteNumber(),
-                               (float)atval, "");
+        if (surge->storage.echoMIDIctrlToOSC)
+            paramChangeToListeners(nullptr, true, SCT_POLY_ATOUCH, (float)ch,
+                                   (float)m.getNoteNumber(), (float)atval, "");
     }
     else if (m.isPitchWheel())
     {
         int pwval = m.getPitchWheelValue() - 8192;
         surge->pitchBend(ch, pwval);
-        paramChangeToListeners(nullptr, true, SCT_PITCHBEND, (float)ch, pwval, .0, "");
+        if (surge->storage.echoMIDIctrlToOSC)
+            paramChangeToListeners(nullptr, true, SCT_PITCHBEND, (float)ch, pwval, .0, "");
     }
     else if (m.isController())
     {
         surge->channelController(ch, m.getControllerNumber(), m.getControllerValue());
-        paramChangeToListeners(nullptr, true, SCT_CC, (float)ch, (float)m.getControllerNumber(),
-                               (float)m.getControllerValue(), "");
+        if (surge->storage.echoMIDIctrlToOSC)
+            paramChangeToListeners(nullptr, true, SCT_CC, (float)ch, (float)m.getControllerNumber(),
+                                   (float)m.getControllerValue(), "");
     }
     else if (m.isProgramChange())
     {

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -1406,7 +1406,7 @@ void SurgeSynthProcessor::applyMidi(const juce::MidiMessage &m)
         int pwval = m.getPitchWheelValue() - 8192;
         surge->pitchBend(ch, pwval);
         if (surge->storage.echoMIDIctrlToOSC)
-            paramChangeToListeners(nullptr, true, SCT_PITCHBEND, (float)ch, pwval, .0, "");
+            paramChangeToListeners(nullptr, true, SCT_PITCHBEND, (float)ch, pwval / 8192., .0, "");
     }
     else if (m.isController())
     {

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -431,6 +431,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
     void patch_load_to_OSC(fs::path newpath);
     void param_change_to_OSC(std::string paramPath, int numvals, float val0, float val1, float val2,
                              std::string valStr);
+
     enum specialCaseType
     {
         SCT_MACRO,

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -1136,9 +1136,8 @@ bool OpenSoundControl::initOSCOut(int port, std::string ipaddr)
         auto *mm = juce::MessageManager::getInstanceWithoutCreating();
         if (mm)
         {
-            mm->callAsync([ssp, oname, fval]() {
-                ssp->param_change_to_OSC("/" + oname, 1, fval, 0., 0., "");
-            });
+            mm->callAsync(
+                [ssp, oname, fval]() { ssp->param_change_to_OSC(oname, 1, fval, 0., 0., ""); });
         }
         else
         {


### PR DESCRIPTION
Parameter changes generated within SurgeSynthesizer (e.g. from 'learned' MIDI control input) are now properly echoed to OSC out.  Fixes https://github.com/surge-synthesizer/surge/issues/7592.

Fixed scaling of echoed MIDI pitch bend (is now -1.0 - 1.0, like OSC /pbend message).