### PR TITLE
OSC enhancements: wavetable selection support, etc.

### DIFF
--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -386,8 +386,13 @@
                                    <td class="nw">load patch from<br> user patch directory</td>
                                    <td>file path (relative to user patch dir, no extension, overwrites if file exists)
                                    </td>
+<<<<<<< Updated upstream
                               </tr>
                               <tr>
+=======
+                                   </tr>
+                                   <tr>
+>>>>>>> Stashed changes
                                    <td class="nw">/patch/save</td>
                                    <td class="nw">save patch</td>
                                    <td>none: overwrites current patch <b>or</b>
@@ -399,8 +404,13 @@
                                    <td class="nw">save patch to<br> user patch directory</td>
                                    <td>file path (relative to user patch dir, no extension, overwrites if file exists)
                                    </td>
+<<<<<<< Updated upstream
                               </tr>
                               <tr>
+=======
+                                   </tr>
+                                   <tr>
+>>>>>>> Stashed changes
                                    <td class="nw">/patch/incr</td>
                                    <td class="nw">increment patch</td>
                                    <td>(none)</td>
@@ -464,7 +474,30 @@
                               </tr>
                          </table>
                     </div>
+                    <div class="tablewrap fr cr" style="margin-top: 0px;">
+                         <div class="heading">
+                              <h2>Wavetables</h2>
+                              <h3>Replace '&lt;s&gt;' with 'a' or 'b' (scene) and &lt;n&gt; with '1' through '3'
+                                   (oscillator #)
+                              </h3>
 
+                         </div>
+                         <table style="border: 2px solid black;">
+                              <tr>
+                                   <th>Address</th>
+                                   <th>Description</th>
+                                   <th>Appropriate Values</th>
+                              </tr>
+                              <tr>
+                                   <td>/wavetable/&lt;s&gt;/osc/n</td>
+                                   <td> select wavetable by id</td>
+                                   <td>integer (0 - number of wavetables)</td>
+                              </tr>
+                              <tr>
+                                   <td class="center" colspan="3">out-of-range wavetable ids will be ignored</td>
+                              </tr>
+                         </table>
+                         </div>
                     <div style="clear: both;"></div>
 
                     <div style="width: 98%; margin: 0 0 16px 10px; line-height: 1.75">
@@ -1440,8 +1473,12 @@
                                    <td>int (-1:log, 0:linear, or 1:exponential)</td>
                               </tr>
                          </table>
+<<<<<<< Updated upstream
 
                             <div style="clear: both;"></div>
+=======
+<div style="clear: both;"></div>
+>>>>>>> Stashed changes
 
                          <div style="width: 98%; margin: 2em 0 32px 10px; line-height: 1.75">
                               <span><code>/param/a/pitch/extend+ 1</code></span>
@@ -1449,6 +1486,7 @@
                               <span><code>/param/a/aeg/attack/tempo_sync+ 0</code></span>
                               <span><code>/param/a/filter/feedback/deform+ 2</code></span>
                          </div>
+<<<<<<< Updated upstream
                     </div>
 
 
@@ -1506,6 +1544,63 @@
                     <div style="clear: both;"></div>
 
 
+=======
+                         </div>
+                         
+                         
+                         
+                         
+                         <div class="tablewrap fl cl" style="width: 80%; margin: 16px 4px;">
+                              <div class="heading">
+                                   <h2>Parameter Documentation</h2>
+                                   <h3>Sent to OSC client whenever a parameter is queried using '/q/param' or '/q/all_params'.
+                                   </h3>
+                              </div>
+                         
+                              <div style="margin:0 10pt 0 0;">
+                                   <p style="margin-top: 4px;">
+                                        Some parameters provide different functionality depending on other parameters.
+                                        For instance, changing oscillator types, filter types or effects types will
+                                        alter the descriptions and value types of their related parameters.
+                                   </p>
+                                   <p>
+                                        The '/doc/' prefix indicates documentation for a given parameter.
+                                        There are two kinds of documentation, each with a different message structure.</p>
+                                   <p> A parameter documentation message is structured like this:</p>
+                              </div>
+                         
+                              <table style="border: 2px solid black;">
+                                   <tr>
+                                        <td>/doc/&lt;parameter address&gt;</td>
+                                        <td>description</td>
+                                        <td>minimum value</td>
+                                        <td>maximum value</td>
+                                   </tr>
+                         
+                              </table>
+                         
+                              <p>Such a message might look like this:</p>
+                              <span><code>"/doc/param/a/osc/1/param2", "Feedback", "float", "-1.000000", "1.000000"</code></span>
+                         
+                              <p>A parameter extended options documentation message is structured like this:</p>
+                         
+                              <table style="border: 2px solid black;">
+                                   <tr>
+                                        <td>/doc/&lt;parameter address&gt;/ext</td>
+                                        <td>option 1</td>
+                                        <td>option 2</td>
+                                        <td>option 3</td>
+                                        <td>option 4 etc...</td>
+                                   </tr>
+                              </table>
+                         
+                              <p>Such a message might look like this:</p>
+                              <span><code>"/doc/param/a/osc/1/param2/ext", "extend", "deform"</code></span>
+                         
+                         </div>
+                         
+                         <div style="clear: both;"></div>
+>>>>>>> Stashed changes
 
                     <div style="border: 1px solid lightgray;"></div>
                     <div style="margin:10pt 10pt 0 10pt; padding: 5pt 12pt; background: #fafbff;">

--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -386,13 +386,8 @@
                                    <td class="nw">load patch from<br> user patch directory</td>
                                    <td>file path (relative to user patch dir, no extension, overwrites if file exists)
                                    </td>
-<<<<<<< Updated upstream
                               </tr>
                               <tr>
-=======
-                                   </tr>
-                                   <tr>
->>>>>>> Stashed changes
                                    <td class="nw">/patch/save</td>
                                    <td class="nw">save patch</td>
                                    <td>none: overwrites current patch <b>or</b>
@@ -404,13 +399,8 @@
                                    <td class="nw">save patch to<br> user patch directory</td>
                                    <td>file path (relative to user patch dir, no extension, overwrites if file exists)
                                    </td>
-<<<<<<< Updated upstream
                               </tr>
                               <tr>
-=======
-                                   </tr>
-                                   <tr>
->>>>>>> Stashed changes
                                    <td class="nw">/patch/incr</td>
                                    <td class="nw">increment patch</td>
                                    <td>(none)</td>
@@ -497,7 +487,7 @@
                                    <td class="center" colspan="3">out-of-range wavetable ids will be ignored</td>
                               </tr>
                          </table>
-                         </div>
+                    </div>
                     <div style="clear: both;"></div>
 
                     <div style="width: 98%; margin: 0 0 16px 10px; line-height: 1.75">
@@ -531,12 +521,14 @@
                               <tr>
                                    <td>/q/all_params</td>
                                    <td>request all parameters</td>
-                                   <td>Sends a dump of all parameters and their values, extended options (if any), and /doc messages to OSC out</td>
-                                   </tr>
-                                   <tr>
+                                   <td>Sends a dump of all parameters and their values, extended options (if any), and
+                                        /doc messages to OSC out</td>
+                              </tr>
+                              <tr>
                                    <td>/q/&ltparameter address&gt</td>
                                    <td>request one parameter</td>
-                                   <td>Sends one parameter's value, extended options (if any), and /doc message to OSC out</td>
+                                   <td>Sends one parameter's value, extended options (if any), and /doc message to OSC
+                                        out</td>
                               </tr>
                               <tr>
                                    <td>/q/all_mods</td>
@@ -1417,7 +1409,8 @@
 
                          <div style="margin:0 10pt 0 0;">
                               <p style="margin-top: 4px;">
-                                   Some parameters, (sometimes only in certain contexts), may have the following extended options:
+                                   Some parameters, (sometimes only in certain contexts), may have the following
+                                   extended options:
                               </p>
                          </div>
 
@@ -1473,12 +1466,7 @@
                                    <td>int (-1:log, 0:linear, or 1:exponential)</td>
                               </tr>
                          </table>
-<<<<<<< Updated upstream
-
-                            <div style="clear: both;"></div>
-=======
-<div style="clear: both;"></div>
->>>>>>> Stashed changes
+                         <div style="clear: both;"></div>
 
                          <div style="width: 98%; margin: 2em 0 32px 10px; line-height: 1.75">
                               <span><code>/param/a/pitch/extend+ 1</code></span>
@@ -1486,7 +1474,6 @@
                               <span><code>/param/a/aeg/attack/tempo_sync+ 0</code></span>
                               <span><code>/param/a/filter/feedback/deform+ 2</code></span>
                          </div>
-<<<<<<< Updated upstream
                     </div>
 
 
@@ -1495,7 +1482,8 @@
                     <div class="tablewrap fl cl" style="width: 80%; margin: 16px 4px;">
                          <div class="heading">
                               <h2>Parameter Documentation</h2>
-                              <h3>Sent to OSC client whenever a parameter is queried using '/q/param' or '/q/all_params'.
+                              <h3>Sent to OSC client whenever a parameter is queried using '/q/param' or
+                                   '/q/all_params'.
                               </h3>
                          </div>
 
@@ -1508,7 +1496,7 @@
                               <p>
                                    The '/doc/' prefix indicates documentation for a given parameter.
                                    There are two kinds of documentation, each with a different message structure.</p>
-                                   <p> A parameter documentation message is structured like this:</p>
+                              <p> A parameter documentation message is structured like this:</p>
                          </div>
 
                          <table style="border: 2px solid black;">
@@ -1527,80 +1515,21 @@
                          <p>A parameter extended options documentation message is structured like this:</p>
 
                          <table style="border: 2px solid black;">
-                            <tr>
-                                <td>/doc/&lt;parameter address&gt;/ext</td>
-                                <td>option 1</td>
-                                <td>option 2</td>
-                                <td>option 3</td>
-                                <td>option 4 etc...</td>
-                            </tr>
-                        </table>
+                              <tr>
+                                   <td>/doc/&lt;parameter address&gt;/ext</td>
+                                   <td>option 1</td>
+                                   <td>option 2</td>
+                                   <td>option 3</td>
+                                   <td>option 4 etc...</td>
+                              </tr>
+                         </table>
 
-                        <p>Such a message might look like this:</p>
-                        <span><code>"/doc/param/a/osc/1/param2/ext", "extend", "deform"</code></span>
+                         <p>Such a message might look like this:</p>
+                         <span><code>"/doc/param/a/osc/1/param2/ext", "extend", "deform"</code></span>
 
                     </div>
 
                     <div style="clear: both;"></div>
-
-
-=======
-                         </div>
-                         
-                         
-                         
-                         
-                         <div class="tablewrap fl cl" style="width: 80%; margin: 16px 4px;">
-                              <div class="heading">
-                                   <h2>Parameter Documentation</h2>
-                                   <h3>Sent to OSC client whenever a parameter is queried using '/q/param' or '/q/all_params'.
-                                   </h3>
-                              </div>
-                         
-                              <div style="margin:0 10pt 0 0;">
-                                   <p style="margin-top: 4px;">
-                                        Some parameters provide different functionality depending on other parameters.
-                                        For instance, changing oscillator types, filter types or effects types will
-                                        alter the descriptions and value types of their related parameters.
-                                   </p>
-                                   <p>
-                                        The '/doc/' prefix indicates documentation for a given parameter.
-                                        There are two kinds of documentation, each with a different message structure.</p>
-                                   <p> A parameter documentation message is structured like this:</p>
-                              </div>
-                         
-                              <table style="border: 2px solid black;">
-                                   <tr>
-                                        <td>/doc/&lt;parameter address&gt;</td>
-                                        <td>description</td>
-                                        <td>minimum value</td>
-                                        <td>maximum value</td>
-                                   </tr>
-                         
-                              </table>
-                         
-                              <p>Such a message might look like this:</p>
-                              <span><code>"/doc/param/a/osc/1/param2", "Feedback", "float", "-1.000000", "1.000000"</code></span>
-                         
-                              <p>A parameter extended options documentation message is structured like this:</p>
-                         
-                              <table style="border: 2px solid black;">
-                                   <tr>
-                                        <td>/doc/&lt;parameter address&gt;/ext</td>
-                                        <td>option 1</td>
-                                        <td>option 2</td>
-                                        <td>option 3</td>
-                                        <td>option 4 etc...</td>
-                                   </tr>
-                              </table>
-                         
-                              <p>Such a message might look like this:</p>
-                              <span><code>"/doc/param/a/osc/1/param2/ext", "extend", "deform"</code></span>
-                         
-                         </div>
-                         
-                         <div style="clear: both;"></div>
->>>>>>> Stashed changes
 
                     <div style="border: 1px solid lightgray;"></div>
                     <div style="margin:10pt 10pt 0 10pt; padding: 5pt 12pt; background: #fafbff;">

--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -504,17 +504,25 @@
                          <span><code>/patch/save</code></span>
                          <span><code>/patch/incr</code></span>
                     </div>
-                    <div style="width: 98%; margin: 0 0 32px 10px; line-height: 1.75">
+                    <div style="width: 98%; margin: 0 0 16px 10px; line-height: 1.75">
                          <span><code>/tuning/scl ptolemy</code></span>
                          <span><code>/tuning/scl /Users/jane/scala_tunings/ptolemy</code></span>
                          <span><code>/tuning/path/scl /Users/jane/scala_tunings</code></span>
                     </div>
-
+                    <div style="width: 98%; margin: 0 0 32px 10px; line-height: 1.75">
+                         <span><code>/wavetable/a/osc/1/id 32</code></span>
+                         <span><code>/wavetable/b/osc/3/id 98</code></span>
+                         <span><code>/wavetable/a/osc/2/incr</code></span>
+                         <span><code>/wavetable/b/osc/3/decr</code></span>
+                    </div>
                     <div style="clear: both;"></div>
 
                     <div class="tablewrap" style="width: 99%; margin: 24px 8px 16px 8px;">
                          <div class="heading">
                               <h2>Queries</h2>
+                              <h3>Replace '&lt;s&gt;' with 'a' or 'b' (scene) and &lt;n&gt; with '1' through '3'
+                                   (oscillator #)</h3>
+
                          </div>
                          <table style="border: 2px solid black;">
                               <tr>
@@ -554,6 +562,11 @@
                                    <td>request one modulation mapping's mute status</td>
                                    <td>Sends one modulation's mute status to OSC out</td>
                               </tr>
+                              <tr>
+                                   <td>/q/wavetable/&lt;s&gt;/osc/&lt;n&gt;</td>
+                                   <td>request id of wavetable for current scene and oscillator</td>
+                                   <td>Sends id of specified wavetable</td>
+                              </tr>
 
                               <tr>
                                    <td class="center" colspan="3"></td>
@@ -572,6 +585,7 @@
                          <span><code>/q/all_mods</code></span>
                          <span><code>/q/mod/rel_vel /param/a/osc/1/pitch</code></span>
                          <span><code>/q/mod/mute/rel_vel /param/a/osc/1/pitch</code></span>
+                         <span><code>/q/wavetable/a/osc/1</code></span>
                     </div>
 
                     <div style="border: 1px solid lightgray;"></div>

--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -474,21 +474,21 @@
                          <table style="border: 2px solid black;">
                               <tr>
                                    <th>Address</th>
-                                   <th>Description</th>
-                                   <th style="width: 35%;">Appropriate Values</th>
+                                   <th style="width: 29%;">Description</th>
+                                   <th style="width: 33%;">Appropriate Values</th>
                               </tr>
                               <tr>
-                                   <td>/wavetable/&lt;s&gt;/osc/n/id</td>
-                                   <td>select wavetable by id*</td>
-                                   <td>integer (0 - # of wavetables)</td>
+                                   <td>/wavetable/&lt;s&gt;/osc/&lt;n&gt;/id</td>
+                                   <td>select wavetable by id</td>
+                                   <td>int (0 - # of wavetables)*</td>
                               </tr>
                               <tr>
-                                   <td>/wavetable/&lt;s&gt;/osc/n/incr</td>
+                                   <td>/wavetable/&lt;s&gt;/osc/&lt;n&gt;/incr</td>
                                    <td>increment wavetable</td>
                                    <td></td>
                                    </tr>
                                    <tr>
-                                        <td>/wavetable/&lt;s&gt;/osc/n/decr</td>
+                                        <td>/wavetable/&lt;s&gt;/osc/&lt;n&gt;/decr</td>
                                         <td>decrement wavetable</td>
                                         <td></td>
                                    </tr>

--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -564,8 +564,8 @@
                               </tr>
                               <tr>
                                    <td>/q/wavetable/&lt;s&gt;/osc/&lt;n&gt;</td>
-                                   <td>request id of wavetable for current scene and oscillator</td>
-                                   <td>Sends id of specified wavetable</td>
+                                   <td>request wavetable info for specified scene and oscillator</td>
+                                   <td>Sends id and name of specified wavetable</td>
                               </tr>
 
                               <tr>

--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -470,21 +470,30 @@
                               <h3>Replace '&lt;s&gt;' with 'a' or 'b' (scene) and &lt;n&gt; with '1' through '3'
                                    (oscillator #)
                               </h3>
-
                          </div>
                          <table style="border: 2px solid black;">
                               <tr>
                                    <th>Address</th>
                                    <th>Description</th>
-                                   <th>Appropriate Values</th>
+                                   <th style="width: 35%;">Appropriate Values</th>
                               </tr>
                               <tr>
-                                   <td>/wavetable/&lt;s&gt;/osc/n</td>
-                                   <td> select wavetable by id</td>
-                                   <td>integer (0 - number of wavetables)</td>
+                                   <td>/wavetable/&lt;s&gt;/osc/n/id</td>
+                                   <td>select wavetable by id*</td>
+                                   <td>integer (0 - # of wavetables)</td>
                               </tr>
                               <tr>
-                                   <td class="center" colspan="3">out-of-range wavetable ids will be ignored</td>
+                                   <td>/wavetable/&lt;s&gt;/osc/n/incr</td>
+                                   <td>increment wavetable</td>
+                                   <td></td>
+                                   </tr>
+                                   <tr>
+                                        <td>/wavetable/&lt;s&gt;/osc/n/decr</td>
+                                        <td>decrement wavetable</td>
+                                        <td></td>
+                                   </tr>
+                                   <tr>
+                                        <td class="center" colspan="3">*out-of-range wavetable ids will be ignored</td>
                               </tr>
                          </table>
                     </div>

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -427,6 +427,15 @@ void SurgeSynthProcessor::paramChangeToListeners(Parameter *p, bool isSpecialCas
                 (it.second)("/chan_at", 2, f0, f1, .0, "");
                 break;
 
+            case SCT_WAVETABLE:
+            {
+                std::stringstream s;
+                std::string scene = f0 > 0.0 ? "b" : "a";
+                s << "/wavetable/" << scene << "/osc/" << ((int)f1) + 1;
+                (it.second)(s.str(), 1, f2, .0, .0, newValue);
+            }
+            break;
+
             default:
                 break;
             }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -448,7 +448,8 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         SCT_PITCHBEND,
         SCT_CC,
         SCT_CHAN_ATOUCH,
-        SCT_POLY_ATOUCH
+        SCT_POLY_ATOUCH,
+        SCT_WAVETABLE
     };
 
     void paramChangeToListeners(Parameter *p, bool isSpecialCase = false, int specialCaseType = -1,

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -96,6 +96,10 @@ OscillatorWaveformDisplay::OscillatorWaveformDisplay()
             sge->enqueueAccessibleAnnouncement(announce);
 
             oscdata->wt.queue_id = id;
+            auto new_name = storage->wt_list.at(id).name;
+            SurgeSynthProcessor *ssp = &sge->juceEditor->processor;
+            ssp->paramChangeToListeners(nullptr, true, ssp->SCT_WAVETABLE, (float)scene,
+                                        (float)oscInScene, (float)id, new_name);
         }
     };
     ol->onReturnKey = [ov = ol.get()](OscillatorWaveformDisplay *d) {
@@ -1017,6 +1021,10 @@ void OscillatorWaveformDisplay::loadWavetable(int id)
             sge->enqueueAccessibleAnnouncement(announce);
         }
         oscdata->wt.queue_id = id;
+        auto new_name = storage->wt_list.at(id).name;
+        SurgeSynthProcessor *ssp = &sge->juceEditor->processor;
+        ssp->paramChangeToListeners(nullptr, true, ssp->SCT_WAVETABLE, (float)scene,
+                                    (float)oscInScene, (float)id, new_name);
     }
 }
 
@@ -1092,7 +1100,6 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
     {
         int id = oscdata->wt.current_id;
         bool openMenu = false;
-        auto &ssp = sge->juceEditor->processor;
 
         if (leftJog.contains(event.position))
         {
@@ -1112,6 +1119,10 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
                     }
 
                     oscdata->wt.queue_id = id;
+                    auto new_name = storage->wt_list.at(id).name;
+                    SurgeSynthProcessor *ssp = &sge->juceEditor->processor;
+                    ssp->paramChangeToListeners(nullptr, true, ssp->SCT_WAVETABLE, (float)scene,
+                                                (float)oscInScene, (float)id, new_name);
                 }
             }
             else
@@ -1138,10 +1149,10 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
                     }
 
                     oscdata->wt.queue_id = id;
-
                     auto new_name = storage->wt_list.at(id).name;
-                    ssp.paramChangeToListeners(nullptr, true, ssp.SCT_WAVETABLE, (float)scene,
-                                               (float)oscInScene, (float)id, new_name);
+                    SurgeSynthProcessor *ssp = &sge->juceEditor->processor;
+                    ssp->paramChangeToListeners(nullptr, true, ssp->SCT_WAVETABLE, (float)scene,
+                                                (float)oscInScene, (float)id, new_name);
                 }
             }
             else

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -22,6 +22,8 @@
 
 #include "OscillatorWaveformDisplay.h"
 #include "SurgeStorage.h"
+#include "SurgeSynthProcessor.h"
+#include "SurgeSynthEditor.h"
 #include "Oscillator.h"
 #include "OscillatorBase.h"
 #include "RuntimeFont.h"
@@ -1090,6 +1092,7 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
     {
         int id = oscdata->wt.current_id;
         bool openMenu = false;
+        auto &ssp = sge->juceEditor->processor;
 
         if (leftJog.contains(event.position))
         {
@@ -1135,6 +1138,10 @@ void OscillatorWaveformDisplay::mouseDown(const juce::MouseEvent &event)
                     }
 
                     oscdata->wt.queue_id = id;
+
+                    auto new_name = storage->wt_list.at(id).name;
+                    ssp.paramChangeToListeners(nullptr, true, ssp.SCT_WAVETABLE, (float)scene,
+                                               (float)oscInScene, (float)id, new_name);
                 }
             }
             else

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -186,6 +186,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     std::getline(split, throwaway, '/');
 
     std::string address1, address2, address3;
+    std::string address1, address2, address3;
     std::getline(split, address1, '/');
     bool querying = false;
 
@@ -755,10 +756,10 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         }
     }
 
+    // Wavetable control
     else if (address1 == "wavetable")
     {
         std::getline(split, address2, '/');
-        // Wavetable control
         if (!(address2 == "a" || address2 == "b"))
         {
             sendError("/wavetable must specify a scene (a or b)");

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -186,7 +186,6 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     std::getline(split, throwaway, '/');
 
     std::string address1, address2, address3;
-    std::string address1, address2, address3;
     std::getline(split, address1, '/');
     bool querying = false;
 


### PR DESCRIPTION
Added /wavetable messages, allowing setting, querying, incrementing and decrementing of wavetable id.

File functions for wavetables are not yet supported over OSC.

NOTE: The commit entitled "Refactored some confusing..." creates many (simple) diffs which might make code review difficult if not viewed in isolation, so it is recommended to not squash commits until after reviewing.