### PR TITLE
Osc work mid april: bug fixes

### DIFF
--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -565,7 +565,7 @@
                               <tr>
                                    <td>/q/wavetable/&lt;s&gt;/osc/&lt;n&gt;</td>
                                    <td>request wavetable info for specified scene and oscillator</td>
-                                   <td>Sends id and name of specified wavetable</td>
+                                   <td>Sends id and name of specified wavetable to OSC out</td>
                               </tr>
 
                               <tr>

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -396,19 +396,19 @@ void SurgeSynthProcessor::paramChangeToListeners(Parameter *p, bool isSpecialCas
                 break;
 
             case SCT_EX_PORTA_CONRATE:
-                (it.second)(p->oscName + "/portamento/const_rate+", 1, f0, .0, .0, "");
+                (it.second)(p->oscName + "/const_rate+", 1, f0, .0, .0, "");
                 break;
 
             case SCT_EX_PORTA_GLISS:
-                (it.second)(p->oscName + "/portamento/gliss+", 1, f0, .0, .0, "");
+                (it.second)(p->oscName + "/gliss+", 1, f0, .0, .0, "");
                 break;
 
             case SCT_EX_PORTA_RETRIG:
-                (it.second)(p->oscName + "/portamento/retrig+", 1, f0, .0, .0, "");
+                (it.second)(p->oscName + "/retrig+", 1, f0, .0, .0, "");
                 break;
 
             case SCT_EX_PORTA_CURVE:
-                (it.second)(p->oscName + "/portamento/curve+", 1, f0, .0, .0, "");
+                (it.second)(p->oscName + "/curve+", 1, f0, .0, .0, "");
                 break;
 
             case SCT_PITCHBEND:

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -1358,7 +1358,7 @@ void OpenSoundControl::sendParameterExtOptions(const Parameter *p, bool needsMes
         sendParameter(p, needsMessageThread, "deform");
     if (p->has_portaoptions())
     {
-        sendParameter(p, needsMessageThread, "crate");
+        sendParameter(p, needsMessageThread, "const_rate");
         sendParameter(p, needsMessageThread, "gliss");
         sendParameter(p, needsMessageThread, "retrig");
         sendParameter(p, needsMessageThread, "curve");
@@ -1538,6 +1538,7 @@ void OpenSoundControl::sendParameter(const Parameter *p, bool needsMessageThread
         if (extension == "curve")
             val01 = (float)p->porta_curve;
         addr = p->oscName + "/" + extension + "+";
+        std::cout << "p->oscName: " << p->oscName << std::endl;
     }
 
     juce::OSCMessage om = juce::OSCMessage(juce::OSCAddressPattern(juce::String(addr)));


### PR DESCRIPTION
Fixed two minor bugs: /portamento/portamento was getting sent on echo; removed redundant '/portamento'. 'conrate' changed to 'const_rate' in one place where it was missed. OSC spec tweaked.