### PR TITLE
OSC: /tuning info output now supported

### DIFF
--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -533,7 +533,7 @@
                               <tr>
                                    <td>/q/patch</td>
                                    <td>request current patch</td>
-                                   <td>Sends the full path of the current patch to OSC out</td>
+                                   <td>Sends the full path (minus extension) of the current patch to OSC out</td>
                               </tr>
                               <tr>
                                    <td>/q/all_params</td>
@@ -566,6 +566,16 @@
                                    <td>/q/wavetable/&lt;s&gt;/osc/&lt;n&gt;</td>
                                    <td>request wavetable info for specified scene and oscillator</td>
                                    <td>Sends id and name of specified wavetable to OSC out</td>
+                              </tr>
+                              <tr>
+                                   <td>/q/tuning/scl</td>
+                                   <td>request current tuning</td>
+                                   <td>Sends full path (minus extension) of current .scl tuning to OSC out</td>
+                              </tr>
+                              <tr>
+                                   <td>/q/tuning/kbm</td>
+                                   <td>request current keyboard mapping</td>
+                                   <td>Sends full path (minus extension) of current .kbm mapping to OSC out</td>
                               </tr>
 
                               <tr>

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -436,6 +436,20 @@ void SurgeSynthProcessor::paramChangeToListeners(Parameter *p, bool isSpecialCas
             }
             break;
 
+            case SCT_TUNING_SCL:
+            {
+                std::string s = "/tuning/scl";
+                (it.second)(s, 0, .0, .0, .0, newValue);
+            }
+            break;
+
+            case SCT_TUNING_KBM:
+            {
+                std::string s = "/tuning/kbm";
+                (it.second)(s, 0, .0, .0, .0, newValue);
+            }
+            break;
+
             default:
                 break;
             }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -449,7 +449,9 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         SCT_CC,
         SCT_CHAN_ATOUCH,
         SCT_POLY_ATOUCH,
-        SCT_WAVETABLE
+        SCT_WAVETABLE,
+        SCT_TUNING_SCL,
+        SCT_TUNING_KBM
     };
 
     void paramChangeToListeners(Parameter *p, bool isSpecialCase = false, int specialCaseType = -1,

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -399,19 +399,18 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
 
         tuningSubMenu.addSeparator();
 
-        tuningSubMenu.addItem(Surge::GUI::toOSCase("Set to Standard Tuning"),
-                              !this->synth->storage.isStandardTuning, false, [this]() {
-                                  this->synth->storage.retuneTo12TETScaleC261Mapping();
-                                  this->synth->storage.resetTuningToggle();
-                                  this->synth->refresh_editor = true;
-                                  tuningChanged();
-                                  juceEditor->processor.paramChangeToListeners(
-                                      nullptr, true, juceEditor->processor.SCT_TUNING_SCL, .0, .0,
-                                      .0, "(standard)");
-                                  juceEditor->processor.paramChangeToListeners(
-                                      nullptr, true, juceEditor->processor.SCT_TUNING_KBM, .0, .0,
-                                      .0, "(standard)");
-                              });
+        tuningSubMenu.addItem(
+            Surge::GUI::toOSCase("Set to Standard Tuning"), !this->synth->storage.isStandardTuning,
+            false, [this]() {
+                this->synth->storage.retuneTo12TETScaleC261Mapping();
+                this->synth->storage.resetTuningToggle();
+                this->synth->refresh_editor = true;
+                tuningChanged();
+                juceEditor->processor.paramChangeToListeners(
+                    nullptr, true, juceEditor->processor.SCT_TUNING_SCL, .0, .0, .0, "(standard)");
+                juceEditor->processor.paramChangeToListeners(
+                    nullptr, true, juceEditor->processor.SCT_TUNING_KBM, .0, .0, .0, "(standard)");
+            });
 
         tuningSubMenu.addItem(Surge::GUI::toOSCase("Set to Standard Mapping (Concert C)"),
                               (!this->synth->storage.isStandardMapping), false, [this]() {

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -405,6 +405,12 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                                   this->synth->storage.resetTuningToggle();
                                   this->synth->refresh_editor = true;
                                   tuningChanged();
+                                  juceEditor->processor.paramChangeToListeners(
+                                      nullptr, true, juceEditor->processor.SCT_TUNING_SCL, .0, .0,
+                                      .0, "(standard)");
+                                  juceEditor->processor.paramChangeToListeners(
+                                      nullptr, true, juceEditor->processor.SCT_TUNING_KBM, .0, .0,
+                                      .0, "(standard)");
                               });
 
         tuningSubMenu.addItem(Surge::GUI::toOSCase("Set to Standard Mapping (Concert C)"),
@@ -412,6 +418,9 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                                   this->synth->storage.remapToConcertCKeyboard();
                                   this->synth->refresh_editor = true;
                                   tuningChanged();
+                                  juceEditor->processor.paramChangeToListeners(
+                                      nullptr, true, juceEditor->processor.SCT_TUNING_KBM, .0, .0,
+                                      .0, "(standard)");
                               });
 
         tuningSubMenu.addItem(Surge::GUI::toOSCase("Set to Standard Scale (12-TET)"),
@@ -419,6 +428,9 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                                   this->synth->storage.retuneTo12TETScale();
                                   this->synth->refresh_editor = true;
                                   tuningChanged();
+                                  juceEditor->processor.paramChangeToListeners(
+                                      nullptr, true, juceEditor->processor.SCT_TUNING_SCL, .0, .0,
+                                      .0, "(standard)");
                               });
 
         tuningSubMenu.addSeparator();
@@ -454,6 +466,10 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                     synth->storage.reportError(e.what(), "Loading Error");
                 }
                 tuningChanged();
+                auto tuningLabel = path_to_string(fs::path(synth->storage.currentScale.name));
+                tuningLabel = tuningLabel.substr(0, tuningLabel.find_last_of("."));
+                juceEditor->processor.paramChangeToListeners(
+                    nullptr, true, juceEditor->processor.SCT_TUNING_SCL, .0, .0, .0, tuningLabel);
             };
 
             auto scl_path = this->synth->storage.datapath / "tuning_library" / "SCL";
@@ -475,6 +491,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                     auto dir =
                         string_to_path(res.getParentDirectory().getFullPathName().toStdString());
                     cb(rString);
+
                     if (dir != scl_path)
                     {
                         Surge::Storage::updateUserDefaultPath(&(this->synth->storage),
@@ -515,6 +532,10 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                     synth->storage.reportError(e.what(), "Loading Error");
                 }
                 tuningChanged();
+                auto mappingLabel = synth->storage.currentMapping.name;
+                mappingLabel = mappingLabel.substr(0, mappingLabel.find_last_of("."));
+                juceEditor->processor.paramChangeToListeners(
+                    nullptr, true, juceEditor->processor.SCT_TUNING_KBM, .0, .0, .0, mappingLabel);
             };
 
             auto kbm_path = this->synth->storage.datapath / "tuning_library" / "KBM Concert Pitch";

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -1538,7 +1538,6 @@ void OpenSoundControl::sendParameter(const Parameter *p, bool needsMessageThread
         if (extension == "curve")
             val01 = (float)p->porta_curve;
         addr = p->oscName + "/" + extension + "+";
-        std::cout << "p->oscName: " << p->oscName << std::endl;
     }
 
     juce::OSCMessage om = juce::OSCMessage(juce::OSCAddressPattern(juce::String(addr)));

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -930,9 +930,6 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
     // Tuning switching
     else if (addr_part == "tuning")
     {
-        if (querying)
-            return; // Not yet implemented
-
         fs::path path = getWholeString(message);
         fs::path def_path;
 
@@ -940,6 +937,9 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         // Tuning files path control
         if (addr_part == "path")
         {
+            if (querying)
+                return; // Not supported
+
             std::string dataStr = getWholeString(message);
             if ((dataStr != "_reset") && (!fs::exists(dataStr)))
             {
@@ -955,6 +955,8 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
             {
                 if (dataStr == "_reset")
                 {
+                    if (querying)
+                        return; // Not sensical
                     ppath = synth->storage.datapath;
                     ppath /= "tuning_library/SCL";
                 }
@@ -975,6 +977,19 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         // Tuning file selection
         else if (addr_part == "scl")
         {
+            if (querying)
+            {
+                auto tuningLabel = path_to_string(fs::path(synth->storage.currentScale.name));
+                tuningLabel = tuningLabel.substr(0, tuningLabel.find_last_of("."));
+                if (tuningLabel == "Scale from patch")
+                    tuningLabel = "(standard)";
+                std::string addr = "/tuning/scl";
+                juce::OSCMessage om = juce::OSCMessage(juce::OSCAddressPattern(juce::String(addr)));
+                om.addString(tuningLabel);
+                OpenSoundControl::send(om, true);
+                return;
+            }
+
             if (path.is_relative())
             {
                 def_path = Surge::Storage::getUserDefaultPath(
@@ -993,6 +1008,19 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
         // KBM mapping file selection
         else if (addr_part == "kbm")
         {
+            if (querying)
+            {
+                auto mappingLabel = synth->storage.currentMapping.name;
+                mappingLabel = mappingLabel.substr(0, mappingLabel.find_last_of("."));
+                if (mappingLabel == "")
+                    mappingLabel = "(standard)";
+                std::string addr = "/tuning/kbm";
+                juce::OSCMessage om = juce::OSCMessage(juce::OSCAddressPattern(juce::String(addr)));
+                om.addString(mappingLabel);
+                OpenSoundControl::send(om, true);
+                return;
+            }
+
             if (path.is_relative())
             {
                 def_path = Surge::Storage::getUserDefaultPath(


### PR DESCRIPTION
OSC '/tuning' now supports output (changes to .scl and/or .kbm in GUI are echoed, and queries of current scl/kbm are supported).