### PR TITLE
Only turn on the -fnochar8 options in C++20 or above

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     $<$<BOOL:${SURGE_SANITIZE}>:-fsanitize=undefined>
 
     # Do *not* use the new, breaking char8_t UTF-8 bits in C++20.
-    $<$<COMPILE_LANGUAGE:CXX>:-fno-char8_t>
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_STANDARD},20>>:-fno-char8_t>
   )
 
   add_link_options(


### PR DESCRIPTION
Implements the review request languishing in https://github.com/surge-synthesizer/surge/pull/7562/files