### PR TITLE
Changed 'deact' to 'enable' in OSC output; tweak to OSC spec.

### DIFF
--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -168,7 +168,7 @@
                                    not how messages are to be formatted for OSC).
                               </p>
                               <p style="margin-top: 28px;">
-                                   <b>OSC Output</b>: All parameter, patch and modulation mapping changes made on Surge
+                                   <b>OSC Output</b>: All parameter, patch, tuning and modulation mapping changes made on Surge
                                    XT are reported to
                                    OSC out, if OSC output is enabled.
                                    Parameters are reported in the ranges given under "Appropriate Values" (0.0 - 1.0 for
@@ -1506,6 +1506,7 @@
                               <span><code>/param/a/osc/1/pitch/abs+ 1</code></span>
                               <span><code>/param/a/aeg/attack/tempo_sync+ 0</code></span>
                               <span><code>/param/a/filter/feedback/deform+ 2</code></span>
+                              <span><code>/param/a/portamento/curve+ 1</code></span>
                          </div>
                     </div>
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1935,6 +1935,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             p->deactivated = !p->deactivated;
                             synth->storage.getPatch().isDirty = true;
                             synth->refresh_editor = true;
+
+                            // output updated value to OSC
+                            juceEditor->processor.paramChangeToListeners(
+                                p, true, juceEditor->processor.SCT_EX_ENABLE,
+                                (float)!p->deactivated, .0, .0, "");
                         });
                     }
                 }

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -1550,7 +1550,7 @@ void OpenSoundControl::sendParameter(const Parameter *p, bool needsMessageThread
         if (extension == "abs")
             val01 = (float)p->absolute;
         if (extension == "enable")
-            val01 = (float)p->deactivated;
+            val01 = (float)!p->deactivated;
         if (extension == "tempo_sync")
             val01 = (float)p->temposync;
         if (extension == "extend")

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -1377,7 +1377,7 @@ void OpenSoundControl::sendParameterExtOptions(const Parameter *p, bool needsMes
     if (p->can_be_absolute())
         sendParameter(p, needsMessageThread, "abs");
     if (p->can_deactivate())
-        sendParameter(p, needsMessageThread, "deact");
+        sendParameter(p, needsMessageThread, "enable");
     if (p->can_temposync())
         sendParameter(p, needsMessageThread, "tempo_sync");
     if (p->can_extend_range())


### PR DESCRIPTION
pre-release cleanup:

1. fix of leftover 'deact' (should be 'enable') in OSC out message. 
2. found additional place where 'enable' was changed in GUI, added a paramChangeToListeners() to it.
3. Specification tweaks.