### PR TITLE
Osc pre 132: fixes for #7579 and #7626; VST3 automation parameter changes echoed to OSC.

### DIFF
--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -168,12 +168,10 @@
                                    not how messages are to be formatted for OSC).
                               </p>
                               <p style="margin-top: 28px;">
-                                   <b>OSC Output</b>: All parameter, patch, tuning and modulation mapping changes made on Surge
-                                   XT are reported to
-                                   OSC out, if OSC output is enabled.
-                                   Parameters are reported in the ranges given under "Appropriate Values" (0.0 - 1.0 for
-                                   'float' parameters), followed by a
-                                   displayable string.
+                                   <b>OSC Output</b>: Parameter, patch, tuning and modulation mapping changes
+                                   made on Surge XT are reported to OSC out, if OSC output is enabled.
+                                   Parameters are reported in the ranges given under "Appropriate Values"
+                                   (0.0 - 1.0 for 'float' parameters), followed by a displayable string.
                                    Errors are reported (when feasible) to "/error".
                               </p>
                               <div style="margin: 16px 0 8px 0" ;>

--- a/resources/surge-shared/oscspecification.html
+++ b/resources/surge-shared/oscspecification.html
@@ -1535,6 +1535,7 @@
                               <tr>
                                    <td>/doc/&lt;parameter address&gt;</td>
                                    <td>description</td>
+                                   <td>type</td>
                                    <td>minimum value</td>
                                    <td>maximum value</td>
                               </tr>

--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -601,7 +601,8 @@ void SurgeSynthEditor::endParameterEdit(Parameter *p)
     auto par = processor.paramsByID[processor.surge->idForParameter(p)];
     par->inEditGesture = false;
     par->endChangeGesture();
-    processor.paramChangeToListeners(p);
+    if (fireListenersOnEndEdit)
+        processor.paramChangeToListeners(p);
 }
 
 void SurgeSynthEditor::beginMacroEdit(long macroNum)

--- a/src/surge-xt/SurgeSynthEditor.h
+++ b/src/surge-xt/SurgeSynthEditor.h
@@ -99,6 +99,8 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     int midiKeyboardOctave{5};
     float midiKeyboardVelocity{127.f / 127.f}; // see issue #6409
 
+    bool fireListenersOnEndEdit{true};
+
     std::unique_ptr<juce::Component> pitchwheel, modwheel, suspedal;
     std::unique_ptr<juce::MidiKeyboardComponent> keyboard;
     std::unique_ptr<juce::Label> tempoLabel, sustainLabel;

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -938,17 +938,12 @@ void SurgeSynthProcessor::processBlockOSC()
                 newDisabledMask = curmask & msk;
             }
             else // set selected bit to one
-            {
                 newDisabledMask = curmask | msk;
-            }
 
             surge->storage.getPatch().fx_disable.val.i = newDisabledMask;
-            if (surge->fx_suspend_bitmask != newDisabledMask)
-            {
-                surge->fx_suspend_bitmask = newDisabledMask;
-                surge->storage.getPatch().isDirty = true;
-                surge->refresh_editor = true;
-            }
+            surge->fx_suspend_bitmask = newDisabledMask;
+            surge->storage.getPatch().isDirty = true;
+            surge->refresh_editor = true;
         }
         break;
 

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -943,6 +943,10 @@ void SurgeSynthProcessor::processBlockOSC()
             {
                 newDisabledMask = curmask | msk;
             }
+
+            std::cout << "FX_DISABLE, selected_mask = " << selected_mask
+                      << " newval = " << newDisabledMask << " pptr: " << om.param << std::endl;
+
             surge->storage.getPatch().fx_disable.val.i = newDisabledMask;
             if (surge->fx_suspend_bitmask != newDisabledMask)
             {
@@ -1709,8 +1713,7 @@ void SurgeParamToJuceParamAdapter::setValue(float f)
     if (!matches && !inEditGesture)
     {
         s->setParameter01(s->idForParameter(p), f, true);
-        // Probably OSC needs this
-        // ssp->paramChangeToListeners(p);
+        ssp->paramChangeToListeners(p);
     }
 }
 

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -358,10 +358,10 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         int scene{0}, index{0};
 
         oscToAudio() {}
-        oscToAudio(oscToAudio_type omtype, Parameter *p, float f, int i, char c0, char c1, bool on,
-                   int32_t noteid, int scene, int index)
-            : type(omtype), param(p = nullptr), fval(f = 0.0), ival(i = 0), char0(c0 = 0),
-              char1(c1 = 0), on(on = 0), noteid(noteid = 0), scene(scene = 0), index(index = 0)
+        explicit oscToAudio(oscToAudio_type omtype, Parameter *p, float f, int i, char c0, char c1,
+                            bool on, int32_t noteid, int scene, int index)
+            : type(omtype), param(p), fval(f), ival(i), char0(c0), char1(c1), on(on),
+              noteid(noteid), scene(scene), index(index)
         {
         }
 

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -358,6 +358,13 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         int scene{0}, index{0};
 
         oscToAudio() {}
+        oscToAudio(oscToAudio_type omtype, Parameter *p, float f, int i, char c0, char c1, bool on,
+                   int32_t noteid, int scene, int index)
+            : type(omtype), param(p = nullptr), fval(f = 0.0), ival(i = 0), char0(c0 = 0),
+              char1(c1 = 0), on(on = 0), noteid(noteid = 0), scene(scene = 0), index(index = 0)
+        {
+        }
+
         oscToAudio(oscToAudio_type omtype, char c0, char c1, int i)
             : type(omtype), char0(c0), char1(c1), ival(i)
         {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1285,6 +1285,7 @@ void SurgeGUIEditor::idle()
         }
     }
 
+    juceEditor->fireListenersOnEndEdit = false;
     for (int s = 0; s < n_scenes; ++s)
     {
         for (int o = 0; o < n_oscs; ++o)
@@ -1317,6 +1318,7 @@ void SurgeGUIEditor::idle()
             juceEditor->endParameterEdit(&par);
         }
     }
+    juceEditor->fireListenersOnEndEdit = true;
 }
 
 void SurgeGUIEditor::toggle_mod_editing()

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -699,7 +699,6 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
 
             fxslot = std::distance(std::begin(fxslot_shortoscname), found);
             int selected_mask = 1 << fxslot;
-
             if (querying)
             {
                 int deac_mask = synth->storage.getPatch().fx_disable.val.i;
@@ -731,7 +730,6 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                 // Send packet to audio thread
                 //         explicit oscToAudio(oscToAudio_type omtype, Parameter *p, float f, int i,
                 //         char c0, char c1, bool on, int32_t noteid, int scene, int index)
-
                 sspPtr->oscRingBuf.push(
                     SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::FX_DISABLE, nullptr, 0.0,
                                                     selected_mask, 0, 0, onoff > 0, 0, 0, 0));

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -728,8 +728,6 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                 }
 
                 // Send packet to audio thread
-                //         explicit oscToAudio(oscToAudio_type omtype, Parameter *p, float f, int i,
-                //         char c0, char c1, bool on, int32_t noteid, int scene, int index)
                 sspPtr->oscRingBuf.push(
                     SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::FX_DISABLE, nullptr, 0.0,
                                                     selected_mask, 0, 0, onoff > 0, 0, 0, 0));

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -729,7 +729,12 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                 }
 
                 // Send packet to audio thread
-                sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(selected_mask, onoff));
+                //         explicit oscToAudio(oscToAudio_type omtype, Parameter *p, float f, int i,
+                //         char c0, char c1, bool on, int32_t noteid, int scene, int index)
+
+                sspPtr->oscRingBuf.push(
+                    SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::FX_DISABLE, nullptr, 0.0,
+                                                    selected_mask, 0, 0, onoff > 0, 0, 0, 0));
             }
         }
 


### PR DESCRIPTION
OSC work, pre-release 1.3.2.

- Issues https://github.com/surge-synthesizer/surge/issues/7579 and https://github.com/surge-synthesizer/surge/issues/7626# fixed.
- VST3 automation-caused parameter changes are now echoed to OSC out