### PR TITLE
Dragging a non-mod param in mod mode now allows undo

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2556,7 +2556,13 @@ void SurgeGUIEditor::controlBeginEdit(Surge::GUI::IComponentTagValue *control)
 
     if (ptag >= 0 && ptag < synth->storage.getPatch().param_ptr.size())
     {
-        if (mod_editor)
+        bool isModEdit = mod_editor;
+        if (isModEdit)
+        {
+            auto *pp = synth->storage.getPatch().param_ptr[ptag];
+            isModEdit = isModEdit && synth->isValidModulation(pp->id, modsource);
+        }
+        if (isModEdit)
         {
             auto mci = dynamic_cast<Surge::Widgets::ModulatableControlInterface *>(control);
             if (mci)
@@ -2599,7 +2605,13 @@ void SurgeGUIEditor::controlEndEdit(Surge::GUI::IComponentTagValue *control)
 
     if (ptag >= 0 && ptag < synth->storage.getPatch().param_ptr.size())
     {
-        if (mod_editor)
+        bool isModEdit = mod_editor;
+        if (isModEdit)
+        {
+            auto *pp = synth->storage.getPatch().param_ptr[ptag];
+            isModEdit = isModEdit && synth->isValidModulation(pp->id, modsource);
+        }
+        if (isModEdit)
         {
             auto mci = dynamic_cast<Surge::Widgets::ModulatableControlInterface *>(control);
             if (mci)


### PR DESCRIPTION
Dragging a non-modulatable parameter (like, say, FM2 M2 ratio) with modulation armed (so like Macro green) meant the change neither correctly fired a start/end param change gesture nor participated in undo, since the control begin/edit only looked at armed state, not armed and modulatable. Fix.