### PR TITLE
Osc 0504 - refactor oscToAudio messages

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -983,9 +983,9 @@ void SurgeSynthProcessor::processBlockOSC()
             break;
 
         case SurgeSynthProcessor::DEFORM_X:
-            if (om.param->deform_type != om.on)
+            if (om.param->deform_type != om.ival)
             {
-                om.param->deform_type = om.on;
+                om.param->deform_type = om.ival;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -964,7 +964,6 @@ void SurgeSynthProcessor::processBlockOSC()
             // This parameter is stored as 'disabled', but UI uses 'enabled',
             //  so logic is flipped here:
             bool disabled = !om.on;
-            std::cout << om.param->oscName << " - disabled: " << disabled << std::endl;
             if (om.param->deactivated != disabled)
             {
                 om.param->deactivated = disabled;

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -1019,9 +1019,9 @@ void SurgeSynthProcessor::processBlockOSC()
             break;
 
         case SurgeSynthProcessor::PORTA_CURVE_X:
-            if (om.param->porta_curve != om.on)
+            if (om.param->porta_curve != om.ival)
             {
-                om.param->porta_curve = om.on;
+                om.param->porta_curve = om.ival;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -861,7 +861,7 @@ void SurgeSynthProcessor::processBlockOSC()
             break;
 
         case SurgeSynthProcessor::CHAN_ATOUCH:
-            surge->channelAftertouch(om.char0, om.fval);
+            surge->channelAftertouch(om.char0, om.ival);
             break;
 
         case SurgeSynthProcessor::POLY_ATOUCH:
@@ -942,18 +942,18 @@ void SurgeSynthProcessor::processBlockOSC()
         break;
 
         case SurgeSynthProcessor::ABSOLUTE_X:
-            if (om.param->absolute != (bool)om.ival)
+            if (om.param->absolute != (bool)om.on)
             {
-                om.param->absolute = om.ival;
+                om.param->absolute = om.on;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }
             break;
 
         case SurgeSynthProcessor::TEMPOSYNC_X:
-            if (om.param->temposync != (bool)om.ival)
+            if (om.param->temposync != (bool)om.on)
             {
-                om.param->temposync = om.ival;
+                om.param->temposync = om.on;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }
@@ -963,7 +963,8 @@ void SurgeSynthProcessor::processBlockOSC()
         {
             // This parameter is stored as 'disabled', but UI uses 'enabled',
             //  so logic is flipped here:
-            bool disabled = !(bool)om.ival;
+            bool disabled = !om.on;
+            std::cout << om.param->oscName << " - disabled: " << disabled << std::endl;
             if (om.param->deactivated != disabled)
             {
                 om.param->deactivated = disabled;
@@ -974,54 +975,54 @@ void SurgeSynthProcessor::processBlockOSC()
         break;
 
         case SurgeSynthProcessor::EXTEND_X:
-            if (om.param->extend_range != (bool)om.ival)
+            if (om.param->extend_range != om.on)
             {
-                om.param->extend_range = om.ival;
+                om.param->extend_range = om.on;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }
             break;
 
         case SurgeSynthProcessor::DEFORM_X:
-            if (om.param->deform_type != om.ival)
+            if (om.param->deform_type != om.on)
             {
-                om.param->deform_type = om.ival;
+                om.param->deform_type = om.on;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }
             break;
 
         case SurgeSynthProcessor::PORTA_CONSTRATE_X:
-            if (om.param->porta_constrate != (bool)om.ival)
+            if (om.param->porta_constrate != om.on)
             {
-                om.param->porta_constrate = om.ival;
+                om.param->porta_constrate = om.on;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }
             break;
 
         case SurgeSynthProcessor::PORTA_GLISS_X:
-            if (om.param->porta_gliss != (bool)om.ival)
+            if (om.param->porta_gliss != om.on)
             {
-                om.param->porta_gliss = om.ival;
+                om.param->porta_gliss = om.on;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }
             break;
 
         case SurgeSynthProcessor::PORTA_RETRIGGER_X:
-            if (om.param->porta_retrigger != (bool)om.ival)
+            if (om.param->porta_retrigger != om.on)
             {
-                om.param->porta_retrigger = om.ival;
+                om.param->porta_retrigger = om.on;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }
             break;
 
         case SurgeSynthProcessor::PORTA_CURVE_X:
-            if (om.param->porta_curve != om.ival)
+            if (om.param->porta_curve != om.on)
             {
-                om.param->porta_curve = om.ival;
+                om.param->porta_curve = om.on;
                 surge->storage.getPatch().isDirty = true;
                 surge->queueForRefresh(om.param->id);
             }

--- a/src/surge-xt/SurgeSynthProcessor.h
+++ b/src/surge-xt/SurgeSynthProcessor.h
@@ -346,6 +346,7 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         POLY_ATOUCH
     };
 
+    // Message from OSC input to the audio thread
     struct oscToAudio
     {
         oscToAudio_type type;
@@ -358,40 +359,15 @@ class SurgeSynthProcessor : public juce::AudioProcessor,
         int scene{0}, index{0};
 
         oscToAudio() {}
+        // Various OSC messages use different subsets of the following fields
         explicit oscToAudio(oscToAudio_type omtype, Parameter *p, float f, int i, char c0, char c1,
                             bool on, int32_t noteid, int scene, int index)
             : type(omtype), param(p), fval(f), ival(i), char0(c0), char1(c1), on(on),
               noteid(noteid), scene(scene), index(index)
         {
         }
-
-        oscToAudio(oscToAudio_type omtype, char c0, char c1, int i)
-            : type(omtype), char0(c0), char1(c1), ival(i)
-        {
-        }
-        oscToAudio(oscToAudio_type omtype, char c, int i) : type(omtype), char0(c), ival(i) {}
-        oscToAudio(oscToAudio_type omtype) : type(omtype) {}
-        oscToAudio(oscToAudio_type omtype, Parameter *p, int i) : type(omtype), param(p), ival(i) {}
-        oscToAudio(int mask, int on) : type(FX_DISABLE), ival(mask), on(on) {}
-        oscToAudio(int macnum, float f) : type(MACRO), ival(macnum), fval(f) {}
+        // Constructor for common parameter updates
         oscToAudio(Parameter *p, float f) : type(PARAMETER), param(p), fval(f) {}
-        oscToAudio(Parameter *p, int modulator, int sc, int idx, float depth)
-            : type(MOD), param(p), ival(modulator), scene(sc), index(idx), fval(depth)
-        {
-        }
-        oscToAudio(Parameter *p, int modulator, int sc, int idx, float depth, bool mute)
-            : type(MOD_MUTE), param(p), ival(modulator), scene(sc), index(idx), fval(depth)
-        {
-        }
-        oscToAudio(float freq, char velocity, bool noteon, int32_t nid)
-            : type(FREQNOTE), fval(freq), char1(velocity), on(noteon), noteid(nid)
-        {
-        }
-        oscToAudio(char note, char velocity, bool noteon, int32_t nid)
-            : type(MNOTE), char0(note), char1(velocity), on(noteon), noteid(nid)
-        {
-        }
-        oscToAudio(oscToAudio_type type, int32_t nid, float f) : type(type), noteid(nid), fval(f) {}
     };
     sst::cpputils::SimpleRingBuffer<oscToAudio, 4096> oscRingBuf;
 

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -639,7 +639,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                         sendError("Param " + p->oscName + " doesn't have deform options.");
                     else
                         sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(
-                            SurgeSynthProcessor::DEFORM_X, p, 0.0, 0, 0, 0, static_cast<bool>(val),
+                            SurgeSynthProcessor::DEFORM_X, p, 0.0, static_cast<int>(val), 0, 0, 0,
                             0, 0, 0));
                 }
                 else if (extension == "const_rate")

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -674,9 +674,14 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                     if (!p->has_portaoptions())
                         sendError("Param " + p->oscName + " doesn't have portamento options.");
                     else
-                        sspPtr->oscRingBuf.push(SurgeSynthProcessor::oscToAudio(
-                            SurgeSynthProcessor::PORTA_CURVE_X, p, 0.0, 0, 0, 0,
-                            static_cast<bool>(val), 0, 0, 0));
+                    {
+                        int new_curve = static_cast<int>(val);
+                        if ((new_curve < -1) || (new_curve > 1))
+                            new_curve = 0;
+                        sspPtr->oscRingBuf.push(
+                            SurgeSynthProcessor::oscToAudio(SurgeSynthProcessor::PORTA_CURVE_X, p,
+                                                            0.0, new_curve, 0, 0, false, 0, 0, 0));
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Refactor the constructor mess for oscToAudio messages, down to two constructors; there should be no functional difference to 1.3.2 OSC code.