### PR TITLE
FM2 osc and Freq Shifter param definition fixes

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -276,6 +276,7 @@ bool Parameter::can_extend_range() const
     case ct_pitch_semi7bp:
     case ct_pitch_semi7bp_absolutable:
     case ct_pitch_extendable_very_low_minval:
+    case ct_freq_fm2_offset:
     case ct_freq_reson_band1:
     case ct_freq_reson_band2:
     case ct_freq_reson_band3:
@@ -415,6 +416,7 @@ bool Parameter::is_bipolar() const
     case ct_percent_bipolar_w_dynamic_unipolar_formatting:
     case ct_noise_color:
     case ct_twist_aux_mix:
+    case ct_freq_fm2_offset:
     case ct_freq_shift:
     case ct_filter_feedback:
     case ct_osc_feedback_negative:
@@ -704,6 +706,7 @@ void Parameter::set_type(int ctrltype)
         val_default.f = 0; // semitones
         moverate = 0.5f;
         break;
+    case ct_freq_fm2_offset:
     case ct_freq_shift:
         valtype = vt_float;
         val_min.f = -10;   // Hz
@@ -1403,13 +1406,13 @@ void Parameter::set_type(int ctrltype)
     case ct_tape_drive:
         displayType = LinearWithScale;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "%%");
-        displayInfo.scale = 100;
+        displayInfo.scale = 100.f;
         break;
     case ct_percent_bipolar_w_dynamic_unipolar_formatting:
     case ct_twist_aux_mix:
         displayType = LinearWithScale;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "%%");
-        displayInfo.scale = 100;
+        displayInfo.scale = 100.f;
         displayInfo.customFeatures = ParamDisplayFeatures::kScaleBasedOnIsBiPolar;
         break;
     case ct_percent_bipolar_stereo:
@@ -1422,7 +1425,7 @@ void Parameter::set_type(int ctrltype)
         snprintf(displayInfo.minLabel, DISPLAYINFO_TXT_SIZE, "-100.00 %% (Left)");
         snprintf(displayInfo.defLabel, DISPLAYINFO_TXT_SIZE, "0.00 %% (Stereo)");
         snprintf(displayInfo.maxLabel, DISPLAYINFO_TXT_SIZE, "100.00 %% (Right)");
-        displayInfo.scale = 100;
+        displayInfo.scale = 100.f;
         break;
     case ct_percent_bipolar_pan:
         displayType = LinearWithScale;
@@ -1434,7 +1437,7 @@ void Parameter::set_type(int ctrltype)
         snprintf(displayInfo.minLabel, DISPLAYINFO_TXT_SIZE, "-100.00 %% (Left)");
         snprintf(displayInfo.defLabel, DISPLAYINFO_TXT_SIZE, "0.00 %% (Center)");
         snprintf(displayInfo.maxLabel, DISPLAYINFO_TXT_SIZE, "100.00 %% (Right)");
-        displayInfo.scale = 100;
+        displayInfo.scale = 100.f;
         break;
     case ct_percent_bipolar_stringbal:
         displayType = LinearWithScale;
@@ -1446,18 +1449,18 @@ void Parameter::set_type(int ctrltype)
         snprintf(displayInfo.minLabel, DISPLAYINFO_TXT_SIZE, "-100.00 %% (String 1)");
         snprintf(displayInfo.defLabel, DISPLAYINFO_TXT_SIZE, "0.00 %% (Strings 1+2)");
         snprintf(displayInfo.maxLabel, DISPLAYINFO_TXT_SIZE, "100.00 %% (String 2)");
-        displayInfo.scale = 100;
+        displayInfo.scale = 100.f;
         break;
 
         /*
           Again the missing breaks here are on purpose but we pick out a few for Tuning later
          */
     case ct_pitch_semi7bp_absolutable:
-        displayInfo.absoluteFactor = 10.0;
+        displayInfo.absoluteFactor = 10.f;
         snprintf(displayInfo.absoluteUnit, DISPLAYINFO_TXT_SIZE, "Hz");
     case ct_pitch_semi7bp:
     case ct_flangerspacing:
-        displayInfo.extendFactor = 12.0;
+        displayInfo.extendFactor = 12.f;
     case ct_pitch:
     case ct_pitch4oct:
     case ct_pitch_extendable_very_low_minval:
@@ -1495,13 +1498,17 @@ void Parameter::set_type(int ctrltype)
         displayInfo.supportsNoteName = true;
         displayInfo.customFeatures = ParamDisplayFeatures::kAllowsModulationsInNotesAndCents;
         break;
-
+    case ct_freq_fm2_offset:
+        displayType = LinearWithScale;
+        snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "Hz");
+        displayInfo.extendFactor = 100.f;
+        break;
     case ct_freq_shift:
         displayType = LinearWithScale;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "Hz");
-        displayInfo.extendFactor = 100.0;
+        displayInfo.scale = 10.f;
+        displayInfo.extendFactor = 100.f;
         break;
-
     case ct_envtime_lfodecay:
         snprintf(displayInfo.maxLabel, DISPLAYINFO_TXT_SIZE, "Forever");
         displayInfo.customFeatures = ParamDisplayFeatures::kHasCustomMaxString;
@@ -1537,19 +1544,19 @@ void Parameter::set_type(int ctrltype)
     case ct_decibel_extendable:
         displayType = LinearWithScale;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "dB");
-        displayInfo.extendFactor = 3;
+        displayInfo.extendFactor = 3.f;
         break;
 
     case ct_decibel_narrow_extendable:
         displayType = LinearWithScale;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "dB");
-        displayInfo.extendFactor = 5;
+        displayInfo.extendFactor = 5.f;
         break;
 
     case ct_decibel_narrow_short_extendable:
         displayType = LinearWithScale;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "dB");
-        displayInfo.extendFactor = 2;
+        displayInfo.extendFactor = 2.f;
         break;
 
     case ct_decibel:
@@ -1565,7 +1572,7 @@ void Parameter::set_type(int ctrltype)
     case ct_decibel_extra_narrow_deactivatable:
     case ct_bonsai_bass_boost:
         displayType = LinearWithScale;
-        displayInfo.extendFactor = 3;
+        displayInfo.extendFactor = 3.f;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "dB");
         break;
 
@@ -1576,35 +1583,35 @@ void Parameter::set_type(int ctrltype)
 
     case ct_detuning:
         displayType = LinearWithScale;
-        displayInfo.scale = 100.0;
-        displayInfo.extendFactor = 6;
+        displayInfo.scale = 100.f;
+        displayInfo.extendFactor = 6.f;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "cents");
         break;
 
     case ct_stereowidth:
         displayType = LinearWithScale;
-        displayInfo.scale = 1.0;
+        displayInfo.scale = 1.f;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "º");
         break;
 
     case ct_oscspread:
     case ct_oscspread_bipolar:
         displayType = LinearWithScale;
-        displayInfo.scale = 100.0;
+        displayInfo.scale = 100.f;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "cents");
         snprintf(displayInfo.absoluteUnit, DISPLAYINFO_TXT_SIZE, "Hz");
         displayInfo.absoluteFactor =
             0.16; // absolute factor also takes scale into account hence the /100
-        displayInfo.extendFactor = 12;
+        displayInfo.extendFactor = 12.f;
         break;
 
     case ct_filter_feedback:
     case ct_osc_feedback:
     case ct_osc_feedback_negative:
         displayType = LinearWithScale;
-        displayInfo.scale = 100.0;
+        displayInfo.scale = 100.f;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "%%");
-        displayInfo.extendFactor = 4;
+        displayInfo.extendFactor = 4.f;
         break;
 
     case ct_amplitude:
@@ -1619,7 +1626,7 @@ void Parameter::set_type(int ctrltype)
     case ct_airwindows_param_bipolar:
     case ct_airwindows_param_integral:
         displayType = DelegatedToFormatter;
-        displayInfo.scale = 1.0;
+        displayInfo.scale = 1.f;
         displayInfo.unit[0] = 0;
         displayInfo.decimals = 3;
         break;
@@ -1654,14 +1661,14 @@ void Parameter::set_type(int ctrltype)
 
     case ct_tape_microns:
         displayType = LinearWithScale;
-        displayInfo.scale = 1.0f;
+        displayInfo.scale = 1.f;
         displayInfo.decimals = 2;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "μm");
         break;
 
     case ct_tape_speed:
         displayType = LinearWithScale;
-        displayInfo.scale = 1.0f;
+        displayInfo.scale = 1.f;
         displayInfo.decimals = 2;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "ips");
         break;
@@ -1680,7 +1687,7 @@ void Parameter::set_type(int ctrltype)
         break;
 
     case ct_float_toggle:
-        displayInfo.scale = 100.0f;
+        displayInfo.scale = 100.f;
         displayInfo.decimals = 2;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "%%");
         snprintf(displayInfo.minLabel, DISPLAYINFO_TXT_SIZE, "Off");
@@ -1910,16 +1917,18 @@ void Parameter::bound_value(bool force_integer)
             val.f = floor(val.f * 10) / 10.0;
             break;
         }
+        case ct_freq_fm2_offset:
         case ct_freq_shift:
         {
             if (extend_range)
             {
-                val.f = floor(val.f * 100) / 100.0;
+                val.f = floor((val.f * 1000.f) / 10.f) * 0.01f;
             }
             else
             {
-                val.f = floor(val.f + 0.5f);
+                val.f = floor((val.f * 10.f) + 0.5f) * 0.1f;
             }
+
             break;
         }
         case ct_countedset_percent:
@@ -2236,6 +2245,7 @@ float Parameter::get_extended(float f) const
 
     switch (ctrltype)
     {
+    case ct_freq_fm2_offset:
     case ct_freq_shift:
         return 100.f * f;
     case ct_pitch_semi7bp:
@@ -2413,10 +2423,10 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
         if (res.has_value())
         {
 #if DEBUG_MOD_STRINGS
-            std::cout << "  value  : " << res->value << std::endl;
-            std::cout << "  summm  : " << res->summary << std::endl;
-            std::cout << "  change : " << res->changeUp << " | " << res->changeDown << std::endl;
-            std::cout << "  vUpDn  : " << res->valUp << " | " << res->valDown << std::endl;
+            std::cout << "  value   : " << res->value << std::endl;
+            std::cout << "  summary : " << res->summary << std::endl;
+            std::cout << "  change  : " << res->changeUp << " | " << res->changeDown << std::endl;
+            std::cout << "  valUpDn : " << res->valUp << " | " << res->valDown << std::endl;
 #endif
             switch (displaymode)
             {
@@ -3098,8 +3108,8 @@ float Parameter::quantize_modulation(float inputval) const
         // fall back
     case LinearWithScale:
     {
-        float ext_mul = (can_extend_range() && extend_range) ? displayInfo.extendFactor : 1.0;
-        float abs_mul = (can_be_absolute() && absolute) ? displayInfo.absoluteFactor : 1.0;
+        float ext_mul = (can_extend_range() && extend_range) ? displayInfo.extendFactor : 1.f;
+        float abs_mul = (can_be_absolute() && absolute) ? displayInfo.absoluteFactor : 1.f;
         float factor = ext_mul * abs_mul;
         float tempval = (val_max.f - val_min.f) * displayInfo.scale * factor;
 
@@ -4366,6 +4376,7 @@ bool Parameter::can_setvalue_from_string() const
     case ct_freq_reson_band1:
     case ct_freq_reson_band2:
     case ct_freq_reson_band3:
+    case ct_freq_fm2_offset:
     case ct_freq_shift:
     case ct_freq_hpf:
     case ct_freq_vocoder_low:
@@ -4748,8 +4759,8 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
             }
         }
 
-        float ext_mul = (can_extend_range() && extend_range) ? displayInfo.extendFactor : 1.0;
-        float abs_mul = (can_be_absolute() && absolute) ? displayInfo.absoluteFactor : 1.0;
+        float ext_mul = (can_extend_range() && extend_range) ? displayInfo.extendFactor : 1.f;
+        float abs_mul = (can_be_absolute() && absolute) ? displayInfo.absoluteFactor : 1.f;
         float factor = ext_mul * abs_mul;
         float res = nv / displayInfo.scale / factor;
         float minval = val_min.f;

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -96,6 +96,7 @@ enum ctrltypes
     ct_freq_mod,
     ct_freq_hpf,
     ct_freq_shift,
+    ct_freq_fm2_offset,
     ct_freq_vocoder_low,
     ct_freq_vocoder_high,
     ct_bandwidth,

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -87,56 +87,58 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 
 // clang-format off
 // XML file format revision history
-// 0 -> 1                      new filter/amp EG attack shapes (0 -> 1, 1 -> 2, 2 -> 2)
-// 1 -> 2                      new LFO EG stages (if (decay == max) sustain = max else sustain = min)
-// 2 -> 3                      filter subtypes added: Comb defaults to 1, Legacy Ladder defaults to 3
-// 3 -> 4                      Comb+ and Comb- are now combined into one filter type
-//                             (type, subtype: +, 0 -> 0 | +, 1 -> 1 | -, 0 -> 2 | -, 1 -> 3)
-// 4 -> 5                      Stereo filter configuration has separate pan controls now
-// 5 -> 6                      (1.2.0 release) filter resonance response changed (same parameters, different sound)
-// 6 -> 7                      custom controller state now stored in DAW recall
-// 7 -> 8                      larger resonance range (old filters are set to subtype 1)
-//                             Pan 2 -> Width
-// 8 -> 9                      macros extended to 8 (offset IDs larger than ctrl7 by 1)
-//                             macros can now be named (guess the name for older patches)
-// 9 -> 10                     added Character parameter
-// 10 -> 11 (1.6.2 release)    added DAW extra state
-// 11 -> 12 (1.6.3 release)    added new parameters to Distortion effect
-// 12 -> 13 (1.7.0 release)    added slider deactivation facility
-//                             Sine LP/HP filters
-//                             Sine/FM2/FM3 feedback extension/bipolar
-// 13 -> 14 (1.8.0 nightlies)  add Phaser Stages/Center/Spread parameters
-//                             add ability to configure Vocoder modulator input (monosum/L/R/stereo)
-//                             add comb filter tuning and compatibility block
-// 14 -> 15 (1.8.0 release)    the great remapping of filter types (GitHub issue #3006, PR #3329)
-// 15 -> 16 (1.9.0 release)    oscillator retrigger is consistent now (GitHub issue #3171, PR #3785)
-//                             added tuningApplicationMode to patch
-//                             added disable toggle to Low/High Cut filters in various effects
-//                             added disable toggle to Phaser Rate, and different waveform options
-// 16 -> 17 (XT 1.0 release)   added continuous morph toggle to Window oscillator
-//                             added (a lot of) new waveshapers
-//                             added two additional FX slots to all FX chains
-//                             added new Conditioner parameter (Side Low Cut)
-//                             read Global Volume from the patch (it was always stored just never read)
-// 17 -> 18 (XT 1.1 nightlies) added clipping options to Delay Feedback parameter (via deform)
-//                             added Tone parameter to Phaser effect
-// 18 -> 19 (XT 1.1 nightlies) added String deform options (interpolation, bipolar Decay params, Stiffness options)
-//                             added Extend to Delay Feedback parameter (allows negative delay)
-// 19 -> 20 (XT 1.1 release)   added voice envelope mode, but super late so don't break 19
-// 20 -> 21 (XT 1.2 nightlies) added absolutable mode for Combulator Offset 1/2 (to match the behavior of Center parameter)
-//                             added oddsound_as_mts_main
-// 21 -> 22 (XT 1.3 nighlies)  added new ring modulator modes in the mixer
-//                             added Bonsai distortion effect
-//                             changed MIDI mapping behavior
-//                             added capability to deactivate scenes
-//                             added Vintage FM feedback mode to FM2, FM3 and Sine oscillator types
-//                             added extend mode to Delay Crossfeed and Mod Depth parameters
-// 22 -> 23 (XT 1.3.2 release) added storing of Tempo parameter to the patch (will be loaded in Standalone only if option enabled)
-//                             added output filter to the Ensemble effect
-//                             added deform option for Release parameter of Filter/Amp EG, which only produces an open gate for the release stage
+// 0 -> 1                        new filter/amp EG attack shapes (0 -> 1, 1 -> 2, 2 -> 2)
+// 1 -> 2                        new LFO EG stages (if (decay == max) sustain = max else sustain = min)
+// 2 -> 3                        filter subtypes added: Comb defaults to 1, Legacy Ladder defaults to 3
+// 3 -> 4                        Comb+ and Comb- are now combined into one filter type
+//                               (type, subtype: +, 0 -> 0 | +, 1 -> 1 | -, 0 -> 2 | -, 1 -> 3)
+// 4 -> 5                        Stereo filter configuration has separate pan controls now
+// 5 -> 6                        (1.2.0 release) filter resonance response changed (same parameters, different sound)
+// 6 -> 7                        custom controller state now stored in DAW recall
+// 7 -> 8                        larger resonance range (old filters are set to subtype 1)
+//                               Pan 2 -> Width
+// 8 -> 9                        macros extended to 8 (offset IDs larger than ctrl7 by 1)
+//                               macros can now be named (guess the name for older patches)
+// 9 -> 10                       added Character parameter
+// 10 -> 11 (1.6.2 release)      added DAW extra state
+// 11 -> 12 (1.6.3 release)      added new parameters to Distortion effect
+// 12 -> 13 (1.7.0 release)      added slider deactivation facility
+//                               Sine LP/HP filters
+//                               Sine/FM2/FM3 feedback extension/bipolar
+// 13 -> 14 (1.8.0 nightlies)    add Phaser Stages/Center/Spread parameters
+//                               add ability to configure Vocoder modulator input (monosum/L/R/stereo)
+//                               add comb filter tuning and compatibility block
+// 14 -> 15 (1.8.0 release)      the great remapping of filter types (GitHub issue #3006, PR #3329)
+// 15 -> 16 (1.9.0 release)      oscillator retrigger is consistent now (GitHub issue #3171, PR #3785)
+//                               added tuningApplicationMode to patch
+//                               added disable toggle to Low/High Cut filters in various effects
+//                               added disable toggle to Phaser Rate, and different waveform options
+// 16 -> 17 (XT 1.0 release)     added continuous morph toggle to Window oscillator
+//                               added (a lot of) new waveshapers
+//                               added two additional FX slots to all FX chains
+//                               added new Conditioner parameter (Side Low Cut)
+//                               read Global Volume from the patch (it was always stored just never read)
+// 17 -> 18 (XT 1.1 nightlies)   added clipping options to Delay Feedback parameter (via deform)
+//                               added Tone parameter to Phaser effect
+// 18 -> 19 (XT 1.1 nightlies)   added String deform options (interpolation, bipolar Decay params, Stiffness options)
+//                               added Extend to Delay Feedback parameter (allows negative delay)
+// 19 -> 20 (XT 1.1 release)     added voice envelope mode, but super late so don't break 19
+// 20 -> 21 (XT 1.2 nightlies)   added absolutable mode for Combulator Offset 1/2 (to match the behavior of Center parameter)
+//                               added oddsound_as_mts_main
+// 21 -> 22 (XT 1.3 nighlies)    added new ring modulator modes in the mixer
+//                               added Bonsai distortion effect
+//                               changed MIDI mapping behavior
+//                               added capability to deactivate scenes
+//                               added Vintage FM feedback mode to FM2, FM3 and Sine oscillator types
+//                               added extend mode to Delay Crossfeed and Mod Depth parameters
+// 22 -> 23 (XT 1.3.2 release)   added storing of Tempo parameter to the patch (will be loaded in Standalone only if option enabled)
+//                               added output filter to the Ensemble effect
+//                               added deform option for Release parameter of Filter/Amp EG, which only produces an open gate for the release stage
+// 23 -> 24 (XT 1.3.3 nightlies) added actually functioning extend mode to FM2 oscillator's M1/2 Offset parameter
+//                                     (old patches load with extend disabled even if they had it enabled)
 // clang-format on
 
-const int ff_revision = 23;
+const int ff_revision = 24;
 
 const int n_scene_params = 273;
 const int n_global_params = 11 + n_fx_slots * (n_fx_params + 1); // each param plus a type

--- a/src/common/dsp/effects/FrequencyShifterEffect.cpp
+++ b/src/common/dsp/effects/FrequencyShifterEffect.cpp
@@ -68,6 +68,8 @@ void FrequencyShifterEffect::setvars(bool init)
                       FIRoffset);
     mix.set_target_smoothed(*pd_float[freq_mix]);
 
+    // TODO XT2: This is wrong, we should just get_extended() to get a range extending from 10 Hz to
+    // 1000 Hz, this increases far too much (from 100 Hz to 10 kHz)!
     double shift = *pd_float[freq_shift] * (fxdata->p[freq_shift].extend_range ? 1000.0 : 10.0);
     double omega = shift * M_PI * 2.0 * storage->dsamplerate_inv;
     o1L.set_rate(M_PI * 0.5 - min(0.0, omega));

--- a/src/common/dsp/oscillators/FM2Oscillator.cpp
+++ b/src/common/dsp/oscillators/FM2Oscillator.cpp
@@ -82,7 +82,9 @@ void FM2Oscillator::process_block_internal(float pitch, float drift, float fmdep
 {
     auto driftlfo = driftLFO.next() * drift;
     double omega = min(M_PI, (double)pitch_to_omega(pitch + driftlfo));
-    double sh = localcopy[oscdata->p[fm2_m12offset].param_id_in_scene].f * storage->dsamplerate_inv;
+    double sh = oscdata->p[fm2_m12offset].get_extended(
+                    localcopy[oscdata->p[fm2_m12offset].param_id_in_scene].f) *
+                storage->dsamplerate_inv;
 
     fb_val = oscdata->p[fm2_feedback].get_extended(
         localcopy[oscdata->p[fm2_feedback].param_id_in_scene].f);
@@ -154,7 +156,7 @@ void FM2Oscillator::init_ctrltypes()
     oscdata->p[fm2_m2ratio].set_name("M2 Ratio");
     oscdata->p[fm2_m2ratio].set_type(ct_fmratio_int);
     oscdata->p[fm2_m12offset].set_name("M1/2 Offset");
-    oscdata->p[fm2_m12offset].set_type(ct_freq_shift);
+    oscdata->p[fm2_m12offset].set_type(ct_freq_fm2_offset);
     oscdata->p[fm2_m12phase].set_name("M1/2 Phase");
     oscdata->p[fm2_m12phase].set_type(ct_percent);
     oscdata->p[fm2_feedback].set_name("Feedback");
@@ -188,5 +190,10 @@ void FM2Oscillator::handleStreamingMismatches(int streamingRevision,
     if (streamingRevision <= 21)
     {
         oscdata->p[fm2_feedback].deform_type = 0;
+    }
+
+    if (streamingRevision <= 23)
+    {
+        oscdata->p[fm2_m12offset].extend_range = false;
     }
 }


### PR DESCRIPTION
Extend mode now actually works for FM2 M1/2 Offset.
Increase streaming version (patches with sv < 24 will always load with M1/2 Offset extend disabled to retain their sound).

Frequency Shifter's Range was mistakenly showing 10x smaller values in all the displays.
Fixed this by adding a new ctype (to discern it from FM2 oscillator's M1/2 Offset parameter,
and doing everything necessary to ensure proper value display and conversion from string input etc.