### PR TITLE
WIP, attempt to add audio inputs to surge-cli

### DIFF
--- a/src/surge-xt/cli/cli-main.cpp
+++ b/src/surge-xt/cli/cli-main.cpp
@@ -189,6 +189,10 @@ struct SurgePlayback : juce::MidiInputCallback, juce::AudioIODeviceCallback
             }
             outputChannelData[0][i] = proc->surge->output[0][pos];
             outputChannelData[1][i] = proc->surge->output[1][pos];
+
+            proc->surge->input[0][pos] = inputChannelData[0][i];
+            proc->surge->input[1][pos] = inputChannelData[1][i];
+
             pos++;
         }
     }


### PR DESCRIPTION
I'm trying to make it so that CLI binds to the audio inputs of the selected audio device, this compiles but gives a segfault when I run it.

I am not particularly strong with C/C++ so opening a draft if anyone knows how to do it