### PR TITLE
Turn on WT Lua

### DIFF
--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -587,9 +587,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
 
     contextMenu.addSeparator();
 
-    /*
-    We've decided to postpone this feature until after XT 1.0
-
+#define INCLUDE_WT_SCRIPTING_EDITOR 1
+#if INCLUDE_WT_SCRIPTING_EDITOR
     contextMenu.addSeparator();
 
     auto owts = [this]() {
@@ -598,7 +597,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
     };
 
     contextMenu.addItem(Surge::GUI::toOSCase("Wavetable Script Editor..."), owts);
-    */
+    contextMenu.addSeparator();
+#endif
 
     // add this option only if we have any wavetables in the list
     if (idx > 0)


### PR DESCRIPTION
In case there are volunteers to finish it

If  we are doing a release and this isn't finished, change the INCLUDE_WT_SCRIPTING_EDITOR define in OscillatorWaveformDisplay.cpp to 0, test, and puhs