### PR TITLE
Pybind: Add ability to process inputs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,3 +59,4 @@ Keith Zantow <kzantow@gmail.com>
 Vincent Zauhar <v.zauhar@bell.net>
 Alexandr Zyurkalov <Alexander.Zyurkalov@gmail.com>
 簡志瑋 <dppss92132@gmail.com>
+Daniel Hatadi <https://github.com/dhatadi>

--- a/src/surge-python/surgepy.cpp
+++ b/src/surge-python/surgepy.cpp
@@ -754,7 +754,9 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
         }
     }
 
-    void processMultiBlockWithInput(const py::array_t<float> &in_arr, const py::array_t<float> &out_arr, int startBlock = 0, int nBlocks = -1)
+    void processMultiBlockWithInput(const py::array_t<float> &in_arr,
+                                    const py::array_t<float> &out_arr, int startBlock = 0,
+                                    int nBlocks = -1)
     {
         auto in_buf = in_arr.request();
         auto out_buf = out_arr.request(true);
@@ -1134,12 +1136,14 @@ PYBIND11_MODULE(surgepy, m)
              "Either populate the\n"
              "entire array, or starting at startBlock position in the output, populate nBlocks.",
              py::arg("val"), py::arg("startBlock") = 0, py::arg("nBlocks") = -1)
-        .def("processMultiBlockWithInput", &SurgeSynthesizerWithPythonExtensions::processMultiBlockWithInput,
+        .def("processMultiBlockWithInput",
+             &SurgeSynthesizerWithPythonExtensions::processMultiBlockWithInput,
              "Run the Surge XT engine for multiple blocks using the input numpy array, "
              "updating the value in the output numpy array. "
              "Either populate the\n"
              "entire array, or starting at startBlock position in the output, populate nBlocks.",
-             py::arg("inVal"), py::arg("outVal"), py::arg("startBlock") = 0, py::arg("nBlocks") = -1)
+             py::arg("inVal"), py::arg("outVal"), py::arg("startBlock") = 0,
+             py::arg("nBlocks") = -1)
 
         .def("getPatch", &SurgeSynthesizerWithPythonExtensions::getPatchAsPy,
              "Get a Python dictionary with the Surge XT parameters laid out in the logical patch "

--- a/src/surge-python/surgepy/_surgepy/__init__.pyi
+++ b/src/surge-python/surgepy/_surgepy/__init__.pyi
@@ -191,6 +191,12 @@ class SurgeSynthesizer:
         Run the Surge XT engine for multiple blocks, updating the value in the numpy array. Either populate the
         entire array, or starting at startBlock position in the output, populate nBlocks.
         """
+    def processMultiBlockWithInput(self, inVal: numpy.ndarray[numpy.float32], outVal: numpy.ndarray[numpy.float32], startBlock: int = 0, nBlocks: int = -1) -> None:
+        """
+        Run the Surge XT engine for multiple blocks using the input numpy array,
+        updating the value in the output numpy array. Either populate the
+        entire array, or starting at startBlock position in the output, populate nBlocks.
+        """
     def releaseNote(self, channel: int, midiNote: int, releaseVelocity: int = 0) -> None:
         """
         Release a note on this Surge XT instance.

--- a/src/surge-python/tests/test_surgepy.py
+++ b/src/surge-python/tests/test_surgepy.py
@@ -26,6 +26,20 @@ def test_render_note():
     s.processMultiBlock(buf)
     assert not np.all(buf == 0.0)
 
+def test_render_note_with_input():
+    """
+    Test rendering a note with an input buffer into an output buffer.
+    """
+    s = surgepy.createSurge(44100)
+    n_blocks = int(2 * s.getSampleRate() / s.getBlockSize())
+    in_buf = s.createMultiBlock(n_blocks)
+    in_buf[0] = np.random.normal(0, 1000, size=in_buf[0].size)
+    in_buf[1] = np.random.normal(0, 1000, size=in_buf[1].size)
+    out_buf = s.createMultiBlock(n_blocks)
+    s.playNote(0, 60, 127, 0)
+    s.processMultiBlockWithInput(in_buf, out_buf)
+    assert not np.all(out_buf == 0.0)
+
 
 def test_default_mpeEnabled():
     """


### PR DESCRIPTION
Added extra function called processMultiBlockWithInput on Python side which takes two arrays, one for input and one for output. This copies data to the SurgeSynthesizer input array before processing. Note that the input and output arrays must match in size, type, and dimensions.