### PR TITLE
Some small fixes for wavetable script editor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Korridor <fabian.kempe@gmail.com>
 Mario Krušelj a.k.a. EvilDragon <http://github.com/mkruselj>
 muhl <https://github.com/mynameismuhl>
 Marty Lake <matthieu@talbot.audio>
+nuoun <https://github.com/nuoun>
 Luna Langton <https://github.com/selenologist>
 Jacky Ligon <http://jackyligon.com>
 Erik-Jan Maalderink <fonkle@gmx.com>

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -130,7 +130,7 @@ bool constructWavetable(SurgeStorage *storage, const std::string &eqn, int resol
 
     for (int i = 0; i < frames; ++i)
     {
-        auto v = evaluateScriptAtFrame(storage, eqn, resolution, i, frames);
+        auto v = evaluateScriptAtFrame(storage, eqn, resolution, i + 1, frames);
         memcpy(&(wd[i * resolution]), &(v[0]), resolution * sizeof(float));
     }
     return true;
@@ -142,10 +142,10 @@ std::string defaultWavetableFormula()
 --- generator function. The function takes an array of x values (xs) and a frame number (n) and
 --- generates the result as the n-th frame. The sample below generates a Fourier sine to saw
 --- which, remember, is: sum 2 / pi n * sin n x
-    res = {}
+    local res = {}
     for i,x in ipairs(config.xs) do
-        lv = 0
-        for q = 1,(config.n+1) do
+        local lv = 0
+        for q = 1,(config.n) do
             lv = lv + 2 * sin ( q * x * 2 * pi ) / ( pi * q )
         end
         res[i] = lv

--- a/src/common/dsp/WavetableScriptEvaluator.h
+++ b/src/common/dsp/WavetableScriptEvaluator.h
@@ -36,15 +36,15 @@ namespace WavetableScript
  * not at the evaluation or synthesis time. As such I expect you call it from
  * one thread at a time and just you know generally be careful.
  */
-std::vector<float> evaluateScriptAtFrame(const std::string &eqn, int resolution, int frame,
-                                         int nFrames);
+std::vector<float> evaluateScriptAtFrame(SurgeStorage *storage, const std::string &eqn,
+                                         int resolution, int frame, int nFrames);
 
 /*
  * Generate all the data required to call BuildWT. The wavdata here is data you
  * must free with delete[]
  */
-bool constructWavetable(const std::string &eqn, int resolution, int frames, wt_header &wh,
-                        float **wavdata);
+bool constructWavetable(SurgeStorage *storage, const std::string &eqn, int resolution, int frames,
+                        wt_header &wh, float **wavdata);
 
 std::string defaultWavetableFormula();
 

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -665,6 +665,7 @@ TEST_CASE("Wavetable Script", "[formula]")
 {
     SECTION("Just The Sines")
     {
+        SurgeStorage storage;
         const std::string s = R"FN(
 function generate(config)
     res = config.xs
@@ -676,7 +677,7 @@ end
         )FN";
         for (int fno = 0; fno < 4; ++fno)
         {
-            auto fr = Surge::WavetableScript::evaluateScriptAtFrame(s, 512, fno, 4);
+            auto fr = Surge::WavetableScript::evaluateScriptAtFrame(nullptr, s, 512, fno, 4);
             REQUIRE(fr.size() == 512);
             auto dp = 1.0 / (512 - 1);
             for (int i = 0; i < 512; ++i)

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -668,9 +668,9 @@ TEST_CASE("Wavetable Script", "[formula]")
         SurgeStorage storage;
         const std::string s = R"FN(
 function generate(config)
-    res = config.xs
+    local res = config.xs
     for i,x in ipairs(config.xs) do
-        res[i] = math.sin(x * (config.n+1) * 2 * math.pi)
+        res[i] = math.sin(x * (config.n) * 2 * math.pi)
     end
     return res
 end

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -1112,7 +1112,8 @@ void WavetableEquationEditor::rerenderFromUIState()
 {
     auto resi = resolution->getSelectedId();
     auto nfr = std::atoi(frames->getText().toRawUTF8());
-    auto cfr = (int)round(nfr * currentFrame->getValue() / 10.0);
+    auto cfr =
+        (int)round(1 + (nfr - 1) * currentFrame->getValue() / 10); // map slider to 1 .. Nframes
 
     auto respt = 32;
     for (int i = 1; i < resi; ++i)
@@ -1133,13 +1134,13 @@ void WavetableEquationEditor::buttonClicked(juce::Button *button)
 {
     if (button == generate.get())
     {
-        std::cout << "GENERATE" << std::endl;
         auto resi = resolution->getSelectedId();
         auto nfr = std::atoi(frames->getText().toRawUTF8());
         auto respt = 32;
         for (int i = 1; i < resi; ++i)
             respt *= 2;
-
+        std::cout << "Generating wavetable with " << respt << " samples and " << nfr << " frames."
+                  << std::endl;
         wt_header wh;
         float *wd = nullptr;
         Surge::WavetableScript::constructWavetable(

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -1119,7 +1119,7 @@ void WavetableEquationEditor::rerenderFromUIState()
         respt *= 2;
 
     renderer->points = Surge::WavetableScript::evaluateScriptAtFrame(
-        mainDocument->getAllContent().toStdString(), respt, cfr, nfr);
+        storage, mainDocument->getAllContent().toStdString(), respt, cfr, nfr);
     renderer->frameNumber = cfr;
     renderer->repaint();
 }
@@ -1142,8 +1142,8 @@ void WavetableEquationEditor::buttonClicked(juce::Button *button)
 
         wt_header wh;
         float *wd = nullptr;
-        Surge::WavetableScript::constructWavetable(mainDocument->getAllContent().toStdString(),
-                                                   respt, nfr, wh, &wd);
+        Surge::WavetableScript::constructWavetable(
+            storage, mainDocument->getAllContent().toStdString(), respt, nfr, wh, &wd);
         storage->waveTableDataMutex.lock();
         osc->wt.BuildWT(wd, wh, wh.flags & wtf_is_sample);
         osc->wavetable_display_name = "Scripted Wavetable";

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -587,9 +587,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
 
     contextMenu.addSeparator();
 
-    /*
-    We've decided to postpone this feature until after XT 1.0
-
+#define INCLUDE_WT_SCRIPTING_EDITOR 1
+#if INCLUDE_WT_SCRIPTING_EDITOR
     contextMenu.addSeparator();
 
     auto owts = [this]() {
@@ -598,7 +597,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
     };
 
     contextMenu.addItem(Surge::GUI::toOSCase("Wavetable Script Editor..."), owts);
-    */
+    contextMenu.addSeparator();
+#endif
 
     // add this option only if we have any wavetables in the list
     if (idx > 0)


### PR DESCRIPTION
* change the frame slider in the Wavescript editor overlay so slider goes from 1 .. Nframes instead of starting at 0 and having an extra frame
* update wavetable generate function so it sets lua table to config.n = 1 at first frame
* update the default placeholder and UnitTestsLUA scripts to reflect 1 based index change
* update default and test scripts to use local variables to promote best lua practice
* make std::cout message when generating wavetable more verbose 