### PR TITLE
Small fixes for wavetable script editor

### DIFF
--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -130,7 +130,7 @@ bool constructWavetable(SurgeStorage *storage, const std::string &eqn, int resol
 
     for (int i = 0; i < frames; ++i)
     {
-        auto v = evaluateScriptAtFrame(storage, eqn, resolution, i, frames);
+        auto v = evaluateScriptAtFrame(storage, eqn, resolution, i + 1, frames);
         memcpy(&(wd[i * resolution]), &(v[0]), resolution * sizeof(float));
     }
     return true;
@@ -142,10 +142,10 @@ std::string defaultWavetableFormula()
 --- generator function. The function takes an array of x values (xs) and a frame number (n) and
 --- generates the result as the n-th frame. The sample below generates a Fourier sine to saw
 --- which, remember, is: sum 2 / pi n * sin n x
-    res = {}
+    local res = {}
     for i,x in ipairs(config.xs) do
-        lv = 0
-        for q = 1,(config.n+1) do
+        local lv = 0
+        for q = 1,(config.n) do
             lv = lv + 2 * sin ( q * x * 2 * pi ) / ( pi * q )
         end
         res[i] = lv

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -668,9 +668,9 @@ TEST_CASE("Wavetable Script", "[formula]")
         SurgeStorage storage;
         const std::string s = R"FN(
 function generate(config)
-    res = config.xs
+    local res = config.xs
     for i,x in ipairs(config.xs) do
-        res[i] = math.sin(x * (config.n+1) * 2 * math.pi)
+        res[i] = math.sin(x * (config.n) * 2 * math.pi)
     end
     return res
 end

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -1112,7 +1112,8 @@ void WavetableEquationEditor::rerenderFromUIState()
 {
     auto resi = resolution->getSelectedId();
     auto nfr = std::atoi(frames->getText().toRawUTF8());
-    auto cfr = (int)round(nfr * currentFrame->getValue() / 10.0);
+    auto cfr = (int)round(1 + (nfr - 1) * currentFrame->getValue() /
+                                  10); // map frame slider to 1 .. Nframes
 
     auto respt = 32;
     for (int i = 1; i < resi; ++i)
@@ -1133,12 +1134,13 @@ void WavetableEquationEditor::buttonClicked(juce::Button *button)
 {
     if (button == generate.get())
     {
-        std::cout << "GENERATE" << std::endl;
         auto resi = resolution->getSelectedId();
         auto nfr = std::atoi(frames->getText().toRawUTF8());
         auto respt = 32;
         for (int i = 1; i < resi; ++i)
             respt *= 2;
+        std::cout << "Generating wavetable with " << respt << " samples and " << nfr << " frames"
+                  << std::endl;
 
         wt_header wh;
         float *wd = nullptr;


### PR DESCRIPTION
* change the frame slider in the wt script editor overlay so slider goes from 1 .. Nframes instead of starting at 0
* update wavetable generate function so it sets lua table to config.n = 1 at first frame
* update the default placeholder and UnitTestsLUA scripts to reflect 1 based index change
* update default and test scripts to use local variables to promote best lua practice
* more verbose cout message when generating wavetable