### PR TITLE
Wt script editor Lua changes

### DIFF
--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -58,14 +58,14 @@ std::vector<float> evaluateScriptAtFrame(SurgeStorage *storage, const std::strin
         double dp = 1.0 / (resolution - 1);
         for (auto i = 0; i < resolution; ++i)
         {
-            lua_pushinteger(L, i + 1); // lua has a 1 based convention
+            lua_pushinteger(L, i + 1); // lua has a 1 based index convention
             lua_pushnumber(L, i * dp);
             lua_settable(L, -3);
         }
         lua_settable(L, -3);
 
         lua_pushstring(L, "n");
-        lua_pushinteger(L, frame);
+        lua_pushinteger(L, frame + 1);
         lua_settable(L, -3);
 
         lua_pushstring(L, "nTables");
@@ -138,15 +138,22 @@ bool constructWavetable(SurgeStorage *storage, const std::string &eqn, int resol
 std::string defaultWavetableFormula()
 {
     return R"FN(function generate(config)
---- This function was inserted as a guide, since the wavetable editor in this patch/oscillator has no
---- generator function. The function takes an array of x values (xs) and a frame number (n) and
---- generates the result as the n-th frame. The sample below generates a Fourier sine to saw
---- which, remember, is: sum 2 / pi n * sin n x
-    res = {}
+-- This script serves as the default example for the wavetable script editor. Unlike the formula editor, which executes
+-- repeatedly every block, the Lua code here runs only upon applying new settings or receiving GUI inputs like the frame slider.
+--
+-- When the Generate button is pressed, this function is called for each frame, and the results are collected and sent
+-- to the Wavetable oscillator. The oscillator can sweep through these frames to evolve the sound produced using the Morph parameter.
+--
+-- The for loops iterate over an array of sample values (xs) and a frame number (n) and generate the result for the n-th frame.
+-- This example uses additive synthesis, a technique that adds sine waves to create waveshapes. The initial frame starts with a
+-- single sine wave, and additional sine waves are added in subsequent frames. This process creates a Fourier series sawtooth wave
+-- defined by the formula: sum 2 / pi n * sin n x. See the tutorial patches for more info.
+
+    local res = {}
     for i,x in ipairs(config.xs) do
-        lv = 0
-        for q = 1,(config.n+1) do
-            lv = lv + 2 * sin ( q * x * 2 * pi ) / ( pi * q )
+        local lv = 0
+        for q = 1,(config.n) do
+            lv = lv + 2 * sin(2 * pi * q * x) / (pi * q)
         end
         res[i] = lv
     end

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -670,7 +670,7 @@ TEST_CASE("Wavetable Script", "[formula]")
 function generate(config)
     res = config.xs
     for i,x in ipairs(config.xs) do
-        res[i] = math.sin(x * (config.n+1) * 2 * math.pi)
+        res[i] = math.sin(x * (config.n) * 2 * math.pi)
     end
     return res
 end

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -1112,7 +1112,7 @@ void WavetableEquationEditor::rerenderFromUIState()
 {
     auto resi = resolution->getSelectedId();
     auto nfr = std::atoi(frames->getText().toRawUTF8());
-    auto cfr = (int)round(nfr * currentFrame->getValue() / 10.0);
+    auto cfr = (int)round((nfr - 1) * currentFrame->getValue() / 10.0);
 
     auto respt = 32;
     for (int i = 1; i < resi; ++i)
@@ -1120,7 +1120,7 @@ void WavetableEquationEditor::rerenderFromUIState()
 
     renderer->points = Surge::WavetableScript::evaluateScriptAtFrame(
         storage, mainDocument->getAllContent().toStdString(), respt, cfr, nfr);
-    renderer->frameNumber = cfr;
+    renderer->frameNumber = cfr + 1;
     renderer->repaint();
 }
 
@@ -1133,12 +1133,13 @@ void WavetableEquationEditor::buttonClicked(juce::Button *button)
 {
     if (button == generate.get())
     {
-        std::cout << "GENERATE" << std::endl;
         auto resi = resolution->getSelectedId();
         auto nfr = std::atoi(frames->getText().toRawUTF8());
         auto respt = 32;
         for (int i = 1; i < resi; ++i)
             respt *= 2;
+        std::cout << "Generating wavetable with " << respt << " samples and " << nfr << " frames"
+                  << std::endl;
 
         wt_header wh;
         float *wd = nullptr;


### PR DESCRIPTION
* change frame slider in WT script editor overlay so slider goes from 0 .. Nframes - 1
* make config.n start at 1 rather than 0
* update default and unittestLUA scripts to reflect above change
* text edit and some style changes in default script
* more verbose cout message when generating wavetable