### PR TITLE
FX parameter change from OSC in: more granular parameter update

### DIFF
--- a/src/surge-fx/FXOpenSoundControl.cpp
+++ b/src/surge-fx/FXOpenSoundControl.cpp
@@ -188,10 +188,6 @@ void FXOpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                 SurgefxAudioProcessor::FX_PARAM, newval, index - 1));
         }
     }
-    else
-    {
-        storage->reportError("Badly-formed '/fx/param/...' message.", "OSC input error");
-    }
 }
 
 bool FXOpenSoundControl::hasEnding(std::string const &fullString, std::string const &ending)

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -486,8 +486,12 @@ void SurgefxAudioProcessor::processBlockOSC()
         {
         case SurgefxAudioProcessor::FX_PARAM:
         {
-            fxstorage->p[fx_param_remap[om->p_index]].set_value_f01(om->fval);
-            resetFxParams(true);
+            prepareParametersAbsentAudio();
+            setFXParamValue01(om->p_index, om->fval);
+            // this order does matter
+            changedParamsValue[om->p_index] = om->fval;
+            changedParams[om->p_index] = true;
+            triggerAsyncUpdate();
         }
         break;
         }


### PR DESCRIPTION
Fix to Surge FX OSC input code; previous version used a full parameter reset to make the OSC parameter change take effect. It's now handled in a more gentle way.