### PR TITLE
Explicitly set process_input to false in non-input python

### DIFF
--- a/src/surge-python/surgepy.cpp
+++ b/src/surge-python/surgepy.cpp
@@ -743,6 +743,8 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
         float *dL = ptr + startBlock * BLOCK_SIZE;
         float *dR = ptr + buf.shape[1] + startBlock * BLOCK_SIZE;
 
+        process_input = false;
+
         for (auto i = 0; i < blockIterations; ++i)
         {
             process();


### PR DESCRIPTION
since in some cases audio in can get a random buffer.

Closes #7701