### PR TITLE
Correct WT and Window handling og 16 full range wt files

### DIFF
--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -247,11 +247,14 @@ bool Wavetable::BuildWT(void *wdata, wt_header &wh, bool AppendSilence)
                                        &((short *)wdata)[this->size * j], this->size);
             if (this->flags & wtf_int16_is_16)
             {
-                i16toi15_block(&this->TableI16WeakPointers[0][j][FIRoffsetI16],
-                               &this->TableI16WeakPointers[0][j][FIRoffsetI16], this->size);
+                i162float_block(&this->TableI16WeakPointers[0][j][FIRoffsetI16],
+                                this->TableF32WeakPointers[0][j], this->size);
             }
-            i152float_block(&this->TableI16WeakPointers[0][j][FIRoffsetI16],
-                            this->TableF32WeakPointers[0][j], this->size);
+            else
+            {
+                i152float_block(&this->TableI16WeakPointers[0][j][FIRoffsetI16],
+                                this->TableF32WeakPointers[0][j], this->size);
+            }
         }
     }
     else

--- a/src/common/dsp/oscillators/WindowOscillator.h
+++ b/src/common/dsp/oscillators/WindowOscillator.h
@@ -77,7 +77,7 @@ class WindowOscillator : public Oscillator
     void applyFilter();
     template <bool is_init> void update_lagvals();
 
-    void ProcessWindowOscs(bool stereo, bool FM);
+    template <bool FM, bool Full16> void ProcessWindowOscs(bool stereo);
     lag<double> FMdepth[MAX_UNISON];
     lag<float> l_morph;
 

--- a/src/common/dsp/vembertech/basic_dsp.h
+++ b/src/common/dsp/vembertech/basic_dsp.h
@@ -54,6 +54,15 @@ inline void i152float_block(short *s, float *f, int n)
     }
 }
 
+inline void i162float_block(short *s, float *f, int n)
+{
+    const float scale = 1.f / (16384.f * 2);
+    for (int i = 0; i < n; i++)
+    {
+        f[i] = (float)s[i] * scale;
+    }
+}
+
 inline void i16toi15_block(short *s, short *o, int n)
 {
     for (int i = 0; i < n; i++)


### PR DESCRIPTION
wt files with full-range 16 bit ints (so 16-is-16 or flag 0x8 + 0x4 = 0xC) was broken in a couple of ways, but most importnatly, didn't survive a save/restore roundtrip.

This fixes it in three ways

1. When converting 16-as-16 to float scale accordingly with a different function and leave the ints untouched
2. Modify the window oscillator so if it gets a 16-as-16 it reduces the height of the ints to be consistent with a 15 with an extra shift, making I15 WT vs Window and I16 WT vs Window consistent
3. Make sure it streams properly. No change required but tested.

Update wt-tool to allow int16 and int15 options both

Closes #7694
