### PR TITLE
Fix problem with FX Unit Typein and OSC

### DIFF
--- a/scripts/osc-tests/FXUnit.py
+++ b/scripts/osc-tests/FXUnit.py
@@ -1,0 +1,47 @@
+# brew install python-tk is the trick you want
+import tkinter as tk
+from osc4py3.as_eventloop import *
+from osc4py3 import oscbuildparse
+# from tkinter import messagebox
+
+# Function to handle button clicks
+def button_click(button_id):
+    if button_id == 1:
+        # messagebox.showinfo("Button 1", "You clicked Button 1!")
+        msg = oscbuildparse.OSCMessage("/fx/param/1", ",f", [0.2])
+        osc_send(msg, "oscout")
+        osc_process()
+
+    elif button_id == 2:
+        # messagebox.showinfo("Button 2", "You clicked Button 2!")
+        msg = oscbuildparse.OSCMessage("/fx/param/1", ",f", [0.7])
+        osc_send(msg, "oscout")
+        osc_process()
+
+
+# Function to create buttons
+def create_buttons():
+    button1 = tk.Button(root, text="Send '0'", command=lambda: button_click(1))
+    button1.pack()
+
+    button2 = tk.Button(root, text="Send '1'", command=lambda: button_click(2))
+    button2.pack()
+
+
+# Create the main window
+root = tk.Tk()
+root.title("Simple OSC Test")
+root.minsize(200, 100)
+
+# init OSC
+ip = "127.0.0.1"
+port = 53290        #Surge FX default OSC in port
+osc_startup()
+osc_udp_client(ip, port, "oscout")
+
+
+# Call function to create buttons
+create_buttons()
+
+# Start the tkinter main loop
+root.mainloop()

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -4545,13 +4545,13 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
             switch (valtype)
             {
             case vt_int:
-                val.i = (int)std::round(*res);
+                ontoThis.i = (int)std::round(*res);
                 break;
             case vt_float:
-                val.f = *res;
+                ontoThis.f = *res;
                 break;
             case vt_bool:
-                val.b = (*res > 0.5);
+                ontoThis.b = (*res > 0.5);
                 break;
             }
             return true;

--- a/src/surge-fx/SurgeFXEditor.cpp
+++ b/src/surge-fx/SurgeFXEditor.cpp
@@ -354,7 +354,7 @@ void SurgefxAudioProcessorEditor::paramsChangedCallback()
             if (i < n_fx_params)
             {
                 fxParamSliders[i].setValue(fv[i], juce::NotificationType::dontSendNotification);
-                fxParamDisplay[i].setDisplay(processor.getParamValue(i));
+                fxParamDisplay[i].setDisplay(processor.getParamValueFor(i, fv[i]));
             }
             else
             {

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -788,8 +788,15 @@ float SurgefxAudioProcessor::getParameterValueForString(int i, const std::string
     pdata v;
     // TODO: range error reporting
     std::string errMsg;
-    p->set_value_from_string_onto(s, v, errMsg);
-    return v.f;
+    auto res = p->set_value_from_string_onto(s, v, errMsg);
+    if (res)
+    {
+        return p->value_to_normalized(v.f);
+    }
+    else
+    {
+        return 0;
+    }
 }
 void SurgefxAudioProcessor::setParameterByString(int i, const std::string &s)
 {


### PR DESCRIPTION
1. Messages through trigger update used the old value to repaint the display, which caused issues with OSC and other automation paths (less so)

2. Type-ins via the parameter mechanism when using the ported-to-sst-effects effects with param metadata worked with in-app typeins but not with from-daw typeins since string to value onto in that case wrote the wrong item. Remediate.