### PR TITLE
Clean up channel keyboard state from latch mode

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2783,7 +2783,17 @@ bool SurgeSynthesizer::setParameter01(long index, float value, bool external, bo
                 int s = storage.getPatch().param_ptr[index]->scene - 1;
                 release_if_latched[s & 1] = true;
                 release_anyway[s & 1] = true;
-                // release old notes if previous polymode was latch
+                if (!voices[s].empty())
+                {
+                    // The release if latched initiates a release scene
+                    // which kills all voices but doesn't clear up the
+                    // keyboard state. So
+                    for (auto &v : voices[s])
+                    {
+                        const auto &st = v->state;
+                        channelState[st.channel].keyState[st.key].keystate = 0;
+                    }
+                }
             }
             break;
         case ct_filtertype:


### PR DESCRIPTION
The channel state was left in a corrupted state when not latching. This meant latch -> mono -> key -> release could trigger the latch voice if the key you pressed was not the latch voice. There was even a comment to clean up, but we ended up cleaning up by terminating the entire scene in latch (more appropriately)

So this also udpates the keybed state to avoid that voice edge case

Closes #7628