### PR TITLE
fix mistake in silm modes 3 and 4

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -214,20 +214,22 @@ enum CombinatorMode
     cxm_cxor43_0,
     cxm_cxor43_1,
     cxm_cxor43_2,
-    cxm_cxor43_3,
-    cxm_cxor43_4,
+    cxm_cxor43_3_legacy,
+    cxm_cxor43_4_legacy,
     cxm_cxor93_0,
     cxm_cxor93_1,
     cxm_cxor93_2,
     cxm_cxor93_3,
     cxm_cxor93_4,
+    cxm_cxor43_3,
+    cxm_cxor43_4,
 
     n_cxm_modes,
 };
 
 const char combinator_mode_names[n_cxm_modes][20] = {
-    "Ring Modulation", "Continuous XOR", "Type 1", "Type 2", "Type 3", "Type 4",
-    "Type 5",          "Type 6",         "Type 7", "Type 8", "Type 9",
+    "Ring Modulation", "Continuous XOR", "Type 1", "Type 2", "Type 3 (legacy)", "Type 4 (legacy)",
+    "Type 5",          "Type 6",         "Type 7", "Type 8", "Type 9", "Type 3", "Type 4",
 };
 
 enum lfo_trigger_mode

--- a/src/common/dsp/CXOR.h
+++ b/src/common/dsp/CXOR.h
@@ -54,6 +54,26 @@ inline void cxor43_2_block(float *__restrict src1, float *__restrict src2, float
     }
 }
 
+inline void cxor43_3_legacy_block(float *__restrict src1, float *__restrict src2, float *__restrict dst,
+                           unsigned int nquads)
+{
+    for (auto i = 0U; i < nquads << 2; ++i)
+    {
+        const auto cx = fmin(fmax(src1[i], src2[i]), -fmin(src1[i], src2[i]));
+        dst[i] = fmin(-fmin(cx, -src2[i]), fmax(src1[i], src2[i])); // minus was in the wrong place
+    }
+}
+
+inline void cxor43_4_legacy_block(float *__restrict src1, float *__restrict src2, float *__restrict dst,
+                           unsigned int nquads)
+{
+    for (auto i = 0U; i < nquads << 2; ++i)
+    {
+        const auto cx = fmin(fmax(src1[i], src2[i]), -fmin(src1[i], src2[i]));
+        dst[i] = fmin(-fmin(cx, src2[i]), fmax(src1[i], cx)); // wasn't supposed to have a minus sign
+    }
+}
+
 inline void cxor43_3_block(float *__restrict src1, float *__restrict src2, float *__restrict dst,
                            unsigned int nquads)
 {

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -933,13 +933,13 @@ inline void all_ring_modes_block(float *__restrict src1_l, float *__restrict src
             cxor43_2_block(src1_l, src2_l, dst_l, nquads);
             cxor43_2_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case CombinatorMode::cxm_cxor43_3:
-            cxor43_3_block(src1_l, src2_l, dst_l, nquads);
-            cxor43_3_block(src1_r, src2_r, dst_r, nquads);
+        case CombinatorMode::cxm_cxor43_3_legacy:
+            cxor43_3_legacy_block(src1_l, src2_l, dst_l, nquads);
+            cxor43_3_legacy_block(src1_r, src2_r, dst_r, nquads);
             break;
-        case CombinatorMode::cxm_cxor43_4:
-            cxor43_4_block(src1_l, src2_l, dst_l, nquads);
-            cxor43_4_block(src1_r, src2_r, dst_r, nquads);
+        case CombinatorMode::cxm_cxor43_4_legacy:
+            cxor43_4_legacy_block(src1_l, src2_l, dst_l, nquads);
+            cxor43_4_legacy_block(src1_r, src2_r, dst_r, nquads);
             break;
         case CombinatorMode::cxm_cxor93_0:
             cxor93_0_block(src1_l, src2_l, dst_l, nquads);
@@ -961,6 +961,14 @@ inline void all_ring_modes_block(float *__restrict src1_l, float *__restrict src
             cxor93_4_block(src1_l, src2_l, dst_l, nquads);
             cxor93_4_block(src1_r, src2_r, dst_r, nquads);
             break;
+        case CombinatorMode::cxm_cxor43_3:
+            cxor43_3_block(src1_l, src2_l, dst_l, nquads);
+            cxor43_3_block(src1_r, src2_r, dst_r, nquads);
+            break;
+        case CombinatorMode::cxm_cxor43_4:
+            cxor43_4_block(src1_l, src2_l, dst_l, nquads);
+            cxor43_4_block(src1_r, src2_r, dst_r, nquads);
+            break;
         }
         osclevels.multiply_2_blocks(dst_l, dst_r, nquads);
     }
@@ -980,11 +988,11 @@ inline void all_ring_modes_block(float *__restrict src1_l, float *__restrict src
         case CombinatorMode::cxm_cxor43_2:
             cxor43_2_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case CombinatorMode::cxm_cxor43_3:
-            cxor43_3_block(src1_l, src2_l, dst_l, nquads);
+        case CombinatorMode::cxm_cxor43_3_legacy:
+            cxor43_3_legacy_block(src1_l, src2_l, dst_l, nquads);
             break;
-        case CombinatorMode::cxm_cxor43_4:
-            cxor43_4_block(src1_l, src2_l, dst_l, nquads);
+        case CombinatorMode::cxm_cxor43_4_legacy:
+            cxor43_4_legacy_block(src1_l, src2_l, dst_l, nquads);
             break;
         case CombinatorMode::cxm_cxor93_0:
             cxor93_0_block(src1_l, src2_l, dst_l, nquads);
@@ -1000,6 +1008,12 @@ inline void all_ring_modes_block(float *__restrict src1_l, float *__restrict src
             break;
         case CombinatorMode::cxm_cxor93_4:
             cxor93_4_block(src1_l, src2_l, dst_l, nquads);
+            break;
+        case CombinatorMode::cxm_cxor43_3:
+            cxor43_3_block(src1_l, src2_l, dst_l, nquads);
+            break;
+        case CombinatorMode::cxm_cxor43_4:
+            cxor43_4_block(src1_l, src2_l, dst_l, nquads);
             break;
         }
         osclevels.multiply_block(dst_l, nquads);

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2511,13 +2511,15 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         addEntry(cxm_cxor43_1);
                         addEntry(cxm_cxor43_2);
-                        addEntry(cxm_cxor43_3);
-                        addEntry(cxm_cxor43_4);
+                        addEntry(cxm_cxor43_3_legacy);
+                        addEntry(cxm_cxor43_4_legacy);
                         addEntry(cxm_cxor93_0);
                         addEntry(cxm_cxor93_1);
                         addEntry(cxm_cxor93_2);
                         addEntry(cxm_cxor93_3);
                         addEntry(cxm_cxor93_4);
+                        addEntry(cxm_cxor43_3);
+                        addEntry(cxm_cxor43_4);
 
                         break;
                     }


### PR DESCRIPTION
rename existing to -(legacy) and add new corrected 3 and 4 modes at end of list