### PR TITLE
Remove libsamplerate dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "libs/JUCE"]
 	path = libs/JUCE
 	url = https://github.com/surge-synthesizer/JUCE
-[submodule "libs/libsamplerate"]
-	path = libs/libsamplerate
-	url = https://github.com/libsndfile/libsamplerate.git
 [submodule "libs/luajitlib/LuaJIT"]
 	path = libs/luajitlib/LuaJIT
 	url = https://github.com/LuaJIT/LuaJIT.git

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -14,11 +14,6 @@ else()
   add_library(surge::oddsound-mts ALIAS oddsound-mts)
 endif()
 
-if(MINGW)
-  set(HAVE_VISIBILITY 0 CACHE INTERNAL "Force-disable libsamplerate's visibility check on MinGW")
-endif()
-
-surge_add_lib_subdirectory(libsamplerate)
 surge_add_lib_subdirectory(pffft)
 surge_add_lib_subdirectory(tuning-library)
 surge_add_lib_subdirectory(sqlite-3.23.3)
@@ -369,7 +364,6 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC
   fmt
   luajit-5.1
-  samplerate
   surge::airwindows
   surge::eurorack
 

--- a/src/common/dsp/oscillators/TwistOscillator.h
+++ b/src/common/dsp/oscillators/TwistOscillator.h
@@ -24,8 +24,6 @@
  * What's our samplerate strategy
  */
 #include "globals.h"
-#define SAMPLERATE_SRC 0
-#define SAMPLERATE_LANCZOS 1
 
 #include "OscillatorBase.h"
 #include <memory>
@@ -33,10 +31,8 @@
 #include "DSPUtils.h"
 #include "OscillatorCommonFunctions.h"
 
-#if SAMPLERATE_LANCZOS
 // #include "LanczosResampler.h"
 #include "sst/basic-blocks/dsp/LanczosResampler.h"
-#endif
 
 namespace plaits
 {
@@ -49,8 +45,6 @@ namespace stmlib
 {
 class BufferAllocator;
 }
-
-struct SRC_STATE_tag;
 
 class TwistOscillator : public Oscillator
 {
@@ -95,15 +89,13 @@ class TwistOscillator : public Oscillator
     char *shared_buffer{nullptr};
 
     // Keep this here for now even if using lanczos since I'm using SRC for FM still
-    SRC_STATE_tag *srcstate, *fmdownsamplestate;
     float fmlagbuffer[BLOCK_SIZE_OS << 1];
     int fmwp, fmrp;
 
     bool useCorrectLPGBlockSize{false}; // See #6760
 
-#if SAMPLERATE_LANCZOS
-    std::unique_ptr<sst::basic_blocks::dsp::LanczosResampler<BLOCK_SIZE>> lancRes;
-#endif
+    using resamp_t = sst::basic_blocks::dsp::LanczosResampler<BLOCK_SIZE>;
+    std::unique_ptr<resamp_t> lancRes, fmDownSampler;
 
     float carryover[BLOCK_SIZE_OS][2];
     int carrover_size = 0;

--- a/src/surge-testrunner/CMakeLists.txt
+++ b/src/surge-testrunner/CMakeLists.txt
@@ -32,7 +32,6 @@ add_executable(${PROJECT_NAME}
   )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  samplerate
   surge-lua-src
   surge::catch2_v3
   surge::surge-common

--- a/src/surge-testrunner/UnitTestsDSP.cpp
+++ b/src/surge-testrunner/UnitTestsDSP.cpp
@@ -29,8 +29,6 @@
 
 #include "UnitTestUtilities.h"
 
-#include "samplerate.h"
-
 #include "SSEComplex.h"
 #include <complex>
 #include "sst/basic-blocks/mechanics/simd-ops.h"
@@ -339,76 +337,6 @@ TEST_CASE("All Patches Have Bounded Output", "[dsp]")
     };
 
     // Surge::Headless::playOnNRandomPatches(surge, scale, 100, callBack);
-}
-
-TEST_CASE("libsamplerate Basics", "[dsp]")
-{
-    for (auto tsr : {44100, 48000}) // { 44100, 48000, 88200, 96000, 192000 })
-    {
-        for (auto ssr : {44100, 48000, 88200})
-        {
-            DYNAMIC_SECTION("libsamplerate from " << ssr << " to " << tsr)
-            {
-                int error;
-                auto state = src_new(SRC_SINC_FASTEST, 1, &error);
-                REQUIRE(state);
-                REQUIRE(error == 0);
-
-                static constexpr int buffer_size = 1024 * 100;
-                static constexpr int output_block = 64;
-
-                float input_data[buffer_size];
-                float copied_output[buffer_size];
-
-                int cwp = 0, irp = 0;
-                float output_data[output_block];
-
-                float dPhase = 440.0 / ssr * 2.0 * M_PI;
-                float phase = 0;
-                for (int i = 0; i < buffer_size; ++i)
-                {
-                    input_data[i] = std::sin(phase);
-                    phase += dPhase;
-                    if (phase >= 2.0 * M_PI)
-                        phase -= 2.0 * M_PI;
-                }
-
-                SRC_DATA sdata;
-                sdata.end_of_input = 0;
-                while (irp + output_block < buffer_size && cwp + output_block < buffer_size)
-                {
-                    sdata.data_in = &(input_data[irp]);
-                    sdata.data_out = output_data;
-                    sdata.input_frames = 64;
-                    sdata.output_frames = 64;
-                    sdata.src_ratio = 1.0 * tsr / ssr;
-
-                    auto res = src_process(state, &sdata);
-                    memcpy((void *)(copied_output + cwp), (void *)output_data,
-                           sdata.output_frames_gen * sizeof(float));
-                    irp += sdata.input_frames_used;
-                    cwp += sdata.output_frames_gen;
-                    REQUIRE(res == 0);
-                    REQUIRE(sdata.input_frames_used + sdata.output_frames_gen > 0);
-                }
-
-                state = src_delete(state);
-                REQUIRE(!state);
-
-                // At this point the output block should be a 440hz sine wave at the target rate
-                dPhase = 440.0 / tsr * 2.0 * M_PI;
-                phase = 0;
-                for (int i = 0; i < cwp; ++i)
-                {
-                    auto cw = std::sin(phase);
-                    REQUIRE(copied_output[i] == Approx(cw).margin(1e-2));
-                    phase += dPhase;
-                    if (phase >= 2.0 * M_PI)
-                        phase -= 2.0 * M_PI;
-                }
-            }
-        }
-    }
 }
 
 TEST_CASE("Every Oscillator Plays", "[dsp]")


### PR DESCRIPTION
After porting Nimbus ot lanczos in 4b3ffe6 we can now remove the libsamplerate dependency altogether as long as we fix up the twist fm (which we did with a simple application of another lanczos ds) and remove src code from the unit tests (where it was explicitly tested)