### PR TITLE
Fix a logic error in creating Surge XT folder in new session

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -348,30 +348,12 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
              * This code doesn't work because fs:: doesn't have a writable check and I don't
              * want to create a file just to see in every startup path. We find out later
              * anyway when we set up the directories.
-            auto stat = fs::status(userDataPath);
-            std::cout << std::oct << (int)stat.permissions() << " " << (int)fs::perms::owner_write
-            << std::endl; if ((stat.permissions() & fs::perms::owner_write) != fs::perms::none)
-            {
-                userDataPathValid = true;
-            }
-            else
-            {
-                reportError(std::string() + "Your user directory '" + userDataPath.u8string() + "'
-            is not writable.", "Path Error");
-            }
              */
-        }
-        else
-        {
-            reportError(std::string() + "Your user directory '" + userDataPath.u8string() +
-                            "' is not a directory.",
-                        "Path Error");
         }
     }
     catch (const fs::filesystem_error &e)
     {
         userDataPathValid = false;
-        reportError(e.what(), "Path Error");
     }
 
     userDefaultFilePath = userDataPath;
@@ -399,7 +381,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     extraThirdPartyWavetablesPath = config.extraThirdPartyWavetablesPath;
     extraUserWavetablesPath = config.extraUsersWavetablesPath;
 
-    if (config.createUserDirectory && userDataPathValid)
+    if (config.createUserDirectory && !userDataPathValid)
     {
         createUserDirectory();
     }

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -381,7 +381,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     extraThirdPartyWavetablesPath = config.extraThirdPartyWavetablesPath;
     extraUserWavetablesPath = config.extraUsersWavetablesPath;
 
-    if (config.createUserDirectory && !userDataPathValid)
+    if (config.createUserDirectory)
     {
         createUserDirectory();
     }
@@ -636,6 +636,7 @@ void SurgeStorage::createUserDirectory()
                             userSkinsPath, userMidiMappingsPath})
                 fs::create_directories(s);
 
+            userDataPathValid = true;
 #if HAS_JUCE
             auto rd = std::string(SurgeSharedBinary::README_UserArea_txt,
                                   SurgeSharedBinary::README_UserArea_txtSize) +


### PR DESCRIPTION
In a new session, Surge XT would not accurately create a user folder. Correct this.