### PR TITLE
Remove 32 bit windows builds from CI and Release

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,17 +13,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: "windows msvc"
+          - name: "windows msvc common only"
             os: windows-latest
-            target: surge-xt_Standalone
+            target: surge-common
             cmakeConfig: -A x64
-            cmakeOpt: DEBUG
-            runTests: false
-
-          - name: "windows msvc 32 bit"
-            os: windows-latest
-            target: surge-xt_Standalone
-            cmakeConfig: -A Win32
             cmakeOpt: DEBUG
             runTests: false
 
@@ -65,7 +58,7 @@ jobs:
           - name: "windows test runner"
             os: windows-latest
             target: surge-testrunner
-            cmakeConfig: -A x64
+            cmakeConfig: -GNinja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
             cmakeOpt: RELEASE
             runTests: true
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,9 +53,7 @@ jobs:
           - os: windows-latest
             name: windows-64bit
             cmakeArgs: -GNinja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
-          - os: windows-latest
-            name: windows-32bit
-            cmakeArgs: -A Win32
+
           - os: macos-latest
             name: macos
             cmakeArgs: -D"CMAKE_OSX_ARCHITECTURES=arm64;x86_64"


### PR DESCRIPTION
1. No more 32 bit windows builds
2. MSVC PR test just builds surge-common; juce will build and relesae is clang

Should lead to faster CI and faster release builds