### PR TITLE
initial morph value fix

### DIFF
--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -86,7 +86,6 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
     nointerp = !oscdata->p[wt_morph].extend_range;
 
     float shape = l_shape.v;
-    //float shape = oscdata->p[wt_morph].val.f;
 
     float intpart;
     shape *= ((float)oscdata->wt.n_tables - 1.f + nointerp) * 0.99999f;

--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -84,7 +84,10 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
     // nointerp adjusts the tableid range so that it scans the whole wavetable
     // rather than wavetable from first to second to last frame
     nointerp = !oscdata->p[wt_morph].extend_range;
-    float shape = oscdata->p[wt_morph].val.f;
+
+    float shape = l_shape.v;
+    //float shape = oscdata->p[wt_morph].val.f;
+
     float intpart;
     shape *= ((float)oscdata->wt.n_tables - 1.f + nointerp) * 0.99999f;
     tableipol = modff(shape, &intpart);


### PR DESCRIPTION
If you modulate the morph value of a wavetable oscillator, the initial value is never set. Instead it interpolates to the initial value from zero, which can cause a glitch in the beginning of each note.

Fixes #7774 

[edit] It interpolates from the values the morph slider is set to manually. Not necessary zero