### PR TITLE
wavetable morph interpolation discontinuity

### DIFF
--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -62,12 +62,10 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
 
     n_unison = limit_range(oscdata->p[wt_unison_voices].val.i, 1, MAX_UNISON);
 
-    isOneShot = 0;
     if (oscdata->wt.flags & wtf_is_sample)
     {
         sampleloop = n_unison;
         n_unison = 1;
-        isOneShot = 1;
     }
 
     if (is_display)
@@ -448,6 +446,28 @@ void WavetableOscillator::process_block(float pitch0, float drift, bool stereo, 
         tableipol = shape;
         modff(shape, &intpart);
         tableid = limit_range((int)intpart, 0, (int)oscdata->wt.n_tables - 2 + nointerp);
+        /*
+        if (tableid > last_tableid)
+        {
+            if (last_tableipol != 1.f)
+            {
+                tableid = last_tableid;
+                tableipol = 1.f;
+            }
+            else
+                last_tableipol = 0.0f;
+        }
+        else if (tableid < last_tableid)
+        {
+            if (last_tableipol != 0.f)
+            {
+                tableid = last_tableid;
+                tableipol = 0.f;
+            }
+            else
+                last_tableipol = 1.0f;
+        }
+        */
     }
 
     if (FM)

--- a/src/common/dsp/oscillators/WavetableOscillator.h
+++ b/src/common/dsp/oscillators/WavetableOscillator.h
@@ -72,7 +72,6 @@ class WavetableOscillator : public AbstractBlitOscillator
     int nointerp;
     float FMmul_inv;
     int sampleloop;
-    bool isOneShot;
 };
 
 #endif // SURGE_SRC_COMMON_DSP_OSCILLATORS_WAVETABLEOSCILLATOR_H

--- a/src/common/dsp/oscillators/WavetableOscillator.h
+++ b/src/common/dsp/oscillators/WavetableOscillator.h
@@ -72,6 +72,7 @@ class WavetableOscillator : public AbstractBlitOscillator
     int nointerp;
     float FMmul_inv;
     int sampleloop;
+    bool isOneShot;
 };
 
 #endif // SURGE_SRC_COMMON_DSP_OSCILLATORS_WAVETABLEOSCILLATOR_H


### PR DESCRIPTION
This addresses the following:

**Continuous frame interpolation**
The interpolation between frames weren't continuous, which could introduce lots of noise in some cases. It was especially apparent in noisy/phase shifting wavetables.  

**Seamless loop in "one shot"-mode**
So it turns out that you can actually loop "one shots". In one-shot-mode the unison voices parameter acts as a loop counter.
Anything between 1-6 loops the sample that amount of times. Anything over 7 will loop forever. 
The loop was not seamless though, so that has been adressed.

Addresses #7777



