### PR TITLE
Wavetable Option Plubming

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -299,6 +299,7 @@ bool Parameter::can_extend_range() const
     case ct_percent_oscdrift:
     case ct_twist_aux_mix:
     case ct_countedset_percent_extendable:
+    case ct_countedset_percent_extendable_wtdeform:
     case ct_dly_fb_clippingmodes:
     case ct_bonsai_bass_boost:
     case ct_detuning:
@@ -378,6 +379,7 @@ bool Parameter::has_deformoptions() const
     case ct_envtime_deformable:
     case ct_filter_feedback:
     case ct_osc_feedback_negative:
+    case ct_countedset_percent_extendable_wtdeform:
         return true;
     default:
         break;
@@ -527,6 +529,7 @@ void Parameter::set_user_data(ParamUserData *ud)
     {
     case ct_countedset_percent:
     case ct_countedset_percent_extendable:
+    case ct_countedset_percent_extendable_wtdeform:
         if (dynamic_cast<CountedSetUserData *>(ud))
         {
             user_data = ud;
@@ -1123,6 +1126,7 @@ void Parameter::set_type(int ctrltype)
         break;
     case ct_countedset_percent:
     case ct_countedset_percent_extendable:
+    case ct_countedset_percent_extendable_wtdeform:
         val_min.f = 0;
         val_max.f = 1;
         valtype = vt_float;
@@ -1398,6 +1402,7 @@ void Parameter::set_type(int ctrltype)
     case ct_rotarydrive:
     case ct_countedset_percent:
     case ct_countedset_percent_extendable:
+    case ct_countedset_percent_extendable_wtdeform:
     case ct_lfoamplitude:
     case ct_lfophaseshuffle:
     case ct_reson_res_extendable:
@@ -1933,6 +1938,7 @@ void Parameter::bound_value(bool force_integer)
         }
         case ct_countedset_percent:
         case ct_countedset_percent_extendable:
+        case ct_countedset_percent_extendable_wtdeform:
         {
             CountedSetUserData *cs = reinterpret_cast<CountedSetUserData *>(user_data);
             if (cs)
@@ -3343,6 +3349,7 @@ void Parameter::get_display_alt(char *txt, bool external, float ef) const
     }
     case ct_countedset_percent:
     case ct_countedset_percent_extendable:
+    case ct_countedset_percent_extendable_wtdeform:
         if (user_data != nullptr)
         {
             // We check when set so the reinterpret cast is safe and fast
@@ -4430,6 +4437,7 @@ bool Parameter::can_setvalue_from_string() const
     case ct_oscspread_bipolar:
     case ct_countedset_percent:
     case ct_countedset_percent_extendable:
+    case ct_countedset_percent_extendable_wtdeform:
     case ct_flangerpitch:
     case ct_flangervoices:
     case ct_flangerspacing:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -149,8 +149,9 @@ enum ctrltypes
     ct_sineoscmode,
     ct_ringmod_sineoscmode,
     ct_sinefmlegacy,
-    ct_countedset_percent,            // what % through a counted set are we
-    ct_countedset_percent_extendable, // what % through a counted set are we
+    ct_countedset_percent,                     // what % through a counted set are we
+    ct_countedset_percent_extendable,          // what % through a counted set are we
+    ct_countedset_percent_extendable_wtdeform, // what % through a counted set are we
     ct_vocoder_bandcount,
     ct_distortion_waveshape,
     ct_flangerpitch,

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -137,9 +137,10 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 // 23 -> 24 (XT 1.3.3 nightlies) added actually functioning extend mode to FM2 oscillator's M1/2 Offset parameter
 //                                     (old patches load with extend disabled even if they had it enabled)
 // 24 -> 25 (XT 1.3.4 nightlies) added storing of Wavetable Script Editor window state
+// 25 -> 26 (XT 1.4.* nightlies) added WT Deform for new WT features
 // clang-format on
 
-const int ff_revision = 25;
+const int ff_revision = 26;
 
 const int n_scene_params = 273;
 const int n_global_params = 11 + n_fx_slots * (n_fx_params + 1); // each param plus a type

--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -130,7 +130,7 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
 void WavetableOscillator::init_ctrltypes()
 {
     oscdata->p[wt_morph].set_name("Morph");
-    oscdata->p[wt_morph].set_type(ct_countedset_percent_extendable);
+    oscdata->p[wt_morph].set_type(ct_countedset_percent_extendable_wtdeform);
     oscdata->p[wt_morph].set_user_data(oscdata);
     oscdata->p[wt_skewv].set_name("Skew Vertical");
     oscdata->p[wt_skewv].set_type(ct_percent_bipolar);
@@ -150,6 +150,7 @@ void WavetableOscillator::init_default_values()
 {
     oscdata->p[wt_morph].val.f = 0.0f;
     oscdata->p[wt_morph].set_extend_range(true);
+    oscdata->p[wt_morph].deform_type = FeatureDeform::XT_14;
     oscdata->p[wt_skewv].val.f = 0.0f;
     oscdata->p[wt_saturate].val.f = 0.f;
     oscdata->p[wt_formant].val.f = 0.f;
@@ -407,6 +408,18 @@ template <bool is_init> void WavetableOscillator::update_lagvals()
 void WavetableOscillator::process_block(float pitch0, float drift, bool stereo, bool FM,
                                         float depth)
 {
+    auto fd = (FeatureDeform)oscdata->p[wt_morph].deform_type;
+#if 0
+    if (fd == XT_134_EARLIER)
+    {
+        std::cout << "OLD WAY" << std::endl;
+    }
+    else
+    {
+        std::cout << "NEW WAY" << std::endl;
+    }
+#endif
+
     pitch_last = pitch_t;
     pitch_t = min(148.f, pitch0);
     pitchmult_inv =
@@ -563,5 +576,9 @@ void WavetableOscillator::handleStreamingMismatches(int streamingRevision,
     if (streamingRevision <= 16)
     {
         oscdata->p[wt_morph].set_extend_range(true);
+    }
+    if (streamingRevision <= 25)
+    {
+        oscdata->p[wt_morph].deform_type = (int)FeatureDeform::XT_134_EARLIER;
     }
 }

--- a/src/common/dsp/oscillators/WavetableOscillator.h
+++ b/src/common/dsp/oscillators/WavetableOscillator.h
@@ -42,6 +42,12 @@ class WavetableOscillator : public AbstractBlitOscillator
         wt_unison_voices,
     };
 
+    enum FeatureDeform
+    {
+        XT_134_EARLIER = 0,
+        XT_14 = 1 << 0
+    };
+
     lipol_ps li_hpf, li_DC, li_integratormult;
     WavetableOscillator(SurgeStorage *storage, OscillatorStorage *oscdata, pdata *localcopy,
                         pdata *localcopyUnmod);

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -49,6 +49,7 @@
 #include "overlays/ModulationEditor.h"
 #include "overlays/PatchStoreDialog.h"
 #include "overlays/TypeinParamEditor.h"
+#include "WavetableOscillator.h"
 
 std::string decodeControllerID(int id)
 {
@@ -2600,6 +2601,29 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         break;
                     }
+                    case ct_countedset_percent_extendable_wtdeform:
+                    {
+                        contextMenu.addSeparator();
+                        auto dt = p->deform_type;
+                        for (const auto &[opt, lab] :
+                             {std::make_pair(WavetableOscillator::FeatureDeform::XT_134_EARLIER,
+                                             "Slow Lag and WT Jump Noise (<= 1.3.4 behavior)"),
+                              {WavetableOscillator::FeatureDeform::XT_14,
+                               "No Modulation Lag and No WT Jump Noise (1.4 and later)"}})
+                        {
+                            contextMenu.addItem(Surge::GUI::toOSCase(lab), true, dt == (int)opt,
+                                                [this, p, ov = opt]() {
+                                                    undoManager()->pushParameterChange(p->id, p,
+                                                                                       p->val);
+                                                    update_deform_type(p, (int)ov);
+                                                    synth->storage.getPatch().isDirty = true;
+                                                    frame->repaint();
+                                                });
+                        }
+
+                        contextMenu.addSeparator();
+                    }
+                    break;
                     default:
                     {
                         break;
@@ -2647,6 +2671,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             txt = "Pan Main and Auxiliary Signals";
                             break;
                         case ct_countedset_percent_extendable:
+                        case ct_countedset_percent_extendable_wtdeform:
                             txt = "Continuous Morph";
                             break;
                         default:

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2605,21 +2605,20 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                     {
                         contextMenu.addSeparator();
                         auto dt = p->deform_type;
-                        for (const auto &[opt, lab] :
-                             {std::make_pair(WavetableOscillator::FeatureDeform::XT_134_EARLIER,
-                                             "Slow Lag and WT Jump Noise (<= 1.3.4 behavior)"),
-                              {WavetableOscillator::FeatureDeform::XT_14,
-                               "No Modulation Lag and No WT Jump Noise (1.4 and later)"}})
-                        {
-                            contextMenu.addItem(Surge::GUI::toOSCase(lab), true, dt == (int)opt,
-                                                [this, p, ov = opt]() {
-                                                    undoManager()->pushParameterChange(p->id, p,
-                                                                                       p->val);
-                                                    update_deform_type(p, (int)ov);
-                                                    synth->storage.getPatch().isDirty = true;
-                                                    frame->repaint();
-                                                });
-                        }
+
+                        contextMenu.addItem(
+                            Surge::GUI::toOSCase("Legacy Lag, Smooth and Table Interp"), true,
+                            dt == (int)WavetableOscillator::FeatureDeform::XT_134_EARLIER,
+                            [this, p, dt]() {
+                                undoManager()->pushParameterChange(p->id, p, p->val);
+                                auto ov =
+                                    (dt == WavetableOscillator::FeatureDeform::XT_134_EARLIER
+                                         ? WavetableOscillator::FeatureDeform::XT_14
+                                         : WavetableOscillator::FeatureDeform::XT_134_EARLIER);
+                                update_deform_type(p, (int)ov);
+                                synth->storage.getPatch().isDirty = true;
+                                frame->repaint();
+                            });
 
                         contextMenu.addSeparator();
                     }


### PR DESCRIPTION
This makes the Wavetable Morph option available and sets up options for future changes too if we want.

Critically it doesn't *do* anything with the deform state it just versions and edits it appropriately.

Addresses #7784