### PR TITLE
morph switch

### DIFF
--- a/src/common/dsp/oscillators/WavetableOscillator.h
+++ b/src/common/dsp/oscillators/WavetableOscillator.h
@@ -65,6 +65,14 @@ class WavetableOscillator : public AbstractBlitOscillator
     void convolute(int voice, bool FM, bool stereo);
     template <bool is_init> void update_lagvals();
     inline float distort_level(float);
+    void readDeformType();
+    void selectDeform();
+    float getMorph();
+    float deformLegacy(float, int);
+    float deformContinuous(float, int);
+    float deformMorph(float, int);
+
+    float (WavetableOscillator::*deformSelected)(float, int);
     bool first_run;
     float oscpitch[MAX_UNISON];
     float dc, dc_uni[MAX_UNISON], last_level[MAX_UNISON];
@@ -80,6 +88,7 @@ class WavetableOscillator : public AbstractBlitOscillator
     float FMmul_inv;
     int sampleloop;
     pdata *unmodulatedLocalcopy;
+    FeatureDeform deformType;
 };
 
 #endif // SURGE_SRC_COMMON_DSP_OSCILLATORS_WAVETABLEOSCILLATOR_H


### PR DESCRIPTION
Implemented switch for handling legacy vs new interpolation

I decided to move the actual calculations of the interpolations outside of convolute, to make it more clear if we for some reason decide to add more interpolation modes. 

I then have a function pointer that is set on each block that points to the active interpolation function. I though that would be more optimal than having several if-statements inside of convolute(). 

I have also included the morph interpolation that I talked about yesterday. It is only used in cases where the morph value has changed more than 5 frames in a block. It works pretty well to reduce noise in those cases. 
A nice side effect is that it also reduces the noise when changing value with GUI, as those stepped changes will now morph instead of scrub. 

Addresses #7784 #7777 #7696

