### PR TITLE
Temporary fix for JUCE 8 DocumentWindow regression

### DIFF
--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -280,6 +280,15 @@ struct TearOutWindow : public juce::DocumentWindow, public Surge::GUI::SkinConsu
         repaint();
     }
 
+    WindowControlKind findControlAtPoint(juce::Point<float> point) const override
+    {
+        // See issue 7805 for this temporary fix
+        auto res = DocumentWindow::findControlAtPoint(point);
+        if (res == WindowControlKind::minimise || res == WindowControlKind::close)
+            return WindowControlKind::client;
+        return res;
+    }
+
     void mouseDoubleClick(const juce::MouseEvent &event) override
     {
         auto oc = dynamic_cast<Surge::Overlays::OverlayComponent *>(wrapping->primaryChild.get());


### PR DESCRIPTION
This temporarily fixes the lack of tearin in JUCE 8 due to the issue described in #7805. In an ideal world a future juce would fix this bug and we will revert this change before 1.4