### PR TITLE
Re-enable Ensemble and Tape SIMD Hysteresis ARM64

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1178,18 +1178,11 @@ void Parameter::set_type(int ctrltype)
         break;
     case ct_ensemble_stages:
     {
-#if defined(_M_ARM64EC)
-        valtype = vt_int;
-        val_min.i = 0;
-        val_max.i = 1;
-        val_default.i = 0;
-#else
         extern int ensemble_stage_count();
         valtype = vt_int;
         val_min.i = 0;
         val_max.i = ensemble_stage_count() - 1;
         val_default.i = 0;
-#endif
         break;
     }
     case ct_stringosc_excitation_model:
@@ -4071,12 +4064,8 @@ std::string Parameter::get_display(bool external, float ef) const
         break;
         case ct_ensemble_stages:
         {
-#if defined(_M_ARM64EC)
-            txt = "name";
-#else
             extern std::string ensemble_stage_name(int);
             txt = ensemble_stage_name(i);
-#endif
         }
         break;
         case ct_reson_mode:

--- a/src/common/dsp/Effect.cpp
+++ b/src/common/dsp/Effect.cpp
@@ -20,10 +20,7 @@
  * https://github.com/surge-synthesizer/surge
  */
 
-#if !defined(_M_ARM64EC)
 #include "BBDEnsembleEffect.h"
-#endif
-
 #include "BonsaiEffect.h"
 #include "ChorusEffectImpl.h"
 #include "CombulatorEffect.h"
@@ -108,11 +105,7 @@ Effect *spawn_effect(int id, SurgeStorage *storage, FxStorage *fxdata, pdata *pd
     case fxt_tape:
         return new chowdsp::TapeEffect(storage, fxdata, pd);
     case fxt_ensemble:
-#if defined(_M_ARM64EC)
-        return nullptr;
-#else
         return new BBDEnsembleEffect(storage, fxdata, pd);
-#endif
     case fxt_treemonster:
         return new TreemonsterEffect(storage, fxdata, pd);
     case fxt_waveshaper:

--- a/src/common/dsp/effects/BBDEnsembleEffect.cpp
+++ b/src/common/dsp/effects/BBDEnsembleEffect.cpp
@@ -20,8 +20,6 @@
  * https://github.com/surge-synthesizer/surge
  */
 
-#if !defined(_M_ARM64EC)
-
 #include "BBDEnsembleEffect.h"
 
 #include "sst/basic-blocks/mechanics/block-ops.h"
@@ -571,5 +569,3 @@ void BBDEnsembleEffect::handleStreamingMismatches(int streamingRevision,
         fxdata->p[ens_output_filter].deactivated = true;
     }
 }
-
-#endif

--- a/src/common/dsp/effects/BBDEnsembleEffect.h
+++ b/src/common/dsp/effects/BBDEnsembleEffect.h
@@ -23,8 +23,6 @@
 #ifndef SURGE_SRC_COMMON_DSP_EFFECTS_BBDENSEMBLEEFFECT_H
 #define SURGE_SRC_COMMON_DSP_EFFECTS_BBDENSEMBLEEFFECT_H
 
-#if !defined(_M_ARM64EC)
-
 #include "Effect.h"
 #include "BiquadFilter.h"
 #include "DSPUtils.h"
@@ -111,6 +109,5 @@ class BBDEnsembleEffect : public Effect
     BiquadFilter sincInputFilter;
 };
 
-#endif
 
 #endif // SURGE_SRC_COMMON_DSP_EFFECTS_BBDENSEMBLEEFFECT_H

--- a/src/common/dsp/effects/BBDEnsembleEffect.h
+++ b/src/common/dsp/effects/BBDEnsembleEffect.h
@@ -109,5 +109,4 @@ class BBDEnsembleEffect : public Effect
     BiquadFilter sincInputFilter;
 };
 
-
 #endif // SURGE_SRC_COMMON_DSP_EFFECTS_BBDENSEMBLEEFFECT_H

--- a/src/common/dsp/effects/chowdsp/tape/HysteresisOps.h
+++ b/src/common/dsp/effects/chowdsp/tape/HysteresisOps.h
@@ -26,11 +26,7 @@
 #include "globals.h"
 #include "sst/basic-blocks/dsp/FastMath.h"
 
-#if defined(_M_ARM64EC)
-#define CHOWTAPE_HYSTERESIS_USE_SIMD 0
-#else
 #define CHOWTAPE_HYSTERESIS_USE_SIMD 1
-#endif
 
 namespace HysteresisOps
 {


### PR DESCRIPTION
Now we moved to actual neon rather than emulated simd, msvc 2022 no longer dumps core, so turn these back on.