### PR TITLE
Apicolypse::parseParameterValueFromString - use return value

### DIFF
--- a/libs/airwindows/src/Apicolypse.cpp
+++ b/libs/airwindows/src/Apicolypse.cpp
@@ -153,7 +153,7 @@ bool Apicolypse::parseParameterValueFromString(VstInt32 index, const char* txt, 
 
    if (index == kParamD)
    {
-      string2dB(txt, v);
+      f = string2dB(txt, v);
    }
    else
    {


### PR DESCRIPTION
Apicolypse::parseParameterValueFromString was not using the value returned from string2dB.