### PR TITLE
Comparing an int to 0.5

### DIFF
--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -671,9 +671,7 @@ struct FormulaControlArea : public juce::Component,
         {
         case tag_select_tab:
         {
-            int m = c->getValue();
-
-            if (m > 0.5)
+            if (c->getValue() > 0.5)
             {
                 overlay->showPreludeCode();
             }
@@ -1446,9 +1444,7 @@ struct WavetableScriptControlArea : public juce::Component,
         {
         case tag_select_tab:
         {
-            int m = c->getValue();
-
-            if (m > 0.5)
+            if (c->getValue() > 0.5)
             {
                 overlay->showPreludeCode();
             }


### PR DESCRIPTION
A floating point value was truncated to an int and then compared to 0.5 - which seems wrong. Just compare the float value itself.