### PR TITLE
Misc1

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -4680,7 +4680,7 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
         }
         case ct_pbdepth:
         {
-            if (extend_range && s.find("/") != std::string::npos)
+            if (extend_range && s.find('/') != std::string::npos)
             {
                 if (!supports_tuning_value_from_string(s, errMsg))
                     return false;
@@ -4813,7 +4813,7 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
         if (displayInfo.customFeatures & ParamDisplayFeatures::kAllowsTuningFractionTypein)
         {
             // Check for a fraction
-            if (s.find("/") != std::string::npos)
+            if (s.find('/') != std::string::npos)
             {
                 if (!supports_tuning_value_from_string(s, errMsg))
                     return false;
@@ -5016,7 +5016,7 @@ bool Parameter::set_value_from_string_onto(const std::string &s, pdata &ontoThis
             // OK so do we contain a /?
             const char *slp;
 
-            if ((slp = strstr(strip, "/")) != nullptr)
+            if ((slp = strchr(strip, '/')) != nullptr)
             {
                 float num = std::atof(strip);
                 float den = std::atof(slp + 1);
@@ -5120,7 +5120,7 @@ float Parameter::calculate_modulation_value_from_string(const std::string &s, st
         if (displayInfo.customFeatures & ParamDisplayFeatures::kAllowsTuningFractionTypein)
         {
             // Check for a fraction
-            if (s.find("/") != std::string::npos)
+            if (s.find('/') != std::string::npos)
             {
                 if (!supports_tuning_value_from_string(s, errMsg))
                     return false;
@@ -5435,7 +5435,7 @@ float Parameter::calculate_modulation_value_from_string(const std::string &s, st
             // OK so do we contain a /?
             const char *slp;
 
-            if ((slp = strstr(strip, "/")) != nullptr)
+            if ((slp = strchr(strip, '/')) != nullptr)
             {
                 float num = std::atof(strip);
                 float den = std::atof(slp + 1);

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1336,8 +1336,8 @@ void LFOAndStepDisplay::paintStepSeq(juce::Graphics &g)
     auto q = boxo;
 
     const auto tfpath = juce::AffineTransform()
-                  .scaled(boxo.getWidth() / valScale, boxo.getHeight() / valScale)
-                  .translated(q.getTopLeft().x, q.getTopLeft().y);
+                            .scaled(boxo.getWidth() / valScale, boxo.getHeight() / valScale)
+                            .translated(q.getTopLeft().x, q.getTopLeft().y);
 
     g.setColour(skin->getColor(Colors::LFO::StepSeq::Envelope));
 

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1335,9 +1335,9 @@ void LFOAndStepDisplay::paintStepSeq(juce::Graphics &g)
 
     auto q = boxo;
 
-    const auto tfpath = juce::AffineTransform()
-                            .scaled(boxo.getWidth() / valScale, boxo.getHeight() / valScale)
-                            .translated(q.getTopLeft().x, q.getTopLeft().y);
+    const auto tfpath = juce::AffineTransform().
+                            scaled(boxo.getWidth() / valScale, boxo.getHeight() / valScale).
+                            translated(q.getTopLeft().x, q.getTopLeft().y);
 
     g.setColour(skin->getColor(Colors::LFO::StepSeq::Envelope));
 

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1335,11 +1335,9 @@ void LFOAndStepDisplay::paintStepSeq(juce::Graphics &g)
 
     auto q = boxo;
 
-    auto tf = juce::AffineTransform()
+    const auto tfpath = juce::AffineTransform()
                   .scaled(boxo.getWidth() / valScale, boxo.getHeight() / valScale)
                   .translated(q.getTopLeft().x, q.getTopLeft().y);
-
-    auto tfpath = tf;
 
     g.setColour(skin->getColor(Colors::LFO::StepSeq::Envelope));
 
@@ -2609,7 +2607,7 @@ void LFOAndStepDisplay::showStepTypein(int i)
     }
 
     auto handleTypein = [this, i](const std::string &s) {
-        auto divPos = s.find("/");
+        auto divPos = s.find('/');
         float v = 0.f;
 
         if (divPos != std::string::npos)

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1335,9 +1335,9 @@ void LFOAndStepDisplay::paintStepSeq(juce::Graphics &g)
 
     auto q = boxo;
 
-    const auto tfpath = juce::AffineTransform().
-                            scaled(boxo.getWidth() / valScale, boxo.getHeight() / valScale).
-                            translated(q.getTopLeft().x, q.getTopLeft().y);
+    const auto tfpath = juce::AffineTransform()
+                            .scaled(boxo.getWidth() / valScale, boxo.getHeight() / valScale)
+                            .translated(q.getTopLeft().x, q.getTopLeft().y);
 
     g.setColour(skin->getColor(Colors::LFO::StepSeq::Envelope));
 

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -1210,11 +1210,11 @@ bool PatchSelector::populatePatchMenuForCategory(int c, juce::PopupMenu &context
 
         if (n_subc > 1)
         {
-            name = fmt::format("{} {}", menuName, subc + 1).c_str();
+            name = fmt::format("{} {}", menuName, subc + 1);
         }
         else
         {
-            name = menuName.c_str();
+            name = menuName;
         }
 
         if (!single_category)


### PR DESCRIPTION
PatchSelector - remove unnecessary uses of .c_str().
LFOAndStepDisplay - remove unnessary variable.
Find single chars rather than single character strings, it's faster.