### PR TITLE
More refs to eliminate copies

### DIFF
--- a/src/surge-testrunner/UnitTestsMOD.cpp
+++ b/src/surge-testrunner/UnitTestsMOD.cpp
@@ -20,7 +20,6 @@
  * https://github.com/surge-synthesizer/surge
  */
 #include <iostream>
-#include <iostream>
 #include <iomanip>
 #include <sstream>
 #include <algorithm>
@@ -172,9 +171,9 @@ TEST_CASE("ADSR Envelope Behaviour", "[mod]")
         {
             if (sturns.size() != 3)
             {
-                for (auto s : simple)
+                for (const auto &s : simple)
                     std::cout << s.first << " " << s.second << std::endl;
-                for (auto s : sturns)
+                for (const auto &s : sturns)
                     std::cout << s.first << " " << s.second << std::endl;
             }
             REQUIRE(sturns.size() == 3);
@@ -189,10 +188,10 @@ TEST_CASE("ADSR Envelope Behaviour", "[mod]")
         {
             if (sturns.size() != 5)
             {
-                for (auto s : simple)
+                for (const auto &s : simple)
                     std::cout << s.first << " " << s.second << std::endl;
                 std::cout << "TURNS" << std::endl;
-                for (auto s : sturns)
+                for (const auto &s : sturns)
                     std::cout << s.first << " " << s.second << std::endl;
             }
             REQUIRE(sturns.size() == 5);
@@ -247,7 +246,7 @@ TEST_CASE("ADSR Envelope Behaviour", "[mod]")
     SECTION("Digital Envelope With Quadratic Slope Hits Zero")
     {
         auto res = runAdsr(0.1, 0.1, 0.0, 0.1, 0, 1, 0, false, 0.4, 0.5);
-        for (auto p : res)
+        for (const auto &p : res)
         {
             if (p.first > 0.22)
             {
@@ -271,7 +270,7 @@ TEST_CASE("ADSR Envelope Behaviour", "[mod]")
             float zerot = 0;
             float valAtRelEnd = -1;
             std::vector<float> heldPeriod;
-            for (auto obs : ae)
+            for (const auto &obs : ae)
             {
                 // std::cout << obs.first << " " << obs.second << std::endl;
 
@@ -335,7 +334,7 @@ TEST_CASE("ADSR Envelope Behaviour", "[mod]")
         auto testSusPush = [&](float s1, float s2) {
             auto digPush = runAdsr(0.05, 0.05, s1, 0.1, 0, 0, 0, false, 0.5, s2, 0.25, s2);
             int obs = 0;
-            for (auto s : digPush)
+            for (const auto &s : digPush)
             {
                 if (s.first > 0.2 && obs == 0)
                 {
@@ -486,7 +485,7 @@ TEST_CASE("ADSR Envelope Behaviour", "[mod]")
 
             int obs = 0;
             INFO("Non-SIMD Analog Envelope Passes Sustain Push");
-            for (auto s : aDupPush)
+            for (const auto &s : aDupPush)
             {
                 if (s.first > 0.2 && obs == 0)
                 {
@@ -502,7 +501,7 @@ TEST_CASE("ADSR Envelope Behaviour", "[mod]")
 
             obs = 0;
             INFO("SSE Analog Envelope Passes Sustain Push");
-            for (auto s : aSurgePush)
+            for (const auto &s : aSurgePush)
             {
                 if (s.first > 0.2 && obs == 0)
                 {
@@ -659,15 +658,18 @@ TEST_CASE("Extended Pitch Bend", "[mod]")
 
 TEST_CASE("Pitch Bend And Tuning", "[mod][tun]")
 {
-    std::vector<std::string> testScales = {"resources/test-data/scl/12-intune.scl",
-                                           "resources/test-data/scl/zeus22.scl",
-                                           "resources/test-data/scl/6-exact.scl"};
-
     SECTION("Multi Scale Bend Distances")
     {
         auto surge = surgeOnSine();
         surge->storage.tuningApplicationMode = SurgeStorage::RETUNE_ALL;
         surge->mpeEnabled = false;
+
+        // clang-format off
+        static constexpr std::initializer_list<const char *> testScales
+                    {"resources/test-data/scl/12-intune.scl",
+                     "resources/test-data/scl/zeus22.scl",
+                     "resources/test-data/scl/6-exact.scl"};
+        // clang-format on
 
         for (auto sclf : testScales)
         {

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -67,7 +67,7 @@ struct EditorColors
     static void setColorsFromSkin(juce::CodeEditorComponent *comp,
                                   const Surge::GUI::Skin::ptr_t &skin)
     {
-        auto cs = comp->getColourScheme();
+        juce::CodeEditorComponent::ColourScheme cs = comp->getColourScheme();
 
         cs.set("Bracket", skin->getColor(Colors::FormulaEditor::Lua::Bracket));
         cs.set("Comment", skin->getColor(Colors::FormulaEditor::Lua::Comment));
@@ -362,7 +362,7 @@ struct ExpandingFormulaDebugger : public juce::Component, public Surge::GUI::Ski
 
         std::string getText(int rowNumber, int columnId)
         {
-            auto r = rows[rowNumber];
+            const auto &r = rows[rowNumber];
 
             if (columnId == 1)
             {
@@ -391,7 +391,7 @@ struct ExpandingFormulaDebugger : public juce::Component, public Surge::GUI::Ski
             if (rowNumber < 0 || rowNumber >= rows.size())
                 return;
 
-            auto r = rows[rowNumber];
+            const auto &r = rows[rowNumber];
             auto b = juce::Rectangle<int>(0, 0, w, h);
             g.setFont(skin->fontManager->getFiraMonoAtSize(9));
             if (r.isInternal)
@@ -1354,7 +1354,7 @@ struct WavetableScriptControlArea : public juce::Component,
 
             contextMenu.addSeparator();
 
-            for (auto op : options)
+            for (const auto &op : options)
             {
                 auto val = op.second;
 


### PR DESCRIPTION
A few more instances where refs can be used to eliminate unnecessary copies.
In setColorsFromSkin(), auto -> actual type change to eliminate situation where analysers may recommend changing auto's to be a ref, but actually need a copy.