### PR TITLE
Simplify process_block_until_close()

### DIFF
--- a/src/common/ModulationSource.h
+++ b/src/common/ModulationSource.h
@@ -562,18 +562,15 @@ template <int NDX = 1> class ControllerModulationSourceVector : public Modulatio
     {
         assert(samplerate > 1000);
 
-        if (smoothingMode == Modulator::SmoothingMode::LEGACY)
-        {
-            processSmoothing(Modulator::SmoothingMode::SLOW_EXP, sigma);
-        }
-        else
-        {
-            processSmoothing(smoothingMode, sigma);
-        }
+        const auto sm = smoothingMode == Modulator::SmoothingMode::LEGACY
+                            ? Modulator::SmoothingMode::SLOW_EXP
+                            : smoothingMode;
 
-        auto res = (value[0] != target[0]);
+        processSmoothing(sm, sigma);
 
-        for (int i = 1; i < NDX; ++i)
+        bool res = true;
+
+        for (int i = 0; (i < NDX) && res; ++i)
         {
             res &= (value[i] != target[i]);
         }


### PR DESCRIPTION
In process_block_until_close(), the equality checking was performed in 2 steps and as in all cases NDX was 1, analysers warned that the loop part was ineffective.
To eliminate this warning, and simplify the code, just do a single loop from zero and also exit the loop when it fails the first test (should there ever be a use with NDX > 1).
Also simplify to only have the single call to processSmoothing.