### PR TITLE
Fix Rotary Speaker processOnlyControl

### DIFF
--- a/src/common/dsp/effects/SurgeSSTFXAdapter.h
+++ b/src/common/dsp/effects/SurgeSSTFXAdapter.h
@@ -148,12 +148,12 @@ struct SurgeFXConfig
     static inline float dbToLinear(GlobalStorage *s, float f) { return s->db_to_linear(f); }
 };
 
-template <typename T> class Has_processControlOnly
+template <typename T> class Has_processOnlyControl
 {
     using No = uint8_t;
     using Yes = uint64_t;
     static_assert(sizeof(No) != sizeof(Yes));
-    template <typename C> static Yes test(decltype(C::processControlOnly) *);
+    template <typename C> static Yes test(decltype(&C::processOnlyControl) *);
     template <typename C> static No test(...);
 
   public:
@@ -270,11 +270,11 @@ template <typename T> struct SurgeSSTFXBase : T
         }
     }
 
-    void process_control_only()
+    void process_only_control() override
     {
-        if constexpr (sstfx::Has_processControlOnly<T>::value)
+        if constexpr (sstfx::Has_processOnlyControl<T>::value)
         {
-            this->processControlOnly();
+            this->processOnlyControl();
         }
     }
 };


### PR DESCRIPTION
2 problems, mostly with names and punctuaction. One of those thigns I couldn't find in an hour a month ago and found in 5 minutes tonight.

Closes #7788