### PR TITLE
Fix a problem with occasional unstable low drive distortions

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -3974,8 +3974,13 @@ std::string Parameter::get_display(bool external, float ef) const
             txt = fmt::format("{:d} bands", i);
             break;
         case ct_distortion_waveshape:
-            txt = sst::waveshapers::wst_names[(int)FXWaveShapers[i]];
-            break;
+        {
+            if (i < 0 || i >= FXWaveShapers.size())
+                txt = "ERROR " + std::to_string(i);
+            else
+                txt = sst::waveshapers::wst_names[(int)FXWaveShapers[i]];
+        }
+        break;
         case ct_mscodec:
             switch (i)
             {

--- a/src/common/dsp/effects/DistortionEffect.cpp
+++ b/src/common/dsp/effects/DistortionEffect.cpp
@@ -49,9 +49,6 @@ void DistortionEffect::init()
     bi = 0.f;
     L = 0.f;
     R = 0.f;
-
-    for (int i = 0; i < sst::waveshapers::n_waveshaper_registers; ++i)
-        wsState.R[i] = SIMD_MM(setzero_ps)();
 }
 
 void DistortionEffect::setvars(bool init)
@@ -65,9 +62,16 @@ void DistortionEffect::setvars(bool init)
                            fxdata->p[dist_preeq_bw].val.f, pregain);
         band2.coeff_peakEQ(band2.calc_omega(fxdata->p[dist_posteq_freq].val.f / 12.f),
                            fxdata->p[dist_posteq_bw].val.f, postgain);
-        auto dE = storage->db_to_linear(fxdata->p[dist_drive].get_extended(*pd_float[dist_drive]));
+        auto dE =
+            storage->db_to_linear(fxdata->p[dist_drive].get_extended(fxdata->p[dist_drive].val.f));
         drive.set_target_smoothed(dE);
         outgain.set_target_smoothed(storage->db_to_linear(*pd_float[dist_gain]));
+
+        for (int i = 0; i < sst::waveshapers::n_waveshaper_registers; ++i)
+        {
+            wsState.R[i] = SIMD_MM(setzero_ps)();
+            *(((unsigned int *)&wsState.init) + 1) = 0xFFFFFFFF;
+        }
     }
     else
     {
@@ -113,8 +117,6 @@ void DistortionEffect::process(float *dataL, float *dataR)
     float bR alignas(16)[BLOCK_SIZE << dist_OS_bits];
     assert(dist_OS_bits == 2);
 
-    drive.multiply_2_blocks(dataL, dataR, BLOCK_SIZE_QUAD);
-
     // FX waveshapers have value at wst_soft for 0; so don't add wst_soft here (like we did in 1.9)
     bool useSSEShaper = (ws >= sst::waveshapers::WaveshaperType::wst_sine);
     auto wsop = sst::waveshapers::GetQuadWaveshaper(ws);
@@ -124,6 +126,11 @@ void DistortionEffect::process(float *dataL, float *dataR)
     if (useSSEShaper)
     {
         dD = (dE - dS) / (BLOCK_SIZE * dist_OS_bits);
+    }
+    else
+    {
+        // The lookup assumes a driven value
+        drive.multiply_2_blocks(dataL, dataR, BLOCK_SIZE_QUAD);
     }
 
     for (int k = 0; k < BLOCK_SIZE; k++)
@@ -147,10 +154,10 @@ void DistortionEffect::process(float *dataL, float *dataR)
             if (useSSEShaper)
             {
                 float sb alignas(16)[4];
-                auto dInv = 1.f / dNow;
 
-                sb[0] = L * dInv;
-                sb[1] = R * dInv;
+                sb[0] =
+                    L; // since we only drive multiply if not see, we don't need to back out drive
+                sb[1] = R;
                 auto lr128 = SIMD_MM(load_ps)(sb);
                 auto wsres = wsop(&wsState, lr128, SIMD_MM(set1_ps)(dNow));
                 SIMD_MM(store_ps)(sb, wsres);


### PR DESCRIPTION
The distortion effect used to do

input *= drive; Loopup input in table

When we added the waveshaper function versions we made it

input *= drive

if (waveshaper)
  input /= drive
  waveshaper(input, drive)
else
  lookuip

but this was usntable for very low drives.

Fix it so the first scaling only happens in the lookup branch

Also do a few other harmless protections and cleanups

Closes https://github.com/surge-synthesizer/surge/issues/7648