### PR TITLE
WT legacy config; skin support; control state

### DIFF
--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -279,9 +279,6 @@ std::optional<std::vector<float>> LuaWTEvaluator::evaluateScriptAtFrame(size_t f
         lua_pushinteger(L, resolution);
         lua_setfield(L, -2, "sample_count");
 
-        lua_getglobal(L, statetable);
-        lua_setfield(L, -2, "state");
-
         // So stack is now the table and the function
         auto pcr = lua_pcall(L, 1, 1, 0);
         if (pcr == LUA_OK)

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -224,8 +224,21 @@ std::optional<std::vector<float>> LuaWTEvaluator::evaluateScriptAtFrame(size_t f
 
         lua_pushnil(L); /* first key */
         assert(lua_istable(L, -2));
+        bool useLegacyNames{true};
+
         while (lua_next(L, -2) != 0)
         {
+            // stack is now new > global  > k > v but we want to see if k 'legacy_config' is true
+            if (lua_isstring(L, -2))
+            {
+                if (strcmp(lua_tostring(L, -2), "legacy_config") == 0)
+                {
+                    if (lua_isboolean(L, -1))
+                    {
+                        useLegacyNames = lua_toboolean(L, -1);
+                    }
+                }
+            }
             // stack is now new > global > k > v
             lua_pushvalue(L, -2);
             // stack is now new > global > k > v > k
@@ -237,23 +250,25 @@ std::optional<std::vector<float>> LuaWTEvaluator::evaluateScriptAtFrame(size_t f
         // pop the remaining key
         lua_pop(L, 1);
 
-        // xs is an array of the x locations in phase space
-        lua_createtable(L, resolution, 0);
-
-        double dp = 1.0 / (resolution - 1);
-        for (auto i = 0; i < resolution; ++i)
+        if (useLegacyNames)
         {
-            lua_pushinteger(L, i + 1); // lua has a 1 based index convention
-            lua_pushnumber(L, i * dp);
-            lua_settable(L, -3);
+            // xs is an array of the x locations in phase space
+            lua_createtable(L, resolution, 0);
+            double dp = 1.0 / (resolution - 1);
+            for (auto i = 0; i < resolution; ++i)
+            {
+                lua_pushinteger(L, i + 1); // lua has a 1 based index convention
+                lua_pushnumber(L, i * dp);
+                lua_settable(L, -3);
+            }
+            lua_setfield(L, -2, "xs");
+
+            lua_pushinteger(L, frame + 1);
+            lua_setfield(L, -2, "n");
+
+            lua_pushinteger(L, nFrames);
+            lua_setfield(L, -2, "nTables");
         }
-        lua_setfield(L, -2, "xs");
-
-        lua_pushinteger(L, frame + 1);
-        lua_setfield(L, -2, "n");
-
-        lua_pushinteger(L, nFrames);
-        lua_setfield(L, -2, "nTables");
 
         lua_pushinteger(L, frame + 1);
         lua_setfield(L, -2, "frame");

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -957,13 +957,12 @@ struct WavetablePreviewComponent : public juce::Component, public Surge::GUI::Sk
 {
     WavetableScriptEditor *overlay{nullptr};
     SurgeGUIEditor *editor{nullptr};
-    Surge::GUI::Skin::ptr_t skin;
 
     WavetablePreviewComponent(WavetableScriptEditor *ol, SurgeGUIEditor *ed,
                               Surge::GUI::Skin::ptr_t skin)
-        : overlay(ol), editor(ed), skin(skin)
-
+        : overlay(ol), editor(ed)
     {
+        setSkin(skin);
     }
 
     void setSingleFrame() { mode = 0; }
@@ -1223,6 +1222,8 @@ struct WavetablePreviewComponent : public juce::Component, public Surge::GUI::Sk
         }
     }
 
+    void onSkinChanged() override { repaint(); }
+
     int frameNumber{1};
     std::vector<float> points;
     std::vector<std::vector<float>> fsPoints;
@@ -1452,6 +1453,12 @@ struct WavetableScriptControlArea : public juce::Component,
             generateS->setSkin(skin, associatedBitmapStore);
             generateS->setEnabled(true);
             addAndMakeVisible(*generateS);
+
+            if (overlay->rendererComponent->mode == 1)
+            {
+                currentFrameL->setVisible(false);
+                currentFrameN->setVisible(false);
+            }
         }
     }
 
@@ -1782,7 +1789,7 @@ void WavetableScriptEditor::onSkinChanged()
     preludeDisplay->setFont(skin->getFont(Fonts::LuaEditor::Code));
     EditorColors::setColorsFromSkin(preludeDisplay.get(), skin);
     controlArea->setSkin(skin, associatedBitmapStore);
-    rendererComponent->setSkin(skin, associatedBitmapStore); // FIXME
+    rendererComponent->setSkin(skin, associatedBitmapStore);
 }
 
 void WavetableScriptEditor::setupEvaluator()


### PR DESCRIPTION
1. If you set `wt.legacy_config=false` in your init, you will no longer get the legacy names 'n', 'nFrames', and 'xs'
2. Skin changes update the graph
3. If you are in filmstrip mode at outset, hide current frame control