### PR TITLE
Several WT script editor tweaks

### DIFF
--- a/src/surge-xt/gui/overlays/LuaEditors.h
+++ b/src/surge-xt/gui/overlays/LuaEditors.h
@@ -66,7 +66,7 @@ class CodeEditorContainerWithApply : public OverlayComponent,
     void buttonClicked(juce::Button *button) override;
     void codeDocumentTextDeleted(int startIndex, int endIndex) override;
     void codeDocumentTextInserted(const juce::String &newText, int insertIndex) override;
-    void removeStringTrailsFromDocument();
+    void removeTrailingWhitespaceFromDocument();
     bool autoCompleteStringDeclaration(juce::String str);
     bool keyPressed(const juce::KeyPress &key, Component *originatingComponent) override;
 

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -36,6 +36,9 @@
 #include "UserDefaults.h"
 #include "fmt/core.h"
 
+// Change this to 0 to disable WTSE component, to disable for release: change value, test, and push
+#define INCLUDE_WT_SCRIPTING_EDITOR 1
+
 namespace Surge
 {
 namespace Widgets
@@ -599,11 +602,7 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
 
     contextMenu.addSeparator();
 
-// Change this to 0 to disable WTSE component, to disable for release: change value, test, and push
-#define INCLUDE_WT_SCRIPTING_EDITOR 1
 #if INCLUDE_WT_SCRIPTING_EDITOR
-    contextMenu.addSeparator();
-
     auto owts = [this]() {
         if (sge)
             sge->showOverlay(SurgeGUIEditor::WTSCRIPT_EDITOR);
@@ -715,6 +714,18 @@ void OscillatorWaveformDisplay::createWTMenuItems(juce::PopupMenu &contextMenu, 
             auto text = fmt::format("Switch to {} Display", (customEditor) ? "2D" : "3D");
 
             contextMenu.addItem(Surge::GUI::toOSCase(text), action);
+
+#if INCLUDE_WT_SCRIPTING_EDITOR
+            contextMenu.addSeparator();
+
+            auto owts = [this]() {
+                if (sge)
+                    sge->showOverlay(SurgeGUIEditor::WTSCRIPT_EDITOR);
+            };
+
+            contextMenu.addItem(Surge::GUI::toOSCase("Wavetable Script Editor..."), owts);
+            contextMenu.addSeparator();
+#endif
 
             contextMenu.addSeparator();
 


### PR DESCRIPTION
Trim trailing whitespace on script apply (also in Formula editor)
No vertical axis, grid, nor frame gap in filmstrip
More visible frame number in filmstrip (also aligned top right)
Checkerboard background of odd frames in filmstrip
Add frame number to single view (aligned top right)
Add menu entry to open WT script editor when right-clicking the oscillator display

Addresses one item in #4539 