### PR TITLE
Export BWS WT as well as WAV Wavetables; begin metadata

### DIFF
--- a/resources/data/wavetables/WT fileformat.txt
+++ b/resources/data/wavetables/WT fileformat.txt
@@ -9,6 +9,10 @@ byte
               if set, wave data is in int16 format
         0008: if not set, a sample with 0 dBFS peak will end up having a peak of 2^14 (uses 15 bits, -6 dBFS peak)
               if set, int16 data uses the full 16-bit range
-12-end	wave data
-        float32 format: 4 * wave_size * wave_count bytes
-        int16 format:   2 * wave_size * wave_count bytes
+        0010: if set, there is a metadata block after the wave data
+12-(12+size)	wave data
+        float32 format: size = 4 * wave_size * wave_count bytes
+        int16 format:   sise = 2 * wave_size * wave_count bytes
+12+size+1-end   metadata (if flags & 0x10)
+        metadata is a null terminated XML string with the tag <wtmeta> as the root and application
+        dependent beyond that

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1380,9 +1380,9 @@ void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *os
             osc->wavetable_display_name = fnnoext;
         }
 
-        //osc->wavetable_formula = {};
-        //osc->wavetable_formula_res_base = 5;
-        //osc->wavetable_formula_nframes = 10;
+        // osc->wavetable_formula = {};
+        // osc->wavetable_formula_res_base = 5;
+        // osc->wavetable_formula_nframes = 10;
     }
 }
 
@@ -1542,20 +1542,21 @@ bool SurgeStorage::export_wt_wt_portable(const fs::path &fname, Wavetable *wt,
     if (!metadata.empty())
         wth.flags |= wtf_has_metadata;
 
-    wfp.sputn((const char*)&wth, 12);
+    wfp.sputn((const char *)&wth, 12);
 
     bool is16 = (wt->flags & wtf_int16) || (wt->flags & wtf_int16_is_16);
 
     if (is16)
     {
-        for (int i=0; i<wt->n_tables; ++i)
+        for (int i = 0; i < wt->n_tables; ++i)
         {
-            wfp.sputn((const char *)&wt->TableI16WeakPointers[0][i][FIRoffsetI16], wt->size * sizeof(short));
+            wfp.sputn((const char *)&wt->TableI16WeakPointers[0][i][FIRoffsetI16],
+                      wt->size * sizeof(short));
         }
     }
     else
     {
-        for (int i=0; i<wt->n_tables; ++i)
+        for (int i = 0; i < wt->n_tables; ++i)
         {
             wfp.sputn((const char *)&wt->TableF32WeakPointers[0][i][0], wt->size * sizeof(float));
         }
@@ -1565,7 +1566,6 @@ bool SurgeStorage::export_wt_wt_portable(const fs::path &fname, Wavetable *wt,
 
     return true;
 }
-
 
 bool SurgeStorage::getOverrideDataHome(std::string &v)
 {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1391,8 +1391,10 @@ class alignas(16) SurgeStorage
     bool load_wt_wt(std::string filename, Wavetable *wt);
     bool load_wt_wt_mem(const char *data, const size_t dataSize, Wavetable *wt);
     bool load_wt_wav_portable(std::string filename, Wavetable *wt);
-    std::string export_wt_wav_portable(const std::string &fbase, Wavetable *wt, const std::string &metadata);
-    std::string export_wt_wav_portable(const fs::path &fpath, Wavetable *wt, const std::string &metadata);
+    std::string export_wt_wav_portable(const std::string &fbase, Wavetable *wt,
+                                       const std::string &metadata);
+    std::string export_wt_wav_portable(const fs::path &fpath, Wavetable *wt,
+                                       const std::string &metadata);
     bool export_wt_wt_portable(const fs::path &fpath, Wavetable *wt, const std::string &metadata);
 
     void clipboard_copy(int type, int scene, int entry, modsources ms = ms_original);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1391,7 +1391,10 @@ class alignas(16) SurgeStorage
     bool load_wt_wt(std::string filename, Wavetable *wt);
     bool load_wt_wt_mem(const char *data, const size_t dataSize, Wavetable *wt);
     bool load_wt_wav_portable(std::string filename, Wavetable *wt);
-    std::string export_wt_wav_portable(std::string fbase, Wavetable *wt);
+    std::string export_wt_wav_portable(const std::string &fbase, Wavetable *wt, const std::string &metadata);
+    std::string export_wt_wav_portable(const fs::path &fpath, Wavetable *wt, const std::string &metadata);
+    bool export_wt_wt_portable(const fs::path &fpath, Wavetable *wt, const std::string &metadata);
+
     void clipboard_copy(int type, int scene, int entry, modsources ms = ms_original);
     // this function is a bit of a hack to stop me having a reference to SurgeSynth here
     // and also to stop me having to move all of isValidModulation and its buddies onto SurgeStorage

--- a/src/common/WAVFileSupport.cpp
+++ b/src/common/WAVFileSupport.cpp
@@ -544,7 +544,7 @@ bool SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
     return true;
 }
 
-std::string SurgeStorage::export_wt_wav_portable(std::string fbase, Wavetable *wt)
+std::string SurgeStorage::export_wt_wav_portable(const std::string &fbase, Wavetable *wt, const std::string &metadata)
 {
     auto path = userDataPath / "Wavetables" / "Exported";
     fs::create_directories(path);
@@ -559,7 +559,11 @@ std::string SurgeStorage::export_wt_wav_portable(std::string fbase, Wavetable *w
         fnamePre = fbase + "_" + std::to_string(fnum) + ".wav";
         fnum++;
     }
+    return export_wt_wav_portable(fname, wt, metadata);
+}
 
+std::string SurgeStorage::export_wt_wav_portable(const fs::path &fname, Wavetable *wt, const std::string &metadata)
+{
     std::string errorMessage = "Unknown error!";
 
     {
@@ -608,12 +612,10 @@ std::string SurgeStorage::export_wt_wav_portable(std::string fbase, Wavetable *w
 
         // OK so how much data do I have.
         unsigned int tableSize = nChannels * bitsPerSample / 8 * wt->n_tables * wt->size;
-        unsigned int dataSize = 4 +          // 'WAVE'
-                                4 + 4 + 18 + // fmt chunk
-                                4 + 4 + tableSize;
-
-        if (!isSample)
-            dataSize += 4 + 4 + 8; // srge chunk
+        unsigned int dataSize = 4 +                 // 'WAVE'
+                                4 + 4 + 18 +        // fmt chunk
+                                4 + 4 + tableSize + // data chunk
+                                4 + 4 + 8;          // srgo/srge chunk
 
         w4i(dataSize);
         wfp.sputn("WAVE", 4);

--- a/src/common/WAVFileSupport.cpp
+++ b/src/common/WAVFileSupport.cpp
@@ -544,7 +544,8 @@ bool SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt)
     return true;
 }
 
-std::string SurgeStorage::export_wt_wav_portable(const std::string &fbase, Wavetable *wt, const std::string &metadata)
+std::string SurgeStorage::export_wt_wav_portable(const std::string &fbase, Wavetable *wt,
+                                                 const std::string &metadata)
 {
     auto path = userDataPath / "Wavetables" / "Exported";
     fs::create_directories(path);
@@ -562,7 +563,8 @@ std::string SurgeStorage::export_wt_wav_portable(const std::string &fbase, Wavet
     return export_wt_wav_portable(fname, wt, metadata);
 }
 
-std::string SurgeStorage::export_wt_wav_portable(const fs::path &fname, Wavetable *wt, const std::string &metadata)
+std::string SurgeStorage::export_wt_wav_portable(const fs::path &fname, Wavetable *wt,
+                                                 const std::string &metadata)
 {
     std::string errorMessage = "Unknown error!";
 

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -76,8 +76,8 @@ enum wtflags
 {
     wtf_is_sample = 1,
     wtf_loop_sample = 2,
-    wtf_int16 = 4,       // If this is set we have int16 in range 0-2^15
-    wtf_int16_is_16 = 8, // and in this case, range 0-2^16 if with above
+    wtf_int16 = 4,           // If this is set we have int16 in range 0-2^15
+    wtf_int16_is_16 = 8,     // and in this case, range 0-2^16 if with above
     wtf_has_metadata = 0x10, // null term xml at end of file
 };
 

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -78,6 +78,7 @@ enum wtflags
     wtf_loop_sample = 2,
     wtf_int16 = 4,       // If this is set we have int16 in range 0-2^15
     wtf_int16_is_16 = 8, // and in this case, range 0-2^16 if with above
+    wtf_has_metadata = 0x10, // null term xml at end of file
 };
 
 #endif // SURGE_SRC_COMMON_DSP_WAVETABLE_H

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -671,12 +671,13 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
             }
 
             auto nm = isWav ? "Export WAV Wavetable" : "Export WT Wavetable";
+            auto that = this; // i hate msvc
             sge->fileChooser =
                 std::make_unique<juce::FileChooser>(nm, juce::File(path.u8string().c_str()));
             sge->fileChooser->launchAsync(
                 juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles |
                     juce::FileBrowserComponent::warnAboutOverwriting,
-                [w = this, isWav](const juce::FileChooser &c) {
+                [w = that, isWav](const juce::FileChooser &c) {
                     auto result = c.getResults();
                     if (result.isEmpty() || result.size() > 1)
                     {

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -691,7 +691,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
                         {
                             fsp = fsp.replace_extension(".wav");
                         }
-                        auto fn = w->storage->export_wt_wav_portable(fsp, &(w->oscdata->wt), metadata);
+                        auto fn =
+                            w->storage->export_wt_wav_portable(fsp, &(w->oscdata->wt), metadata);
                     }
                     else
                     {
@@ -701,7 +702,8 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
                         }
                         if (!w->storage->export_wt_wt_portable(fsp, &(w->oscdata->wt), metadata))
                         {
-                            w->storage->reportError("Unable to save wt to " + fsp.u8string(), "WT Export");
+                            w->storage->reportError("Unable to save wt to " + fsp.u8string(),
+                                                    "WT Export");
                         }
                     }
                     w->storage->refresh_wtlist();


### PR DESCRIPTION
1. Export a BWS WT as well as a WAV wavetable. Closes #7880
2. Begin the work to have metadata in wav and wt by having the write-side API present, but don't complete that work