### PR TITLE
Add metadata into the wt with lua script

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -3377,9 +3377,9 @@ static const std::string base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                         "abcdefghijklmnopqrstuvwxyz"
                                         "0123456789+/";
 
-inline bool is_base64(unsigned char c) { return (isalnum(c) || (c == '+') || (c == '/')); }
+bool is_base64(unsigned char c) { return (isalnum(c) || (c == '+') || (c == '/')); }
 
-inline std::string base64_encode(unsigned char const *bytes_to_encode, unsigned int in_len)
+std::string base64_encode(unsigned char const *bytes_to_encode, unsigned int in_len)
 {
     std::string ret;
     int i = 0;

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -438,7 +438,8 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
 #else
     if (fs::exists(datapath / "windows.wt"))
     {
-        if (!load_wt_wt(path_to_string(datapath / "windows.wt"), &WindowWT))
+        std::string metadata;
+        if (!load_wt_wt(path_to_string(datapath / "windows.wt"), &WindowWT, metadata))
         {
             WindowWT.size = 0;
             std::ostringstream oss;
@@ -1353,14 +1354,15 @@ void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *os
     }
 
     bool loaded = false;
+    std::string metadata;
 
     if (extension.compare(".wt") == 0)
     {
-        loaded = load_wt_wt(filename, wt);
+        loaded = load_wt_wt(filename, wt, metadata);
     }
     else if (extension.compare(".wav") == 0)
     {
-        loaded = load_wt_wav_portable(filename, wt);
+        loaded = load_wt_wav_portable(filename, wt, metadata);
     }
     else
     {
@@ -1380,14 +1382,29 @@ void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *os
             osc->wavetable_display_name = fnnoext;
         }
 
-        // osc->wavetable_formula = {};
-        // osc->wavetable_formula_res_base = 5;
-        // osc->wavetable_formula_nframes = 10;
+        if (metadata.empty())
+        {
+            osc->wavetable_formula = {};
+            osc->wavetable_formula_res_base = 5;
+            osc->wavetable_formula_nframes = 10;
+        }
+        else
+        {
+            if (!parse_wt_metadata(metadata, osc))
+            {
+                reportError("Unable to parse metadata", "WaveTable Load");
+                std::cerr << metadata << std::endl;
+                osc->wavetable_formula = {};
+                osc->wavetable_formula_res_base = 5;
+                osc->wavetable_formula_nframes = 10;
+            }
+        }
     }
 }
 
-bool SurgeStorage::load_wt_wt(string filename, Wavetable *wt)
+bool SurgeStorage::load_wt_wt(string filename, Wavetable *wt, std::string &metadata)
 {
+    metadata = {};
     std::filebuf f;
 
     if (!f.open(string_to_path(filename), std::ios::binary | std::ios::in))
@@ -1434,6 +1451,21 @@ bool SurgeStorage::load_wt_wt(string filename, Wavetable *wt)
         auto dpad = data.get() + read;
         auto drest = ds - read;
         memset(dpad, 0, drest);
+    }
+
+    if (mech::endian_read_int16LE(wh.flags) & wtf_has_metadata)
+    {
+        std::ostringstream xml;
+        char buffer[1024]; // Adjust buffer size as needed
+        std::streamsize bytesRead;
+
+        while ((bytesRead = f.sgetn(buffer, sizeof(buffer))))
+        {
+            // Process the data read into 'buffer'
+            xml.write(buffer, bytesRead);
+        }
+
+        metadata = xml.str();
     }
 
     waveTableDataMutex.lock();
@@ -1562,7 +1594,94 @@ bool SurgeStorage::export_wt_wt_portable(const fs::path &fname, Wavetable *wt,
         }
     }
 
+    if (!metadata.empty())
+    {
+        wfp.sputn(metadata.c_str(), metadata.length() + 1); // include null term
+    }
+
     wfp.close();
+
+    return true;
+}
+
+std::string SurgeStorage::make_wt_metadata(OscillatorStorage *oscdata)
+{
+    bool hasMeta{false};
+    TiXmlDocument doc("wtmeta");
+    TiXmlElement root("wtmeta");
+    TiXmlElement surge("surge");
+    if (!oscdata->wavetable_formula.empty())
+    {
+        TiXmlElement script("script");
+
+        auto wtfo = oscdata->wavetable_formula;
+        auto wtfol = wtfo.length();
+
+        script.SetAttribute(
+            "lua", Surge::Storage::base64_encode((unsigned const char *)wtfo.c_str(), wtfol));
+        script.SetAttribute("nframes", oscdata->wavetable_formula_nframes);
+        script.SetAttribute("res_base", oscdata->wavetable_formula_res_base);
+        surge.InsertEndChild(script);
+        hasMeta = true;
+    }
+
+    root.InsertEndChild(surge);
+    doc.InsertEndChild(root);
+    if (hasMeta)
+    {
+        std::string res;
+        res << doc;
+        return res;
+    }
+    return {};
+}
+bool SurgeStorage::parse_wt_metadata(const std::string &m, OscillatorStorage *oscdata)
+{
+    TiXmlDocument doc("wtmeta");
+    doc.Parse(m.c_str());
+
+    auto root = TINYXML_SAFE_TO_ELEMENT(doc.FirstChildElement("wtmeta"));
+    if (!root)
+    {
+        std::cout << "NO ROOT" << std::endl;
+        return false;
+    }
+
+    auto surge = TINYXML_SAFE_TO_ELEMENT(root->FirstChildElement("surge"));
+    if (!surge)
+    {
+        std::cout << "NO SURGE" << std::endl;
+        return false;
+    }
+
+    auto script = TINYXML_SAFE_TO_ELEMENT(surge->FirstChildElement("script"));
+    if (!script)
+    {
+        std::cout << "NO SCRIPT" << std::endl;
+        return false;
+    }
+
+    int n, s;
+    if (script->QueryIntAttribute("nframes", &n) != TIXML_SUCCESS)
+    {
+        std::cout << "NO NFRAMES" << std::endl;
+        return false;
+    }
+    if (script->QueryIntAttribute("res_base", &s) != TIXML_SUCCESS)
+    {
+        std::cout << "NO RES_BASE" << std::endl;
+        return false;
+    }
+    auto bscript = script->Attribute("lua");
+    if (!bscript)
+    {
+        std::cout << "NO LUA" << std::endl;
+        return false;
+    }
+
+    oscdata->wavetable_formula = Surge::Storage::base64_decode(bscript);
+    oscdata->wavetable_formula_nframes = n;
+    oscdata->wavetable_formula_res_base = s;
 
     return true;
 }
@@ -3250,6 +3369,100 @@ string findReplaceSubstring(string &source, const string &from, const string &to
     source.swap(newString);
 
     return newString;
+}
+
+// BASE 64 SUPPORT, THANKS TO:
+// https://renenyffenegger.ch/notes/development/Base64/Encoding-and-decoding-base-64-with-cpp
+static const std::string base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                        "abcdefghijklmnopqrstuvwxyz"
+                                        "0123456789+/";
+
+inline bool is_base64(unsigned char c) { return (isalnum(c) || (c == '+') || (c == '/')); }
+
+inline std::string base64_encode(unsigned char const *bytes_to_encode, unsigned int in_len)
+{
+    std::string ret;
+    int i = 0;
+    int j = 0;
+    unsigned char char_array_3[3];
+    unsigned char char_array_4[4];
+
+    while (in_len--)
+    {
+        char_array_3[i++] = *(bytes_to_encode++);
+        if (i == 3)
+        {
+            char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+            char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+            char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+            char_array_4[3] = char_array_3[2] & 0x3f;
+
+            for (i = 0; (i < 4); i++)
+                ret += base64_chars[char_array_4[i]];
+            i = 0;
+        }
+    }
+
+    if (i)
+    {
+        for (j = i; j < 3; j++)
+            char_array_3[j] = '\0';
+
+        char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+        char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+        char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+
+        for (j = 0; (j < i + 1); j++)
+            ret += base64_chars[char_array_4[j]];
+
+        while ((i++ < 3))
+            ret += '=';
+    }
+
+    return ret;
+}
+
+std::string base64_decode(std::string const &encoded_string)
+{
+    int in_len = encoded_string.size();
+    int i = 0;
+    int j = 0;
+    int in_ = 0;
+    unsigned char char_array_4[4], char_array_3[3];
+    std::string ret;
+
+    while (in_len-- && (encoded_string[in_] != '=') && is_base64(encoded_string[in_]))
+    {
+        char_array_4[i++] = encoded_string[in_];
+        in_++;
+        if (i == 4)
+        {
+            for (i = 0; i < 4; i++)
+                char_array_4[i] = base64_chars.find(char_array_4[i]);
+
+            char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+            char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+            char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+            for (i = 0; (i < 3); i++)
+                ret += char_array_3[i];
+            i = 0;
+        }
+    }
+
+    if (i)
+    {
+        for (j = 0; j < i; j++)
+            char_array_4[j] = base64_chars.find(char_array_4[j]);
+
+        char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+        char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+
+        for (j = 0; (j < i - 1); j++)
+            ret += char_array_3[j];
+    }
+
+    return ret;
 }
 
 Surge::Storage::ScenesOutputData::ScenesOutputData()

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1388,14 +1388,17 @@ class alignas(16) SurgeStorage
 
     void load_wt(int id, Wavetable *wt, OscillatorStorage *);
     void load_wt(std::string filename, Wavetable *wt, OscillatorStorage *);
-    bool load_wt_wt(std::string filename, Wavetable *wt);
+    bool load_wt_wt(std::string filename, Wavetable *wt, std::string &metadata);
     bool load_wt_wt_mem(const char *data, const size_t dataSize, Wavetable *wt);
-    bool load_wt_wav_portable(std::string filename, Wavetable *wt);
+    bool load_wt_wav_portable(std::string filename, Wavetable *wt, std::string &metadata);
     std::string export_wt_wav_portable(const std::string &fbase, Wavetable *wt,
                                        const std::string &metadata);
     std::string export_wt_wav_portable(const fs::path &fpath, Wavetable *wt,
                                        const std::string &metadata);
     bool export_wt_wt_portable(const fs::path &fpath, Wavetable *wt, const std::string &metadata);
+
+    std::string make_wt_metadata(OscillatorStorage *);
+    bool parse_wt_metadata(const std::string &, OscillatorStorage *);
 
     void clipboard_copy(int type, int scene, int entry, modsources ms = ms_original);
     // this function is a bit of a hack to stop me having a reference to SurgeSynth here
@@ -1811,6 +1814,10 @@ bool isValidUTF8(const std::string &testThis);
 
 std::string findReplaceSubstring(std::string &source, const std::string &from,
                                  const std::string &to);
+
+bool is_base64(unsigned char c);
+std::string base64_encode(unsigned char const *bytes_to_encode, unsigned int in_len);
+std::string base64_decode(std::string const &encoded_string);
 
 } // namespace Storage
 } // namespace Surge

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -51,10 +51,12 @@ TEST_CASE("We Can Read Wavetables", "[io]")
     auto surge = Surge::Headless::createSurge(44100);
     REQUIRE(surge.get());
 
+    std::string metadata;
+
     SECTION("Wavetable.wav")
     {
         auto wt = &(surge->storage.getPatch().scene[0].osc[0].wt);
-        surge->storage.load_wt_wav_portable("resources/test-data/wav/Wavetable.wav", wt);
+        surge->storage.load_wt_wav_portable("resources/test-data/wav/Wavetable.wav", wt, metadata);
         REQUIRE(wt->size == 2048);
         REQUIRE(wt->n_tables == 256);
         REQUIRE((wt->flags & wtf_is_sample) == 0);
@@ -63,7 +65,7 @@ TEST_CASE("We Can Read Wavetables", "[io]")
     SECTION("05_BELL.WAV")
     {
         auto wt = &(surge->storage.getPatch().scene[0].osc[0].wt);
-        surge->storage.load_wt_wav_portable("resources/test-data/wav/05_BELL.WAV", wt);
+        surge->storage.load_wt_wav_portable("resources/test-data/wav/05_BELL.WAV", wt, metadata);
         REQUIRE(wt->size == 2048);
         REQUIRE(wt->n_tables == 33);
         REQUIRE((wt->flags & wtf_is_sample) == 0);
@@ -72,7 +74,7 @@ TEST_CASE("We Can Read Wavetables", "[io]")
     SECTION("pluckalgo.wav")
     {
         auto wt = &(surge->storage.getPatch().scene[0].osc[0].wt);
-        surge->storage.load_wt_wav_portable("resources/test-data/wav/pluckalgo.wav", wt);
+        surge->storage.load_wt_wav_portable("resources/test-data/wav/pluckalgo.wav", wt, metadata);
         REQUIRE(wt->size == 2048);
         REQUIRE(wt->n_tables == 9);
         REQUIRE((wt->flags & wtf_is_sample) == 0);

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -670,10 +670,16 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
             {
             }
 
+            auto startNm = path / oscdata->wavetable_display_name;
+            if (isWav)
+                startNm = startNm.replace_extension(".wav");
+            else
+                startNm = startNm.replace_extension(".wt");
+
             auto nm = isWav ? "Export WAV Wavetable" : "Export WT Wavetable";
             auto that = this; // i hate msvc
             sge->fileChooser =
-                std::make_unique<juce::FileChooser>(nm, juce::File(path.u8string().c_str()));
+                std::make_unique<juce::FileChooser>(nm, juce::File(startNm.u8string().c_str()));
             sge->fileChooser->launchAsync(
                 juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles |
                     juce::FileBrowserComponent::warnAboutOverwriting,
@@ -685,7 +691,7 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
                     }
                     auto fsp = fs::path{result[0].getFullPathName().toStdString()};
 
-                    std::string metadata{};
+                    std::string metadata = w->storage->make_wt_metadata(w->oscdata);
                     if (isWav)
                     {
                         if (fsp.extension() != ".wav")


### PR DESCRIPTION
1. wt format gets metadata chunk and flag which we can read/write
2. wav file gets `wtmd` riff chunk which we can read/wrote
3. load_wt variants save and restore metadata
4. metadata is a xml blob optionally populated
5. if there's a script, its populated with the script
6. script clear on watetable change

Closes #7897