### PR TITLE
surge-fx: change from bool to std::atomic<bool>

### DIFF
--- a/src/surge-fx/SurgeFXEditor.cpp
+++ b/src/surge-fx/SurgeFXEditor.cpp
@@ -589,7 +589,7 @@ juce::PopupMenu SurgefxAudioProcessorEditor::makeOSCMenu()
 {
     auto oscSubMenu = juce::PopupMenu();
 
-    if (processor.oscReceiving)
+    if (processor.oscReceiving.load())
     {
         oscSubMenu.addItem(Surge::GUI::toOSCase("Stop OSC Connections"),
                            [this]() { processor.oscHandler.stopListening(); });

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -166,7 +166,7 @@ bool SurgefxAudioProcessor::initOSCIn(int port)
 
     auto state = oscHandler.initOSCIn(port);
 
-    oscReceiving = state;
+    oscReceiving.store(state);
     oscStartIn = true;
 
     return state;
@@ -174,7 +174,7 @@ bool SurgefxAudioProcessor::initOSCIn(int port)
 
 bool SurgefxAudioProcessor::changeOSCInPort(int new_port)
 {
-    oscReceiving = false;
+    oscReceiving.store(false);
     oscHandler.stopListening();
     return initOSCIn(new_port);
 }
@@ -470,7 +470,7 @@ void SurgefxAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         }
     }
 
-    if (oscReceiving)
+    if (oscReceiving.load())
         processBlockOSC();
 }
 

--- a/src/surge-fx/SurgeFXProcessor.h
+++ b/src/surge-fx/SurgeFXProcessor.h
@@ -26,7 +26,7 @@
 #include "SurgeStorage.h"
 #include "Effect.h"
 #include "FXOpenSoundControl.h"
-
+#include <atomic>
 #include "sst/filters/HalfRateFilter.h"
 
 #include "juce_audio_processors/juce_audio_processors.h"
@@ -97,7 +97,7 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
     bool initOSCIn(int port);
     bool changeOSCInPort(int newport);
     void initOSCError(int port, std::string outIP = "");
-    bool oscReceiving = false;
+    std::atomic<bool> oscReceiving{false};
 
     //==============================================================================
     const juce::String getName() const override;


### PR DESCRIPTION
# Description
This is not necessarily a bug per se since assignment and reads of `bool` are atomic in modern OSs, but the explicit nature makes it guaranteed and provides better readability & understanding within `processBlock`. 

# Testing: 

From surge root ran:
`cmake -B build`
`cmake --build build` 
Opened standalone `SurgeXT` and `SurgeXT Effects` and fiddled with the knobs. 

 