### PR TITLE
Restore python builds, macos, post JUCE8 upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ math(EXPR SURGE_BITNESS "${CMAKE_SIZEOF_VOID_P} * 8" OUTPUT_FORMAT DECIMAL)
 message(STATUS "Targeting ${SURGE_BITNESS}-bit configuration")
 # }}}
 
+if (APPLE)
+        enable_language(OBJC)
+        enable_language(OBJCXX)
+endif()
+
 # Make Sure the REpo is properly cloned {{{
 set(SURGE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 if (NOT EXISTS "${SURGE_SOURCE_DIR}/libs/tuning-library/README.md")

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -64,20 +64,29 @@ else()
   add_library(surge-common-binary INTERFACE)
   target_compile_definitions(surge-common-binary INTERFACE HAS_JUCE=0 SKIP_JUCE=1)
 
-  add_library(juce_dsp_rack_sub STATIC
-    ${SURGE_JUCE_PATH}/modules/juce_audio_basics/juce_audio_basics.cpp
-    ${SURGE_JUCE_PATH}/modules/juce_dsp/juce_dsp.cpp
-  )
+  if (APPLE)
+    add_library(juce_dsp_rack_sub STATIC
+      ${SURGE_JUCE_PATH}/modules/juce_audio_basics/juce_audio_basics.mm
+      ${SURGE_JUCE_PATH}/modules/juce_dsp/juce_dsp.cpp
+    )
+  else()
+    add_library(juce_dsp_rack_sub STATIC
+      ${SURGE_JUCE_PATH}/modules/juce_audio_basics/juce_audio_basics.cpp
+      ${SURGE_JUCE_PATH}/modules/juce_dsp/juce_dsp.cpp
+    )
+  endif()
 
   if(APPLE)
     target_sources(juce_dsp_rack_sub PRIVATE
       ${SURGE_JUCE_PATH}/modules/juce_core/juce_core.mm
       ${SURGE_JUCE_PATH}/modules/juce_audio_formats/juce_audio_formats.mm
+      ${SURGE_JUCE_PATH}/modules/juce_core/juce_core_CompilationTime.cpp
     )
   else()
     target_sources(juce_dsp_rack_sub PRIVATE
       ${SURGE_JUCE_PATH}/modules/juce_core/juce_core.cpp
       ${SURGE_JUCE_PATH}/modules/juce_audio_formats/juce_audio_formats.cpp
+      ${SURGE_JUCE_PATH}/modules/juce_core/juce_core_CompilationTime.cpp
     )
   endif()
 


### PR DESCRIPTION
This commit restores python builds post JUCE8 upgrade, although it only tests it up to the point of building, not running.

With this commit

cmake -Bignore/noj -DSURGE_SKIP_JUCE_FOR_RACK=TRUE -DSURGE_BUILD_PYTHON_BINDINGS=TRUE

will create a cpython lib

Addresses #7934