### PR TITLE
Code Editor scrolling fix

### DIFF
--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -1118,20 +1118,28 @@ void SurgeCodeEditorComponent::mouseWheelMove(const juce::MouseEvent &e,
     juce::MouseWheelDetails w(wheel);
     w.deltaY *= 4;
 
+    enum
+    {
+        verticalScrollbar,
+        horizontalScrollbar
+    };
+
     // makes it possible to mouse wheel scroll and select text at the same time
     if (e.mods.isShiftDown())
     {
-        auto scrollbar = dynamic_cast<juce::ScrollBar *>(getChildren()[1]);
-        auto pos = scrollbar->getCurrentRange().getStart();
+        auto scrollbar = dynamic_cast<juce::ScrollBar *>(getChildren()[horizontalScrollbar]);
 
-        auto width = scrollbar->getCurrentRangeSize();
-        auto maxScroll = std::max((double)0, scrollbar->getMaximumRangeLimit() - width);
+        if (scrollbar != nullptr)
+        {
+            auto pos = scrollbar->getCurrentRange().getStart();
+            auto width = scrollbar->getCurrentRangeSize();
+            auto maxScroll = std::max((double)0, scrollbar->getMaximumRangeLimit() - width);
 
-        scrollToColumn(std::min((double)maxScroll, pos - w.deltaY * 10));
+            scrollToColumn(std::min((double)maxScroll, pos - w.deltaY * 10));
+        }
     }
     else
     {
-        auto scrollbar = dynamic_cast<juce::ScrollBar *>(getChildren()[0]);
         auto maxScroll = std::max(0, getDocument().getNumLines() - getNumLinesOnScreen());
         auto scrollPos = getFirstLineOnScreen();
 

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -1123,11 +1123,19 @@ void SurgeCodeEditorComponent::mouseWheelMove(const juce::MouseEvent &e,
     {
         auto scrollbar = dynamic_cast<juce::ScrollBar *>(getChildren()[1]);
         auto pos = scrollbar->getCurrentRange().getStart();
-        scrollToColumn(pos - w.deltaY * 10);
+
+        auto width = scrollbar->getCurrentRangeSize();
+        auto maxScroll = std::max((double)0, scrollbar->getMaximumRangeLimit() - width);
+
+        scrollToColumn(std::min((double)maxScroll, pos - w.deltaY * 10));
     }
     else
     {
-        scrollBy(-w.deltaY * 10);
+        auto scrollbar = dynamic_cast<juce::ScrollBar *>(getChildren()[0]);
+        auto maxScroll = std::max(0, getDocument().getNumLines() - getNumLinesOnScreen());
+        auto scrollPos = getFirstLineOnScreen();
+
+        scrollToLine(std::min((double)maxScroll, (double)scrollPos - w.deltaY * 10));
     }
 }
 

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -1117,7 +1117,18 @@ void SurgeCodeEditorComponent::mouseWheelMove(const juce::MouseEvent &e,
 {
     juce::MouseWheelDetails w(wheel);
     w.deltaY *= 4;
-    CodeEditorComponent::mouseWheelMove(e, w);
+
+    // makes it possible to mouse wheel scroll and select text at the same time
+    if (e.mods.isShiftDown())
+    {
+        auto scrollbar = dynamic_cast<juce::ScrollBar *>(getChildren()[1]);
+        auto pos = scrollbar->getCurrentRange().getStart();
+        scrollToColumn(pos - w.deltaY * 10);
+    }
+    else
+    {
+        scrollBy(-w.deltaY * 10);
+    }
 }
 
 // Handles auto indentation


### PR DESCRIPTION
It turns out that scrollBy() sucks, as it scrolls way past its maximum limit. So went with another approach

