### PR TITLE
Minor UX tweaks

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2439,13 +2439,7 @@ void Parameter::get_display_of_modulation_depth(char *txt, float modulationDepth
 {
 #define ITXT_SIZE 1024
 
-    int detailedMode = false;
-
-    if (storage)
-    {
-        detailedMode =
-            Surge::Storage::getUserDefaultValue(storage, Surge::Storage::HighPrecisionReadouts, 0);
-    }
+    const bool detailedMode = Surge::Storage::getValueDispPrecision(storage);
 
     if (basicBlocksParamMetaData.has_value() && basicBlocksParamMetaData->supportsStringConversion)
     {
@@ -3286,8 +3280,7 @@ void Parameter::get_display_alt(char *txt, bool external, float ef) const
         }
     }
 
-    int detailedMode =
-        Surge::Storage::getUserDefaultValue(storage, Surge::Storage::HighPrecisionReadouts, 0);
+    const bool detailedMode = Surge::Storage::getValueDispPrecision(storage);
 
     txt[0] = 0;
     switch (ctrltype)
@@ -3454,13 +3447,7 @@ std::string Parameter::get_display(bool external, float ef) const
     float f;
     bool b;
 
-    int detailedMode = 0;
-
-    if (storage)
-    {
-        detailedMode =
-            Surge::Storage::getUserDefaultValue(storage, Surge::Storage::HighPrecisionReadouts, 0);
-    }
+    const bool detailedMode = Surge::Storage::getValueDispPrecision(storage);
 
     if (basicBlocksParamMetaData.has_value() && basicBlocksParamMetaData->supportsStringConversion)
     {
@@ -3591,7 +3578,7 @@ std::string Parameter::get_display(bool external, float ef) const
                 {
                     dval *= 1000.f;
                     u = "ms";
-                    dec = detailedMode ? 2 : 1;
+                    dec = detailedMode ? 3 : 1;
                 }
             }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1819,6 +1819,8 @@ bool is_base64(unsigned char c);
 std::string base64_encode(unsigned char const *bytes_to_encode, unsigned int in_len);
 std::string base64_decode(std::string const &encoded_string);
 
+bool getValueDispPrecision(SurgeStorage *storage);
+
 } // namespace Storage
 } // namespace Surge
 

--- a/src/common/dsp/effects/airwindows/AirWindowsEffect.cpp
+++ b/src/common/dsp/effects/airwindows/AirWindowsEffect.cpp
@@ -282,13 +282,8 @@ void AirWindowsEffect::process(float *dataL, float *dataR)
 void AirWindowsEffect::setupSubFX(int sfx, bool useStreamedValues)
 {
     const auto &r = fxreg[sfx];
-
-    bool detailedMode = false;
-    if (storage)
-        detailedMode =
-            Surge::Storage::getUserDefaultValue(storage, Surge::Storage::HighPrecisionReadouts, 0);
-
-    int dp = (detailedMode ? 6 : 2);
+    const bool detailedMode = Surge::Storage::getValueDispPrecision(storage);
+    int dp = detailedMode ? 6 : 2;
 
     airwin = r.create(r.id, storage->dsamplerate, dp); // FIXME
     airwin->storage = storage;

--- a/src/common/dsp/effects/airwindows/AirWindowsEffect.h
+++ b/src/common/dsp/effects/airwindows/AirWindowsEffect.h
@@ -134,14 +134,8 @@ class alignas(16) AirWindowsEffect : public Effect
                         fx->airwin->setParameter(idx, value);
                     }
 
-                    if (fx->storage)
-                    {
-                        auto detailedMode = Surge::Storage::getUserDefaultValue(
-                            fx->storage, Surge::Storage::HighPrecisionReadouts, 0);
-
-                        fx->airwin->displayPrecision = (detailedMode ? 6 : 2);
-                    }
-
+                    fx->airwin->displayPrecision =
+                        Surge::Storage::getValueDispPrecision(fx->storage) ? 6 : 2;
                     fx->airwin->getParameterLabel(idx, lab);
                     fx->airwin->getParameterDisplay(idx, dis, value, true);
                 }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3435,8 +3435,7 @@ void SurgeGUIEditor::promptForUserValueEntry(Parameter *p, juce::Component *c, i
     }
     else
     {
-        int detailedMode = Surge::Storage::getUserDefaultValue(
-            &(this->synth->storage), Surge::Storage::HighPrecisionReadouts, 0);
+        const bool detailedMode = Surge::Storage::getValueDispPrecision(&(this->synth->storage));
         auto cms = ((ControllerModulationSource *)synth->storage.getPatch()
                         .scene[current_scene]
                         .modsources[ms]);

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -1140,14 +1140,13 @@ juce::PopupMenu SurgeGUIEditor::makeValueDisplaysMenu(const juce::Point<int> &wh
 {
     auto dispDefMenu = juce::PopupMenu();
 
-    bool precReadout = Surge::Storage::getUserDefaultValue(
-        &(this->synth->storage), Surge::Storage::HighPrecisionReadouts, false);
+    const bool detailedMode = Surge::Storage::getValueDispPrecision(&(this->synth->storage));
 
-    dispDefMenu.addItem(Surge::GUI::toOSCase("High Precision Value Readouts"), true, precReadout,
-                        [this, precReadout]() {
+    dispDefMenu.addItem(Surge::GUI::toOSCase("High Precision Value Readouts"), true, detailedMode,
+                        [this, detailedMode]() {
                             Surge::Storage::updateUserDefaultValue(
                                 &(this->synth->storage), Surge::Storage::HighPrecisionReadouts,
-                                !precReadout);
+                                !detailedMode);
                         });
 
     // modulation value readout shows bounds

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -936,8 +936,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
             bool cancellearn = false;
             int ccid = 0;
-            int detailedMode = Surge::Storage::getUserDefaultValue(
-                &(this->synth->storage), Surge::Storage::HighPrecisionReadouts, 0);
+            const bool detailedMode =
+                Surge::Storage::getValueDispPrecision(&(this->synth->storage));
 
             // should start at 0, but it started at 1 before
             // there might be a reason but I don't remember why

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -2455,6 +2455,36 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
         contextMenu.addSeparator();
 
+        const int detailedMode = Surge::Storage::getValueDispPrecision(storage) ? 6 : 2;
+
+        contextMenu.addItem(
+            fmt::format("Duration: {:.{}f}", ms->segments[tts].duration, detailedMode), false,
+            false, nullptr);
+        contextMenu.addItem(fmt::format("Value: {:.{}f}", ms->segments[tts].v0, detailedMode),
+                            false, false, nullptr);
+
+        const bool is2Dcp =
+            ms->segments[tts].type == type::QUAD_BEZIER || ms->segments[tts].type == type::BROWNIAN;
+
+        if (ms->segments[tts].type != type::HOLD)
+        {
+            auto curveStr = fmt::format(
+                "Control Point{}: {:.{}f}", is2Dcp ? " X" : "",
+                (is2Dcp ? ms->segments[tts].cpduration : ms->segments[tts].cpv), detailedMode);
+
+            contextMenu.addItem(curveStr, false, false, nullptr);
+        }
+
+        if (is2Dcp)
+        {
+            auto curveStrY =
+                fmt::format("Control Point Y: {:.{}f}", ms->segments[tts].cpv, detailedMode);
+
+            contextMenu.addItem(curveStrY, false, false, nullptr);
+        }
+
+        contextMenu.addSeparator();
+
         if (ms->editMode != MSEGStorage::LFO && ms->loopMode != MSEGStorage::LoopMode::ONESHOT)
         {
             if (tts <= ms->loop_end + 1 && tts != ms->loop_start)

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -1547,24 +1547,16 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                         g.fillRect(r);
                     };
 
-                    int prec = 2;
-
-                    if (storage)
-                    {
-                        if (Surge::Storage::getUserDefaultValue(
-                                storage, Surge::Storage::HighPrecisionReadouts, 0))
-                        {
-                            prec = 6;
-                        }
-                    }
+                    const bool detailedMode = Surge::Storage::getValueDispPrecision(storage);
+                    const int dp = detailedMode ? 6 : 2;
 
                     g.setFont(skin->fontManager->lfoTypeFont);
 
                     float val = h.specialEndpoint ? ms->segments[h.associatedSegment].nv1
                                                   : ms->segments[h.associatedSegment].v0;
 
-                    std::string txt = fmt::format("X: {:.{}f}", pxt(cx), prec),
-                                txt2 = fmt::format("Y: {:.{}f}", val, prec);
+                    std::string txt = fmt::format("X: {:.{}f}", pxt(cx), dp),
+                                txt2 = fmt::format("Y: {:.{}f}", val, dp);
 
                     int sw1 = SST_STRING_WIDTH_INT(g.getCurrentFont(), txt),
                         sw2 = SST_STRING_WIDTH_INT(g.getCurrentFont(), txt2);

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -1461,22 +1461,11 @@ void LFOAndStepDisplay::paintStepSeq(juce::Graphics &g)
     // Finally draw the drag label
     if (dragMode == VALUES && draggedStep >= 0 && draggedStep < n_stepseqsteps)
     {
-        int prec = 2;
-
-        if (storage)
-        {
-            int detailedMode = Surge::Storage::getUserDefaultValue(
-                storage, Surge::Storage::HighPrecisionReadouts, 0);
-
-            if (detailedMode)
-            {
-                prec = 6;
-            }
-        }
+        const bool detailedMode = Surge::Storage::getValueDispPrecision(storage);
 
         g.setFont(skin->fontManager->lfoTypeFont);
 
-        std::string txt = fmt::format("{:.{}f} %", ss->steps[draggedStep] * 100.f, prec);
+        std::string txt = fmt::format("{:.{}f} %", ss->steps[draggedStep] * 100.f, detailedMode);
 
         int sw = SST_STRING_WIDTH_INT(g.getCurrentFont(), txt);
 
@@ -2672,15 +2661,10 @@ void LFOAndStepDisplay::showStepRMB(int i)
 
     contextMenu.addSeparator();
 
-    int decimals = 2;
+    const bool detailedMode = Surge::Storage::getValueDispPrecision(storage);
 
-    if (storage)
-    {
-        decimals = 2 + (4 * Surge::Storage::getUserDefaultValue(
-                                storage, Surge::Storage::HighPrecisionReadouts, 0));
-    }
-
-    auto msg = fmt::format("Edit Step {} Value: {:.{}f} %", i + 1, ss->steps[i] * 100.f, decimals);
+    auto msg =
+        fmt::format("Edit Step {} Value: {:.{}f} %", i + 1, ss->steps[i] * 100.f, detailedMode);
 
     contextMenu.addItem(Surge::GUI::toOSCase(msg), true, false, [this, i]() { showStepTypein(i); });
 
@@ -2689,13 +2673,7 @@ void LFOAndStepDisplay::showStepRMB(int i)
 
 void LFOAndStepDisplay::showStepTypein(int i)
 {
-    int decimals = 2;
-
-    if (storage)
-    {
-        decimals = 2 + (4 * Surge::Storage::getUserDefaultValue(
-                                storage, Surge::Storage::HighPrecisionReadouts, 0));
-    }
+    const bool detailedMode = Surge::Storage::getValueDispPrecision(storage);
 
     auto handleTypein = [this, i](const std::string &s) {
         auto divPos = s.find('/');
@@ -2735,10 +2713,10 @@ void LFOAndStepDisplay::showStepTypein(int i)
 
     stepEditor->callback = handleTypein;
     stepEditor->setMainLabel(fmt::format("Edit Step {} Value", std::to_string(i + 1)));
-    stepEditor->setValueLabels(fmt::format("current: {:.{}f} %", ss->steps[i] * 100.f, decimals),
-                               "");
+    stepEditor->setValueLabels(
+        fmt::format("current: {:.{}f} %", ss->steps[i] * 100.f, detailedMode), "");
     stepEditor->setSkin(skin, associatedBitmapStore);
-    stepEditor->setEditableText(fmt::format("{:.{}f} %", ss->steps[i] * 100.f, decimals));
+    stepEditor->setEditableText(fmt::format("{:.{}f} %", ss->steps[i] * 100.f, detailedMode));
     stepEditor->setReturnFocusTarget(stepSliderOverlays[i].get());
 
     auto topOfControl = getY();

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -2680,7 +2680,7 @@ void LFOAndStepDisplay::showStepRMB(int i)
                                 storage, Surge::Storage::HighPrecisionReadouts, 0));
     }
 
-    auto msg = fmt::format("Edit Step {}: {:.{}f} %", i + 1, ss->steps[i] * 100.f, decimals);
+    auto msg = fmt::format("Edit Step {} Value: {:.{}f} %", i + 1, ss->steps[i] * 100.f, decimals);
 
     contextMenu.addItem(Surge::GUI::toOSCase(msg), true, false, [this, i]() { showStepTypein(i); });
 
@@ -2734,7 +2734,7 @@ void LFOAndStepDisplay::showStepTypein(int i)
     }
 
     stepEditor->callback = handleTypein;
-    stepEditor->setMainLabel("Edit Step " + std::to_string(i + 1));
+    stepEditor->setMainLabel(fmt::format("Edit Step {} Value", std::to_string(i + 1)));
     stepEditor->setValueLabels(fmt::format("current: {:.{}f} %", ss->steps[i] * 100.f, decimals),
                                "");
     stepEditor->setSkin(skin, associatedBitmapStore);


### PR DESCRIPTION
* Add disabled entries to MSEG Segment context menu - these show the segment's duration, value and control point info
* Adjust name of step seq value edit menu entries (from "Step x" to "Step X Value").
* Small code cleanup for MSEGEditor
* Add getValueDispPrecision() to SurgeStorage
* Update all cases of checking HighPrecisionReadouts option consequently
