### PR TITLE
Backwards-compatible option to use mathematically correct tilt noise.

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -155,6 +155,8 @@ add_library(${PROJECT_NAME}
   dsp/SurgeVoice.cpp
   dsp/SurgeVoice.h
   dsp/SurgeVoiceState.h
+  dsp/TiltNoiseAdapter.cpp
+  dsp/TiltNoiseAdapter.h
   dsp/Wavetable.cpp
   dsp/Wavetable.h
   dsp/WavetableScriptEvaluator.cpp

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -210,6 +210,12 @@ enum NoiseColorChannels
     MONO = 1
 };
 
+enum NoiseColorValue
+{
+    LEGACY = 0,
+    TILT = 1,
+};
+
 enum CombinatorMode
 {
     cxm_ring = 0,

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -25,6 +25,7 @@
 #include "SurgeStorage.h"
 #include "Oscillator.h"
 #include "SurgeVoiceState.h"
+#include "TiltNoiseAdapter.h"
 #include "ADSRModulationSource.h"
 #include "LFOModulationSource.h"
 #include <sst/voice-effects/generator/TiltNoise.h>
@@ -33,6 +34,17 @@
 #include <array>
 
 struct QuadFilterChainState;
+
+enum lag_entries
+{
+    le_osc1,
+    le_osc2,
+    le_osc3,
+    le_noise,
+    le_ring12,
+    le_ring23,
+    le_pfg,
+};
 
 class alignas(16) SurgeVoice
 {
@@ -300,42 +312,9 @@ class alignas(16) SurgeVoice
     bool mpeEnabled;
 
   private:
-    // Adapter for sst-effects TiltNoise to allow it to be used directly from SurgeVoice.
-    struct TiltNoiseAdapter
-    {
-        // Simple wrapper that holds the SurgeVoice storage and params. Be VERY CAREFUL with
-        // lifetime here. These are raw pointers! They're only valid for when they're valid in
-        // SurgeVoice.
-        struct StorageContainer
-        {
-            SurgeVoice const *s;
-
-            StorageContainer() = default;
-            StorageContainer(const StorageContainer &) = delete;
-            StorageContainer(StorageContainer &&) = delete;
-        };
-
-        static constexpr uint16_t blockSize{BLOCK_SIZE_OS};
-        using BaseClass = StorageContainer;
-
-        static inline float getFloatParam(const StorageContainer *o, size_t index);
-        static inline int getIntParam(const StorageContainer *o, size_t index);
-        static inline float dbToLinear(const StorageContainer *o, float db);
-        static inline float equalNoteToPitch(const StorageContainer *o, float f);
-        static inline float getSampleRate(const StorageContainer *o);
-        static inline float getSampleRateInv(const StorageContainer *o);
-
-        // None of these are used by TiltNoise and will print errors to the console if they are
-        // called.
-        static inline void setFloatParam(StorageContainer *o, size_t index, float val);
-        static inline void setIntParam(StorageContainer *o, size_t index, int val);
-        static inline void preReservePool(StorageContainer *o, size_t size);
-        static inline uint8_t *checkoutBlock(StorageContainer *o, size_t size);
-        static inline void returnBlock(StorageContainer *o, uint8_t *b, size_t size);
-    };
-    friend class TiltNoiseAdapter;
+    friend class VoiceTiltNoiseAdapter;
     // Single per-voice instance.
-    sst::voice_effects::generator::TiltNoise<TiltNoiseAdapter> tilt_noise;
+    sst::voice_effects::generator::TiltNoise<VoiceTiltNoiseAdapter> tilt_noise;
     // Helper functions for doing noise generations.
     void generate_legacy_noise(bool wide, bool stereo, float *blockL, float *blockR);
     void generate_tilt_noise(bool wide, bool stereo, float *blockL, float *blockR);

--- a/src/common/dsp/TiltNoiseAdapter.cpp
+++ b/src/common/dsp/TiltNoiseAdapter.cpp
@@ -104,13 +104,11 @@ void VoiceTiltNoiseAdapter::preReservePool(StorageContainer *o, size_t size)
 
 uint8_t *VoiceTiltNoiseAdapter::checkoutBlock(StorageContainer *o, size_t size)
 {
-    std::cout << "Unsupported attempt to call checkoutBlock in VoiceTiltNoiseAdapter."
-              << std::endl;
+    std::cout << "Unsupported attempt to call checkoutBlock in VoiceTiltNoiseAdapter." << std::endl;
     return NULL;
 }
 
 void VoiceTiltNoiseAdapter::returnBlock(StorageContainer *o, uint8_t *b, size_t size)
 {
-    std::cout << "Unsupported attempt to call returnBlock in VoiceTiltNoiseAdapter."
-              << std::endl;
+    std::cout << "Unsupported attempt to call returnBlock in VoiceTiltNoiseAdapter." << std::endl;
 }

--- a/src/common/dsp/TiltNoiseAdapter.cpp
+++ b/src/common/dsp/TiltNoiseAdapter.cpp
@@ -1,0 +1,116 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#include "TiltNoiseAdapter.h"
+#include "SurgeVoice.h"
+#include <sst/voice-effects/generator/TiltNoise.h>
+
+float VoiceTiltNoiseAdapter::getFloatParam(const StorageContainer *o, size_t index)
+{
+    using TN = sst::voice_effects::generator::TiltNoise<VoiceTiltNoiseAdapter>;
+
+    // Multiple float parameters.
+    switch (index)
+    {
+    case TN::fpLevel:
+        // TiltNoise expects it in dB, converts to linear internally.
+        return o->s->localcopy[o->s->lag_id[le_noise]].f;
+    case TN::fpTilt:
+    {
+        // TiltNoise scale is -6 to +6; our slider is -1 to +1.
+        int id = o->s->scene->noise_colour.param_id_in_scene;
+        float col = limit_range(o->s->localcopy[id].f, -1.f, 1.f);
+        return col * 6.f;
+        break;
+    }
+    case TN::fpStereoWidth:
+        return 1.f;
+    default:
+        std::cout << "Attempted to access an undefined float parameter # " << index
+                  << " in VoiceTiltNoiseAdapter!" << std::endl;
+        return 0.f;
+    }
+    return 0.f;
+}
+
+int VoiceTiltNoiseAdapter::getIntParam(const StorageContainer *o, size_t index)
+{
+    // TiltNoise only has a single int param, stereo.
+    int id = o->s->scene->noise_colour.param_id_in_scene;
+    bool is_wide = o->s->scene->filterblock_configuration.val.i == fc_wide;
+    // Inverted from the deform bit.
+    if ((id & 1) && is_wide)
+    {
+        return 0;
+    }
+    return 1;
+}
+
+float VoiceTiltNoiseAdapter::dbToLinear(const StorageContainer *o, float db)
+{
+    return o->s->storage->db_to_linear(db);
+}
+
+float VoiceTiltNoiseAdapter::equalNoteToPitch(const StorageContainer *o, float f)
+{
+    return o->s->storage->note_to_pitch(f);
+}
+
+float VoiceTiltNoiseAdapter::getSampleRate(const StorageContainer *o)
+{
+    return o->s->storage->samplerate;
+}
+float VoiceTiltNoiseAdapter::getSampleRateInv(const StorageContainer *o)
+{
+    return 1.0 / o->s->storage->samplerate;
+}
+
+void VoiceTiltNoiseAdapter::setFloatParam(StorageContainer *o, size_t index, float val)
+{
+    std::cout << "Unsupported attempt to set a float parameter in VoiceTiltNoiseAdapter."
+              << std::endl;
+}
+
+void VoiceTiltNoiseAdapter::setIntParam(StorageContainer *o, size_t index, int val)
+{
+    std::cout << "Unsupported attempt to set an int parameter in VoiceTiltNoiseAdapter."
+              << std::endl;
+}
+
+void VoiceTiltNoiseAdapter::preReservePool(StorageContainer *o, size_t size)
+{
+    std::cout << "Unsupported attempt to call preReservePool in VoiceTiltNoiseAdapter."
+              << std::endl;
+}
+
+uint8_t *VoiceTiltNoiseAdapter::checkoutBlock(StorageContainer *o, size_t size)
+{
+    std::cout << "Unsupported attempt to call checkoutBlock in VoiceTiltNoiseAdapter."
+              << std::endl;
+    return NULL;
+}
+
+void VoiceTiltNoiseAdapter::returnBlock(StorageContainer *o, uint8_t *b, size_t size)
+{
+    std::cout << "Unsupported attempt to call returnBlock in VoiceTiltNoiseAdapter."
+              << std::endl;
+}

--- a/src/common/dsp/TiltNoiseAdapter.h
+++ b/src/common/dsp/TiltNoiseAdapter.h
@@ -61,4 +61,4 @@ struct VoiceTiltNoiseAdapter
     static void returnBlock(StorageContainer *o, uint8_t *b, size_t size);
 };
 
-#endif  // SURGE_SRC_COMMON_DSP_TILTNOISEADAPTER_H
+#endif // SURGE_SRC_COMMON_DSP_TILTNOISEADAPTER_H

--- a/src/common/dsp/TiltNoiseAdapter.h
+++ b/src/common/dsp/TiltNoiseAdapter.h
@@ -1,0 +1,64 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#ifndef SURGE_SRC_COMMON_DSP_TILTNOISEADAPTER_H
+#define SURGE_SRC_COMMON_DSP_TILTNOISEADAPTER_H
+
+#include "globals.h"
+
+class SurgeVoice;
+
+// Adapter for sst-effects TiltNoise to allow it to be used directly from SurgeVoice.
+struct VoiceTiltNoiseAdapter
+{
+    // Simple wrapper that holds the SurgeVoice storage and params. Be VERY CAREFUL with
+    // lifetime here. These are raw pointers! They're only valid for when they're valid in
+    // SurgeVoice.
+    struct StorageContainer
+    {
+        SurgeVoice const *s;
+
+        StorageContainer() = default;
+        StorageContainer(const StorageContainer &) = delete;
+        StorageContainer(StorageContainer &&) = delete;
+    };
+
+    static constexpr uint16_t blockSize{BLOCK_SIZE_OS};
+    using BaseClass = StorageContainer;
+
+    static float getFloatParam(const StorageContainer *o, size_t index);
+    static int getIntParam(const StorageContainer *o, size_t index);
+    static float dbToLinear(const StorageContainer *o, float db);
+    static float equalNoteToPitch(const StorageContainer *o, float f);
+    static float getSampleRate(const StorageContainer *o);
+    static float getSampleRateInv(const StorageContainer *o);
+
+    // None of these are used by TiltNoise and will print errors to the console if they are
+    // called.
+    static void setFloatParam(StorageContainer *o, size_t index, float val);
+    static void setIntParam(StorageContainer *o, size_t index, int val);
+    static void preReservePool(StorageContainer *o, size_t size);
+    static uint8_t *checkoutBlock(StorageContainer *o, size_t size);
+    static void returnBlock(StorageContainer *o, uint8_t *b, size_t size);
+};
+
+#endif  // SURGE_SRC_COMMON_DSP_TILTNOISEADAPTER_H

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -284,6 +284,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void adjustSize(float &width, float &height) const;
 
     void update_deform_type(Parameter *p, int type);
+    // Only updates a single bitfield. Does not check values.
+    void update_deform_type_bit(Parameter *p, int type, int bit);
 
     struct patchdata
     {

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2503,10 +2503,10 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             auto dt = (p->deform_type & 0x2) >> 1;
 
                             Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
-                                contextMenu, "NOISE GENERATOR COLOR TYPE");
+                                contextMenu, "NOISE GENERATOR TYPE");
 
                             contextMenu.addItem(
-                                "Legacy (Pre-XT 1.4)", true, dt == NoiseColorValue::LEGACY,
+                                "Legacy (<XT 1.4)", true, dt == NoiseColorValue::LEGACY,
                                 [this, p]() {
                                     undoManager()->pushParameterChange(p->id, p, p->val);
                                     update_deform_type_bit(p, NoiseColorValue::LEGACY, 1);
@@ -2514,7 +2514,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                                     frame->repaint();
                                 });
                             contextMenu.addItem(
-                                "Tilt", true, dt == NoiseColorValue::TILT, [this, p]() {
+                                "Tilt Filter", true, dt == NoiseColorValue::TILT, [this, p]() {
                                     undoManager()->pushParameterChange(p->id, p, p->val);
                                     update_deform_type_bit(p, NoiseColorValue::TILT, 1);
                                     synth->storage.getPatch().isDirty = true;


### PR DESCRIPTION
Briefly tested with the Oscilloscope to make sure the tilt was right and the noise levels were the same between the two modes.