### PR TITLE
fix the virtual keyboard causes the E and F to be triggered (#7604)

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -742,10 +742,14 @@ bool SurgeSynthEditor::keyPressed(const juce::KeyPress &key, juce::Component *or
                 case Surge::GUI::VKB_OCTAVE_DOWN:
                     midiKeyboardOctave = std::clamp(midiKeyboardOctave - 1, 0, 9);
                     keyboard->setKeyPressBaseOctave(midiKeyboardOctave);
+                    // sometimes a note off command get lost
+                    processor.midiKeyboardState.allNotesOff(keyboard->getMidiChannel() );
                     return true;
                 case Surge::GUI::VKB_OCTAVE_UP:
                     midiKeyboardOctave = std::clamp(midiKeyboardOctave + 1, 0, 9);
                     keyboard->setKeyPressBaseOctave(midiKeyboardOctave);
+                    // sometimes a note off command get lost
+                    processor.midiKeyboardState.allNotesOff(keyboard->getMidiChannel() );
                     return true;
                 case Surge::GUI::VKB_VELOCITY_DOWN_10PCT:
                     midiKeyboardVelocity = std::clamp(midiKeyboardVelocity - 0.1f, 0.f, 1.f);

--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -743,13 +743,13 @@ bool SurgeSynthEditor::keyPressed(const juce::KeyPress &key, juce::Component *or
                     midiKeyboardOctave = std::clamp(midiKeyboardOctave - 1, 0, 9);
                     keyboard->setKeyPressBaseOctave(midiKeyboardOctave);
                     // sometimes a note off command get lost
-                    processor.midiKeyboardState.allNotesOff(keyboard->getMidiChannel() );
+                    processor.midiKeyboardState.allNotesOff(keyboard->getMidiChannel());
                     return true;
                 case Surge::GUI::VKB_OCTAVE_UP:
                     midiKeyboardOctave = std::clamp(midiKeyboardOctave + 1, 0, 9);
                     keyboard->setKeyPressBaseOctave(midiKeyboardOctave);
                     // sometimes a note off command get lost
-                    processor.midiKeyboardState.allNotesOff(keyboard->getMidiChannel() );
+                    processor.midiKeyboardState.allNotesOff(keyboard->getMidiChannel());
                     return true;
                 case Surge::GUI::VKB_VELOCITY_DOWN_10PCT:
                     midiKeyboardVelocity = std::clamp(midiKeyboardVelocity - 0.1f, 0.f, 1.f);


### PR DESCRIPTION
It seems when the octave up/down shortcut is pressed along with a note, this issue appears. It also shows up on Windows. 
My solution is to stop all the pressed notes after changing the octave, as key repeat will trigger the changed note. With this, it worked on on Ubuntu. 
(BTW: my first pull request :-) ) 