### PR TITLE
Fix FM3 m3 display; update CMake cpputils/basic blcosk order

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -27,9 +27,9 @@ else()
   target_compile_definitions(luajit-5.1 INTERFACE HAS_LUA=0)
 endif()
 
+surge_add_lib_subdirectory(sst/sst-cpputils)
 set(SST_BASIC_BLOCKS_SIMD_OMIT_NATIVE_ALIASES ON CACHE BOOL "No Native Aliases for SCXT") # Makes ARM64EC use neon basically
 surge_add_lib_subdirectory(sst/sst-basic-blocks)
-surge_add_lib_subdirectory(sst/sst-cpputils)
 surge_add_lib_subdirectory(sst/sst-plugininfra)
 surge_add_lib_subdirectory(sst/sst-filters)
 surge_add_lib_subdirectory(sst/sst-waveshapers)

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1527,7 +1527,18 @@ void Parameter::set_type(int ctrltype)
     case ct_freq_ringmod:
         displayType = ATwoToTheBx;
         snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "Hz");
-        displayInfo.a = (ctrltype == ct_freq_ringmod) ? 8.175798 : 440.0;
+        if (ctrltype == ct_freq_ringmod)
+        {
+            displayInfo.a = 8.175798;
+        }
+        else if (ctrltype == ct_freq_audible_fm3_extendable)
+        {
+            displayInfo.a = 440 * pow(2.f, -9.f / 12.f);
+        }
+        else
+        {
+            displayInfo.a = 440.0;
+        }
         displayInfo.b = 1.0f / 12.0f;
         displayInfo.decimals = 2;
         displayInfo.modulationCap = 880.f * powf(2.0, (val_max.f) / 12.0f);


### PR DESCRIPTION
1. FM3 m3 display was 440 based but the DSP is note60/261 baseds. Adjust the tooltip to match. Closes #7992

2. Basic Blocks optionally needs cpputils and warns if its not there. So change the add order in cmakelists