### PR TITLE
The step editor reparent logic corrected

### DIFF
--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -2709,6 +2709,10 @@ void LFOAndStepDisplay::showStepTypein(int i)
     if (!stepEditor)
     {
         stepEditor = std::make_unique<Surge::Overlays::TypeinLambdaEditor>(handleTypein);
+    }
+
+    if (getParentComponent()->getIndexOfChildComponent(stepEditor.get()) < 0)
+    {
         getParentComponent()->addChildComponent(*stepEditor);
     }
 


### PR DESCRIPTION
The step editor, when you did a rebuild of the entire ui, didn't properly reparent the typein component, but it was retained. Upshot: no text editable steps if you changed from step to sine to step after edit.