### PR TITLE
Add option for compiling cmake release without LTO.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
 
+if(NOT ENABLE_LTO)
+  option(ENABLE_LTO "Turns on link-time optimization for release builds" ON)
+endif()
+
 if(NOT BUILD_TESTING)
   option(BUILD_TESTING "" OFF)
 endif()
@@ -69,9 +73,12 @@ endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 17)
 
-if(CMAKE_BUILD_TYPE MATCHES "Release")
+# Enable LTO if unspecified, for release builds.
+if(CMAKE_BUILD_TYPE MATCHES "Release" AND ENABLE_LTO)
   message(STATUS "Enabling LTO for Release build.")
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+  message(STATUS "LTO is disabled.")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND UNIX AND NOT APPLE AND NOT SURGE_SKIP_PIE_CHANGE)


### PR DESCRIPTION
There have been complaints of it bloating build times.