### PR TITLE
modulation buttons

### DIFF
--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -138,11 +138,12 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 //                                     (old patches load with extend disabled even if they had it enabled)
 // 24 -> 25 (XT 1.3.4 nightlies) added storing of Wavetable Editor window state
 // 25 -> 26 (XT 1.4.* nightlies) added WT Deform for new WT features
-// 26 -> 27 (XT 1.4.* nightlies) added to formulaEditState and wavetable: debuggerUserVariablesOpen, debuggerBuiltInVariablesOpen, debuggerFilterText, scroll, caretPosition, selectStart, selectEnd
+//                               (dawExtraState) added to formulaEditState and wavetable: debuggerUserVariablesOpen, debuggerBuiltInVariablesOpen, debuggerFilterText, scroll, caretPosition, selectStart, selectEnd
 //                               popupOpen, popupType, popupCaseSensitive, popupWholeWord, popupText1, popupText2, popupCurrentResult. ( for saving the state of code editors )
+//                               (dawExtraState) modulationSourceButtonState - index
 // clang-format on
 
-const int ff_revision = 27;
+const int ff_revision = 26;
 
 const int n_scene_params = 273;
 const int n_global_params = 11 + n_fx_slots * (n_fx_params + 1); // each param plus a type
@@ -922,6 +923,22 @@ struct DAWExtraStateStorage
         {
             int timeEditMode = 0;
         } msegEditState[n_scenes][n_lfos];
+
+        struct ModulationSourceButtonState
+        {
+            int index{0};
+        } modulationSourceButtonState[n_scenes][n_lfos];
+
+        void clearAllModulationSourceButtonStates()
+        {
+            for (int s = 0; s < n_scenes; s++)
+            {
+                for (int o = 0; o < n_oscs; o++)
+                {
+                    modulationSourceButtonState[s][o].index = 0;
+                }
+            }
+        }
 
         /*
          * Window state parameters for Formula Editor overlay

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -933,7 +933,7 @@ struct DAWExtraStateStorage
         {
             for (int s = 0; s < n_scenes; s++)
             {
-                for (int o = 0; o < n_oscs; o++)
+                for (int o = 0; o < n_lfos; o++)
                 {
                     modulationSourceButtonState[s][o].index = 0;
                 }

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -194,9 +194,6 @@ void SurgeSynthesizer::selectRandomPatch()
 
 void SurgeSynthesizer::loadPatch(int id)
 {
-    storage.getPatch().dawExtraState.editor.clearAllFormulaStates();
-    storage.getPatch().dawExtraState.editor.clearAllWTEStates();
-
     if (id < 0)
         id = 0;
     if (id >= storage.patch_list.size())
@@ -213,6 +210,8 @@ bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, cons
                                        bool forceIsPreset)
 {
     storage.getPatch().dawExtraState.editor.clearAllFormulaStates();
+    storage.getPatch().dawExtraState.editor.clearAllWTEStates();
+    storage.getPatch().dawExtraState.editor.clearAllModulationSourceButtonStates();
 
     using namespace sst::io;
 

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.cpp
@@ -39,6 +39,7 @@ namespace Widgets
 ModulationSourceButton::ModulationSourceButton()
     : juce::Component(), WidgetBaseMixin<ModulationSourceButton>(this)
 {
+
     setDescription("Modulator");
     setAccessible(true);
     setFocusContainerType(FocusContainerType::focusContainer);
@@ -409,6 +410,13 @@ void ModulationSourceButton::buildHamburgerMenu(juce::PopupMenu &menu,
                 menu.addItem(modName, true, ticked, [this, sge, idx]() {
                     sge->forceLfoDisplayRepaint();
                     this->modlistIndex = idx;
+
+                    int lfo_id = getCurrentModSource() - ms_lfo1;
+                    storage->getPatch()
+                        .dawExtraState.editor
+                        .modulationSourceButtonState[sge->current_scene][lfo_id]
+                        .index = this->modlistIndex;
+
                     mouseMode = HAMBURGER;
                     notifyValueChanged();
                     mouseMode = NONE;
@@ -658,7 +666,7 @@ void ModulationSourceButton::onSkinChanged()
 void ModulationSourceButton::mouseUp(const juce::MouseEvent &event)
 {
     mouseUpLongHold(event);
-
+    setAlpha(1);
     setMouseCursor(juce::MouseCursor::NormalCursor);
 
     transientArmed = false;
@@ -757,7 +765,12 @@ void ModulationSourceButton::mouseDrag(const juce::MouseEvent &event)
 
     if (event.getDistanceFromDragStart() < 4)
     {
+        setBounds(mouseDownBounds);
         return;
+    }
+    else
+    {
+        setAlpha(0.7);
     }
 
     auto sge = firstListenerOfType<SurgeGUIEditor>();

--- a/src/surge-xt/gui/widgets/ModulationSourceButton.h
+++ b/src/surge-xt/gui/widgets/ModulationSourceButton.h
@@ -84,8 +84,19 @@ struct ModulationSourceButton : public juce::Component,
     int modlistIndex{0};
     void setModList(const modlist_t &m)
     {
-        modlistIndex = limit_range(modlistIndex, 0, (int)(m.size() - 1));
         modlist = m;
+        modlistIndex = 0;
+
+        auto sge = firstListenerOfType<SurgeGUIEditor>();
+        int lfo_id = getCurrentModSource() - ms_lfo1;
+        auto scene = sge->current_scene;
+
+        modlistIndex =
+            storage->getPatch()
+                .dawExtraState.editor.modulationSourceButtonState[sge->current_scene][lfo_id]
+                .index;
+        modlistIndex = limit_range(modlistIndex, 0, (int)(m.size() - 1));
+
         setAccessibleLabel(getCurrentModLabel());
         selectAccButton->setVisible(true);
         if (isLFO())


### PR DESCRIPTION
* Reverted to 26 in surgestorage, as it wasnt suppose to increase in my previous PR.

* Fixes glitchy behaviour when mouse-dragging a modulation button ( now with 0.7 opacity while dragging )

![modsource-glitch](https://github.com/user-attachments/assets/1cd7ab3a-e3a5-4778-8411-2101df94615c)
![modsource-glitch-fix](https://github.com/user-attachments/assets/54c7e21c-e778-4fa9-b1a7-01a88b7fd299)

* adds state to modulation buttons that saves its current modulation index
* button state is cleared when loading new patch/initialise