### PR TITLE
Portable Linux User Dir

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -217,7 +217,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
 
         while (datapath.empty() && cp.has_parent_path() && cp != cp.parent_path())
         {
-            auto portable = cp / L"SurgeXTData";
+            auto portable = cp / "SurgeXTData";
 
             if (fs::is_directory(portable))
             {
@@ -259,7 +259,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
 
     while (userDataPath.empty() && up.has_parent_path() && up != up.parent_path())
     {
-        auto portable = up / L"SurgeXTUserData";
+        auto portable = up / "SurgeXTUserData";
 
         if (fs::is_directory(portable))
         {
@@ -268,7 +268,10 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
 
         up = up.parent_path();
     }
-    userDataPath = sst::plugininfra::paths::bestDocumentsFolderPathFor(sxt);
+    if (userDataPath.empty())
+    {
+        userDataPath = sst::plugininfra::paths::bestDocumentsFolderPathFor(sxt);
+    }
 
 #elif WINDOWS
     const auto installPath = sst::plugininfra::paths::sharedLibraryBinaryPath().parent_path();


### PR DESCRIPTION
In the never ending quest to answer the question "where does all the stuff go", we continue to plow a path, innovating on this difficult question (except on mac, where it's easy)

In this case, the portable linux user dir was always overwritten so add a check that if it is found preserves it.