### PR TITLE
Fix popup menu scaling

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2424,6 +2424,9 @@ bool SurgeGUIEditor::open(void *parent)
     frame->setBounds(0, 0, currentSkin->getWindowSizeX(), currentSkin->getWindowSizeY());
     frame->setSurgeGUIEditor(this);
 
+    menu_scaler = std::make_unique<juce::Component>();
+    juceEditor->addChildComponent(*menu_scaler);
+
     // Comment this in to always start with focus debugger
     // debugFocus = true;
     // y-frame->debugFocus = true;
@@ -2889,7 +2892,7 @@ void SurgeGUIEditor::toggleMPE()
 juce::PopupMenu::Options SurgeGUIEditor::popupMenuOptions(const juce::Point<int> &where)
 {
     auto o = juce::PopupMenu::Options();
-    o = o.withTargetComponent(juceEditor);
+    o = o.withTargetComponent(*menu_scaler);
     if (where.x > 0 && where.y > 0)
     {
         auto r = juce::Rectangle<int>().withWidth(1).withHeight(1).withPosition(
@@ -3060,6 +3063,12 @@ void SurgeGUIEditor::setZoomFactor(float zf, bool resizeWindow)
     if (frame)
     {
         frame->setTransform(juce::AffineTransform().scaled(zff));
+    }
+
+    if (menu_scaler)
+    {
+        // 0.75 scales the menus so that they match the rest of the UI.
+        menu_scaler->setTransform(juce::AffineTransform().scaled(zff * 0.75));
     }
 
     if (oscWaveform)

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -136,6 +136,14 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     std::unique_ptr<Surge::Widgets::MainFrame> frame;
 
+    /*
+     * Dummy component used to make sure the scale of the menus visually matches
+     * the scale of the rest of the interface. Using `juceEditor` results in the
+     * scale being set only once, and using `frame` results in the scale being
+     * too big.
+     */
+    std::unique_ptr<juce::Component> menu_scaler;
+
     std::atomic<int> errorItemCount{0};
     std::deque<std::tuple<std::string, std::string, SurgeStorage::ErrorType>> errorItems;
     std::mutex errorItemsMutex;


### PR DESCRIPTION
This is a draft PR with a problem statement and a possible solution.

---

Currently, the scaling of the popup menus seems to be determined once. Setting the zoom level doesn't change the scale factor of the popup menus. The solution I have relies on creating a dummy component that follows the scale set by the user with a factor of 0.75 and using this component as the target component for the popup menus. It's not very clean, but seems to work pretty well. However, there's a caveat. **It seems impossible to close a popup menu by clicking the button again.**

The main technical point here is that JUCE uses `Component::getApproximateScaleFactorForComponent()` on the target component to determine what the scale of the popup menu should be. It seems to boil down to taking whatever we set using `Component::setTransform()` as the scale.

With this in mind, I tried the following approaches:

1. Using `setZoomFactor()` on `juceEditor` in `SurgeGUIEditor::setZoomFactor()` instead of the current (more manual?) approach to scaling. This called `setTransform()` and the menus scaled. However, I was getting a lot of scaling glitches with the main interface and never got it to work properly.

2. Using `o.withTargetComponent(*frame)` instead of `withTargetComponent(juceEditor)` when creating the popup menus. This works kind of alright, because `frame->setTransform()` is called each time the scale changes. However, the menus were to big compared to the rest of the interface. 

3. I created a dummy component called `menu_scaler` that mirrors the scale set on `frame`, but scales it by 0.75. This seems to hit the right spot.

I've tested this on a Linux machine running X11 and Wayland in Reaper and Bitwig using VST3 and CLAP, and the standalone.

The question is: **Is there a better way?**