### PR TITLE
Fix keyboard/mouse shortcut used to clear FX slot.

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -5329,7 +5329,7 @@ void SurgeSynthesizer::changeModulatorSmoothing(Modulator::SmoothingMode m)
 void SurgeSynthesizer::reorderFx(int source, int target, FXReorderMode m)
 {
     if (source < 0 || source >= n_fx_slots || target < 0 || target >= n_fx_slots ||
-        source == target)
+        (source == target && m != FXReorderMode::NONE))
     {
         return;
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -5108,7 +5108,7 @@ void SurgeGUIEditor::enqueueFXChainClear(int fxchain)
 void SurgeGUIEditor::swapFX(int source, int target, SurgeSynthesizer::FXReorderMode m)
 {
     if (source < 0 || source >= n_fx_slots || target < 0 || target >= n_fx_slots ||
-        source == target)
+        (source == target && m != SurgeSynthesizer::FXReorderMode::NONE))
     {
         return;
     }


### PR DESCRIPTION
It appears PR 7086 introduced a regression which broke this shortcut. The source==target test should only cause an early return if FX reorder mode is not NONE.

Fixes #8066