### PR TITLE
Fix soft takeover failing after patch load

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1492,6 +1492,8 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 {
                     param_ptr[i]->val.f = param_ptr[i]->val_default.f;
                 }
+
+                param_ptr[i]->miditakeover_status = sts_waiting_for_first_look;
             }
             else
             {


### PR DESCRIPTION
Previously, soft takeover was unaware that the knob has changed its value after a patch was loaded. Now, with a single line of code (at least for all float params, which is all we really care about here), they do, and soft takeover will work for MIDI learned parameters after a patch load (previously, it would just jump, as if soft takeover wasn't enabled).