### PR TITLE
feat: Add TCP control API for programmatic preset and parameter control

### DIFF
--- a/doc/tcp-control/BUILD_INSTRUCTIONS.md
+++ b/doc/tcp-control/BUILD_INSTRUCTIONS.md
@@ -1,0 +1,111 @@
+# Surge TCP Control Integration Build Instructions
+
+## Overview
+This modification adds a TCP control interface to Surge XT, enabling your AI assistant to programmatically control presets and parameters through the pipeline:
+**NLP → MCP JavaScript → Lua/ReaScript → Surge TCP**
+
+## Prerequisites
+- Surge XT source code from GitHub
+- C++ build environment (Visual Studio on Windows, Xcode on macOS, GCC on Linux)
+- CMake 3.15+
+- Reaper with ReaScript enabled
+- LuaSocket library for Reaper
+
+## Step 1: Fork and Clone Surge
+```bash
+git clone https://github.com/surge-synthesizer/surge.git
+cd surge
+git checkout main
+```
+
+## Step 2: Add TCP Controller Files
+Copy these files to the Surge source tree:
+```
+surge/src/common/TCPControl/SurgeTCPController.h
+surge/src/common/TCPControl/SurgeTCPController.cpp
+```
+
+## Step 3: Modify CMakeLists.txt
+Add to `surge/CMakeLists.txt`:
+```cmake
+set(SURGE_TCP_CONTROL_SOURCES
+    src/common/TCPControl/SurgeTCPController.cpp
+    src/common/TCPControl/SurgeTCPController.h
+)
+
+target_sources(surge-common PRIVATE ${SURGE_TCP_CONTROL_SOURCES})
+```
+
+## Step 4: Integrate with SurgeSynthesizer
+Edit `surge/src/common/SurgeSynthesizer.h`:
+```cpp
+// Add include
+#include "TCPControl/SurgeTCPController.h"
+
+// Add member variable
+std::unique_ptr<Surge::TCPControl::TCPController> tcpController;
+```
+
+Edit `surge/src/common/SurgeSynthesizer.cpp`:
+```cpp
+// In constructor, add:
+initializeTCPControl(); // Add the function from SurgeIntegration.cpp
+
+// In destructor, add:
+if (tcpController) {
+    tcpController->stop();
+}
+```
+
+## Step 5: Build Surge
+```bash
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release --target surge-xt_VST3
+```
+
+## Step 6: Install Modified Surge
+- Copy the built VST3 to your plugin folder
+- Verify it loads in Reaper
+
+## Step 7: Setup Reaper Scripts
+1. Copy Lua files to Reaper Scripts folder:
+   - `surge_tcp_client.lua`
+   - `ai_assistant_integration.lua`
+
+2. Install LuaSocket for Reaper:
+   - Download from: https://luarocks.org/modules/luasocket/luasocket
+   - Place in Reaper's Lua folder
+
+## Step 8: Setup MCP Bridge
+1. Install your MCP server with the JavaScript bridge
+2. Configure `mcp_surge_bridge.js` with your specific bridge mechanism
+
+## Testing
+1. Load Surge in Reaper
+2. Run the test script:
+```lua
+-- In Reaper's Actions window, run:
+dofile(reaper.GetResourcePath() .. "/Scripts/ai_assistant_integration.lua")
+```
+
+3. Check Reaper console for test results
+
+## Security Notes
+- TCP listener is bound to localhost only (127.0.0.1)
+- No authentication implemented (add if needed for production)
+- Consider using Unix sockets instead of TCP for better security
+
+## Troubleshooting
+- **Port 7833 in use**: Change port in both C++ and Lua files
+- **Connection refused**: Ensure Surge is loaded and TCP listener started
+- **Preset not found**: Check preset names match exactly
+- **LuaSocket not found**: Verify LuaSocket installation in Reaper
+
+## Maintenance
+When updating Surge:
+```bash
+git fetch upstream
+git merge upstream/main
+# Resolve any conflicts in your TCP control code
+cmake --build build
+```

--- a/doc/tcp-control/integration_example.cpp
+++ b/doc/tcp-control/integration_example.cpp
@@ -1,0 +1,70 @@
+// Add this to SurgeSynthesizer.cpp or your main plugin class
+
+#include "SurgeTCPController.h"
+
+// In your SurgeSynthesizer class header, add:
+// std::unique_ptr<Surge::TCPControl::TCPController> tcpController;
+
+// In constructor or initialization:
+void SurgeSynthesizer::initializeTCPControl() {
+    tcpController = std::make_unique<Surge::TCPControl::TCPController>();
+    
+    // Hook up preset loading
+    tcpController->setPresetLoadCallback([this](const std::string& presetName) -> bool {
+        // Find preset by name in storage
+        auto* storage = this->storage.getPatch();
+        
+        // Search through factory and user presets
+        for (const auto& category : storage->preset_categories) {
+            for (const auto& preset : category.presets) {
+                if (preset.name == presetName) {
+                    // Load the preset using Surge's internal method
+                    this->loadPatchFromFile(preset.path);
+                    return true;
+                }
+            }
+        }
+        
+        // Try direct file path if not found by name
+        if (fs::exists(presetName)) {
+            this->loadPatchFromFile(presetName);
+            return true;
+        }
+        
+        return false;
+    });
+    
+    // Hook up parameter setting
+    tcpController->setParamSetCallback([this](int paramId, float value) -> bool {
+        if (paramId >= 0 && paramId < n_total_params) {
+            // Set parameter through Surge's automation system
+            this->setParameter01(paramId, value, true);
+            return true;
+        }
+        return false;
+    });
+    
+    // Hook up preset listing
+    tcpController->setPresetListCallback([this]() -> std::vector<std::string> {
+        std::vector<std::string> presetNames;
+        auto* storage = this->storage.getPatch();
+        
+        for (const auto& category : storage->preset_categories) {
+            for (const auto& preset : category.presets) {
+                presetNames.push_back(preset.name);
+            }
+        }
+        
+        return presetNames;
+    });
+    
+    // Start the TCP listener
+    tcpController->start(7833);
+}
+
+// In destructor:
+void SurgeSynthesizer::cleanup() {
+    if (tcpController) {
+        tcpController->stop();
+    }
+}

--- a/doc/tcp-control/surge_tcp_protocol.md
+++ b/doc/tcp-control/surge_tcp_protocol.md
@@ -1,0 +1,49 @@
+# Surge TCP Control Protocol
+
+## Connection
+- Port: 7833 (SURGETCP)
+- Host: localhost only (security)
+- Format: Simple text commands with JSON responses
+
+## Commands
+
+### Load Preset
+```
+PRESET:LOAD:<preset_name>
+```
+Response:
+```json
+{"status": "ok", "preset": "DeepBass"}
+```
+
+### Set Parameter
+```
+PARAM:SET:<param_id>:<value>
+```
+Response:
+```json
+{"status": "ok", "param": "cutoff", "value": 0.75}
+```
+
+### Get Preset List
+```
+PRESET:LIST
+```
+Response:
+```json
+{"status": "ok", "presets": ["DeepBass", "WarmPad", "PluckLead"]}
+```
+
+### Health Check
+```
+PING
+```
+Response:
+```json
+{"status": "ok", "version": "1.0"}
+```
+
+## Error Responses
+```json
+{"status": "error", "message": "Preset not found: FakeName"}
+```

--- a/scripts/reaper/ai_assistant_integration.lua
+++ b/scripts/reaper/ai_assistant_integration.lua
@@ -1,0 +1,147 @@
+-- AI Assistant Integration for Reaper + Surge
+-- This demonstrates the full pipeline: MCP JS -> Lua -> Surge TCP
+
+local SurgeClient = dofile(reaper.GetResourcePath() .. "/Scripts/surge_tcp_client.lua")
+
+-- Initialize Surge client
+local surge = SurgeClient:new()
+
+-- Function called by your MCP JavaScript tool
+function loadSurgePresetFromAI(presetName, trackIndex)
+    -- Validate connection
+    local status = surge:ping()
+    if not status or status.status ~= "ok" then
+        return {success = false, error = "Surge TCP control not available"}
+    end
+    
+    -- Load the preset
+    local result = surge:loadPreset(presetName)
+    
+    if result and result.status == "ok" then
+        reaper.ShowConsoleMsg(string.format("AI Assistant: Loaded '%s' on track %d\n", 
+                                           presetName, trackIndex))
+        return {success = true, preset = presetName}
+    else
+        local errorMsg = result and result.message or "Unknown error"
+        reaper.ShowConsoleMsg(string.format("AI Assistant: Failed to load preset - %s\n", 
+                                           errorMsg))
+        return {success = false, error = errorMsg}
+    end
+end
+
+-- Function to get semantic preset recommendations
+function getPresetsByCategory(category)
+    local allPresets = surge:getPresetList()
+    if not allPresets or allPresets.status ~= "ok" then
+        return {}
+    end
+    
+    -- Simple category matching (enhance with your AI logic)
+    local categoryMap = {
+        bass = {"Deep", "Sub", "Bass", "808"},
+        pad = {"Pad", "Ambient", "Warm", "Soft"},
+        lead = {"Lead", "Pluck", "Saw", "Square"},
+        arp = {"Arp", "Seq", "Gate"},
+        fx = {"FX", "Noise", "Sweep", "Riser"}
+    }
+    
+    local keywords = categoryMap[category:lower()] or {}
+    local matches = {}
+    
+    for _, preset in ipairs(allPresets.presets) do
+        for _, keyword in ipairs(keywords) do
+            if preset:lower():find(keyword:lower()) then
+                table.insert(matches, preset)
+                break
+            end
+        end
+    end
+    
+    return matches
+end
+
+-- Example MCP bridge function
+function processAICommand(command)
+    -- Parse AI intent (this would come from your MCP JS tool)
+    -- Example: {action = "load_preset", category = "bass", track = 0}
+    
+    if command.action == "load_preset" then
+        if command.preset then
+            -- Direct preset load
+            return loadSurgePresetFromAI(command.preset, command.track or 0)
+        elseif command.category then
+            -- Category-based selection
+            local presets = getPresetsByCategory(command.category)
+            if #presets > 0 then
+                -- Pick first match or use AI to select best
+                return loadSurgePresetFromAI(presets[1], command.track or 0)
+            else
+                return {success = false, error = "No presets found for category: " .. command.category}
+            end
+        end
+    elseif command.action == "morph_parameter" then
+        -- Gradually change a parameter
+        local startVal = command.start or 0
+        local endVal = command.target or 1
+        local steps = command.steps or 20
+        
+        for i = 0, steps do
+            local value = startVal + (endVal - startVal) * (i / steps)
+            surge:setParameter(command.param, value)
+            reaper.defer(function() end) -- Small delay
+        end
+        
+        return {success = true, param = command.param, value = endVal}
+    end
+    
+    return {success = false, error = "Unknown command"}
+end
+
+-- Test the integration
+function testIntegration()
+    reaper.ShowConsoleMsg("=== AI Assistant Surge Integration Test ===\n")
+    
+    -- Test 1: Connection
+    local ping = surge:ping()
+    if ping and ping.status == "ok" then
+        reaper.ShowConsoleMsg("✓ TCP connection established\n")
+    else
+        reaper.ShowConsoleMsg("✗ TCP connection failed\n")
+        return
+    end
+    
+    -- Test 2: List presets
+    local presets = surge:getPresetList()
+    if presets and presets.status == "ok" then
+        reaper.ShowConsoleMsg(string.format("✓ Found %d presets\n", #presets.presets))
+    else
+        reaper.ShowConsoleMsg("✗ Failed to list presets\n")
+    end
+    
+    -- Test 3: Simulate AI command
+    local aiCommand = {
+        action = "load_preset",
+        category = "bass",
+        track = 0
+    }
+    
+    local result = processAICommand(aiCommand)
+    if result.success then
+        reaper.ShowConsoleMsg("✓ AI command processed successfully\n")
+    else
+        reaper.ShowConsoleMsg("✗ AI command failed: " .. (result.error or "unknown") .. "\n")
+    end
+    
+    reaper.ShowConsoleMsg("=== Test Complete ===\n")
+end
+
+-- Run test if executed directly
+if not ... then
+    testIntegration()
+end
+
+return {
+    loadPreset = loadSurgePresetFromAI,
+    getPresetsByCategory = getPresetsByCategory,
+    processAICommand = processAICommand
+}

--- a/scripts/reaper/mcp_surge_bridge.js
+++ b/scripts/reaper/mcp_surge_bridge.js
@@ -1,0 +1,198 @@
+// MCP (Model Context Protocol) Tool for Surge Control
+// This bridges between your AI agent and ReaScript
+
+export class SurgeControlTool {
+    constructor() {
+        this.name = "surge_control";
+        this.description = "Control Surge XT synthesizer presets and parameters";
+    }
+
+    // Tool schema for MCP
+    getSchema() {
+        return {
+            name: this.name,
+            description: this.description,
+            parameters: {
+                type: "object",
+                properties: {
+                    action: {
+                        type: "string",
+                        enum: ["load_preset", "set_parameter", "list_presets", "morph"],
+                        description: "Action to perform on Surge"
+                    },
+                    preset: {
+                        type: "string",
+                        description: "Preset name to load (for load_preset action)"
+                    },
+                    category: {
+                        type: "string",
+                        enum: ["bass", "pad", "lead", "arp", "fx", "percussion"],
+                        description: "Preset category for semantic search"
+                    },
+                    track: {
+                        type: "integer",
+                        description: "Track index in Reaper (0-based)"
+                    },
+                    parameter: {
+                        type: "integer",
+                        description: "Parameter ID to modify"
+                    },
+                    value: {
+                        type: "number",
+                        minimum: 0,
+                        maximum: 1,
+                        description: "Parameter value (0-1)"
+                    }
+                },
+                required: ["action"]
+            }
+        };
+    }
+
+    // Execute the tool
+    async execute(params) {
+        try {
+            // Build Lua command based on action
+            let luaCode = '';
+            
+            switch (params.action) {
+                case 'load_preset':
+                    if (params.preset) {
+                        luaCode = `
+                            local ai = dofile(reaper.GetResourcePath() .. "/Scripts/ai_assistant_integration.lua")
+                            local result = ai.loadPreset("${params.preset}", ${params.track || 0})
+                            return result.success and "OK:" .. result.preset or "ERROR:" .. result.error
+                        `;
+                    } else if (params.category) {
+                        luaCode = `
+                            local ai = dofile(reaper.GetResourcePath() .. "/Scripts/ai_assistant_integration.lua")
+                            local result = ai.processAICommand({
+                                action = "load_preset",
+                                category = "${params.category}",
+                                track = ${params.track || 0}
+                            })
+                            return result.success and "OK" or "ERROR:" .. result.error
+                        `;
+                    }
+                    break;
+                    
+                case 'set_parameter':
+                    luaCode = `
+                        local SurgeClient = dofile(reaper.GetResourcePath() .. "/Scripts/surge_tcp_client.lua")
+                        local surge = SurgeClient:new()
+                        local result = surge:setParameter(${params.parameter}, ${params.value})
+                        return result.status == "ok" and "OK" or "ERROR"
+                    `;
+                    break;
+                    
+                case 'list_presets':
+                    luaCode = `
+                        local SurgeClient = dofile(reaper.GetResourcePath() .. "/Scripts/surge_tcp_client.lua")
+                        local surge = SurgeClient:new()
+                        local result = surge:getPresetList()
+                        if result.status == "ok" then
+                            return table.concat(result.presets, ",")
+                        else
+                            return "ERROR"
+                        end
+                    `;
+                    break;
+                    
+                case 'morph':
+                    luaCode = `
+                        local ai = dofile(reaper.GetResourcePath() .. "/Scripts/ai_assistant_integration.lua")
+                        local result = ai.processAICommand({
+                            action = "morph_parameter",
+                            param = ${params.parameter},
+                            target = ${params.value},
+                            steps = 20
+                        })
+                        return result.success and "OK" or "ERROR"
+                    `;
+                    break;
+            }
+            
+            // Execute via ReaScript bridge
+            const result = await this.executeReaScript(luaCode);
+            
+            if (result.startsWith("OK")) {
+                return {
+                    success: true,
+                    message: `Successfully executed ${params.action}`,
+                    data: result.substring(3)
+                };
+            } else {
+                return {
+                    success: false,
+                    error: result.substring(6) || "Operation failed"
+                };
+            }
+            
+        } catch (error) {
+            return {
+                success: false,
+                error: error.message
+            };
+        }
+    }
+    
+    // Bridge to ReaScript execution
+    async executeReaScript(luaCode) {
+        // This would be implemented based on your specific bridge mechanism
+        // Options include:
+        // 1. Write to temp file and execute via Reaper API
+        // 2. Use OSC to trigger ReaScript
+        // 3. Use a custom bridge process
+        
+        // Example pseudo-code:
+        const tempFile = `/tmp/surge_control_${Date.now()}.lua`;
+        await fs.writeFile(tempFile, luaCode);
+        
+        // Trigger execution in Reaper (implementation depends on your setup)
+        const result = await this.reaperBridge.runScript(tempFile);
+        
+        await fs.unlink(tempFile);
+        return result;
+    }
+}
+
+// Example usage in your AI agent
+export async function handleUserIntent(intent) {
+    const surgeTool = new SurgeControlTool();
+    
+    // Parse natural language to tool parameters
+    let params = {};
+    
+    if (intent.includes("bass sound") || intent.includes("deep bass")) {
+        params = {
+            action: "load_preset",
+            category: "bass",
+            track: 0
+        };
+    } else if (intent.includes("warm pad")) {
+        params = {
+            action: "load_preset",
+            preset: "WarmPad",
+            track: 0
+        };
+    } else if (intent.includes("brighten") || intent.includes("filter")) {
+        params = {
+            action: "set_parameter",
+            parameter: 10, // Assuming param 10 is filter cutoff
+            value: 0.8
+        };
+    }
+    
+    const result = await surgeTool.execute(params);
+    
+    if (result.success) {
+        return `I've ${params.action === 'load_preset' ? 'loaded the preset' : 'adjusted the parameter'} as requested.`;
+    } else {
+        return `I encountered an issue: ${result.error}`;
+    }
+}
+
+// Export for MCP registration
+export default {
+    tools: [new SurgeControlTool()]
+};

--- a/scripts/reaper/surge_tcp_client.lua
+++ b/scripts/reaper/surge_tcp_client.lua
@@ -1,0 +1,116 @@
+-- Surge TCP Control Client for ReaScript
+-- Usage: Load this module in your ReaScript to control Surge presets
+
+local socket = require("socket")
+local json = require("json") -- You may need to install json.lua
+
+local SurgeClient = {}
+SurgeClient.__index = SurgeClient
+
+function SurgeClient:new(host, port)
+    local self = setmetatable({}, SurgeClient)
+    self.host = host or "127.0.0.1"
+    self.port = port or 7833
+    self.timeout = 1.0
+    return self
+end
+
+function SurgeClient:sendCommand(command)
+    local client = socket.tcp()
+    client:settimeout(self.timeout)
+    
+    local success, err = client:connect(self.host, self.port)
+    if not success then
+        return nil, "Connection failed: " .. (err or "unknown error")
+    end
+    
+    client:send(command)
+    local response = client:receive("*l")
+    client:close()
+    
+    if response then
+        local ok, result = pcall(json.decode, response)
+        if ok then
+            return result
+        else
+            return {status = "error", message = "Invalid JSON response"}
+        end
+    else
+        return nil, "No response from Surge"
+    end
+end
+
+function SurgeClient:loadPreset(presetName)
+    local cmd = "PRESET:LOAD:" .. presetName
+    return self:sendCommand(cmd)
+end
+
+function SurgeClient:setParameter(paramId, value)
+    local cmd = string.format("PARAM:SET:%d:%.4f", paramId, value)
+    return self:sendCommand(cmd)
+end
+
+function SurgeClient:getPresetList()
+    return self:sendCommand("PRESET:LIST")
+end
+
+function SurgeClient:ping()
+    return self:sendCommand("PING")
+end
+
+-- ReaScript integration functions
+function SurgeClient:loadPresetForTrack(trackIndex, presetName)
+    local track = reaper.GetTrack(0, trackIndex)
+    if not track then
+        return false, "Track not found"
+    end
+    
+    -- Find Surge instance on track
+    local fxCount = reaper.TrackFX_GetCount(track)
+    for i = 0, fxCount - 1 do
+        local _, fxName = reaper.TrackFX_GetFXName(track, i, "")
+        if string.find(fxName:lower(), "surge") then
+            -- Load preset via TCP
+            local result = self:loadPreset(presetName)
+            if result and result.status == "ok" then
+                return true, "Preset loaded: " .. presetName
+            else
+                return false, result and result.message or "Failed to load preset"
+            end
+        end
+    end
+    
+    return false, "Surge not found on track"
+end
+
+-- Example usage in ReaScript:
+--[[
+local surge = SurgeClient:new()
+
+-- Check connection
+local status = surge:ping()
+if status and status.status == "ok" then
+    reaper.ShowConsoleMsg("Surge TCP control connected!\n")
+    
+    -- Load a preset
+    local result = surge:loadPreset("DeepBass")
+    if result.status == "ok" then
+        reaper.ShowConsoleMsg("Loaded preset: " .. result.preset .. "\n")
+    end
+    
+    -- Set a parameter
+    surge:setParameter(10, 0.75) -- Set param 10 to 75%
+    
+    -- Get preset list
+    local presets = surge:getPresetList()
+    if presets.status == "ok" then
+        for _, preset in ipairs(presets.presets) do
+            reaper.ShowConsoleMsg("Available: " .. preset .. "\n")
+        end
+    end
+else
+    reaper.ShowConsoleMsg("Surge TCP control not available\n")
+end
+--]]
+
+return SurgeClient

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -141,6 +141,8 @@ add_library(${PROJECT_NAME}
   SurgeSynthesizer.cpp
   SurgeSynthesizer.h
   SurgeSynthesizerIO.cpp
+  TCPControl/SurgeTCPController.cpp
+  TCPControl/SurgeTCPController.h
   UnitConversions.h
   UserDefaults.cpp
   UserDefaults.h

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -28,8 +28,15 @@
 #include "BiquadFilter.h"
 #include <set>
 #include <sst/filters/HalfRateFilter.h>
+#include <memory>
 
 struct QuadFilterChainState;
+
+namespace Surge {
+namespace TCPControl {
+class TCPController;
+}
+}
 
 #include <list>
 #include <utility>
@@ -579,8 +586,10 @@ class alignas(16) SurgeSynthesizer
     // these have to be thread-safe, so keep them private
   private:
     PluginLayer *_parent = nullptr;
+    std::unique_ptr<Surge::TCPControl::TCPController> tcpController;
 
     void switch_toggled();
+    void initializeTCPControl();
 
     // MIDI control interpolators
     static constexpr int num_controlinterpolators = 128;

--- a/src/common/TCPControl/SurgeTCPController.cpp
+++ b/src/common/TCPControl/SurgeTCPController.cpp
@@ -1,0 +1,153 @@
+#include "SurgeTCPController.h"
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <cstring>
+#include <sstream>
+#include <vector>
+
+namespace Surge {
+namespace TCPControl {
+
+TCPController::TCPController() {}
+
+TCPController::~TCPController() {
+    stop();
+}
+
+void TCPController::start(int portNum) {
+    if (running) return;
+    
+    port = portNum;
+    running = true;
+    listenerThread = std::thread(&TCPController::listenLoop, this);
+}
+
+void TCPController::stop() {
+    if (!running) return;
+    
+    running = false;
+    if (serverSocket >= 0) {
+        close(serverSocket);
+    }
+    if (listenerThread.joinable()) {
+        listenerThread.join();
+    }
+}
+
+void TCPController::listenLoop() {
+    serverSocket = socket(AF_INET, SOCK_STREAM, 0);
+    if (serverSocket < 0) return;
+    
+    int opt = 1;
+    setsockopt(serverSocket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    
+    sockaddr_in serverAddr{};
+    serverAddr.sin_family = AF_INET;
+    serverAddr.sin_addr.s_addr = inet_addr("127.0.0.1"); // localhost only
+    serverAddr.sin_port = htons(port);
+    
+    if (bind(serverSocket, (struct sockaddr*)&serverAddr, sizeof(serverAddr)) < 0) {
+        close(serverSocket);
+        return;
+    }
+    
+    listen(serverSocket, 5);
+    
+    while (running) {
+        sockaddr_in clientAddr{};
+        socklen_t clientLen = sizeof(clientAddr);
+        int clientSocket = accept(serverSocket, (struct sockaddr*)&clientAddr, &clientLen);
+        
+        if (clientSocket < 0) continue;
+        
+        char buffer[1024] = {0};
+        int bytesRead = read(clientSocket, buffer, sizeof(buffer) - 1);
+        
+        if (bytesRead > 0) {
+            std::string response = processCommand(std::string(buffer));
+            write(clientSocket, response.c_str(), response.length());
+        }
+        
+        close(clientSocket);
+    }
+    
+    close(serverSocket);
+}
+
+std::string TCPController::processCommand(const std::string& cmd) {
+    std::istringstream iss(cmd);
+    std::string token;
+    std::vector<std::string> tokens;
+    
+    while (std::getline(iss, token, ':')) {
+        tokens.push_back(token);
+    }
+    
+    if (tokens.empty()) {
+        return jsonResponse(false, "Invalid command");
+    }
+    
+    if (tokens[0] == "PING") {
+        return "{\"status\":\"ok\",\"version\":\"1.0\"}";
+    }
+    
+    if (tokens[0] == "PRESET" && tokens.size() >= 2) {
+        if (tokens[1] == "LOAD" && tokens.size() >= 3) {
+            if (presetLoadCb) {
+                bool success = presetLoadCb(tokens[2]);
+                if (success) {
+                    return "{\"status\":\"ok\",\"preset\":\"" + tokens[2] + "\"}";
+                } else {
+                    return jsonResponse(false, "Failed to load preset: " + tokens[2]);
+                }
+            }
+            return jsonResponse(false, "Preset load callback not set");
+        }
+        
+        if (tokens[1] == "LIST") {
+            if (presetListCb) {
+                auto presets = presetListCb();
+                std::string json = "{\"status\":\"ok\",\"presets\":[";
+                for (size_t i = 0; i < presets.size(); ++i) {
+                    json += "\"" + presets[i] + "\"";
+                    if (i < presets.size() - 1) json += ",";
+                }
+                json += "]}";
+                return json;
+            }
+            return jsonResponse(false, "Preset list callback not set");
+        }
+    }
+    
+    if (tokens[0] == "PARAM" && tokens.size() >= 4 && tokens[1] == "SET") {
+        if (paramSetCb) {
+            try {
+                int paramId = std::stoi(tokens[2]);
+                float value = std::stof(tokens[3]);
+                bool success = paramSetCb(paramId, value);
+                if (success) {
+                    return "{\"status\":\"ok\",\"param\":\"" + tokens[2] + 
+                           "\",\"value\":" + tokens[3] + "}";
+                }
+            } catch (...) {
+                return jsonResponse(false, "Invalid parameter format");
+            }
+        }
+        return jsonResponse(false, "Param set callback not set");
+    }
+    
+    return jsonResponse(false, "Unknown command: " + tokens[0]);
+}
+
+std::string TCPController::jsonResponse(bool success, const std::string& data) {
+    if (success) {
+        return "{\"status\":\"ok\",\"data\":\"" + data + "\"}";
+    } else {
+        return "{\"status\":\"error\",\"message\":\"" + data + "\"}";
+    }
+}
+
+} // namespace TCPControl
+} // namespace Surge

--- a/src/common/TCPControl/SurgeTCPController.h
+++ b/src/common/TCPControl/SurgeTCPController.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <thread>
+#include <atomic>
+#include <string>
+#include <functional>
+
+namespace Surge {
+namespace TCPControl {
+
+class TCPController {
+public:
+    TCPController();
+    ~TCPController();
+    
+    void start(int port = 7833);
+    void stop();
+    
+    using PresetCallback = std::function<bool(const std::string&)>;
+    using ParamCallback = std::function<bool(int, float)>;
+    using ListCallback = std::function<std::vector<std::string>()>;
+    
+    void setPresetLoadCallback(PresetCallback cb) { presetLoadCb = cb; }
+    void setParamSetCallback(ParamCallback cb) { paramSetCb = cb; }
+    void setPresetListCallback(ListCallback cb) { presetListCb = cb; }
+    
+private:
+    void listenLoop();
+    std::string processCommand(const std::string& cmd);
+    std::string jsonResponse(bool success, const std::string& data = "");
+    
+    std::thread listenerThread;
+    std::atomic<bool> running{false};
+    int serverSocket{-1};
+    int port{7833};
+    
+    PresetCallback presetLoadCb;
+    ParamCallback paramSetCb;
+    ListCallback presetListCb;
+};
+
+} // namespace TCPControl
+} // namespace Surge


### PR DESCRIPTION
- Add TCP listener on port 7833 for external control
- Implement preset loading by name and file path
- Add parameter setting via TCP commands
- Include Lua/ReaScript client for Reaper integration
- Add MCP JavaScript bridge for AI assistant workflow
- Support for NLP -> MCP JS -> Lua/ReaScript -> TCP pipeline

This enables AI assistants and automation tools to control Surge XT without GUI interaction, supporting preset loading, parameter control, and preset enumeration via simple TCP commands.