### PR TITLE
Auto-load patch on keyboard browsing through patch search results

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -1284,8 +1284,8 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
     bool patchStickySearchbox = Surge::Storage::getUserDefaultValue(
         &(this->synth->storage), Surge::Storage::RetainPatchSearchboxAfterLoad, true);
 
-    wfMenu.addItem(Surge::GUI::toOSCase("Retain Patch Search Results After Loading"), true,
-                   patchStickySearchbox, [this, patchStickySearchbox]() {
+    wfMenu.addItem(Surge::GUI::toOSCase("Retain Patch Search Results After Loading Via Click"),
+                   true, patchStickySearchbox, [this, patchStickySearchbox]() {
                        Surge::Storage::updateUserDefaultValue(
                            &(this->synth->storage), Surge::Storage::RetainPatchSearchboxAfterLoad,
                            !patchStickySearchbox);

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -199,7 +199,6 @@ PatchSelector::PatchSelector() : juce::Component(), WidgetBaseMixin<PatchSelecto
     typeAhead = std::make_unique<Surge::Widgets::TypeAhead>("Patch select", patchDbProvider.get());
     typeAhead->setVisible(false);
     typeAhead->addTypeAheadListener(this);
-    typeAhead->setToElementZeroOnReturn = true;
 
     addChildComponent(*typeAhead);
 
@@ -1291,11 +1290,14 @@ int PatchSelector::getCurrentPatchId() const { return current_patch; }
 
 int PatchSelector::getCurrentCategoryId() const { return current_category; }
 
-void PatchSelector::itemSelected(int providerIndex)
+void PatchSelector::itemSelected(int providerIndex, bool dontCloseTypeAhead)
 {
     auto sr = patchDbProvider->lastSearchResult[providerIndex];
     auto sge = firstListenerOfType<SurgeGUIEditor>();
-    toggleTypeAheadSearch(false);
+
+    if (dontCloseTypeAhead)
+        toggleTypeAheadSearch(false);
+
     if (sge)
     {
         sge->queuePatchFileLoad(sr.file);

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -109,7 +109,7 @@ struct PatchSelector : public juce::Component,
     void setTags(const std::vector<SurgePatch::Tag> &itag) { tags = itag; }
 
     /// TypeAhead API
-    void itemSelected(int providerIndex) override;
+    void itemSelected(int providerIndex, bool dontCloseTypeAhead) override;
     void itemFocused(int providerIndex) override;
     void typeaheadCanceled() override;
 
@@ -210,7 +210,7 @@ struct PatchSelector : public juce::Component,
 struct PatchSelectorCommentTooltip : public juce::Component,
                                      public Surge::GUI::SkinConsumingComponent
 {
-    PatchSelectorCommentTooltip(){};
+    PatchSelectorCommentTooltip() {};
     void paint(juce::Graphics &g) override;
 
     std::string comment;

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -210,7 +210,7 @@ struct PatchSelector : public juce::Component,
 struct PatchSelectorCommentTooltip : public juce::Component,
                                      public Surge::GUI::SkinConsumingComponent
 {
-    PatchSelectorCommentTooltip() {};
+    PatchSelectorCommentTooltip() {}
     void paint(juce::Graphics &g) override;
 
     std::string comment;

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -181,7 +181,9 @@ struct TypeAheadListBoxModel : public juce::ListBoxModel
     void selectedRowsChanged(int lastRowSelected) override
     {
         if (lastRowSelected >= 0 && lastRowSelected < search.size())
+        {
             ta->updateSelected(search[lastRowSelected]);
+        }
     }
 
     juce::Component *refreshComponentForRow(int rowNumber, bool isRowSelected,
@@ -300,6 +302,7 @@ void TypeAhead::dismissWithValue(int providerIdx, const std::string &s,
 
     lbox->selectRow(providerIdx);
     lbox->repaint();
+
     for (auto l : taList)
     {
         l->itemSelected(providerIdx);
@@ -324,6 +327,7 @@ void TypeAhead::updateSelected(int providerIdx)
     for (auto l : taList)
     {
         l->itemFocused(providerIdx);
+        l->itemSelected(providerIdx);
     }
 }
 

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -71,7 +71,7 @@ struct TypeAhead : public juce::TextEditor, juce::TextEditor::Listener
     {
         virtual ~TypeAheadListener() = default;
         virtual void itemFocused(int providerIndex) {}
-        virtual void itemSelected(int providerIndex) = 0;
+        virtual void itemSelected(int providerIndex, bool dontCloseTypeAhead = false) = 0;
         virtual void typeaheadCanceled() = 0;
     };
 


### PR DESCRIPTION
Previously, presets would have loaded only when clicking entries via mouse, or when pressing Enter and option "Retain patch search results after loading" enabled.

This is a lot better now. Search result list will now respond with patch loading when pressing Up/Down/Page Up/Page Down/Home/End keys as expected.

Renamed that option so that it's clear it only matters when mouse clicking the search results.