### PR TITLE
Improve patch search result list behavior

### DIFF
--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -57,7 +57,6 @@ struct PatchDBTypeAheadProvider : public TypeAheadDataProvider,
     std::vector<PatchStorage::PatchDB::patchRecord> lastSearchResult;
     std::vector<int> searchFor(const std::string &s) override
     {
-        std::cout << "search for " << s << "\n";
         lastSearchResult = storage->patchDB->queryFromQueryString(s);
         std::vector<int> res(lastSearchResult.size());
         std::iota(res.begin(), res.end(), 0);

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -101,6 +101,8 @@ struct TypeAhead : public juce::TextEditor, juce::TextEditor::Listener
     void textEditorEscapeKeyPressed(juce::TextEditor &editor) override;
 
     bool keyPressed(const juce::KeyPress &press) override;
+
+    juce::SparseSet<int> lastSelectedRow;
 };
 
 } // namespace Widgets


### PR DESCRIPTION
Previously, if we reopened search results that already had one result focused/loaded, pressing the down arrow key would select the first entry in the results list. This is not really intuitive, it would be expected to move to the next entry if we press the down arrow, or the prior entry if we press the up arrow.

This PR makes it so!