### PR TITLE
Close search results when pressing Find Patch keybinding while results are shown

### DIFF
--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -1414,13 +1414,17 @@ void PatchSelector::toggleTypeAheadSearch(bool b)
         }
         else
         {
-            typeAhead->searchAndShowLBox();
+            typeAhead->searchAndShowListBox();
         }
     }
     else
     {
         if (typeAhead->isVisible() && sge)
+        {
             sge->vkbForward--;
+        }
+
+        typeAhead->closeListBox();
         typeAhead->setVisible(false);
     }
     repaint();
@@ -1458,7 +1462,7 @@ void PatchSelector::enableTypeAheadIfReady()
     {
         typeAhead->grabKeyboardFocus();
         typeAhead->selectAll();
-        typeAhead->searchAndShowLBox();
+        typeAhead->searchAndShowListBox();
     }
     else
     {

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -383,17 +383,19 @@ void TypeAhead::parentHierarchyChanged()
     }
 }
 
-void TypeAhead::searchAndShowLBox()
+void TypeAhead::searchAndShowListBox()
 {
     lboxmodel->setSearch(getText().toStdString());
 
-    showLbox();
+    showListBox();
 
     lbox->updateContent();
     lbox->repaint();
 }
 
-void TypeAhead::showLbox()
+void TypeAhead::closeListBox() { lbox->setVisible(false); }
+
+void TypeAhead::showListBox()
 {
     auto p = getParentComponent();
 
@@ -425,7 +427,7 @@ void TypeAhead::textEditorTextChanged(TextEditor &editor)
 
     if (!lbox->isVisible())
     {
-        showLbox();
+        showListBox();
     }
 
     lbox->setSelectedRows(lastSelectedRow);
@@ -445,7 +447,7 @@ bool TypeAhead::keyPressed(const juce::KeyPress &press)
         {
             lastSearch = "";
             lboxmodel->setSearch("");
-            showLbox();
+            showListBox();
 
             lbox->updateContent();
             lbox->repaint();
@@ -506,7 +508,7 @@ void TypeAhead::focusLost(juce::Component::FocusChangeType type)
         return;
     }
 
-    lbox->setVisible(false);
+    closeListBox();
 
     for (auto l : taList)
     {

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.h
@@ -89,8 +89,9 @@ struct TypeAhead : public juce::TextEditor, juce::TextEditor::Listener
     std::unique_ptr<TypeAheadListBoxModel> lboxmodel;
 
     bool isRowMouseOver(int row);
-    void searchAndShowLBox();
-    void showLbox();
+    void searchAndShowListBox();
+    void showListBox();
+    void closeListBox();
     void parentHierarchyChanged() override;
     void textEditorTextChanged(juce::TextEditor &editor) override;
 


### PR DESCRIPTION
Previously the search results would linger around, while the search mode did get terminated.