### PR TITLE
Filter analysis overlay gets value popup and some fixes

### DIFF
--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -1587,14 +1587,17 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
                     // if the readout intersects with a node rect, shift it up
                     // (this only happens in bottom right corner)
-                    if (readout.intersectRectangles(dragX, dragY, dragW, dragH, r.getX(), r.getY(),
-                                                    r.getWidth(), r.getHeight()))
+                    auto overlap = r.getIntersection(readout);
+
+                    if (!overlap.isEmpty())
                     {
-                        readout.translate(-(r.getHeight() / 2), -(r.getHeight() / 2));
+                        readout = readout.withRightX(r.getX()).withBottomY(r.getY());
                     }
 
                     fillr(readout, skin->getColor(Colors::LFO::StepSeq::InfoWindow::Border));
-                    readout = readout.reduced(1, 1);
+
+                    readout.reduce(1, 1);
+
                     fillr(readout, skin->getColor(Colors::LFO::StepSeq::InfoWindow::Background));
 
                     readout = readout.withTrimmedLeft(2).withHeight(10);


### PR DESCRIPTION
The cursor hotzone was offset upwards by 18 px because when hotzone rect was assigned, this apparently didn't take the current juce::Graphics context transform into account, so it needed an additional translate.

The cursor was moving even when clicking outside of the plot bounds.

Minimum resonance value was 0.51% and maximum cutoff also wasn't reachable, because while rx0 and rx1 had 1 subtracted from plot area's width/height, the calculation of current value along the axes used full width/height. So that needs 1 subtracted, too.

In process of fiddling here I also figured out a nicer node/popup overlap resolving method, so I backported that to MSEG editor as well.