### PR TITLE
Fix BP subtype used in Resonator FX

### DIFF
--- a/src/common/dsp/effects/ResonatorEffect.cpp
+++ b/src/common/dsp/effects/ResonatorEffect.cpp
@@ -132,6 +132,7 @@ void ResonatorEffect::process(float *dataL, float *dataR)
     case rm_bandpass_n:
     {
         type = fut_bp12;
+        subtype = sst::filters::FilterSubType::st_bp12_LegacyDriven;
         break;
     }
     case rm_highpass:


### PR DESCRIPTION
Consequence of fixing the Vember classic BP filter snafu.