### PR TITLE
WTScript file loading fixes

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2954,6 +2954,7 @@ void SurgeGUIEditor::wtscriptFileDropped(const string &fn)
 
     evaluator->loadWtscript(fs::path(fn), &synth->storage, oscdata);
 
+    oscdata->wt.current_id = -1;
     oscdata->wt.refresh_display = true;
     oscdata->wt.force_refresh_display = true;
     oscdata->wt.refresh_script_editor = true;

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -3947,6 +3947,10 @@ void WavetableScriptEditor::forceRefresh()
 {
     mainDocument->replaceAllContent(osc->wavetable_formula);
     editor->repaintFrame();
+    setApplyEnabled(false);
+
+    setupEvaluator();
+    rerenderFromUIState();
 }
 
 void WavetableScriptEditor::setApplyEnabled(bool b)

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
@@ -105,10 +105,11 @@ struct OscillatorWaveformDisplay : public juce::Component,
 
     bool keyPressed(const juce::KeyPress &key) override;
 
+    void handleWavetableLoad(int id);
     void loadWavetable(int id);
     void loadWavetableFromFile();
 
-    void loadWavetableScript(const fs::path &location, SurgeStorage *storage,
+    void loadWavetableScript(int id, const fs::path &location, SurgeStorage *storage,
                              OscillatorStorage *oscdata);
     void saveWavetableScript(const fs::path &location, SurgeStorage *storage,
                              OscillatorStorage *oscdata);

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -860,6 +860,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
 
             evaluator->loadWtscript(synth->storage.wt_list[new_id].path, &synth->storage, oscdata);
 
+            oscdata->wt.current_id = -1;
             oscdata->wt.refresh_display = true;
             oscdata->wt.force_refresh_display = true;
             oscdata->wt.refresh_script_editor = true;


### PR DESCRIPTION
- Fixes OWD menu item and category selection due to not setting oscdata->wt.current_id
- Fixes editor preview refresh and sets apply code on script load
- Added branching for missed event handlers for loading script using mouse and keyboard in OWD
- Added "Save script as" default name and overwrite confirmation dialog
