### PR TITLE
More WTS fixes

### DIFF
--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -3110,8 +3110,7 @@ struct WavetablePreviewComponent : public juce::Component, public Surge::GUI::Sk
                 auto cpointOpt = overlay->evaluator->getFrame(idx);
                 if (!cpointOpt.has_value())
                 {
-                    xpos += height + fsGap;
-                    continue;
+                    break; // Exit loop on invalid frame to prevent repeating Lua script errors
                 }
 
                 const auto &cpoint = *cpointOpt;
@@ -3946,6 +3945,9 @@ void WavetableScriptEditor::applyCode()
 void WavetableScriptEditor::forceRefresh()
 {
     mainDocument->replaceAllContent(osc->wavetable_formula);
+    controlArea->resolutionN->setIntValue(osc->wavetable_formula_res_base);
+    controlArea->framesN->setIntValue(osc->wavetable_formula_nframes);
+
     editor->repaintFrame();
     setApplyEnabled(false);
 

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -860,7 +860,7 @@ void OpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
 
             evaluator->loadWtscript(synth->storage.wt_list[new_id].path, &synth->storage, oscdata);
 
-            oscdata->wt.current_id = -1;
+            oscdata->wt.current_id = new_id;
             oscdata->wt.refresh_display = true;
             oscdata->wt.force_refresh_display = true;
             oscdata->wt.refresh_script_editor = true;


### PR DESCRIPTION
Fix wt.current_id not being set when loading .wtscript with OSC commands
Fix repeating Lua script errors in filmstrip mode
Add setting WTS editor controls on loading .wtscript
Improve WTS editor Lua error messages
Remove legacy WTS state table variables