### PR TITLE
Use Inno Setup installer action

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -92,6 +92,11 @@ jobs:
           p12-file-base64: ${{ secrets.MAC_CERTS_P12 }}
           p12-password: ${{ secrets.CERT_PWD }}
 
+      - uses: surge-synthesizer/sst-githubactions/install-innosetup@main
+        if: runner.os == 'Windows'
+        with:
+          version: "6.5.1"
+
       - name: Prepare for JUCE
         uses: surge-synthesizer/sst-githubactions/prepare-for-juce@main
         with:


### PR DESCRIPTION
Uses the recently added Inno Setup installer action from https://github.com/surge-synthesizer/sst-githubactions/pull/1

This should install and cache Inno Setup, and our new find_program logic should just pick it up, skipping a download every time we build a release.