### PR TITLE
Editor overlay things

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1791,6 +1791,11 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
         {
             clipboard_wt[0].Copy(&getPatch().scene[scene].osc[entry].wt);
             clipboard_wt_names[0] = getPatch().scene[scene].osc[entry].wavetable_display_name;
+            clipboard_wavetable_formula[0] = getPatch().scene[scene].osc[entry].wavetable_formula;
+            clipboard_wavetable_formula_nframes[0] =
+                getPatch().scene[scene].osc[entry].wavetable_formula_nframes;
+            clipboard_wavetable_formula_res_base[0] =
+                getPatch().scene[scene].osc[entry].wavetable_formula_res_base;
         }
 
         clipboard_extraconfig[0] = getPatch().scene[scene].osc[entry].extraConfig;
@@ -1848,6 +1853,11 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
             clipboard_wt[i].Copy(&getPatch().scene[scene].osc[i].wt);
             clipboard_wt_names[i] = getPatch().scene[scene].osc[i].wavetable_display_name;
             clipboard_extraconfig[i] = getPatch().scene[scene].osc[i].extraConfig;
+            clipboard_wavetable_formula[i] = getPatch().scene[scene].osc[i].wavetable_formula;
+            clipboard_wavetable_formula_res_base[i] =
+                getPatch().scene[scene].osc[i].wavetable_formula_res_base;
+            clipboard_wavetable_formula_nframes[i] =
+                getPatch().scene[scene].osc[i].wavetable_formula_nframes;
         }
 
         auto fxOffset = 0;
@@ -2111,6 +2121,11 @@ void SurgeStorage::clipboard_paste(
             getPatch().scene[scene].osc[i].extraConfig = clipboard_extraconfig[i];
             getPatch().scene[scene].osc[i].wt.Copy(&clipboard_wt[i]);
             getPatch().scene[scene].osc[i].wavetable_display_name = clipboard_wt_names[i];
+            getPatch().scene[scene].osc[i].wavetable_formula = clipboard_wavetable_formula[i];
+            getPatch().scene[scene].osc[i].wavetable_formula_res_base =
+                clipboard_wavetable_formula_res_base[i];
+            getPatch().scene[scene].osc[i].wavetable_formula_nframes =
+                clipboard_wavetable_formula_nframes[i];
         }
 
         auto fxOffset = 0;
@@ -2210,6 +2225,12 @@ void SurgeStorage::clipboard_paste(
             {
                 getPatch().scene[scene].osc[entry].wt.Copy(&clipboard_wt[0]);
                 getPatch().scene[scene].osc[entry].wavetable_display_name = clipboard_wt_names[0];
+                getPatch().scene[scene].osc[entry].wavetable_formula =
+                    clipboard_wavetable_formula[0];
+                getPatch().scene[scene].osc[entry].wavetable_formula_res_base =
+                    clipboard_wavetable_formula_res_base[0];
+                getPatch().scene[scene].osc[entry].wavetable_formula_nframes =
+                    clipboard_wavetable_formula_nframes[0];
             }
 
             // copy modroutings

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -136,7 +136,7 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 //                               added deform option for Release parameter of Filter/Amp EG, which only produces an open gate for the release stage
 // 23 -> 24 (XT 1.3.3 nightlies) added actually functioning extend mode to FM2 oscillator's M1/2 Offset parameter
 //                                     (old patches load with extend disabled even if they had it enabled)
-// 24 -> 25 (XT 1.3.4 nightlies) added storing of Wavetable Editor window state
+// 24 -> 25 (XT 1.3.4 nightlies) added storing of Wavetable Script Editor window state
 // 25 -> 26 (XT 1.4.* nightlies) added WT Deform for new WT features
 //                               changed how extend-to-bipolar works for LFO Amplitude parameter
 //                               added DAWExtraState members for saving the state of Lua code editors, and variable group states in debugger
@@ -1841,6 +1841,10 @@ class alignas(16) SurgeStorage
         clipboard_modulation_global;
     Wavetable clipboard_wt[n_oscs];
     std::array<std::string, n_oscs> clipboard_wt_names;
+    std::array<std::string, n_oscs> clipboard_wavetable_formula;
+    std::array<int, n_oscs> clipboard_wavetable_formula_res_base;
+    std::array<int, n_oscs> clipboard_wavetable_formula_nframes;
+
     char clipboard_modulator_names[n_lfos][max_lfo_indices][CUSTOM_CONTROLLER_LABEL_SIZE + 1];
     MonoVoicePriorityMode clipboard_primode = NOTE_ON_LATEST_RETRIGGER_HIGHEST;
     MonoVoiceEnvelopeMode clipboard_envmode = RESTART_FROM_ZERO;

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -214,6 +214,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     void changeSelectedOsc(int value);
     void changeSelectedScene(int value);
+    void closeOrRefreshWTSEditor();
 
     void refreshSkin();
 

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -290,7 +290,7 @@ inline std::string keyboardActionDescription(KeyboardActions a)
         break;
 #if INCLUDE_WT_SCRIPTING_EDITOR
     case TOGGLE_WT_EDITOR:
-        desc = "Wavetable Editor";
+        desc = "Wavetable Script Editor";
         break;
 #endif
     case TOGGLE_MODLIST:

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -294,7 +294,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
             this, &(this->synth->storage), os, current_osc[current_scene], current_scene,
             currentSkin);
 
-        std::string title = fmt::format("Osc {} Wavetable Editor", current_osc[current_scene] + 1);
+        std::string title =
+            fmt::format("Osc {} Wavetable Script Editor", current_osc[current_scene] + 1);
 
         wtse->setSkin(currentSkin, bitmapStore);
         wtse->setEnclosingParentTitle(title);
@@ -822,6 +823,7 @@ bool SurgeGUIEditor::updateOverlayContentIfPresent(OverlayTags tag)
     case TUNING_EDITOR:
     {
         auto tunol = dynamic_cast<Surge::Overlays::TuningOverlay *>(getOverlayIfOpen(tag));
+
         if (tunol)
         {
             tunol->setTuning(synth->storage.currentTuning);
@@ -838,16 +840,38 @@ bool SurgeGUIEditor::updateOverlayContentIfPresent(OverlayTags tag)
         }
         break;
     }
-    case WAVESHAPER_ANALYZER:
+    case FORMULA_EDITOR:
     {
-        updateWaveshaperOverlay();
+        auto feol = dynamic_cast<Surge::Overlays::FormulaModulatorEditor *>(getOverlayIfOpen(tag));
+
+        if (feol)
+        {
+            feol->forceRefresh();
+        }
+        break;
+    }
+    case WT_EDITOR:
+    {
+        auto wtsol = dynamic_cast<Surge::Overlays::WavetableScriptEditor *>(getOverlayIfOpen(tag));
+
+        if (wtsol)
+        {
+            wtsol->forceRefresh();
+        }
         break;
     }
     case FILTER_ANALYZER:
     {
         auto f = getOverlayIfOpen(tag);
         if (f)
+        {
             f->repaint();
+        }
+        break;
+    }
+    case WAVESHAPER_ANALYZER:
+    {
+        updateWaveshaperOverlay();
         break;
     }
     default:

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -404,6 +404,8 @@ void SurgeGUIEditor::changeSelectedOsc(int value)
         }
     }
 
+    closeOrRefreshWTSEditor();
+
     queue_refresh = true;
 }
 
@@ -448,9 +450,57 @@ void SurgeGUIEditor::changeSelectedScene(int value)
         }
     }
 
+    closeOrRefreshWTSEditor();
+
     refresh_mod();
 
     queue_refresh = true;
+}
+
+void SurgeGUIEditor::closeOrRefreshWTSEditor()
+{
+    bool hadExtendedOverlay = false;
+    bool wasTornOut = false;
+    juce::Point<int> tearOutLoc;
+    auto otag = WT_EDITOR;
+
+    if (isAnyOverlayPresent(otag))
+    {
+        auto c = getOverlayWrapperIfOpen(otag);
+        if (c)
+        {
+            wasTornOut = c->isTornOut();
+            tearOutLoc = c->currentTearOutLocation();
+        }
+        if (!wasTornOut)
+        {
+            closeOverlay(otag);
+        }
+        hadExtendedOverlay = true;
+    }
+
+    if (hadExtendedOverlay)
+    {
+        auto &oscdata =
+            synth->storage.getPatch().scene[current_scene].osc[current_osc[current_scene]];
+
+        if (oscdata.type.val.i == ot_wavetable)
+        {
+            if (wasTornOut)
+            {
+                closeOverlay(otag);
+            }
+            showOverlay(otag);
+            if (wasTornOut)
+            {
+                auto c = getOverlayWrapperIfOpen(otag);
+                if (c)
+                {
+                    c->doTearOut(tearOutLoc);
+                }
+            }
+        }
+    }
 }
 
 void SurgeGUIEditor::refreshSkin()

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -2807,6 +2807,7 @@ void FormulaModulatorEditor::applyCode()
 void FormulaModulatorEditor::forceRefresh()
 {
     mainDocument->replaceAllContent(formulastorage->formulaString);
+    setApplyEnabled(false);
     editor->repaintFrame();
 }
 
@@ -3770,26 +3771,11 @@ struct WavetableScriptControlArea : public juce::Component,
         break;
         case tag_frames_value:
         {
-            /*
-            int currentFrame = currentFrameN->getIntValue();
-            int maxFrames = framesN->getIntValue();
-            if (currentFrame > maxFrames)
-            {
-                currentFrameN->setIntValue(maxFrames);
-                overlay->rendererComponent->frameNumber = maxFrames;
-            }
-            overlay->osc->wavetable_formula_nframes = maxFrames;
-            overlay->rerenderFromUIState();
-            */
             overlay->setApplyEnabled(true);
         }
         break;
         case tag_res_value:
         {
-            /*
-            overlay->osc->wavetable_formula_res_base = resolutionN->getIntValue();
-            overlay->rerenderFromUIState();
-            */
             overlay->setApplyEnabled(true);
         }
         break;
@@ -3852,7 +3838,7 @@ WavetableScriptEditor::WavetableScriptEditor(SurgeGUIEditor *ed, SurgeStorage *s
     mainEditor->setDescription("Wavetable Code");
     mainEditor->onFocusLost = [this]() { this->saveState(); };
 
-    if (osc->wavetable_formula == "")
+    if (osc->wavetable_formula.empty())
     {
         mainDocument->insertText(0,
                                  Surge::WavetableScript::LuaWTEvaluator::defaultWavetableScript());
@@ -3944,7 +3930,16 @@ void WavetableScriptEditor::applyCode()
 
 void WavetableScriptEditor::forceRefresh()
 {
-    mainDocument->replaceAllContent(osc->wavetable_formula);
+    if (osc->wavetable_formula.empty())
+    {
+        mainDocument->replaceAllContent(
+            Surge::WavetableScript::LuaWTEvaluator::defaultWavetableScript());
+    }
+    else
+    {
+        mainDocument->replaceAllContent(osc->wavetable_formula);
+    }
+
     controlArea->resolutionN->setIntValue(osc->wavetable_formula_res_base);
     controlArea->framesN->setIntValue(osc->wavetable_formula_nframes);
 
@@ -4110,8 +4105,8 @@ WavetableScriptEditor::getPreCloseChickenBoxMessage()
 {
     if (controlArea->applyS->isEnabled())
     {
-        return std::make_pair("Close Wavetable Editor",
-                              "Do you really want to close the wavetable editor? Any "
+        return std::make_pair("Close Wavetable Script Editor",
+                              "Do you really want to close the script editor? Any "
                               "changes that were not applied will be lost!");
     }
     return std::nullopt;


### PR DESCRIPTION
- Add WTS data to Copy Osc and Copy Scene
- Switch active WTS overlay on Osc and Scene select if applicable (new osc type == wavetable)
- Use forceRefresh() for editors on patch / preset load instead of opening and closing
- Sets editor apply buttons on forceRefresh() to fix case where unapplied changes prompts chickenbox dialog box hidden behind opened overlay on patch change
- Close active WTS overlay on patch change if applicable
- Disable WTS Editor keybind action if current osc is not wavetable
- Rename some instances of "Wavetable Editor" to "Wavetable Script Editor"