### PR TITLE
WTS undomanager and UI tweaks again

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1406,6 +1406,7 @@ void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *os
                 osc->wavetable_formula_nframes = 10;
             }
         }
+        osc->wt.refresh_script_editor = true;
     }
 }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2955,18 +2955,16 @@ void SurgeGUIEditor::toggleTuning()
 void SurgeGUIEditor::wtscriptFileDropped(const string &fn)
 {
     undoManager()->pushWavetable(current_scene, current_osc[current_scene]);
-    OscillatorStorage *oscdata =
-        &synth->storage.getPatch().scene[current_scene].osc[current_osc[current_scene]];
 
     if (!evaluator)
         evaluator = std::make_unique<Surge::WavetableScript::LuaWTEvaluator>();
 
+    OscillatorStorage *oscdata =
+        &synth->storage.getPatch().scene[current_scene].osc[current_osc[current_scene]];
     evaluator->loadWtscript(fs::path(fn), &synth->storage, oscdata);
 
     oscdata->wt.current_id = -1;
-    oscdata->wt.refresh_display = true;
-    oscdata->wt.force_refresh_display = true;
-    oscdata->wt.refresh_script_editor = true;
+    oscdata->queue_type = ot_wavetable; // Setting queue_type also handles OWD/editor refresh
 }
 
 void SurgeGUIEditor::scaleFileDropped(const string &fn)


### PR DESCRIPTION
- Fix undomanager for .wtscript files and use wt.Copy() for snapshots
- Also refresh editor on loading wavetable
- Switch osc type on .wtscript file drop