### PR TITLE
Fix trivial typos in Mac installer message.

### DIFF
--- a/scripts/installer_mac/Resources/Readme.rtf
+++ b/scripts/installer_mac/Resources/Readme.rtf
@@ -17,7 +17,7 @@
 \
 Surge XT is maintained by a group of volunteers and is distributed as an AU, CLAP, VST3 and Standalone app. This package also contains the Surge XT Effects Bank, also as an AU, CLAP, VST3 and Standalone.\
 \
-The Surge mac team tests regularly in Logic Reaper and Bitwig.\
+The Surge Mac team tests regularly in Logic, Reaper and Bitwig.\
 \
 If you want to chat with the Surge XT maintainers, we strongly encourage you to join our discord!\
 \


### PR DESCRIPTION
* Add comma between Logic and Reaper.
* Capitalize Mac for consistency with Apple's naming style.