### PR TITLE
WTS renames and cleanup

### DIFF
--- a/resources/data/skins/dark-mode.surge-skin/skin.xml
+++ b/resources/data/skins/dark-mode.surge-skin/skin.xml
@@ -460,7 +460,7 @@
         <control ui_identifier="msegeditor.window" y="57" w="748"/>
         <control ui_identifier="formulaeditor.window" y="57" w="748"/>
         <control ui_identifier="tuningeditor.window" y="57" w="748" h="512"/>
-        <control ui_identifier="wteditor.window" x="149" y="56" w="755" h="513"/>
+        <control ui_identifier="wtseditor.window" x="149" y="56" w="755" h="513"/>
         <control ui_identifier="modlist.window" x="149" y="56" w="600" h="513"/>
         <control ui_identifier="filter.filter_analysis.window" x="298" y="261" h="211"/>
         <control ui_identifier="filter.waveshaper_analysis.window" x="449" y="238"/>

--- a/src/common/ModulatorPresetManager.cpp
+++ b/src/common/ModulatorPresetManager.cpp
@@ -33,7 +33,7 @@ namespace Storage
 {
 
 const static std::string PresetDir = "Modulator Presets";
-const static std::string PresetXtn = ".modpreset";
+const static std::string PresetExt = ".modpreset";
 
 void ModulatorPreset::savePresetToUser(const fs::path &location, SurgeStorage *s, int scene,
                                        int lfoid)
@@ -68,7 +68,7 @@ void ModulatorPreset::savePresetToUser(const fs::path &location, SurgeStorage *s
 
         auto comppath = containingPath;
         auto fullLocation =
-            (containingPath / location).lexically_normal().replace_extension(PresetXtn);
+            (containingPath / location).lexically_normal().replace_extension(PresetExt);
 
         // make sure your category isnt "../../../etc/config"
         auto [_, compIt] = std::mismatch(fullLocation.begin(), fullLocation.end(), comppath.begin(),
@@ -337,7 +337,7 @@ std::vector<ModulatorPreset::Category> ModulatorPreset::getPresets(SurgeStorage 
                 auto dp = fs::path(d);
                 auto base = dp.stem();
                 auto ext = dp.extension();
-                if (path_to_string(ext) != PresetXtn)
+                if (path_to_string(ext) != PresetExt)
                 {
                     continue;
                 }

--- a/src/common/SkinModel.cpp
+++ b/src/common/SkinModel.cpp
@@ -604,8 +604,8 @@ Connector mseg_editor = Connector("msegeditor.window", 0, 57, 750, 366, Componen
 Connector formula_editor = Connector("formulaeditor.window", 0, 57, 750, 366, Components::Custom,
                                      Connector::FORMULA_EDITOR_WINDOW);
 
-Connector wt_editor = Connector("wteditor.window", 150, 57, 756, 512, Components::Custom,
-                                Connector::WT_EDITOR_WINDOW);
+Connector wts_editor = Connector("wtseditor.window", 150, 57, 756, 512, Components::Custom,
+                                 Connector::WTS_EDITOR_WINDOW);
 
 Connector tuning_editor = Connector("tuningeditor.window", 0, 57, 750, 512, Components::Custom,
                                     Connector::TUNING_EDITOR_WINDOW);

--- a/src/common/SkinModel.h
+++ b/src/common/SkinModel.h
@@ -285,7 +285,7 @@ struct Connector
         OSCILLOSCOPE_WINDOW,
         WAVESHAPER_ANALYSIS_WINDOW,
         FORMULA_EDITOR_WINDOW,
-        WT_EDITOR_WINDOW,
+        WTS_EDITOR_WINDOW,
         TUNING_EDITOR_WINDOW,
         MOD_LIST_WINDOW,
 
@@ -454,7 +454,7 @@ extern Surge::Skin::Connector vu_meter;
 
 extern Surge::Skin::Connector patch_browser;
 
-extern Surge::Skin::Connector mseg_editor, formula_editor, wt_editor, tuning_editor;
+extern Surge::Skin::Connector mseg_editor, formula_editor, wts_editor, tuning_editor;
 
 extern Surge::Skin::Connector mod_list;
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -153,9 +153,9 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
         {
             // Initialize the display name here
             scene[sc].osc[osc].wavetable_display_name = "";
-            scene[sc].osc[osc].wavetable_formula = "";
-            scene[sc].osc[osc].wavetable_formula_nframes = 10;
-            scene[sc].osc[osc].wavetable_formula_res_base = 5;
+            scene[sc].osc[osc].wavetable_script = "";
+            scene[sc].osc[osc].wavetable_script_nframes = 10;
+            scene[sc].osc[osc].wavetable_script_res_base = 5;
 
             a->push_back(scene[sc].osc[osc].type.assign(
                 p_id.next(), id_s++, "type", "Type",
@@ -2268,9 +2268,9 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
         for (int osc = 0; osc < n_oscs; osc++)
         {
             scene[sc].osc[osc].wavetable_display_name = "";
-            scene[sc].osc[osc].wavetable_formula = "";
-            scene[sc].osc[osc].wavetable_formula_nframes = 10;
-            scene[sc].osc[osc].wavetable_formula_res_base = 5;
+            scene[sc].osc[osc].wavetable_script = "";
+            scene[sc].osc[osc].wavetable_script_nframes = 10;
+            scene[sc].osc[osc].wavetable_script_res_base = 5;
         }
     }
 
@@ -2293,22 +2293,41 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                         lkid->Attribute("wavetable_display_name");
                 }
 
+                if (lkid->Attribute("wavetable_script"))
+                {
+                    int wfi;
+
+                    scene[ssc].osc[sos].wavetable_script =
+                        Surge::Storage::base64_decode(lkid->Attribute("wavetable_script"));
+
+                    if (lkid->QueryIntAttribute("wavetable_script_nframes", &wfi) == TIXML_SUCCESS)
+                    {
+                        scene[ssc].osc[sos].wavetable_script_nframes = wfi;
+                    }
+
+                    if (lkid->QueryIntAttribute("wavetable_script_res_base", &wfi) == TIXML_SUCCESS)
+                    {
+                        scene[ssc].osc[sos].wavetable_script_res_base = wfi;
+                    }
+                }
+
+                // TODO: Deprecated, remove later
                 if (lkid->Attribute("wavetable_formula"))
                 {
                     int wfi;
 
-                    scene[ssc].osc[sos].wavetable_formula =
+                    scene[ssc].osc[sos].wavetable_script =
                         Surge::Storage::base64_decode(lkid->Attribute("wavetable_formula"));
 
                     if (lkid->QueryIntAttribute("wavetable_formula_nframes", &wfi) == TIXML_SUCCESS)
                     {
-                        scene[ssc].osc[sos].wavetable_formula_nframes = wfi;
+                        scene[ssc].osc[sos].wavetable_script_nframes = wfi;
                     }
 
                     if (lkid->QueryIntAttribute("wavetable_formula_res_base", &wfi) ==
                         TIXML_SUCCESS)
                     {
-                        scene[ssc].osc[sos].wavetable_formula_res_base = wfi;
+                        scene[ssc].osc[sos].wavetable_script_res_base = wfi;
                     }
                 }
 
@@ -3563,16 +3582,16 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
             {
                 on.SetAttribute("wavetable_display_name", scene[sc].osc[os].wavetable_display_name);
 
-                auto wtfo = scene[sc].osc[os].wavetable_formula;
+                auto wtfo = scene[sc].osc[os].wavetable_script;
                 auto wtfol = wtfo.length();
 
                 on.SetAttribute(
-                    "wavetable_formula",
+                    "wavetable_script",
                     Surge::Storage::base64_encode((unsigned const char *)wtfo.c_str(), wtfol));
-                on.SetAttribute("wavetable_formula_nframes",
-                                scene[sc].osc[os].wavetable_formula_nframes);
-                on.SetAttribute("wavetable_formula_res_base",
-                                scene[sc].osc[os].wavetable_formula_res_base);
+                on.SetAttribute("wavetable_script_nframes",
+                                scene[sc].osc[os].wavetable_script_nframes);
+                on.SetAttribute("wavetable_script_res_base",
+                                scene[sc].osc[os].wavetable_script_res_base);
             }
 
             auto ec = &(scene[sc].osc[os].extraConfig);

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1391,9 +1391,9 @@ void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *os
 
         if (metadata.empty())
         {
-            osc->wavetable_formula = {};
-            osc->wavetable_formula_res_base = 5;
-            osc->wavetable_formula_nframes = 10;
+            osc->wavetable_script = {};
+            osc->wavetable_script_res_base = 5;
+            osc->wavetable_script_nframes = 10;
         }
         else
         {
@@ -1401,9 +1401,9 @@ void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *os
             {
                 reportError("Unable to parse metadata", "WaveTable Load");
                 std::cerr << metadata << std::endl;
-                osc->wavetable_formula = {};
-                osc->wavetable_formula_res_base = 5;
-                osc->wavetable_formula_nframes = 10;
+                osc->wavetable_script = {};
+                osc->wavetable_script_res_base = 5;
+                osc->wavetable_script_nframes = 10;
             }
         }
         osc->wt.refresh_script_editor = true;
@@ -1618,17 +1618,17 @@ std::string SurgeStorage::make_wt_metadata(OscillatorStorage *oscdata)
     TiXmlDocument doc("wtmeta");
     TiXmlElement root("wtmeta");
     TiXmlElement surge("surge");
-    if (!oscdata->wavetable_formula.empty())
+    if (!oscdata->wavetable_script.empty())
     {
         TiXmlElement script("script");
 
-        auto wtfo = oscdata->wavetable_formula;
+        auto wtfo = oscdata->wavetable_script;
         auto wtfol = wtfo.length();
 
         script.SetAttribute(
             "lua", Surge::Storage::base64_encode((unsigned const char *)wtfo.c_str(), wtfol));
-        script.SetAttribute("nframes", oscdata->wavetable_formula_nframes);
-        script.SetAttribute("res_base", oscdata->wavetable_formula_res_base);
+        script.SetAttribute("nframes", oscdata->wavetable_script_nframes);
+        script.SetAttribute("res_base", oscdata->wavetable_script_res_base);
         surge.InsertEndChild(script);
         hasMeta = true;
     }
@@ -1687,9 +1687,9 @@ bool SurgeStorage::parse_wt_metadata(const std::string &m, OscillatorStorage *os
         return false;
     }
 
-    oscdata->wavetable_formula = Surge::Storage::base64_decode(bscript);
-    oscdata->wavetable_formula_nframes = n;
-    oscdata->wavetable_formula_res_base = s;
+    oscdata->wavetable_script = Surge::Storage::base64_decode(bscript);
+    oscdata->wavetable_script_nframes = n;
+    oscdata->wavetable_script_res_base = s;
 
     return true;
 }
@@ -1792,11 +1792,11 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
         {
             clipboard_wt[0].Copy(&getPatch().scene[scene].osc[entry].wt);
             clipboard_wt_names[0] = getPatch().scene[scene].osc[entry].wavetable_display_name;
-            clipboard_wavetable_formula[0] = getPatch().scene[scene].osc[entry].wavetable_formula;
-            clipboard_wavetable_formula_nframes[0] =
-                getPatch().scene[scene].osc[entry].wavetable_formula_nframes;
-            clipboard_wavetable_formula_res_base[0] =
-                getPatch().scene[scene].osc[entry].wavetable_formula_res_base;
+            clipboard_wavetable_script[0] = getPatch().scene[scene].osc[entry].wavetable_script;
+            clipboard_wavetable_script_nframes[0] =
+                getPatch().scene[scene].osc[entry].wavetable_script_nframes;
+            clipboard_wavetable_script_res_base[0] =
+                getPatch().scene[scene].osc[entry].wavetable_script_res_base;
         }
 
         clipboard_extraconfig[0] = getPatch().scene[scene].osc[entry].extraConfig;
@@ -1854,11 +1854,11 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
             clipboard_wt[i].Copy(&getPatch().scene[scene].osc[i].wt);
             clipboard_wt_names[i] = getPatch().scene[scene].osc[i].wavetable_display_name;
             clipboard_extraconfig[i] = getPatch().scene[scene].osc[i].extraConfig;
-            clipboard_wavetable_formula[i] = getPatch().scene[scene].osc[i].wavetable_formula;
-            clipboard_wavetable_formula_res_base[i] =
-                getPatch().scene[scene].osc[i].wavetable_formula_res_base;
-            clipboard_wavetable_formula_nframes[i] =
-                getPatch().scene[scene].osc[i].wavetable_formula_nframes;
+            clipboard_wavetable_script[i] = getPatch().scene[scene].osc[i].wavetable_script;
+            clipboard_wavetable_script_res_base[i] =
+                getPatch().scene[scene].osc[i].wavetable_script_res_base;
+            clipboard_wavetable_script_nframes[i] =
+                getPatch().scene[scene].osc[i].wavetable_script_nframes;
         }
 
         auto fxOffset = 0;
@@ -2122,11 +2122,11 @@ void SurgeStorage::clipboard_paste(
             getPatch().scene[scene].osc[i].extraConfig = clipboard_extraconfig[i];
             getPatch().scene[scene].osc[i].wt.Copy(&clipboard_wt[i]);
             getPatch().scene[scene].osc[i].wavetable_display_name = clipboard_wt_names[i];
-            getPatch().scene[scene].osc[i].wavetable_formula = clipboard_wavetable_formula[i];
-            getPatch().scene[scene].osc[i].wavetable_formula_res_base =
-                clipboard_wavetable_formula_res_base[i];
-            getPatch().scene[scene].osc[i].wavetable_formula_nframes =
-                clipboard_wavetable_formula_nframes[i];
+            getPatch().scene[scene].osc[i].wavetable_script = clipboard_wavetable_script[i];
+            getPatch().scene[scene].osc[i].wavetable_script_res_base =
+                clipboard_wavetable_script_res_base[i];
+            getPatch().scene[scene].osc[i].wavetable_script_nframes =
+                clipboard_wavetable_script_nframes[i];
         }
 
         auto fxOffset = 0;
@@ -2226,12 +2226,11 @@ void SurgeStorage::clipboard_paste(
             {
                 getPatch().scene[scene].osc[entry].wt.Copy(&clipboard_wt[0]);
                 getPatch().scene[scene].osc[entry].wavetable_display_name = clipboard_wt_names[0];
-                getPatch().scene[scene].osc[entry].wavetable_formula =
-                    clipboard_wavetable_formula[0];
-                getPatch().scene[scene].osc[entry].wavetable_formula_res_base =
-                    clipboard_wavetable_formula_res_base[0];
-                getPatch().scene[scene].osc[entry].wavetable_formula_nframes =
-                    clipboard_wavetable_formula_nframes[0];
+                getPatch().scene[scene].osc[entry].wavetable_script = clipboard_wavetable_script[0];
+                getPatch().scene[scene].osc[entry].wavetable_script_res_base =
+                    clipboard_wavetable_script_res_base[0];
+                getPatch().scene[scene].osc[entry].wavetable_script_nframes =
+                    clipboard_wavetable_script_nframes[0];
             }
 
             // copy modroutings

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -654,9 +654,9 @@ struct OscillatorStorage : public CountedSetUserData // The counted set is the w
     Wavetable wt;
 
     std::string wavetable_display_name;
-    std::string wavetable_formula = "";
-    int wavetable_formula_res_base = 5, // 32 * 2^this
-        wavetable_formula_nframes = 10;
+    std::string wavetable_script = "";
+    int wavetable_script_res_base = 5, // 32 * 2^this
+        wavetable_script_nframes = 10;
 
     void *queue_xmldata;
     int queue_type;
@@ -1841,9 +1841,9 @@ class alignas(16) SurgeStorage
         clipboard_modulation_global;
     Wavetable clipboard_wt[n_oscs];
     std::array<std::string, n_oscs> clipboard_wt_names;
-    std::array<std::string, n_oscs> clipboard_wavetable_formula;
-    std::array<int, n_oscs> clipboard_wavetable_formula_res_base;
-    std::array<int, n_oscs> clipboard_wavetable_formula_nframes;
+    std::array<std::string, n_oscs> clipboard_wavetable_script;
+    std::array<int, n_oscs> clipboard_wavetable_script_res_base;
+    std::array<int, n_oscs> clipboard_wavetable_script_nframes;
 
     char clipboard_modulator_names[n_lfos][max_lfo_indices][CUSTOM_CONTROLLER_LABEL_SIZE + 1];
     MonoVoicePriorityMode clipboard_primode = NOTE_ON_LATEST_RETRIGGER_HIGHEST;

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -406,9 +406,9 @@ void LuaWTEvaluator::generateWavetable(SurgeStorage *storage, OscillatorStorage 
                                        Wavetable *wt, bool exportMode)
 {
 #if HAS_LUA
-    auto res_base = oscdata->wavetable_formula_res_base;
-    auto nframes = oscdata->wavetable_formula_nframes;
-    auto script = oscdata->wavetable_formula;
+    auto res_base = oscdata->wavetable_script_res_base;
+    auto nframes = oscdata->wavetable_script_nframes;
+    auto script = oscdata->wavetable_script;
 
     auto respt = 32;
     for (int i = 1; i < res_base; ++i)
@@ -489,9 +489,9 @@ void LuaWTEvaluator::loadWtscript(const fs::path &filename, SurgeStorage *storag
         return;
     }
 
-    oscdata->wavetable_formula_nframes = nframes;
-    oscdata->wavetable_formula_res_base = res_base;
-    oscdata->wavetable_formula = Surge::Storage::base64_decode(b64script);
+    oscdata->wavetable_script_nframes = nframes;
+    oscdata->wavetable_script_res_base = res_base;
+    oscdata->wavetable_script = Surge::Storage::base64_decode(b64script);
 
     generateWavetable(storage, oscdata, &oscdata->wt);
 #endif

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -410,7 +410,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         PATCH_BROWSER,
         MODULATION_EDITOR,
         FORMULA_EDITOR,
-        WT_EDITOR,
+        WTS_EDITOR,
         TUNING_EDITOR,
         WAVESHAPER_ANALYZER,
         FILTER_ANALYZER,
@@ -554,6 +554,22 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
     void playNote(char key, char vel);
     void releaseNote(char key, char vel);
+
+    enum WTExportFormat
+    {
+        WAV,
+        WT,
+        SERUM,
+        VCVRACK
+    };
+    void exportWavetableAs(WTExportFormat exportFormat);
+    void loadWavetableScript();
+    void loadWavetableScript(int id, const fs::path &location, SurgeStorage *storage,
+                             OscillatorStorage *oscdata,
+                             Surge::WavetableScript::LuaWTEvaluator *evaluator);
+    void saveWavetableScript();
+    void saveWavetableScript(const fs::path &location, SurgeStorage *storage,
+                             OscillatorStorage *oscdata);
 
   private:
     juce::Rectangle<int> positionForModulationGrid(modsources entry);

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -64,7 +64,7 @@ enum KeyboardActions
     TOGGLE_KEYBIND_EDITOR,
     TOGGLE_LFO_EDITOR,
 #if INCLUDE_WT_SCRIPTING_EDITOR
-    TOGGLE_WT_EDITOR,
+    TOGGLE_WTS_EDITOR,
 #endif
     TOGGLE_MODLIST,
     TOGGLE_TUNING_EDITOR,
@@ -154,8 +154,8 @@ inline std::string keyboardActionName(KeyboardActions a)
         return "SHOW_KEYBINDINGS_EDITOR";
     case TOGGLE_LFO_EDITOR:
         return "SHOW_LFO_EDITOR";
-    case TOGGLE_WT_EDITOR:
-        return "SHOW_WT_EDITOR";
+    case TOGGLE_WTS_EDITOR:
+        return "SHOW_WTS_EDITOR";
     case TOGGLE_MODLIST:
         return "SHOW_MODLIST";
     case TOGGLE_TUNING_EDITOR:
@@ -289,7 +289,7 @@ inline std::string keyboardActionDescription(KeyboardActions a)
         desc = "LFO Editor (MSEG or Formula)";
         break;
 #if INCLUDE_WT_SCRIPTING_EDITOR
-    case TOGGLE_WT_EDITOR:
+    case TOGGLE_WTS_EDITOR:
         desc = "Wavetable Script Editor";
         break;
 #endif

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -214,7 +214,7 @@ juce::PopupMenu SurgeGUIEditor::makeLfoMenu(const juce::Point<int> &where)
     lfoSubMenu.addItem(
         Surge::GUI::toOSCase("Save " + what + " Preset As..."), [this, currentLfoId, what]() {
             promptForMiniEdit(
-                "", "Enter the preset name:", what + " Preset Name", juce::Point<int>{},
+                "", "Enter the preset name:", "Save " + what + " Preset", juce::Point<int>{},
                 [this, currentLfoId](const std::string &s) {
                     this->synth->storage.modulatorPreset->savePresetToUser(
                         string_to_path(s), &(this->synth->storage), current_scene, currentLfoId);

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -280,7 +280,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         return fme;
     }
 
-    case WT_EDITOR:
+    case WTS_EDITOR:
     {
 
         auto os = &synth->storage.getPatch().scene[current_scene].osc[current_osc[current_scene]];
@@ -304,7 +304,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
                              Surge::Storage::WTScriptOverlayTearOutAlwaysOnTop_Plugin});
         wtse->setCanTearOutResize({true, Surge::Storage::WTScriptOverlaySizeTearOut});
         wtse->setMinimumSize(500, 400);
-        locationGet(wtse.get(), Surge::Skin::Connector::NonParameterConnection::WT_EDITOR_WINDOW,
+        locationGet(wtse.get(), Surge::Skin::Connector::NonParameterConnection::WTS_EDITOR_WINDOW,
                     Surge::Storage::WTScriptOverlayLocation);
 
         return wtse;
@@ -582,7 +582,7 @@ void SurgeGUIEditor::closeOverlay(OverlayTags olt)
 
     if (isAnyOverlayPresent(olt))
     {
-        if (olt == FORMULA_EDITOR || olt == WT_EDITOR)
+        if (olt == FORMULA_EDITOR || olt == WTS_EDITOR)
         {
             // Run the chickenbox path
             olw->onClose();
@@ -860,7 +860,7 @@ bool SurgeGUIEditor::updateOverlayContentIfPresent(OverlayTags tag)
         }
         break;
     }
-    case WT_EDITOR:
+    case WTS_EDITOR:
     {
         auto wtsol = dynamic_cast<Surge::Overlays::WavetableScriptEditor *>(getOverlayIfOpen(tag));
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -465,7 +465,7 @@ void SurgeGUIEditor::closeOrRefreshWTSEditor()
     bool hadExtendedOverlay = false;
     bool wasTornOut = false;
     juce::Point<int> tearOutLoc;
-    auto otag = WT_EDITOR;
+    auto otag = WTS_EDITOR;
 
     if (isAnyOverlayPresent(otag))
     {

--- a/src/surge-xt/gui/UndoManager.cpp
+++ b/src/surge-xt/gui/UndoManager.cpp
@@ -115,9 +115,9 @@ struct UndoManagerImpl
 
         std::string displayName;
 
-        std::string wavetable_formula = "";
-        int wavetable_formula_res_base = 5, // 32 * 2^this
-            wavetable_formula_nframes = 10;
+        std::string wavetable_script = "";
+        int wavetable_script_res_base = 5, // 32 * 2^this
+            wavetable_script_nframes = 10;
     };
     struct UndoOscillatorExtraConfig
     {
@@ -594,11 +594,11 @@ struct UndoManagerImpl
         {
             r.wt = std::make_shared<Wavetable>();
             r.wt->Copy(&(os->wt));
-            if (!os->wavetable_formula.empty())
+            if (!os->wavetable_script.empty())
             {
-                r.wavetable_formula = os->wavetable_formula;
-                r.wavetable_formula_res_base = os->wavetable_formula_res_base;
-                r.wavetable_formula_nframes = os->wavetable_formula_nframes;
+                r.wavetable_script = os->wavetable_script;
+                r.wavetable_script_res_base = os->wavetable_script_res_base;
+                r.wavetable_script_nframes = os->wavetable_script_nframes;
             }
         }
 
@@ -944,9 +944,9 @@ struct UndoManagerImpl
                 os->wt.Copy(p->wt.get());
                 synth->refresh_editor = true;
 
-                os->wavetable_formula = p->wavetable_formula;
-                os->wavetable_formula_res_base = p->wavetable_formula_res_base;
-                os->wavetable_formula_nframes = p->wavetable_formula_nframes;
+                os->wavetable_script = p->wavetable_script;
+                os->wavetable_script_res_base = p->wavetable_script_res_base;
+                os->wavetable_script_nframes = p->wavetable_script_nframes;
                 os->wt.refresh_script_editor = true;
             }
             else

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -3444,7 +3444,7 @@ struct WavetableScriptControlArea : public juce::Component,
             btnrect = juce::Rectangle(xpos, ypos, numfieldWidth, numfieldHeight);
             framesN->setBounds(btnrect);
             framesN->setControlMode(Surge::Skin::Parameters::WTSE_FRAMES);
-            framesN->setIntValue(overlay->osc->wavetable_formula_nframes);
+            framesN->setIntValue(overlay->osc->wavetable_script_nframes);
             framesN->addListener(this);
             framesN->setTag(tag_frames_value);
             framesN->setStorage(overlay->storage);
@@ -3474,7 +3474,7 @@ struct WavetableScriptControlArea : public juce::Component,
             btnrect = juce::Rectangle(xpos, ypos, numfieldWidth, numfieldHeight);
             resolutionN->setBounds(btnrect);
             resolutionN->setControlMode(Surge::Skin::Parameters::WTSE_RESOLUTION);
-            resolutionN->setIntValue(overlay->osc->wavetable_formula_res_base);
+            resolutionN->setIntValue(overlay->osc->wavetable_script_res_base);
             resolutionN->addListener(this);
             resolutionN->setTag(tag_res_value);
             resolutionN->setStorage(overlay->storage);
@@ -3538,7 +3538,7 @@ struct WavetableScriptControlArea : public juce::Component,
         {
             auto contextMenu = juce::PopupMenu();
 
-            auto msurl = editor->helpURLForSpecial("wtse-editor");
+            auto msurl = editor->helpURLForSpecial("wts-editor");
             auto hurl = editor->fullyResolvedHelpURL(msurl);
 
             editor->addHelpHeaderTo("Wavetable Script Editor", hurl, contextMenu);
@@ -3606,7 +3606,7 @@ struct WavetableScriptControlArea : public juce::Component,
         {
             auto contextMenu = juce::PopupMenu();
 
-            auto msurl = SurgeGUIEditor::helpURLForSpecial(overlay->storage, "wtse-editor");
+            auto msurl = SurgeGUIEditor::helpURLForSpecial(overlay->storage, "wts-editor");
             auto hurl = SurgeGUIEditor::fullyResolvedHelpURL(msurl);
             auto tcomp = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>(menuName, hurl);
 
@@ -3804,14 +3804,14 @@ WavetableScriptEditor::WavetableScriptEditor(SurgeGUIEditor *ed, SurgeStorage *s
     mainEditor->setDescription("Wavetable Code");
     mainEditor->onFocusLost = [this]() { this->saveState(); };
 
-    if (osc->wavetable_formula.empty())
+    if (osc->wavetable_script.empty())
     {
         mainDocument->insertText(0,
                                  Surge::WavetableScript::LuaWTEvaluator::defaultWavetableScript());
     }
     else
     {
-        mainDocument->insertText(0, osc->wavetable_formula);
+        mainDocument->insertText(0, osc->wavetable_script);
     }
 
     mainDocument->clearUndoHistory();
@@ -3880,9 +3880,9 @@ void WavetableScriptEditor::applyCode()
 {
     removeTrailingWhitespaceFromDocument();
 
-    osc->wavetable_formula = mainDocument->getAllContent().toStdString();
-    osc->wavetable_formula_res_base = controlArea->resolutionN->getIntValue();
-    osc->wavetable_formula_nframes = controlArea->framesN->getIntValue();
+    osc->wavetable_script = mainDocument->getAllContent().toStdString();
+    osc->wavetable_script_res_base = controlArea->resolutionN->getIntValue();
+    osc->wavetable_script_nframes = controlArea->framesN->getIntValue();
 
     int currentFrame = rendererComponent->frameNumber;
     int maxFrames = controlArea->framesN->getIntValue();
@@ -3904,18 +3904,18 @@ void WavetableScriptEditor::applyCode()
 
 void WavetableScriptEditor::forceRefresh()
 {
-    if (osc->wavetable_formula.empty())
+    if (osc->wavetable_script.empty())
     {
         mainDocument->replaceAllContent(
             Surge::WavetableScript::LuaWTEvaluator::defaultWavetableScript());
     }
     else
     {
-        mainDocument->replaceAllContent(osc->wavetable_formula);
+        mainDocument->replaceAllContent(osc->wavetable_script);
     }
 
-    controlArea->resolutionN->setIntValue(osc->wavetable_formula_res_base);
-    controlArea->framesN->setIntValue(osc->wavetable_formula_nframes);
+    controlArea->resolutionN->setIntValue(osc->wavetable_script_res_base);
+    controlArea->framesN->setIntValue(osc->wavetable_script_nframes);
 
     editor->repaintFrame();
     setApplyEnabled(false);
@@ -4059,267 +4059,36 @@ void WavetableScriptEditor::createMenu(juce::PopupMenu &menu)
 {
     Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(menu, "FUNCTIONS");
 
-    menu.addItem(Surge::GUI::toOSCase("Load .wtscript..."), [this]() { loadWavetableScript(); });
+    menu.addItem(Surge::GUI::toOSCase("Load .wtscript..."),
+                 [this]() { this->editor->loadWavetableScript(); });
 
-    if (!osc->wavetable_formula.empty())
+    if (!osc->wavetable_script.empty())
     {
         menu.addItem(Surge::GUI::toOSCase("Save as .wtscript..."),
-                     [this]() { saveWavetableScript(); });
+                     [this]() { this->editor->saveWavetableScript(); });
         menu.addSeparator();
 
-        menu.addItem(Surge::GUI::toOSCase("Export as .wav..."),
-                     [this]() { exportWavetableAs(ExportFormat::WAV); });
-        menu.addItem(Surge::GUI::toOSCase("Export as .wt..."),
-                     [this]() { exportWavetableAs(ExportFormat::WT); });
+        menu.addItem(Surge::GUI::toOSCase("Export as .wav..."), [this]() {
+            this->editor->exportWavetableAs(SurgeGUIEditor::WTExportFormat::WAV);
+        });
+        menu.addItem(Surge::GUI::toOSCase("Export as .wt..."), [this]() {
+            this->editor->exportWavetableAs(SurgeGUIEditor::WTExportFormat::WT);
+        });
         menu.addSeparator();
 
-        menu.addItem("Export for Serum...", [this]() { exportWavetableAs(ExportFormat::SERUM); });
-        menu.addItem("Export for VCV Rack...",
-                     [this]() { exportWavetableAs(ExportFormat::VCVRACK); });
+        menu.addItem("Export for Serum...", [this]() {
+            this->editor->exportWavetableAs(SurgeGUIEditor::WTExportFormat::SERUM);
+        });
+        menu.addItem("Export for VCV Rack...", [this]() {
+            this->editor->exportWavetableAs(SurgeGUIEditor::WTExportFormat::VCVRACK);
+        });
     }
     menu.addSeparator();
 
-    auto msurl = editor->helpURLForSpecial("wtse-editor");
+    auto msurl = editor->helpURLForSpecial("wts-editor");
     auto hurl = editor->fullyResolvedHelpURL(msurl);
 
     editor->addHelpHeaderTo("Wavetable Script Editor", hurl, menu);
-}
-
-void WavetableScriptEditor::loadWavetableScript()
-{
-    auto wtPath = storage->userWavetablesPath / "Scripted";
-    wtPath = Surge::Storage::getUserDefaultPath(storage, Surge::Storage::LastWavetablePath, wtPath);
-
-    juce::String fileTypes = "*.wtscript";
-
-    editor->fileChooser = std::make_unique<juce::FileChooser>(
-        "Select Wavetable script", juce::File(path_to_string(wtPath)), fileTypes);
-    editor->fileChooser->launchAsync(
-        juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
-        [this, wtPath](const juce::FileChooser &c) {
-            auto ress = c.getResults();
-
-            if (ress.size() != 1)
-            {
-                return;
-            }
-
-            auto res = c.getResult();
-            auto rString = res.getFullPathName().toStdString();
-
-            if (res.hasFileExtension(".wtscript"))
-            {
-                loadWavetableScript(-1, fs::path(rString), storage, osc, evaluator.get());
-            }
-
-            auto dir = string_to_path(res.getParentDirectory().getFullPathName().toStdString());
-
-            if (dir != wtPath)
-            {
-                Surge::Storage::updateUserDefaultPath(storage, Surge::Storage::LastWavetablePath,
-                                                      dir);
-            }
-        });
-}
-
-void WavetableScriptEditor::loadWavetableScript(int id, const fs::path &location,
-                                                SurgeStorage *storage, OscillatorStorage *oscdata,
-                                                Surge::WavetableScript::LuaWTEvaluator *evaluator)
-{
-    evaluator->loadWtscript(location, storage, oscdata);
-
-    oscdata->wt.current_id = id;
-    oscdata->wt.refresh_display = true;
-    oscdata->wt.force_refresh_display = true;
-    oscdata->wt.refresh_script_editor = true;
-}
-
-void WavetableScriptEditor::saveWavetableScript()
-{
-    std::string defaultFilename = osc->wavetable_display_name;
-    if (defaultFilename.empty())
-        defaultFilename = "Untitled";
-    editor->promptForMiniEdit(
-        defaultFilename, "Enter the file name:", "Wavetable Script File Name", juce::Point<int>{},
-        [this](const std::string &s) {
-            this->saveWavetableScript(string_to_path(s), this->storage, this->osc);
-        },
-        this);
-}
-
-void WavetableScriptEditor::saveWavetableScript(const fs::path &location, SurgeStorage *storage,
-                                                OscillatorStorage *oscdata)
-{
-    try
-    {
-        auto containingPath = storage->userWavetablesPath / "Scripted";
-
-        // validate location before using
-        if (!location.is_relative())
-        {
-            storage->reportError(
-                "Please use relative paths when saving scripts. Referring to drive names directly "
-                "and using absolute paths is not allowed!",
-                "Relative Path Required");
-            return;
-        }
-
-        auto comppath = containingPath;
-        auto fullLocation =
-            (containingPath / location).lexically_normal().replace_extension(".wtscript");
-
-        // make sure your category isnt "../../../etc/config"
-        auto [_, compIt] = std::mismatch(fullLocation.begin(), fullLocation.end(), comppath.begin(),
-                                         comppath.end());
-        if (compIt != comppath.end())
-        {
-            storage->reportError(
-                "Your save path is not a directory inside the user scripts directory. "
-                "This usually means you are trying to use ../ in your script name.",
-                "Invalid Save Path");
-            return;
-        }
-
-        fs::create_directories(fullLocation.parent_path());
-
-        auto doSave = [fullLocation, storage, oscdata]() {
-            TiXmlDeclaration decl("1.0", "UTF-8", "yes");
-            TiXmlDocument doc;
-            doc.InsertEndChild(decl);
-            TiXmlElement wtscript("wtscript");
-            TiXmlElement script("script");
-
-            if (!oscdata->wavetable_formula.empty())
-            {
-                auto wtfo = oscdata->wavetable_formula;
-                auto wtfol = wtfo.length();
-
-                script.SetAttribute("lua", Surge::Storage::base64_encode(
-                                               (unsigned const char *)wtfo.c_str(), wtfol));
-
-                script.SetAttribute("frames", oscdata->wavetable_formula_nframes);
-                script.SetAttribute("samples", oscdata->wavetable_formula_res_base);
-            }
-
-            wtscript.InsertEndChild(script);
-            doc.InsertEndChild(wtscript);
-            if (!doc.SaveFile(fullLocation))
-            {
-                storage->reportError("Failed to save XML file.", "XML Save Error");
-            }
-
-            storage->refresh_wtlist();
-        };
-
-        if (fs::exists(fullLocation))
-        {
-            storage->okCancelProvider("The wavetable script '" + location.string() +
-                                          "' already exists. "
-                                          "Are you sure you want to overwrite it?",
-                                      "Overwrite Wavetable Script", SurgeStorage::OK,
-                                      [doSave](SurgeStorage::OkCancel okc) {
-                                          if (okc == SurgeStorage::OK)
-                                          {
-                                              doSave();
-                                          }
-                                      });
-        }
-        else
-        {
-            doSave();
-        }
-    }
-    catch (const fs::filesystem_error &e)
-    {
-        std::ostringstream oss;
-        oss << "Exception occurred while attempting to write the wavetable script! "
-               "Most likely, invalid characters or a reserved name was used to name "
-               "the script. Please try again with a different name!\n"
-            << "Details " << e.what();
-        storage->reportError(oss.str(), "Script Write Error");
-    }
-}
-
-void WavetableScriptEditor::exportWavetableAs(ExportFormat exportFormat)
-{
-    auto path = editor->synth->storage.userDataPath / "Wavetables" / "Exported";
-    try
-    {
-        fs::create_directories(path);
-    }
-    catch (const fs::filesystem_error &e)
-    {
-    }
-
-    auto defaultFilename = path / osc->wavetable_display_name;
-    if (exportFormat == WT)
-    {
-        defaultFilename = defaultFilename.replace_extension(".wt");
-    }
-    else
-    {
-        defaultFilename = defaultFilename.replace_extension(".wav");
-    }
-
-    editor->fileChooser = std::make_unique<juce::FileChooser>(
-        "Export Wavetable", juce::File(defaultFilename.u8string().c_str()));
-    editor->fileChooser->launchAsync(
-        juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles |
-            juce::FileBrowserComponent::warnAboutOverwriting,
-        [this, exportFormat](const juce::FileChooser &c) {
-            auto result = c.getResults();
-            if (result.isEmpty() || result.size() > 1)
-            {
-                return;
-            }
-
-            auto fsp = fs::path{result[0].getFullPathName().toStdString()};
-            if (exportFormat != WT && fsp.extension() != ".wav")
-            {
-                fsp.replace_extension(".wav");
-            }
-            else if (exportFormat == WT && fsp.extension() != ".wt")
-            {
-                fsp.replace_extension(".wt");
-            }
-
-            switch (exportFormat)
-            {
-            case WAV:
-            {
-                std::string metadata = storage->make_wt_metadata(osc);
-                evaluator->generateWavetable(storage, osc, &osc->wt);
-                storage->export_wt_wav_portable(fsp, &osc->wt, metadata);
-                break;
-            }
-            case WT:
-            {
-                std::string metadata = storage->make_wt_metadata(osc);
-                evaluator->generateWavetable(storage, osc, &osc->wt);
-                if (!storage->export_wt_wt_portable(fsp, &osc->wt, metadata))
-                {
-                    storage->reportError("Unable to save wt to " + fsp.u8string(),
-                                         "Wavetable Export");
-                }
-                break;
-            }
-            case SERUM:
-            case VCVRACK:
-            {
-                int oldres = osc->wavetable_formula_res_base;
-                osc->wavetable_formula_res_base = (exportFormat == SERUM ? 7 : 4);
-                Wavetable wt;
-                evaluator->generateWavetable(storage, osc, &wt, true);
-                osc->wavetable_formula_res_base = oldres;
-
-                std::string metadata = storage->make_wt_metadata(osc);
-                bool exportForSerum = (exportFormat == SERUM);
-                storage->export_wt_wav_portable(fsp, &wt, metadata, exportForSerum);
-                break;
-            }
-            }
-            storage->refresh_wtlist();
-        });
 }
 
 std::optional<std::pair<std::string, std::string>>

--- a/src/surge-xt/gui/overlays/LuaEditors.h
+++ b/src/surge-xt/gui/overlays/LuaEditors.h
@@ -380,22 +380,6 @@ struct WavetableScriptEditor : public CodeEditorContainerWithApply, public Refre
     void setCurrentFrame(int value);
 
     void createMenu(juce::PopupMenu &menu);
-    void loadWavetableScript();
-    static void loadWavetableScript(int id, const fs::path &location, SurgeStorage *storage,
-                                    OscillatorStorage *oscdata,
-                                    Surge::WavetableScript::LuaWTEvaluator *evaluator);
-    void saveWavetableScript();
-    static void saveWavetableScript(const fs::path &location, SurgeStorage *storage,
-                                    OscillatorStorage *oscdata);
-
-    enum ExportFormat
-    {
-        WAV,
-        WT,
-        SERUM,
-        VCVRACK
-    };
-    void exportWavetableAs(ExportFormat exportFormat);
 
     int lastRes{-1}, lastFrames{-1}, lastFrame{-1}, lastRm{-1};
 

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
@@ -119,15 +119,6 @@ struct OscillatorWaveformDisplay : public juce::Component,
 
     void createWTLoadMenu(juce::PopupMenu &contextMenu);
     void createWTExportMenu(juce::PopupMenu &contextMenu);
-
-    enum ExportFormat
-    {
-        WAV,
-        WT,
-        SERUM,
-        VCVRACK
-    };
-    void exportWavetableAs(ExportFormat exportFormat);
     void createWTRenameMenu(juce::PopupMenu &contextMenu);
     void createOpenScriptEditorMenu(juce::PopupMenu &contextMenu);
     void refreshWavetablesMenu(juce::PopupMenu &contextMenu);


### PR DESCRIPTION
- Move duplicate WTS load/save/export functions to SGE
- Change save mod preset dialog title LFO Preset Name -> Save LFO Preset

Variable renames:

- wavetable_formula -> wavetable_script
- WT_EDITOR -> WTS_EDITOR
- wtse-editor -> wts-editor
- PresetXtn -> PresetExt