### PR TITLE
Windows installer: Use sst-cmake helper for Inno Setup

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: surge-synthesizer/sst-githubactions/install-innosetup@main
         if: runner.os == 'Windows'
         with:
-          version: "6.5.1"
+          version: "6.5.4"
 
       - name: "Prepare for JUCE"
         uses: surge-synthesizer/sst-githubactions/prepare-for-juce@main

--- a/.gitmodules
+++ b/.gitmodules
@@ -59,3 +59,6 @@
 [submodule "libs/sst/sst-jucegui"]
 	path = libs/sst/sst-jucegui
 	url = https://github.com/surge-synthesizer/sst-jucegui.git
+[submodule "libs/sst/sst-cmake"]
+	path = libs/sst/sst-cmake
+	url = https://github.com/surge-synthesizer/sst-cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ if(${SURGE_BUILD_TESTRUNNER})
   enable_testing()
 endif()
 
+add_subdirectory(libs/sst/sst-cmake)
 add_subdirectory(resources)
 add_subdirectory(src)
 

--- a/README.md
+++ b/README.md
@@ -186,9 +186,10 @@ on Windows, run `sys.path.append("ignore/bpy/src/surge-python/Debug")` instead, 
 ## Building an Installer
 
 The CMake target `surge-xt-distribution` builds an install image on your platform at the end of the build process. On
-Mac and Linux, the installer generator is built into the platform; on Windows, our CMake file will download
-InnoSetup from the official website. On Windows we also require [7-Zip](https://7-zip.org/), so location of `7z.exe` should be in
-the PATH (which is normally `C:\Program Files\7-Zip`).
+Mac and Linux, the installer generator is built into the platform; on Windows, [Inno Setup](https://jrsoftware.org/isinfo.php)
+and [7-Zip](https://7-zip.org/) should be on your PATH. The directory containing `7z.exe` (normally `C:\Program Files\7-Zip`)
+and the directory containing `ISCC.exe` (normally `C:\Program Files (x86)\Inno Setup 6\ISCC.exe`) must be in your
+PATH environment variable.
 
 ## Using CMake on the Command Line for More
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ on Windows, run `sys.path.append("ignore/bpy/src/surge-python/Debug")` instead, 
 The CMake target `surge-xt-distribution` builds an install image on your platform at the end of the build process. On
 Mac and Linux, the installer generator is built into the platform; on Windows, [Inno Setup](https://jrsoftware.org/isinfo.php)
 and [7-Zip](https://7-zip.org/) should be on your PATH. The directory containing `7z.exe` (normally `C:\Program Files\7-Zip`)
-and the directory containing `ISCC.exe` (normally `C:\Program Files (x86)\Inno Setup 6\ISCC.exe`) must be in your
+and the directory containing `ISCC.exe` (normally `C:\Program Files (x86)\Inno Setup 6`) must be in your
 PATH environment variable.
 
 ## Using CMake on the Command Line for More

--- a/src/cmake/lib.cmake
+++ b/src/cmake/lib.cmake
@@ -202,18 +202,11 @@ function(surge_make_installers)
         (NOT "${SURGE_EXTRA_ZIP_NAME}" STREQUAL ""))
       message(STATUS "Not making installer for arm or juce7")
     else()
-      find_program(INNOSETUP_COMPILER_EXE iscc)
-      if(NOT INNOSETUP_COMPILER_EXE)
-        file(DOWNLOAD "https://files.jrsoftware.org/is/6/innosetup-6.5.1.exe" "${CMAKE_BINARY_DIR}/innosetup-6.5.1.exe" EXPECTED_HASH SHA256=3622FFDAD7B2534239370099149C33ADB85B90054799D901CB8EC844DF7A0E41)
-        execute_process(COMMAND "${CMAKE_BINARY_DIR}/innosetup-6.5.1.exe" /VERYSILENT /CURRENTUSER /DIR=innosetup-6.5.1)
-        find_program(INNOSETUP_COMPILER_EXE iscc PATHS ${CMAKE_BINARY_DIR}/innosetup-6.5.1)
-      endif()
-      if(INNOSETUP_COMPILER_EXE)
-        message(STATUS "Using Inno Setup Compiler from ${INNOSETUP_COMPILER_EXE}")
+      if(TARGET innosetup::compiler)
         add_custom_command(TARGET surge-xt-distribution
           POST_BUILD
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-          COMMAND ${INNOSETUP_COMPILER_EXE} /O"${SURGE_XT_DIST_OUTPUT_DIR}" /DSURGE_SRC="${CMAKE_SOURCE_DIR}" /DSURGE_BIN="${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}/scripts/installer_win/surge${SURGE_BITNESS}.iss"
+          COMMAND innosetup::compiler /O"${SURGE_XT_DIST_OUTPUT_DIR}" /DSURGE_SRC="${CMAKE_SOURCE_DIR}" /DSURGE_BIN="${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}/scripts/installer_win/surge${SURGE_BITNESS}.iss"
         )
       endif()
     endif()


### PR DESCRIPTION
This replaces our problematic manual download of Inno Setup (which replaced the unofficial nuget package, which has not been updated for Inno Setup 6.5). This brings Surge in line with our other recent projects that use a shared installer script. For now we are still using the same .iss file for Surge.

This does mean Inno Setup needs to be downloaded and put on PATH, same as 7zip. The README has been updated to reflect this.