### PR TITLE
Fix some MIDI Channel/MTS-ESP things

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -880,7 +880,7 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
             }
             else if (storage.mapChannelToOctave)
             {
-                auto keyadj = SurgeVoice::channelKeyEquvialent(key, channel, mpeEnabled, &storage);
+                auto keyadj = SurgeVoice::channelKeyEquivalent(key, channel, &storage);
 
                 for (int k = lowkey; k < hikey; ++k)
                 {
@@ -888,8 +888,7 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
                     {
                         if (channelState[ch].keyState[k].keystate)
                         {
-                            auto kadj =
-                                SurgeVoice::channelKeyEquvialent(k, ch, mpeEnabled, &storage);
+                            auto kadj = SurgeVoice::channelKeyEquivalent(k, ch, &storage);
 
                             if (primode == ALWAYS_HIGHEST && kadj > keyadj)
                                 createVoice = false;
@@ -1042,7 +1041,7 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
             }
             else if (storage.mapChannelToOctave)
             {
-                auto keyadj = SurgeVoice::channelKeyEquvialent(key, channel, mpeEnabled, &storage);
+                auto keyadj = SurgeVoice::channelKeyEquivalent(key, channel, &storage);
 
                 for (int k = lowkey; k < hikey; ++k)
                 {
@@ -1050,8 +1049,7 @@ void SurgeSynthesizer::playVoice(int scene, char channel, char key, char velocit
                     {
                         if (channelState[ch].keyState[k].keystate)
                         {
-                            auto kadj =
-                                SurgeVoice::channelKeyEquvialent(k, ch, mpeEnabled, &storage);
+                            auto kadj = SurgeVoice::channelKeyEquivalent(k, ch, &storage);
 
                             if (primode == ALWAYS_HIGHEST && kadj > keyadj)
                                 createVoice = false;
@@ -1434,8 +1432,7 @@ void SurgeSynthesizer::releaseNotePostHoldCheck(int scene, char channel, char ke
                     }
                     else if (!mpeEnabled && storage.mapChannelToOctave)
                     {
-                        auto keyadj =
-                            SurgeVoice::channelKeyEquvialent(key, channel, mpeEnabled, &storage);
+                        auto keyadj = SurgeVoice::channelKeyEquivalent(key, channel, &storage);
 
                         int highest = -1, lowest = 128, latest = -1;
                         int highestadj = -100, lowestadj = 1000;
@@ -1448,8 +1445,7 @@ void SurgeSynthesizer::releaseNotePostHoldCheck(int scene, char channel, char ke
                             {
                                 if (channelState[ch].keyState[k].keystate)
                                 {
-                                    auto kadj = SurgeVoice::channelKeyEquvialent(k, ch, mpeEnabled,
-                                                                                 &storage);
+                                    auto kadj = SurgeVoice::channelKeyEquivalent(k, ch, &storage);
                                     if (kadj >= highestadj)
                                     {
                                         /*
@@ -1659,8 +1655,7 @@ void SurgeSynthesizer::releaseNotePostHoldCheck(int scene, char channel, char ke
                     }
                     else if (!mpeEnabled && storage.mapChannelToOctave)
                     {
-                        auto keyadj =
-                            SurgeVoice::channelKeyEquvialent(key, channel, mpeEnabled, &storage);
+                        auto keyadj = SurgeVoice::channelKeyEquivalent(key, channel, &storage);
 
                         int highest = -1, lowest = 128, latest = -1;
                         int highestadj = -1000, lowestadj = 1000;
@@ -1673,8 +1668,7 @@ void SurgeSynthesizer::releaseNotePostHoldCheck(int scene, char channel, char ke
                             {
                                 if (channelState[ch].keyState[k].keystate)
                                 {
-                                    auto kadj = SurgeVoice::channelKeyEquvialent(k, ch, mpeEnabled,
-                                                                                 &storage);
+                                    auto kadj = SurgeVoice::channelKeyEquivalent(k, ch, &storage);
 
                                     if (kadj >= highestadj)
                                     {

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -77,49 +77,54 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
         res = storage->remapKeyInMidiOnlyMode(res);
     }
 
-    res = SurgeVoice::channelKeyEquvialent(res, channel, mpeEnabled, storage, false);
+    if (!mpeEnabled && storage->mapChannelToOctave)
+    {
+        res = SurgeVoice::channelKeyEquivalent(res, channel, storage, false);
+    }
 
     return res;
 }
 
-float SurgeVoice::channelKeyEquvialent(float key, int channel, bool isMpeEnabled,
-                                       SurgeStorage *storage, bool remapKeyForTuning)
+float SurgeVoice::channelKeyEquivalent(float key, int channel, SurgeStorage *storage,
+                                       bool remapKeyForTuning)
 {
     float res = key;
-    if (storage->mapChannelToOctave && !isMpeEnabled)
-    {
-        if (remapKeyForTuning)
-        {
-            res = storage->remapKeyInMidiOnlyMode(res);
-        }
 
-        float shift;
-        if (channel > 7)
-        {
-            shift = channel - 16;
-        }
-        else
-        {
-            shift = channel;
-        }
-        if (storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL)
-        {
-            // keys are in scale space so move scale.count
-            res += storage->currentScale.count * shift;
-        }
-        else
-        {
-            // keys are in tuning space so move cents worth of keys
-            // We don't know the period in MTS-ESP so default to octave for now
-            if (storage->isStandardTuning || storage->oddsound_mts_active_as_client)
-                res += 12 * shift;
-            else
-            {
-                auto ct = storage->currentScale.tones[storage->currentScale.count - 1].cents;
-                res += ct / 100 * shift;
-            }
-        }
+    if (remapKeyForTuning)
+    {
+        res = storage->remapKeyInMidiOnlyMode(res);
     }
+
+    float shift;
+    if (channel > 7)
+    {
+        shift = channel - 16;
+    }
+    else
+    {
+        shift = channel;
+    }
+
+    if (storage->isStandardTuning)
+    {
+        res += 12 * shift;
+    }
+    else if (storage->oddsound_mts_active_as_client)
+    {
+        res += MTS_GetMapSize(storage->oddsound_mts_client) * shift;
+    }
+    else if (storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL)
+    {
+        // keys are in scale space so move scale.count
+        res += storage->currentScale.count * shift;
+    }
+    else
+    {
+        // keys are in tuning space so move cents worth of keys
+        auto ct = storage->currentScale.tones[storage->currentScale.count - 1].cents;
+        res += ct / 100 * shift;
+    }
+
     return res;
 }
 
@@ -204,8 +209,6 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
     state.mpePitchBend.set_samplerate(storage->samplerate, storage->samplerate_inv);
     state.mpePitchBend.init(voiceChannelState->pitchBend / 8192.f);
 
-    state.tunedkey = state.getPitch(storage);
-
 #ifndef SURGE_SKIP_ODDSOUND_MTS
     const bool isCh23Mode = Surge::Storage::getUserDefaultValue(
         storage, Surge::Storage::UseCh2Ch3ToPlayScenesIndividually, true, false);
@@ -214,6 +217,8 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
     state.mtsUseChannelWhenRetuning =
         !(mpeEnabled || isChSplitMode || isCh23Mode || storage->mapChannelToOctave);
 #endif
+
+    state.tunedkey = state.getPitch(storage);
 
     resetPortamentoFrom(storage->last_key[scene_id], channel);
 
@@ -1654,8 +1659,7 @@ void SurgeVoice::resetPortamentoFrom(int key, int channel)
 #endif
         {
             if (storage->mapChannelToOctave && !mpeEnabled)
-                state.portasrc_key =
-                    channelKeyEquvialent(lk, state.channel, mpeEnabled, storage, true);
+                state.portasrc_key = channelKeyEquivalent(lk, state.channel, storage, true);
             else
                 state.portasrc_key = storage->remapKeyInMidiOnlyMode(lk);
         }

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -63,7 +63,7 @@ float SurgeVoiceState::getPitch(SurgeStorage *storage)
         {
             keyRetuningForKey = key;
             keyRetuning = MTS_RetuningInSemitones(storage->oddsound_mts_client, key + mpeBend,
-                                                  mtsUseChannelWhenRetuning ? 0 : channel);
+                                                  mtsUseChannelWhenRetuning ? channel : -1);
         }
         auto rkey = keyRetuning;
 
@@ -212,7 +212,7 @@ SurgeVoice::SurgeVoice(SurgeStorage *storage, SurgeSceneStorage *oscene, pdata *
     const bool isChSplitMode = storage->getPatch().scenemode.val.i == sm_chsplit;
 
     state.mtsUseChannelWhenRetuning =
-        (mpeEnabled || isChSplitMode || isCh23Mode || storage->mapChannelToOctave);
+        !(mpeEnabled || isChSplitMode || isCh23Mode || storage->mapChannelToOctave);
 #endif
 
     resetPortamentoFrom(storage->last_key[scene_id], channel);

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -222,8 +222,8 @@ class alignas(16) SurgeVoice
     void retriggerOSCWithIndependentAttacks();
     void resetPortamentoFrom(int key, int channel);
 
-    static float channelKeyEquvialent(float key, int channel, bool isMpeEnabled,
-                                      SurgeStorage *storage, bool remapKeyForTuning = true);
+    static float channelKeyEquivalent(float key, int channel, SurgeStorage *storage,
+                                      bool remapKeyForTuning = true);
 
   private:
     template <bool first> void calc_ctrldata(QuadFilterChainState *, int);


### PR DESCRIPTION
- mtsUseChannelWhenRetuning had its logic backwards from what the name suggested
- Also, when false (after the fix) it passed 0 to channel, which incidentally work but spec says to use -1 so. 
- Fix a typo in the channel/octave function 
- Remove a redundant mpeEnabled argument (the func never gets called if it's true)
- ...and an equally redundant mapChannelToOctave branch inside it (same thing)
- And finally, use the scale period for channel/octave also in MTS-ESP mode