### PR TITLE
Fix out of range vector access in RadialScaleGraph::paint()

### DIFF
--- a/src/surge-xt/gui/overlays/TuningOverlays.cpp
+++ b/src/surge-xt/gui/overlays/TuningOverlays.cpp
@@ -1299,7 +1299,7 @@ void RadialScaleGraph::paint(juce::Graphics &g)
                 auto irsf = 1.0 / rsf;
                 g.addTransform(juce::AffineTransform::scale(rsf, rsf));
 
-                if (notesOn[i])
+                if (i < notesOn.size() && notesOn[i])
                 {
                     g.setColour(juce::Colour(255, 255, 255));
                 }


### PR DESCRIPTION
Minor issue it seems, only failing an assert in debug builds.