### PR TITLE
Some editors accessibility improvements

### DIFF
--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -2585,15 +2585,17 @@ struct FormulaControlArea : public juce::Component,
             int bpos = getWidth() - 10 - btnWidth;
             int ypos = 1 + labelHeight + margin;
 
-            auto ma = [&](const std::string &l, tags t) {
+            auto ma = [&](const std::string &label, const std::string title, tags tag) {
                 auto res = std::make_unique<Surge::Widgets::MultiSwitchSelfDraw>();
                 auto btnrect = juce::Rectangle<int>(bpos, ypos - 1, btnWidth, buttonHeight);
 
                 res->setBounds(btnrect);
                 res->setStorage(overlay->storage);
-                res->setLabels({l});
+                res->setTitle(title);
+                res->setDescription(title);
+                res->setLabels({label});
                 res->addListener(this);
-                res->setTag(t);
+                res->setTag(tag);
                 res->setHeightOfOneImage(buttonHeight);
                 res->setRows(1);
                 res->setColumns(1);
@@ -2604,16 +2606,17 @@ struct FormulaControlArea : public juce::Component,
             };
 
             auto isOpen = overlay->debugPanel->isOpen;
-            showS = ma(isOpen ? "Hide" : "Show", tag_debugger_show);
+            showS = ma(isOpen ? "Hide" : "Show", isOpen ? "Hide Debugger" : "Show Debugger",
+                       tag_debugger_show);
             addAndMakeVisible(*showS);
             bpos -= btnWidth + margin;
 
-            stepS = ma("Step", tag_debugger_step);
+            stepS = ma("Step", "Step Debugger", tag_debugger_step);
             stepS->setVisible(isOpen);
             addChildComponent(*stepS);
             bpos -= btnWidth + margin;
 
-            initS = ma("Init", tag_debugger_init);
+            initS = ma("Init", "Init Debugger", tag_debugger_init);
             initS->setVisible(isOpen);
             addChildComponent(*initS);
             bpos -= btnWidth + margin;
@@ -3315,6 +3318,7 @@ struct WavetableScriptControlArea : public juce::Component,
                 w->overlay->createMenu(menu);
                 return menu;
             };
+            menuB->setExplicitFocusOrder(10);
             addAndMakeVisible(*menuB);
 
             codeL = newL("Code");
@@ -3343,6 +3347,7 @@ struct WavetableScriptControlArea : public juce::Component,
             codeS->setDraggable(true);
             codeS->setValue(overlay->getEditState().codeOrPrelude);
             codeS->setSkin(skin, associatedBitmapStore);
+            codeS->setExplicitFocusOrder(20);
             addAndMakeVisible(*codeS);
 
             renderModeS = std::make_unique<Surge::Widgets::MultiSwitchSelfDraw>();
@@ -3350,8 +3355,8 @@ struct WavetableScriptControlArea : public juce::Component,
             btnrect = juce::Rectangle(xpos, ypos - 1, btnWidth, buttonHeight);
             renderModeS->setBounds(btnrect);
             renderModeS->setStorage(overlay->storage);
-            renderModeS->setTitle("Display Mode");
-            renderModeS->setDescription("Display Mode");
+            renderModeS->setTitle("Preview Mode");
+            renderModeS->setDescription("Preview Mode");
             renderModeS->setLabels({"Filmstrip", "Single"});
             renderModeS->addListener(this);
             renderModeS->setTag(tag_select_rendermode);
@@ -3362,6 +3367,7 @@ struct WavetableScriptControlArea : public juce::Component,
             renderModeS->setValue(overlay->rendererComponent->mode);
             renderModeS->setSkin(skin, associatedBitmapStore);
             renderModeS->setAccessible(false);
+            renderModeS->setExplicitFocusOrder(30);
             addAndMakeVisible(*renderModeS);
 
             applyS = std::make_unique<Surge::Widgets::MultiSwitchSelfDraw>();
@@ -3381,6 +3387,7 @@ struct WavetableScriptControlArea : public juce::Component,
             applyS->setDraggable(true);
             applyS->setSkin(skin, associatedBitmapStore);
             applyS->setEnabled(false);
+            applyS->setExplicitFocusOrder(40);
             addAndMakeVisible(*applyS);
 
             auto images = skin->standardHoverAndHoverOnForIDB(IDB_MSEG_SNAPVALUE_NUMFIELD,
@@ -3398,8 +3405,8 @@ struct WavetableScriptControlArea : public juce::Component,
             currentFrameN->addListener(this);
             currentFrameN->setTag(tag_current_frame);
             currentFrameN->setStorage(overlay->storage);
-            currentFrameN->setTitle("Current Frame");
-            currentFrameN->setDescription("Current Frame");
+            currentFrameN->setTitle("Preview Frame");
+            currentFrameN->setDescription("Preview Frame");
             currentFrameN->setSkin(skin, associatedBitmapStore);
             currentFrameN->setBounds(btnrect);
             currentFrameN->setBackgroundDrawable(images[0]);
@@ -3407,6 +3414,8 @@ struct WavetableScriptControlArea : public juce::Component,
             currentFrameN->setTextColour(skin->getColor(Colors::MSEGEditor::NumberField::Text));
             currentFrameN->setHoverTextColour(
                 skin->getColor(Colors::MSEGEditor::NumberField::TextHover));
+            renderModeS->setAccessible(false);
+            currentFrameN->setExplicitFocusOrder(50);
             addAndMakeVisible(*currentFrameN);
 
             framesL = newL("Frames");
@@ -3422,8 +3431,8 @@ struct WavetableScriptControlArea : public juce::Component,
             framesN->addListener(this);
             framesN->setTag(tag_frames_value);
             framesN->setStorage(overlay->storage);
-            framesN->setTitle("Max Frame");
-            framesN->setDescription("Max Frame");
+            framesN->setTitle("Frames");
+            framesN->setDescription("Frames");
             framesN->setSkin(skin, associatedBitmapStore);
             framesN->setBackgroundDrawable(images[0]);
             framesN->setHoverBackgroundDrawable(images[1]);
@@ -3437,6 +3446,7 @@ struct WavetableScriptControlArea : public juce::Component,
                 }
                 return false;
             };
+            framesN->setExplicitFocusOrder(60);
             addAndMakeVisible(*framesN);
 
             resolutionL = newL("Samples");
@@ -3460,6 +3470,7 @@ struct WavetableScriptControlArea : public juce::Component,
             resolutionN->setTextColour(skin->getColor(Colors::MSEGEditor::NumberField::Text));
             resolutionN->setHoverTextColour(
                 skin->getColor(Colors::MSEGEditor::NumberField::TextHover));
+            resolutionN->setExplicitFocusOrder(70);
             addAndMakeVisible(*resolutionN);
 
             generateS = std::make_unique<Surge::Widgets::MultiSwitchSelfDraw>();
@@ -3478,6 +3489,7 @@ struct WavetableScriptControlArea : public juce::Component,
             generateS->setDraggable(false);
             generateS->setSkin(skin, associatedBitmapStore);
             generateS->setEnabled(true);
+            generateS->setExplicitFocusOrder(80);
             addAndMakeVisible(*generateS);
         }
     }

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -3457,6 +3457,7 @@ void MSEGControlRegion::rebuild()
         {
             movementMode->setValue(eds->timeEditMode / 2.f);
         }
+        movementMode->setExplicitFocusOrder(10);
         addAndMakeVisible(*movementMode);
         // this value centers the loop mode and snap sections against the MSEG editor width
         // if more controls are to be added to that center section, reduce this value
@@ -3499,6 +3500,7 @@ void MSEGControlRegion::rebuild()
         editMode->setHoverOnSwitchDrawable(std::get<2>(dbl));
 
         editMode->setValue(ms->editMode);
+        editMode->setExplicitFocusOrder(20);
         addAndMakeVisible(*editMode);
 
         xpos += segWidth;
@@ -3539,6 +3541,7 @@ void MSEGControlRegion::rebuild()
         loopMode->setHoverOnSwitchDrawable(std::get<2>(dbl));
 
         loopMode->setValue((ms->loopMode - 1) / 2.f);
+        loopMode->setExplicitFocusOrder(30);
         addAndMakeVisible(*loopMode);
 
         xpos += segWidth;
@@ -3575,6 +3578,7 @@ void MSEGControlRegion::rebuild()
             nullptr, dynamic_cast<SurgeImage *>(hsbmp), associatedBitmapStore,
             Surge::GUI::Skin::HoverType::HOVER);
         hSnapButton->setHoverSwitchDrawable(hoverBmp);
+        hSnapButton->setExplicitFocusOrder(40);
         addAndMakeVisible(*hSnapButton);
 
         svt = fmt::format("{:d}", (int)round(1.f / ms->hSnapDefault));
@@ -3601,6 +3605,7 @@ void MSEGControlRegion::rebuild()
             }
             return false;
         };
+        hSnapSize->setExplicitFocusOrder(50);
         addAndMakeVisible(*hSnapSize);
 
         xpos += segWidth;
@@ -3617,6 +3622,7 @@ void MSEGControlRegion::rebuild()
         hoverBmp = skin->hoverBitmapOverlayForBackgroundBitmap(
             nullptr, vsbmp, associatedBitmapStore, Surge::GUI::Skin::HoverType::HOVER);
         vSnapButton->setHoverSwitchDrawable(hoverBmp);
+        vSnapButton->setExplicitFocusOrder(60);
         addAndMakeVisible(*vSnapButton);
 
         svt = fmt::format("{:d}", (int)round(1.f / ms->vSnapDefault));
@@ -3643,6 +3649,7 @@ void MSEGControlRegion::rebuild()
             }
             return false;
         };
+        vSnapSize->setExplicitFocusOrder(70);
         addAndMakeVisible(*vSnapSize);
     }
 }

--- a/src/surge-xt/gui/widgets/MenuButtonFromIcon.cpp
+++ b/src/surge-xt/gui/widgets/MenuButtonFromIcon.cpp
@@ -198,5 +198,17 @@ bool MenuButtonFromIcon::keyPressed(const juce::KeyPress &key)
     return false;
 }
 
+void MenuButtonFromIcon::focusGained(juce::Component::FocusChangeType cause)
+{
+    isActive = true;
+    repaint();
+}
+
+void MenuButtonFromIcon::focusLost(juce::Component::FocusChangeType cause)
+{
+    isActive = false;
+    repaint();
+}
+
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/MenuButtonFromIcon.h
+++ b/src/surge-xt/gui/widgets/MenuButtonFromIcon.h
@@ -53,6 +53,8 @@ struct MenuButtonFromIcon : public juce::Component,
     void mouseExit(const juce::MouseEvent &) override;
     void mouseDown(const juce::MouseEvent &e) override;
     bool keyPressed(const juce::KeyPress &key) override;
+    void focusGained(juce::Component::FocusChangeType cause) override;
+    void focusLost(juce::Component::FocusChangeType cause) override;
 
     std::function<juce::PopupMenu()> menuFactory;
     std::unique_ptr<juce::Drawable> baseIcon;


### PR DESCRIPTION
- Set tab focus order explicitly for WTS and MSEG editors
- Add title / description to Formula debugger buttons
- Turn off accessibility for preview frame numberfield
- Some title / descriptions changes for WTS editor buttons
- Paint focus on MenuButtonFromIcon