### PR TITLE
Migrate most of the FX parameter overlay into its own component.

### DIFF
--- a/src/common/dsp/Effect.h
+++ b/src/common/dsp/Effect.h
@@ -61,9 +61,6 @@ class alignas(16) Effect
     // this is called after the loading state of an item that has changed
     virtual void updateAfterReload() {}
 
-    virtual Surge::ParamConfig::VUType vu_type(int id) { return Surge::ParamConfig::vut_off; }
-    virtual int vu_ypos(int id) { return id; } // in 'half-hslider' heights
-
     virtual const char *group_label(int id) { return 0; }
     virtual int group_label_ypos(int id) { return 0; }
 
@@ -97,7 +94,6 @@ class alignas(16) Effect
     // virtual void processSSE3(float *dataL, float *dataR){ return; }
     // virtual void processT<int architecture>(float *dataL, float *dataR){ return; }
     virtual void suspend() { return; }
-    float vu[KNumVuSlots]; // stereo pairs, just use every other when mono
 
     // Most of the fx read the sample rate at sample time but airwindows
     // keeps a cache so give loaded fx a notice when the sample rate changes

--- a/src/common/dsp/effects/ConditionerEffect.cpp
+++ b/src/common/dsp/effects/ConditionerEffect.cpp
@@ -63,7 +63,7 @@ void ConditionerEffect::init()
     vu[0][0] = 0.f;
     vu[0][1] = 0.f;
     vu[1][0] = 1.f;
-    vu[1][1] = 0.f;  // unused, vu[1] is mono.
+    vu[1][1] = 0.f; // unused, vu[1] is mono.
     vu[2][0] = 0.f;
     vu[2][1] = 0.f;
 }

--- a/src/common/dsp/effects/ConditionerEffect.cpp
+++ b/src/common/dsp/effects/ConditionerEffect.cpp
@@ -60,12 +60,12 @@ void ConditionerEffect::init()
     memset(delayed[0], 0, sizeof(float) * lookahead);
     memset(delayed[1], 0, sizeof(float) * lookahead);
 
-    vu[0] = 0.f;
-    vu[1] = 0.f;
-    vu[2] = 1.f;
-    vu[4] = 0.f;
-    vu[5] = 0.f;
-    assert(KNumVuSlots >= 5);
+    vu[0][0] = 0.f;
+    vu[0][1] = 0.f;
+    vu[1][0] = 1.f;
+    vu[1][1] = 0.f;  // unused, vu[1] is mono.
+    vu[2][0] = 0.f;
+    vu[2][1] = 0.f;
 }
 
 void ConditionerEffect::setvars(bool init)
@@ -87,10 +87,10 @@ void ConditionerEffect::process_only_control()
     float release = 0.0001f * rm * rm;
 
     float a = storage->vu_falloff;
-    vu[0] = min(8.f, a * vu[0]);
-    vu[1] = min(8.f, a * vu[1]);
-    vu[4] = min(8.f, a * vu[4]);
-    vu[5] = min(8.f, a * vu[5]);
+    vu[0][0] = min(8.f, a * vu[0][0]);
+    vu[0][1] = min(8.f, a * vu[0][1]);
+    vu[2][0] = min(8.f, a * vu[2][0]);
+    vu[2][1] = min(8.f, a * vu[2][1]);
 
     for (int k = 0; k < BLOCK_SIZE; k++)
     {
@@ -102,7 +102,7 @@ void ConditionerEffect::process_only_control()
         gain = 1.f / filtered_lamax2;
     }
 
-    vu[2] = gain;
+    vu[1][0] = gain;
 }
 
 void ConditionerEffect::process(float *dataL, float *dataR)
@@ -113,10 +113,10 @@ void ConditionerEffect::process(float *dataL, float *dataR)
     float release = 0.0001f * rm * rm;
 
     float a = storage->vu_falloff;
-    vu[0] = min(8.f, a * vu[0]);
-    vu[1] = min(8.f, a * vu[1]);
-    vu[4] = min(8.f, a * vu[4]);
-    vu[5] = min(8.f, a * vu[5]);
+    vu[0][0] = min(8.f, a * vu[0][0]);
+    vu[0][1] = min(8.f, a * vu[0][1]);
+    vu[2][0] = min(8.f, a * vu[2][0]);
+    vu[2][1] = min(8.f, a * vu[2][1]);
 
     setvars(false);
 
@@ -151,8 +151,8 @@ void ConditionerEffect::process(float *dataL, float *dataR)
     ampL.multiply_block(dataL, BLOCK_SIZE_QUAD);
     ampR.multiply_block(dataR, BLOCK_SIZE_QUAD);
 
-    vu[0] = max(vu[0], mech::blockAbsMax<BLOCK_SIZE>(dataL));
-    vu[1] = max(vu[1], mech::blockAbsMax<BLOCK_SIZE>(dataR));
+    vu[0][0] = max(vu[0][0], mech::blockAbsMax<BLOCK_SIZE>(dataL));
+    vu[0][1] = max(vu[0][1], mech::blockAbsMax<BLOCK_SIZE>(dataR));
 
     for (int k = 0; k < BLOCK_SIZE; k++)
     {
@@ -193,10 +193,10 @@ void ConditionerEffect::process(float *dataL, float *dataR)
 
     postamp.multiply_2_blocks(dataL, dataR, BLOCK_SIZE_QUAD);
 
-    vu[2] = gain;
+    vu[1][0] = gain;
 
-    vu[4] = max(vu[4], mech::blockAbsMax<BLOCK_SIZE>(dataL));
-    vu[5] = max(vu[5], mech::blockAbsMax<BLOCK_SIZE>(dataR));
+    vu[2][0] = max(vu[2][0], mech::blockAbsMax<BLOCK_SIZE>(dataL));
+    vu[2][1] = max(vu[2][1], mech::blockAbsMax<BLOCK_SIZE>(dataR));
 }
 
 Surge::ParamConfig::VUType ConditionerEffect::vu_type(int id)

--- a/src/common/dsp/effects/ConditionerEffect.h
+++ b/src/common/dsp/effects/ConditionerEffect.h
@@ -68,7 +68,7 @@ class ConditionerEffect : public Effect
     float vu[3][2]; // stereo pairs, just use first only when mono
 
     static Surge::ParamConfig::VUType vu_type(int id);
-    static int vu_ypos(int id);  // In half-hslider amount.
+    static int vu_ypos(int id); // In half-hslider amount.
 
   private:
     BiquadFilter band1, band2, hp;

--- a/src/common/dsp/effects/ConditionerEffect.h
+++ b/src/common/dsp/effects/ConditionerEffect.h
@@ -47,8 +47,6 @@ class ConditionerEffect : public Effect
     void setvars(bool init);
     virtual void init_ctrltypes() override;
     virtual void init_default_values() override;
-    virtual Surge::ParamConfig::VUType vu_type(int id) override;
-    virtual int vu_ypos(int id) override;
     virtual const char *group_label(int id) override;
     virtual int group_label_ypos(int id) override;
 
@@ -66,6 +64,11 @@ class ConditionerEffect : public Effect
         cond_gain,
         cond_hpwidth,
     };
+
+    float vu[3][2]; // stereo pairs, just use first only when mono
+
+    static Surge::ParamConfig::VUType vu_type(int id);
+    static int vu_ypos(int id);  // In half-hslider amount.
 
   private:
     BiquadFilter band1, band2, hp;

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -154,6 +154,8 @@ target_sources(${PROJECT_NAME} PRIVATE
   gui/overlays/WaveShaperAnalysis.cpp
   gui/overlays/WaveShaperAnalysis.h
   gui/overlays/OpenSoundControlSettings.cpp
+  gui/widgets/CurrentFxDisplay.cpp
+  gui/widgets/CurrentFxDisplay.h
   gui/widgets/EffectChooser.cpp
   gui/widgets/EffectChooser.h
   gui/widgets/EffectLabel.h

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1705,41 +1705,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
                 {
                     vu[i + 1] = 0;
                 }
-
-                const char *label = synth->fx[current_fx]->group_label(i);
-
-                if (label)
-                {
-                    auto vr = fxRect.withTrimmedTop(-1)
-                                  .withTrimmedRight(-5)
-                                  .translated(5, -12)
-                                  .translated(0, yofs * synth->fx[current_fx]->group_label_ypos(i));
-
-                    if (!effectLabels[i])
-                    {
-                        effectLabels[i] = std::make_unique<Surge::Widgets::EffectLabel>();
-                    }
-
-                    effectLabels[i]->setBounds(vr);
-                    effectLabels[i]->setSkin(currentSkin, bitmapStore);
-
-                    if (i == 0 &&
-                        synth->storage.getPatch().fx[current_fx].type.val.i == fxt_vocoder)
-                    {
-                        effectLabels[i]->setLabel(
-                            fmt::format("Input delayed {} samples", BLOCK_SIZE));
-                    }
-                    else
-                    {
-                        effectLabels[i]->setLabel(label);
-                    }
-
-                    addAndMakeVisibleWithTracking(frame.get(), *effectLabels[i]);
-                }
-                else
-                {
-                    effectLabels[i].reset(nullptr);
-                }
             }
         }
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2126,7 +2126,8 @@ void SurgeGUIEditor::openOrRecreateEditor()
     }
 
     // Update the FX display window.
-    Surge::Widgets::CurrentFxDisplay *disp = dynamic_cast<Surge::Widgets::CurrentFxDisplay *>(frame->getControlGroupLayer(cg_FX));
+    Surge::Widgets::CurrentFxDisplay *disp =
+        dynamic_cast<Surge::Widgets::CurrentFxDisplay *>(frame->getControlGroupLayer(cg_FX));
     disp->updateCurrentFx(current_fx);
     uiidToSliderLabel.insert(disp->uiidToSliderLabel.begin(), disp->uiidToSliderLabel.end());
 
@@ -2223,8 +2224,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
         {
             mtext = ctext;
         }
-
-        std::cout << "Label with text " << *mtext << std::endl;
 
         if (mtext.has_value())
         {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -949,7 +949,8 @@ void SurgeGUIEditor::idle()
             }
         }
 
-        dynamic_cast<Surge::Widgets::CurrentFxDisplay *>(frame->getControlGroupLayer(cg_FX))->renderCurrentFx();
+        dynamic_cast<Surge::Widgets::CurrentFxDisplay *>(frame->getControlGroupLayer(cg_FX))
+            ->renderCurrentFx();
 
         for (int i = 0; i < 8; i++)
         {
@@ -1773,11 +1774,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
             break;
         }
-        case Surge::Skin::Connector::NonParameterConnection::JOG_FX:
-        {
-            // Handled in the CurrentFxDisplay component.
-            break;
-        }
         case Surge::Skin::Connector::NonParameterConnection::STATUS_MPE:
         {
             statusMPE = layoutComponentForSkin(skinCtrl, tag_status_mpe);
@@ -1882,11 +1878,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
             break;
         }
 
-        case Surge::Skin::Connector::NonParameterConnection::FXPRESET_LABEL:
-        {
-            // Handled in the CurrentFxDisplay component.
-            break;
-        }
         case Surge::Skin::Connector::NonParameterConnection::PATCH_BROWSER:
         {
             componentForSkinSessionOwnedByMember(skinCtrl->sessionid, patchSelector);
@@ -1910,11 +1901,6 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
             addAndMakeVisibleWithTracking(frame.get(), *patchSelector);
 
-            break;
-        }
-        case Surge::Skin::Connector::NonParameterConnection::FX_SELECTOR:
-        {
-            // Handled in the CurrentFxDisplay component.
             break;
         }
         case Surge::Skin::Connector::NonParameterConnection::MAIN_VU_METER:
@@ -1943,6 +1929,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
         case Surge::Skin::Connector::NonParameterConnection::OSCILLOSCOPE_WINDOW:
         case Surge::Skin::Connector::NonParameterConnection::WAVESHAPER_ANALYSIS_WINDOW:
         case Surge::Skin::Connector::NonParameterConnection::N_NONCONNECTED:
+        case Surge::Skin::Connector::NonParameterConnection::FXPRESET_LABEL:
+        case Surge::Skin::Connector::NonParameterConnection::FX_SELECTOR:
+        case Surge::Skin::Connector::NonParameterConnection::JOG_FX:
             break;
         }
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -86,6 +86,7 @@ struct Switch;
 struct VerticalLabel;
 struct VuMeter;
 
+struct CurrentFxDisplay;
 struct MainFrame;
 
 struct WaveShaperSelector;
@@ -929,6 +930,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
      * the add remove handlers
      */
     friend class Surge::Widgets::MainFrame;
+    friend class Surge::Widgets::CurrentFxDisplay;
     std::unordered_map<juce::Component *, juce::Component *> containedComponents;
     void addComponentWithTracking(juce::Component *target, juce::Component &source);
     void addAndMakeVisibleWithTracking(juce::Component *target, juce::Component &source);

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -732,8 +732,6 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     /*
      * This is the JUCE component management
      */
-    std::array<std::unique_ptr<Surge::Widgets::EffectLabel>, 15> effectLabels;
-
     bool scanJuceSkinComponents{false};
     std::unordered_map<Surge::GUI::Skin::Control::sessionid_t, std::unique_ptr<juce::Component>>
         juceSkinComponents;

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -621,7 +621,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     std::unique_ptr<Surge::Widgets::FxMenu> fxMenu;
 
   private:
-    std::array<std::unique_ptr<Surge::Widgets::VuMeter>, n_fx_slots + 1> vu;
+    std::unique_ptr<Surge::Widgets::VuMeter> vu;
+    //std::array<std::unique_ptr<Surge::Widgets::VuMeter>, n_fx_slots + 1> vu;
     bool firstTimePatchLoad{true};
     std::unique_ptr<Surge::Widgets::PatchSelector> patchSelector;
     std::unique_ptr<Surge::Widgets::PatchSelectorCommentTooltip> patchSelectorComment;

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -622,7 +622,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
 
   private:
     std::unique_ptr<Surge::Widgets::VuMeter> vu;
-    //std::array<std::unique_ptr<Surge::Widgets::VuMeter>, n_fx_slots + 1> vu;
+    // std::array<std::unique_ptr<Surge::Widgets::VuMeter>, n_fx_slots + 1> vu;
     bool firstTimePatchLoad{true};
     std::unique_ptr<Surge::Widgets::PatchSelector> patchSelector;
     std::unique_ptr<Surge::Widgets::PatchSelectorCommentTooltip> patchSelectorComment;

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
@@ -59,8 +59,7 @@ void CurrentFxDisplay::updateCurrentFx(int current_fx)
     auto makeParameter = [this, &currentSkin](int n) {
         Parameter *p = editor_->synth->storage.getPatch().param_ptr[n];
         Surge::Skin::Connector conn = Surge::Skin::Connector::connectorByID(p->ui_identifier);
-        if (p->hasSkinConnector &&
-            conn.payload->defaultComponent != Surge::Skin::Components::None)
+        if (p->hasSkinConnector && conn.payload->defaultComponent != Surge::Skin::Components::None)
         {
             auto skinCtrl = currentSkin->getOrCreateControlForConnector(conn);
             currentSkin->resolveBaseParentOffsets(skinCtrl);
@@ -68,10 +67,13 @@ void CurrentFxDisplay::updateCurrentFx(int current_fx)
                 editor_->layoutComponentForSkin(skinCtrl, p->id + start_paramtags, n, p,
                                                 p->ctrlstyle | conn.payload->controlStyleFlags);
             uiidToSliderLabel[p->ui_identifier] = p->get_name();
-            if (p->id == editor_->synth->learn_param_from_cc || p->id == editor_->synth->learn_param_from_note)
+            if (p->id == editor_->synth->learn_param_from_cc ||
+                p->id == editor_->synth->learn_param_from_note)
             {
-                editor_->showMidiLearnOverlay(
-                    editor_->param[p->id]->asControlValueInterface()->asJuceComponent()->getBounds());
+                editor_->showMidiLearnOverlay(editor_->param[p->id]
+                                                  ->asControlValueInterface()
+                                                  ->asJuceComponent()
+                                                  ->getBounds());
             }
         }
     };
@@ -112,16 +114,19 @@ void CurrentFxDisplay::layoutFxSelector()
 
     for (int fxi = 0; fxi < n_fx_slots; fxi++)
     {
-        editor_->effectChooser->setEffectType(fxi, editor_->synth->storage.getPatch().fx[fxi].type.val.i);
+        editor_->effectChooser->setEffectType(
+            fxi, editor_->synth->storage.getPatch().fx[fxi].type.val.i);
     }
 
     editor_->effectChooser->setBypass(editor_->synth->storage.getPatch().fx_bypass.val.i);
-    editor_->effectChooser->setDeactivatedBitmask(editor_->synth->storage.getPatch().fx_disable.val.i);
+    editor_->effectChooser->setDeactivatedBitmask(
+        editor_->synth->storage.getPatch().fx_disable.val.i);
 
-    editor_->addAndMakeVisibleWithTracking(editor_->frame->getControlGroupLayer(cg_FX), *editor_->effectChooser);
+    editor_->addAndMakeVisibleWithTracking(editor_->frame->getControlGroupLayer(cg_FX),
+                                           *editor_->effectChooser);
 
     editor_->setAccessibilityInformationByTitleAndAction(editor_->effectChooser->asJuceComponent(),
-                                                "FX Slots", "Select");
+                                                         "FX Slots", "Select");
 }
 
 void CurrentFxDisplay::layoutFxPresetLabel()
@@ -136,13 +141,14 @@ void CurrentFxDisplay::layoutFxPresetLabel()
     }
 
     editor_->fxPresetLabel->setColour(juce::Label::textColourId,
-                             editor_->currentSkin->getColor(Colors::Effect::Preset::Name));
+                                      editor_->currentSkin->getColor(Colors::Effect::Preset::Name));
     editor_->fxPresetLabel->setFont(editor_->currentSkin->fontManager->displayFont);
     editor_->fxPresetLabel->setJustificationType(juce::Justification::centredRight);
 
     editor_->fxPresetLabel->setText(editor_->fxPresetName[current_fx_], juce::dontSendNotification);
     editor_->fxPresetLabel->setBounds(skinCtrl->getRect());
-    editor_->setAccessibilityInformationByTitleAndAction(editor_->fxPresetLabel.get(), "FX Preset", "Show");
+    editor_->setAccessibilityInformationByTitleAndAction(editor_->fxPresetLabel.get(), "FX Preset",
+                                                         "Show");
 
     editor_->addAndMakeVisibleWithTracking(this, *editor_->fxPresetLabel);
 }

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
@@ -17,16 +17,13 @@ namespace Surge
 namespace Widgets
 {
 
-CurrentFxDisplay::CurrentFxDisplay()
-{}
-
-CurrentFxDisplay::~CurrentFxDisplay() {}
-
-void CurrentFxDisplay::setSurgeGUIEditor(SurgeGUIEditor *e)
+CurrentFxDisplay::CurrentFxDisplay(SurgeGUIEditor *e)
 {
     editor_ = e;
     storage_ = e->getStorage();
 }
+
+CurrentFxDisplay::~CurrentFxDisplay() {}
 
 void CurrentFxDisplay::renderCurrentFx()
 {
@@ -194,7 +191,8 @@ void CurrentFxDisplay::conditionerRender()
         return;
 
     // Set the current VUs to their values.
-    const ConditionerEffect& fx = dynamic_cast<ConditionerEffect &>(*editor_->synth->fx[current_fx_]);
+    const ConditionerEffect &fx =
+        dynamic_cast<ConditionerEffect &>(*editor_->synth->fx[current_fx_]);
     for (int i = 0; i < 3; i++)
     {
         // Ensure the layout has actually happened by this point.

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
@@ -1,0 +1,164 @@
+#include "CurrentFxDisplay.h"
+#include "EffectChooser.h"
+#include "RuntimeFont.h"
+#include "SkinModel.h"
+#include "SurgeGUIEditor.h"
+#include "SurgeGUIEditorTags.h"
+
+namespace Surge
+{
+namespace Widgets
+{
+
+CurrentFxDisplay::CurrentFxDisplay() {}
+
+CurrentFxDisplay::~CurrentFxDisplay() {}
+
+void CurrentFxDisplay::setSurgeGUIEditor(SurgeGUIEditor *e)
+{
+    editor_ = e;
+    storage_ = e->getStorage();
+}
+
+void CurrentFxDisplay::updateCurrentFx(int current_fx)
+{
+    std::unordered_map<int, int> paramToParamIndex;
+    current_fx_ = current_fx;
+    FxStorage &fx = storage_->getPatch().fx[current_fx];
+
+    // This is kinda dumb, but we have to provide an absolute param index number
+    // to layoutComponentForSkin, so figure it out here.
+    int i = 0;
+    // IDs of others that we need to lay out.
+    int fx_type = -1;
+
+    std::vector<Parameter *>::iterator iter;
+    for (iter = editor_->synth->storage.getPatch().param_ptr.begin();
+         iter != editor_->synth->storage.getPatch().param_ptr.end(); iter++, i++)
+    {
+        Parameter *p = *iter;
+        if (strcmp(p->ui_identifier, "fx.type") == 0)
+        {
+            fx_type = i;
+            continue;
+        }
+
+        for (int j = 0; j < n_fx_params; j++)
+        {
+            if (p == &fx.p[j])
+            {
+                paramToParamIndex[j] = i;
+                break;
+            }
+        }
+    }
+
+    Surge::GUI::Skin::ptr_t currentSkin = editor_->currentSkin;
+
+    // Code to lay out the parameter and wire it up.
+    auto makeParameter = [this, &currentSkin](int n) {
+        Parameter *p = editor_->synth->storage.getPatch().param_ptr[n];
+        Surge::Skin::Connector conn = Surge::Skin::Connector::connectorByID(p->ui_identifier);
+        if (p->hasSkinConnector &&
+            conn.payload->defaultComponent != Surge::Skin::Components::None)
+        {
+            auto skinCtrl = currentSkin->getOrCreateControlForConnector(conn);
+            currentSkin->resolveBaseParentOffsets(skinCtrl);
+            auto comp =
+                editor_->layoutComponentForSkin(skinCtrl, p->id + start_paramtags, n, p,
+                                                p->ctrlstyle | conn.payload->controlStyleFlags);
+            uiidToSliderLabel[p->ui_identifier] = p->get_name();
+            if (p->id == editor_->synth->learn_param_from_cc || p->id == editor_->synth->learn_param_from_note)
+            {
+                editor_->showMidiLearnOverlay(
+                    editor_->param[p->id]->asControlValueInterface()->asJuceComponent()->getBounds());
+            }
+        }
+    };
+
+    // First the FX Selector, type, preset, and jog.
+    layoutFxSelector();
+    // This one's a little weird: the construction is done in layoutComponentForSkin.
+    makeParameter(fx_type);
+    layoutFxPresetLabel();
+    layoutJogFx();
+
+    // Now the FX params.
+    for (i = 0; i < n_fx_params; i++)
+    {
+        if (fx.p[i].ctrltype != ct_none)
+        {
+            makeParameter(paramToParamIndex[i]);
+        }
+    }
+}
+
+void CurrentFxDisplay::layoutFxSelector()
+{
+    auto currentSkin = editor_->currentSkin;
+    auto conn = Surge::Skin::Connector::connectorByID("fx.selector");
+    auto skinCtrl = currentSkin->getOrCreateControlForConnector(conn);
+
+    // FIXOWN
+    editor_->componentForSkinSessionOwnedByMember(skinCtrl->sessionid, editor_->effectChooser);
+
+    editor_->effectChooser->addListener(editor_);
+    editor_->effectChooser->setStorage(&(editor_->synth->storage));
+    editor_->effectChooser->setBounds(skinCtrl->getRect());
+    editor_->effectChooser->setTag(tag_fx_select);
+    editor_->effectChooser->setSkin(currentSkin, editor_->bitmapStore);
+    editor_->effectChooser->setBackgroundDrawable(editor_->bitmapStore->getImage(IDB_FX_GRID));
+    editor_->effectChooser->setCurrentEffect(current_fx_);
+
+    for (int fxi = 0; fxi < n_fx_slots; fxi++)
+    {
+        editor_->effectChooser->setEffectType(fxi, editor_->synth->storage.getPatch().fx[fxi].type.val.i);
+    }
+
+    editor_->effectChooser->setBypass(editor_->synth->storage.getPatch().fx_bypass.val.i);
+    editor_->effectChooser->setDeactivatedBitmask(editor_->synth->storage.getPatch().fx_disable.val.i);
+
+    editor_->addAndMakeVisibleWithTracking(editor_->frame->getControlGroupLayer(cg_FX), *editor_->effectChooser);
+
+    editor_->setAccessibilityInformationByTitleAndAction(editor_->effectChooser->asJuceComponent(),
+                                                "FX Slots", "Select");
+}
+
+void CurrentFxDisplay::layoutFxPresetLabel()
+{
+    auto currentSkin = editor_->currentSkin;
+    auto conn = Surge::Skin::Connector::connectorByID("fx.preset.name");
+    auto skinCtrl = currentSkin->getOrCreateControlForConnector(conn);
+
+    if (!editor_->fxPresetLabel)
+    {
+        editor_->fxPresetLabel = std::make_unique<juce::Label>("FX Preset Name");
+    }
+
+    editor_->fxPresetLabel->setColour(juce::Label::textColourId,
+                             editor_->currentSkin->getColor(Colors::Effect::Preset::Name));
+    editor_->fxPresetLabel->setFont(editor_->currentSkin->fontManager->displayFont);
+    editor_->fxPresetLabel->setJustificationType(juce::Justification::centredRight);
+
+    editor_->fxPresetLabel->setText(editor_->fxPresetName[current_fx_], juce::dontSendNotification);
+    editor_->fxPresetLabel->setBounds(skinCtrl->getRect());
+    editor_->setAccessibilityInformationByTitleAndAction(editor_->fxPresetLabel.get(), "FX Preset", "Show");
+
+    editor_->addAndMakeVisibleWithTracking(this, *editor_->fxPresetLabel);
+}
+
+void CurrentFxDisplay::layoutJogFx()
+{
+    auto currentSkin = editor_->currentSkin;
+    auto conn = Surge::Skin::Connector::connectorByID("fx.preset.prevnext");
+    auto skinCtrl = currentSkin->getOrCreateControlForConnector(conn);
+
+    // This one's a little weird -- it's just a multiswitch, which is set up
+    // by default in layoutComponentForSkin for the tag. Since it's set up
+    // there, they own the component.
+    auto q = editor_->layoutComponentForSkin(skinCtrl, tag_mp_jogfx);
+    editor_->setAccessibilityInformationByTitleAndAction(q->asJuceComponent(), "FX Preset", "Jog");
+}
+
+} // namespace Widgets
+} // namespace Surge

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.h
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.h
@@ -24,9 +24,11 @@
 #define SURGE_SRC_SURGE_XT_GUI_WIDGETS_CURRENTFXDISPLAY_H
 
 #include "Effect.h"
+#include "EffectLabel.h"
 #include "MainFrame.h"
 #include "SurgeStorage.h"
 
+#include <array>
 #include <juce_gui_basics/juce_gui_basics.h>
 
 namespace Surge
@@ -49,11 +51,14 @@ class CurrentFxDisplay : public MainFrame::OverlayComponent
     void layoutFxSelector();
     void layoutFxPresetLabel();
     void layoutJogFx();
+    void layoutSectionLabels();
 
     int current_fx_{-1};
+    Effect *effect_{nullptr};  // unique_ptr owned by synth.
     SurgeGUIEditor *editor_{nullptr};
     SurgeStorage *storage_{nullptr};
 
+    std::array<std::unique_ptr<Surge::Widgets::EffectLabel>, n_fx_params> labels_;
     // Note: Due to the existing code that refers to it, the effectChooser and
     // fxPresetLabel widgets are held in the SurgeGUIEditor class, rather than here.
     // If the code (callbacks) can end up localized here too, we can move the

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.h
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.h
@@ -1,0 +1,66 @@
+/*
+ * Surge XT - a free and open source hybrid synthesizer,
+ * built by Surge Synth Team
+ *
+ * Learn more at https://surge-synthesizer.github.io/
+ *
+ * Copyright 2018-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * Surge XT is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Surge was a commercial product from 2004-2018, copyright and ownership
+ * held by Claes Johanson at Vember Audio during that period.
+ * Claes made Surge open source in September 2018.
+ *
+ * All source for Surge XT is available at
+ * https://github.com/surge-synthesizer/surge
+ */
+
+#ifndef SURGE_SRC_SURGE_XT_GUI_WIDGETS_CURRENTFXDISPLAY_H
+#define SURGE_SRC_SURGE_XT_GUI_WIDGETS_CURRENTFXDISPLAY_H
+
+#include "Effect.h"
+#include "MainFrame.h"
+#include "SurgeStorage.h"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace Surge
+{
+namespace Widgets
+{
+
+class CurrentFxDisplay : public MainFrame::OverlayComponent
+{
+  public:
+    CurrentFxDisplay();
+    ~CurrentFxDisplay() override;
+
+    void setSurgeGUIEditor(SurgeGUIEditor *e);
+    void updateCurrentFx(int current_fx);
+
+    std::unordered_map<std::string, std::string> uiidToSliderLabel;
+
+  private:
+    void layoutFxSelector();
+    void layoutFxPresetLabel();
+    void layoutJogFx();
+
+    int current_fx_{-1};
+    SurgeGUIEditor *editor_{nullptr};
+    SurgeStorage *storage_{nullptr};
+
+    // Note: Due to the existing code that refers to it, the effectChooser and
+    // fxPresetLabel widgets are held in the SurgeGUIEditor class, rather than here.
+    // If the code (callbacks) can end up localized here too, we can move the
+    // ownership here where it belongs.
+};
+
+} // namespace Widgets
+} // namespace Surge
+
+#endif // SURGE_SRC_SURGE_XT_GUI_WIDGETS_CURRENTFXDISPLAY_H

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.h
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.h
@@ -40,10 +40,8 @@ namespace Widgets
 class CurrentFxDisplay : public MainFrame::OverlayComponent
 {
   public:
-    CurrentFxDisplay();
+    explicit CurrentFxDisplay(SurgeGUIEditor *e);
     ~CurrentFxDisplay() override;
-
-    void setSurgeGUIEditor(SurgeGUIEditor *e);
 
     void renderCurrentFx();
     void updateCurrentFx(int current_fx);

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.h
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.h
@@ -48,6 +48,11 @@ class CurrentFxDisplay : public MainFrame::OverlayComponent
     std::unordered_map<std::string, std::string> uiidToSliderLabel;
 
   private:
+    // Individual FX layouts.
+    void defaultLayout();
+    void vocoderLayout();
+
+    // Generic layout helpers.
     void layoutFxSelector();
     void layoutFxPresetLabel();
     void layoutJogFx();

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.h
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.h
@@ -27,6 +27,7 @@
 #include "EffectLabel.h"
 #include "MainFrame.h"
 #include "SurgeStorage.h"
+#include "VuMeter.h"
 
 #include <array>
 #include <juce_gui_basics/juce_gui_basics.h>
@@ -43,6 +44,8 @@ class CurrentFxDisplay : public MainFrame::OverlayComponent
     ~CurrentFxDisplay() override;
 
     void setSurgeGUIEditor(SurgeGUIEditor *e);
+
+    void renderCurrentFx();
     void updateCurrentFx(int current_fx);
 
     std::unordered_map<std::string, std::string> uiidToSliderLabel;
@@ -50,7 +53,11 @@ class CurrentFxDisplay : public MainFrame::OverlayComponent
   private:
     // Individual FX layouts.
     void defaultLayout();
+    void conditionerLayout();
     void vocoderLayout();
+
+    // Individual renders.
+    void conditionerRender();
 
     // Generic layout helpers.
     void layoutFxSelector();
@@ -58,12 +65,19 @@ class CurrentFxDisplay : public MainFrame::OverlayComponent
     void layoutJogFx();
     void layoutSectionLabels();
 
+    // For laying out things roughly slider shaped (labels, VUs).
+    juce::Rectangle<int> fxRect();
+
     int current_fx_{-1};
-    Effect *effect_{nullptr};  // unique_ptr owned by synth.
+    Effect *effect_{nullptr}; // unique_ptr owned by synth.
     SurgeGUIEditor *editor_{nullptr};
     SurgeStorage *storage_{nullptr};
 
+    // Used by everything.
     std::array<std::unique_ptr<Surge::Widgets::EffectLabel>, n_fx_params> labels_;
+    // Used by the conditioner.
+    std::array<std::unique_ptr<Surge::Widgets::VuMeter>, 3> vus;
+
     // Note: Due to the existing code that refers to it, the effectChooser and
     // fxPresetLabel widgets are held in the SurgeGUIEditor class, rather than here.
     // If the code (callbacks) can end up localized here too, we can move the

--- a/src/surge-xt/gui/widgets/MainFrame.cpp
+++ b/src/surge-xt/gui/widgets/MainFrame.cpp
@@ -24,6 +24,7 @@
 #include "SurgeGUIEditor.h"
 #include "SurgeGUICallbackInterfaces.h"
 #include "AccessibleHelpers.h"
+#include "CurrentFxDisplay.h"
 #include "MultiSwitch.h"
 #include "SurgeGUIEditorTags.h"
 #include <version.h>
@@ -126,8 +127,6 @@ juce::Component *MainFrame::getControlGroupLayer(ControlGroup cg)
     if (!cgOverlays[cg])
     {
         auto ol = std::make_unique<OverlayComponent>();
-        ol->setBounds(getLocalBounds());
-        ol->setInterceptsMouseClicks(false, true);
         auto t = "Group " + std::to_string((int)cg);
         switch (cg)
         {
@@ -151,11 +150,20 @@ juce::Component *MainFrame::getControlGroupLayer(ControlGroup cg)
             break;
         case cg_FX:
             t = "FX Controls";
+            // Special case: we have an overlay component just for this.
+            ol = std::make_unique<CurrentFxDisplay>();
+            {
+                CurrentFxDisplay *a = dynamic_cast<CurrentFxDisplay*>(ol.get());
+                // Careful -- do these values ever need to be updated?
+                a->setSurgeGUIEditor(editor);
+            }
             break;
         default:
             t = "Unknown Controls";
             break;
         }
+        ol->setBounds(getLocalBounds());
+        ol->setInterceptsMouseClicks(false, true);
         ol->setDescription(t);
         ol->setTitle(t);
         ol->getProperties().set("ControlGroup", (int)cg + 1000);

--- a/src/surge-xt/gui/widgets/MainFrame.cpp
+++ b/src/surge-xt/gui/widgets/MainFrame.cpp
@@ -151,12 +151,7 @@ juce::Component *MainFrame::getControlGroupLayer(ControlGroup cg)
         case cg_FX:
             t = "FX Controls";
             // Special case: we have an overlay component just for this.
-            ol = std::make_unique<CurrentFxDisplay>();
-            {
-                CurrentFxDisplay *a = dynamic_cast<CurrentFxDisplay *>(ol.get());
-                // Careful -- do these values ever need to be updated?
-                a->setSurgeGUIEditor(editor);
-            }
+            ol = std::make_unique<CurrentFxDisplay>(editor);
             break;
         default:
             t = "Unknown Controls";

--- a/src/surge-xt/gui/widgets/MainFrame.cpp
+++ b/src/surge-xt/gui/widgets/MainFrame.cpp
@@ -153,7 +153,7 @@ juce::Component *MainFrame::getControlGroupLayer(ControlGroup cg)
             // Special case: we have an overlay component just for this.
             ol = std::make_unique<CurrentFxDisplay>();
             {
-                CurrentFxDisplay *a = dynamic_cast<CurrentFxDisplay*>(ol.get());
+                CurrentFxDisplay *a = dynamic_cast<CurrentFxDisplay *>(ol.get());
                 // Careful -- do these values ever need to be updated?
                 a->setSurgeGUIEditor(editor);
             }


### PR DESCRIPTION
This moves the code that's laying it out, but generally doesn't move ownership, which is an extremely complex beast in the Surge editor.