### PR TITLE
wavetable display - skewH

### DIFF
--- a/src/common/dsp/oscillators/WavetableOscillator.h
+++ b/src/common/dsp/oscillators/WavetableOscillator.h
@@ -63,6 +63,9 @@ class WavetableOscillator : public AbstractBlitOscillator
 
     void processSamplesForDisplay(float *samples, int size, bool real) override;
 
+    static const int SAMPLES_FOR_DISPLAY = 60;
+    static double skewHPhaseResponse[SAMPLES_FOR_DISPLAY];
+
   private:
     void convolute(int voice, bool FM, bool stereo);
     template <bool is_init> void update_lagvals();
@@ -89,6 +92,7 @@ class WavetableOscillator : public AbstractBlitOscillator
     int nointerp;
     float FMmul_inv;
     int sampleloop;
+
     pdata *unmodulatedLocalcopy;
     FeatureDeform deformType;
 };

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -26,6 +26,7 @@
 #include "SurgeSynthEditor.h"
 #include "Oscillator.h"
 #include "OscillatorBase.h"
+#include "WavetableOscillator.h"
 #include "RuntimeFont.h"
 #include "SurgeGUIUtils.h"
 #include "SurgeGUIEditor.h"
@@ -1562,7 +1563,7 @@ struct WaveTable3DEditor : public juce::Component,
     int wt_size = 0;
     int wt_nframes = 64;
     int rendered_frames = 40;
-    int rendered_samples = 60;
+    int rendered_samples = WavetableOscillator::SAMPLES_FOR_DISPLAY;
     float paddingX = 0.017679932260795936;
     float paddingY = 0.2127688399661304;
     float skew = 0.3;


### PR DESCRIPTION
SkewH finally added to the wavetable oscillator display. 

It's not the prettiest solution, but it works quite well and should at least in theory be faster than actually using the real skew equation. 
I really tried to implement the equation, but I never got it to match the waveform output, so this will have to do for now. 

