### PR TITLE
Remove juce dependency from BBDEnsemble and Neuron

### DIFF
--- a/src/common/dsp/effects/chowdsp/bbd_utils/BBDCompander.h
+++ b/src/common/dsp/effects/chowdsp/bbd_utils/BBDCompander.h
@@ -22,8 +22,6 @@
 #ifndef SURGE_SRC_COMMON_DSP_EFFECTS_CHOWDSP_BBD_UTILS_BBDCOMPANDER_H
 #define SURGE_SRC_COMMON_DSP_EFFECTS_CHOWDSP_BBD_UTILS_BBDCOMPANDER_H
 
-#include "juce_core/juce_core.h"
-
 /**
  * Signal averager used for BBD companding.
  * Borrowed from Fig. 11, from Huovilainen's DAFx-05 paper

--- a/src/common/dsp/effects/chowdsp/spring_reverb/ReflectionNetwork.h
+++ b/src/common/dsp/effects/chowdsp/spring_reverb/ReflectionNetwork.h
@@ -24,6 +24,7 @@
 #define SURGE_SRC_COMMON_DSP_EFFECTS_CHOWDSP_SPRING_REVERB_REFLECTIONNETWORK_H
 
 #include <array>
+#include <cstdint>
 
 #include "globals.h"
 #include "UnitConversions.h"
@@ -44,7 +45,7 @@ class ReflectionNetwork
         fs = sampleRate;
 
         for (auto &d : delays)
-            d.prepare({sampleRate, (juce::uint32)samplesPerBlock, 2});
+            d.prepare({sampleRate, (size_t)samplesPerBlock, 2});
 
         shelfFilter.reset();
     }

--- a/src/common/dsp/effects/chowdsp/spring_reverb/SpringReverbProc.cpp
+++ b/src/common/dsp/effects/chowdsp/spring_reverb/SpringReverbProc.cpp
@@ -19,10 +19,12 @@
  * All source for Surge XT is available at
  * https://github.com/surge-synthesizer/surge
  */
+
 #include <random>
 
 #include "SpringReverbProc.h"
 #include "sst/basic-blocks/dsp/FastMath.h"
+#include <cstdint>
 
 namespace
 {
@@ -44,7 +46,7 @@ void SpringReverbProc::prepare(float sampleRate, int samplesPerBlock)
 {
     fs = sampleRate;
 
-    delay.prepare({sampleRate, (juce::uint32)samplesPerBlock, 2});
+    delay.prepare({sampleRate, (size_t)samplesPerBlock, 2});
 
     dcBlocker.prepare(sampleRate, 2);
     dcBlocker.setCutoffFrequency(40.0f);

--- a/src/common/dsp/effects/chowdsp/spring_reverb/SpringReverbProc.h
+++ b/src/common/dsp/effects/chowdsp/spring_reverb/SpringReverbProc.h
@@ -30,6 +30,7 @@
 
 #include "ReflectionNetwork.h"
 #include "SchroederAllpass.h"
+#include "juce_dsp/juce_dsp.h"
 
 namespace chowdsp
 {

--- a/src/surge-testrunner/UnitTestsDSP.cpp
+++ b/src/surge-testrunner/UnitTestsDSP.cpp
@@ -19,6 +19,7 @@
  * All source for Surge XT is available at
  * https://github.com/surge-synthesizer/surge
  */
+
 #include <iostream>
 #include <algorithm>
 
@@ -34,6 +35,7 @@
 #include "sst/basic-blocks/mechanics/simd-ops.h"
 
 #include "sst/plugininfra/cpufeatures.h"
+#include "dsp/effects/chowdsp/shared/chowdsp_DelayLine.h"
 
 using namespace Surge::Test;
 
@@ -744,6 +746,33 @@ TEST_CASE("Oscillator Onset", "[dsp]") // See issue 7570
                "
                       << (continueChecking ? "Unknown" : std::to_string(itUntilBigger))
                       << std::endl;*/
+        }
+    }
+}
+
+TEST_CASE("Chow DSP Delay", "[dsp]")
+{
+    chowdsp::DelayLine<float> floatDelay(1024);
+    floatDelay.prepare({48000, 16, 2});
+    floatDelay.setDelay(128);
+    for (int i = 0; i < 1024; ++i)
+    {
+        auto dL = floatDelay.popSample(0);
+        auto dR = floatDelay.popSample(1);
+        floatDelay.pushSample(0, i / 1024.);
+        floatDelay.pushSample(1, 1 - i / 1024.);
+        if (i >= 128)
+        {
+            INFO("I = " << i);
+            auto ni = i - 128;
+            REQUIRE(dL == ni / 1024.);
+            REQUIRE(dR == 1 - ni / 1024.);
+        }
+        else
+        {
+            INFO("i = " << i);
+            REQUIRE(dL == 0.f);
+            REQUIRE(dR == 0.f);
         }
     }
 }


### PR DESCRIPTION
Modify chowdsp::DelayLineBase to no longer reply on the relativlly trivial classes juce::AudioBlock and juce::ProcessorSpec and juce::HeapBlock, replacing them with fairly standard allocating delay lines and spec objects instead. Similarly replace juce::jmax with std::max and so on.

Upshot: Neuron and BBDEnsemble no lnoger require juce::dsp.

Spring Reverb is harder. Working on that still.