### PR TITLE
Correct Tx 2, 4, 6 and 8 waveforms

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -1086,13 +1086,13 @@ void Parameter::set_type(int ctrltype)
         break;
     case ct_sineoscmode:
         val_min.i = 0;
-        val_max.i = 27;
+        val_max.i = 27 + 4; // In surge 1.4 added 4 corrected shapes
         valtype = vt_int;
         val_default.i = 0;
         break;
     case ct_ringmod_sineoscmode:
         val_min.i = 0;
-        val_max.i = 28; // above sineosc + 1 for audio in
+        val_max.i = 28 + 4; // above sineosc + 1 for audio in
         valtype = vt_int;
         val_default.i = 0;
         break;
@@ -3998,7 +3998,13 @@ std::string Parameter::get_display(bool external, float ef) const
             case 7:
                 txt = fmt::format("Wave {:d} (TX {:d})", i + 1, i + 1);
                 break;
-            case 28: // only hit in ringmod_sineoscmode
+            case 28:
+            case 29:
+            case 30:
+            case 31:
+                txt = fmt::format("Wave {:d} (Legacy TX {:d})", i + 1, (i - 27) * 2);
+                break;
+            case 32: // only hit in ringmod_sineoscmode
                 txt = "Audio In";
                 break;
             default:

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2244,6 +2244,46 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             }
         }
     }
+
+    if (revision <= 27)
+    {
+        // Sine Osc adds waveforms
+        for (auto &sc : scene)
+        {
+            for (auto &o : sc.osc)
+            {
+                if (o.type.val.i == ot_sine)
+                {
+                    auto shp = o.p[0].val.i;
+                    if (shp >= 1 && shp <= 7)
+                    {
+                        if (shp % 2 == 1)
+                        {
+                            auto q = (shp - 1) / 2 + 28;
+                            o.p[0].val.i = q;
+                        }
+                    }
+                }
+            }
+        }
+        for (auto &f : fx)
+        {
+            if (f.type.val.i == fxt_ringmod)
+            {
+                auto sh = f.p[0].val.i;
+                if (sh == 28)
+                {
+                    sh = 33;
+                }
+                if (sh == 1 || sh == 3 || sh == 5 || sh == 7)
+                {
+                    sh = (sh - 1) / 2 + 28;
+                }
+                f.p[0].val.i = sh;
+            }
+        }
+    }
+
     // ensure that filter subtype is a valid value
     for (auto &sc : scene)
     {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -142,9 +142,10 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 //                               added DAWExtraState members for saving the state of Lua code editors, and variable group states in debugger
 // 26 -> 27 (XT 1.4.* nightlies) fix OBXD and BP12 legacy streaming for sst-filters upgrade
 //                               fix extendable parameters not extending in Waveshaper effect
+// 27 -> 28 (XT 1.4.* nightlies) Add corrected TX shapes to sine proc
 // clang-format on
 
-const int ff_revision = 27;
+const int ff_revision = 28;
 
 const int n_scene_params = 273;
 const int n_global_params = 11 + n_fx_slots * (n_fx_params + 1); // each param plus a type

--- a/src/common/dsp/oscillators/AliasOscillator.cpp
+++ b/src/common/dsp/oscillators/AliasOscillator.cpp
@@ -67,7 +67,18 @@ void AliasOscillator::init(float pitch, bool is_display, bool nonzero_init_drift
             {
                 float c = std::cos(k * dPhase);
                 float s = std::sin(k * dPhase);
-                auto r = SineOscillator::valueFromSinAndCos(s, c, i + 1);
+
+                /*
+                 * Editoridal decision: Rather than add a slew
+                 * of shapes to alias, retain the pre-xt 1.4
+                 * shapes for the 'spiky' waveforms which will
+                 * sound better here anyway. Don't add the corrected
+                 * ones sinceosc has
+                 */
+                auto wf = i + 1;
+                if (i % 2 == 0)
+                    wf = i / 2 + 28;
+                auto r = SineOscillator::valueFromSinAndCos(s, c, wf);
                 auto r01 = (r + 1) * 0.5;
                 shaped_sinetable[i][k] = (uint8_t)(r01 * 0xFF);
             }


### PR DESCRIPTION
When writing Six Sines I realized the forms we had for TX 245 and 8 were too "spiky" and while these matched the manual they didn't matc a scope from a TX which was really just doubled shifted cos etc...

So port that fix back here from six sines and add the 4 legacy even shapes as new modes and adjust streaming.

Keep the alias oscillator having the old shapes only.

Closes #7965