### PR TITLE
Fix a chowdsp_DelayLine port-away-from-juce ownership issue

### DIFF
--- a/src/common/dsp/effects/chowdsp/shared/chowdsp_DelayLine.cpp
+++ b/src/common/dsp/effects/chowdsp/shared/chowdsp_DelayLine.cpp
@@ -68,8 +68,8 @@ void DelayLine<SampleType, InterpolationType>::prepare(
 {
     assert(spec.numChannels > 0);
 
-    this->bufferData =
-        typename DelayLineBase<SampleType>::AudioBlock(spec.numChannels, 2 * (size_t)totalSize);
+    this->bufferData = typename DelayLineBase<SampleType>::AudioBlock(
+        this->dataBlock, spec.numChannels, 2 * (size_t)totalSize);
 
     this->writePos.resize(spec.numChannels);
     this->readPos.resize(spec.numChannels);


### PR DESCRIPTION
which caused a sprint reverb crash

Basically the lifetime of the audio block overlay is different than the block which is why originally there was an external heap block. Restore that ownership with the vector buffer and avoid an occasional mis-owned crash

Closes #8177