### PR TITLE
Improve FX Unit Zoom behavior

### DIFF
--- a/src/surge-fx/SurgeFXEditor.cpp
+++ b/src/surge-fx/SurgeFXEditor.cpp
@@ -46,7 +46,7 @@ struct Picker : public juce::Component
         g.setColour(edge);
         g.drawRoundedRectangle(bounds, 5, 1);
         g.setColour(findColour(SurgeLookAndFeel::SurgeColourIds::paramDisplay));
-        g.setFont(SST_JUCE_FONT_OPTIONS(28));
+        g.setFont(SST_JUCE_FONT_OPTIONS(28 * editor->getImpliedZoom()));
         g.drawText(fx_type_names[editor->processor.getEffectType()], bounds.reduced(8, 3),
                    juce::Justification::centred);
 
@@ -238,7 +238,9 @@ void SurgefxAudioProcessorEditor::paint(juce::Graphics &g)
 
 void SurgefxAudioProcessorEditor::resized()
 {
-    picker->setBounds(100, 10, getWidth() - 200, topSection - 30);
+    auto impliedZoom = getImpliedZoom();
+
+    picker->setBounds(100, 10, getWidth() - 200, (topSection - 30) * impliedZoom);
     int ypos0 = topSection - 5;
     int rowHeight = (getHeight() - topSection - 40 - 10) / 6.0;
     int byoff = 7;

--- a/src/surge-fx/SurgeFXEditor.h
+++ b/src/surge-fx/SurgeFXEditor.h
@@ -69,6 +69,8 @@ class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor,
     void paint(juce::Graphics &) override;
     void resized() override;
 
+    float getImpliedZoom() const { return getWidth() * 1.0 / baseWidth; }
+
     /**
      * findLargestFittingZoomBetween
      *

--- a/src/surge-fx/SurgeLookAndFeel.h
+++ b/src/surge-fx/SurgeLookAndFeel.h
@@ -93,8 +93,7 @@ class SurgeLookAndFeel : public juce::LookAndFeel_V4
         setColour(juce::Slider::trackColourId, fxStandaloneGray3);
         setColour(juce::Slider::backgroundColourId, juce::Colour((juce::uint8)255, 255, 255, 20.f));
 
-        setColour(SurgeColourIds::componentBgStart,
-                  surgeGrayBg.interpolatedWith(surgeOrangeMedium, 0.1));
+        setColour(SurgeColourIds::componentBgStart, juce::Colour(205, 206, 212));
         setColour(SurgeColourIds::componentBgEnd, surgeGrayBg);
         setColour(SurgeColourIds::orange, surgeOrange);
         setColour(SurgeColourIds::orangeDark, surgeOrangeDark);
@@ -354,7 +353,10 @@ class SurgeFXParamDisplay : public juce::Component
 
     void resized() override
     {
-        overlayEditor->setBounds(getLocalBounds().reduced(2, 3).withTrimmedTop(getHeight() - 28));
+        auto hScale = getHeight() / 55.0;
+
+        overlayEditor->setBounds(
+            getLocalBounds().reduced(2, 3).withTrimmedTop(getHeight() - 28 * hScale));
     }
 
     void mouseDoubleClick(const juce::MouseEvent &e) override
@@ -378,6 +380,8 @@ class SurgeFXParamDisplay : public juce::Component
         if (!allowsTypein)
             return;
 
+        auto hScale = getHeight() / 55.0;
+
         overlayEditor->setColour(juce::TextEditor::textColourId,
                                  findColour(SurgeLookAndFeel::SurgeColourIds::paramDisplay));
         overlayEditor->setColour(juce::TextEditor::outlineColourId,
@@ -387,7 +391,8 @@ class SurgeFXParamDisplay : public juce::Component
         overlayEditor->setColour(juce::TextEditor::ColourIds::highlightColourId,
                                  juce::Colour(0xFF775522));
         overlayEditor->setJustification(juce::Justification::bottomLeft);
-        overlayEditor->setFont(SST_JUCE_FONT_OPTIONS(20));
+        overlayEditor->setFont(SST_JUCE_FONT_OPTIONS(20 * hScale));
+        overlayEditor->applyFontToAllText(SST_JUCE_FONT_OPTIONS(20 * hScale), true);
         overlayEditor->setText(display, juce::dontSendNotification);
         overlayEditor->setVisible(true);
         overlayEditor->grabKeyboardFocus();


### PR DESCRIPTION
1. Zoom the picker display
2. Zoom the typein param value. Closes #7983
3. Consistent background color