### PR TITLE
Restart the AudioComponentRegistrar in Mac Install

### DIFF
--- a/scripts/installer_mac/ResourcesPackageScript/postinstall
+++ b/scripts/installer_mac/ResourcesPackageScript/postinstall
@@ -6,3 +6,5 @@ chown -R $USER:staff "/Library/Application Support/Surge XT"
 chown -R $USER:staff "/Applications/Surge XT.app"
 chown -R $USER:staff "/Applications/Surge XT Effects.app"
 rm -rf "/tmp/SXT"
+
+killall -9 AudioComponentRegistrar


### PR DESCRIPTION
Basically killall -9 the ACR when we do the postinstall step. Tested and it does indeed restart it!

Closes #8009