### PR TITLE
Add wt import from oscdata to wavetable script state

### DIFF
--- a/src/common/PatchFileHeaderStructs.h
+++ b/src/common/PatchFileHeaderStructs.h
@@ -51,6 +51,12 @@ struct patch_header
     // (but also since it's used in streaming, do it with care!)
     unsigned int xmlsize, wtsize[2][3];
 };
+
+struct wtscript_header
+{
+    char tag[4]; // 'wts1'
+    unsigned int xmlsize, blobsize;
+};
 #pragma pack(pop)
 } // namespace sst::io
 #endif // SURGE_FXPHEADERSTRUCTS_H

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1324,15 +1324,17 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
                         continue;
 
                     // One blob per slot: [uint32 n_tables][uint32 n_samples][float data...]
-                    uint32_t nt = snap->n_tables;
-                    uint32_t ns = snap->size;
-                    std::vector<uint8_t> blob(8 + static_cast<size_t>(nt) * ns * sizeof(float));
-                    std::memcpy(blob.data() + 0, &nt, 4);
-                    std::memcpy(blob.data() + 4, &ns, 4);
-                    for (uint32_t t = 0; t < nt; t++)
+                    uint32_t ntables = snap->n_tables;
+                    uint32_t nsamples = snap->size;
+                    std::vector<uint8_t> blob(8 + static_cast<size_t>(ntables) * nsamples *
+                                                      sizeof(float));
+                    std::memcpy(blob.data() + 0, &ntables, 4);
+                    std::memcpy(blob.data() + 4, &nsamples, 4);
+                    for (uint32_t t = 0; t < ntables; t++)
                     {
-                        std::memcpy(blob.data() + 8 + static_cast<size_t>(t) * ns * sizeof(float),
-                                    snap->TableF32WeakPointers[0][t], ns * sizeof(float));
+                        std::memcpy(blob.data() + 8 +
+                                        static_cast<size_t>(t) * nsamples * sizeof(float),
+                                    snap->TableF32WeakPointers[0][t], nsamples * sizeof(float));
                     }
 
                     auto key = fmt::format("snap_{}", slot);
@@ -1491,7 +1493,6 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
             }
 
             // Rebuild wavetable snapshots from the staged blobs.
-            // Format per slot: [uint32 n_tables][uint32 n_samples][float data...]
             for (int slot = 0; slot < n_wt_snapshots; slot++)
             {
                 auto key = fmt::format("snap_{}", slot);
@@ -1503,25 +1504,23 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
                 if (raw.size() < 8)
                     continue;
 
-                uint32_t nt = 0, ns = 0;
-                std::memcpy(&nt, raw.data() + 0, 4);
-                std::memcpy(&ns, raw.data() + 4, 4);
-                if (nt == 0 || ns == 0)
+                uint32_t ntables = 0, nsamples = 0;
+                std::memcpy(&ntables, raw.data() + 0, 4);
+                std::memcpy(&nsamples, raw.data() + 4, 4);
+                if (ntables == 0 || nsamples == 0)
                     continue;
-                if (raw.size() != 8 + static_cast<size_t>(nt) * ns * sizeof(float))
+                if (raw.size() != 8 + static_cast<size_t>(ntables) * nsamples * sizeof(float))
                     continue;
 
                 wt_header wh{};
-                wh.n_samples = ns;
-                wh.n_tables = nt;
+                wh.n_samples = nsamples;
+                wh.n_tables = ntables;
                 wh.flags = 0;
 
                 auto &snap = scene[sc].osc[osc].wtSnapshots[slot];
                 snap.emplace();
 
-                storage->waveTableDataMutex.lock();
                 snap->BuildWT(reinterpret_cast<float *>(raw.data() + 8), wh, false);
-                storage->waveTableDataMutex.unlock();
 
                 if (!snap->everBuilt)
                 {

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1343,6 +1343,7 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
                 }
                 std::string key = fmt::format("osc_{}_{}", sc, osc);
                 binn_object_set_object(map, key.c_str(), oscmap);
+                binn_free(oscmap);
             }
         }
     }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1310,7 +1310,8 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
         binn_object_set_object(map, key.c_str(), fxmap);
     }
 
-    if (snapshotsStoredInPatch)
+    // User opt-in for patch files, always include for DAW state saves.
+    if (snapshotsStoredInPatch || (dawExtraState.isPopulated && hasAnySnapshots()))
     {
         for (int sc = 0; sc < n_scenes; sc++)
         {
@@ -1521,6 +1522,10 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
                 if (!snap->everBuilt)
                 {
                     snap.reset();
+                }
+                else
+                {
+                    snapshotsStoredInPatch = true;
                 }
             }
         }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2943,7 +2943,7 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
         }
     }
 
-    // Clear all snapshots before potentially restoring from arb storage
+    // Clear all snapshots before potentially restoring from arbitrary_block_storage
     snapshotsStoredInPatch = false;
     for (int sc = 0; sc < n_scenes; sc++)
         for (int osc = 0; osc < n_oscs; osc++)

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1310,6 +1310,43 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
         binn_object_set_object(map, key.c_str(), fxmap);
     }
 
+    if (snapshotsStoredInPatch)
+    {
+        for (int sc = 0; sc < n_scenes; sc++)
+        {
+            for (int osc = 0; osc < n_oscs; osc++)
+            {
+                binn *oscmap = binn_object();
+                for (int slot = 0; slot < n_wt_snapshots; slot++)
+                {
+                    auto &snap = scene[sc].osc[osc].wtSnapshots[slot];
+                    if (!snap.has_value() || !snap->everBuilt)
+                        continue;
+
+                    // One blob per slot: [uint32 n_tables][uint32 n_samples][float data...]
+                    uint32_t nt = snap->n_tables;
+                    uint32_t ns = snap->size;
+                    std::vector<uint8_t> blob(8 +
+                                              static_cast<size_t>(nt) * ns * sizeof(float));
+                    std::memcpy(blob.data() + 0, &nt, 4);
+                    std::memcpy(blob.data() + 4, &ns, 4);
+                    for (uint32_t t = 0; t < nt; t++)
+                    {
+                        std::memcpy(blob.data() + 8 +
+                                        static_cast<size_t>(t) * ns * sizeof(float),
+                                    snap->TableF32WeakPointers[0][t], ns * sizeof(float));
+                    }
+
+                    auto key = fmt::format("snap_{}", slot);
+                    binn_object_set_blob(oscmap, key.c_str(), blob.data(),
+                                         static_cast<int>(blob.size()));
+                }
+                std::string key = fmt::format("osc_{}_{}", sc, osc);
+                binn_object_set_object(map, key.c_str(), oscmap);
+            }
+        }
+    }
+
     // Now compress it with zstd
     auto size = binn_size(map);
     void *ptr = binn_ptr(map);
@@ -1360,6 +1397,7 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
     binn *b = binn_open_ex(data, sz);
 
     std::regex fx_regex("fx([0-9]+)");
+    std::regex osc_regex("osc_([0-9]+)_([0-9]+)");
     binn_iter outer;
     binn obj;
     char key[256];
@@ -1411,6 +1449,86 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
                 else
                     vdata->resize(binn_size(&data));
                 std::memcpy(vdata->data(), data.ptr, binn_size(&data));
+            }
+        }
+
+        // Try deserializing oscillator snapshot data.
+        else if (std::regex_match(key, m, osc_regex))
+        {
+            int sc = -1, osc = -1;
+            try
+            {
+                sc = std::stoi(m[1].str());
+                osc = std::stoi(m[2].str());
+            }
+            catch (std::invalid_argument const &ex)
+            {
+                std::cerr << "Error deserializing " << key << "; possible patch corruption."
+                          << std::endl;
+                continue;
+            }
+
+            // Deserialize the oscillator snapshot data.
+            std::unordered_map<std::string, std::shared_ptr<std::vector<std::uint8_t>>> arb;
+            binn_iter inner;
+            binn data;
+            char osckey[256];
+            binn_iter_init(&inner, &obj, BINN_OBJECT);
+            while (binn_object_next(&inner, osckey, &data))
+            {
+                if (data.type != BINN_BLOB)
+                {
+                    std::cerr << "Binn value for " << osckey
+                              << " is not a blob, possible patch corruption." << std::endl;
+                    continue;
+                }
+
+                std::string converted = std::string(osckey);
+                std::shared_ptr<std::vector<std::uint8_t>> &vdata = arb[converted];
+                if (!vdata)
+                    vdata = std::make_shared<std::vector<std::uint8_t>>(binn_size(&data));
+                else
+                    vdata->resize(binn_size(&data));
+                std::memcpy(vdata->data(), data.ptr, binn_size(&data));
+            }
+
+            // Rebuild wavetable snapshots from the staged blobs.
+            // Format per slot: [uint32 n_tables][uint32 n_samples][float data...]
+            for (int slot = 0; slot < n_wt_snapshots; slot++)
+            {
+                auto key = fmt::format("snap_{}", slot);
+                auto it = arb.find(key);
+                if (it == arb.end())
+                    continue;
+
+                auto &raw = *it->second;
+                if (raw.size() < 8)
+                    continue;
+
+                uint32_t nt = 0, ns = 0;
+                std::memcpy(&nt, raw.data() + 0, 4);
+                std::memcpy(&ns, raw.data() + 4, 4);
+                if (nt == 0 || ns == 0)
+                    continue;
+                if (raw.size() != 8 + static_cast<size_t>(nt) * ns * sizeof(float))
+                    continue;
+
+                wt_header wh{};
+                wh.n_samples = ns;
+                wh.n_tables = nt;
+                wh.flags = 0;
+
+                auto &snap = scene[sc].osc[osc].wtSnapshots[slot];
+                snap.emplace();
+
+                storage->waveTableDataMutex.lock();
+                snap->BuildWT(reinterpret_cast<float *>(raw.data() + 8), wh, false);
+                storage->waveTableDataMutex.unlock();
+
+                if (!snap->everBuilt)
+                {
+                    snap.reset();
+                }
             }
         }
     }
@@ -2831,6 +2949,13 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             patchTuning.mappingName = td;
         }
     }
+
+    // Clear all snapshots before potentially restoring from arb storage
+    snapshotsStoredInPatch = false;
+    for (int sc = 0; sc < n_scenes; sc++)
+        for (int osc = 0; osc < n_oscs; osc++)
+            for (int slot = 0; slot < n_wt_snapshots; slot++)
+                scene[sc].osc[osc].wtSnapshots[slot].reset();
 
     bool userPrefOverrideTempoOnPatchLoad = Surge::Storage::getUserDefaultValue(
         storage, Surge::Storage::OverrideTempoOnPatchLoad, true);
@@ -4522,32 +4647,37 @@ void SurgePatch::formulaFromXMLElement(FormulaModulatorStorage *fs, TiXmlElement
     }
 }
 
-void SurgePatch::captureWavetableSnapshot(int scene, int slot, int osc)
+void SurgePatch::captureWavetableSnapshot(int scene, int srcOsc, int dstOsc, int slot)
 {
-    auto &snap = dawExtraState.editor.wtSnapshot[slot];
-    snap = DAWExtraStateStorage::EditorState::WavetableSnapshot{};
-    const auto &wt = this->scene[scene].osc[osc].wt;
+    assert(slot >= 0 && slot < n_wt_snapshots);
+    auto &snap = this->scene[scene].osc[dstOsc].wtSnapshots[slot];
+    auto &src = this->scene[scene].osc[srcOsc].wt;
 
     // Check if we have a valid WT to copy
-    if (!wt.everBuilt || wt.n_tables == 0 || wt.size == 0 ||
-        wt.TableF32WeakPointers[0][0] == nullptr)
+    if (!src.everBuilt || src.n_tables == 0 || src.size == 0 ||
+        src.TableF32WeakPointers[0][0] == nullptr)
     {
-        return; // leave snap.enabled = false
+        snap.reset();
+        return;
     }
 
     storage->waveTableDataMutex.lock();
 
-    snap.n_tables = wt.n_tables;
-    snap.size = wt.size;
-    snap.frames.resize(wt.n_tables);
-
-    for (int t = 0; t < wt.n_tables; ++t)
+    if (!snap.has_value())
     {
-        snap.frames[t].assign(wt.TableF32WeakPointers[0][t],
-                              wt.TableF32WeakPointers[0][t] + wt.size);
+        snap.emplace();
     }
+    snap->Copy(&src);
 
     storage->waveTableDataMutex.unlock();
+}
 
-    snap.enabled = true;
+bool SurgePatch::hasAnySnapshots() const
+{
+    for (int sc = 0; sc < n_scenes; sc++)
+        for (int osc = 0; osc < n_oscs; osc++)
+            for (int slot = 0; slot < n_wt_snapshots; slot++)
+                if (scene[sc].osc[osc].wtSnapshots[slot].has_value())
+                    return true;
+    return false;
 }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -4521,3 +4521,33 @@ void SurgePatch::formulaFromXMLElement(FormulaModulatorStorage *fs, TiXmlElement
         fs->interpreter = (FormulaModulatorStorage::Interpreter)(interp);
     }
 }
+
+void SurgePatch::captureWavetableSnapshot(int scene, int slot, int osc)
+{
+    auto &snap = dawExtraState.editor.wtSnapshot[slot];
+    snap = DAWExtraStateStorage::EditorState::WavetableSnapshot{};
+    const auto &wt = this->scene[scene].osc[osc].wt;
+
+    // Check if we have a valid WT to copy
+    if (!wt.everBuilt || wt.n_tables == 0 || wt.size == 0 ||
+        wt.TableF32WeakPointers[0][0] == nullptr)
+    {
+        return; // leave snap.enabled = false
+    }
+
+    storage->waveTableDataMutex.lock();
+
+    snap.n_tables = wt.n_tables;
+    snap.size = wt.size;
+    snap.frames.resize(wt.n_tables);
+
+    for (int t = 0; t < wt.n_tables; ++t)
+    {
+        snap.frames[t].assign(wt.TableF32WeakPointers[0][t],
+                              wt.TableF32WeakPointers[0][t] + wt.size);
+    }
+
+    storage->waveTableDataMutex.unlock();
+
+    snap.enabled = true;
+}

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1320,7 +1320,7 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
                 for (int slot = 0; slot < n_wt_snapshots; slot++)
                 {
                     auto &snap = scene[sc].osc[osc].wtSnapshots[slot];
-                    if (!snap.has_value() || !snap->everBuilt)
+                    if (!snap || !snap->everBuilt)
                         continue;
 
                     // One blob per slot: [uint32 n_tables][uint32 n_samples][float data...]
@@ -1518,7 +1518,7 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
                 wh.flags = 0;
 
                 auto &snap = scene[sc].osc[osc].wtSnapshots[slot];
-                snap.emplace();
+                snap = std::make_unique<Wavetable>();
 
                 snap->BuildWT(reinterpret_cast<float *>(raw.data() + 8), wh, false);
 
@@ -4650,19 +4650,16 @@ void SurgePatch::captureWavetableSnapshot(int scene, int srcOsc, int dstOsc, int
     auto &snap = this->scene[scene].osc[dstOsc].wtSnapshots[slot];
     auto &src = this->scene[scene].osc[srcOsc].wt;
 
-    // Check if we have a valid WT to copy
-    if (!src.everBuilt || src.n_tables == 0 || src.size == 0 ||
-        src.TableF32WeakPointers[0][0] == nullptr)
+    if (!src.everBuilt || src.n_tables == 0 || src.size == 0)
     {
-        snap.reset();
         return;
     }
 
     storage->waveTableDataMutex.lock();
 
-    if (!snap.has_value())
+    if (!snap)
     {
-        snap.emplace();
+        snap = std::make_unique<Wavetable>();
     }
     snap->Copy(&src);
 
@@ -4674,7 +4671,7 @@ bool SurgePatch::hasAnySnapshots() const
     for (int sc = 0; sc < n_scenes; sc++)
         for (int osc = 0; osc < n_oscs; osc++)
             for (int slot = 0; slot < n_wt_snapshots; slot++)
-                if (scene[sc].osc[osc].wtSnapshots[slot].has_value())
+                if (scene[sc].osc[osc].wtSnapshots[slot])
                     return true;
     return false;
 }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1326,14 +1326,12 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
                     // One blob per slot: [uint32 n_tables][uint32 n_samples][float data...]
                     uint32_t nt = snap->n_tables;
                     uint32_t ns = snap->size;
-                    std::vector<uint8_t> blob(8 +
-                                              static_cast<size_t>(nt) * ns * sizeof(float));
+                    std::vector<uint8_t> blob(8 + static_cast<size_t>(nt) * ns * sizeof(float));
                     std::memcpy(blob.data() + 0, &nt, 4);
                     std::memcpy(blob.data() + 4, &ns, 4);
                     for (uint32_t t = 0; t < nt; t++)
                     {
-                        std::memcpy(blob.data() + 8 +
-                                        static_cast<size_t>(t) * ns * sizeof(float),
+                        std::memcpy(blob.data() + 8 + static_cast<size_t>(t) * ns * sizeof(float),
                                     snap->TableF32WeakPointers[0][t], ns * sizeof(float));
                     }
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1323,10 +1323,10 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
                     if (!snap || !snap->everBuilt)
                         continue;
 
-                    uint32_t ntables = snap->n_tables;
-                    uint32_t nsamples = snap->size;
+                    std::uint32_t ntables = snap->n_tables;
+                    std::uint32_t nsamples = snap->size;
                     std::vector<float> data(static_cast<size_t>(ntables) * nsamples);
-                    for (uint32_t t = 0; t < ntables; t++)
+                    for (std::uint32_t t = 0; t < ntables; t++)
                     {
                         std::memcpy(data.data() + static_cast<size_t>(t) * nsamples,
                                     snap->TableF32WeakPointers[0][t], nsamples * sizeof(float));
@@ -1475,7 +1475,6 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
             binn_iter_init(&inner, &obj, BINN_OBJECT);
             while (binn_object_next(&inner, osckey, &data))
             {
-                // Skip non-blob values; ntables/nsamples are stored as uint32 keys.
                 if (data.type != BINN_BLOB)
                     continue;
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1323,23 +1323,22 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
                     if (!snap || !snap->everBuilt)
                         continue;
 
-                    // One blob per slot: [uint32 n_tables][uint32 n_samples][float data...]
                     uint32_t ntables = snap->n_tables;
                     uint32_t nsamples = snap->size;
-                    std::vector<uint8_t> blob(8 + static_cast<size_t>(ntables) * nsamples *
-                                                      sizeof(float));
-                    std::memcpy(blob.data() + 0, &ntables, 4);
-                    std::memcpy(blob.data() + 4, &nsamples, 4);
+                    std::vector<float> data(static_cast<size_t>(ntables) * nsamples);
                     for (uint32_t t = 0; t < ntables; t++)
                     {
-                        std::memcpy(blob.data() + 8 +
-                                        static_cast<size_t>(t) * nsamples * sizeof(float),
+                        std::memcpy(data.data() + static_cast<size_t>(t) * nsamples,
                                     snap->TableF32WeakPointers[0][t], nsamples * sizeof(float));
                     }
 
-                    auto key = fmt::format("snap_{}", slot);
-                    binn_object_set_blob(oscmap, key.c_str(), blob.data(),
-                                         static_cast<int>(blob.size()));
+                    binn_object_set_uint32(oscmap, fmt::format("snap_{}_ntables", slot).c_str(),
+                                           ntables);
+                    binn_object_set_uint32(oscmap, fmt::format("snap_{}_nsamples", slot).c_str(),
+                                           nsamples);
+                    binn_object_set_blob(oscmap, fmt::format("snap_{}_data", slot).c_str(),
+                                         data.data(),
+                                         static_cast<int>(data.size() * sizeof(float)));
                 }
                 std::string key = fmt::format("osc_{}_{}", sc, osc);
                 binn_object_set_object(map, key.c_str(), oscmap);
@@ -1476,12 +1475,9 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
             binn_iter_init(&inner, &obj, BINN_OBJECT);
             while (binn_object_next(&inner, osckey, &data))
             {
+                // Skip non-blob values; ntables/nsamples are stored as uint32 keys.
                 if (data.type != BINN_BLOB)
-                {
-                    std::cerr << "Binn value for " << osckey
-                              << " is not a blob, possible patch corruption." << std::endl;
                     continue;
-                }
 
                 std::string converted = std::string(osckey);
                 std::shared_ptr<std::vector<std::uint8_t>> &vdata = arb[converted];
@@ -1495,21 +1491,22 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
             // Rebuild wavetable snapshots from the staged blobs.
             for (int slot = 0; slot < n_wt_snapshots; slot++)
             {
-                auto key = fmt::format("snap_{}", slot);
-                auto it = arb.find(key);
+                auto it = arb.find(fmt::format("snap_{}_data", slot));
                 if (it == arb.end())
                     continue;
 
-                auto &raw = *it->second;
-                if (raw.size() < 8)
+                unsigned int ntables = 0, nsamples = 0;
+                if (!binn_object_get_uint32(&obj, fmt::format("snap_{}_ntables", slot).c_str(),
+                                            &ntables))
                     continue;
-
-                uint32_t ntables = 0, nsamples = 0;
-                std::memcpy(&ntables, raw.data() + 0, 4);
-                std::memcpy(&nsamples, raw.data() + 4, 4);
+                if (!binn_object_get_uint32(&obj, fmt::format("snap_{}_nsamples", slot).c_str(),
+                                            &nsamples))
+                    continue;
                 if (ntables == 0 || nsamples == 0)
                     continue;
-                if (raw.size() != 8 + static_cast<size_t>(ntables) * nsamples * sizeof(float))
+
+                auto &raw = *it->second;
+                if (raw.size() != static_cast<size_t>(ntables) * nsamples * sizeof(float))
                     continue;
 
                 wt_header wh{};
@@ -1520,7 +1517,7 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
                 auto &snap = scene[sc].osc[osc].wtSnapshots[slot];
                 snap = std::make_unique<Wavetable>();
 
-                snap->BuildWT(reinterpret_cast<float *>(raw.data() + 8), wh, false);
+                snap->BuildWT(reinterpret_cast<float *>(raw.data()), wh, false);
 
                 if (!snap->everBuilt)
                 {

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2114,6 +2114,20 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
         }
 
         clipboard_extraconfig[0] = getPatch().scene[scene].osc[entry].extraConfig;
+
+        for (int s = 0; s < n_wt_snapshots; ++s)
+        {
+            auto &src = getPatch().scene[scene].osc[entry].wtSnapshots[s];
+            if (src.has_value())
+            {
+                clipboard_wtSnapshots[0][s].emplace();
+                clipboard_wtSnapshots[0][s]->Copy(&src.value());
+            }
+            else
+            {
+                clipboard_wtSnapshots[0][s].reset();
+            }
+        }
     }
 
     if (type & cp_lfo)
@@ -2173,6 +2187,20 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
                 getPatch().scene[scene].osc[i].wavetable_script_res_base;
             clipboard_wavetable_script_nframes[i] =
                 getPatch().scene[scene].osc[i].wavetable_script_nframes;
+
+            for (int s = 0; s < n_wt_snapshots; ++s)
+            {
+                auto &src = getPatch().scene[scene].osc[i].wtSnapshots[s];
+                if (src.has_value())
+                {
+                    clipboard_wtSnapshots[i][s].emplace();
+                    clipboard_wtSnapshots[i][s]->Copy(&src.value());
+                }
+                else
+                {
+                    clipboard_wtSnapshots[i][s].reset();
+                }
+            }
         }
 
         auto fxOffset = 0;
@@ -2405,6 +2433,21 @@ void SurgeStorage::clipboard_paste(
         getPatch().update_controls(false, &getPatch().scene[scene].osc[entry]);
 
         getPatch().scene[scene].osc[entry].extraConfig = clipboard_extraconfig[0];
+
+        for (int s = 0; s < n_wt_snapshots; ++s)
+        {
+            auto &src = clipboard_wtSnapshots[0][s];
+            auto &dst = getPatch().scene[scene].osc[entry].wtSnapshots[s];
+            if (src.has_value())
+            {
+                dst.emplace();
+                dst->Copy(&src.value());
+            }
+            else
+            {
+                dst.reset();
+            }
+        }
     }
 
     if (type & cp_lfo)
@@ -2441,6 +2484,21 @@ void SurgeStorage::clipboard_paste(
                 clipboard_wavetable_script_res_base[i];
             getPatch().scene[scene].osc[i].wavetable_script_nframes =
                 clipboard_wavetable_script_nframes[i];
+
+            for (int s = 0; s < n_wt_snapshots; ++s)
+            {
+                auto &src = clipboard_wtSnapshots[i][s];
+                auto &dst = getPatch().scene[scene].osc[i].wtSnapshots[s];
+                if (src.has_value())
+                {
+                    dst.emplace();
+                    dst->Copy(&src.value());
+                }
+                else
+                {
+                    dst.reset();
+                }
+            }
         }
 
         auto fxOffset = 0;

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2118,10 +2118,10 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
         for (int s = 0; s < n_wt_snapshots; ++s)
         {
             auto &src = getPatch().scene[scene].osc[entry].wtSnapshots[s];
-            if (src.has_value())
+            if (src)
             {
-                clipboard_wtSnapshots[0][s].emplace();
-                clipboard_wtSnapshots[0][s]->Copy(&src.value());
+                clipboard_wtSnapshots[0][s] = std::make_unique<Wavetable>();
+                clipboard_wtSnapshots[0][s]->Copy(src.get());
             }
             else
             {
@@ -2191,10 +2191,10 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
             for (int s = 0; s < n_wt_snapshots; ++s)
             {
                 auto &src = getPatch().scene[scene].osc[i].wtSnapshots[s];
-                if (src.has_value())
+                if (src)
                 {
-                    clipboard_wtSnapshots[i][s].emplace();
-                    clipboard_wtSnapshots[i][s]->Copy(&src.value());
+                    clipboard_wtSnapshots[i][s] = std::make_unique<Wavetable>();
+                    clipboard_wtSnapshots[i][s]->Copy(src.get());
                 }
                 else
                 {
@@ -2438,10 +2438,10 @@ void SurgeStorage::clipboard_paste(
         {
             auto &src = clipboard_wtSnapshots[0][s];
             auto &dst = getPatch().scene[scene].osc[entry].wtSnapshots[s];
-            if (src.has_value())
+            if (src)
             {
-                dst.emplace();
-                dst->Copy(&src.value());
+                dst = std::make_unique<Wavetable>();
+                dst->Copy(src.get());
             }
             else
             {
@@ -2489,10 +2489,10 @@ void SurgeStorage::clipboard_paste(
             {
                 auto &src = clipboard_wtSnapshots[i][s];
                 auto &dst = getPatch().scene[scene].osc[i].wtSnapshots[s];
-                if (src.has_value())
+                if (src)
                 {
-                    dst.emplace();
-                    dst->Copy(&src.value());
+                    dst = std::make_unique<Wavetable>();
+                    dst->Copy(src.get());
                 }
                 else
                 {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1181,6 +1181,15 @@ struct DAWExtraStateStorage
         {
             int editMode = 0;
         } tuningOverlayState;
+
+        // Wavetable snapshots for use in the Wavetable Script Editor
+        struct WavetableSnapshot
+        {
+            std::vector<std::vector<float>> frames; // frames[table][sample]
+            int n_tables{0};
+            int size{0};
+            bool enabled{false};
+        } wtSnapshot[n_oscs];
     } editor;
 
     bool mpeEnabled = false;
@@ -1255,6 +1264,8 @@ class SurgePatch
     void stepSeqFromXmlElement(StepSequencerStorage *ss, TiXmlElement *parent) const;
     void formulaToXMLElement(FormulaModulatorStorage *ms, TiXmlElement &parent) const;
     void formulaFromXMLElement(FormulaModulatorStorage *ms, TiXmlElement *parent) const;
+
+    void captureWavetableSnapshot(int scene, int slot, int osc);
 
     void load_patch(const void *data, int size, bool preset);
     unsigned int load_arbitrary_block_storage(const void *data, std::size_t remainder);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -48,7 +48,6 @@
 #include <random>
 #include <chrono>
 #include <array>
-#include <optional>
 
 #include "Tunings.h"
 #include "PatchDB.h"
@@ -722,7 +721,7 @@ struct OscillatorStorage : public CountedSetUserData // The counted set is the w
     std::string wavetable_script = "";
     int wavetable_script_res_base = 5, // 32 * 2^this
         wavetable_script_nframes = 10;
-    std::array<std::optional<Wavetable>, n_wt_snapshots> wtSnapshots;
+    std::array<std::unique_ptr<Wavetable>, n_wt_snapshots> wtSnapshots;
 
     void *queue_xmldata;
     int queue_type;
@@ -1973,7 +1972,8 @@ class alignas(16) SurgeStorage
     std::array<std::string, n_oscs> clipboard_wavetable_script;
     std::array<int, n_oscs> clipboard_wavetable_script_res_base;
     std::array<int, n_oscs> clipboard_wavetable_script_nframes;
-    std::array<std::array<std::optional<Wavetable>, n_wt_snapshots>, n_oscs> clipboard_wtSnapshots;
+    std::array<std::array<std::unique_ptr<Wavetable>, n_wt_snapshots>, n_oscs>
+        clipboard_wtSnapshots;
 
     char clipboard_modulator_names[n_lfos][max_lfo_indices][CUSTOM_CONTROLLER_LABEL_SIZE + 1];
     MonoVoicePriorityMode clipboard_primode = NOTE_ON_LATEST_RETRIGGER_HIGHEST;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -47,6 +47,8 @@
 #include <type_traits>
 #include <random>
 #include <chrono>
+#include <array>
+#include <optional>
 
 #include "Tunings.h"
 #include "PatchDB.h"
@@ -156,6 +158,7 @@ const int n_total_params = n_global_params + 2 * n_scene_params + n_global_postp
 const int n_scenes = 2;
 const int n_filterunits_per_scene = 2;
 const int n_max_filter_subtypes = 16;
+const int n_wt_snapshots = 2;
 
 enum scene_mode
 {
@@ -719,6 +722,7 @@ struct OscillatorStorage : public CountedSetUserData // The counted set is the w
     std::string wavetable_script = "";
     int wavetable_script_res_base = 5, // 32 * 2^this
         wavetable_script_nframes = 10;
+    std::array<std::optional<Wavetable>, n_wt_snapshots> wtSnapshots;
 
     void *queue_xmldata;
     int queue_type;
@@ -1181,15 +1185,6 @@ struct DAWExtraStateStorage
         {
             int editMode = 0;
         } tuningOverlayState;
-
-        // Wavetable snapshots for use in the Wavetable Script Editor
-        struct WavetableSnapshot
-        {
-            std::vector<std::vector<float>> frames; // frames[table][sample]
-            int n_tables{0};
-            int size{0};
-            bool enabled{false};
-        } wtSnapshot[n_oscs];
     } editor;
 
     bool mpeEnabled = false;
@@ -1265,14 +1260,14 @@ class SurgePatch
     void formulaToXMLElement(FormulaModulatorStorage *ms, TiXmlElement &parent) const;
     void formulaFromXMLElement(FormulaModulatorStorage *ms, TiXmlElement *parent) const;
 
-    void captureWavetableSnapshot(int scene, int slot, int osc);
-
     void load_patch(const void *data, int size, bool preset);
     unsigned int load_arbitrary_block_storage(const void *data, std::size_t remainder);
     void load_arbitrary_block_storage_xml(const TiXmlElement *patch);
+    bool hasAnySnapshots() const;
     unsigned int save_patch(void **data);
     std::vector<std::uint8_t> save_arbitrary_block_storage();
     Parameter *parameterFromOSCName(std::string stName);
+    void captureWavetableSnapshot(int scene, int srcOsc, int dstOsc, int slot);
 
     // data
     SurgeSceneStorage scene[n_scenes], morphscene;
@@ -1300,6 +1295,7 @@ class SurgePatch
     FormulaModulatorStorage formulamods[n_scenes][n_lfos];
 
     PatchTuningStorage patchTuning;
+    bool snapshotsStoredInPatch = false;
     DAWExtraStateStorage dawExtraState;
 
     std::vector<Parameter *> param_ptr;
@@ -1977,6 +1973,7 @@ class alignas(16) SurgeStorage
     std::array<std::string, n_oscs> clipboard_wavetable_script;
     std::array<int, n_oscs> clipboard_wavetable_script_res_base;
     std::array<int, n_oscs> clipboard_wavetable_script_nframes;
+    std::array<std::array<std::optional<Wavetable>, n_wt_snapshots>, n_oscs> clipboard_wtSnapshots;
 
     char clipboard_modulator_names[n_lfos][max_lfo_indices][CUSTOM_CONTROLLER_LABEL_SIZE + 1];
     MonoVoicePriorityMode clipboard_primode = NOTE_ON_LATEST_RETRIGGER_HIGHEST;

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -176,9 +176,7 @@ struct LuaWTEvaluator::Details
                     lua_pop(L, 1);
                 }
                 if (gen)
-                {
                     res = values;
-                }
             }
         }
         else

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -131,7 +131,7 @@ struct LuaWTEvaluator::Details
                 lua_newtable(L); // Slot table (empty if not imported)
                 const auto &snap = oscdata.wtSnapshots[s];
 
-                if (snap.has_value() && snap->everBuilt && snap->n_tables > 0 && snap->size > 0)
+                if (snap && snap->everBuilt && snap->n_tables > 0 && snap->size > 0)
                 {
                     const unsigned int nframes = snap->n_tables;
                     const int nsamples = snap->size;
@@ -575,7 +575,7 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
             wh.n_tables = nframes;
             wh.flags = 0;
 
-            oscdata->wtSnapshots[slot].emplace();
+            oscdata->wtSnapshots[slot] = std::make_unique<Wavetable>();
             oscdata->wtSnapshots[slot]->BuildWT(decoded.data(), wh, false);
             if (!oscdata->wtSnapshots[slot]->everBuilt)
             {

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -42,6 +42,8 @@ static constexpr const char *statetable{"statetable"};
 struct LuaWTEvaluator::Details
 {
     SurgeStorage *storage{nullptr};
+    int current_scene{0};
+    int current_osc{0};
     std::string script{};
     size_t resolution{2048};
     size_t frameCount{10};
@@ -123,25 +125,27 @@ struct LuaWTEvaluator::Details
         lua_newtable(L); // Outer snapshot table
         if (storage)
         {
-            for (int s = 0; s < n_oscs; ++s)
+            auto &oscdata = storage->getPatch().scene[current_scene].osc[current_osc];
+            for (int s = 0; s < n_wt_snapshots; ++s)
             {
                 lua_newtable(L); // Slot table (empty if not imported)
-                if (storage->getPatch().dawExtraState.editor.wtSnapshot[s].enabled)
-                {
-                    const auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[s];
+                const auto &snap = oscdata.wtSnapshots[s];
 
-                    if (snap.enabled && snap.n_tables > 0 && snap.size > 0)
+                if (snap.has_value() && snap->everBuilt && snap->n_tables > 0 && snap->size > 0)
+                {
+                    const unsigned int nframes = snap->n_tables;
+                    const int nsamples = snap->size;
+
+                    for (unsigned int t = 0; t < nframes; ++t)
                     {
-                        for (int t = 0; t < snap.n_tables; ++t)
+                        lua_newtable(L); // Frame table
+                        const float *tbl = snap->TableF32WeakPointers[0][t];
+                        for (int i = 0; i < nsamples; ++i)
                         {
-                            lua_newtable(L); // Frame table
-                            for (int i = 0; i < snap.size; ++i)
-                            {
-                                lua_pushnumber(L, snap.frames[t][i]); // Push sample value
-                                lua_rawseti(L, -2, i + 1);            // frame[i + 1] = value
-                            }
-                            lua_rawseti(L, -2, t + 1); // slot[t + 1] = frame table
+                            lua_pushnumber(L, tbl[i]); // Push sample value
+                            lua_rawseti(L, -2, i + 1); // frame[i + 1] = value
                         }
+                        lua_rawseti(L, -2, t + 1); // slot[t + 1] = frame table
                     }
                 }
                 lua_rawseti(L, -2, s + 1); // snapshot[slot + 1] = slot table
@@ -343,6 +347,14 @@ void LuaWTEvaluator::setStorage(SurgeStorage *s)
 #endif
 }
 
+void LuaWTEvaluator::setOscillatorStorage(int scene, int osc)
+{
+#if HAS_LUA
+    details->current_scene = scene;
+    details->current_osc = osc;
+#endif
+}
+
 void LuaWTEvaluator::setScript(const std::string &e)
 {
 #if HAS_LUA
@@ -477,8 +489,9 @@ void LuaWTEvaluator::generateWavetable(SurgeStorage *storage, OscillatorStorage 
 #endif
 }
 
-std::optional<LuaWTEvaluator::WtscriptData> LuaWTEvaluator::parseWtscript(const fs::path &filename,
-                                                                          SurgeStorage *storage)
+std::optional<LuaWTEvaluator::WtscriptData>
+LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
+                              OscillatorStorage *oscdata)
 {
 #if HAS_LUA
     TiXmlDocument doc;
@@ -529,17 +542,21 @@ std::optional<LuaWTEvaluator::WtscriptData> LuaWTEvaluator::parseWtscript(const 
     data.nframes = nframes;
     data.res_base = res_base;
 
-    // Skips parsing snapshots if absent
     auto sn = TINYXML_SAFE_TO_ELEMENT(wtscript->FirstChildElement("snapshots"));
     if (sn)
     {
         for (auto child = sn->FirstChildElement("snapshot"); child;
              child = child->NextSiblingElement("snapshot"))
         {
-            int slot = 0, n_tables = 0, size = 0;
+            int slot = 0, nframes = 0, nsamples = 0;
             if (child->QueryIntAttribute("slot", &slot) != TIXML_SUCCESS ||
-                child->QueryIntAttribute("n_tables", &n_tables) != TIXML_SUCCESS ||
-                child->QueryIntAttribute("size", &size) != TIXML_SUCCESS)
+                child->QueryIntAttribute("frames", &nframes) != TIXML_SUCCESS ||
+                child->QueryIntAttribute("samples", &nsamples) != TIXML_SUCCESS)
+            {
+                continue;
+            }
+
+            if (slot < 0 || slot >= n_wt_snapshots)
             {
                 continue;
             }
@@ -550,26 +567,22 @@ std::optional<LuaWTEvaluator::WtscriptData> LuaWTEvaluator::parseWtscript(const 
                 continue;
             }
             auto decoded = Surge::Storage::base64_decode(b64data);
-            if (decoded.size() != (size_t)(n_tables * size * (int)sizeof(float)))
+            if (decoded.size() != (size_t)(nframes * nsamples * (int)sizeof(float)))
             {
                 continue;
             }
 
-            DAWExtraStateStorage::EditorState::WavetableSnapshot snap;
-            snap.n_tables = n_tables;
-            snap.size = size;
-            snap.frames.resize(n_tables);
+            wt_header wh{};
+            wh.n_samples = nsamples;
+            wh.n_tables = nframes;
+            wh.flags = 0;
 
-            // Split the flat decoded buffer back into tables: frames[table][sample]
-            for (int t = 0; t < n_tables; ++t)
+            oscdata->wtSnapshots[slot].emplace();
+            oscdata->wtSnapshots[slot]->BuildWT(decoded.data(), wh, false);
+            if (!oscdata->wtSnapshots[slot]->everBuilt)
             {
-                snap.frames[t].resize(size);
-                std::memcpy(snap.frames[t].data(), decoded.data() + t * size * sizeof(float),
-                            size * sizeof(float));
+                oscdata->wtSnapshots[slot].reset();
             }
-
-            snap.enabled = true;
-            data.snapshots.emplace_back(slot, std::move(snap));
         }
     }
 
@@ -583,7 +596,12 @@ void LuaWTEvaluator::loadWtscript(const fs::path &filename, SurgeStorage *storag
                                   OscillatorStorage *oscdata)
 {
 #if HAS_LUA
-    auto data = parseWtscript(filename, storage);
+    for (auto &snap : oscdata->wtSnapshots)
+    {
+        snap.reset();
+    }
+
+    auto data = parseWtscript(filename, storage, oscdata);
     if (!data)
     {
         return;
@@ -592,19 +610,6 @@ void LuaWTEvaluator::loadWtscript(const fs::path &filename, SurgeStorage *storag
     oscdata->wavetable_script_nframes = data->nframes;
     oscdata->wavetable_script_res_base = data->res_base;
     oscdata->wavetable_script = data->script;
-
-    if (!data->snapshots.empty())
-    {
-        for (auto &[slot, sd] : data->snapshots)
-        {
-            if (slot < 0 || slot >= n_oscs)
-            {
-                continue;
-            }
-
-            storage->getPatch().dawExtraState.editor.wtSnapshot[slot] = std::move(sd);
-        }
-    }
 
     details->invalidate();
     generateWavetable(storage, oscdata, &oscdata->wt);
@@ -615,7 +620,7 @@ void LuaWTEvaluator::loadWtscriptForTesting(const fs::path &filename, SurgeStora
                                             OscillatorStorage *oscdata)
 {
 #if HAS_LUA
-    auto data = parseWtscript(filename, storage);
+    auto data = parseWtscript(filename, storage, oscdata);
     if (!data)
     {
         return;

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -483,6 +483,7 @@ bool LuaWTEvaluator::populateWavetable(wt_header &wh, float **wavdata)
         }
         else
         {
+            delete[] wd;
             return false;
         }
     }

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -58,7 +58,7 @@ struct LuaWTEvaluator::Details
     std::string wtName{"Scripted Wavetable"};
 
     lua_State *L{nullptr};
-    int snapshotRef{LUA_NOREF}; // registry ref for cached wt.snapshot table
+    int snapshotRef{LUA_NOREF}; // Registry ref for cached wt.snapshot table
 
     void invalidate()
     {
@@ -539,7 +539,7 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
     using sst::io::wtscript_header;
 
     /* File layout:
-       - Legacy / snapshot-less: pure XML text
+       - Snapshot-less: pure XML text
        - With snapshots: [wtscript_header][XML][zstd-compressed snapshot blob]
         where wtscript_header = { tag "wts1", xmlsize, blobsize }
     */

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -23,10 +23,15 @@
 #include "WavetableScriptEvaluator.h"
 
 #include "LuaSupport.h"
-
+#include "PatchFileHeaderStructs.h"
 #include "lua/LuaSources.h"
 
+#include "sst/basic-blocks/mechanics/endian-ops.h"
+
+#include <cstring>
+#include <fstream>
 #include <tinyxml/tinyxml.h>
+#include "zstd.h"
 
 // #define LOG(...) std::cout << __FILE__ << ":" << __LINE__ << " " << __VA_ARGS__ << std::endl;
 #define LOG(...)
@@ -53,11 +58,65 @@ struct LuaWTEvaluator::Details
     std::string wtName{"Scripted Wavetable"};
 
     lua_State *L{nullptr};
+    int snapshotRef{LUA_NOREF}; // registry ref for cached wt.snapshot table
 
     void invalidate()
     {
         isValid = false;
         frameCache.clear();
+    }
+
+    // Push a freshly built wt.snapshot 3D table onto the Lua stack
+    void pushSnapshotTable()
+    {
+        lua_newtable(L); // Outer snapshot table
+        if (!storage)
+            return;
+
+        auto &oscdata = storage->getPatch().scene[current_scene].osc[current_osc];
+        for (int s = 0; s < n_wt_snapshots; ++s)
+        {
+            lua_newtable(L); // Slot table (empty if not imported)
+            const auto &snap = oscdata.wtSnapshots[s];
+
+            if (snap && snap->everBuilt && snap->n_tables > 0 && snap->size > 0)
+            {
+                const unsigned int nframes = snap->n_tables;
+                const int nsamples = snap->size;
+
+                for (unsigned int t = 0; t < nframes; ++t)
+                {
+                    lua_newtable(L); // Frame table
+                    const float *tbl = snap->TableF32WeakPointers[0][t];
+                    for (int i = 0; i < nsamples; ++i)
+                    {
+                        lua_pushnumber(L, tbl[i]); // Push sample value
+                        lua_rawseti(L, -2, i + 1); // frame[i + 1] = value
+                    }
+                    lua_rawseti(L, -2, t + 1); // slot[t + 1] = frame table
+                }
+            }
+            lua_rawseti(L, -2, s + 1); // snapshot[slot + 1] = slot table
+        }
+    }
+
+    // Build the snapshot table and stash it in the Lua registry so each generate call can reuse it
+    void cacheSnapshotTable()
+    {
+        if (!L)
+            return;
+        releaseSnapshotTable();
+        pushSnapshotTable();
+        snapshotRef = luaL_ref(L, LUA_REGISTRYINDEX);
+    }
+
+    void releaseSnapshotTable()
+    {
+        if (L && snapshotRef != LUA_NOREF)
+        {
+            luaL_unref(L, LUA_REGISTRYINDEX, snapshotRef);
+            snapshotRef = LUA_NOREF;
+        }
     }
 
     void makeEmptyState(bool pushToGlobal)
@@ -122,35 +181,11 @@ struct LuaWTEvaluator::Details
         lua_setfield(L, tidx, "sample_count");
 
         // Inject snapshotted wavetables as a single 3D table: wt.snapshot[slot][frame][sample]
-        lua_newtable(L); // Outer snapshot table
-        if (storage)
-        {
-            auto &oscdata = storage->getPatch().scene[current_scene].osc[current_osc];
-            for (int s = 0; s < n_wt_snapshots; ++s)
-            {
-                lua_newtable(L); // Slot table (empty if not imported)
-                const auto &snap = oscdata.wtSnapshots[s];
-
-                if (snap && snap->everBuilt && snap->n_tables > 0 && snap->size > 0)
-                {
-                    const unsigned int nframes = snap->n_tables;
-                    const int nsamples = snap->size;
-
-                    for (unsigned int t = 0; t < nframes; ++t)
-                    {
-                        lua_newtable(L); // Frame table
-                        const float *tbl = snap->TableF32WeakPointers[0][t];
-                        for (int i = 0; i < nsamples; ++i)
-                        {
-                            lua_pushnumber(L, tbl[i]); // Push sample value
-                            lua_rawseti(L, -2, i + 1); // frame[i + 1] = value
-                        }
-                        lua_rawseti(L, -2, t + 1); // slot[t + 1] = frame table
-                    }
-                }
-                lua_rawseti(L, -2, s + 1); // snapshot[slot + 1] = slot table
-            }
-        }
+        // populateWavetable() pre-builds and caches once per regen cycle so we can reuse it
+        if (snapshotRef != LUA_NOREF)
+            lua_rawgeti(L, LUA_REGISTRYINDEX, snapshotRef);
+        else
+            pushSnapshotTable();
         lua_setfield(L, tidx, "snapshot");
 
         // So stack is now the table and the function
@@ -422,6 +457,14 @@ bool LuaWTEvaluator::populateWavetable(wt_header &wh, float **wavdata)
     if (!details->makeValid())
         return false;
 
+    // Build then cache the wt.snapshot Lua table once for this regen cycle
+    struct SnapshotCacheGuard
+    {
+        Details *d;
+        ~SnapshotCacheGuard() { d->releaseSnapshotTable(); }
+    } snapshotCacheGuard{details.get()};
+    details->cacheSnapshotTable();
+
     auto resolution = details->resolution;
     auto frames = details->frameCount;
 
@@ -492,10 +535,68 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
                               OscillatorStorage *oscdata)
 {
 #if HAS_LUA
-    TiXmlDocument doc;
-    if (!doc.LoadFile(filename))
+    namespace mech = sst::basic_blocks::mechanics;
+    using sst::io::wtscript_header;
+
+    /* File layout:
+       - Legacy / snapshot-less: pure XML text
+       - With snapshots: [wtscript_header][XML][zstd-compressed snapshot blob]
+        where wtscript_header = { tag "wts1", xmlsize, blobsize }
+    */
+
+    std::ifstream inFile(filename, std::ios::binary | std::ios::ate);
+    if (!inFile)
     {
         storage->reportError("Failed to load XML file.", "XML Load Error");
+        return std::nullopt;
+    }
+    const auto fileSize = static_cast<size_t>(inFile.tellg());
+    inFile.seekg(0);
+    std::vector<char> fileData(fileSize);
+    if (fileSize > 0)
+    {
+        inFile.read(fileData.data(), fileSize);
+    }
+    inFile.close();
+
+    // Detect the binary header by its 4-byte tag. If absent, treat the whole file as XML
+    const bool hasHeader =
+        fileSize >= sizeof(wtscript_header) && std::memcmp(fileData.data(), "wts1", 4) == 0;
+
+    size_t xmlOffset = 0;
+    size_t xmlSize = fileSize;
+    size_t blobOffset = 0;
+    size_t blobSize = 0;
+
+    if (hasHeader)
+    {
+        wtscript_header header{};
+        std::memcpy(&header, fileData.data(), sizeof(header));
+        header.xmlsize = mech::endian_read_int32LE(header.xmlsize);
+        header.blobsize = mech::endian_read_int32LE(header.blobsize);
+
+        xmlOffset = sizeof(wtscript_header);
+        xmlSize = header.xmlsize;
+        blobSize = header.blobsize;
+
+        const size_t bytesAfterHeader = fileSize - xmlOffset;
+        if (xmlSize > bytesAfterHeader || blobSize > bytesAfterHeader - xmlSize)
+        {
+            storage->reportError("Wavetable script file is truncated or corrupt.",
+                                 "XML Load Error");
+            return std::nullopt;
+        }
+
+        blobOffset = xmlOffset + xmlSize;
+    }
+
+    // Parse only the XML portion
+    std::string xmlStr(fileData.data() + xmlOffset, xmlSize);
+    TiXmlDocument doc;
+    doc.Parse(xmlStr.c_str(), nullptr, TIXML_ENCODING_LEGACY);
+    if (doc.Error())
+    {
+        storage->reportError("Failed to parse wavetable script XML.", "XML Load Error");
         return std::nullopt;
     }
 
@@ -540,46 +641,76 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
     data.nframes = nframes;
     data.res_base = res_base;
 
+    // Snapshots: metadata lives in XML; float data comes from the compressed trailing blob
     auto sn = TINYXML_SAFE_TO_ELEMENT(wtscript->FirstChildElement("snapshots"));
-    if (sn)
+    if (sn && blobSize > 0)
     {
-        for (auto child = sn->FirstChildElement("snapshot"); child;
-             child = child->NextSiblingElement("snapshot"))
-        {
-            int slot = 0, nframes = 0, nsamples = 0;
+        auto validSnapshot = [](TiXmlElement *child, int &slot, int &nframes, int &nsamples) {
             if (child->QueryIntAttribute("slot", &slot) != TIXML_SUCCESS ||
                 child->QueryIntAttribute("frames", &nframes) != TIXML_SUCCESS ||
                 child->QueryIntAttribute("samples", &nsamples) != TIXML_SUCCESS)
-            {
-                continue;
-            }
+                return false;
+            return slot >= 0 && slot < n_wt_snapshots && nframes > 0 && nframes <= max_subtables &&
+                   nsamples > 0 && nsamples <= max_wtable_size;
+        };
 
-            if (slot < 0 || slot >= n_wt_snapshots)
-            {
-                continue;
-            }
+        size_t expectedFloats = 0;
+        for (auto child = sn->FirstChildElement("snapshot"); child;
+             child = child->NextSiblingElement("snapshot"))
+        {
+            int slot, nframes, nsamples;
+            if (validSnapshot(child, slot, nframes, nsamples))
+                expectedFloats += static_cast<size_t>(nframes) * nsamples;
+        }
 
-            auto b64data = child->Attribute("data");
-            if (!b64data)
+        if (expectedFloats > 0)
+        {
+            const std::uint8_t *compData =
+                reinterpret_cast<const std::uint8_t *>(fileData.data() + blobOffset);
+            const auto decompressedSize = ZSTD_getFrameContentSize(compData, blobSize);
+            if (decompressedSize == ZSTD_CONTENTSIZE_ERROR ||
+                decompressedSize == ZSTD_CONTENTSIZE_UNKNOWN ||
+                decompressedSize != expectedFloats * sizeof(float))
             {
-                continue;
+                storage->reportError("Snapshot blob size mismatch; snapshots not loaded.",
+                                     "Wavetable Script Load Warning");
             }
-            auto decoded = Surge::Storage::base64_decode(b64data);
-            if (decoded.size() != (size_t)(nframes * nsamples * (int)sizeof(float)))
+            else
             {
-                continue;
-            }
+                std::vector<float> decompressed(expectedFloats);
+                const size_t result =
+                    ZSTD_decompress(decompressed.data(), decompressedSize, compData, blobSize);
+                if (ZSTD_isError(result) || result != decompressedSize)
+                {
+                    storage->reportError(
+                        "Failed to decompress snapshot blob; snapshots not loaded.",
+                        "Wavetable Script Load Warning");
+                }
+                else
+                {
+                    size_t floatOffset = 0;
+                    for (auto child = sn->FirstChildElement("snapshot"); child;
+                         child = child->NextSiblingElement("snapshot"))
+                    {
+                        int slot, nframes, nsamples;
+                        if (!validSnapshot(child, slot, nframes, nsamples))
+                            continue;
 
-            wt_header wh{};
-            wh.n_samples = nsamples;
-            wh.n_tables = nframes;
-            wh.flags = 0;
+                        wt_header wh{};
+                        wh.n_samples = nsamples;
+                        wh.n_tables = nframes;
+                        wh.flags = 0;
 
-            oscdata->wtSnapshots[slot] = std::make_unique<Wavetable>();
-            oscdata->wtSnapshots[slot]->BuildWT(decoded.data(), wh, false);
-            if (!oscdata->wtSnapshots[slot]->everBuilt)
-            {
-                oscdata->wtSnapshots[slot].reset();
+                        oscdata->wtSnapshots[slot] = std::make_unique<Wavetable>();
+                        oscdata->wtSnapshots[slot]->BuildWT(decompressed.data() + floatOffset, wh,
+                                                            false);
+                        if (!oscdata->wtSnapshots[slot]->everBuilt)
+                        {
+                            oscdata->wtSnapshots[slot].reset();
+                        }
+                        floatOffset += static_cast<size_t>(nframes) * nsamples;
+                    }
+                }
             }
         }
     }

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -121,28 +121,31 @@ struct LuaWTEvaluator::Details
 
         // Inject snapshotted wavetables as a single 3D table: wt.snapshot[slot][frame][sample]
         lua_newtable(L); // Outer snapshot table
-        for (int s = 0; s < n_oscs; ++s)
+        if (storage)
         {
-            lua_newtable(L); // Slot table (empty if not imported)
-            if (storage->getPatch().dawExtraState.editor.wtSnapshot[s].enabled)
+            for (int s = 0; s < n_oscs; ++s)
             {
-                const auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[s];
-
-                if (snap.enabled && snap.n_tables > 0 && snap.size > 0)
+                lua_newtable(L); // Slot table (empty if not imported)
+                if (storage->getPatch().dawExtraState.editor.wtSnapshot[s].enabled)
                 {
-                    for (int t = 0; t < snap.n_tables; ++t)
+                    const auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[s];
+
+                    if (snap.enabled && snap.n_tables > 0 && snap.size > 0)
                     {
-                        lua_newtable(L); // Frame table
-                        for (int i = 0; i < snap.size; ++i)
+                        for (int t = 0; t < snap.n_tables; ++t)
                         {
-                            lua_pushnumber(L, snap.frames[t][i]); // Push sample value
-                            lua_rawseti(L, -2, i + 1);            // frame[i + 1] = value
+                            lua_newtable(L); // Frame table
+                            for (int i = 0; i < snap.size; ++i)
+                            {
+                                lua_pushnumber(L, snap.frames[t][i]); // Push sample value
+                                lua_rawseti(L, -2, i + 1);            // frame[i + 1] = value
+                            }
+                            lua_rawseti(L, -2, t + 1); // slot[t + 1] = frame table
                         }
-                        lua_rawseti(L, -2, t + 1); // slot[t + 1] = frame table
                     }
                 }
+                lua_rawseti(L, -2, s + 1); // snapshot[slot + 1] = slot table
             }
-            lua_rawseti(L, -2, s + 1); // snapshot[slot + 1] = slot table
         }
         lua_setfield(L, tidx, "snapshot");
 

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -49,7 +49,6 @@ struct LuaWTEvaluator::Details
     bool isValid{false};
     std::vector<std::optional<frame_t>> frameCache;
     std::string wtName{"Scripted Wavetable"};
-    void prepareIfInvalid();
 
     lua_State *L{nullptr};
 
@@ -74,7 +73,6 @@ struct LuaWTEvaluator::Details
     LuaWTEvaluator::frame_t generateScriptAtFrame(size_t frame)
     {
         LOG("generateScriptAtFrame " << frame);
-        auto &eqn = script;
 
         if (!makeValid())
             return std::nullopt;
@@ -121,6 +119,33 @@ struct LuaWTEvaluator::Details
         lua_pushinteger(L, resolution);
         lua_setfield(L, tidx, "sample_count");
 
+        // Inject snapshotted wavetables as a single 3D table: wt.snapshot[slot][frame][sample]
+        lua_newtable(L); // Outer snapshot table
+        for (int s = 0; s < n_oscs; ++s)
+        {
+            lua_newtable(L); // Slot table (empty if not imported)
+            if (storage->getPatch().dawExtraState.editor.wtSnapshot[s].enabled)
+            {
+                const auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[s];
+
+                if (snap.enabled && snap.n_tables > 0 && snap.size > 0)
+                {
+                    for (int t = 0; t < snap.n_tables; ++t)
+                    {
+                        lua_newtable(L); // Frame table
+                        for (int i = 0; i < snap.size; ++i)
+                        {
+                            lua_pushnumber(L, snap.frames[t][i]); // Push sample value
+                            lua_rawseti(L, -2, i + 1);            // frame[i + 1] = value
+                        }
+                        lua_rawseti(L, -2, t + 1); // slot[t + 1] = frame table
+                    }
+                }
+            }
+            lua_rawseti(L, -2, s + 1); // snapshot[slot + 1] = slot table
+        }
+        lua_setfield(L, tidx, "snapshot");
+
         // So stack is now the table and the function
         auto pcr = lua_pcall(L, 1, 1, 0);
         if (pcr == LUA_OK)
@@ -144,7 +169,9 @@ struct LuaWTEvaluator::Details
                     lua_pop(L, 1);
                 }
                 if (gen)
+                {
                     res = values;
+                }
             }
         }
         else
@@ -433,18 +460,14 @@ void LuaWTEvaluator::generateWavetable(SurgeStorage *storage, OscillatorStorage 
 
     if (populateWavetable(wh, &wd))
     {
-        if (!exportMode)
-        {
-            storage->waveTableDataMutex.lock();
-        }
-
+        storage->waveTableDataMutex.lock();
         wt->BuildWT(wd, wh, wh.flags & wtf_is_sample);
 
         if (!exportMode)
         {
             oscdata->wavetable_display_name = getSuggestedWavetableName();
-            storage->waveTableDataMutex.unlock();
         }
+        storage->waveTableDataMutex.unlock();
 
         delete[] wd;
     }
@@ -503,6 +526,50 @@ std::optional<LuaWTEvaluator::WtscriptData> LuaWTEvaluator::parseWtscript(const 
     data.nframes = nframes;
     data.res_base = res_base;
 
+    // Skips parsing snapshots if absent
+    auto sn = TINYXML_SAFE_TO_ELEMENT(wtscript->FirstChildElement("snapshots"));
+    if (sn)
+    {
+        for (auto child = sn->FirstChildElement("snapshot"); child;
+             child = child->NextSiblingElement("snapshot"))
+        {
+            int slot = 0, n_tables = 0, size = 0;
+            if (child->QueryIntAttribute("slot", &slot) != TIXML_SUCCESS ||
+                child->QueryIntAttribute("n_tables", &n_tables) != TIXML_SUCCESS ||
+                child->QueryIntAttribute("size", &size) != TIXML_SUCCESS)
+            {
+                continue;
+            }
+
+            auto b64data = child->Attribute("data");
+            if (!b64data)
+            {
+                continue;
+            }
+            auto decoded = Surge::Storage::base64_decode(b64data);
+            if (decoded.size() != (size_t)(n_tables * size * (int)sizeof(float)))
+            {
+                continue;
+            }
+
+            DAWExtraStateStorage::EditorState::WavetableSnapshot snap;
+            snap.n_tables = n_tables;
+            snap.size = size;
+            snap.frames.resize(n_tables);
+
+            // Split the flat decoded buffer back into tables: frames[table][sample]
+            for (int t = 0; t < n_tables; ++t)
+            {
+                snap.frames[t].resize(size);
+                std::memcpy(snap.frames[t].data(), decoded.data() + t * size * sizeof(float),
+                            size * sizeof(float));
+            }
+
+            snap.enabled = true;
+            data.snapshots.emplace_back(slot, std::move(snap));
+        }
+    }
+
     return data;
 #else
     return std::nullopt;
@@ -522,8 +589,21 @@ void LuaWTEvaluator::loadWtscript(const fs::path &filename, SurgeStorage *storag
     oscdata->wavetable_script_nframes = data->nframes;
     oscdata->wavetable_script_res_base = data->res_base;
     oscdata->wavetable_script = data->script;
-    details->invalidate();
 
+    if (!data->snapshots.empty())
+    {
+        for (auto &[slot, sd] : data->snapshots)
+        {
+            if (slot < 0 || slot >= n_oscs)
+            {
+                continue;
+            }
+
+            storage->getPatch().dawExtraState.editor.wtSnapshot[slot] = std::move(sd);
+        }
+    }
+
+    details->invalidate();
     generateWavetable(storage, oscdata, &oscdata->wt);
 #endif
 }

--- a/src/common/dsp/WavetableScriptEvaluator.h
+++ b/src/common/dsp/WavetableScriptEvaluator.h
@@ -43,6 +43,7 @@ struct LuaWTEvaluator
                                             Surge::LuaSupport::EnvironmentFeatures::HAS_FFT;
 
     void setStorage(SurgeStorage *);
+    void setOscillatorStorage(int scene, int osc);
     void setScript(const std::string &);
     void setResolution(size_t);
     void setFrameCount(size_t);
@@ -75,10 +76,9 @@ struct LuaWTEvaluator
         std::string script;
         int nframes = 0;
         int res_base = 0;
-
-        std::vector<std::pair<int, DAWExtraStateStorage::EditorState::WavetableSnapshot>> snapshots;
     };
-    std::optional<WtscriptData> parseWtscript(const fs::path &filename, SurgeStorage *storage);
+    std::optional<WtscriptData> parseWtscript(const fs::path &filename, SurgeStorage *storage,
+                                              OscillatorStorage *oscdata);
 };
 
 } // namespace WavetableScript

--- a/src/common/dsp/WavetableScriptEvaluator.h
+++ b/src/common/dsp/WavetableScriptEvaluator.h
@@ -75,6 +75,8 @@ struct LuaWTEvaluator
         std::string script;
         int nframes = 0;
         int res_base = 0;
+
+        std::vector<std::pair<int, DAWExtraStateStorage::EditorState::WavetableSnapshot>> snapshots;
     };
     std::optional<WtscriptData> parseWtscript(const fs::path &filename, SurgeStorage *storage);
 };

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -1010,7 +1010,7 @@ TEST_CASE("Wavetable Script Snapshots", "[wts]")
         auto &osc = storage.getPatch().scene[0].osc[0];
 
         // Populate snapshot slot 0 with a known 2-frame, 64-sample ramp
-        osc.wtSnapshots[0].emplace();
+        osc.wtSnapshots[0] = std::make_unique<Wavetable>();
         auto &snap = *osc.wtSnapshots[0];
 
         constexpr int nframes = 2;

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -1002,6 +1002,123 @@ end
     }
 }
 
+TEST_CASE("Wavetable Script Snapshots", "[wts]")
+{
+    SECTION("Script Can Read Snapshot Data")
+    {
+        SurgeStorage storage;
+
+        // Populate snapshot slot 0 with a known 2-frame, 64-sample ramp
+        auto &snap = storage.getPatch().dawExtraState.editor.wtSnapshot[0];
+        snap.n_tables = 2;
+        snap.size = 64;
+        snap.frames.resize(2);
+        for (int t = 0; t < 2; ++t)
+        {
+            snap.frames[t].resize(64);
+            for (int i = 0; i < 64; ++i)
+            {
+                snap.frames[t][i] = (float)(t + 1) * (float)i / 63.0f;
+            }
+        }
+        snap.enabled = true;
+
+        // Script that copies snapshot slot 1 (Lua 1-indexed), frame matching wt.frame
+        const std::string s = R"FN(
+function init(wt)
+    wt.name = "Snapshot Test"
+    return wt
+end
+
+function generate(wt)
+    local res = {}
+    local slot = wt.snapshot[1]
+    if slot and slot[wt.frame] then
+        for i = 1, wt.sample_count do
+            if slot[wt.frame][i] then
+                res[i] = slot[wt.frame][i]
+            else
+                res[i] = 0
+            end
+        end
+    else
+        for i = 1, wt.sample_count do
+            res[i] = 0
+        end
+    end
+    return res
+end
+        )FN";
+
+        auto la = std::make_unique<Surge::WavetableScript::LuaWTEvaluator>();
+        la->setResolution(64);
+        la->setStorage(&storage);
+        la->setFrameCount(2);
+        la->setScript(s);
+
+        auto fr0 = la->getFrame(0);
+        REQUIRE(fr0.has_value());
+        REQUIRE(fr0->size() == 64);
+        for (int i = 0; i < 64; ++i)
+        {
+            float expected = 1.0f * (float)i / 63.0f;
+            REQUIRE((*fr0)[i] == Approx(expected).margin(1e-6));
+        }
+
+        auto fr1 = la->getFrame(1);
+        REQUIRE(fr1.has_value());
+        REQUIRE(fr1->size() == 64);
+        for (int i = 0; i < 64; ++i)
+        {
+            float expected = 2.0f * (float)i / 63.0f;
+            REQUIRE((*fr1)[i] == Approx(expected).margin(1e-6));
+        }
+    }
+
+    SECTION("Empty Snapshot Slot Returns Empty Table")
+    {
+        SurgeStorage storage;
+
+        // All snapshots disabled by default, script should still run
+        const std::string s = R"FN(
+function init(wt)
+    wt.name = "Empty Snapshot Test"
+    return wt
+end
+
+function generate(wt)
+    local res = {}
+    local slot = wt.snapshot[1]
+    local hasData = false
+    if slot then
+        for k, v in pairs(slot) do
+            hasData = true
+            break
+        end
+    end
+    for i = 1, wt.sample_count do
+        res[i] = hasData and 1.0 or 0.0
+    end
+    return res
+end
+        )FN";
+
+        auto la = std::make_unique<Surge::WavetableScript::LuaWTEvaluator>();
+        la->setResolution(64);
+        la->setStorage(&storage);
+        la->setFrameCount(1);
+        la->setScript(s);
+
+        auto fr = la->getFrame(0);
+        REQUIRE(fr.has_value());
+        REQUIRE(fr->size() == 64);
+        for (int i = 0; i < 64; ++i)
+        {
+            REQUIRE((*fr)[i] == Approx(0.0).margin(1e-6));
+        }
+    }
+}
+
 TEST_CASE("PFFFT Wrapper", "[wts]")
 {
     SECTION("Round-Trip FFT")

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -1007,21 +1007,28 @@ TEST_CASE("Wavetable Script Snapshots", "[wts]")
     SECTION("Script Can Read Snapshot Data")
     {
         SurgeStorage storage;
+        auto &osc = storage.getPatch().scene[0].osc[0];
 
         // Populate snapshot slot 0 with a known 2-frame, 64-sample ramp
-        auto &snap = storage.getPatch().dawExtraState.editor.wtSnapshot[0];
-        snap.n_tables = 2;
-        snap.size = 64;
-        snap.frames.resize(2);
-        for (int t = 0; t < 2; ++t)
+        osc.wtSnapshots[0].emplace();
+        auto &snap = *osc.wtSnapshots[0];
+
+        constexpr int nframes = 2;
+        constexpr int nsamples = 64;
+        std::vector<float> flat(nframes * nsamples);
+        for (int t = 0; t < nframes; ++t)
         {
-            snap.frames[t].resize(64);
-            for (int i = 0; i < 64; ++i)
+            for (int i = 0; i < nsamples; ++i)
             {
-                snap.frames[t][i] = (float)(t + 1) * (float)i / 63.0f;
+                flat[t * nsamples + i] = (float)(t + 1) * (float)i / 63.0f;
             }
         }
-        snap.enabled = true;
+
+        wt_header wh{};
+        wh.n_samples = nsamples;
+        wh.n_tables = nframes;
+        wh.flags = 0;
+        snap.BuildWT(flat.data(), wh, false);
 
         // Script that copies snapshot slot 1 (Lua 1-indexed), frame matching wt.frame
         const std::string s = R"FN(
@@ -1053,6 +1060,7 @@ end
         auto la = std::make_unique<Surge::WavetableScript::LuaWTEvaluator>();
         la->setResolution(64);
         la->setStorage(&storage);
+        la->setOscillatorStorage(0, 0);
         la->setFrameCount(2);
         la->setScript(s);
 
@@ -1106,6 +1114,7 @@ end
         auto la = std::make_unique<Surge::WavetableScript::LuaWTEvaluator>();
         la->setResolution(64);
         la->setStorage(&storage);
+        la->setOscillatorStorage(0, 0);
         la->setFrameCount(1);
         la->setScript(s);
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6796,26 +6796,30 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
 
             TiXmlElement sn("snapshots");
             bool hasSnapshots = false;
-            for (int slot = 0; slot < n_oscs; ++slot)
+            for (int slot = 0; slot < n_wt_snapshots; ++slot)
             {
-                const auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[slot];
-                if (!snap.enabled)
+                const auto &snap = oscdata->wtSnapshots[slot];
+                if (!snap.has_value() || !snap->everBuilt)
                 {
                     continue;
                 }
 
-                // Flatten 2D frames[table][sample] into a single float array
+                const unsigned int nframes = snap->n_tables;
+                const int nsamples = snap->size;
+
+                // Flatten mip-level-0 samples into a single float array
                 std::vector<float> flat;
-                flat.reserve(snap.n_tables * snap.size);
-                for (int t = 0; t < snap.n_tables; ++t)
+                flat.reserve(static_cast<size_t>(nframes) * nsamples);
+                for (unsigned int t = 0; t < nframes; ++t)
                 {
-                    flat.insert(flat.end(), snap.frames[t].begin(), snap.frames[t].end());
+                    const float *tbl = snap->TableF32WeakPointers[0][t];
+                    flat.insert(flat.end(), tbl, tbl + nsamples);
                 }
 
                 TiXmlElement sl("snapshot");
                 sl.SetAttribute("slot", slot);
-                sl.SetAttribute("n_tables", snap.n_tables);
-                sl.SetAttribute("size", snap.size);
+                sl.SetAttribute("frames", nframes);
+                sl.SetAttribute("samples", nsamples);
                 sl.SetAttribute("data",
                                 Surge::Storage::base64_encode((unsigned const char *)flat.data(),
                                                               flat.size() * sizeof(float)));

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6799,7 +6799,7 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
             for (int slot = 0; slot < n_wt_snapshots; ++slot)
             {
                 const auto &snap = oscdata->wtSnapshots[slot];
-                if (!snap.has_value() || !snap->everBuilt)
+                if (!snap || !snap->everBuilt)
                 {
                     continue;
                 }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6793,6 +6793,40 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
             }
 
             wtscript.InsertEndChild(script);
+
+            TiXmlElement sn("snapshots");
+            bool hasSnapshots = false;
+            for (int slot = 0; slot < n_oscs; ++slot)
+            {
+                const auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[slot];
+                if (!snap.enabled)
+                {
+                    continue;
+                }
+
+                // Flatten 2D frames[table][sample] into a single float array
+                std::vector<float> flat;
+                flat.reserve(snap.n_tables * snap.size);
+                for (int t = 0; t < snap.n_tables; ++t)
+                {
+                    flat.insert(flat.end(), snap.frames[t].begin(), snap.frames[t].end());
+                }
+
+                TiXmlElement sl("snapshot");
+                sl.SetAttribute("slot", slot);
+                sl.SetAttribute("n_tables", snap.n_tables);
+                sl.SetAttribute("size", snap.size);
+                sl.SetAttribute("data",
+                                Surge::Storage::base64_encode((unsigned const char *)flat.data(),
+                                                              flat.size() * sizeof(float)));
+                sn.InsertEndChild(sl);
+                hasSnapshots = true;
+            }
+            if (hasSnapshots)
+            {
+                wtscript.InsertEndChild(sn);
+            }
+
             doc.InsertEndChild(wtscript);
             if (!doc.SaveFile(fullLocation))
             {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -39,6 +39,7 @@
 #include "ModulatorPresetManager.h"
 #include "ModulationSource.h"
 #include "WavetableScriptEvaluator.h"
+#include "PatchFileHeaderStructs.h"
 
 #include "SurgeSynthEditor.h"
 #include "SurgeJUCELookAndFeel.h"
@@ -78,9 +79,12 @@
 #include "widgets/XMLConfiguredMenus.h"
 
 #include "ModulationGridConfiguration.h"
+
 #include "sst/plugininfra/strnatcmp.h"
+#include "sst/basic-blocks/mechanics/endian-ops.h"
 
 #include <cstring>
+#include <fstream>
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -103,6 +107,7 @@
 
 #include "filesystem/import.h"
 #include "RuntimeFont.h"
+#include "zstd.h"
 
 #include "juce_core/juce_core.h"
 #include "AccessibleHelpers.h"
@@ -6794,8 +6799,9 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
 
             wtscript.InsertEndChild(script);
 
+            // Collect snapshot float data and build per-slot XML metadata
             TiXmlElement sn("snapshots");
-            bool hasSnapshots = false;
+            std::vector<float> snapshotFloats;
             for (int slot = 0; slot < n_wt_snapshots; ++slot)
             {
                 const auto &snap = oscdata->wtSnapshots[slot];
@@ -6807,34 +6813,75 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
                 const unsigned int nframes = snap->n_tables;
                 const int nsamples = snap->size;
 
-                // Flatten mip-level-0 samples into a single float array
-                std::vector<float> flat;
-                flat.reserve(static_cast<size_t>(nframes) * nsamples);
                 for (unsigned int t = 0; t < nframes; ++t)
                 {
                     const float *tbl = snap->TableF32WeakPointers[0][t];
-                    flat.insert(flat.end(), tbl, tbl + nsamples);
+                    snapshotFloats.insert(snapshotFloats.end(), tbl, tbl + nsamples);
                 }
 
                 TiXmlElement sl("snapshot");
                 sl.SetAttribute("slot", slot);
                 sl.SetAttribute("frames", nframes);
                 sl.SetAttribute("samples", nsamples);
-                sl.SetAttribute("data",
-                                Surge::Storage::base64_encode((unsigned const char *)flat.data(),
-                                                              flat.size() * sizeof(float)));
                 sn.InsertEndChild(sl);
-                hasSnapshots = true;
             }
-            if (hasSnapshots)
+            if (!snapshotFloats.empty())
             {
                 wtscript.InsertEndChild(sn);
             }
 
             doc.InsertEndChild(wtscript);
-            if (!doc.SaveFile(fullLocation))
+
+            // Serialize XML to a string
+            std::string xmlStr;
+            xmlStr << doc;
+
+            std::ofstream outFile(fullLocation, std::ios::binary);
+            if (!outFile)
             {
-                storage->reportError("Failed to save XML file.", "XML Save Error");
+                storage->reportError("Failed to open file for writing.", "Save Error");
+                return;
+            }
+
+            if (snapshotFloats.empty())
+            {
+                // Just the XML
+                outFile.write(xmlStr.data(), xmlStr.size());
+            }
+            else
+            {
+                // Compress the snapshot float data
+                namespace mech = sst::basic_blocks::mechanics;
+                const size_t rawSize = snapshotFloats.size() * sizeof(float);
+                const size_t compBound = ZSTD_compressBound(rawSize);
+                std::vector<uint8_t> compressed(compBound);
+                const size_t compSize =
+                    ZSTD_compress(compressed.data(), compBound, snapshotFloats.data(), rawSize, 3);
+                if (ZSTD_isError(compSize))
+                {
+                    storage->reportError("Failed to compress snapshot data.", "Save Error");
+                    return;
+                }
+                compressed.resize(compSize);
+
+                // Fixed binary header: tag + xmlsize + blobsize
+                sst::io::wtscript_header header{};
+                std::memcpy(header.tag, "wts1", 4);
+                header.xmlsize =
+                    mech::endian_write_int32LE(static_cast<unsigned int>(xmlStr.size()));
+                header.blobsize =
+                    mech::endian_write_int32LE(static_cast<unsigned int>(compressed.size()));
+
+                outFile.write(reinterpret_cast<const char *>(&header), sizeof(header));
+                outFile.write(xmlStr.data(), xmlStr.size());
+                outFile.write(reinterpret_cast<const char *>(compressed.data()), compressed.size());
+            }
+
+            outFile.close();
+            if (!outFile)
+            {
+                storage->reportError("Failed to write file.", "Save Error");
+                return;
             }
 
             storage->refresh_wtlist();

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -105,6 +105,8 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::makeStorePatc
     pb->setSurgeGUIEditor(this);
     pb->setStorage(&(this->synth->storage));
     pb->setStoreTuningInPatch(this->synth->storage.getPatch().patchTuning.tuningStoredInPatch);
+    pb->setHasSnapshots(synth->storage.getPatch().hasAnySnapshots());
+    pb->setStoreSnapshotsInPatch(synth->storage.getPatch().snapshotsStoredInPatch);
 
     // since it is now modal center in the window
     auto posRect = skinCtrl->getRect().withCentre(frame->getBounds().getCentre());

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -4259,33 +4259,6 @@ bool WavetableScriptEditor::populateMenuForCategory(juce::PopupMenu &contextMenu
         subMenu = &contextMenu;
     }
 
-    for (auto child : cat.children)
-    {
-        if (child.numberOfPatchesInCategoryAndChildren > 0)
-        {
-            // this isn't the best approach but it works
-            int cidx = 0;
-
-            for (auto &cc : storage->wt_category)
-            {
-                if (cc.name == child.name)
-                {
-                    break;
-                }
-
-                cidx++;
-            }
-
-            bool childHasWTS = populateMenuForCategory(*subMenu, cidx, selectedItem, false);
-
-            if (childHasWTS)
-            {
-                hasAnyWTS = true;
-                selected = selected || childHasWTS;
-            }
-        }
-    }
-
     for (auto p : storage->wtOrdering)
     {
         if (storage->wt_list[p].category == categoryId)
@@ -4327,6 +4300,33 @@ bool WavetableScriptEditor::populateMenuForCategory(juce::PopupMenu &contextMenu
                 {
                     Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(*subMenu, "");
                 }
+            }
+        }
+    }
+
+    for (auto child : cat.children)
+    {
+        if (child.numberOfPatchesInCategoryAndChildren > 0)
+        {
+            // this isn't the best approach but it works
+            int cidx = 0;
+
+            for (auto &cc : storage->wt_category)
+            {
+                if (cc.name == child.name)
+                {
+                    break;
+                }
+
+                cidx++;
+            }
+
+            bool childHasWTS = populateMenuForCategory(*subMenu, cidx, selectedItem, false);
+
+            if (childHasWTS)
+            {
+                hasAnyWTS = true;
+                selected = selected || childHasWTS;
             }
         }
     }

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -4014,6 +4014,7 @@ void WavetableScriptEditor::setupEvaluator()
         respt *= 2;
     }
     evaluator->setStorage(storage);
+    evaluator->setOscillatorStorage(scene, osc_id);
     evaluator->setScript(mainDocument->getAllContent().toStdString());
     evaluator->setResolution(respt);
     evaluator->setFrameCount(controlArea->framesN->getIntValue());
@@ -4085,18 +4086,21 @@ void WavetableScriptEditor::createMenu(juce::PopupMenu &menu)
     menu.addSeparator();
 
     // Import snapshot submenu
-    juce::PopupMenu importMenu;
+    juce::PopupMenu snapshotMenu;
     std::string sceneName = (scene == 0) ? "Scene A" : "Scene B";
 
-    for (int slot = 0; slot < n_oscs; ++slot)
+    for (int slot = 0; slot < n_wt_snapshots; ++slot)
     {
-        const auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[slot];
+        const auto &snap = osc->wtSnapshots[slot];
+        const bool populated = snap.has_value() && snap->everBuilt;
 
         std::string snapLabel = "Snapshot " + std::to_string(slot + 1);
-        if (snap.enabled)
-            snapLabel += " (" + std::to_string(snap.n_tables) +
-                         (snap.n_tables == 1 ? " frame" : " frames") + ", " +
-                         std::to_string(snap.size) + " samples)";
+        if (populated)
+        {
+            const unsigned int frames = snap->n_tables;
+            snapLabel += " (" + std::to_string(frames) + (frames == 1 ? " frame" : " frames") +
+                         ", " + std::to_string(snap->size) + " samples)";
+        }
 
         auto comp = std::make_unique<Surge::Widgets::WavetableSnapshotMenuComponent>(
             snapLabel, sceneName,
@@ -4108,13 +4112,12 @@ void WavetableScriptEditor::createMenu(juce::PopupMenu &menu)
                 }
                 if (action == Surge::Widgets::WavetableSnapshotMenuComponent::Action::Clear)
                 {
-                    storage->getPatch().dawExtraState.editor.wtSnapshot[slot] =
-                        DAWExtraStateStorage::EditorState::WavetableSnapshot{};
+                    osc->wtSnapshots[slot].reset();
                 }
                 else
                 {
-                    const int oscIndex = static_cast<int>(action);
-                    storage->getPatch().captureWavetableSnapshot(scene, slot, oscIndex);
+                    storage->getPatch().captureWavetableSnapshot(scene, static_cast<int>(action),
+                                                                 osc_id, slot);
                 }
                 lastFrames = -1;
                 rerenderFromUIState();
@@ -4122,15 +4125,15 @@ void WavetableScriptEditor::createMenu(juce::PopupMenu &menu)
             });
         comp->setSkin(skin, associatedBitmapStore);
 
-        comp->clearButton->setVisible(snap.enabled);
+        comp->clearButton->setVisible(populated);
 
-        importMenu.addCustomItem(-1, std::move(comp), nullptr, snapLabel);
-        if (slot < n_oscs - 1)
+        if (slot > 0)
         {
-            importMenu.addSeparator();
+            snapshotMenu.addSeparator();
         }
+        snapshotMenu.addCustomItem(-1, std::move(comp), nullptr, snapLabel);
     }
-    menu.addSubMenu(Surge::GUI::toOSCase("Import Wavetable Data"), importMenu);
+    menu.addSubMenu(Surge::GUI::toOSCase("Import Wavetable Data"), snapshotMenu);
     menu.addSeparator();
 
     if (!osc->wavetable_script.empty())
@@ -4394,6 +4397,7 @@ void WavetableScriptEditor::loadWavetableScript(int id)
 // Modified from OscillatorWaveformDisplay::loadWavetableFromFile
 void WavetableScriptEditor::loadWavetableForSnapshot(int slot)
 {
+    assert(slot >= 0 && slot < n_wt_snapshots);
     auto wtPath = storage->userWavetablesPath;
     wtPath = Surge::Storage::getUserDefaultPath(storage, Surge::Storage::LastWavetablePath, wtPath);
 
@@ -4418,26 +4422,18 @@ void WavetableScriptEditor::loadWavetableForSnapshot(int slot)
             auto res = c.getResult();
             auto rString = res.getFullPathName().toStdString();
 
-            Wavetable tempWt;
-            storage->load_wt(rString, &tempWt, nullptr);
-
-            auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[slot];
-            snap = DAWExtraStateStorage::EditorState::WavetableSnapshot{};
-
-            if (tempWt.everBuilt && tempWt.n_tables > 0 && tempWt.size > 0 &&
-                tempWt.TableF32WeakPointers[0][0] != nullptr)
+            auto &snap = osc->wtSnapshots[slot];
+            if (!snap.has_value())
             {
-                snap.n_tables = tempWt.n_tables;
-                snap.size = tempWt.size;
-                snap.frames.resize(tempWt.n_tables);
+                snap.emplace();
+            }
 
-                for (int t = 0; t < tempWt.n_tables; ++t)
-                {
-                    snap.frames[t].assign(tempWt.TableF32WeakPointers[0][t],
-                                          tempWt.TableF32WeakPointers[0][t] + tempWt.size);
-                }
+            storage->load_wt(rString, &snap.value(), nullptr);
 
-                snap.enabled = true;
+            if (!snap->everBuilt || snap->n_tables == 0 || snap->size == 0 ||
+                snap->TableF32WeakPointers[0][0] == nullptr)
+            {
+                snap.reset();
             }
 
             lastFrames = -1;

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -3982,9 +3982,7 @@ void WavetableScriptEditor::rerenderFromUIState()
 
     auto respt = 32;
     for (int i = 1; i < resi; ++i)
-    {
         respt *= 2;
-    }
 
     setupEvaluator();
 
@@ -4010,9 +4008,8 @@ void WavetableScriptEditor::setupEvaluator()
     auto resi = controlArea->resolutionN->getIntValue();
     auto respt = 32;
     for (int i = 1; i < resi; ++i)
-    {
         respt *= 2;
-    }
+
     evaluator->setStorage(storage);
     evaluator->setOscillatorStorage(scene, osc_id);
     evaluator->setScript(mainDocument->getAllContent().toStdString());
@@ -4092,7 +4089,7 @@ void WavetableScriptEditor::createMenu(juce::PopupMenu &menu)
     for (int slot = 0; slot < n_wt_snapshots; ++slot)
     {
         const auto &snap = osc->wtSnapshots[slot];
-        const bool populated = snap.has_value() && snap->everBuilt;
+        const bool populated = snap && snap->everBuilt;
 
         std::string snapLabel = "Snapshot " + std::to_string(slot + 1);
         if (populated)
@@ -4423,15 +4420,14 @@ void WavetableScriptEditor::loadWavetableForSnapshot(int slot)
             auto rString = res.getFullPathName().toStdString();
 
             auto &snap = osc->wtSnapshots[slot];
-            if (!snap.has_value())
+            if (!snap)
             {
-                snap.emplace();
+                snap = std::make_unique<Wavetable>();
             }
 
-            storage->load_wt(rString, &snap.value(), nullptr);
+            storage->load_wt(rString, snap.get(), nullptr);
 
-            if (!snap->everBuilt || snap->n_tables == 0 || snap->size == 0 ||
-                snap->TableF32WeakPointers[0][0] == nullptr)
+            if (!snap->everBuilt || snap->n_tables == 0 || snap->size == 0)
             {
                 snap.reset();
             }

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -3905,6 +3905,7 @@ void WavetableScriptEditor::forceRefresh()
     setApplyEnabled(false);
     setCurrentFrame(1);
 
+    lastFrames = -1;
     rerenderFromUIState();
 }
 
@@ -3981,7 +3982,9 @@ void WavetableScriptEditor::rerenderFromUIState()
 
     auto respt = 32;
     for (int i = 1; i < resi; ++i)
+    {
         respt *= 2;
+    }
 
     setupEvaluator();
 
@@ -4007,8 +4010,9 @@ void WavetableScriptEditor::setupEvaluator()
     auto resi = controlArea->resolutionN->getIntValue();
     auto respt = 32;
     for (int i = 1; i < resi; ++i)
+    {
         respt *= 2;
-
+    }
     evaluator->setStorage(storage);
     evaluator->setScript(mainDocument->getAllContent().toStdString());
     evaluator->setResolution(respt);
@@ -4077,8 +4081,60 @@ void WavetableScriptEditor::createMenu(juce::PopupMenu &menu)
     {
         menu.addItem(Surge::GUI::toOSCase("Save as .wtscript..."),
                      [this]() { this->editor->saveWavetableScript(); });
-        menu.addSeparator();
+    }
+    menu.addSeparator();
 
+    // Import snapshot submenu
+    juce::PopupMenu importMenu;
+    std::string sceneName = (scene == 0) ? "Scene A" : "Scene B";
+
+    for (int slot = 0; slot < n_oscs; ++slot)
+    {
+        const auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[slot];
+
+        std::string snapLabel = "Snapshot " + std::to_string(slot + 1);
+        if (snap.enabled)
+            snapLabel += " (" + std::to_string(snap.n_tables) +
+                         (snap.n_tables == 1 ? " frame" : " frames") + ", " +
+                         std::to_string(snap.size) + " samples)";
+
+        auto comp = std::make_unique<Surge::Widgets::WavetableSnapshotMenuComponent>(
+            snapLabel, sceneName,
+            [this, slot](Surge::Widgets::WavetableSnapshotMenuComponent::Action action) {
+                if (action == Surge::Widgets::WavetableSnapshotMenuComponent::Action::LoadFromFile)
+                {
+                    loadWavetableForSnapshot(slot);
+                    return;
+                }
+                if (action == Surge::Widgets::WavetableSnapshotMenuComponent::Action::Clear)
+                {
+                    storage->getPatch().dawExtraState.editor.wtSnapshot[slot] =
+                        DAWExtraStateStorage::EditorState::WavetableSnapshot{};
+                }
+                else
+                {
+                    const int oscIndex = static_cast<int>(action);
+                    storage->getPatch().captureWavetableSnapshot(scene, slot, oscIndex);
+                }
+                lastFrames = -1;
+                rerenderFromUIState();
+                rendererComponent->repaint();
+            });
+        comp->setSkin(skin, associatedBitmapStore);
+
+        comp->clearButton->setVisible(snap.enabled);
+
+        importMenu.addCustomItem(-1, std::move(comp), nullptr, snapLabel);
+        if (slot < n_oscs - 1)
+        {
+            importMenu.addSeparator();
+        }
+    }
+    menu.addSubMenu(Surge::GUI::toOSCase("Import Wavetable Data"), importMenu);
+    menu.addSeparator();
+
+    if (!osc->wavetable_script.empty())
+    {
         menu.addItem(Surge::GUI::toOSCase("Export as .wav..."), [this]() {
             this->editor->exportWavetableAs(SurgeGUIEditor::WTExportFormat::WAV);
         });
@@ -4093,8 +4149,8 @@ void WavetableScriptEditor::createMenu(juce::PopupMenu &menu)
         menu.addItem("Export for VCV Rack...", [this]() {
             this->editor->exportWavetableAs(SurgeGUIEditor::WTExportFormat::VCVRACK);
         });
+        menu.addSeparator();
     }
-    menu.addSeparator();
 
     auto msurl = editor->helpURLForSpecial("wts-editor");
     auto hurl = editor->fullyResolvedHelpURL(msurl);
@@ -4203,6 +4259,33 @@ bool WavetableScriptEditor::populateMenuForCategory(juce::PopupMenu &contextMenu
         subMenu = &contextMenu;
     }
 
+    for (auto child : cat.children)
+    {
+        if (child.numberOfPatchesInCategoryAndChildren > 0)
+        {
+            // this isn't the best approach but it works
+            int cidx = 0;
+
+            for (auto &cc : storage->wt_category)
+            {
+                if (cc.name == child.name)
+                {
+                    break;
+                }
+
+                cidx++;
+            }
+
+            bool childHasWTS = populateMenuForCategory(*subMenu, cidx, selectedItem, false);
+
+            if (childHasWTS)
+            {
+                hasAnyWTS = true;
+                selected = selected || childHasWTS;
+            }
+        }
+    }
+
     for (auto p : storage->wtOrdering)
     {
         if (storage->wt_list[p].category == categoryId)
@@ -4244,33 +4327,6 @@ bool WavetableScriptEditor::populateMenuForCategory(juce::PopupMenu &contextMenu
                 {
                     Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(*subMenu, "");
                 }
-            }
-        }
-    }
-
-    for (auto child : cat.children)
-    {
-        if (child.numberOfPatchesInCategoryAndChildren > 0)
-        {
-            // this isn't the best approach but it works
-            int cidx = 0;
-
-            for (auto &cc : storage->wt_category)
-            {
-                if (cc.name == child.name)
-                {
-                    break;
-                }
-
-                cidx++;
-            }
-
-            bool childHasWTS = populateMenuForCategory(*subMenu, cidx, selectedItem, false);
-
-            if (childHasWTS)
-            {
-                hasAnyWTS = true;
-                selected = selected || childHasWTS;
             }
         }
     }
@@ -4333,6 +4389,69 @@ void WavetableScriptEditor::loadWavetableScript(int id)
         ssp->paramChangeToListeners(nullptr, true, ssp->SCT_WAVETABLE, (float)scene, (float)osc_id,
                                     (float)id, new_name);
     }
+}
+
+// Modified from OscillatorWaveformDisplay::loadWavetableFromFile
+void WavetableScriptEditor::loadWavetableForSnapshot(int slot)
+{
+    auto wtPath = storage->userWavetablesPath;
+    wtPath = Surge::Storage::getUserDefaultPath(storage, Surge::Storage::LastWavetablePath, wtPath);
+
+    if (!editor)
+    {
+        return;
+    }
+
+    juce::String fileTypes = "*.wav;*.wt";
+    editor->fileChooser = std::make_unique<juce::FileChooser>(
+        "Select Wavetable to Load", juce::File(path_to_string(wtPath)), fileTypes);
+    editor->fileChooser->launchAsync(
+        juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
+        [this, wtPath, slot](const juce::FileChooser &c) {
+            auto ress = c.getResults();
+
+            if (ress.size() != 1)
+            {
+                return;
+            }
+
+            auto res = c.getResult();
+            auto rString = res.getFullPathName().toStdString();
+
+            Wavetable tempWt;
+            storage->load_wt(rString, &tempWt, nullptr);
+
+            auto &snap = storage->getPatch().dawExtraState.editor.wtSnapshot[slot];
+            snap = DAWExtraStateStorage::EditorState::WavetableSnapshot{};
+
+            if (tempWt.everBuilt && tempWt.n_tables > 0 && tempWt.size > 0 &&
+                tempWt.TableF32WeakPointers[0][0] != nullptr)
+            {
+                snap.n_tables = tempWt.n_tables;
+                snap.size = tempWt.size;
+                snap.frames.resize(tempWt.n_tables);
+
+                for (int t = 0; t < tempWt.n_tables; ++t)
+                {
+                    snap.frames[t].assign(tempWt.TableF32WeakPointers[0][t],
+                                          tempWt.TableF32WeakPointers[0][t] + tempWt.size);
+                }
+
+                snap.enabled = true;
+            }
+
+            lastFrames = -1;
+            rerenderFromUIState();
+            rendererComponent->repaint();
+
+            auto dir = string_to_path(res.getParentDirectory().getFullPathName().toStdString());
+
+            if (dir != wtPath)
+            {
+                Surge::Storage::updateUserDefaultPath(storage, Surge::Storage::LastWavetablePath,
+                                                      dir);
+            }
+        });
 }
 
 std::optional<std::pair<std::string, std::string>>

--- a/src/surge-xt/gui/overlays/LuaEditors.h
+++ b/src/surge-xt/gui/overlays/LuaEditors.h
@@ -386,6 +386,7 @@ struct WavetableScriptEditor : public CodeEditorContainerWithApply, public Refre
                                  bool intoTop = false);
     bool categoryHasWtscript(int categoryId) const;
     void loadWavetableScript(int id);
+    void loadWavetableForSnapshot(int slot);
 
     int lastRes{-1}, lastFrames{-1}, lastFrame{-1}, lastRm{-1};
 

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -219,6 +219,16 @@ PatchStoreDialog::PatchStoreDialog()
     storeTuningButton->setTitle(stbTitle);
     storeTuningButton->setDescription(stbTitle);
     addAndMakeVisible(*storeTuningButton);
+
+    auto ssbTitle = "Store Snapshots in Patch";
+
+    storeSnapshotsLabel = makeL(Surge::GUI::toOSCase(ssbTitle));
+
+    storeSnapshotsButton = std::make_unique<juce::ToggleButton>();
+    storeSnapshotsButton->setButtonText("");
+    storeSnapshotsButton->setTitle(ssbTitle);
+    storeSnapshotsButton->setDescription(ssbTitle);
+    addAndMakeVisible(*storeSnapshotsButton);
 }
 
 PatchStoreDialog::~PatchStoreDialog() = default;
@@ -234,6 +244,28 @@ void PatchStoreDialog::setStorage(SurgeStorage *s)
 void PatchStoreDialog::setStoreTuningInPatch(const bool value)
 {
     storeTuningButton->setToggleState(value, juce::dontSendNotification);
+}
+
+void PatchStoreDialog::setStoreSnapshotsInPatch(bool value)
+{
+    storeSnapshotsButton->setToggleState(value, juce::dontSendNotification);
+}
+
+void PatchStoreDialog::setHasSnapshots(bool value)
+{
+    if (value && !hasSnapshots)
+    {
+        auto pos = getEnclosingParentPosition();
+        pos = pos.withHeight(pos.getHeight() + 25);
+        setEnclosingParentPosition(pos);
+    }
+    if (!value && hasSnapshots)
+    {
+        auto pos = getEnclosingParentPosition();
+        pos = pos.withHeight(pos.getHeight() - 25);
+        setEnclosingParentPosition(pos);
+    }
+    hasSnapshots = value;
 }
 
 void PatchStoreDialog::paint(juce::Graphics &g)
@@ -309,11 +341,17 @@ void PatchStoreDialog::onSkinChanged()
     resetLabel(licenseEdL);
     resetLabel(commentEdL);
     resetLabel(storeTuningLabel);
+    resetLabel(storeSnapshotsLabel);
 
     storeTuningButton->setColour(juce::ToggleButton::tickDisabledColourId,
                                  skin->getColor(Colors::Dialog::Checkbox::Border));
     storeTuningButton->setColour(juce::ToggleButton::tickColourId,
                                  skin->getColor(Colors::Dialog::Checkbox::Tick));
+
+    storeSnapshotsButton->setColour(juce::ToggleButton::tickDisabledColourId,
+                                    skin->getColor(Colors::Dialog::Checkbox::Border));
+    storeSnapshotsButton->setColour(juce::ToggleButton::tickColourId,
+                                    skin->getColor(Colors::Dialog::Checkbox::Tick));
 
     catEd->setColour(Surge::Widgets::TypeAhead::ColourIds::emptyBackgroundId,
                      skin->getColor(Colors::Dialog::Entry::Background));
@@ -336,7 +374,9 @@ void PatchStoreDialog::setIsRename(bool b) { isRename = b; }
 void PatchStoreDialog::resized()
 {
     auto h = 25;
-    auto commH = getHeight() - (6 + showTagsField) * h + 8;
+    bool showTuning = editor && !editor->synth->storage.isStandardTuning;
+    int optionRows = hasSnapshots ? 1 : 0;
+    auto commH = getHeight() - (6 + showTagsField + optionRows) * h + 8;
     auto xSplit = 70;
     auto buttonHeight = 17;
     auto buttonWidth = 50;
@@ -410,22 +450,40 @@ void PatchStoreDialog::resized()
 
     cl = cl.translated(0, h);
     commentEdL->setBounds(cl);
-    cl = cl.translated(0, commH)
-             .withY(okButton->getY() - 1)
-             .withWidth(h + buttonWidth * 2.5)
-             .withHeight(okButton->getHeight() + 2);
+    auto optionRow = buttonRow.withX(0)
+                         .withWidth(h + buttonWidth * 2.5)
+                         .withHeight(okButton->getHeight() + 2);
 
-    if (!editor || editor->synth->storage.isStandardTuning)
+    if (!showTuning)
     {
         storeTuningButton->setVisible(false);
         storeTuningLabel->setVisible(false);
     }
     else
     {
-        auto lb = cl.withX(cl.withWidth(h).getRight() - margin).withWidth(buttonWidth * 2.5);
+        auto lb = optionRow.withX(optionRow.withWidth(h).getRight() - margin)
+                      .withWidth(buttonWidth * 2.5);
 
-        storeTuningButton->setBounds(cl);
+        storeTuningButton->setBounds(optionRow);
         storeTuningLabel->setBounds(lb);
+    }
+    optionRow = optionRow.translated(0, h);
+
+    if (!hasSnapshots)
+    {
+        storeSnapshotsButton->setVisible(false);
+        storeSnapshotsLabel->setVisible(false);
+    }
+    else
+    {
+        storeSnapshotsButton->setVisible(true);
+        storeSnapshotsLabel->setVisible(true);
+
+        auto lb = optionRow.withX(optionRow.withWidth(h).getRight() - margin)
+                      .withWidth(buttonWidth * 2.5);
+
+        storeSnapshotsButton->setBounds(optionRow);
+        storeSnapshotsLabel->setBounds(lb);
     }
 }
 
@@ -491,6 +549,9 @@ void PatchStoreDialog::buttonClicked(juce::Button *button)
                     synth->storage.currentMapping.name;
             }
         }
+
+        synth->storage.getPatch().snapshotsStoredInPatch =
+            storeSnapshotsButton->isVisible() && storeSnapshotsButton->getToggleState();
 
         // Ignore whatever comes from the DAW
         synth->storage.getPatch().dawExtraState.isPopulated = false;

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -450,9 +450,8 @@ void PatchStoreDialog::resized()
 
     cl = cl.translated(0, h);
     commentEdL->setBounds(cl);
-    auto optionRow = buttonRow.withX(0)
-                         .withWidth(h + buttonWidth * 2.5)
-                         .withHeight(okButton->getHeight() + 2);
+    auto optionRow =
+        buttonRow.withX(0).withWidth(h + buttonWidth * 2.5).withHeight(okButton->getHeight() + 2);
 
     if (!showTuning)
     {

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -220,7 +220,7 @@ PatchStoreDialog::PatchStoreDialog()
     storeTuningButton->setDescription(stbTitle);
     addAndMakeVisible(*storeTuningButton);
 
-    auto ssbTitle = "Store Snapshots in Patch";
+    auto ssbTitle = "Store WTS Snapshots in Patch";
 
     storeSnapshotsLabel = makeL(Surge::GUI::toOSCase(ssbTitle));
 
@@ -479,7 +479,7 @@ void PatchStoreDialog::resized()
         storeSnapshotsLabel->setVisible(true);
 
         auto lb = optionRow.withX(optionRow.withWidth(h).getRight() - margin)
-                      .withWidth(buttonWidth * 2.5);
+                      .withWidth(buttonWidth * 3.5);
 
         storeSnapshotsButton->setBounds(optionRow);
         storeSnapshotsLabel->setBounds(lb);

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -210,7 +210,7 @@ PatchStoreDialog::PatchStoreDialog()
     okOverButton->addListener(this);
     addAndMakeVisible(*okOverButton);
 
-    auto stbTitle = "Store Tuning in Patch";
+    auto stbTitle = "Save Tuning";
 
     storeTuningLabel = makeL(Surge::GUI::toOSCase(stbTitle));
 
@@ -220,7 +220,7 @@ PatchStoreDialog::PatchStoreDialog()
     storeTuningButton->setDescription(stbTitle);
     addAndMakeVisible(*storeTuningButton);
 
-    auto ssbTitle = "Store WTS Snapshots in Patch";
+    auto ssbTitle = "Save Wavetable Script Snapshots";
 
     storeSnapshotsLabel = makeL(Surge::GUI::toOSCase(ssbTitle));
 
@@ -243,29 +243,13 @@ void PatchStoreDialog::setStorage(SurgeStorage *s)
 
 void PatchStoreDialog::setStoreTuningInPatch(const bool value)
 {
-    storeTuningButton->setToggleState(value, juce::dontSendNotification);
+    bool showTuning = editor && !editor->synth->storage.isStandardTuning;
+    storeTuningButton->setToggleState(showTuning && value, juce::dontSendNotification);
 }
 
-void PatchStoreDialog::setStoreSnapshotsInPatch(bool value)
+void PatchStoreDialog::setStoreSnapshotsInPatch(const bool value)
 {
-    storeSnapshotsButton->setToggleState(value, juce::dontSendNotification);
-}
-
-void PatchStoreDialog::setHasSnapshots(bool value)
-{
-    if (value && !hasSnapshots)
-    {
-        auto pos = getEnclosingParentPosition();
-        pos = pos.withHeight(pos.getHeight() + 25);
-        setEnclosingParentPosition(pos);
-    }
-    if (!value && hasSnapshots)
-    {
-        auto pos = getEnclosingParentPosition();
-        pos = pos.withHeight(pos.getHeight() - 25);
-        setEnclosingParentPosition(pos);
-    }
-    hasSnapshots = value;
+    storeSnapshotsButton->setToggleState(hasSnapshots && value, juce::dontSendNotification);
 }
 
 void PatchStoreDialog::paint(juce::Graphics &g)
@@ -375,8 +359,9 @@ void PatchStoreDialog::resized()
 {
     auto h = 25;
     bool showTuning = editor && !editor->synth->storage.isStandardTuning;
-    int optionRows = hasSnapshots ? 1 : 0;
-    auto commH = getHeight() - (6 + showTagsField + optionRows) * h + 8;
+    bool showCheckboxRow = hasSnapshots || showTuning;
+    int extraRowH = showCheckboxRow ? 22 : 0;
+    auto commH = getHeight() - (6 + showTagsField) * h - extraRowH + 8;
     auto xSplit = 70;
     auto buttonHeight = 17;
     auto buttonWidth = 50;
@@ -419,7 +404,8 @@ void PatchStoreDialog::resized()
     commentEd->setBounds(q);
     ce = ce.translated(0, commH);
 
-    auto buttonRow = getLocalBounds().withHeight(buttonHeight).withY(ce.getY() + (margin2 * 3));
+    auto buttonRow =
+        getLocalBounds().withHeight(buttonHeight).withY(ce.getY() + (margin2 * 3) + extraRowH);
 
     auto be =
         buttonRow.withTrimmedLeft(dialogCenter - buttonWidth - margin2).withWidth(buttonWidth);
@@ -450,39 +436,48 @@ void PatchStoreDialog::resized()
 
     cl = cl.translated(0, h);
     commentEdL->setBounds(cl);
-    auto optionRow =
-        buttonRow.withX(0).withWidth(h + buttonWidth * 2.5).withHeight(okButton->getHeight() + 2);
 
-    if (!showTuning)
+    if (showCheckboxRow)
+    {
+        int checkboxRowH = 32;
+        int checkboxRowY = ce.getY() - (margin2 * 2);
+        int halfW = getLocalBounds().getWidth() / 2;
+        int boxH = 15;
+        int boxW = 17;
+        int boxY = checkboxRowY + (checkboxRowH - boxH) / 2;
+
+        auto tuningBox = juce::Rectangle<int>(margin, boxY, boxW, boxH);
+        auto tuningLabel = juce::Rectangle<int>(margin + boxW, checkboxRowY,
+                                                halfW - (margin + boxW + margin), checkboxRowH);
+
+        auto snapBox = juce::Rectangle<int>(halfW + margin, boxY, boxW, boxH);
+        auto snapLabel = juce::Rectangle<int>(halfW + margin + boxW, checkboxRowY,
+                                              halfW - (margin + boxW + margin), checkboxRowH);
+
+        storeTuningLabel->setVisible(true);
+        storeTuningLabel->setBounds(tuningLabel);
+        storeTuningLabel->setEnabled(showTuning);
+        storeTuningLabel->setAlpha(showTuning ? 1.0f : 0.5f);
+        storeTuningButton->setVisible(true);
+        storeTuningButton->setEnabled(showTuning);
+        storeTuningButton->setAlpha(showTuning ? 1.0f : 0.5f);
+        storeTuningButton->setBounds(tuningBox);
+
+        storeSnapshotsLabel->setVisible(true);
+        storeSnapshotsLabel->setBounds(snapLabel);
+        storeSnapshotsLabel->setEnabled(hasSnapshots);
+        storeSnapshotsLabel->setAlpha(hasSnapshots ? 1.0f : 0.5f);
+        storeSnapshotsButton->setVisible(true);
+        storeSnapshotsButton->setEnabled(hasSnapshots);
+        storeSnapshotsButton->setAlpha(hasSnapshots ? 1.0f : 0.5f);
+        storeSnapshotsButton->setBounds(snapBox);
+    }
+    else
     {
         storeTuningButton->setVisible(false);
         storeTuningLabel->setVisible(false);
-    }
-    else
-    {
-        auto lb = optionRow.withX(optionRow.withWidth(h).getRight() - margin)
-                      .withWidth(buttonWidth * 2.5);
-
-        storeTuningButton->setBounds(optionRow);
-        storeTuningLabel->setBounds(lb);
-    }
-    optionRow = optionRow.translated(0, h);
-
-    if (!hasSnapshots)
-    {
         storeSnapshotsButton->setVisible(false);
         storeSnapshotsLabel->setVisible(false);
-    }
-    else
-    {
-        storeSnapshotsButton->setVisible(true);
-        storeSnapshotsLabel->setVisible(true);
-
-        auto lb = optionRow.withX(optionRow.withWidth(h).getRight() - margin)
-                      .withWidth(buttonWidth * 3.5);
-
-        storeSnapshotsButton->setBounds(optionRow);
-        storeSnapshotsLabel->setBounds(lb);
     }
 }
 
@@ -523,7 +518,9 @@ void PatchStoreDialog::buttonClicked(juce::Button *button)
 
         synth->storage.getPatch().tags = tags;
         synth->storage.getPatch().patchTuning.tuningStoredInPatch =
-            storeTuningButton->isVisible() && storeTuningButton->getToggleState();
+            storeTuningButton->isEnabled() && storeTuningButton->getToggleState();
+        synth->storage.getPatch().snapshotsStoredInPatch =
+            storeSnapshotsButton->isEnabled() && storeSnapshotsButton->getToggleState();
 
         if (synth->storage.getPatch().patchTuning.tuningStoredInPatch)
         {
@@ -548,9 +545,6 @@ void PatchStoreDialog::buttonClicked(juce::Button *button)
                     synth->storage.currentMapping.name;
             }
         }
-
-        synth->storage.getPatch().snapshotsStoredInPatch =
-            storeSnapshotsButton->isVisible() && storeSnapshotsButton->getToggleState();
 
         // Ignore whatever comes from the DAW
         synth->storage.getPatch().dawExtraState.isPopulated = false;

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.h
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.h
@@ -96,6 +96,11 @@ struct PatchStoreDialog : public OverlayComponent,
     std::unique_ptr<Widgets::SurgeTextButton> okButton, okOverButton, cancelButton;
     std::unique_ptr<juce::Label> storeTuningLabel;
     std::unique_ptr<juce::ToggleButton> storeTuningButton;
+    std::unique_ptr<juce::Label> storeSnapshotsLabel;
+    std::unique_ptr<juce::ToggleButton> storeSnapshotsButton;
+    bool hasSnapshots{false};
+    void setHasSnapshots(bool value);
+    void setStoreSnapshotsInPatch(bool value);
 
     bool isRename{false};
     void setIsRename(bool b);

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.h
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.h
@@ -87,6 +87,9 @@ struct PatchStoreDialog : public OverlayComponent,
     void setComment(const std::string &c) { commentEd->setText(c, juce::dontSendNotification); }
     void setTags(const std::vector<SurgePatch::Tag> &t);
     void setStoreTuningInPatch(const bool value);
+    void setStoreSnapshotsInPatch(const bool value);
+    bool hasSnapshots{false};
+    void setHasSnapshots(bool s) { hasSnapshots = s; };
 
     void onSkinChanged() override;
     void textEditorFocusLost(juce::TextEditor &) override;
@@ -98,9 +101,6 @@ struct PatchStoreDialog : public OverlayComponent,
     std::unique_ptr<juce::ToggleButton> storeTuningButton;
     std::unique_ptr<juce::Label> storeSnapshotsLabel;
     std::unique_ptr<juce::ToggleButton> storeSnapshotsButton;
-    bool hasSnapshots{false};
-    void setHasSnapshots(bool value);
-    void setStoreSnapshotsInPatch(bool value);
 
     bool isRename{false};
     void setIsRename(bool b);

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -531,5 +531,189 @@ std::unique_ptr<juce::PopupMenu> ModMenuForAllComponent::createAccessibleSubMenu
     return std::move(res);
 }
 
+WavetableSnapshotMenuComponent::WavetableSnapshotMenuComponent(const std::string &label,
+                                                               const std::string &sName,
+                                                               std::function<void(Action)> cb)
+    : juce::PopupMenu::CustomComponent(false), snapLabel(label), sceneName(sName),
+      callback(std::move(cb))
+{
+    oscHitBoxes.fill(juce::Rectangle<int>());
+
+    auto clear = std::make_unique<TinyLittleIconButton>(1, [this]() {
+        callback(Action::Clear);
+        triggerMenuItem();
+    });
+    clear->accLabel = "Clear " + label;
+    addAndMakeVisible(*clear);
+    clearButton = std::move(clear);
+
+    setAccessible(true);
+    setTitle(label);
+}
+
+void WavetableSnapshotMenuComponent::getIdealSize(int &idealWidth, int &idealHeight)
+{
+    idealHeight = 36;
+    idealWidth = 366;
+}
+
+void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
+{
+    auto r = getLocalBounds().reduced(1);
+
+    auto ft = getLookAndFeel().getPopupMenuFont().withHeight(
+        getLookAndFeel().getPopupMenuFont().getHeight() - 1);
+
+    // Snapshot top label bold, detail text normal
+    auto sjlf = dynamic_cast<SurgeJUCELookAndFeel *>(&getLookAndFeel());
+    auto boldFt = sjlf ? sjlf->getPopupMenuBoldFont() : ft.boldened();
+    auto topRow = r.withHeight(r.getHeight() / 2).withTrimmedLeft(6);
+
+    g.setColour(getLookAndFeel().findColour(juce::PopupMenu::ColourIds::textColourId));
+
+    // Find where the detail portion starts
+    auto parenPos = snapLabel.find(" (");
+    std::string boldPart =
+        parenPos != std::string::npos ? snapLabel.substr(0, parenPos) : snapLabel;
+    std::string detailPart = parenPos != std::string::npos ? snapLabel.substr(parenPos) : "";
+
+    g.setFont(boldFt);
+    int boldW = boldFt.getStringWidth(boldPart);
+    g.drawText(boldPart, topRow.withWidth(boldW), juce::Justification::centredLeft);
+
+    if (!detailPart.empty())
+    {
+        g.setFont(ft);
+        g.drawText(detailPart, topRow.withTrimmedLeft(boldW), juce::Justification::centredLeft);
+    }
+
+    auto bottomRow = r.withTrimmedTop(r.getHeight() / 2).withHeight(r.getHeight() / 2);
+    g.setFont(ft);
+
+    // Draw "Import from Scene A/B" prefix
+    std::string prefix = "Import from " + sceneName + ": ";
+    int prefixW = ft.getStringWidth(prefix);
+    g.drawText(prefix, bottomRow.withTrimmedLeft(6), juce::Justification::centredLeft);
+
+    // Draw clickable items
+    int x = 6 + prefixW;
+    auto baseColour = getLookAndFeel().findColour(juce::PopupMenu::textColourId);
+    auto hoverColour = getLookAndFeel().findColour(juce::PopupMenu::highlightedBackgroundColourId);
+
+    for (int i = 0; i < 3; ++i)
+    {
+        std::string oscLabel = "Osc " + std::to_string(i + 1);
+        int w = boldFt.getStringWidth(oscLabel);
+        auto box = bottomRow.withLeft(x).withWidth(w);
+        oscHitBoxes[i] = box;
+        x += w + 6;
+
+        if (hoveredOsc == i)
+        {
+            g.setColour(hoverColour);
+            g.fillRoundedRectangle(box.toFloat().reduced(1), 2.f);
+            g.setColour(baseColour);
+        }
+        else
+        {
+            g.setColour(baseColour);
+        }
+        g.setFont(boldFt);
+        g.drawText(oscLabel, box, juce::Justification::centredLeft);
+    }
+
+    {
+        std::string fileLabel = ".wav/.wt";
+        int w = boldFt.getStringWidth(fileLabel) + 4;
+        auto box = bottomRow.withLeft(x).withWidth(w);
+        loadFileHitBox = box;
+
+        if (hoveredFile)
+        {
+            g.setColour(hoverColour);
+            g.fillRoundedRectangle(box.toFloat().reduced(1), 2.f);
+            g.setColour(baseColour);
+        }
+        else
+        {
+            g.setColour(baseColour);
+        }
+        g.setFont(boldFt);
+        g.drawText(fileLabel, box, juce::Justification::centredLeft);
+    }
+}
+
+void WavetableSnapshotMenuComponent::resized()
+{
+    auto r = getLocalBounds().reduced(1);
+    int halfH = r.getHeight() / 2;
+    auto bottomRow = r.withTrimmedTop(halfH);
+    int iconW = 15;
+    int y = bottomRow.getY() + (bottomRow.getHeight() - iconW) / 2;
+    clearButton->setBounds(r.getRight() - iconW - 4, y, iconW, iconW);
+}
+
+void WavetableSnapshotMenuComponent::mouseDown(const juce::MouseEvent &e)
+{
+    for (int i = 0; i < 3; ++i)
+    {
+        if (oscHitBoxes[i].contains(e.getPosition()))
+        {
+            callback(static_cast<Action>(i));
+            triggerMenuItem();
+            return;
+        }
+    }
+
+    if (loadFileHitBox.contains(e.getPosition()))
+    {
+        callback(Action::LoadFromFile);
+        triggerMenuItem();
+    }
+}
+
+void WavetableSnapshotMenuComponent::mouseMove(const juce::MouseEvent &e)
+{
+    int prev = hoveredOsc;
+    bool prevFile = hoveredFile;
+    hoveredOsc = -1;
+    hoveredFile = false;
+
+    for (int i = 0; i < 3; ++i)
+    {
+        if (oscHitBoxes[i].contains(e.getPosition()))
+        {
+            hoveredOsc = i;
+            break;
+        }
+    }
+
+    if (hoveredOsc == -1)
+    {
+        hoveredFile = loadFileHitBox.contains(e.getPosition());
+    }
+
+    if (hoveredOsc != prev || hoveredFile != prevFile)
+    {
+        repaint();
+    }
+}
+
+void WavetableSnapshotMenuComponent::mouseExit(const juce::MouseEvent &e)
+{
+    hoveredOsc = -1;
+    hoveredFile = false;
+    repaint();
+}
+
+void WavetableSnapshotMenuComponent::onSkinChanged()
+{
+    if (associatedBitmapStore)
+    {
+        clearButton->icons = associatedBitmapStore->getImage(IDB_MODMENU_ICONS);
+    }
+    repaint();
+}
+
 } // namespace Widgets
 } // namespace Surge

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -600,7 +600,7 @@ void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
     auto baseColour = getLookAndFeel().findColour(juce::PopupMenu::textColourId);
     auto hoverColour = getLookAndFeel().findColour(juce::PopupMenu::highlightedBackgroundColourId);
 
-    for (int i = 0; i < 3; ++i)
+    for (int i = 0; i < n_oscs; ++i)
     {
         std::string oscLabel = "Osc " + std::to_string(i + 1);
         int w = SST_STRING_WIDTH_INT(boldFt, oscLabel);
@@ -655,7 +655,7 @@ void WavetableSnapshotMenuComponent::resized()
 
 void WavetableSnapshotMenuComponent::mouseDown(const juce::MouseEvent &e)
 {
-    for (int i = 0; i < 3; ++i)
+    for (int i = 0; i < n_oscs; ++i)
     {
         if (oscHitBoxes[i].contains(e.getPosition()))
         {
@@ -679,7 +679,7 @@ void WavetableSnapshotMenuComponent::mouseMove(const juce::MouseEvent &e)
     hoveredOsc = -1;
     hoveredFile = false;
 
-    for (int i = 0; i < 3; ++i)
+    for (int i = 0; i < n_oscs; ++i)
     {
         if (oscHitBoxes[i].contains(e.getPosition()))
         {

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -578,7 +578,7 @@ void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
     std::string detailPart = parenPos != std::string::npos ? snapLabel.substr(parenPos) : "";
 
     g.setFont(boldFt);
-    int boldW = boldFt.getStringWidth(boldPart);
+    int boldW = juce::GlyphArrangement::getStringWidthInt(boldFt, boldPart);
     g.drawText(boldPart, topRow.withWidth(boldW), juce::Justification::centredLeft);
 
     if (!detailPart.empty())
@@ -592,7 +592,7 @@ void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
 
     // Draw "Import from Scene A/B" prefix
     std::string prefix = "Import from " + sceneName + ": ";
-    int prefixW = ft.getStringWidth(prefix);
+    int prefixW = juce::GlyphArrangement::getStringWidthInt(ft, prefix);
     g.drawText(prefix, bottomRow.withTrimmedLeft(6), juce::Justification::centredLeft);
 
     // Draw clickable items
@@ -603,7 +603,7 @@ void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
     for (int i = 0; i < 3; ++i)
     {
         std::string oscLabel = "Osc " + std::to_string(i + 1);
-        int w = boldFt.getStringWidth(oscLabel);
+        int w = juce::GlyphArrangement::getStringWidthInt(boldFt, oscLabel);
         auto box = bottomRow.withLeft(x).withWidth(w);
         oscHitBoxes[i] = box;
         x += w + 6;
@@ -624,7 +624,7 @@ void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
 
     {
         std::string fileLabel = ".wav/.wt";
-        int w = boldFt.getStringWidth(fileLabel) + 4;
+        int w = juce::GlyphArrangement::getStringWidthInt(boldFt, fileLabel) + 4;
         auto box = bottomRow.withLeft(x).withWidth(w);
         loadFileHitBox = box;
 

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.cpp
@@ -578,7 +578,7 @@ void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
     std::string detailPart = parenPos != std::string::npos ? snapLabel.substr(parenPos) : "";
 
     g.setFont(boldFt);
-    int boldW = juce::GlyphArrangement::getStringWidthInt(boldFt, boldPart);
+    int boldW = SST_STRING_WIDTH_INT(boldFt, boldPart);
     g.drawText(boldPart, topRow.withWidth(boldW), juce::Justification::centredLeft);
 
     if (!detailPart.empty())
@@ -592,7 +592,7 @@ void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
 
     // Draw "Import from Scene A/B" prefix
     std::string prefix = "Import from " + sceneName + ": ";
-    int prefixW = juce::GlyphArrangement::getStringWidthInt(ft, prefix);
+    int prefixW = SST_STRING_WIDTH_INT(ft, prefix);
     g.drawText(prefix, bottomRow.withTrimmedLeft(6), juce::Justification::centredLeft);
 
     // Draw clickable items
@@ -603,7 +603,7 @@ void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
     for (int i = 0; i < 3; ++i)
     {
         std::string oscLabel = "Osc " + std::to_string(i + 1);
-        int w = juce::GlyphArrangement::getStringWidthInt(boldFt, oscLabel);
+        int w = SST_STRING_WIDTH_INT(boldFt, oscLabel);
         auto box = bottomRow.withLeft(x).withWidth(w);
         oscHitBoxes[i] = box;
         x += w + 6;
@@ -624,7 +624,7 @@ void WavetableSnapshotMenuComponent::paint(juce::Graphics &g)
 
     {
         std::string fileLabel = ".wav/.wt";
-        int w = juce::GlyphArrangement::getStringWidthInt(boldFt, fileLabel) + 4;
+        int w = SST_STRING_WIDTH_INT(boldFt, fileLabel) + 4;
         auto box = bottomRow.withLeft(x).withWidth(w);
         loadFileHitBox = box;
 

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -25,6 +25,7 @@
 
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "SkinSupport.h"
+#include "SurgeStorage.h"
 
 namespace Surge
 {
@@ -216,7 +217,7 @@ struct WavetableSnapshotMenuComponent : juce::PopupMenu::CustomComponent,
     std::string sceneName;
 
     std::unique_ptr<TinyLittleIconButton> clearButton;
-    std::array<juce::Rectangle<int>, 3> oscHitBoxes;
+    std::array<juce::Rectangle<int>, n_oscs> oscHitBoxes;
     int hoveredOsc{-1};
     juce::Rectangle<int> loadFileHitBox;
     bool hoveredFile{false};

--- a/src/surge-xt/gui/widgets/MenuCustomComponents.h
+++ b/src/surge-xt/gui/widgets/MenuCustomComponents.h
@@ -186,6 +186,44 @@ struct ModMenuForAllComponent : ModMenuCustomComponent
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModMenuForAllComponent);
 };
 
+struct WavetableSnapshotMenuComponent : juce::PopupMenu::CustomComponent,
+                                        Surge::GUI::SkinConsumingComponent
+{
+    enum class Action
+    {
+        CaptureOsc1 = 0,
+        CaptureOsc2 = 1,
+        CaptureOsc3 = 2,
+        LoadFromFile = -1,
+        Clear = -2
+    };
+
+    std::function<void(Action)> callback;
+
+    WavetableSnapshotMenuComponent(const std::string &label, const std::string &sceneName,
+                                   std::function<void(Action)> cb);
+    ~WavetableSnapshotMenuComponent() noexcept override = default;
+
+    void getIdealSize(int &idealWidth, int &idealHeight) override;
+    void paint(juce::Graphics &g) override;
+    void resized() override;
+    void mouseDown(const juce::MouseEvent &e) override;
+    void mouseMove(const juce::MouseEvent &e) override;
+    void mouseExit(const juce::MouseEvent &e) override;
+    void onSkinChanged() override;
+
+    std::string snapLabel;
+    std::string sceneName;
+
+    std::unique_ptr<TinyLittleIconButton> clearButton;
+    std::array<juce::Rectangle<int>, 3> oscHitBoxes;
+    int hoveredOsc{-1};
+    juce::Rectangle<int> loadFileHitBox;
+    bool hoveredFile{false};
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WavetableSnapshotMenuComponent);
+};
+
 } // namespace Widgets
 } // namespace Surge
 


### PR DESCRIPTION
Draft - do not merge yet.

So this adds the option to import wavetable data from each oscillator to the WTS Lua state table with an opt in so existing tables can be processed, edited, used with the PFFFT wrapper, etc.

If `wt.importwt = true` is true in init() it populates wt.osc1, wt.osc2, etc in the state table passed to generate(). The table layout is wt.osc#[frame index][sample index].

Thoughts welcome!

