### PR TITLE
Revert "Fix a problem with occasional unstable low drive distortions …

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -4021,13 +4021,8 @@ std::string Parameter::get_display(bool external, float ef) const
             txt = fmt::format("{:d} bands", i);
             break;
         case ct_distortion_waveshape:
-        {
-            if (i < 0 || i >= FXWaveShapers.size())
-                txt = "ERROR " + std::to_string(i);
-            else
-                txt = sst::waveshapers::wst_names[(int)FXWaveShapers[i]];
-        }
-        break;
+            txt = sst::waveshapers::wst_names[(int)FXWaveShapers[i]];
+            break;
         case ct_mscodec:
             switch (i)
             {


### PR DESCRIPTION
…(#7876)"

This reverts commit aed97a261c3b7b769503496ca89876fba776b068.

Basically aed97a mis-diagnosed the problem which is with feedback and dc offset and scaling at very low drives, so caused substantial sound changes elsewhere like #8195