### PR TITLE
Surge Editor: Remove unused private variable

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.h
+++ b/src/surge-xt/SurgeSynthEditor.h
@@ -61,6 +61,8 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
     void parentHierarchyChanged() override;
     void resetWindowFromSkin();
 
+    void paramsChangedCallback();
+    void setEffectType(int i);
 
     void handleAsyncUpdate() override;
 


### PR DESCRIPTION
I am new to the Surge XT codebase. I was having trouble with understanding it because I would have to frequently trace where a variable was declared due to the non-obvious abbreviation.

Furthermore, I located a variable which was not being used at all (a unique pointer to a logo). All builds including test builds were functional, so I removed it.

I read that the developer guide encouraged these "campground" commits, so I hope that even though these might be small, perhaps nitpicky to some, that they help the codebase in some form.

If I misunderstand what was meant by this policy, I apologize in advance.
<img width="1569" height="318" alt="image" src="https://github.com/user-attachments/assets/bdf088c3-2941-4d6b-ae04-8f94e7ee16c5" />
