### PR TITLE
Add menu item to oscillator drop list (menu) items to allow an indirectly assigned CC to be removed. #8232

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2016,6 +2016,18 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         });
                     }
                 }
+
+                // the vt_int from OSC need a midi handling. So that assinged
+                // midi controlls can be removed
+                std::unordered_set<int> grpForMidiHandling = {ctrltypes::ct_wt2window,
+                    ctrltypes::ct_sineoscmode, ctrltypes::ct_sinefmlegacy,
+                    ctrltypes::ct_stringosc_excitation_model,
+                    ctrltypes::ct_twist_engine, ctrltypes::ct_alias_wave};
+
+                if ( grpForMidiHandling.count(p->ctrltype) ){
+                    contextMenu.addSeparator();
+                    createMIDILearnMenuEntries(contextMenu, param_cc, p->id, control);
+                }
             }
 
             if (p->valtype == vt_float)


### PR DESCRIPTION
Adds the MIDILearnMenuEntries to all vt_int (selection boxes) which can show up in the oscillator section. 
Tested on all the boxes (I found) with by assigning the CC1 (Modulation wheel) with virtual keyboard. 

Note: Does not add the MIDILearnMenuEntries to all vt_int (selection boxes). This requires more adaptations. 

![Screenshot3](https://github.com/user-attachments/assets/0a7af21b-e6af-420e-b9a5-629aca5c6d37)

