### PR TITLE
Disable errno and SIGFPE for math operations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   # Any Clang or any GCC
   add_compile_options(
     -Wno-multichar
+    -fno-math-errno
+    -fno-trapping-math
 
     # Targeting Windows with GCC/Clang is experimental
     $<$<NOT:$<OR:$<BOOL:${WIN32}>,$<BOOL:${SURGE_SKIP_WERROR}>>>:-Werror>


### PR DESCRIPTION
Do not need these flags for MSVC, they do it already.