### PR TITLE
Add menu item to oscillator drop list  items to allow an indirectly assigned cc to be removed #8232

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2016,18 +2016,9 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         });
                     }
                 }
-
-                // the vt_int from OSC need a midi handling. So that assinged
-                // midi controlls can be removed
-                std::unordered_set<int> grpForMidiHandling = {ctrltypes::ct_wt2window,
-                    ctrltypes::ct_sineoscmode, ctrltypes::ct_sinefmlegacy,
-                    ctrltypes::ct_stringosc_excitation_model,
-                    ctrltypes::ct_twist_engine, ctrltypes::ct_alias_wave};
-
-                if ( grpForMidiHandling.count(p->ctrltype) ){
-                    contextMenu.addSeparator();
-                    createMIDILearnMenuEntries(contextMenu, param_cc, p->id, control);
-                }
+                // adds the menu to all vt_int controlls
+                contextMenu.addSeparator();
+                createMIDILearnMenuEntries(contextMenu, param_cc, p->id, control);
             }
 
             if (p->valtype == vt_float)


### PR DESCRIPTION
As discussed on Discord, adds the midi control to all integer controls elements (vt_int). Assignment works for Oscillators and FX section. The others needs additional handling. 
 
Tested by assigning the CC1 (Modulation wheel) to the virtual keyboard.

<img width="885" height="692" alt="Screenshot 2025-12-28 192248" src="https://github.com/user-attachments/assets/81e2d862-454a-453c-92ab-851a2a544c0a" />
