### PR TITLE
docs: Add VST3 build command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ cmake --build build --config Release --target surge-staged-assets
 This will build all the Surge XT binary assets in the directory `build/surge_xt_products` and is often enough of a formula
 to do a build.
 
+> [!TIP]
+> To only build the VST3, replace the above final command with this:
+```bash
+cmake --build build --config Release --target surge-xt_VST3
+```
+
 ## Developing from your own fork
 
 Our [Git How To](doc/How%20to%20Git.md) explains how we are using Git. If you want to develop from your own fork, please


### PR DESCRIPTION
This PR adds a line in the README on how to build only the VST3 target.

Building everything is a bit of a waste of a time if you only need one target so showing how to build one thing could be useful.

Feel free to make changes.