### PR TITLE
Add FAV= and FAVORITES= search keywords to Patch DB query

### DIFF
--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -1516,6 +1516,11 @@ std::string PatchDB::sqlWhereClauseFor(const std::unique_ptr<PatchDBQueryParser:
         {
             oss << "(category LIKE '%" << protect(t->children[0]->content) << "%' )";
         }
+        else if (t->content == "FAVORITES" || t->content == "FAV")
+        {
+            // Value after = is ignored; any value filters to favorites
+            oss << "(p.path IN (SELECT path FROM Favorites))";
+        }
         else
         {
             oss << "(1 == 1)";

--- a/src/common/PatchDBQueryParser.cpp
+++ b/src/common/PatchDBQueryParser.cpp
@@ -50,9 +50,11 @@ struct binary : pegtl::seq<expression, pegtl::plus<pegtl::space>, bin_op, pegtl:
 
 struct author : TAO_PEGTL_STRING( "AUTHOR" ) {};
 struct category : TAO_PEGTL_STRING( "CATEGORY" ) {};
+struct favorites : TAO_PEGTL_STRING( "FAVORITES" ) {};
 struct auth : TAO_PEGTL_STRING( "AUTH" ) {};
 struct cat : TAO_PEGTL_STRING( "CAT" ) {};
-struct subsearch_keyword : pegtl::sor<author, category, auth, cat> {};
+struct fav : TAO_PEGTL_STRING( "FAV" ) {};
+struct subsearch_keyword : pegtl::sor<author, category, favorites, auth, cat, fav> {};
 
 struct subsearch : pegtl::seq< subsearch_keyword, pegtl::one< '=' >, value >{};
 

--- a/src/surge-testrunner/UnitTestsQUERY.cpp
+++ b/src/surge-testrunner/UnitTestsQUERY.cpp
@@ -137,6 +137,30 @@ TEST_CASE("Simple Query Parse", "[query]")
         REQUIRE(t->children[1]->children[0]->content == "bacon");
     }
 
+    SECTION("Favorite Keywords")
+    {
+        auto t = Surge::PatchStorage::PatchDBQueryParser::parseQuery("FAV=yes");
+        REQUIRE(t->type == Surge::PatchStorage::PatchDBQueryParser::KEYWORD_EQUALS);
+        REQUIRE(t->content == "FAV");
+        REQUIRE(t->children[0]->content == "yes");
+    }
+
+    SECTION("Favorite Long Form Keywords")
+    {
+        auto t = Surge::PatchStorage::PatchDBQueryParser::parseQuery("FAVORITES=yes");
+        REQUIRE(t->type == Surge::PatchStorage::PatchDBQueryParser::KEYWORD_EQUALS);
+        REQUIRE(t->content == "FAVORITES");
+        REQUIRE(t->children[0]->content == "yes");
+    }
+
+    SECTION("Favorite Keyword With Empty Value")
+    {
+        auto t = Surge::PatchStorage::PatchDBQueryParser::parseQuery("FAV=");
+        REQUIRE(t->type == Surge::PatchStorage::PatchDBQueryParser::KEYWORD_EQUALS);
+        REQUIRE(t->content == "FAV");
+        REQUIRE(t->children[0]->content.empty());
+    }
+
     SECTION("Compound Keywords")
     {
         auto t = Surge::PatchStorage::PatchDBQueryParser::parseQuery(
@@ -179,5 +203,34 @@ TEST_CASE("SQL Generation", "[query]")
         auto s = Surge::PatchStorage::PatchDB::sqlWhereClauseFor(t);
         REQUIRE(s ==
                 "( ( p.search_over LIKE '%in''it''%' ) AND ( p.search_over LIKE '%''''sine%' ) )");
+    }
+
+    SECTION("Favorite Keyword")
+    {
+        auto t = Surge::PatchStorage::PatchDBQueryParser::parseQuery("FAV=yes");
+        auto s = Surge::PatchStorage::PatchDB::sqlWhereClauseFor(t);
+        REQUIRE(s == "(p.path IN (SELECT path FROM Favorites))");
+    }
+
+    SECTION("Favorite Long Form Keyword")
+    {
+        auto t = Surge::PatchStorage::PatchDBQueryParser::parseQuery("FAVORITES=yes");
+        auto s = Surge::PatchStorage::PatchDB::sqlWhereClauseFor(t);
+        REQUIRE(s == "(p.path IN (SELECT path FROM Favorites))");
+    }
+
+    SECTION("Favorite With Empty Value")
+    {
+        auto t = Surge::PatchStorage::PatchDBQueryParser::parseQuery("FAV=");
+        auto s = Surge::PatchStorage::PatchDB::sqlWhereClauseFor(t);
+        REQUIRE(s == "(p.path IN (SELECT path FROM Favorites))");
+    }
+
+    SECTION("Favorite Combined With Literal")
+    {
+        auto t = Surge::PatchStorage::PatchDBQueryParser::parseQuery("pad FAV=yes");
+        auto s = Surge::PatchStorage::PatchDB::sqlWhereClauseFor(t);
+        REQUIRE(s ==
+                "( ( p.search_over LIKE '%pad%' ) AND (p.path IN (SELECT path FROM Favorites)) )");
     }
 }


### PR DESCRIPTION
## Summary
- Adds `FAV=` and `FAVORITES=` search keywords to the patch browser query system, allowing users to filter search results to only show favorited patches
- Uses a subquery against the existing `Favorites` table (`p.path IN (SELECT path FROM Favorites)`)
- Follows the existing `AUTHOR=/AUTH=` and `CATEGORY=/CAT=` keyword pattern in both the PEGTL grammar and SQL generation

Closes #7465

## Test plan
- [x] Added 3 parse tests (FAV=yes, FAVORITES=yes, FAV= with empty value)
- [x] Added 4 SQL generation tests (FAV=, FAVORITES=, empty value, combined with literal search)
- [x] All 72 query test assertions pass (`surge-testrunner "[query]"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)