### PR TITLE
Scalable, leak free wavetable menu

### DIFF
--- a/scripts/gen-wt-stress.py
+++ b/scripts/gen-wt-stress.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Generate a large stress-test wavetable directory structure under
+~/Documents/Surge Synth Team/Surge XT/Wavetables/test-scale
+
+Structure: 4 levels deep, 3-4 wide, ~200k wavetable copies in ~1k leaf dirs.
+"""
+
+import os
+import shutil
+import random
+import string
+
+SOURCE_WT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                         "resources", "data", "wavetables", "Basic", "Sine Octaves.wt")
+
+BASE_DIR = os.path.expanduser(
+    "~/Documents/Surge Synth Team/Surge XT/Wavetables/test-scale"
+)
+
+ADJECTIVES = [
+    "bright", "dark", "warm", "cold", "soft", "hard", "deep", "thin",
+    "rich", "pure", "raw", "smooth", "sharp", "round", "flat", "wide",
+    "narrow", "dense", "sparse", "heavy", "light", "fast", "slow", "high",
+    "low", "loud", "quiet", "clean", "dirty", "crisp"
+]
+
+NOUNS = [
+    "wave", "tone", "pulse", "ring", "bell", "pad", "lead", "bass",
+    "drum", "pluck", "bow", "blow", "hit", "sweep", "drone", "chord",
+    "arp", "seq", "mod", "lfo", "env", "osc", "vco", "vcf", "vca",
+    "fx", "rev", "del", "cho", "fla"
+]
+
+random.seed(42)
+
+def unique_name(used, pool_a, pool_b, suffix=""):
+    while True:
+        name = random.choice(pool_a) + "-" + random.choice(pool_b) + suffix
+        if name not in used:
+            used.add(name)
+            return name
+
+def make_dir_tree(base, depth=4, width_range=(3, 4)):
+    """Recursively create directories; return list of leaf dirs."""
+    if depth == 0:
+        return [base]
+    leaves = []
+    used = set()
+    width = random.randint(*width_range)
+    for _ in range(width):
+        name = unique_name(used, ADJECTIVES, NOUNS)
+        child = os.path.join(base, name)
+        os.makedirs(child, exist_ok=True)
+        leaves.extend(make_dir_tree(child, depth - 1, width_range))
+    return leaves
+
+def main():
+    if not os.path.isfile(SOURCE_WT):
+        print(f"ERROR: source wavetable not found: {SOURCE_WT}")
+        return
+
+    print(f"Creating directory tree under: {BASE_DIR}")
+    os.makedirs(BASE_DIR, exist_ok=True)
+
+    leaves = make_dir_tree(BASE_DIR, depth=4, width_range=(3, 4))
+    print(f"Created {len(leaves)} leaf directories")
+
+    # Distribute ~200k copies across leaf dirs
+    target_total = 200_000
+    copies_per_leaf = max(1, target_total // len(leaves))
+
+    print(f"Copying ~{copies_per_leaf} wavetables into each leaf dir "
+          f"(target total: ~{copies_per_leaf * len(leaves):,})")
+
+    total = 0
+    wt_nouns = [
+        "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta",
+        "iota", "kappa", "lambda", "mu", "nu", "xi", "omicron", "pi",
+        "rho", "sigma", "tau", "upsilon", "phi", "chi", "psi", "omega"
+    ]
+
+    for leaf in leaves:
+        used = set()
+        for i in range(copies_per_leaf):
+            # Build a unique filename per leaf
+            fname = f"wt-{i:05d}-" + random.choice(ADJECTIVES) + "-" + random.choice(wt_nouns) + ".wt"
+            dest = os.path.join(leaf, fname)
+            shutil.copy2(SOURCE_WT, dest)
+            total += 1
+
+        if total % 10_000 == 0:
+            print(f"  {total:,} files written...")
+
+    print(f"Done. Total wavetables written: {total:,} across {len(leaves)} directories.")
+
+if __name__ == "__main__":
+    main()

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1275,10 +1275,16 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir, const fs::path &init
 
 void SurgeStorage::refresh_wtlist()
 {
+    using clock_t = std::chrono::high_resolution_clock;
+    using ms_t = std::chrono::duration<double, std::milli>;
+
+    auto t0 = clock_t::now();
+
     wt_category.clear();
     wt_list.clear();
 
     refresh_wtlistAddDir(false, "wavetables");
+    auto t_factory = clock_t::now();
 
     firstThirdPartyWTCategory = wt_category.size();
     if (extraThirdPartyWavetablesPath.empty() ||
@@ -1290,6 +1296,8 @@ void SurgeStorage::refresh_wtlist()
     {
         refresh_wtlistFrom(false, extraThirdPartyWavetablesPath, "wavetables_3rdparty");
     }
+    auto t_3rdparty = clock_t::now();
+
     firstUserWTCategory = wt_category.size();
     refresh_wtlistAddDir(true, "Wavetables");
 
@@ -1297,6 +1305,7 @@ void SurgeStorage::refresh_wtlist()
     {
         refresh_wtlistFrom(true, extraUserWavetablesPath, "");
     }
+    auto t_user = clock_t::now();
 
     wtCategoryOrdering = std::vector<int>(wt_category.size());
     std::iota(wtCategoryOrdering.begin(), wtCategoryOrdering.end(), 0);
@@ -1356,6 +1365,7 @@ void SurgeStorage::refresh_wtlist()
         std::sort(std::next(wtCategoryOrdering.begin(), groups[i]),
                   std::next(wtCategoryOrdering.begin(), groups[i + 1]), categoryCompare);
     }
+    auto t_catsort = clock_t::now();
 
     for (int i = 0; i < wt_category.size(); i++)
         wt_category[wtCategoryOrdering[i]].order = i;
@@ -1380,9 +1390,25 @@ void SurgeStorage::refresh_wtlist()
         std::sort(std::next(wtOrdering.begin(), start), std::next(wtOrdering.begin(), end),
                   wtCompare);
     }
+    auto t_wtsort = clock_t::now();
 
     for (int i = 0; i < wt_list.size(); i++)
         wt_list[wtOrdering[i]].order = i;
+
+    auto t_end = clock_t::now();
+
+    /*
+    std::cout << "refresh_wtlist timing:"
+              << "\n  factory scan:    " << ms_t(t_factory - t0).count() << " ms"
+              << "\n  3rd-party scan:  " << ms_t(t_3rdparty - t_factory).count() << " ms"
+              << "\n  user scan:       " << ms_t(t_user - t_3rdparty).count() << " ms"
+              << "\n  category sort:   " << ms_t(t_catsort - t_user).count() << " ms"
+              << "\n  wt sort:         " << ms_t(t_wtsort - t_catsort).count() << " ms"
+              << "\n  order assign:    " << ms_t(t_end - t_wtsort).count() << " ms"
+              << "\n  TOTAL:           " << ms_t(t_end - t0).count() << " ms"
+              << "\n  categories: " << wt_category.size() << "  wavetables: " << wt_list.size()
+              << "\n" << std::endl;
+              */
 }
 
 void SurgeStorage::refresh_wtlistAddDir(bool userDir, const std::string &subdir)

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -558,6 +558,9 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
     bool addUserLabel = false;
     int idx = 0;
 
+    wtFileIcon->replaceColour(juce::Colours::white, skin->getColor(Colors::PopupMenu::Text));
+    wtScriptIcon->replaceColour(juce::Colours::white, skin->getColor(Colors::PopupMenu::Text));
+
     if (selectedItem >= 0 && selectedItem < storage->wt_list.size() && singleCategory)
     {
         Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "WAVETABLES");
@@ -1106,6 +1109,50 @@ void OscillatorWaveformDisplay::createAliasOptionsMenu(const bool useComponentBo
     contextMenu.showMenuAsync(sge->popupMenuOptions(useComponentBounds ? this : nullptr));
 }
 
+struct ItemWithSharedIcon : juce::PopupMenu::Item
+{
+    ItemWithSharedIcon(const juce::String &s) : juce::PopupMenu::Item(s) {}
+
+    void setSharedDrawable(std::shared_ptr<juce::Drawable> d) { sharedDrawable = d; }
+    std::shared_ptr<juce::Drawable> sharedDrawable;
+};
+
+struct ItemWithSharedIconComponent : juce::PopupMenu::CustomComponent
+{
+    ItemWithSharedIcon item;
+    juce::PopupMenu::Options options;
+    ItemWithSharedIconComponent(ItemWithSharedIcon &i) : item(i) {}
+
+    bool hl{false};
+    void mouseEnter(const juce::MouseEvent &event) override
+    {
+        hl = true;
+        repaint();
+    }
+    void mouseExit(const juce::MouseEvent &event) override
+    {
+        hl = false;
+        repaint();
+    }
+    void paint(juce::Graphics &g) override
+    {
+        const auto colour = item.colour != juce::Colour() ? &item.colour : nullptr;
+        const auto hasSubMenu =
+            item.subMenu != nullptr && (item.itemID == 0 || item.subMenu->getNumItems() > 0);
+
+        getLookAndFeel().drawPopupMenuItem(
+            g, getLocalBounds(), item.isSeparator, item.isEnabled, hl, item.isTicked, hasSubMenu,
+            item.text, item.shortcutKeyDescription, item.sharedDrawable.get(), colour);
+    }
+
+    void getIdealSize(int &idealWidth, int &idealHeight) override
+    {
+        getLookAndFeel().getIdealPopupMenuItemSizeWithOptions(item.text, item.isSeparator,
+                                                              options.getStandardItemHeight(),
+                                                              idealWidth, idealHeight, options);
+    }
+};
+
 bool OscillatorWaveformDisplay::populateMenuForCategory(juce::PopupMenu &contextMenu,
                                                         int categoryId, int selectedItem,
                                                         bool intoTop)
@@ -1135,20 +1182,16 @@ bool OscillatorWaveformDisplay::populateMenuForCategory(juce::PopupMenu &context
             }
 
             bool isWTS = storage->wt_list[p].path.extension() == ".wtscript";
-            auto item = new juce::PopupMenu::Item(storage->wt_list[p].name);
+            auto item = ItemWithSharedIcon(storage->wt_list[p].name);
 
-            wtFileIcon.get()->replaceColour(juce::Colours::white,
-                                            skin->getColor(Colors::PopupMenu::Text));
-            wtScriptIcon.get()->replaceColour(juce::Colours::white,
-                                              skin->getColor(Colors::PopupMenu::Text));
+            item.setEnabled(true);
+            item.setTicked(checked);
+            item.setAction(action);
+            item.setSharedDrawable(isWTS ? wtScriptIcon : wtFileIcon);
 
-            item->setEnabled(true);
-            item->setTicked(checked);
-            item->setAction(action);
-            item->setImage(isWTS ? wtScriptIcon.get()->createCopy()
-                                 : wtFileIcon.get()->createCopy());
-
-            subMenu->addItem(*item);
+            // subMenu->addItem(item);
+            subMenu->addCustomItem(1, std::make_unique<ItemWithSharedIconComponent>(item), nullptr,
+                                   "foo");
 
             sub++;
 

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
@@ -148,8 +148,8 @@ struct OscillatorWaveformDisplay : public juce::Component,
     std::string lastWavetableFilename;
 
   private:
-    std::unique_ptr<juce::Drawable> wtFileIcon;
-    std::unique_ptr<juce::Drawable> wtScriptIcon;
+    std::shared_ptr<juce::Drawable> wtFileIcon;
+    std::shared_ptr<juce::Drawable> wtScriptIcon;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OscillatorWaveformDisplay);
 };


### PR DESCRIPTION
The wavetable menu didn't scale to very large collections mostly because of the icons, but also because of a bit of a leak. Fix.

It also introduces a script to populate a big wavetable directory for testing if you want, and timing - off by default - in the wavetable scal

Closes #8235