### PR TITLE
Do not hide mouse cursor when running in Logic Pro or GarageBand

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -378,6 +378,10 @@ SurgeGUIEditor::SurgeGUIEditor(SurgeSynthEditor *jEd, SurgeSynthesizer *synth)
     Surge::GUI::setIsStandalone(juceEditor->processor.wrapperType ==
                                 juce::AudioProcessor::wrapperType_Standalone);
 
+    // Logic Pro and GarageBand do not support cursor hiding
+    Surge::GUI::setHostRequiresShowCursor(juce::PluginHostType().isLogic() ||
+                                          juce::PluginHostType().isGarageBand());
+
     currentSkin = Surge::GUI::SkinDB::get()->defaultSkin(&(this->synth->storage));
 
     // init the size of the plugin

--- a/src/surge-xt/gui/SurgeGUIUtils.cpp
+++ b/src/surge-xt/gui/SurgeGUIUtils.cpp
@@ -34,8 +34,15 @@ namespace Surge
 {
 namespace GUI
 {
+static bool hostRequiresShowCursor{false};
+void setHostRequiresShowCursor(bool b) { hostRequiresShowCursor = b; }
+bool getHostRequiresShowCursor() { return hostRequiresShowCursor; }
+
 bool showCursor(SurgeStorage *storage)
 {
+    if (hostRequiresShowCursor)
+        return true;
+
     bool sc =
         Surge::Storage::getUserDefaultValue(storage, Surge::Storage::ShowCursorWhileEditing, 0);
     bool tm = Surge::Storage::getUserDefaultValue(storage, Surge::Storage::TouchMouseMode, false);

--- a/src/surge-xt/gui/SurgeGUIUtils.h
+++ b/src/surge-xt/gui/SurgeGUIUtils.h
@@ -47,6 +47,10 @@ inline bool openFileOrFolder(const fs::path &f) { return openFileOrFolder(path_t
 void setIsStandalone(bool);
 bool getIsStandalone();
 
+// Some hosts (Logic Pro, GarageBand) do not support cursor hiding
+void setHostRequiresShowCursor(bool);
+bool getHostRequiresShowCursor();
+
 } // namespace GUI
 } // namespace Surge
 


### PR DESCRIPTION
Logic Pro and GarageBand do not support cursor hiding, causing broken behavior when dragging controls. Detect these hosts at editor startup via juce::PluginHostType and set a flag that causes showCursor() to return true unconditionally, bypassing all cursor-hide logic.

Fixes #8122