### PR TITLE
Add period-aware octave transposition for tuned scales, closes #8137

### DIFF
--- a/scripts/misc/surgepy-params.py
+++ b/scripts/misc/surgepy-params.py
@@ -1,0 +1,45 @@
+import sys
+sys.path.append( "cmake-build-release/src/surge-python/" )
+
+import surgepy
+
+surge = surgepy.createSurge(48000)
+patch = surge.getPatch()
+
+def set_osc_type(patch, ot):
+    osc_type = patch['scene'][0]['osc'][0]['type']
+    surge.setParamVal(osc_type, ot)
+
+def get_osc_params(patch):
+    osc = patch['scene'][0]['osc'][0]
+    osc_type = osc['type']
+    osc_contextual_params = osc['p']
+    print(f"Oscillator Type {surge.getParamDisplay(osc_type)} / {surge.getParamVal(osc_type)}")
+    for param in osc_contextual_params:
+        print(surge.getParamInfo(param))
+
+
+# Print initial parameters
+# As osc type is classic should return Shape, Width 1, Width 2, Sub Mix, Sync, Unison Detune, Unison Voices
+print("---Initial Parameters:------------------")
+get_osc_params(patch)
+
+
+# Change osc type to FM3 and refresh conditional params
+set_osc_type(patch, 5)
+surge.process()
+patch = surge.getPatch()
+
+# As osc type is now FM3 should return M1 Amount, M1 Ratio, M2 Amount, M2 Ratio, M3 Amount, M3 Frequency, Feedback
+print("---New Parameters:----------------------")
+get_osc_params(patch)
+
+
+# Change osc type to Window and refresh conditional params
+set_osc_type(patch, 7)
+surge.process()
+patch = surge.getPatch()
+
+# As osc type is now Window should return Morph, Formant, Window, Low Cut, High Cut, Unison Detune, Unison Voices
+print("---New Parameters:----------------------")
+get_osc_params(patch)

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -3428,6 +3428,13 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 dawExtraState.mapChannelToOctave = (ival != 0);
             }
 
+            p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("transposeByTuningPeriod"));
+
+            if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
+            {
+                dawExtraState.transposeByTuningPeriod = (ival != 0);
+            }
+
             p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("midictrl_map"));
 
             if (p)
@@ -4198,6 +4205,10 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         TiXmlElement mcto("mapChannelToOctave");
         mcto.SetAttribute("v", (int)(storage->mapChannelToOctave));
         dawExtraXML.InsertEndChild(mcto);
+
+        TiXmlElement tbtp("transposeByTuningPeriod");
+        tbtp.SetAttribute("v", (int)(bool)(storage->transposeByTuningPeriod));
+        dawExtraXML.InsertEndChild(tbtp);
 
         /*
         ** Add the MIDI learned controls

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -574,6 +574,9 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     monoPedalMode = (MonoPedalMode)Surge::Storage::getUserDefaultValue(
         this, Surge::Storage::MonoPedalMode, MonoPedalMode::HOLD_ALL_NOTES);
 
+    transposeByTuningPeriod = (bool)Surge::Storage::getUserDefaultValue(
+        this, Surge::Storage::DefaultTransposeByTuningPeriod, 0);
+
     for (int s = 0; s < n_scenes; ++s)
     {
         getPatch().scene[s].drift.set_extend_range(true);
@@ -3224,6 +3227,23 @@ void SurgeStorage::setTuningApplicationMode(const TuningApplicationMode m)
 SurgeStorage::TuningApplicationMode SurgeStorage::getTuningApplicationMode() const
 {
     return tuningApplicationMode;
+}
+
+float SurgeStorage::tuningPeriodSemitones() const
+{
+#ifndef SURGE_SKIP_ODDSOUND_MTS
+    if (oddsound_mts_client && oddsound_mts_active_as_client)
+        return (float)MTS_GetPeriodSemitones(oddsound_mts_client);
+#endif
+    if (isStandardTuning)
+        return 12.0f;
+    // In RETUNE_ALL mode pitch values are in scale-note-index space, so scale.count
+    // steps equal one period (e.g. 13 for ED3-13 Bohlen-Pierce, 19 for ED2-19).
+    if (tuningApplicationMode == RETUNE_ALL)
+        return (float)currentScale.count;
+    // In RETUNE_MIDI_ONLY mode pitch values are in semitone space, so the period in
+    // semitones (cents of the last scale tone / 100) is the correct step size.
+    return currentScale.tones[currentScale.count - 1].cents / 100.0f;
 }
 
 bool SurgeStorage::skipLoadWtAndPatch = false;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1195,6 +1195,7 @@ struct DAWExtraStateStorage
     std::string mappingName = "";
 
     bool mapChannelToOctave = false;
+    bool transposeByTuningPeriod = false;
 
     std::map<int, int> midictrl_map;           // param -> midictrl
     std::map<int, int> midichan_map;           // param -> midichan
@@ -1755,6 +1756,7 @@ class alignas(16) SurgeStorage
     bool hasPatchStoredTuning{false};
 
     std::atomic<bool> mapChannelToOctave; // When other midi modes come along, clean this up.
+    std::atomic<bool> transposeByTuningPeriod{false};
 
     bool mpeEnabled{false};
 
@@ -1893,6 +1895,17 @@ class alignas(16) SurgeStorage
         RETUNE_CONSTANT = 0,
         RETUNE_NOTE_ON_ONLY = 1
     } oddsoundRetuneMode = RETUNE_CONSTANT;
+
+    /*
+     * tuningPeriodSemitones returns the number of pitch units that correspond to one
+     * period of the current tuning. The meaning of "pitch units" depends on context:
+     * - In MTS mode: pitch is in semitone space; MTS_GetPeriodSemitones gives the period.
+     * - In RETUNE_ALL mode: pitch is in scale-note-index space; scale.count steps = one period.
+     * - In RETUNE_MIDI_ONLY mode: pitch is in semitone space; cents of last tone / 100 = one
+     * period.
+     * - Standard tuning: always 12 (one octave = 12 semitones).
+     */
+    float tuningPeriodSemitones() const;
 
     /*
      * If we tune at keyboard or with MTS, we don't reset the internal tuning table.

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -5092,6 +5092,7 @@ void SurgeSynthesizer::populateDawExtraState()
     }
 
     des.mapChannelToOctave = storage.mapChannelToOctave;
+    des.transposeByTuningPeriod = storage.transposeByTuningPeriod;
 
     int n = n_global_params + (n_scene_params * n_scenes);
 
@@ -5195,6 +5196,7 @@ void SurgeSynthesizer::loadFromDawExtraState()
     }
 
     storage.mapChannelToOctave = des.mapChannelToOctave;
+    storage.transposeByTuningPeriod = des.transposeByTuningPeriod;
 
     int n = n_global_params + (n_scene_params * n_scenes);
     int nOld = n_global_params + n_scene_params;

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -130,6 +130,9 @@ std::string defaultKeyToString(DefaultKey k)
     case OverrideTempoOnPatchLoad:
         r = "overrideTempoOnPatchLoad";
         break;
+    case DefaultTransposeByTuningPeriod:
+        r = "defaultTransposeByTuningPeriod";
+        break;
     case DefaultPatchAuthor:
         r = "defaultPatchAuthor";
         break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -74,6 +74,7 @@ enum DefaultKey
     OverrideTuningOnPatchLoad,
     OverrideMappingOnPatchLoad,
     OverrideTempoOnPatchLoad,
+    DefaultTransposeByTuningPeriod,
 
     RememberTabPositionsPerScene,
     RestoreMSEGSnapFromPatch,

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -806,8 +806,15 @@ template <bool first> void SurgeVoice::calc_ctrldata(QuadFilterChainState *Q, in
         pb *= (float)scene->pbrange_dn.val.i * (scene->pbrange_dn.extend_range ? 0.01f : 1.f);
 
     octaveSize = 12.0f;
-    if (!storage->isStandardTuning && storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL)
+    if (storage->transposeByTuningPeriod)
+    {
+        octaveSize = storage->tuningPeriodSemitones();
+    }
+    else if (!storage->isStandardTuning &&
+             storage->tuningApplicationMode == SurgeStorage::RETUNE_ALL)
+    {
         octaveSize = storage->currentScale.count;
+    }
 
     state.scenepbpitch = pb + localcopy[pitch_id].f * (scene->pitch.extend_range ? 12.f : 1.f) +
                          (octaveSize * localcopy[octave_id].i);

--- a/src/surge-testrunner/UnitTestsTUN.cpp
+++ b/src/surge-testrunner/UnitTestsTUN.cpp
@@ -1726,3 +1726,231 @@ TEST_CASE("Portamento With Repeated Notes", "[tun]")
         }
     }
 }
+
+TEST_CASE("Transpose by Tuning Period", "[tun]")
+{
+    /*
+     * transposeByTuningPeriod=true: unconditionally uses tuningPeriodSemitones().
+     *   RETUNE_ALL    → scale.count (same as the else-branch, so no visible change)
+     *   RETUNE_MIDI_ONLY → cents/100 (e.g. ~19.02 for BP, giving the 3:1 tritave)
+     *   MTS           → MTS_GetPeriodSemitones (not exercised in unit tests)
+     *
+     * transposeByTuningPeriod=false (else-branch):
+     *   RETUNE_ALL + non-standard tuning → scale.count (old pre-feature behaviour)
+     *   everything else                  → 12 (standard octave)
+     */
+
+    // osc octave+1 frequency ratio on note 60
+    auto oscRatio = [](std::shared_ptr<SurgeSynthesizer> surge) {
+        surge->storage.getPatch().scene[0].osc[0].octave.val.i = 0;
+        auto fBase = frequencyForNote(surge, 60);
+        surge->storage.getPatch().scene[0].osc[0].octave.val.i = 1;
+        auto fUp = frequencyForNote(surge, 60);
+        surge->storage.getPatch().scene[0].osc[0].octave.val.i = 0;
+        return fUp / fBase;
+    };
+
+    // osc octave-1 frequency ratio on note 60
+    auto oscRatioDown = [](std::shared_ptr<SurgeSynthesizer> surge) {
+        surge->storage.getPatch().scene[0].osc[0].octave.val.i = 0;
+        auto fBase = frequencyForNote(surge, 60);
+        surge->storage.getPatch().scene[0].osc[0].octave.val.i = -1;
+        auto fDown = frequencyForNote(surge, 60);
+        surge->storage.getPatch().scene[0].osc[0].octave.val.i = 0;
+        return fDown / fBase;
+    };
+
+    // scene octave+1 frequency ratio on note 60
+    auto sceneRatio = [](std::shared_ptr<SurgeSynthesizer> surge) {
+        surge->storage.getPatch().scene[0].octave.val.i = 0;
+        auto fBase = frequencyForNote(surge, 60);
+        surge->storage.getPatch().scene[0].octave.val.i = 1;
+        auto fUp = frequencyForNote(surge, 60);
+        surge->storage.getPatch().scene[0].octave.val.i = 0;
+        return fUp / fBase;
+    };
+
+    // scene octave-1 frequency ratio on note 60
+    auto sceneRatioDown = [](std::shared_ptr<SurgeSynthesizer> surge) {
+        surge->storage.getPatch().scene[0].octave.val.i = 0;
+        auto fBase = frequencyForNote(surge, 60);
+        surge->storage.getPatch().scene[0].octave.val.i = -1;
+        auto fDown = frequencyForNote(surge, 60);
+        surge->storage.getPatch().scene[0].octave.val.i = 0;
+        return fDown / fBase;
+    };
+
+    // ---- ED2-12  (period == standard octave, bool makes no observable difference) ----
+
+    SECTION("ED2-12 RETUNE_ALL bool off: osc octave up doubles, down halves")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(2, 12));
+        surge->storage.transposeByTuningPeriod = false;
+        REQUIRE(oscRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(oscRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    SECTION("ED2-12 RETUNE_ALL bool on: osc octave up doubles, down halves")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(2, 12));
+        surge->storage.transposeByTuningPeriod = true;
+        REQUIRE(oscRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(oscRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    SECTION("ED2-12 RETUNE_ALL bool off: scene octave up doubles, down halves")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(2, 12));
+        surge->storage.transposeByTuningPeriod = false;
+        REQUIRE(sceneRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(sceneRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    SECTION("ED2-12 RETUNE_ALL bool on: scene octave up doubles, down halves")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(2, 12));
+        surge->storage.transposeByTuningPeriod = true;
+        REQUIRE(sceneRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(sceneRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    // ---- ED2-19  (period == octave; scale.count=19 = one 2:1 period) ----
+
+    SECTION("ED2-19 RETUNE_ALL bool off: osc octave up doubles, down halves")
+    {
+        // else-branch: octaveSize = scale.count = 19, one full 2:1 period
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(2, 19));
+        surge->storage.transposeByTuningPeriod = false;
+        REQUIRE(oscRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(oscRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    SECTION("ED2-19 RETUNE_ALL bool on: osc octave up doubles, down halves")
+    {
+        // tuningPeriodSemitones() = scale.count = 19 in RETUNE_ALL, same result
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(2, 19));
+        surge->storage.transposeByTuningPeriod = true;
+        REQUIRE(oscRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(oscRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    SECTION("ED2-19 RETUNE_ALL bool off: scene octave up doubles, down halves")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(2, 19));
+        surge->storage.transposeByTuningPeriod = false;
+        REQUIRE(sceneRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(sceneRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    SECTION("ED2-19 RETUNE_ALL bool on: scene octave up doubles, down halves")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(2, 19));
+        surge->storage.transposeByTuningPeriod = true;
+        REQUIRE(sceneRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(sceneRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    // ---- ED3-13 Bohlen-Pierce (period == tritave 3:1; scale.count=13) ----
+
+    SECTION("ED3-13 RETUNE_ALL bool off: osc octave up triples, down thirds")
+    {
+        // else-branch: octaveSize = scale.count = 13, one full 3:1 tritave
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(3, 13));
+        surge->storage.transposeByTuningPeriod = false;
+        REQUIRE(oscRatio(surge) == Approx(3.0).margin(0.05));
+        REQUIRE(oscRatioDown(surge) == Approx(1.0 / 3.0).margin(0.005));
+    }
+
+    SECTION("ED3-13 RETUNE_ALL bool on: osc octave up triples, down thirds")
+    {
+        // tuningPeriodSemitones() = scale.count = 13 in RETUNE_ALL, same result
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(3, 13));
+        surge->storage.transposeByTuningPeriod = true;
+        REQUIRE(oscRatio(surge) == Approx(3.0).margin(0.05));
+        REQUIRE(oscRatioDown(surge) == Approx(1.0 / 3.0).margin(0.005));
+    }
+
+    SECTION("ED3-13 RETUNE_ALL bool off: scene octave up triples, down thirds")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(3, 13));
+        surge->storage.transposeByTuningPeriod = false;
+        REQUIRE(sceneRatio(surge) == Approx(3.0).margin(0.05));
+        REQUIRE(sceneRatioDown(surge) == Approx(1.0 / 3.0).margin(0.005));
+    }
+
+    SECTION("ED3-13 RETUNE_ALL bool on: scene octave up triples, down thirds")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_ALL);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(3, 13));
+        surge->storage.transposeByTuningPeriod = true;
+        REQUIRE(sceneRatio(surge) == Approx(3.0).margin(0.05));
+        REQUIRE(sceneRatioDown(surge) == Approx(1.0 / 3.0).margin(0.005));
+    }
+
+    // ---- RETUNE_MIDI_ONLY: standard 12-semitone octave is always preserved ----
+
+    SECTION("ED3-13 RETUNE_MIDI_ONLY bool off: osc octave doubles (standard 12-semitone shift)")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(3, 13));
+        surge->storage.transposeByTuningPeriod = false;
+        REQUIRE(oscRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(oscRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    SECTION("ED3-13 RETUNE_MIDI_ONLY bool on: osc octave gives BP tritave (period-aware)")
+    {
+        // tuningPeriodSemitones() returns cents/100 ~= 19.02 in RETUNE_MIDI_ONLY.
+        // In the 12-TET pitch table that is 2^(19.02/12) ~= 3.0x — the BP tritave.
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(3, 13));
+        surge->storage.transposeByTuningPeriod = true;
+        REQUIRE(oscRatio(surge) == Approx(3.0).margin(0.05));
+        REQUIRE(oscRatioDown(surge) == Approx(1.0 / 3.0).margin(0.01));
+    }
+
+    SECTION("ED3-13 RETUNE_MIDI_ONLY bool off: scene octave doubles")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(3, 13));
+        surge->storage.transposeByTuningPeriod = false;
+        REQUIRE(sceneRatio(surge) == Approx(2.0).margin(0.01));
+        REQUIRE(sceneRatioDown(surge) == Approx(0.5).margin(0.005));
+    }
+
+    SECTION("ED3-13 RETUNE_MIDI_ONLY bool on: scene octave gives BP tritave (period-aware)")
+    {
+        auto surge = surgeOnSine();
+        surge->storage.setTuningApplicationMode(SurgeStorage::RETUNE_MIDI_ONLY);
+        surge->storage.retuneToScale(Tunings::evenDivisionOfSpanByM(3, 13));
+        surge->storage.transposeByTuningPeriod = true;
+        REQUIRE(sceneRatio(surge) == Approx(3.0).margin(0.05));
+        REQUIRE(sceneRatioDown(surge) == Approx(1.0 / 3.0).margin(0.01));
+    }
+}

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -684,7 +684,6 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                                   this->synth->storage.mapChannelToOctave =
                                       !(this->synth->storage.mapChannelToOctave);
                               });
-
         tuningSubMenu.addSeparator();
 
         tuningSubMenu.addItem(
@@ -700,6 +699,26 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
 
         tuningSubMenu.addSeparator();
     }
+
+
+    tuningSubMenu.addItem(Surge::GUI::toOSCase("Transpose Octave by Tuning Period"), true,
+                          (bool)(synth->storage.transposeByTuningPeriod), [this]() {
+                              this->synth->storage.transposeByTuningPeriod =
+                                  !(this->synth->storage.transposeByTuningPeriod);
+                          });
+
+    {
+        bool defVal = (bool)Surge::Storage::getUserDefaultValue(
+            &(synth->storage), Surge::Storage::DefaultTransposeByTuningPeriod, 0);
+        tuningSubMenu.addItem(
+            Surge::GUI::toOSCase("Set Transpose Octave by Tuning Period as Default"), true,
+            defVal, [this, defVal]() {
+                Surge::Storage::updateUserDefaultValue(
+                    &(this->synth->storage), Surge::Storage::DefaultTransposeByTuningPeriod,
+                    defVal ? 0 : 1);
+            });
+    }
+    tuningSubMenu.addSeparator();
 
 #ifndef SURGE_SKIP_ODDSOUND_MTS
     auto canMaster = MTS_CanRegisterMaster();

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -700,7 +700,6 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
         tuningSubMenu.addSeparator();
     }
 
-
     tuningSubMenu.addItem(Surge::GUI::toOSCase("Transpose Octave by Tuning Period"), true,
                           (bool)(synth->storage.transposeByTuningPeriod), [this]() {
                               this->synth->storage.transposeByTuningPeriod =
@@ -711,8 +710,8 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
         bool defVal = (bool)Surge::Storage::getUserDefaultValue(
             &(synth->storage), Surge::Storage::DefaultTransposeByTuningPeriod, 0);
         tuningSubMenu.addItem(
-            Surge::GUI::toOSCase("Set Transpose Octave by Tuning Period as Default"), true,
-            defVal, [this, defVal]() {
+            Surge::GUI::toOSCase("Set Transpose Octave by Tuning Period as Default"), true, defVal,
+            [this, defVal]() {
                 Surge::Storage::updateUserDefaultValue(
                     &(this->synth->storage), Surge::Storage::DefaultTransposeByTuningPeriod,
                     defVal ? 0 : 1);


### PR DESCRIPTION
When "Transpose Octave by Tuning Period" is enabled (off by default), the oscillator and scene octave parameters shift by one period of the current tuning rather than a fixed 12 semitones.

Behaviour by mode when the option is on:
  RETUNE_ALL        — octaveSize = scale.count (e.g. 13 for Bohlen-Pierce,
                      19 for ED2-19); same result as the prior implicit
                      behaviour, now made explicit and toggleable.
  RETUNE_MIDI_ONLY  — octaveSize = last-tone cents / 100, so a BP scale
                      shifts by ~19.02 semitones (the 3:1 tritave) rather
                      than the usual 12-semitone octave.
  MTS               — octaveSize = MTS_GetPeriodSemitones().

When the option is off the prior behaviour is preserved exactly:
  RETUNE_ALL + non-standard tuning → scale.count; everything else → 12.

Changes:
  SurgeStorage: add tuningPeriodSemitones() and atomic transposeByTuningPeriod
  SurgeVoice:   use transposeByTuningPeriod / tuningPeriodSemitones() for octaveSize
  DAWExtraState/SurgePatch: persist transposeByTuningPeriod in session XML
  SurgeSynthesizer: populate/load transposeByTuningPeriod from DAW extra state
  UserDefaults: DefaultTransposeByTuningPeriod seeds the creation-time value
  Tuning menu: "Transpose Octave by Tuning Period" (session toggle) and
               "Set … as Default" (persists via user defaults), placed
               outside the isStandardTuning guard so always visible
  UnitTestsTUN: test ED2-12, ED2-19, ED3-13 (Bohlen-Pierce) for osc and
               scene octave, up and down, bool on and off, RETUNE_ALL and
               RETUNE_MIDI_ONLY modes

Closes #8137 