### PR TITLE
Refactor snapshot serialization

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1327,18 +1327,34 @@ bool SurgePatch::readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc)
         if (!binn_object_get_value(oscmap, fmt::format("snap_{}", slot).c_str(), &frames))
             continue;
         if (frames.type != BINN_LIST)
+        {
+            std::cerr << "Snapshot frames list missing or malformed; possibly corrupted patch."
+                      << std::endl;
             continue;
+        }
 
         int ntables = binn_count(&frames);
         if (ntables <= 0 || ntables > max_subtables)
+        {
+            std::cerr << "Snapshot table count out of range; possibly corrupted patch."
+                      << std::endl;
             continue;
+        }
 
         binn first;
         if (!binn_list_get_value(&frames, 1, &first) || first.type != BINN_BLOB)
+        {
+            std::cerr << "Snapshot frame blob missing or malformed; possibly corrupted patch."
+                      << std::endl;
             continue;
+        }
         int nsamples = binn_size(&first) / sizeof(float);
         if (nsamples <= 0 || nsamples > max_wtable_size)
+        {
+            std::cerr << "Snapshot sample count out of range; possibly corrupted patch."
+                      << std::endl;
             continue;
+        }
 
         std::vector<float> data(static_cast<size_t>(ntables) * nsamples);
         binn_iter fiter;
@@ -1355,7 +1371,10 @@ bool SurgePatch::readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc)
             t++;
         }
         if (t != ntables)
+        {
+            std::cerr << "Snapshot frame count mismatch; possibly corrupted patch." << std::endl;
             continue;
+        }
 
         wt_header wh{};
         wh.n_samples = nsamples;

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1318,9 +1318,9 @@ bool SurgePatch::writeOscSnapshotsToBinn(binn *oscmap, const OscillatorStorage &
     return any;
 }
 
-int SurgePatch::readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc)
+bool SurgePatch::readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc)
 {
-    int built = 0;
+    bool any = false;
     for (int slot = 0; slot < n_wt_snapshots; ++slot)
     {
         binn frames;
@@ -1373,10 +1373,10 @@ int SurgePatch::readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc)
         }
         else
         {
-            ++built;
+            any = true;
         }
     }
-    return built;
+    return any;
 }
 
 std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
@@ -1544,7 +1544,7 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
             }
 
             // Rebuild wavetable snapshots from the stored frame lists.
-            if (readOscSnapshotsFromBinn(&obj, scene[sc].osc[osc]) > 0)
+            if (readOscSnapshotsFromBinn(&obj, scene[sc].osc[osc]))
             {
                 snapshotsStoredInPatch = true;
             }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1296,6 +1296,89 @@ unsigned int SurgePatch::save_patch(void **data)
     return psize;
 }
 
+bool SurgePatch::writeOscSnapshotsToBinn(binn *oscmap, const OscillatorStorage &osc)
+{
+    bool any = false;
+    for (int slot = 0; slot < n_wt_snapshots; ++slot)
+    {
+        const auto &snap = osc.wtSnapshots[slot];
+        if (!snap || !snap->everBuilt)
+            continue;
+
+        binn *frames = binn_list();
+        for (std::uint32_t t = 0; t < snap->n_tables; ++t)
+        {
+            binn_list_add_blob(frames, snap->TableF32WeakPointers[0][t],
+                               snap->size * sizeof(float));
+        }
+        binn_object_set_list(oscmap, fmt::format("snap_{}", slot).c_str(), frames);
+        binn_free(frames);
+        any = true;
+    }
+    return any;
+}
+
+int SurgePatch::readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc)
+{
+    int built = 0;
+    for (int slot = 0; slot < n_wt_snapshots; ++slot)
+    {
+        binn frames;
+        if (!binn_object_get_value(oscmap, fmt::format("snap_{}", slot).c_str(), &frames))
+            continue;
+        if (frames.type != BINN_LIST)
+            continue;
+
+        int ntables = binn_count(&frames);
+        if (ntables <= 0 || ntables > max_subtables)
+            continue;
+
+        binn first;
+        if (!binn_list_get_value(&frames, 1, &first) || first.type != BINN_BLOB)
+            continue;
+        int nsamples = binn_size(&first) / sizeof(float);
+        if (nsamples <= 0 || nsamples > max_wtable_size)
+            continue;
+
+        std::vector<float> data(static_cast<size_t>(ntables) * nsamples);
+        binn_iter fiter;
+        binn frame;
+        binn_iter_init(&fiter, &frames, BINN_LIST);
+        int t = 0;
+        while (binn_list_next(&fiter, &frame))
+        {
+            if (frame.type != BINN_BLOB ||
+                binn_size(&frame) != nsamples * static_cast<int>(sizeof(float)))
+                break;
+            std::memcpy(data.data() + static_cast<size_t>(t) * nsamples, frame.ptr,
+                        nsamples * sizeof(float));
+            t++;
+        }
+        if (t != ntables)
+            continue;
+
+        wt_header wh{};
+        wh.n_samples = nsamples;
+        wh.n_tables = ntables;
+        wh.flags = 0;
+
+        auto &snap = osc.wtSnapshots[slot];
+        snap = std::make_unique<Wavetable>();
+
+        snap->BuildWT(data.data(), wh, false);
+
+        if (!snap->everBuilt)
+        {
+            snap.reset();
+        }
+        else
+        {
+            ++built;
+        }
+    }
+    return built;
+}
+
 std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
 {
     binn *map = binn_object();
@@ -1319,21 +1402,7 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
             for (int osc = 0; osc < n_oscs; osc++)
             {
                 binn *oscmap = binn_object();
-                for (int slot = 0; slot < n_wt_snapshots; slot++)
-                {
-                    auto &snap = scene[sc].osc[osc].wtSnapshots[slot];
-                    if (!snap || !snap->everBuilt)
-                        continue;
-
-                    binn *frames = binn_list();
-                    for (std::uint32_t t = 0; t < snap->n_tables; t++)
-                    {
-                        binn_list_add_blob(frames, snap->TableF32WeakPointers[0][t],
-                                           snap->size * sizeof(float));
-                    }
-                    binn_object_set_list(oscmap, fmt::format("snap_{}", slot).c_str(), frames);
-                    binn_free(frames);
-                }
+                writeOscSnapshotsToBinn(oscmap, scene[sc].osc[osc]);
                 std::string key = fmt::format("osc_{}_{}", sc, osc);
                 binn_object_set_object(map, key.c_str(), oscmap);
                 binn_free(oscmap);
@@ -1475,60 +1544,9 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
             }
 
             // Rebuild wavetable snapshots from the stored frame lists.
-            for (int slot = 0; slot < n_wt_snapshots; slot++)
+            if (readOscSnapshotsFromBinn(&obj, scene[sc].osc[osc]) > 0)
             {
-                binn frames;
-                if (!binn_object_get_value(&obj, fmt::format("snap_{}", slot).c_str(), &frames))
-                    continue;
-                if (frames.type != BINN_LIST)
-                    continue;
-
-                int ntables = binn_count(&frames);
-                if (ntables <= 0 || ntables > max_subtables)
-                    continue;
-
-                binn first;
-                if (!binn_list_get_value(&frames, 1, &first) || first.type != BINN_BLOB)
-                    continue;
-                int nsamples = binn_size(&first) / sizeof(float);
-                if (nsamples <= 0 || nsamples > max_wtable_size)
-                    continue;
-
-                std::vector<float> data(static_cast<size_t>(ntables) * nsamples);
-                binn_iter fiter;
-                binn frame;
-                binn_iter_init(&fiter, &frames, BINN_LIST);
-                int t = 0;
-                while (binn_list_next(&fiter, &frame))
-                {
-                    if (frame.type != BINN_BLOB ||
-                        binn_size(&frame) != nsamples * static_cast<int>(sizeof(float)))
-                        break;
-                    std::memcpy(data.data() + static_cast<size_t>(t) * nsamples, frame.ptr,
-                                nsamples * sizeof(float));
-                    t++;
-                }
-                if (t != ntables)
-                    continue;
-
-                wt_header wh{};
-                wh.n_samples = nsamples;
-                wh.n_tables = ntables;
-                wh.flags = 0;
-
-                auto &snap = scene[sc].osc[osc].wtSnapshots[slot];
-                snap = std::make_unique<Wavetable>();
-
-                snap->BuildWT(data.data(), wh, false);
-
-                if (!snap->everBuilt)
-                {
-                    snap.reset();
-                }
-                else
-                {
-                    snapshotsStoredInPatch = true;
-                }
+                snapshotsStoredInPatch = true;
             }
         }
     }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1325,22 +1325,14 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
                     if (!snap || !snap->everBuilt)
                         continue;
 
-                    std::uint32_t ntables = snap->n_tables;
-                    std::uint32_t nsamples = snap->size;
-                    std::vector<float> data(static_cast<size_t>(ntables) * nsamples);
-                    for (std::uint32_t t = 0; t < ntables; t++)
+                    binn *frames = binn_list();
+                    for (std::uint32_t t = 0; t < snap->n_tables; t++)
                     {
-                        std::memcpy(data.data() + static_cast<size_t>(t) * nsamples,
-                                    snap->TableF32WeakPointers[0][t], nsamples * sizeof(float));
+                        binn_list_add_blob(frames, snap->TableF32WeakPointers[0][t],
+                                           snap->size * sizeof(float));
                     }
-
-                    binn_object_set_uint32(oscmap, fmt::format("snap_{}_ntables", slot).c_str(),
-                                           ntables);
-                    binn_object_set_uint32(oscmap, fmt::format("snap_{}_nsamples", slot).c_str(),
-                                           nsamples);
-                    binn_object_set_blob(oscmap, fmt::format("snap_{}_data", slot).c_str(),
-                                         data.data(),
-                                         static_cast<int>(data.size() * sizeof(float)));
+                    binn_object_set_list(oscmap, fmt::format("snap_{}", slot).c_str(), frames);
+                    binn_free(frames);
                 }
                 std::string key = fmt::format("osc_{}_{}", sc, osc);
                 binn_object_set_object(map, key.c_str(), oscmap);
@@ -1428,6 +1420,12 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
                 continue;
             }
 
+            if (id < 0 || id >= n_fx_slots)
+            {
+                std::cerr << "FX index out of range in " << key << "; skipping." << std::endl;
+                continue;
+            }
+
             // Deserialize the FX data.
             std::unordered_map<std::string, std::shared_ptr<std::vector<std::uint8_t>>> &arb =
                 this->fx[id].user_data;
@@ -1470,45 +1468,47 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
                 continue;
             }
 
-            // Deserialize the oscillator snapshot data.
-            std::unordered_map<std::string, std::shared_ptr<std::vector<std::uint8_t>>> arb;
-            binn_iter inner;
-            binn data;
-            char osckey[256];
-            binn_iter_init(&inner, &obj, BINN_OBJECT);
-            while (binn_object_next(&inner, osckey, &data))
+            if (sc < 0 || sc >= n_scenes || osc < 0 || osc >= n_oscs)
             {
-                if (data.type != BINN_BLOB)
-                    continue;
-
-                std::string converted = std::string(osckey);
-                std::shared_ptr<std::vector<std::uint8_t>> &vdata = arb[converted];
-                if (!vdata)
-                    vdata = std::make_shared<std::vector<std::uint8_t>>(binn_size(&data));
-                else
-                    vdata->resize(binn_size(&data));
-                std::memcpy(vdata->data(), data.ptr, binn_size(&data));
+                std::cerr << "Osc index out of range in " << key << "; skipping." << std::endl;
+                continue;
             }
 
-            // Rebuild wavetable snapshots from the staged blobs.
+            // Rebuild wavetable snapshots from the stored frame lists.
             for (int slot = 0; slot < n_wt_snapshots; slot++)
             {
-                auto it = arb.find(fmt::format("snap_{}_data", slot));
-                if (it == arb.end())
+                binn frames;
+                if (!binn_object_get_value(&obj, fmt::format("snap_{}", slot).c_str(), &frames))
+                    continue;
+                if (frames.type != BINN_LIST)
                     continue;
 
-                unsigned int ntables = 0, nsamples = 0;
-                if (!binn_object_get_uint32(&obj, fmt::format("snap_{}_ntables", slot).c_str(),
-                                            &ntables))
-                    continue;
-                if (!binn_object_get_uint32(&obj, fmt::format("snap_{}_nsamples", slot).c_str(),
-                                            &nsamples))
-                    continue;
-                if (ntables == 0 || nsamples == 0)
+                int ntables = binn_count(&frames);
+                if (ntables <= 0 || ntables > max_subtables)
                     continue;
 
-                auto &raw = *it->second;
-                if (raw.size() != static_cast<size_t>(ntables) * nsamples * sizeof(float))
+                binn first;
+                if (!binn_list_get_value(&frames, 1, &first) || first.type != BINN_BLOB)
+                    continue;
+                int nsamples = binn_size(&first) / sizeof(float);
+                if (nsamples <= 0 || nsamples > max_wtable_size)
+                    continue;
+
+                std::vector<float> data(static_cast<size_t>(ntables) * nsamples);
+                binn_iter fiter;
+                binn frame;
+                binn_iter_init(&fiter, &frames, BINN_LIST);
+                int t = 0;
+                while (binn_list_next(&fiter, &frame))
+                {
+                    if (frame.type != BINN_BLOB ||
+                        binn_size(&frame) != nsamples * static_cast<int>(sizeof(float)))
+                        break;
+                    std::memcpy(data.data() + static_cast<size_t>(t) * nsamples, frame.ptr,
+                                nsamples * sizeof(float));
+                    t++;
+                }
+                if (t != ntables)
                     continue;
 
                 wt_header wh{};
@@ -1519,7 +1519,7 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
                 auto &snap = scene[sc].osc[osc].wtSnapshots[slot];
                 snap = std::make_unique<Wavetable>();
 
-                snap->BuildWT(reinterpret_cast<float *>(raw.data()), wh, false);
+                snap->BuildWT(data.data(), wh, false);
 
                 if (!snap->everBuilt)
                 {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1233,6 +1233,7 @@ struct PatchTuningStorage
 
 class SurgeStorage;
 
+// Forward declare binn to avoid including binn.h into this header
 #ifndef BINN_H
 struct binn_struct;
 typedef struct binn_struct binn;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1233,6 +1233,11 @@ struct PatchTuningStorage
 
 class SurgeStorage;
 
+#ifndef BINN_H
+struct binn_struct;
+typedef struct binn_struct binn;
+#endif
+
 class SurgePatch
 {
   public:
@@ -1265,6 +1270,12 @@ class SurgePatch
     bool hasAnySnapshots() const;
     unsigned int save_patch(void **data);
     std::vector<std::uint8_t> save_arbitrary_block_storage();
+
+    // Writes snap_{slot} list entries into `oscmap`. Returns true if any snapshot was added.
+    static bool writeOscSnapshotsToBinn(binn *oscmap, const OscillatorStorage &osc);
+    // Reads snap_{slot} entries from `oscmap` into `osc.wtSnapshots`.
+    // Returns the number of snapshots successfully built.
+    static int readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc);
     Parameter *parameterFromOSCName(std::string stName);
     void captureWavetableSnapshot(int scene, int srcOsc, int dstOsc, int slot);
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1270,12 +1270,8 @@ class SurgePatch
     bool hasAnySnapshots() const;
     unsigned int save_patch(void **data);
     std::vector<std::uint8_t> save_arbitrary_block_storage();
-
-    // Writes snap_{slot} list entries into `oscmap`. Returns true if any snapshot was added.
     static bool writeOscSnapshotsToBinn(binn *oscmap, const OscillatorStorage &osc);
-    // Reads snap_{slot} entries from `oscmap` into `osc.wtSnapshots`.
-    // Returns the number of snapshots successfully built.
-    static int readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc);
+    static bool readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc);
     Parameter *parameterFromOSCName(std::string stName);
     void captureWavetableSnapshot(int scene, int srcOsc, int dstOsc, int slot);
 

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -31,6 +31,8 @@
 #include <cstring>
 #include <fstream>
 #include <tinyxml/tinyxml.h>
+#include "binn/binn.h"
+#include "fmt/core.h"
 #include "zstd.h"
 
 // #define LOG(...) std::cout << __FILE__ << ":" << __LINE__ << " " << __VA_ARGS__ << std::endl;
@@ -531,6 +533,79 @@ void LuaWTEvaluator::generateWavetable(SurgeStorage *storage, OscillatorStorage 
 #endif
 }
 
+static void loadWtscriptSnapshots(const void *compData, size_t blobSize, OscillatorStorage *oscdata)
+{
+    auto decompressedSize = ZSTD_getFrameContentSize(compData, blobSize);
+    if (decompressedSize == ZSTD_CONTENTSIZE_UNKNOWN || decompressedSize == ZSTD_CONTENTSIZE_ERROR)
+        return;
+
+    std::vector<std::uint8_t> decompressed(decompressedSize);
+    decompressedSize = ZSTD_decompress(decompressed.data(), decompressedSize, compData, blobSize);
+    if (ZSTD_isError(decompressedSize))
+        return;
+
+    if (decompressedSize < sizeof(binn_struct))
+        return;
+
+    int sz = 0;
+    if (!binn_is_valid_ex(decompressed.data(), NULL, NULL, &sz))
+        return;
+
+    binn *b = binn_open_ex(decompressed.data(), sz);
+    for (int slot = 0; slot < n_wt_snapshots; slot++)
+    {
+        binn frames;
+        if (!binn_object_get_value(b, fmt::format("snap_{}", slot).c_str(), &frames))
+            continue;
+        if (frames.type != BINN_LIST)
+            continue;
+
+        int ntables = binn_count(&frames);
+        if (ntables <= 0 || ntables > max_subtables)
+            continue;
+
+        binn first;
+        if (!binn_list_get_value(&frames, 1, &first) || first.type != BINN_BLOB)
+            continue;
+        int nsamples = binn_size(&first) / sizeof(float);
+        if (nsamples <= 0 || nsamples > max_wtable_size)
+            continue;
+
+        std::vector<float> data(static_cast<size_t>(ntables) * nsamples);
+        binn_iter fiter;
+        binn frame;
+        binn_iter_init(&fiter, &frames, BINN_LIST);
+        int t = 0;
+        while (binn_list_next(&fiter, &frame))
+        {
+            if (frame.type != BINN_BLOB ||
+                binn_size(&frame) != nsamples * static_cast<int>(sizeof(float)))
+                break;
+            std::memcpy(data.data() + static_cast<size_t>(t) * nsamples, frame.ptr,
+                        nsamples * sizeof(float));
+            t++;
+        }
+        if (t != ntables)
+            continue;
+
+        wt_header wh{};
+        wh.n_samples = nsamples;
+        wh.n_tables = ntables;
+        wh.flags = 0;
+
+        auto &snap = oscdata->wtSnapshots[slot];
+        snap = std::make_unique<Wavetable>();
+
+        snap->BuildWT(data.data(), wh, false);
+
+        if (!snap->everBuilt)
+        {
+            snap.reset();
+        }
+    }
+    binn_free(b);
+}
+
 std::optional<LuaWTEvaluator::WtscriptData>
 LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
                               OscillatorStorage *oscdata)
@@ -541,7 +616,7 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
 
     /* File layout:
        - Snapshot-less: pure XML text
-       - With snapshots: [wtscript_header][XML][zstd-compressed snapshot blob]
+       - With snapshots: [wtscript_header][XML][zstd-compressed binn object]
         where wtscript_header = { tag "wts1", xmlsize, blobsize }
     */
 
@@ -566,9 +641,8 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
 
     size_t xmlOffset = 0;
     size_t xmlSize = fileSize;
-    size_t blobOffset = 0;
-    size_t blobSize = 0;
 
+    // Snapshots stored as a zstd-compressed binn object in the trailing blob
     if (hasHeader)
     {
         wtscript_header header{};
@@ -578,9 +652,9 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
 
         xmlOffset = sizeof(wtscript_header);
         xmlSize = header.xmlsize;
-        blobSize = header.blobsize;
-
+        size_t blobSize = header.blobsize;
         const size_t bytesAfterHeader = fileSize - xmlOffset;
+
         if (xmlSize > bytesAfterHeader || blobSize > bytesAfterHeader - xmlSize)
         {
             storage->reportError("Wavetable script file is truncated or corrupt.",
@@ -588,7 +662,8 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
             return std::nullopt;
         }
 
-        blobOffset = xmlOffset + xmlSize;
+        const void *compData = fileData.data() + xmlOffset + xmlSize;
+        loadWtscriptSnapshots(compData, blobSize, oscdata);
     }
 
     // Parse only the XML portion
@@ -641,80 +716,6 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
     data.script = Surge::Storage::base64_decode(b64script);
     data.nframes = nframes;
     data.res_base = res_base;
-
-    // Snapshots: metadata lives in XML; float data comes from the compressed trailing blob
-    auto sn = TINYXML_SAFE_TO_ELEMENT(wtscript->FirstChildElement("snapshots"));
-    if (sn && blobSize > 0)
-    {
-        auto validSnapshot = [](TiXmlElement *child, int &slot, int &nframes, int &nsamples) {
-            if (child->QueryIntAttribute("slot", &slot) != TIXML_SUCCESS ||
-                child->QueryIntAttribute("frames", &nframes) != TIXML_SUCCESS ||
-                child->QueryIntAttribute("samples", &nsamples) != TIXML_SUCCESS)
-                return false;
-            return slot >= 0 && slot < n_wt_snapshots && nframes > 0 && nframes <= max_subtables &&
-                   nsamples > 0 && nsamples <= max_wtable_size;
-        };
-
-        size_t expectedFloats = 0;
-        for (auto child = sn->FirstChildElement("snapshot"); child;
-             child = child->NextSiblingElement("snapshot"))
-        {
-            int slot, nframes, nsamples;
-            if (validSnapshot(child, slot, nframes, nsamples))
-                expectedFloats += static_cast<size_t>(nframes) * nsamples;
-        }
-
-        if (expectedFloats > 0)
-        {
-            const std::uint8_t *compData =
-                reinterpret_cast<const std::uint8_t *>(fileData.data() + blobOffset);
-            const auto decompressedSize = ZSTD_getFrameContentSize(compData, blobSize);
-            if (decompressedSize == ZSTD_CONTENTSIZE_ERROR ||
-                decompressedSize == ZSTD_CONTENTSIZE_UNKNOWN ||
-                decompressedSize != expectedFloats * sizeof(float))
-            {
-                storage->reportError("Snapshot blob size mismatch; snapshots not loaded.",
-                                     "Wavetable Script Load Warning");
-            }
-            else
-            {
-                std::vector<float> decompressed(expectedFloats);
-                const size_t result =
-                    ZSTD_decompress(decompressed.data(), decompressedSize, compData, blobSize);
-                if (ZSTD_isError(result) || result != decompressedSize)
-                {
-                    storage->reportError(
-                        "Failed to decompress snapshot blob; snapshots not loaded.",
-                        "Wavetable Script Load Warning");
-                }
-                else
-                {
-                    size_t floatOffset = 0;
-                    for (auto child = sn->FirstChildElement("snapshot"); child;
-                         child = child->NextSiblingElement("snapshot"))
-                    {
-                        int slot, nframes, nsamples;
-                        if (!validSnapshot(child, slot, nframes, nsamples))
-                            continue;
-
-                        wt_header wh{};
-                        wh.n_samples = nsamples;
-                        wh.n_tables = nframes;
-                        wh.flags = 0;
-
-                        oscdata->wtSnapshots[slot] = std::make_unique<Wavetable>();
-                        oscdata->wtSnapshots[slot]->BuildWT(decompressed.data() + floatOffset, wh,
-                                                            false);
-                        if (!oscdata->wtSnapshots[slot]->everBuilt)
-                        {
-                            oscdata->wtSnapshots[slot].reset();
-                        }
-                        floatOffset += static_cast<size_t>(nframes) * nsamples;
-                    }
-                }
-            }
-        }
-    }
 
     return data;
 #else

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -553,57 +553,7 @@ static void loadWtscriptSnapshots(const void *compData, size_t blobSize, Oscilla
         return;
 
     binn *b = binn_open_ex(decompressed.data(), sz);
-    for (int slot = 0; slot < n_wt_snapshots; slot++)
-    {
-        binn frames;
-        if (!binn_object_get_value(b, fmt::format("snap_{}", slot).c_str(), &frames))
-            continue;
-        if (frames.type != BINN_LIST)
-            continue;
-
-        int ntables = binn_count(&frames);
-        if (ntables <= 0 || ntables > max_subtables)
-            continue;
-
-        binn first;
-        if (!binn_list_get_value(&frames, 1, &first) || first.type != BINN_BLOB)
-            continue;
-        int nsamples = binn_size(&first) / sizeof(float);
-        if (nsamples <= 0 || nsamples > max_wtable_size)
-            continue;
-
-        std::vector<float> data(static_cast<size_t>(ntables) * nsamples);
-        binn_iter fiter;
-        binn frame;
-        binn_iter_init(&fiter, &frames, BINN_LIST);
-        int t = 0;
-        while (binn_list_next(&fiter, &frame))
-        {
-            if (frame.type != BINN_BLOB ||
-                binn_size(&frame) != nsamples * static_cast<int>(sizeof(float)))
-                break;
-            std::memcpy(data.data() + static_cast<size_t>(t) * nsamples, frame.ptr,
-                        nsamples * sizeof(float));
-            t++;
-        }
-        if (t != ntables)
-            continue;
-
-        wt_header wh{};
-        wh.n_samples = nsamples;
-        wh.n_tables = ntables;
-        wh.flags = 0;
-
-        auto &snap = oscdata->wtSnapshots[slot];
-        snap = std::make_unique<Wavetable>();
-
-        snap->BuildWT(data.data(), wh, false);
-
-        if (!snap->everBuilt)
-        {
-            snap.reset();
-        }
-    }
+    SurgePatch::readOscSnapshotsFromBinn(b, *oscdata);
     binn_free(b);
 }
 #endif

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -533,6 +533,7 @@ void LuaWTEvaluator::generateWavetable(SurgeStorage *storage, OscillatorStorage 
 #endif
 }
 
+#if HAS_LUA
 static void loadWtscriptSnapshots(const void *compData, size_t blobSize, OscillatorStorage *oscdata)
 {
     auto decompressedSize = ZSTD_getFrameContentSize(compData, blobSize);
@@ -605,6 +606,7 @@ static void loadWtscriptSnapshots(const void *compData, size_t blobSize, Oscilla
     }
     binn_free(b);
 }
+#endif
 
 std::optional<LuaWTEvaluator::WtscriptData>
 LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -107,6 +107,7 @@
 
 #include "filesystem/import.h"
 #include "RuntimeFont.h"
+#include "binn/binn.h"
 #include "zstd.h"
 
 #include "juce_core/juce_core.h"
@@ -6820,9 +6821,9 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
 
             wtscript.InsertEndChild(script);
 
-            // Collect snapshot float data and build per-slot XML metadata
-            TiXmlElement sn("snapshots");
-            std::vector<float> snapshotFloats;
+            // Build a binn object holding snapshot frame lists
+            binn *oscmap = binn_object();
+            bool hasSnapshots = false;
             for (int slot = 0; slot < n_wt_snapshots; ++slot)
             {
                 const auto &snap = oscdata->wtSnapshots[slot];
@@ -6831,24 +6832,15 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
                     continue;
                 }
 
-                const unsigned int nframes = snap->n_tables;
-                const int nsamples = snap->size;
-
-                for (unsigned int t = 0; t < nframes; ++t)
+                binn *frames = binn_list();
+                for (unsigned int t = 0; t < snap->n_tables; ++t)
                 {
-                    const float *tbl = snap->TableF32WeakPointers[0][t];
-                    snapshotFloats.insert(snapshotFloats.end(), tbl, tbl + nsamples);
+                    binn_list_add_blob(frames, snap->TableF32WeakPointers[0][t],
+                                       snap->size * sizeof(float));
                 }
-
-                TiXmlElement sl("snapshot");
-                sl.SetAttribute("slot", slot);
-                sl.SetAttribute("frames", nframes);
-                sl.SetAttribute("samples", nsamples);
-                sn.InsertEndChild(sl);
-            }
-            if (!snapshotFloats.empty())
-            {
-                wtscript.InsertEndChild(sn);
+                binn_object_set_list(oscmap, fmt::format("snap_{}", slot).c_str(), frames);
+                binn_free(frames);
+                hasSnapshots = true;
             }
 
             doc.InsertEndChild(wtscript);
@@ -6861,26 +6853,28 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
             if (!outFile)
             {
                 storage->reportError("Failed to open file for writing.", "Save Error");
+                binn_free(oscmap);
                 return;
             }
 
-            if (snapshotFloats.empty())
+            if (!hasSnapshots)
             {
                 // Just the XML
                 outFile.write(xmlStr.data(), xmlStr.size());
             }
             else
             {
-                // Compress the snapshot float data
+                // Compress the binn snapshot data
                 namespace mech = sst::basic_blocks::mechanics;
-                const size_t rawSize = snapshotFloats.size() * sizeof(float);
-                const size_t compBound = ZSTD_compressBound(rawSize);
+                const auto rawSize = binn_size(oscmap);
+                const auto compBound = ZSTD_compressBound(rawSize);
                 std::vector<uint8_t> compressed(compBound);
                 const size_t compSize =
-                    ZSTD_compress(compressed.data(), compBound, snapshotFloats.data(), rawSize, 3);
+                    ZSTD_compress(compressed.data(), compBound, binn_ptr(oscmap), rawSize, 3);
                 if (ZSTD_isError(compSize))
                 {
                     storage->reportError("Failed to compress snapshot data.", "Save Error");
+                    binn_free(oscmap);
                     return;
                 }
                 compressed.resize(compSize);
@@ -6897,6 +6891,7 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
                 outFile.write(xmlStr.data(), xmlStr.size());
                 outFile.write(reinterpret_cast<const char *>(compressed.data()), compressed.size());
             }
+            binn_free(oscmap);
 
             outFile.close();
             if (!outFile)

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6824,8 +6824,7 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
 
             // Build a binn object holding snapshot frame lists
             binn *oscmap = binn_object();
-            const auto freeOscmap =
-                sst::cpputils::make_scope_guard([&] { binn_free(oscmap); });
+            const auto freeOscmap = sst::cpputils::make_scope_guard([&] { binn_free(oscmap); });
             bool hasSnapshots = SurgePatch::writeOscSnapshotsToBinn(oscmap, *oscdata);
 
             doc.InsertEndChild(wtscript);

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6823,25 +6823,7 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
 
             // Build a binn object holding snapshot frame lists
             binn *oscmap = binn_object();
-            bool hasSnapshots = false;
-            for (int slot = 0; slot < n_wt_snapshots; ++slot)
-            {
-                const auto &snap = oscdata->wtSnapshots[slot];
-                if (!snap || !snap->everBuilt)
-                {
-                    continue;
-                }
-
-                binn *frames = binn_list();
-                for (unsigned int t = 0; t < snap->n_tables; ++t)
-                {
-                    binn_list_add_blob(frames, snap->TableF32WeakPointers[0][t],
-                                       snap->size * sizeof(float));
-                }
-                binn_object_set_list(oscmap, fmt::format("snap_{}", slot).c_str(), frames);
-                binn_free(frames);
-                hasSnapshots = true;
-            }
+            bool hasSnapshots = SurgePatch::writeOscSnapshotsToBinn(oscmap, *oscdata);
 
             doc.InsertEndChild(wtscript);
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -46,6 +46,7 @@
 
 #include "SurgeGUIEditorTags.h"
 #include "fmt/core.h"
+#include "sst/cpputils/scope_guard.h"
 
 #include "overlays/AboutScreen.h"
 #include "overlays/MiniEdit.h"
@@ -6823,6 +6824,8 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
 
             // Build a binn object holding snapshot frame lists
             binn *oscmap = binn_object();
+            const auto freeOscmap =
+                sst::cpputils::make_scope_guard([&] { binn_free(oscmap); });
             bool hasSnapshots = SurgePatch::writeOscSnapshotsToBinn(oscmap, *oscdata);
 
             doc.InsertEndChild(wtscript);
@@ -6835,7 +6838,6 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
             if (!outFile)
             {
                 storage->reportError("Failed to open file for writing.", "Save Error");
-                binn_free(oscmap);
                 return;
             }
 
@@ -6856,7 +6858,6 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
                 if (ZSTD_isError(compSize))
                 {
                     storage->reportError("Failed to compress snapshot data.", "Save Error");
-                    binn_free(oscmap);
                     return;
                 }
                 compressed.resize(compSize);
@@ -6873,7 +6874,6 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
                 outFile.write(xmlStr.data(), xmlStr.size());
                 outFile.write(reinterpret_cast<const char *>(compressed.data()), compressed.size());
             }
-            binn_free(oscmap);
 
             outFile.close();
             if (!outFile)


### PR DESCRIPTION
Draft please don't merge yet.

- Store snapshots as binn frame lists instead of blobs with separate metadata keys
- Unify .wtscript snapshot loading into a shared helper matching load_arbitrary_block_storage
- Add missing bounds checks for FX/oscillator indices

Edit: This is a breaking change on how snapshots are saved in patch and .wtscript files.