### PR TITLE
Fix some FX quirks

### DIFF
--- a/src/common/FxPresetAndClipboardManager.cpp
+++ b/src/common/FxPresetAndClipboardManager.cpp
@@ -455,6 +455,7 @@ void copyFx(SurgeStorage *storage, FxStorage *fx, Clipboard &cb)
     cb.fxCopyPaste.clear();
     cb.fxCopyPaste.resize(n_fx_params * 5 + 1); // type then (val; deform; ts; extend; deact)
     cb.fxCopyPaste[0] = fx->type.val.i;
+    cb.user_data = fx->user_data;
     for (int i = 0; i < n_fx_params; ++i)
     {
         int vp = i * 5 + 1;
@@ -490,6 +491,7 @@ void pasteFx(SurgeStorage *storage, FxStorage *fxbuffer, Clipboard &cb)
         return;
 
     fxbuffer->type.val.i = (int)cb.fxCopyPaste[0];
+    fxbuffer->user_data = cb.user_data;
 
     Effect *t_fx = spawn_effect(fxbuffer->type.val.i, storage, fxbuffer, 0);
     if (t_fx)
@@ -537,6 +539,7 @@ void pasteFx(SurgeStorage *storage, FxStorage *fxbuffer, Clipboard &cb)
     }
 
     cb.fxCopyPaste.clear();
+    cb.user_data.clear();
 }
 } // namespace FxClipboard
 } // namespace Surge

--- a/src/common/FxPresetAndClipboardManager.h
+++ b/src/common/FxPresetAndClipboardManager.h
@@ -88,6 +88,7 @@ struct Clipboard
 {
     Clipboard();
     std::vector<float> fxCopyPaste;
+    std::unordered_map<std::string, std::shared_ptr<std::vector<std::uint8_t>>> user_data;
 };
 void copyFx(SurgeStorage *, FxStorage *from, Clipboard &cb);
 bool isPasteAvailable(const Clipboard &cb);

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -3943,6 +3943,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
         if (current_fx != nfx)
         {
             current_fx = nfx;
+            synth->storage.getPatch().dawExtraState.editor.current_fx = nfx;
             activateFromCurrentFx();
 
             queue_refresh = true;

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
@@ -231,7 +231,7 @@ struct FxMenu : public juce::Component, public XMLMenuPopulator, public WidgetBa
     void setFxStorage(FxStorage *s);
     void setFxBuffer(FxStorage *s) { fxbuffer = s; }
 
-    int current_fx;
+    int current_fx{0};
     void setCurrentFx(int i) { current_fx = i; }
 
     static Surge::FxClipboard::Clipboard fxClipboard;


### PR DESCRIPTION
- FX type context menu ticks the slot actually opened, not a stale `dawExtraState.editor.current_fx`
- Copy/Paste FX Preset menu item now carries user_data (Convolution IR was silently dropped)