### PR TITLE
Find and display exact keybind conflicts when choosing different VKB layouts

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -291,7 +291,6 @@ void SurgeSynthEditor::setVKBLayout(const std::string layout)
 {
     auto searchTerm = [&layout](const auto &x) { return x.first == layout; };
     auto search = std::find_if(vkbLayouts.begin(), vkbLayouts.end(), searchTerm);
-    currentVKBLayout = layout;
 
     if (search != vkbLayouts.end())
     {

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -634,7 +634,10 @@ void SurgeGUIEditor::idle()
                 }
                 else
                 {
-                    messageBox(title, msg);
+                    // TODO: Hacky af, but it'll do for now. Improve automatic resizing of message
+                    // box based on length of msg...
+                    int numEOL = std::count(msg.begin(), msg.end(), '\n');
+                    messageBox(title, msg, (numEOL >= 5) ? 14 * (numEOL - 4) : 0);
                 }
             }
         }
@@ -3720,9 +3723,9 @@ void SurgeGUIEditor::promptForMiniEdit(const std::string &value, const std::stri
 
 void SurgeGUIEditor::alertBox(const std::string &title, const std::string &prompt,
                               std::function<void()> onOk, std::function<void()> onCancel,
-                              AlertButtonStyle buttonStyle)
+                              AlertButtonStyle buttonStyle, uint16_t extraHeight)
 {
-    alert = std::make_unique<Surge::Overlays::Alert>();
+    alert = std::make_unique<Surge::Overlays::Alert>(extraHeight);
     alert->setSkin(currentSkin, bitmapStore);
     alert->setDescription(title);
     alert->setWindowTitle(title);

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -881,7 +881,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     };
 
     void alertBox(const std::string &title, const std::string &prompt, std::function<void()> onOk,
-                  std::function<void()> onCancel, AlertButtonStyle buttonStyle);
+                  std::function<void()> onCancel, AlertButtonStyle buttonStyle,
+                  uint16_t extraHeight = 0);
 
     void alertOKCancel(const std::string &title, const std::string &prompt,
                        std::function<void()> onOk, std::function<void()> onCancel = nullptr)
@@ -893,9 +894,10 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     {
         alertBox(title, prompt, onOk, onCancel, AlertButtonStyle::YES_NO);
     }
-    void messageBox(const std::string &title, const std::string &prompt)
+    void messageBox(const std::string &title, const std::string &prompt,
+                    const uint16_t extraHeight = 0)
     {
-        alertBox(title, prompt, nullptr, nullptr, AlertButtonStyle::OK);
+        alertBox(title, prompt, nullptr, nullptr, AlertButtonStyle::OK, extraHeight);
     }
 
     std::unique_ptr<Surge::Overlays::Alert> alert;

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -52,8 +52,9 @@ struct MultiLineSkinLabel : juce::Label, public Surge::GUI::SkinConsumingCompone
     void onSkinChanged() override { repaint(); }
 };
 
-Alert::Alert()
+Alert::Alert(uint16_t extraH)
 {
+    extraHeight = extraH;
     setAccessible(true);
     setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
     setWantsKeyboardFocus(true);
@@ -92,7 +93,8 @@ void Alert::resetAccessibility()
 juce::Rectangle<int> Alert::getDisplayRegion()
 {
     return juce::Rectangle<int>(0, 0, windowWidth,
-                                108 + (dontAskAgainButton ? btnHeight + windowMargin : 0))
+                                108 + (dontAskAgainButton ? btnHeight + windowMargin : 0) +
+                                    extraHeight)
         .withCentre(getBounds().getCentre());
 }
 
@@ -110,7 +112,8 @@ void Alert::resized()
     auto fullRect = getDisplayRegion();
     auto dialogCenter = fullRect.getWidth() / 2;
 
-    labelComponent->setBounds(fullRect.withTrimmedTop(18).withHeight(68).reduced(windowMargin));
+    labelComponent->setBounds(
+        fullRect.withTrimmedTop(18).withHeight(68 + extraHeight).reduced(windowMargin));
 
     auto buttonRow =
         fullRect.withY(fullRect.getY() + fullRect.getHeight() - btnHeight - windowMargin)

--- a/src/surge-xt/gui/overlays/Alert.h
+++ b/src/surge-xt/gui/overlays/Alert.h
@@ -42,9 +42,10 @@ struct Alert : public Surge::Overlays::OverlayComponent,
                public Surge::GUI::SkinConsumingComponent,
                public juce::Button::Listener
 {
-    Alert();
+    Alert(uint16_t extraH = 0);
     ~Alert();
 
+    uint16_t extraHeight{0};
     std::string title, label;
     std::unique_ptr<Surge::Widgets::SurgeTextButton> okButton;
     std::unique_ptr<Surge::Widgets::SurgeTextButton> cancelButton;

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
@@ -360,20 +360,55 @@ void KeyBindingsOverlay::createVKBLayoutMenu()
 
 void KeyBindingsOverlay::changeVKBLayout(const std::string layout)
 {
-    if (layout == "QWERTY 2 Octave")
-    {
-        storage->reportError(
-            "The QWERTY 2 Octave layout has conflicts with the default keyboard shortcuts.\n"
-            "Be sure to change any conflicting shortcuts like X to Shift+X and C to Shift+C or "
-            "other keys of your choice.",
-            "QWERTY 2 Octave Layout Warning");
-    }
-    Surge::Storage::updateUserDefaultValue(editor->getStorage(),
-                                           Surge::Storage::VirtualKeyboardLayout, layout);
-    editor->juceEditor->setVKBLayout(layout);
+    const auto vkbl = editor->juceEditor->vkbLayouts;
+    auto searchTerm = [&layout](const auto &x) { return x.first == layout; };
+    auto search = std::find_if(vkbl.begin(), vkbl.end(), searchTerm);
+    std::vector<Surge::GUI::KeyboardActions> conflicts;
 
-    vkbLayout->setLabels({"VKB Layout: " + layout});
-    vkbLayout->repaint();
+    conflicts.clear();
+
+    if (search != vkbl.end())
+    {
+        for (auto key : search->second)
+        {
+            const auto kc = (key >= 74 && key <= 122) ? key - 32 : key;
+            const auto kp = juce::KeyPress(kc, juce::ModifierKeys::noModifiers, 0);
+
+            for (auto const &[k, b] : editor->keyMapManager->bindings)
+            {
+                if (b.matches(kp))
+                {
+                    conflicts.emplace_back(k);
+                }
+            }
+        }
+    }
+
+    if (!conflicts.empty())
+    {
+        std::string keyNames;
+
+        for (auto &b : conflicts)
+        {
+            keyNames += Surge::GUI::keyboardActionDescription(b) + " (" +
+                        editor->getShortcutDescription(b) + ")\n";
+        }
+
+        storage->reportError(fmt::format("Selected virtual keyboard layout has conflicts with the "
+                                         "following keyboard shortcuts:\n\n{}\nPlease modify these "
+                                         "in order to be able to use this virtual keyboard layout!",
+                                         keyNames),
+                             "Virtual Keyboard Layout Conflict");
+    }
+    else
+    {
+        Surge::Storage::updateUserDefaultValue(editor->getStorage(),
+                                               Surge::Storage::VirtualKeyboardLayout, layout);
+        editor->juceEditor->setVKBLayout(layout);
+
+        vkbLayout->setLabels({"VKB Layout: " + layout});
+        vkbLayout->repaint();
+    }
 }
 
 KeyBindingsOverlay::~KeyBindingsOverlay()
@@ -413,7 +448,7 @@ void KeyBindingsOverlay::resized()
     okS->setBounds(okRect);
     cancelS->setBounds(canRect);
     resetAll->setBounds(canRect.translated(175, 0).withWidth(58));
-    vkbLayout->setBounds(okRect.translated(-183, 0).withWidth(128));
+    vkbLayout->setBounds(okRect.translated(-183, 0).withWidth(138));
 
     bindingList->setBounds(l);
 }

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
@@ -371,8 +371,11 @@ void KeyBindingsOverlay::changeVKBLayout(const std::string layout)
     {
         for (auto key : search->second)
         {
-            const auto kc = (key >= 74 && key <= 122) ? key - 32 : key;
-            const auto kp = juce::KeyPress(kc, juce::ModifierKeys::noModifiers, 0);
+            // VKB layouts store keycodes as lowercase, but SST keybindings store them as uppercase
+            // because of juce::KeyPress::getTextDescription()
+            // see keyCodeToString() template instantiation in SurgeGUIEditor.h
+            const auto kp = juce::KeyPress(juce::CharacterFunctions::toUpperCase(key),
+                                           juce::ModifierKeys::noModifiers, 0);
 
             for (auto const &[k, b] : editor->keyMapManager->bindings)
             {


### PR DESCRIPTION
This required a few hacky solutions (because I couldn't find another way).

First, had to thread an extraHeight parameter to Alert class so that the dialog vertically sizes itself depending on how many lines of text the msg has. 

Second, sst::plugininfra::KeyMapManager seems to store singular letter keystrokes as uppercased, which is diametrically opposite to what JUCE does (JUCE does it correctly as lowercased, because an uppercase letter implies Shift being pressed!). So I had to hack the keybind comparison by adding an uppercasing...

But it works. Woof!