### PR TITLE
Add conflict detection when assigning keyboard bindings

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -54,6 +54,7 @@
 #include "overlays/MSEGEditor.h"
 #include "overlays/LuaEditors.h"
 #include "overlays/ModulationEditor.h"
+#include "overlays/KeyBindingsOverlay.h"
 #include "overlays/TypeinParamEditor.h"
 #include "overlays/Oscilloscope.h"
 #include "overlays/OverlayWrapper.h"
@@ -587,6 +588,7 @@ void SurgeGUIEditor::idle()
 #ifndef SURGE_SKIP_ODDSOUND_MTS
     getStorage()->send_tuning_update();
 #endif
+
     if (editor_open && frame && !synth->halt_engine)
     {
         bool patchChanged = false;
@@ -638,6 +640,21 @@ void SurgeGUIEditor::idle()
                     // box based on length of msg...
                     int numEOL = std::count(msg.begin(), msg.end(), '\n');
                     messageBox(title, msg, (numEOL >= 5) ? 14 * (numEOL - 4) : 0);
+                }
+            }
+        }
+
+        if (kboNeedsRefocus)
+        {
+            if (!(alert && alert->isVisible()))
+            {
+                auto *kbo =
+                    getOverlayIfOpenAs<Surge::Overlays::KeyBindingsOverlay>(KEYBINDINGS_EDITOR);
+
+                if (kbo)
+                {
+                    kbo->restoreFocus();
+                    kboNeedsRefocus = false;
                 }
             }
         }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -644,18 +644,12 @@ void SurgeGUIEditor::idle()
             }
         }
 
-        if (kboNeedsRefocus)
+        if (componentToFocusAfterAlertDismissal)
         {
             if (!(alert && alert->isVisible()))
             {
-                auto *kbo =
-                    getOverlayIfOpenAs<Surge::Overlays::KeyBindingsOverlay>(KEYBINDINGS_EDITOR);
-
-                if (kbo)
-                {
-                    kbo->restoreFocus();
-                    kboNeedsRefocus = false;
-                }
+                componentToFocusAfterAlertDismissal->setWantsKeyboardFocus(true);
+                componentToFocusAfterAlertDismissal->grabKeyboardFocus();
             }
         }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -909,9 +909,9 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         NEVER = 100
     };
 
-    // when KeyBindingsOverlay is learning, we need to give the focus back to it
-    bool kboNeedsRefocus{false};
-    int kboRefocusAction{-1};
+    // sometimes we need to return focus to a specific component after an Alert dialog is dismissed
+    // currently used by KeyBindingsOverlay
+    juce::Component::SafePointer<juce::Component> componentToFocusAfterAlertDismissal{nullptr};
 
     // Return whether we called the OK action automatically or not
     bool promptForOKCancelWithDontAskAgain(const ::std::string &title, const std::string &msg,

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -909,6 +909,10 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         NEVER = 100
     };
 
+    // when KeyBindingsOverlay is learning, we need to give the focus back to it
+    bool kboNeedsRefocus{false};
+    int kboRefocusAction{-1};
+
     // Return whether we called the OK action automatically or not
     bool promptForOKCancelWithDontAskAgain(const ::std::string &title, const std::string &msg,
                                            Surge::Storage::DefaultKey dontAskAgainKey,

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
@@ -328,6 +328,12 @@ KeyBindingsOverlay::KeyBindingsOverlay(SurgeStorage *st, SurgeGUIEditor *ed)
     addAndMakeVisible(*bindingList);
 }
 
+KeyBindingsOverlay::~KeyBindingsOverlay()
+{
+    bindingList.reset(nullptr);
+    bindingListBoxModel.reset(nullptr); // order matters here
+}
+
 void KeyBindingsOverlay::resetAllToDefault()
 {
     for (auto const &[k, b] : editor->keyMapManager->bindings)
@@ -424,12 +430,6 @@ void KeyBindingsOverlay::changeVKBLayout(const std::string layout)
     }
 }
 
-KeyBindingsOverlay::~KeyBindingsOverlay()
-{
-    bindingList.reset(nullptr);
-    bindingListBoxModel.reset(nullptr); // order matters here
-}
-
 void KeyBindingsOverlay::paint(juce::Graphics &g)
 {
     if (!skin)
@@ -478,35 +478,93 @@ void KeyBindingsOverlay::onSkinChanged()
 
 bool KeyBindingsOverlay::keyPressed(const juce::KeyPress &key)
 {
+    using namespace Surge::GUI;
+
     if (isLearning)
     {
-        auto &binding = editor->keyMapManager->bindings[(Surge::GUI::KeyboardActions)learnAction];
+        auto newBinding = editor->keyMapManager->bindings[(KeyboardActions)learnAction];
 
-        binding.type = SurgeGUIEditor::keymap_t::Binding::KEYCODE;
-        binding.keyCode = key.getKeyCode();
-        binding.modifier = 0;
+        newBinding.type = SurgeGUIEditor::keymap_t::Binding::KEYCODE;
+        newBinding.keyCode = key.getKeyCode();
+        newBinding.modifier = 0;
 #if SST_COMMAND_CTRL_SAME_KEY
         if (key.getModifiers().isCommandDown() || key.getModifiers().isCtrlDown())
-            binding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::COMMAND;
+            newBinding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::COMMAND;
 #else
         if (key.getModifiers().isCommandDown())
-            binding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::COMMAND;
+            newBinding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::COMMAND;
         if (key.getModifiers().isCtrlDown())
-            binding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::CONTROL;
+            newBinding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::CONTROL;
 #endif
         if (key.getModifiers().isShiftDown())
-            binding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::SHIFT;
+            newBinding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::SHIFT;
         if (key.getModifiers().isAltDown())
-            binding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::ALT;
+            newBinding.modifier |= SurgeGUIEditor::keymap_t::Modifiers::ALT;
 
-        isLearning = false;
-        learnAction = -1;
+        KeyboardActions conflictedAction{KeyboardActions::n_kbdActions};
 
-        bindingList->updateContent();
+        for (auto const &[k, b] : editor->keyMapManager->bindings)
+        {
+            if (b == newBinding)
+            {
+                conflictedAction = k;
+            }
+        }
 
-        return true;
+        // we've found a conflict
+        if (conflictedAction < KeyboardActions::n_kbdActions)
+        {
+            // which row are we learning
+            auto *rowComp = dynamic_cast<KeyBindingsListRow *>(
+                bindingList->getComponentForRowNumber(learnAction));
+
+            // which learn button we want to keep focus on
+            focusedLearnComponent = rowComp ? rowComp->learn.get() : nullptr;
+
+            std::string keyNames = Surge::GUI::keyboardActionDescription(conflictedAction) + " (" +
+                                   editor->getShortcutDescription(conflictedAction) + ")\n";
+
+            storage->reportError(
+                fmt::format("The keyboard shortcut you have just entered is already assigned "
+                            "to:\n\n{}\nDismiss this dialog and try again!",
+                            keyNames),
+                "Keyboard Shortcut Conflict");
+
+            isLearning = true;
+
+            editor->kboNeedsRefocus = true;
+            editor->kboRefocusAction = (int)learnAction;
+
+            return true;
+        }
+        else
+        {
+            auto &oldBinding = editor->keyMapManager->bindings[(KeyboardActions)learnAction];
+
+            oldBinding = newBinding;
+
+            isLearning = false;
+            learnAction = -1;
+
+            focusedLearnComponent = nullptr;
+
+            bindingList->updateContent();
+
+            return true;
+        }
     }
+
     return Component::keyPressed(key);
+}
+
+// restore the focus after clicking away the reportError dialog
+void KeyBindingsOverlay::restoreFocus()
+{
+    if (isLearning && focusedLearnComponent)
+    {
+        focusedLearnComponent->setWantsKeyboardFocus(true);
+        focusedLearnComponent->grabKeyboardFocus();
+    }
 }
 
 } // namespace Overlays

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
@@ -482,6 +482,7 @@ bool KeyBindingsOverlay::keyPressed(const juce::KeyPress &key)
 
     if (isLearning)
     {
+        // this is a copy in case we conflict with an existing keybinding
         auto newBinding = editor->keyMapManager->bindings[(KeyboardActions)learnAction];
 
         newBinding.type = SurgeGUIEditor::keymap_t::Binding::KEYCODE;
@@ -532,8 +533,7 @@ bool KeyBindingsOverlay::keyPressed(const juce::KeyPress &key)
 
             isLearning = true;
 
-            editor->kboNeedsRefocus = true;
-            editor->kboRefocusAction = (int)learnAction;
+            editor->componentToFocusAfterAlertDismissal = focusedLearnComponent;
 
             return true;
         }
@@ -555,16 +555,6 @@ bool KeyBindingsOverlay::keyPressed(const juce::KeyPress &key)
     }
 
     return Component::keyPressed(key);
-}
-
-// restore the focus after clicking away the reportError dialog
-void KeyBindingsOverlay::restoreFocus()
-{
-    if (isLearning && focusedLearnComponent)
-    {
-        focusedLearnComponent->setWantsKeyboardFocus(true);
-        focusedLearnComponent->grabKeyboardFocus();
-    }
 }
 
 } // namespace Overlays

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.h
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.h
@@ -42,6 +42,7 @@ struct KeyBindingsOverlay : public OverlayComponent, public Surge::GUI::SkinCons
 
     SurgeStorage *storage{nullptr};
     SurgeGUIEditor *editor{nullptr};
+
     KeyBindingsOverlay(SurgeStorage *storage, SurgeGUIEditor *editor);
     ~KeyBindingsOverlay();
 
@@ -56,11 +57,16 @@ struct KeyBindingsOverlay : public OverlayComponent, public Surge::GUI::SkinCons
 
     bool isLearning{false};
     int learnAction{0};
+
     bool keyPressed(const juce::KeyPress &key) override;
+
+    void restoreFocus();
 
     std::unique_ptr<Surge::Widgets::SelfDrawButton> okS, cancelS, resetAll, vkbLayout;
     std::unique_ptr<KeyBindingsListBoxModel> bindingListBoxModel;
     std::unique_ptr<juce::ListBox> bindingList;
+
+    juce::Component::SafePointer<juce::Component> focusedLearnComponent;
 };
 } // namespace Overlays
 } // namespace Surge

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.h
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.h
@@ -60,8 +60,6 @@ struct KeyBindingsOverlay : public OverlayComponent, public Surge::GUI::SkinCons
 
     bool keyPressed(const juce::KeyPress &key) override;
 
-    void restoreFocus();
-
     std::unique_ptr<Surge::Widgets::SelfDrawButton> okS, cancelS, resetAll, vkbLayout;
     std::unique_ptr<KeyBindingsListBoxModel> bindingListBoxModel;
     std::unique_ptr<juce::ListBox> bindingList;


### PR DESCRIPTION
This was a doozy! The conflict detection itself was easy as it was already done for VKB layouts in a prior commit.

But I constantly ended up losing focus from the keybinds overlay! The Learn button would remain lit after dismissing the conflict notification dialog, but since focus got lost, the next keypress (chorded or not) would not work - they would instead bring focus back to keybind overlay. So then you needed to press it once again.

After a long and tedious ordeal of trying various methods (global mouse listener, global component listener, timer shenanigans, focus change listener...) none of which worked, I broke down and simply went back to the main hub: SGE idle(), and did it there. Not sure if this is something @baconpaul will agree with, but I lost 5 hours attempting to make this work, and this worked!

Thoughts welcome!