### PR TITLE
Replace _BitScanReverse with C+20 std::bit_width()

### DIFF
--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -26,11 +26,10 @@
 #include "SurgeStorage.h"
 
 #include "sst/basic-blocks/mechanics/endian-ops.h"
-namespace mech = sst::basic_blocks::mechanics;
 
-#if WINDOWS
-#include <intrin.h>
-#endif
+#include <bit>
+
+namespace mech = sst::basic_blocks::mechanics;
 
 using namespace std;
 
@@ -60,14 +59,6 @@ const int HRFilterI16[64] = {
     -66, -240, 95,    143,   -92,  -74,   72,    31,   -48,   -8,    33,   1};
 
 int min_F32_tables = 3;
-
-#if MAC || LINUX
-bool _BitScanReverse(unsigned int *result, unsigned int bits)
-{
-    *result = __builtin_ctz(bits);
-    return true;
-}
-#endif
 
 //! Calculate the worst-case scenario of the needed samples for a specific wavetable and see if it
 //! fits
@@ -196,15 +187,7 @@ bool Wavetable::BuildWT(void *wdata, wt_header &wh, bool AppendSilence)
         n_tables += 3; // this "3" should match the "3" in RequiredWTSize
     }
 
-#if WINDOWS
-    unsigned long MSBpos;
-    _BitScanReverse(&MSBpos, size);
-#else
-    unsigned int MSBpos;
-    _BitScanReverse(&MSBpos, size);
-#endif
-
-    size_po2 = MSBpos;
+    size_po2 = std::bit_width(static_cast<unsigned int>(size)) - 1;
 
     dt = 1.0f / size;
 

--- a/src/common/dsp/oscillators/WindowOscillator.cpp
+++ b/src/common/dsp/oscillators/WindowOscillator.cpp
@@ -23,21 +23,10 @@
 #include "WindowOscillator.h"
 #include "DSPUtils.h"
 
+#include <bit>
 #include <cstdint>
 #include "DebugHelpers.h"
 
-#ifdef _WIN32
-#include <intrin.h>
-#else
-namespace
-{
-inline bool _BitScanReverse(unsigned long *result, unsigned long bits)
-{
-    *result = __builtin_ctz(bits);
-    return true;
-}
-} // anonymous namespace
-#endif
 int Float2Int(float x) { return int(x + 0.5f); }
 WindowOscillator::WindowOscillator(SurgeStorage *storage, OscillatorStorage *oscdata,
                                    pdata *localcopy)
@@ -324,14 +313,16 @@ template <bool FM, bool Full16> void WindowOscillator::ProcessWindowOscs(bool st
                 Window.Table[1][so] = TablePlusOne;
             }
 
-            unsigned long MSBpos;
             unsigned int bs = BigMULr16(RatioA, 3 * FormantMul);
 
-            if (_BitScanReverse(&MSBpos, bs))
-                MipMapB = limit_range((int)MSBpos - 17, 0, oscdata->wt.size_po2 - 1);
+            if (bs > 0)
+                MipMapB = limit_range((int)std::bit_width(bs) - 18, 0, oscdata->wt.size_po2 - 1);
 
-            if (_BitScanReverse(&MSBpos, 3 * RatioA))
-                MipMapA = limit_range((int)MSBpos - 17, 0, storage->WindowWT.size_po2 - 1);
+            unsigned int ratioA3 = 3 * RatioA;
+
+            if (ratioA3 > 0)
+                MipMapA = limit_range((int)std::bit_width(ratioA3) - 18, 0,
+                                      storage->WindowWT.size_po2 - 1);
 
             short *WaveAdr = oscdata->wt.TableI16WeakPointers[MipMapB][Window.Table[0][so]];
             short *WaveAdrP1 = oscdata->wt.TableI16WeakPointers[MipMapB][Window.Table[1][so]];


### PR DESCRIPTION
Closes #6726

This also fixes a pretty bad bug that's been there since forever: Window oscillator sounded incorrectly on *nixes, because the intrinsic shim for `_BitScanReverse()` used a wrong replacement function. This resulted in mip-map selection ending up basically completely broken, in most cases the most detailed mipmap would have been used even at highest pitches, creating a lot more artifacts than there should be.

Considering it is of utmost importance for a synth to sound the same regardless of the OS used, despite this being a breaking change, both @baconpaul and I agreed it's the right thing to just outright fix this directly, no handling in streaming or any such shenanigans.

Now Window oscillator will sound identical across platforms!