### PR TITLE
LFO phase now stops at 359° instead of going full circle

### DIFF
--- a/src/common/dsp/modulators/LFOModulationSource.cpp
+++ b/src/common/dsp/modulators/LFOModulationSource.cpp
@@ -156,7 +156,7 @@ void LFOModulationSource::msegEnvelopePhaseAdjustment()
 
 void LFOModulationSource::initPhaseFromStartPhase()
 {
-    phase = localcopy[startphase].f;
+    phase = startPhaseRescaled();
     phaseInitialized = true;
 
     if (lfo->shape.val.i == lt_tri && lfo->rate.deactivated && !lfo->unipolar.val.b)
@@ -217,7 +217,7 @@ void LFOModulationSource::attackFrom(float start)
 
     if (is_display)
     {
-        phase = lfo->start_phase.val.f;
+        phase = startPhaseRescaled();
 
         if (lfo->shape.val.i == lt_stepseq)
         {
@@ -239,7 +239,7 @@ void LFOModulationSource::attackFrom(float start)
         }
         else
         {
-            phaseslider = localcopy[startphase].f;
+            phaseslider = startPhaseRescaled();
         }
 
         // With modulation the phaseslider can be outside [0, 1), as in #1524

--- a/src/common/dsp/modulators/LFOModulationSource.h
+++ b/src/common/dsp/modulators/LFOModulationSource.h
@@ -127,8 +127,27 @@ class LFOModulationSource : public ModulationSource
   private:
     pdata *localcopy;
     bool phaseInitialized;
+
     void initPhaseFromStartPhase();
     void msegEnvelopePhaseAdjustment();
+
+    inline float startPhaseRescaled() const
+    {
+        // start_phase doubles as shuffle parameter for step sequencer
+        // where it must remain as unscaled, full [0, 1] range
+        // which is also used in extended mode as (x * 2 - 1).
+        // Scale only for basic LFO shapes
+        if (lfo->shape.val.i == lt_stepseq || lfo->shape.val.i == lt_formula ||
+            lfo->shape.val.i == lt_envelope || lfo->shape.val.i == lt_mseg)
+        {
+            return localcopy[startphase].f;
+        }
+
+        // Prevent full-circle: scale to [0, 1) so val_max != val_min
+        constexpr float maxPhase = 1.0f - (1.0f / 360.0f);
+
+        return localcopy[startphase].f * maxPhase;
+    }
 
     float phase, target, noise, noised1, env_phase, priorPhase;
     int unwrappedphase_intpart;


### PR DESCRIPTION
This is a breaking change, but it's a really small one, and only for basic waveforms (it won't change anything for step seq, envelope, MSEG, or formula).

I think people by and large won't be hugely adversely affected by this change. And if they do, we can easily revert this since the rescaling is done in one spot only.

Fixes #6568