### PR TITLE
Cleanup and assorted fixes

### DIFF
--- a/src/common/LuaSupport.cpp
+++ b/src/common/LuaSupport.cpp
@@ -21,13 +21,6 @@
  */
 
 #include "LuaSupport.h"
-
-#include "basic_dsp.h"
-
-#if HAS_JUCE
-#include "SurgeSharedBinary.h"
-#endif
-
 #include "lua/LuaSources.h"
 
 #include <iostream>
@@ -47,7 +40,7 @@ bool Surge::LuaSupport::parseStringDefiningFunction(lua_State *L, const std::str
 }
 
 int Surge::LuaSupport::parseStringDefiningMultipleFunctions(
-    lua_State *L, const std::string &definition, const std::vector<std::string> functions,
+    lua_State *L, const std::string &definition, const std::vector<std::string> &functions,
     std::string &errorMessage)
 {
 #if HAS_LUA
@@ -459,12 +452,14 @@ bool Surge::LuaSupport::loadSurgePrelude(lua_State *L, const std::string &lua_sc
     {
         std::cout << "Error: Failed to load Lua file! [ " << lua_script.c_str() << " ]"
                   << std::endl;
+        lua_pop(L, 1); // Pop error
         return false;
     }
     auto pcall = lua_pcall(L, 0, 1, 0);
     if (pcall != 0)
     {
         std::cout << "Error: Failed to run Lua file! [ " << lua_script.c_str() << " ]" << std::endl;
+        lua_pop(L, 1); // Pop error
         return false;
     }
     lua_setglobal(L, surgeTableName);

--- a/src/common/LuaSupport.h
+++ b/src/common/LuaSupport.h
@@ -35,8 +35,6 @@ extern "C"
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>
-#include <luajit.h>
-#include <lj_arch.h>
 
 #include <pffft.h>
 }
@@ -61,7 +59,7 @@ namespace LuaSupport
  * stack by 1.
  */
 
-bool parseStringDefiningFunction(lua_State *s, const std::string &definition,
+bool parseStringDefiningFunction(lua_State *L, const std::string &definition,
                                  const std::string &functionName, std::string &errorMessage);
 
 /*
@@ -74,8 +72,8 @@ bool parseStringDefiningFunction(lua_State *s, const std::string &definition,
  * the number which were nil. If the function returns 0 errorMessage will be populated
  * with something.
  */
-int parseStringDefiningMultipleFunctions(lua_State *s, const std::string &definition,
-                                         const std::vector<std::string> functions,
+int parseStringDefiningMultipleFunctions(lua_State *L, const std::string &definition,
+                                         const std::vector<std::string> &functions,
                                          std::string &errorMessage);
 
 /*
@@ -159,4 +157,4 @@ static constexpr const char *sharedTableName{"shared"};
 } // namespace LuaSupport
 } // namespace Surge
 
-#endif // SURGE_XT_LUASUPPORT_H
+#endif // SURGE_SRC_COMMON_LUASUPPORT_H

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -197,7 +197,7 @@ struct LuaWTEvaluator::Details
             if (lua_istable(L, -1))
             {
                 bool gen{true};
-                for (auto i = 0; i < resolution && gen; ++i)
+                for (size_t i = 0; i < resolution && gen; ++i)
                 {
                     lua_pushinteger(L, i + 1);
                     lua_gettable(L, -2);
@@ -317,7 +317,7 @@ struct LuaWTEvaluator::Details
                 wtName = "Scripted Wavetable";
 
                 frameCache.clear();
-                for (int i = 0; i < frameCount; ++i)
+                for (size_t i = 0; i < frameCount; ++i)
                     frameCache.push_back(std::nullopt);
             }
 
@@ -476,7 +476,7 @@ bool LuaWTEvaluator::populateWavetable(wt_header &wh, float **wavdata)
     wh.flags = 0;
     *wavdata = wd;
 
-    for (int i = 0; i < frames; ++i)
+    for (size_t i = 0; i < frames; ++i)
     {
         auto v = getFrame(i);
         if (v.has_value())

--- a/src/common/dsp/WavetableScriptEvaluator.h
+++ b/src/common/dsp/WavetableScriptEvaluator.h
@@ -24,9 +24,15 @@
 #define SURGE_SRC_COMMON_DSP_WAVETABLESCRIPTEVALUATOR_H
 
 #include "LuaSupport.h"
-#include "StringOps.h"
 #include "SurgeStorage.h"
 #include "Wavetable.h"
+#include "filesystem/import.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace Surge
 {
@@ -83,4 +89,4 @@ struct LuaWTEvaluator
 
 } // namespace WavetableScript
 } // namespace Surge
-#endif // SURGE_XT_WAVETABLESCRIPTEVALUATOR_H
+#endif // SURGE_SRC_COMMON_DSP_WAVETABLESCRIPTEVALUATOR_H

--- a/src/common/dsp/modulators/FormulaModulationHelper.cpp
+++ b/src/common/dsp/modulators/FormulaModulationHelper.cpp
@@ -21,13 +21,21 @@
  */
 
 #include "FormulaModulationHelper.h"
+
 #include "LuaSupport.h"
 #include "SurgeVoice.h"
 #include "SurgeStorage.h"
-#include <thread>
-#include <functional>
-#include "fmt/core.h"
+
 #include "lua/LuaSources.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <functional>
+#include <sstream>
+#include <string_view>
+#include "fmt/core.h"
 
 namespace Surge
 {
@@ -48,6 +56,8 @@ bool prepareForEvaluation(SurgeStorage *storage, FormulaModulatorStorage *fs, Ev
         {
 #if HAS_LUA
             stateData.audioState = luaL_newstate();
+            if (!stateData.audioState)
+                return false;
             luaL_openlibs((lua_State *)(stateData.audioState));
 #endif
             firstTimeThrough = true;
@@ -65,6 +75,8 @@ bool prepareForEvaluation(SurgeStorage *storage, FormulaModulatorStorage *fs, Ev
         {
 #if HAS_LUA
             stateData.displayState = luaL_newstate();
+            if (!stateData.displayState)
+                return false;
             luaL_openlibs((lua_State *)(stateData.displayState));
 #endif
             firstTimeThrough = true;
@@ -605,6 +617,7 @@ void valueAt(int phaseIntPart, float phaseFracPart, SurgeStorage *storage,
             auto r = lua_tonumber(s->L, -1);
             lua_pop(s->L, 1);
             output[0] = checkFinite(r);
+            onerr.replace = false;
             return;
         }
         if (!lua_istable(s->L, -1))
@@ -875,7 +888,7 @@ std::vector<DebugRow> createDebugDataOfModState(const EvaluatorState &es, std::s
                 }
             };
 
-            for (auto k : ikeys)
+            for (auto &k : ikeys)
             {
                 std::ostringstream oss;
                 oss << "." << k;
@@ -887,7 +900,7 @@ std::vector<DebugRow> createDebugDataOfModState(const EvaluatorState &es, std::s
                 lua_pop(es.L, 1);
             }
 
-            for (auto s : skeys)
+            for (const auto &s : skeys)
             {
                 if (show == SHOW_ALL || (show == SHOW_USER && isUserDefined(s)) ||
                     (show == SHOW_SYSTEM && !isUserDefined(s)))
@@ -946,7 +959,7 @@ std::vector<DebugRow> createDebugDataOfModState(const EvaluatorState &es, std::s
     // filtering
     if (filter != "")
     {
-        for (int i = 0; i < rows.size(); i++)
+        for (size_t i = 0; i < rows.size(); i++)
         {
             auto search = rows[i].label.find(filter, 0);
             if ((search != std::string::npos))
@@ -954,7 +967,7 @@ std::vector<DebugRow> createDebugDataOfModState(const EvaluatorState &es, std::s
                 rows[i].filterFlag = DebugRow::Found;
 
                 // tag all of its children
-                for (int k = i + 1; k < rows.size(); k++)
+                for (size_t k = i + 1; k < rows.size(); k++)
                 {
                     if (rows[k].depth > rows[i].depth)
                         rows[k].filterFlag = DebugRow::Child;
@@ -965,7 +978,7 @@ std::vector<DebugRow> createDebugDataOfModState(const EvaluatorState &es, std::s
             }
         }
 
-        for (int i = rows.size() - 1; i > -1; i--)
+        for (size_t i = rows.size(); i-- > 0;)
         {
 
             if (rows[i].filterFlag == DebugRow::Found)
@@ -978,7 +991,7 @@ std::vector<DebugRow> createDebugDataOfModState(const EvaluatorState &es, std::s
 
                 if (currentDepth > 0)
                 {
-                    for (int k = i - 1; k > -1; k--)
+                    for (size_t k = i; k-- > 0;)
                     {
 
                         if (rows[k].depth < currentDepth)
@@ -997,7 +1010,7 @@ std::vector<DebugRow> createDebugDataOfModState(const EvaluatorState &es, std::s
             }
         }
 
-        for (int i = rows.size() - 1; i > -1; i--)
+        for (size_t i = rows.size(); i-- > 0;)
         {
             if (rows[i].filterFlag != DebugRow::Found && rows[i].filterFlag != DebugRow::Ignore &&
                 rows[i].filterFlag != DebugRow::Child && !rows[i].isHeader)
@@ -1018,7 +1031,7 @@ std::string createDebugViewOfModState(const EvaluatorState &es)
     bool groupState[8] = {true, true, true, true, true, true, true, true};
     auto r = createDebugDataOfModState(es, "", groupState);
     std::ostringstream oss;
-    for (const auto d : r)
+    for (const auto &d : r)
     {
         oss << std::string(d.depth, ' ') << std::string(d.depth, ' ') << d.label << ": ";
         if (!d.hasValue)
@@ -1156,7 +1169,7 @@ std::variant<float, std::string, bool> runOverModStateForTesting(const std::stri
         return res;
     }
 
-    lua_pop(es.L, 1); // Pop evaluator state
+    lua_pop(es.L, 1); // Pop pcall result
 #endif
     return false;
 }

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -26,8 +26,12 @@
 #include "SurgeStorage.h"
 #include "StringOps.h"
 #include "LuaSupport.h"
-#include <variant>
+
+#include <cstdint>
 #include <memory>
+#include <string>
+#include <variant>
+#include <vector>
 
 class SurgeVoice;
 
@@ -166,4 +170,4 @@ void createInitFormula(FormulaModulatorStorage *fs);
 
 } // namespace Formula
 } // namespace Surge
-#endif // SURGE_XT_FORMULAMODULATIONHELPER_H
+#endif // SURGE_SRC_COMMON_DSP_MODULATORS_FORMULAMODULATIONHELPER_H

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -51,7 +51,7 @@ SurgeStorage::AudioFileInput loadAudioFile(std::string file)
     juce::AudioFormatManager manager;
     manager.registerBasicFormats();
 
-    auto reader = manager.createReaderFor(juce::File(file));
+    std::unique_ptr<juce::AudioFormatReader> reader{manager.createReaderFor(juce::File(file))};
     if (!reader)
         return {};
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -55,9 +55,6 @@
 #include <bitset>
 #include "UndoManager.h"
 
-// Change this to 0 to disable WTSE component, to disable for release: change value, test, and push
-#define HAS_LUA 1
-
 class SurgeSynthEditor;
 
 #if SURGE_INCLUDE_MELATONIN_INSPECTOR

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -55,6 +55,9 @@
 #include <bitset>
 #include "UndoManager.h"
 
+// TODO: Remove this once ARM64EC build gates this correctly
+#define HAS_LUA 1
+
 class SurgeSynthEditor;
 
 #if SURGE_INCLUDE_MELATONIN_INSPECTOR

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -55,9 +55,6 @@
 #include <bitset>
 #include "UndoManager.h"
 
-// TODO: Remove this once ARM64EC build gates this correctly
-#define HAS_LUA 1
-
 class SurgeSynthEditor;
 
 #if SURGE_INCLUDE_MELATONIN_INSPECTOR

--- a/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
+++ b/src/surge-xt/gui/SurgeGUIEditorKeyboardActions.h
@@ -154,8 +154,10 @@ inline std::string keyboardActionName(KeyboardActions a)
         return "SHOW_KEYBINDINGS_EDITOR";
     case TOGGLE_LFO_EDITOR:
         return "SHOW_LFO_EDITOR";
+#if HAS_LUA
     case TOGGLE_WTS_EDITOR:
         return "SHOW_WTS_EDITOR";
+#endif
     case TOGGLE_MODLIST:
         return "SHOW_MODLIST";
     case TOGGLE_TUNING_EDITOR:

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -26,6 +26,7 @@
 #include "RuntimeFont.h"
 #include "SkinColors.h"
 #include "SkinSupport.h"
+#include "StringOps.h"
 #include "SurgeImage.h"
 #include "SurgeImageStore.h"
 #include "SurgeJUCEHelpers.h"
@@ -2817,7 +2818,8 @@ void FormulaModulatorEditor::applyCode()
     updateDebuggerIfNeeded();
     editor->repaintFrame();
     setApplyEnabled(false);
-    mainEditor->grabKeyboardFocus();
+    if (mainEditor->isShowing())
+        mainEditor->grabKeyboardFocus();
 
     if (debugPanel->isOpen)
         debugPanel->initializeLfoDebugger();
@@ -3881,7 +3883,8 @@ void WavetableScriptEditor::applyCode()
     rerenderFromUIState();
     editor->repaintFrame();
     setApplyEnabled(false);
-    mainEditor->grabKeyboardFocus();
+    if (mainEditor->isShowing())
+        mainEditor->grabKeyboardFocus();
 
     repaint();
 }

--- a/src/surge-xt/gui/overlays/LuaEditors.h
+++ b/src/surge-xt/gui/overlays/LuaEditors.h
@@ -169,7 +169,7 @@ class CodeEditorSearch : public TextfieldPopup
     int result[512] = {0};
     int resultCurrent = 0;
     int resultTotal = 0;
-    bool saveCaretStartPositionLock;
+    bool saveCaretStartPositionLock = false;
     juce::String latestSearch;
     juce::CodeDocument::Position startCaretPosition;
 

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
@@ -480,7 +480,7 @@ struct ConvolutionButton : public juce::Component
         if (!sge)
             return;
 
-        juce::String fileTypes = "*.aif,*.aiff,*.flac,*.wav";
+        juce::String fileTypes = "*.aif;*.aiff;*.flac;*.wav";
         sge->fileChooser = std::make_unique<juce::FileChooser>(
             "Select Impulse Response to Load", juce::File(path_to_string(path)), fileTypes);
         auto action = [this, path](const juce::FileChooser &c) {
@@ -516,7 +516,7 @@ struct ConvolutionButton : public juce::Component
         manager.registerBasicFormats();
 
         juce::File f(file);
-        auto reader = manager.createReaderFor(f);
+        std::unique_ptr<juce::AudioFormatReader> reader{manager.createReaderFor(f)};
         if (!reader)
             return false;
         if (reader->numChannels != 1 && reader->numChannels != 2)

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -636,8 +636,10 @@ void OscillatorWaveformDisplay::populateMenu(juce::PopupMenu &contextMenu, int s
     refreshWavetablesMenu(contextMenu);
     contextMenu.addSeparator();
 
+#if HAS_LUA
     createOpenScriptEditorMenu(contextMenu);
     contextMenu.addSeparator();
+#endif
 
     createWTMenuItems(contextMenu);
 }
@@ -771,6 +773,7 @@ void OscillatorWaveformDisplay::createWTRenameMenu(juce::PopupMenu &contextMenu)
 
 void OscillatorWaveformDisplay::createOpenScriptEditorMenu(juce::PopupMenu &contextMenu)
 {
+#if HAS_LUA
     auto owts = [this]() {
         if (sge)
             sge->showOverlay(SurgeGUIEditor::WTS_EDITOR);
@@ -781,6 +784,7 @@ void OscillatorWaveformDisplay::createOpenScriptEditorMenu(juce::PopupMenu &cont
         sge->getShortcutDescription(Surge::GUI::KeyboardActions::TOGGLE_WTS_EDITOR), owts);
 
     contextMenu.addSeparator();
+#endif
 }
 
 void OscillatorWaveformDisplay::refreshWavetablesMenu(juce::PopupMenu &contextMenu)


### PR DESCRIPTION
Some stuff that was still on my list, came up recently with gdb Asan / MSVC debugger or was flagged by Claude:

Convolution:
- Free AudioFormatReader after loading Convolution IR (fixes LeakedObjectDetector tripping on exit)
- Use semicolons for Convolution filepicker extension list

LuaSupport:
- Pass functions to parseStringDefiningMultipleFunctions by `const &`, avoiding a copy
- Pop Lua error messages in `loadSurgePrelude`
- Drop unused `SurgeSharedBinary.h`, `basic_dsp.h`, `luajit.h`, and `lj_arch.h` includes

LuaEditors:
- Fix focus assertion when applying/generating from the Prelude tab
- Initialize `saveCaretStartPositionLock`

FormulaModulationHelper:
- Fix `process()` returning a bare number (instead of a table) being silently replaced by the error fallback after the first call
- Handle `luaL_newstate()` returning null (due to lack of memory) by bailing out of `prepareForEvaluation`
- Avoid making some copies in the debugger iteration loops by using `const auto &`
- Avoid sign mismatch warnings in the debugger loops by switching to `size_t`
- Drop unused `<thread>` and add direct includes

WavetableScriptEvaluator:
- Avoid sign mismatch warnings
- Drop unused `StringOps.h` and add direct includes
