### PR TITLE
Add use_amplitude flag to Formula

### DIFF
--- a/src/common/dsp/modulators/FormulaModulationHelper.cpp
+++ b/src/common/dsp/modulators/FormulaModulationHelper.cpp
@@ -276,6 +276,7 @@ end
             addb("is_voice", s.isVoice);
             addb("is_rendering_to_ui", s.is_display);
             addb("clamp_output", true);
+            addb("use_amplitude", true);
             addb("use_envelope", true);
             addb("retrigger_AEG", false);
             addb("retrigger_FEG", false);
@@ -324,6 +325,7 @@ end
         // the modulator state which is now bound to the state name
         lua_settop(s.L, 0); // Clear all elements from the stack
 
+        s.useAmplitude = true;
         s.useEnvelope = true;
 
         {
@@ -337,6 +339,21 @@ end
             }
             else
             {
+                {
+                    // read off the amplitude control
+                    auto ga = Surge::LuaSupport::SGLD("prepareForEvaluation::amplituderead", s.L);
+                    lua_getfield(s.L, -1, "use_amplitude");
+                    if (lua_isboolean(s.L, -1))
+                    {
+                        s.useAmplitude = lua_toboolean(s.L, -1);
+                    }
+                    else if (lua_isnumber(s.L, -1))
+                    {
+                        s.useAmplitude = (lua_tonumber(s.L, -1) != 0.0);
+                    }
+
+                    lua_pop(s.L, 1); // Pop use_amplitude
+                }
                 {
                     // read off the envelope control
                     auto gv = Surge::LuaSupport::SGLD("prepareForEvaluation::enveloperead", s.L);
@@ -711,6 +728,7 @@ void valueAt(int phaseIntPart, float phaseFracPart, SurgeStorage *storage,
             return res;
         };
 
+        s->useAmplitude = getBoolOrNumberDefault("use_amplitude", true);
         s->useEnvelope = getBoolOrNumberDefault("use_envelope", true);
         s->retrigger_AEG = getBoolOrNumberDefault("retrigger_AEG", false);
         s->retrigger_FEG = getBoolOrNumberDefault("retrigger_FEG", false);
@@ -754,7 +772,7 @@ enum showFilter
 
 bool isUserDefined(std::string str)
 {
-    static constexpr std::array<std::string_view, 55> keywords = {
+    static constexpr std::array<std::string_view, 56> keywords = {
         "amplitude",     "attack",        "block_size",
         "cc_breath",     "cc_expr",       "cc_mw",
         "cc_sus",        "chan_at",       "channel",
@@ -771,9 +789,9 @@ bool isUserDefined(std::string str)
         "released",      "retrigger_AEG", "retrigger_FEG",
         "samplerate",    "scene_mode",    "songpos",
         "split_point",   "startphase",    "sustain",
-        "tempo",         "tuned_key",     "use_envelope",
-        "velocity",      "voice_count",   "voice_id",
-        "subscriptions"};
+        "tempo",         "tuned_key",     "use_amplitude",
+        "use_envelope",  "velocity",      "voice_count",
+        "voice_id",      "subscriptions"};
 
     auto foundInList = std::find(keywords.begin(), keywords.end(), str) != keywords.end();
     // std::cout << "isCustom " << str << " = " << foundInList << "\n";

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -59,6 +59,7 @@ struct EvaluatorState
     char stateName[TXT_SIZE];
 
     bool isvalid = false;
+    bool useAmplitude = true;
     bool useEnvelope = true;
     bool isFinite = true;
 

--- a/src/common/dsp/modulators/LFOModulationSource.cpp
+++ b/src/common/dsp/modulators/LFOModulationSource.cpp
@@ -1238,6 +1238,10 @@ void LFOModulationSource::process_block()
         // Since I'm (right now) the only vector valued modulator just do a little
         // chute and ladder dance here on the output and return
         auto magnf = limit_range(lfo->magnitude.get_extended(localcopy[magn].f), -3.f, 3.f);
+        if (!formulastate.useAmplitude)
+        {
+            magnf = 1.f;
+        }
         auto uni = lfo->unipolar.val.b;
 
         for (auto i = 0; i < formulastate.activeoutputs; ++i)

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -606,7 +606,9 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
         populateLFOMS(tFullWave);
         tFullWave->attack();
     }
-    else if (lfodata->magnitude.val.f != lfodata->magnitude.val_max.f && skin->getVersion() >= 2)
+    else if (lfodata->magnitude.val.f != lfodata->magnitude.val_max.f &&
+             !(lfodata->shape.val.i == lt_formula && !tlfo->formulastate.useAmplitude) &&
+             skin->getVersion() >= 2)
     {
         bool useAmpWave = Surge::Storage::getUserDefaultValue(
             storage, Surge::Storage::ShowGhostedLFOWaveReference, 1);
@@ -728,7 +730,12 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
 
             minval = std::min(tlfo->get_output(modIndex), minval);
             maxval = std::max(tlfo->get_output(modIndex), maxval);
-            eval += tlfo->env_val * lfodata->magnitude.get_extended(lfodata->magnitude.val.f);
+            float evalMag = lfodata->magnitude.get_extended(lfodata->magnitude.val.f);
+            if (lfodata->shape.val.i == lt_formula && !tlfo->formulastate.useAmplitude)
+            {
+                evalMag = 1.f;
+            }
+            eval += tlfo->env_val * evalMag;
         }
 
         val = val / averagingWindow;
@@ -1384,7 +1391,12 @@ void LFOAndStepDisplay::paintStepSeq(juce::Graphics &g)
 
             minval = std::min(tlfo->get_output(0), minval);
             maxval = std::max(tlfo->get_output(0), maxval);
-            eval += tlfo->env_val * lfodata->magnitude.get_extended(lfodata->magnitude.val.f);
+            float evalMag = lfodata->magnitude.get_extended(lfodata->magnitude.val.f);
+            if (lfodata->shape.val.i == lt_formula && !tlfo->formulastate.useAmplitude)
+            {
+                evalMag = 1.f;
+            }
+            eval += tlfo->env_val * evalMag;
         }
 
         val = val / averagingWindow;


### PR DESCRIPTION
The LFO amplitude slider is already one of the modulatable inputs for Formula. It's probably the one that makes most sense to use as a primary input for scripts because of its name and being the only slider that has a (functional) extend range option, but it's currently not that useful since it sets the output. This change makes it so that the shaping can be disabled with `use_amplitude` just like the `use_envelope` bool does for the EG.