### PR TITLE
Extend range option tweaks

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2196,6 +2196,10 @@ void Parameter::set_extend_range(bool er)
             {
                 val.f = val_min.f;
             }
+            else if (val.f > val_max.f)
+            {
+                val.f = val_max.f;
+            }
 
             displayType = LinearWithScale;
             snprintf(displayInfo.unit, DISPLAYINFO_TXT_SIZE, "semitones");
@@ -2207,29 +2211,58 @@ void Parameter::set_extend_range(bool er)
         case ct_freq_audible_fm3_extendable:
         {
             val_min.f = -60; // 13.75 Hz
+
+            if (val.f < val_min.f)
+            {
+                val.f = val_min.f;
+            }
         }
         break;
         case ct_freq_reson_band1:
         {
             // Why the heck are we modifying this here?
             val_max.f = -6.6305f; // 300 Hz
+
+            if (val.f > val_max.f)
+            {
+                val.f = val_max.f;
+            }
         }
         break;
         case ct_freq_reson_band2:
         {
             val_min.f = -6.6305f;  // 300 Hz
             val_max.f = 21.23265f; // 1500 Hz
+
+            if (val.f < val_min.f)
+            {
+                val.f = val_min.f;
+            }
+            else if (val.f > val_max.f)
+            {
+                val.f = val_max.f;
+            }
         }
         break;
         case ct_freq_reson_band3:
         {
             val_min.f = 21.23265f; // 1500 Hz
+
+            if (val.f < val_min.f)
+            {
+                val.f = val_min.f;
+            }
         }
         break;
         case ct_dly_fb_clippingmodes:
         case ct_lfoamplitude:
         {
             val_min.f = 0.f;
+
+            if (val.f < val_min.f)
+            {
+                val.f = val_min.f;
+            }
         }
         break;
         case ct_lfophaseshuffle:

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -5115,6 +5115,16 @@ void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)
         undoManager()->pushParameterChange(
             id, &(synth->storage.getPatch().scene[current_scene].lfo[lfoid].shape), pd);
         synth->storage.getPatch().isDirty = true;
+
+        // Clear phase extend range when leaving step sequencer
+        if (prior == lt_stepseq && curr != lt_stepseq)
+        {
+            auto &phase = synth->storage.getPatch().scene[current_scene].lfo[lfoid].start_phase;
+            if (phase.extend_range)
+            {
+                phase.set_extend_range(false);
+            }
+        }
     }
 
     bool needs_refresh{false};

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2775,6 +2775,13 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         case ct_countedset_percent_extendable_wtdeform:
                             txt = "Continuous Morph";
                             break;
+                        case ct_lfophaseshuffle:
+                        {
+                            auto cge = p->ctrlgroup_entry - ms_lfo1;
+                            auto lf = &(synth->storage.getPatch().scene[p->scene - 1].lfo[cge]);
+                            visible = lf->shape.val.i == lt_stepseq;
+                            break;
+                        }
                         default:
                             break;
                         }


### PR DESCRIPTION
- The LFO Phase's extend range is only used for the step sequencer's shuffle so hide the menu option for other LFO types
- Clear the Phase extend option when leaving the step sequencer
- Clamp `val.f` when disabling the extend range option on these params: `ct_pitch_extendable_very_low_minval`, `ct_freq_audible_fm3_extendable`, `ct_freq_reson_band1-3`, `ct_lfoamplitude` and `ct_dly_fb_clippingmodes`

Assisted-by: Claude Opus 4.7