### PR TITLE
Refresh derived paths and rescan data when user data folder changes

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -353,41 +353,12 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     }
 #endif
 
-    try
-    {
-        userDataPathValid = false;
-        if (fs::is_directory(userDataPath))
-        {
-            userDataPathValid = true;
-            /*
-             * This code doesn't work because fs:: doesn't have a writable check and I don't
-             * want to create a file just to see in every startup path. We find out later
-             * anyway when we set up the directories.
-             */
-        }
-    }
-    catch (const fs::filesystem_error &e)
-    {
-        userDataPathValid = false;
-    }
-
-    userDefaultFilePath = userDataPath;
+    initializeUserDataPaths();
 
     userDefaultsProvider = std::make_unique<Surge::Storage::UserDefaultsProvider>(
         userDataPath, "SurgeXT", Surge::Storage::defaultKeyToString,
         [this](auto &a, auto &b) { reportError(a, b); });
 
-    // append separator if not present
-    userPatchesPath = userDataPath / "Patches";
-    userPatchesMidiProgramChangePath = userPatchesPath / midiProgramChangePatchesSubdir;
-    userWavetablesPath = userDataPath / "Wavetables";
-    userIRsPath = userDataPath / "Impulses";
-    userWavetablesExportPath = userWavetablesPath / "Exported";
-    userWavetableScriptsPath = userWavetablesPath / "Scripted";
-    userFXPath = userDataPath / "FX Presets";
-    userMidiMappingsPath = userDataPath / "MIDI Mappings";
-    userModulatorSettingsPath = userDataPath / "Modulator Presets";
-    userSkinsPath = userDataPath / "Skins";
     extraThirdPartyWavetablesPath = config.extraThirdPartyWavetablesPath;
     extraUserWavetablesPath = config.extraUsersWavetablesPath;
 
@@ -603,6 +574,40 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     memoryPools = std::make_unique<Surge::Memory::SurgeMemoryPools>(this);
 }
 
+void SurgeStorage::initializeUserDataPaths()
+{
+    try
+    {
+        userDataPathValid = false;
+        if (fs::is_directory(userDataPath))
+        {
+            userDataPathValid = true;
+            /*
+             * This code doesn't work because fs:: doesn't have a writable check and I don't
+             * want to create a file just to see in every startup path. We find out later
+             * anyway when we set up the directories.
+             */
+        }
+    }
+    catch (const fs::filesystem_error &e)
+    {
+        userDataPathValid = false;
+    }
+
+    userDefaultFilePath = userDataPath;
+
+    userPatchesPath = userDataPath / "Patches";
+    userPatchesMidiProgramChangePath = userPatchesPath / midiProgramChangePatchesSubdir;
+    userWavetablesPath = userDataPath / "Wavetables";
+    userIRsPath = userDataPath / "Impulses";
+    userWavetablesExportPath = userWavetablesPath / "Exported";
+    userWavetableScriptsPath = userWavetablesPath / "Scripted";
+    userFXPath = userDataPath / "FX Presets";
+    userMidiMappingsPath = userDataPath / "MIDI Mappings";
+    userModulatorSettingsPath = userDataPath / "Modulator Presets";
+    userSkinsPath = userDataPath / "Skins";
+}
+
 void SurgeStorage::createUserDirectory()
 {
     auto p = userDataPath;
@@ -675,47 +680,65 @@ fs::path SurgeStorage::calculateStandardUserDataPath(const std::string &sxt) con
     return res;
 }
 
-fs::path SurgeStorage::getOverridenUserPath() const
+fs::path SurgeStorage::getOverridenUserPath()
 {
     // Read the user data path override from surgeUserDirectoryLocation.xml
     auto overrideFile = localAppDataPath / "surgeUserDirectoryLocation.xml";
 
     if (!fs::exists(overrideFile))
     {
-        return {}; // Return empty path if file doesn't exist
+        return {}; // No override configured
     }
+
+    auto reportMalformed = [this, &overrideFile](const std::string &detail) {
+        reportError("The custom user data folder configuration file at\n" +
+                        path_to_string(overrideFile) + "\nis malformed (" + detail +
+                        "). Falling back to the default user data folder. Use "
+                        "\"Set Custom User Data Folder...\" to reconfigure.",
+                    "Custom User Data Folder Configuration Invalid");
+    };
 
     try
     {
         TiXmlDocument doc;
         if (!doc.LoadFile(path_to_string(overrideFile)))
         {
+            reportMalformed("XML parse error");
             return {};
         }
 
         auto root = doc.FirstChildElement("surge-user-directory");
         if (!root)
         {
+            reportMalformed("missing root element");
             return {};
         }
 
         auto pathElement = root->FirstChildElement("path");
         if (!pathElement || !pathElement->GetText())
         {
+            reportMalformed("missing path element");
             return {};
         }
 
         fs::path userPath{pathElement->GetText()};
 
-        // Verify the path exists before returning it
         if (fs::exists(userPath) && fs::is_directory(userPath))
         {
             return userPath;
         }
+
+        reportError("The configured custom user data folder\n" + path_to_string(userPath) +
+                        "\nno longer exists or is not a directory. Falling back to the default "
+                        "user data folder. Use \"Set Custom User Data Folder...\" to set a "
+                        "new location.",
+                    "Custom User Data Folder Missing");
     }
-    catch (...)
+    catch (const std::exception &e)
     {
-        // If anything goes wrong, return empty path
+        reportError(std::string("Error reading custom user data folder configuration: ") +
+                        e.what() + ". Falling back to the default user data folder.",
+                    "Custom User Data Folder Configuration Error");
     }
 
     return {};

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1594,9 +1594,15 @@ class alignas(16) SurgeStorage
     bool getOverrideDataHome(std::string &value);
     void createUserDirectory();
 
+    // Recompute userDataPathValid, userDefaultFilePath and all userDataPath-derived
+    // sub-paths (Patches, Wavetables, Skins, etc) from the current userDataPath.
+    // Call after any change to userDataPath.
+    void initializeUserDataPaths();
+
     // Methods for handling user data path override stored in a separate file
-    // This returns path.empty() if there's no override
-    fs::path getOverridenUserPath() const;
+    // This returns path.empty() if there's no override, or if the configured
+    // override is invalid (in which case an error is also reported).
+    fs::path getOverridenUserPath();
     void setOverridenUserPath(const fs::path *path);
 
     fs::path resolvePathTokens(fs::path path);

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -3588,6 +3588,40 @@ void SurgeGUIEditor::setupSkinFromEntry(const Surge::GUI::SkinDB::Entry &entry)
     reloadFromSkin();
 }
 
+void SurgeGUIEditor::rescanAllDataFolders()
+{
+    auto &storage = this->synth->storage;
+
+    storage.refresh_wtlist();
+    storage.refresh_patchlist();
+    storage.refresh_irlist();
+    storage.rescanUserMidiMappings();
+
+    if (storage.fxUserPreset)
+        storage.fxUserPreset->doPresetRescan(&storage, true);
+    if (storage.modulatorPreset)
+        storage.modulatorPreset->forcePresetRescan();
+
+    // Force a rescan of MIDI program-change patch folder on next menu open
+    scannedForMidiPresets = false;
+
+    // Rescan skins and reapply the currently selected one
+    auto r = this->currentSkin->root;
+    auto n = this->currentSkin->name;
+
+    auto *db = Surge::GUI::SkinDB::get();
+    db->rescanForSkins(&storage);
+
+    auto e = db->getEntryByRootAndName(r, n);
+    if (e.has_value())
+        setupSkinFromEntry(*e);
+    else
+        setupSkinFromEntry(db->getDefaultSkinEntry());
+
+    // Rebuild the FX menu and other UI that depends on the rescans
+    this->synth->refresh_editor = true;
+}
+
 void SurgeGUIEditor::sliderHoverStart(int tag)
 {
     int ptag = tag - start_paramtags;

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -964,6 +964,14 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
   private:
     void setupSkinFromEntry(const Surge::GUI::SkinDB::Entry &entry);
     void reloadFromSkin();
+
+  public:
+    // Re-scan every user-data folder (patches, wavetables, IRs, FX, modulator
+    // presets, MIDI mappings, skins) and reapply the current skin. Use after
+    // changing the user data folder or when the user asks for a manual rescan.
+    void rescanAllDataFolders();
+
+  private:
     Surge::GUI::IComponentTagValue *
     layoutComponentForSkin(std::shared_ptr<Surge::GUI::Skin::Control> skinCtrl, long tag,
                            int paramIndex = -1, Parameter *p = nullptr, int style = 0);

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -1732,45 +1732,17 @@ juce::PopupMenu SurgeGUIEditor::makeDataMenu(const juce::Point<int> &where)
                                      this->synth->storage.setOverridenUserPath(&newPath);
 
                                      this->synth->storage.userDataPath = s;
+                                     this->synth->storage.initializeUserDataPaths();
                                      synth->storage.createUserDirectory();
 
-                                     this->synth->storage.refresh_wtlist();
-                                     this->synth->storage.refresh_patchlist();
+                                     this->rescanAllDataFolders();
                                  });
     });
 
     dataSubMenu.addSeparator();
 
-    dataSubMenu.addItem(Surge::GUI::toOSCase("Rescan All Data Folders"), [this]() {
-        this->synth->storage.refresh_wtlist();
-        this->synth->storage.refresh_patchlist();
-        this->scannedForMidiPresets = false;
-
-        this->synth->storage.fxUserPreset->doPresetRescan(&(this->synth->storage), true);
-        this->synth->storage.modulatorPreset->forcePresetRescan();
-
-        // Rescan for skins
-        auto r = this->currentSkin->root;
-        auto n = this->currentSkin->name;
-
-        auto *db = Surge::GUI::SkinDB::get();
-        db->rescanForSkins(&(this->synth->storage));
-
-        // So go find the skin
-        auto e = db->getEntryByRootAndName(r, n);
-
-        if (e.has_value())
-        {
-            setupSkinFromEntry(*e);
-        }
-        else
-        {
-            setupSkinFromEntry(db->getDefaultSkinEntry());
-        }
-
-        // Will need to rebuild the FX menu also so...
-        this->synth->refresh_editor = true;
-    });
+    dataSubMenu.addItem(Surge::GUI::toOSCase("Rescan All Data Folders"),
+                        [this]() { this->rescanAllDataFolders(); });
 
     return dataSubMenu;
 }


### PR DESCRIPTION
Setting a custom user data folder only updated userDataPath; the derived sub-paths (Skins, Wavetables, IRs, etc.) kept pointing at the old default, so menus like "Install a New Skin..." and "Load wavetable from file" opened the wrong folder and createUserDirectory rebuilt the default tree on disk.

Also do a full rescan (patches, wavetables, IRs, FX, modulator presets, MIDI mappings, skins) on both "Set Custom User Data Folder..." and "Rescan All Data Folders", and surface a reportError when the configured override path is missing or the override XML is malformed instead of silently falling back.

Closes #8334

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>