### PR TITLE
Turn off SuperCell again

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -10,7 +10,7 @@ surge_add_lib_subdirectory(airwindows)
 surge_add_lib_subdirectory(binn)
 
 # Toggle this to false to turn on superparasites for surge
-set(EURORACK_CLOUDS_IS_CLOUDS FALSE)
+set(EURORACK_CLOUDS_IS_CLOUDS TRUE)
 surge_add_lib_subdirectory(eurorack)
 surge_add_lib_subdirectory(pffft)
 surge_add_lib_subdirectory(fmt)


### PR DESCRIPTION
Ooops! Didn't mean to leave it on

But while doing so, also fix a problem with nimbus setup which causes supercell to crash even on the working modes