### PR TITLE
Fix a problem with menu zoom

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -146,6 +146,11 @@ float SurgeVirtualKeyboard::getCurrentVelocity() const { return editor->midiKeyb
 SurgeSynthEditor::SurgeSynthEditor(SurgeSynthProcessor &p)
     : juce::AudioProcessorEditor(&p), processor(p)
 {
+    // Marks this editor as the popup-scale anchor for the SURGE PATCH in
+    // juce_TextEditor.cpp so TextEditor right-click menus inherit only the
+    // host scale factor and not the UI zoom transform applied to frame.
+    getProperties().set("SSTPopupAnchor", true);
+
     {
         std::lock_guard<std::mutex> grd(surgeLookAndFeelSetupMutex);
         if (auto sp = surgeLookAndFeelWeakPointer.lock())


### PR DESCRIPTION
Juce 8.0.12 parents sub-component menus to 'this' which means our surge strategy or parent components to the editor to avoid picking up intermediate zooms and just get UI zooms blew up specifically on TextEditor

Address with a pretty hokey tag and find strategy and a jcue patch. Sigh

Closes #8319