### PR TITLE
Use string_to_path consistently in a few user-facing spots

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -3494,7 +3494,7 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("lastLoadedPath"));
             if (p && p->Attribute("v"))
             {
-                dawExtraState.lastLoadedPatch = fs::path{p->Attribute("v")};
+                dawExtraState.lastLoadedPatch = string_to_path(p->Attribute("v"));
             }
 
             p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("disconnectFromOddSoundMTS"));

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2893,7 +2893,7 @@ void SurgeGUIEditor::wtscriptFileDropped(const string &fn)
 
     OscillatorStorage *oscdata =
         &synth->storage.getPatch().scene[current_scene].osc[current_osc[current_scene]];
-    evaluator->loadWtscript(fs::path(fn), &synth->storage, oscdata);
+    evaluator->loadWtscript(string_to_path(fn), &synth->storage, oscdata);
 
     oscdata->wt.current_id = -1;
     oscdata->queue_type = ot_wavetable; // Setting queue_type also handles OWD/editor refresh
@@ -6770,7 +6770,7 @@ void SurgeGUIEditor::loadWavetableScript()
 
             if (res.hasFileExtension(".wtscript"))
             {
-                loadWavetableScript(-1, fs::path(rString), &this->synth->storage, &oscdata);
+                loadWavetableScript(-1, string_to_path(rString), &this->synth->storage, &oscdata);
             }
 
             auto dir = string_to_path(res.getParentDirectory().getFullPathName().toStdString());

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -1344,7 +1344,7 @@ void OscillatorWaveformDisplay::loadWavetableFromFile()
 
             if (res.hasFileExtension(".wtscript"))
             {
-                this->sge->loadWavetableScript(-1, fs::path(rString), storage, oscdata);
+                this->sge->loadWavetableScript(-1, string_to_path(rString), storage, oscdata);
             }
             else
             {


### PR DESCRIPTION
When users provide information as utf8 make sure to use the rigth string_to_path to avoid windows japanese explosions and the like.

Closes #8165

Assisted-By: Claude Opus 4.7