### PR TITLE
String Oscillator in Scene B gets Scene A as an exciter

### DIFF
--- a/src/common/dsp/oscillators/StringOscillator.cpp
+++ b/src/common/dsp/oscillators/StringOscillator.cpp
@@ -46,7 +46,7 @@
 #include "StringOscillator.h"
 #include "SurgeMemoryPools.h"
 
-int stringosc_excitations_count() { return 15; }
+int stringosc_excitations_count() { return 16; }
 
 std::string stringosc_excitation_name(int i)
 {
@@ -84,12 +84,30 @@ std::string stringosc_excitation_name(int i)
         return "Constant Sweep";
     case StringOscillator::constant_audioin:
         return "Audio In";
+    case StringOscillator::constant_scene_a_in:
+        return "Scene A In";
     }
     return "Unknown";
 }
 
+StringOscillator::StringOscillator(SurgeStorage *s, OscillatorStorage *o, pdata *p)
+    : Oscillator(s, o, p), charFilt(s), lp(s), hp(s), noiseLp(s), halfband(6, true)
+{
+    if (s)
+    {
+        for (int i = 0; i < n_oscs; ++i)
+            if (&(s->getPatch().scene[1].osc[i]) == o)
+                isInSceneB = true;
+        if (isInSceneB)
+            s->otherscene_clients++;
+    }
+}
+
 StringOscillator::~StringOscillator()
 {
+    if (isInSceneB && storage)
+        storage->otherscene_clients--;
+
     if (storage && !ownDelayLines)
     {
         if (delayLine[0])
@@ -331,6 +349,7 @@ void StringOscillator::init(float pitch, bool is_display, bool nzi)
         break;
 
         case constant_audioin:
+        case constant_scene_a_in:
             dlv[0] = (0);
             dlv[1] = (0);
             break;
@@ -521,6 +540,7 @@ void StringOscillator::process_block(float pitch, float drift, bool stereo, bool
         P(constant_sweep)
 
         P(constant_audioin)
+        P(constant_scene_a_in)
     }
 
 #undef P
@@ -793,6 +813,15 @@ void StringOscillator::process_block_internal(float pitch, float drift, bool ste
                     fbNoOutVal[t] = examp.v * storage->audio_in[t][i / 2];
             }
             break;
+            case constant_scene_a_in:
+            {
+                // only meaningful in scene B; scene A osc menu hides this entry
+                if (OS == 1)
+                    fbNoOutVal[t] = examp.v * storage->audio_otherscene[t][i];
+                if (OS == 2)
+                    fbNoOutVal[t] = examp.v * storage->audio_otherscene[t][i / 2];
+            }
+            break;
             default:
                 // We should do something else with amplitude here
                 val[t] *= examp.v;
@@ -850,6 +879,15 @@ void StringOscillator::process_block_internal(float pitch, float drift, bool ste
             charFilt.process_block(output, BLOCK_SIZE_OS);
         }
     }
+}
+
+void StringOscillator::init_ctrltypes(int scene, int oscnum)
+{
+    init_ctrltypes();
+
+    // Scene A In is only valid in scene B; trim the menu range in scene A
+    if (scene != 1)
+        oscdata->p[str_exciter_mode].val_max.i = constant_audioin;
 }
 
 void StringOscillator::init_ctrltypes()

--- a/src/common/dsp/oscillators/StringOscillator.h
+++ b/src/common/dsp/oscillators/StringOscillator.h
@@ -63,6 +63,7 @@ class StringOscillator : public Oscillator
         constant_square,
         constant_sweep,
         constant_audioin,
+        constant_scene_a_in,
     };
 
     // This coordinates with the UI code in SGE::controlModClicked around
@@ -86,16 +87,15 @@ class StringOscillator : public Oscillator
 
     static constexpr int max_oversample = 2;
 
-    StringOscillator(SurgeStorage *s, OscillatorStorage *o, pdata *p)
-        : Oscillator(s, o, p), charFilt(s), lp(s), hp(s), noiseLp(s), halfband(6, true)
-    {
-    }
+    StringOscillator(SurgeStorage *s, OscillatorStorage *o, pdata *p);
 
     ~StringOscillator();
 
     virtual void init(float pitch, bool is_display = false, bool nonzero_drift = true) override;
-    virtual void init_ctrltypes(int scene, int oscnum) override { init_ctrltypes(); };
+    virtual void init_ctrltypes(int scene, int oscnum) override;
     virtual void init_ctrltypes() override;
+
+    bool isInSceneB{false};
     virtual void init_default_values() override;
     virtual void process_block(float pitch, float drift = 0.f, bool stereo = false, bool FM = false,
                                float FMdepth = 0.f) override;

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -421,8 +421,10 @@ void OscillatorWaveformDisplay::paint(juce::Graphics &g)
         auto osctype = oscdata->type.val.i;
 
         if (osctype == ot_audioinput ||
-            (osctype == ot_string && oscdata->p[StringOscillator::str_exciter_mode].val.i ==
-                                         StringOscillator::constant_audioin) ||
+            (osctype == ot_string && (oscdata->p[StringOscillator::str_exciter_mode].val.i ==
+                                          StringOscillator::constant_audioin ||
+                                      oscdata->p[StringOscillator::str_exciter_mode].val.i ==
+                                          StringOscillator::constant_scene_a_in)) ||
             (osctype == ot_alias &&
              oscdata->p[AliasOscillator::ao_wave].val.i == AliasOscillator::aow_audiobuffer))
         {


### PR DESCRIPTION
Basically exactly following the pattern for Audio-In, add scene A as an exciter source for scene b and only scene b string oscillators.

Closes #8383
Assisted-By: Claude Opus 4.7