### PR TITLE
OSC: support multiple Surge instances on the same machine

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -3451,6 +3451,14 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 storage->oscPortIn = ival;
             }
 
+            p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("oscPortInLastBound"));
+
+            if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
+            {
+                dawExtraState.oscPortInLastBound = ival;
+                storage->oscPortInLastBound = ival;
+            }
+
             p = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("oscPortOut"));
 
             if (p && p->QueryIntAttribute("v", &ival) == TIXML_SUCCESS)
@@ -4309,6 +4317,10 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         TiXmlElement oscPortIn("oscPortIn");
         oscPortIn.SetAttribute("v", dawExtraState.oscPortIn);
         dawExtraXML.InsertEndChild(oscPortIn);
+
+        TiXmlElement oscPortInLastBound("oscPortInLastBound");
+        oscPortInLastBound.SetAttribute("v", dawExtraState.oscPortInLastBound);
+        dawExtraXML.InsertEndChild(oscPortInLastBound);
 
         TiXmlElement oscPortOut("oscPortOut");
         oscPortOut.SetAttribute("v", dawExtraState.oscPortOut);

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1216,6 +1216,7 @@ struct DAWExtraStateStorage
     bool disconnectFromOddSoundMTS{false};
 
     int oscPortIn{DEFAULT_OSC_PORT_IN};
+    int oscPortInLastBound{0}; // Tracks bound port for restoration, 0 = never bound
     int oscPortOut{DEFAULT_OSC_PORT_OUT};
     std::string oscIPAddrOut{DEFAULT_OSC_IPADDR_OUT};
     bool oscStartIn{false};
@@ -1782,6 +1783,7 @@ class alignas(16) SurgeStorage
     bool mpeEnabled{false};
 
     int oscPortIn{DEFAULT_OSC_PORT_IN};
+    int oscPortInLastBound{0}; // Tracks bound port for restoration, 0 = never bound
     int oscPortOut{DEFAULT_OSC_PORT_OUT};
     std::string oscOutIP{"127.0.0.1"};
     bool oscStartIn{false};

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -5064,6 +5064,7 @@ void SurgeSynthesizer::populateDawExtraState()
     des.isPopulated = true;
 
     des.oscPortIn = storage.oscPortIn;
+    des.oscPortInLastBound = storage.oscPortInLastBound;
     des.oscPortOut = storage.oscPortOut;
     des.oscIPAddrOut = storage.oscOutIP;
     des.oscStartIn = storage.oscStartIn;
@@ -5133,6 +5134,7 @@ void SurgeSynthesizer::loadFromDawExtraState()
     mpeEnabled = des.mpeEnabled;
 
     storage.oscPortIn = des.oscPortIn;
+    storage.oscPortInLastBound = des.oscPortInLastBound;
     storage.oscPortOut = des.oscPortOut;
     storage.oscOutIP = des.oscIPAddrOut;
     storage.oscStartIn = des.oscStartIn;

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -68,6 +68,7 @@ const int N_INPUTS = 2;
 const int DEFAULT_POLYLIMIT = 16;
 
 const int DEFAULT_OSC_PORT_IN = 53280;
-const int DEFAULT_OSC_PORT_OUT = 53281;
+const int DEFAULT_OSC_PORT_OUT = 53270; // Out port outside the range of in ports we try binding to
+const int OSC_IN_PORT_SCAN_RANGE = 100; // Number of ports to try binding to
 const inline std::string DEFAULT_OSC_IPADDR_OUT = "127.0.0.1";
 #endif // SURGE_SRC_COMMON_GLOBALS_H

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -271,7 +271,7 @@ void SurgeSynthProcessor::changeProgramName(int index, const juce::String &newNa
 /* OSC (Open Sound Control) */
 bool SurgeSynthProcessor::initOSCIn(int port)
 {
-    if (port <= 0)
+    if (port < 1 || port > 65535)
     {
         return false;
     }
@@ -286,9 +286,20 @@ bool SurgeSynthProcessor::initOSCIn(int port)
 
 bool SurgeSynthProcessor::changeOSCInPort(int new_port)
 {
-    surge->storage.oscReceiving = false;
+    if (new_port < 1 || new_port > 65535)
+    {
+        return false;
+    }
+
+    surge->storage.oscPortInLastBound = 0;
     oscHandler.stopListening();
-    return initOSCIn(new_port);
+
+    bool status = oscHandler.initOSCInRange(new_port, new_port + OSC_IN_PORT_SCAN_RANGE);
+
+    surge->storage.oscReceiving = status;
+    surge->storage.oscStartIn = true;
+
+    return status;
 }
 
 bool SurgeSynthProcessor::initOSCOut(int port, std::string ipaddr)

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -336,7 +336,7 @@ std::unique_ptr<Surge::Overlays::OverlayComponent> SurgeGUIEditor::createOverlay
         te->setEnclosingParentTitle("Open Sound Control Settings");
 
         auto posRect =
-            juce::Rectangle<int>(0, 0, 300, 140).withCentre(frame->getBounds().getCentre());
+            juce::Rectangle<int>(0, 0, 315, 145).withCentre(frame->getBounds().getCentre());
 
         te->setEnclosingParentPosition(posRect);
 

--- a/src/surge-xt/gui/overlays/OpenSoundControlSettings.cpp
+++ b/src/surge-xt/gui/overlays/OpenSoundControlSettings.cpp
@@ -37,6 +37,33 @@ namespace Surge
 namespace Overlays
 {
 
+namespace
+{
+class StatusLabel : public juce::Label
+{
+  public:
+    using juce::Label::Label;
+
+  protected:
+    std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override
+    {
+        class Handler : public juce::AccessibilityHandler
+        {
+          public:
+            explicit Handler(juce::Label &l)
+                : juce::AccessibilityHandler(l, juce::AccessibilityRole::staticText), label(l)
+            {
+            }
+            juce::String getTitle() const override { return label.getText(); }
+
+          private:
+            juce::Label &label;
+        };
+        return std::make_unique<Handler>(*this);
+    }
+};
+} // namespace
+
 OpenSoundControlSettings::OpenSoundControlSettings()
 {
     setAccessible(true);
@@ -49,7 +76,6 @@ OpenSoundControlSettings::OpenSoundControlSettings()
         Surge::Widgets::fixupJuceTextEditorAccessibility(*ed);
         ed->setTitle(n);
         ed->setSelectAllWhenFocused(true);
-        ed->setWantsKeyboardFocus(true);
         addAndMakeVisible(*ed);
         return std::move(ed);
     };
@@ -58,7 +84,6 @@ OpenSoundControlSettings::OpenSoundControlSettings()
     inPort->setJustification(juce::Justification::centred);
     inPort->addListener(this);
     inPort->setInputRestrictions(5, "0123456789");
-    addAndMakeVisible(*inPort);
 
     inPortReset = std::make_unique<Widgets::SurgeTextButton>("Default Port");
     inPortReset->addListener(this);
@@ -69,7 +94,6 @@ OpenSoundControlSettings::OpenSoundControlSettings()
     outPort->setJustification(juce::Justification::centred);
     outPort->addListener(this);
     outPort->setInputRestrictions(5, "0123456789");
-    addAndMakeVisible(*outPort);
 
     outPortReset = std::make_unique<Widgets::SurgeTextButton>("Default Port");
     outPortReset->addListener(this);
@@ -80,7 +104,6 @@ OpenSoundControlSettings::OpenSoundControlSettings()
     outIP->setJustification(juce::Justification::centred);
     outIP->addListener(this);
     outIP->setInputRestrictions(15, "0123456789.");
-    addAndMakeVisible(*outIP);
 
     inL = std::make_unique<juce::Label>("OSC In", "OSC In");
     addAndMakeVisible(*inL);
@@ -123,6 +146,11 @@ OpenSoundControlSettings::OpenSoundControlSettings()
     enableOut->addListener(this);
     enableOut->setTitle("OSC Output Enable");
     addAndMakeVisible(*enableOut);
+
+    statusL = std::make_unique<StatusLabel>("statusL", "");
+    statusL->setJustificationType(juce::Justification::centred);
+    statusL->setWantsKeyboardFocus(true);
+    addAndMakeVisible(*statusL);
 }
 
 OpenSoundControlSettings::~OpenSoundControlSettings() = default;
@@ -160,7 +188,7 @@ void OpenSoundControlSettings::shownInParent()
 void OpenSoundControlSettings::onSkinChanged()
 {
     auto resetColors = [this](const auto &typein) {
-        typein->setFont(skin->getFont(Fonts::System::Display));
+        typein->setFont(skin->getFont(Fonts::PatchStore::TextEntry));
         typein->setColour(juce::TextEditor::backgroundColourId,
                           skin->getColor(Colors::Dialog::Entry::Background));
         typein->setColour(juce::TextEditor::textColourId,
@@ -175,7 +203,7 @@ void OpenSoundControlSettings::onSkinChanged()
                           skin->getColor(Colors::Dialog::Entry::Border));
 
         typein->applyColourToAllText(skin->getColor(Colors::Dialog::Entry::Text));
-        typein->applyFontToAllText(skin->getFont(Fonts::System::Display));
+        typein->applyFontToAllText(skin->getFont(Fonts::PatchStore::TextEntry));
     };
 
     auto resetLabel = [this](const auto &label) {
@@ -190,8 +218,10 @@ void OpenSoundControlSettings::onSkinChanged()
     resetLabel(inL);
     resetLabel(outL);
     resetLabel(outIPL);
+    resetLabel(statusL);
 
-    outIPL->setJustificationType(juce::Justification::centred);
+    outIPL->setJustificationType(juce::Justification::centredRight);
+    outIPL->setBorderSize(juce::BorderSize<int>(1, 5, 1, 0));
 
     enableIn->setColour(juce::ToggleButton::tickDisabledColourId,
                         skin->getColor(Colors::Dialog::Checkbox::Border));
@@ -202,6 +232,8 @@ void OpenSoundControlSettings::onSkinChanged()
                          skin->getColor(Colors::Dialog::Checkbox::Border));
     enableOut->setColour(juce::ToggleButton::tickColourId,
                          skin->getColor(Colors::Dialog::Checkbox::Tick));
+
+    statusL->setBorderSize(juce::BorderSize<int>(1, 0, 1, 0));
 
     inPortReset->setSkin(skin, associatedBitmapStore);
     outPortReset->setSkin(skin, associatedBitmapStore);
@@ -217,32 +249,32 @@ void OpenSoundControlSettings::resized()
     // overall size set in SurgeGUIEditorOverlays.cpp when created
     static constexpr int uheight = 18;
     static constexpr int ushift = 30;
-    static constexpr int margin = 8;
+    static constexpr int margin = 6;
     static constexpr int halfmargin = margin / 2;
     static constexpr int buttonHeight = 17;
     static constexpr int buttonWidth = 50;
     static constexpr int defButtonWidth = 64;
     static constexpr int checkboxWidth = 68;
-
-    auto col = getLocalBounds();
+    static constexpr int ipFieldWidth = checkboxWidth;
+    auto bounds = getLocalBounds();
+    auto col = bounds.withWidth(bounds.getWidth() / 3);
+    const int rightEdge = bounds.getWidth() - margin;
 
     // left
-    col = col.withWidth(col.getWidth() / 3);
-
     {
         auto lcol = col.withHeight(uheight);
-        auto inb = lcol.translated(0, margin).withSizeKeepingCentre(checkboxWidth, buttonHeight);
+        auto inb = lcol.translated(0, margin).withSize(checkboxWidth, buttonHeight).withX(margin);
 
         enableIn->setBounds(inb);
 
         inL->setBounds(inb.translated(20, 0));
 
         lcol = lcol.translated(0, ushift + halfmargin);
-        inPort->setBounds(lcol.withSizeKeepingCentre(defButtonWidth, buttonHeight));
+        inPort->setBounds(lcol.withSize(defButtonWidth, buttonHeight).withX(margin));
         inPort->setIndents(4, 0);
 
         lcol = lcol.translated(0, ushift - halfmargin);
-        inPortReset->setBounds(lcol.withSizeKeepingCentre(defButtonWidth, buttonHeight));
+        inPortReset->setBounds(lcol.withSize(defButtonWidth, buttonHeight).withX(margin));
     }
 
     // center
@@ -266,29 +298,32 @@ void OpenSoundControlSettings::resized()
 
     // right
     col = col.translated(col.getWidth(), 0);
-
     {
+        static constexpr int ipLabelWidth = 88;
         auto lcol = col.withHeight(uheight);
 
-        outIPL->setBounds(lcol.translated(0, margin));
+        outIPL->setBounds(
+            lcol.translated(0, margin).withSize(ipLabelWidth, uheight).withRightX(rightEdge));
 
         lcol = lcol.translated(0, ushift + halfmargin);
-        outIP->setBounds(lcol.reduced(margin + halfmargin, 0));
+        outIP->setBounds(lcol.withSize(ipFieldWidth, buttonHeight).withRightX(rightEdge));
         outIP->setIndents(4, 0);
 
         lcol = lcol.translated(0, ushift - halfmargin);
-        outIPReset->setBounds(lcol.reduced(margin + halfmargin, 0));
+        outIPReset->setBounds(lcol.withSize(defButtonWidth, buttonHeight).withRightX(rightEdge));
     }
 
     // bottom row
-    auto row = getLocalBounds();
-    const auto yPos = getLocalBounds().getHeight() - buttonHeight - margin;
+    const int okY = bounds.getHeight() - buttonHeight - margin;
+    const int resetBottom = inPortReset->getBottom();
+    const int statusY = resetBottom + (okY - resetBottom - buttonHeight) / 2;
+    statusL->setBounds(margin, statusY, bounds.getWidth() - 2 * margin, buttonHeight);
 
-    help->setBounds(row.translated(outIPReset->getRight() - buttonHeight, yPos)
+    auto row = bounds;
+    help->setBounds(row.translated(outIPReset->getRight() - buttonHeight, okY)
                         .withSize(buttonHeight, buttonHeight));
 
-    row = row.translated(row.getWidth() / 2 - buttonWidth / 2, yPos);
-
+    row = row.translated(row.getWidth() / 2 - buttonWidth / 2, okY);
     row.setSize(buttonWidth, buttonHeight);
 
     ok->setBounds(row);
@@ -313,6 +348,37 @@ void OpenSoundControlSettings::setValuesFromEditor()
     outIP->setText(editor->synth->storage.oscOutIP, juce::dontSendNotification);
     outPortReset->setEnabled(editor->synth->storage.oscPortOut != defaultOSCOutPort);
     outIPReset->setEnabled(editor->synth->storage.oscOutIP != defaultOSCOutIP);
+
+    updateStatusLabel();
+}
+
+void OpenSoundControlSettings::updateStatusLabel()
+{
+    if (!editor)
+        return;
+
+    auto &handler = editor->juceEditor->processor.oscHandler;
+    std::string statusText;
+    if (handler.listening)
+    {
+        int actual = handler.iportnum;
+        int preferred = editor->synth->storage.oscPortIn;
+        if (actual == preferred)
+        {
+            statusText = "Listening on port " + std::to_string(actual);
+        }
+        else if (handler.restoredFromLastBound)
+        {
+            statusText =
+                "Listening on port " + std::to_string(actual) + " (restored from last session)";
+        }
+        else
+        {
+            statusText = "Listening on port " + std::to_string(actual) + " (preferred " +
+                         std::to_string(preferred) + " was already in use)";
+        }
+    }
+    statusL->setText(statusText, juce::dontSendNotification);
 }
 
 void OpenSoundControlSettings::textEditorTextChanged(juce::TextEditor &ed) { setAllEnableds(); }
@@ -445,7 +511,7 @@ bool OpenSoundControlSettings::updateAll()
 
     if (isInputChanged())
     {
-        int newPort = std::stoi(inPort->getText().toStdString());
+        int newPort = inPort->getText().getIntValue();
 
         if (enableIn->getToggleState())
         {
@@ -469,9 +535,11 @@ bool OpenSoundControlSettings::updateAll()
         }
     }
 
+    updateStatusLabel();
+
     if (isOutputChanged())
     {
-        int newPort = std::stoi(outPort->getText().toStdString());
+        int newPort = outPort->getText().getIntValue();
 
         if (enableOut->getToggleState())
         {
@@ -501,15 +569,14 @@ bool OpenSoundControlSettings::updateAll()
 bool OpenSoundControlSettings::isInputChanged()
 {
     return ((enableIn->getToggleState() != editor->synth->storage.oscReceiving) ||
-            (inPort->getText().toStdString() != std::to_string(editor->synth->storage.oscPortIn)));
+            (inPort->getText().getIntValue() != editor->synth->storage.oscPortIn));
 }
 
 bool OpenSoundControlSettings::isOutputChanged()
 {
-    return (
-        (enableOut->getToggleState() != editor->synth->storage.oscSending) ||
-        (outPort->getText().toStdString() != std::to_string(editor->synth->storage.oscPortOut)) ||
-        (outIP->getText().toStdString() != editor->synth->storage.oscOutIP));
+    return ((enableOut->getToggleState() != editor->synth->storage.oscSending) ||
+            (outPort->getText().getIntValue() != editor->synth->storage.oscPortOut) ||
+            (outIP->getText().toStdString() != editor->synth->storage.oscOutIP));
 }
 
 bool OpenSoundControlSettings::is_number(const std::string &s)
@@ -520,23 +587,22 @@ bool OpenSoundControlSettings::is_number(const std::string &s)
 // Returns new port integer value if portStr is valid, otherwise returns 0
 int OpenSoundControlSettings::validPort(std::string portStr, std::string type)
 {
-    int newPort = 0;
+    auto reportInvalid = [&] {
+        std::ostringstream msg;
+        msg << type << " port number must be between 1 and 65535!";
+        storage->reportError(msg.str(), "Port Number Error");
+    };
 
     if (!is_number(portStr))
     {
-        std::ostringstream msg;
-        msg << type << " port number must be between 1 and 65535!";
-        storage->reportError(msg.str(), "Port Number Error");
+        reportInvalid();
         return 0;
     }
 
-    newPort = std::stoi(portStr);
-
-    if (newPort > 65535 || newPort < 1)
+    int newPort = std::stoi(portStr);
+    if (newPort < 1 || newPort > 65535)
     {
-        std::ostringstream msg;
-        msg << type << " port number must be between 1 and 65535!";
-        storage->reportError(msg.str(), "Port Number Error");
+        reportInvalid();
         return 0;
     }
 

--- a/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
+++ b/src/surge-xt/gui/overlays/OpenSoundControlSettings.h
@@ -62,6 +62,8 @@ struct OpenSoundControlSettings : public OverlayComponent,
     int defaultOSCOutPort;
     std::string defaultOSCOutIP;
 
+    void updateStatusLabel();
+
     void onSkinChanged() override;
     void buttonClicked(juce::Button *button) override;
 
@@ -81,7 +83,7 @@ struct OpenSoundControlSettings : public OverlayComponent,
     void validateInputs(juce::TextEditor &);
 
     std::unique_ptr<juce::TextEditor> inPort, outPort, outIP;
-    std::unique_ptr<juce::Label> inL, outL, outIPL;
+    std::unique_ptr<juce::Label> inL, outL, outIPL, statusL;
     std::unique_ptr<Widgets::SurgeTextButton> inPortReset, outPortReset, outIPReset, help, apply,
         ok, cancel;
     std::unique_ptr<juce::ToggleButton> enableOut, enableIn;

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -36,6 +36,12 @@
 #include "Tunings.h"
 #include "filesystem/import.h"
 
+#if JUCE_WINDOWS
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#endif
+
 namespace Surge
 {
 namespace OSC
@@ -66,27 +72,60 @@ void OpenSoundControl::tryOSCStartup()
         return;
     }
 
-    bool startOSCInNow = synth->storage.getPatch().dawExtraState.oscStartIn;
+    const auto &des = synth->storage.getPatch().dawExtraState;
 
-    if (startOSCInNow)
+    /*
+    Input port bind strategy:
+        - In a DAW plugin context, if a previous session bound a specific port (lastBound > 0), try
+          that port first so sessions are reproducible across project reloads
+        - If that port is taken, fall back to scanning the next OSC_IN_PORT_SCAN_RANGE ports above
+          the configured preferred port
+        - On a fresh instance (no lastBound), go straight to the range scan
+        - In standalone, lastBound is ignored so each launch starts fresh from the preferred port
+    */
+    if (des.oscStartIn)
     {
-        int defaultOSCInPort = synth->storage.getPatch().dawExtraState.oscPortIn;
+        int startPort = des.oscPortIn;
+        int endPort = startPort + OSC_IN_PORT_SCAN_RANGE;
 
-        if (defaultOSCInPort > 0)
+        // Standalone always starts fresh
+        const bool isStandalone =
+            sspPtr->wrapperType == juce::AudioProcessor::wrapperType_Standalone;
+        int lastBound = isStandalone ? 0 : des.oscPortInLastBound;
+
+        bool status = false;
+
+        // If we have a stored last bound port from a prior session, try it first
+        if (lastBound > 0)
         {
-            if (!initOSCIn(defaultOSCInPort))
+            status = initOSCIn(lastBound);
+            if (status)
             {
-                sspPtr->initOSCError(defaultOSCInPort);
+                // Flag this as a true restore so the dialog can describe it accurately
+                restoredFromLastBound = true;
             }
+            else
+            {
+                // Last bound port not available, fall back to scanning the range
+                status = initOSCInRange(startPort, endPort);
+            }
+        }
+        else if (startPort > 0)
+        {
+            // Fresh instance, scan the range from the preferred port
+            status = initOSCInRange(startPort, endPort);
+        }
+
+        if (!status)
+        {
+            sspPtr->initOSCError(startPort);
         }
     }
 
-    bool startOSCOutNow = synth->storage.getPatch().dawExtraState.oscStartOut;
-
-    if (startOSCOutNow)
+    if (des.oscStartOut)
     {
-        int defaultOSCOutPort = synth->storage.getPatch().dawExtraState.oscPortOut;
-        std::string defaultOSCOutIPAddr = synth->storage.getPatch().dawExtraState.oscIPAddrOut;
+        int defaultOSCOutPort = des.oscPortOut;
+        std::string defaultOSCOutIPAddr = des.oscIPAddrOut;
 
         if (defaultOSCOutPort > 0)
         {
@@ -100,19 +139,81 @@ void OpenSoundControl::tryOSCStartup()
 
 bool OpenSoundControl::initOSCIn(int port)
 {
-    if (port < 1 || port == oportnum)
+    if (port < 1 || port > 65535 || port == oportnum)
     {
         return false;
     }
 
-    if (connect(port))
+    // Build a DatagramSocket so we can clear SO_REUSEADDR to get us port hijack protection
+    auto sock = std::make_unique<juce::DatagramSocket>(false);
+    int handle = sock->getRawSocketHandle();
+    if (handle < 0)
     {
-        addListener(this);
-        listening = true;
-        iportnum = port;
-        synth->storage.oscReceiving = true;
-        synth->storage.oscStartIn = true;
-        return true;
+        std::cerr << "OSC failed to create socket for port " << port << std::endl;
+        return false;
+    }
+
+    auto setOpt = [handle](int name, int val) {
+        return setsockopt(handle, SOL_SOCKET, name, reinterpret_cast<const char *>(&val),
+                          sizeof(val)) == 0;
+    };
+
+    if (!setOpt(SO_REUSEADDR, 0))
+    {
+        std::cerr << "OSC: failed to clear SO_REUSEADDR on port " << port << std::endl;
+    }
+#if JUCE_WINDOWS
+    if (!setOpt(SO_EXCLUSIVEADDRUSE, 1))
+    {
+        std::cerr << "OSC: failed to set SO_EXCLUSIVEADDRUSE on port " << port << std::endl;
+    }
+#endif
+
+    if (!sock->bindToPort(port))
+    {
+        return false;
+    }
+
+    // connectToSocket disconnects any prior receiver, freeing the old socket for replacement
+    if (!connectToSocket(*sock))
+    {
+        std::cerr << "OSC failed to start receiver on port " << port << std::endl;
+        return false;
+    }
+
+    ownedInSocket = std::move(sock);
+    addListener(this);
+    listening = true;
+    iportnum = port;
+    restoredFromLastBound = false;
+    synth->storage.oscReceiving = true;
+    synth->storage.oscStartIn = true;
+
+    // Remember the actual bound port so future sessions can restore it directly
+    if (sspPtr->wrapperType != juce::AudioProcessor::wrapperType_Standalone)
+    {
+        synth->storage.oscPortInLastBound = port;
+    }
+
+    return true;
+}
+
+// Scan a range of ports starting at startPort, stopping at the first successfull bind
+// The actual bound port can be read from iportnum on success
+bool OpenSoundControl::initOSCInRange(int startPort, int endPort)
+{
+    if (endPort < startPort)
+    {
+        endPort = startPort;
+    }
+    endPort = std::min(endPort, 65535);
+
+    for (int p = startPort; p <= endPort; p++)
+    {
+        if (initOSCIn(p))
+        {
+            return true;
+        }
     }
 
     return false;
@@ -126,6 +227,9 @@ void OpenSoundControl::stopListening(bool updateOSCStartInStorage)
     }
 
     removeListener(this);
+    // disconnect() stops the receiver thread; we own the socket so we release it ourselves
+    disconnect();
+    ownedInSocket.reset();
     listening = false;
 
     if (synth)

--- a/src/surge-xt/osc/OpenSoundControl.cpp
+++ b/src/surge-xt/osc/OpenSoundControl.cpp
@@ -20,6 +20,11 @@
  * https://github.com/surge-synthesizer/surge
  */
 
+// winsock2.h must come before anything that might pull in windows.h (JUCE does)
+#if defined(_WIN32) || defined(_WIN64)
+#include <winsock2.h>
+#endif
+
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_gui_extra/juce_gui_extra.h>
 #include "OpenSoundControl.h"
@@ -36,9 +41,7 @@
 #include "Tunings.h"
 #include "filesystem/import.h"
 
-#if JUCE_WINDOWS
-#include <winsock2.h>
-#else
+#if !defined(_WIN32) && !defined(_WIN64)
 #include <sys/socket.h>
 #endif
 

--- a/src/surge-xt/osc/OpenSoundControl.h
+++ b/src/surge-xt/osc/OpenSoundControl.h
@@ -60,6 +60,7 @@ class OpenSoundControl : public juce::OSCReceiver,
 
     void initOSC(SurgeSynthProcessor *ssp, const std::unique_ptr<SurgeSynthesizer> &surge);
     bool initOSCIn(int port);
+    bool initOSCInRange(int startPort, int endPort);
     bool initOSCOut(int port, std::string ipaddr);
     void stopListening(bool updateOSCStartInStorage = true);
     void tryOSCStartup();
@@ -69,8 +70,10 @@ class OpenSoundControl : public juce::OSCReceiver,
     std::string outIPAddr = DEFAULT_OSC_IPADDR_OUT;
     bool listening = false;
     bool sendingOSC = false;
+    bool restoredFromLastBound = false;
 
     std::unique_ptr<Surge::WavetableScript::LuaWTEvaluator> evaluator;
+    std::unique_ptr<juce::DatagramSocket> ownedInSocket;
     void oscMessageReceived(const juce::OSCMessage &message) override;
     void oscBundleReceived(const juce::OSCBundle &bundle) override;
 


### PR DESCRIPTION
Running multiple Surge instances on the same machine didn't actually work for OSC, every instance silently thought it was bound to the configured port, but only one received packets. By switching away from the [OSCReceiver](https://docs.juce.com/master/classjuce_1_1OSCReceiver.html) class and constructing our own [DatagramSocket](https://docs.juce.com/master/classjuce_1_1DatagramSocket.html) we can clear the flags that allow port hijacking and get a meaningful return when a port is already in use.

With this PR Surge tries 100 ports after the configured input port, binding to the first that works. For DAW sessions Surge tracks what the last bound port was and tries to restore that first before falling back to scanning the ports inside the range, for the standalone it ignores the last bound port and always scans the range.

UI wise this status line was added:
<img width="401" height="191" alt="image" src="https://github.com/user-attachments/assets/c1c6e0c2-ee99-4c0b-bf69-754a7870fe39" />

Also sets the default output port to 53270 so it's outside the default range (since by default the output is also localhost).

Tested on Windows and Linux with Reaper (still untested on macOS).

Assisted-By: Claude Opus 4.7