### PR TITLE
Implement FX chain preset functionality (*.srgfxchain)

### DIFF
--- a/src/common/FxPresetAndClipboardManager.cpp
+++ b/src/common/FxPresetAndClipboardManager.cpp
@@ -444,6 +444,334 @@ void FxUserPreset::loadPresetOnto(const Preset &p, SurgeStorage *storage, FxStor
         delete t_fx;
     }
 }
+
+void FxChainUserPreset::doPresetRescan(SurgeStorage *storage, bool forceRescan)
+{
+    if (haveScannedPresets && !forceRescan)
+        return;
+
+    scannedPresets.clear();
+    haveScannedPresets = true;
+
+    auto ud = storage->userFXChainPath; // e.g. userDataPath / "FX Chains"
+
+    std::vector<fs::path> chainFiles;
+    std::deque<fs::path> workStack;
+    workStack.emplace_back(ud);
+
+    try
+    {
+        while (!workStack.empty())
+        {
+            auto top = workStack.front();
+            workStack.pop_front();
+
+            if (fs::is_directory(top))
+            {
+                for (auto &d : fs::directory_iterator(top))
+                {
+                    if (fs::is_directory(d))
+                        workStack.emplace_back(d.path());
+                    else if (path_to_string(d.path().extension()) == ".srgfxchain")
+                        chainFiles.emplace_back(d.path());
+                }
+            }
+        }
+
+        for (const auto &f : chainFiles)
+        {
+            {
+                Preset preset;
+                preset.file = path_to_string(f);
+
+                TiXmlDocument d;
+                if (!d.LoadFile(f))
+                    goto badPreset;
+
+                auto r = TINYXML_SAFE_TO_ELEMENT(d.FirstChild("chain-fx"));
+                if (!r)
+                    goto badPreset;
+
+                preset.streamingVersion = ff_revision;
+                int sv;
+                if (r->QueryIntAttribute("streaming_version", &sv) == TIXML_SUCCESS)
+                    preset.streamingVersion = sv;
+
+                auto s = TINYXML_SAFE_TO_ELEMENT(r->FirstChild("snapshot"));
+                if (!s)
+                    goto badPreset;
+
+                if (!readFromXMLSnapshot(preset, s))
+                    goto badPreset;
+
+                // subPath relative to the root scan dir, for folder grouping in the menu
+                preset.subPath = f.lexically_relative(ud).parent_path();
+
+                scannedPresets.push_back(preset);
+            }
+        badPreset:;
+        }
+
+        std::sort(scannedPresets.begin(), scannedPresets.end(),
+                  [](const Preset &a, const Preset &b) {
+                      if (a.subPath != b.subPath)
+                          return a.subPath < b.subPath;
+                      return _stricmp(a.name.c_str(), b.name.c_str()) < 0;
+                  });
+    }
+    catch (const fs::filesystem_error &e)
+    {
+        std::ostringstream oss;
+        oss << "Experienced file system error when scanning FX chain presets. " << e.what();
+        if (storage)
+            storage->reportError(oss.str(), "FileSystem Error");
+    }
+}
+
+bool FxChainUserPreset::readFromXMLSnapshot(Preset &preset, TiXmlElement *s)
+{
+    if (!s->Attribute("name"))
+        return false;
+
+    preset.name = s->Attribute("name");
+
+    // Each child <fx slot="N" ...> carries one slot's data.
+    auto fxEl = TINYXML_SAFE_TO_ELEMENT(s->FirstChild("fx"));
+    while (fxEl)
+    {
+        int slot = -1;
+        if (fxEl->QueryIntAttribute("slot", &slot) != TIXML_SUCCESS || slot < 0 ||
+            slot >= n_fx_per_chain)
+        {
+            fxEl = fxEl->NextSiblingElement("fx");
+            continue;
+        }
+
+        auto &sd = preset.slots[slot];
+
+        int t = 0;
+        fxEl->QueryIntAttribute("type", &t);
+        sd.type = t;
+
+        if (fxEl->Attribute("preset_name"))
+            sd.presetName = fxEl->Attribute("preset_name");
+
+        // params — only meaningful when type != fxt_off
+        for (int i = 0; i < n_fx_params; ++i)
+        {
+            double fl;
+            std::string p = "p";
+
+            if (fxEl->QueryDoubleAttribute((p + std::to_string(i)).c_str(), &fl) == TIXML_SUCCESS)
+                sd.p[i] = (float)fl;
+
+            if (fxEl->QueryDoubleAttribute((p + std::to_string(i) + "_temposync").c_str(), &fl) ==
+                    TIXML_SUCCESS &&
+                fl != 0)
+                sd.ts[i] = true;
+
+            if (fxEl->QueryDoubleAttribute((p + std::to_string(i) + "_extend_range").c_str(),
+                                           &fl) == TIXML_SUCCESS &&
+                fl != 0)
+                sd.er[i] = true;
+
+            if (fxEl->QueryDoubleAttribute((p + std::to_string(i) + "_deactivated").c_str(), &fl) ==
+                    TIXML_SUCCESS &&
+                fl != 0)
+                sd.da[i] = true;
+
+            if (fxEl->QueryDoubleAttribute((p + std::to_string(i) + "_deform_type").c_str(), &fl) ==
+                TIXML_SUCCESS)
+                sd.dt[i] = (int)fl;
+        }
+
+        if (fxEl->Attribute("filename"))
+            sd.filename = fxEl->Attribute("filename");
+
+        fxEl = fxEl->NextSiblingElement("fx");
+    }
+
+    return true;
+}
+
+void FxChainUserPreset::saveChainPresetIn(SurgeStorage *storage,
+                                          const Preset::SlotData slots[n_fx_per_chain],
+                                          const std::string &s)
+{
+    try
+    {
+        if (s.empty())
+            return;
+
+        auto sp = string_to_path(s);
+        auto spp = sp.parent_path();
+        auto fnp = sp.filename();
+
+        if (!Surge::Storage::isValidName(path_to_string(fnp)))
+            return;
+
+        auto storagePath = storage->userFXChainPath;
+        if (!spp.empty())
+            storagePath /= spp;
+
+        auto outputPath = storagePath / string_to_path(path_to_string(fnp) + ".srgfxchain");
+
+        fs::create_directories(storagePath);
+
+        auto doSave = [this, outputPath, storage, slots, fnp]() {
+            std::ofstream pfile(outputPath, std::ios::out);
+            if (!pfile.is_open())
+            {
+                storage->reportError(std::string("Unable to open FX chain preset file '") +
+                                         path_to_string(outputPath) + "' for writing!",
+                                     "Error");
+                return;
+            }
+
+            auto fixupChars = [](std::string &str) {
+                Surge::Storage::findReplaceSubstring(str, std::string("&"), std::string("&amp;"));
+                Surge::Storage::findReplaceSubstring(str, std::string("<"), std::string("&lt;"));
+                Surge::Storage::findReplaceSubstring(str, std::string(">"), std::string("&gt;"));
+                Surge::Storage::findReplaceSubstring(str, std::string("\""), std::string("&quot;"));
+                Surge::Storage::findReplaceSubstring(str, std::string("'"), std::string("&apos;"));
+            };
+
+            std::string presetNameSub(path_to_string(fnp));
+            fixupChars(presetNameSub);
+
+            pfile << "<chain-fx streaming_version=\"" << ff_revision << "\">\n";
+            pfile << "  <snapshot name=\"" << presetNameSub << "\">\n";
+
+            for (int slot = 0; slot < n_fx_per_chain; ++slot)
+            {
+                const auto &sd = slots[slot];
+
+                std::string pn = sd.presetName;
+                fixupChars(pn);
+
+                pfile << "    <fx slot=\"" << slot << "\"\n";
+                pfile << "       type=\"" << sd.type << "\"\n";
+                pfile << "       preset_name=\"" << pn << "\"\n";
+
+                if (sd.type != fxt_off)
+                {
+                    // We don't have a live FxStorage here to check ctrltype / can_* flags,
+                    // so we write all params that were captured at copy time.
+                    // On load, spawn_effect + init_ctrltypes re-establishes the type info
+                    // before we overwrite values, matching the FxUserPreset pattern.
+                    for (int i = 0; i < n_fx_params; ++i)
+                    {
+                        pfile << "       p" << i << "=\"" << sd.p[i] << "\"\n";
+
+                        if (sd.ts[i])
+                            pfile << "       p" << i << "_temposync=\"1\"\n";
+                        if (sd.er[i])
+                            pfile << "       p" << i << "_extend_range=\"1\"\n";
+                        if (sd.da[i])
+                            pfile << "       p" << i << "_deactivated=\"1\"\n";
+                        if (sd.dt[i] >= 0)
+                            pfile << "       p" << i << "_deform_type=\"" << sd.dt[i] << "\"\n";
+                    }
+
+                    if (!sd.filename.empty())
+                    {
+                        std::string fn = sd.filename;
+                        fixupChars(fn);
+                        pfile << "       filename=\"" << fn << "\"\n";
+                    }
+                }
+
+                pfile << "    />\n";
+            }
+
+            pfile << "  </snapshot>\n";
+            pfile << "</chain-fx>\n";
+            pfile.close();
+
+            doPresetRescan(storage, true);
+        };
+
+        if (fs::exists(outputPath))
+        {
+            storage->okCancelProvider(
+                "The FX chain '" + outputPath.string() +
+                    "' already exists. Are you sure you want to overwrite it?",
+                "Overwrite FX Chain", SurgeStorage::OK, [doSave](SurgeStorage::OkCancel okc) {
+                    if (okc == SurgeStorage::OK)
+                        doSave();
+                });
+        }
+        else
+        {
+            doSave();
+        }
+    }
+    catch (const fs::filesystem_error &e)
+    {
+        std::ostringstream oss;
+        oss << "Exception occurred while attempting to write the chain preset! "
+               "Most likely, invalid characters or a reserved name was used. "
+               "Please try again with a different name!\n"
+            << "Details " << e.what();
+        storage->reportError(oss.str(), "Preset Write Error");
+    }
+}
+
+void FxChainUserPreset::loadPresetOnto(const Preset &p, SurgeStorage *storage,
+                                       FxStorage *fxbuffer[n_fx_per_chain])
+{
+    for (int slot = 0; slot < n_fx_per_chain; ++slot)
+    {
+        const auto &sd = p.slots[slot];
+        FxStorage *buf = fxbuffer[slot];
+
+        buf->type.val.i = sd.type;
+        buf->user_data.clear();
+
+        if (!sd.filename.empty())
+            buf->user_data.emplace("filename", ArbitraryBlockStorage::from_string(path_to_string(
+                                                   storage->resolvePathTokens(sd.filename))));
+
+        // Establish ctrltype metadata before writing param values
+        // exactly as FxUserPreset::loadPresetOnto does.
+        Effect *t_fx = spawn_effect(buf->type.val.i, storage, buf, 0);
+        if (t_fx)
+        {
+            t_fx->init_ctrltypes();
+            t_fx->init_default_values();
+        }
+
+        for (int i = 0; i < n_fx_params; ++i)
+        {
+            switch (buf->p[i].valtype)
+            {
+            case vt_float:
+                buf->p[i].val.f = sd.p[i];
+                break;
+            case vt_int:
+                buf->p[i].val.i = (int)sd.p[i];
+                break;
+            default:
+                break;
+            }
+
+            buf->p[i].temposync = (int)sd.ts[i];
+            buf->p[i].set_extend_range((int)sd.er[i]);
+            buf->p[i].deactivated = (int)sd.da[i];
+
+            if (sd.dt[i] >= 0)
+                buf->p[i].deform_type = sd.dt[i];
+        }
+
+        if (t_fx)
+        {
+            if (p.streamingVersion != ff_revision)
+                t_fx->handleStreamingMismatches(p.streamingVersion, ff_revision);
+            delete t_fx;
+        }
+    }
+}
+
 } // namespace Storage
 
 namespace FxClipboard
@@ -541,5 +869,123 @@ void pasteFx(SurgeStorage *storage, FxStorage *fxbuffer, Clipboard &cb)
     cb.fxCopyPaste.clear();
     cb.user_data.clear();
 }
+
+// ChainClipboard uses the same per-slot flat vector layout as Clipboard,
+// so copy/paste helpers are straightforward wrappers.
+
+void copyFxChain(SurgeStorage *storage, FxStorage *from[n_fx_per_chain],
+                 const std::string presetNames[n_fx_per_chain], ChainClipboard &cb)
+{
+    cb.hasData = false;
+
+    for (int slot = 0; slot < n_fx_per_chain; ++slot)
+    {
+        auto &sc = cb.slots[slot];
+
+        sc.params.clear();
+        sc.user_data.clear();
+        sc.presetName = presetNames ? presetNames[slot] : std::string{};
+
+        FxStorage *fx = from[slot];
+        sc.params.resize(n_fx_params * 5 + 1);
+        sc.params[0] = fx->type.val.i;
+        sc.user_data = fx->user_data;
+
+        for (int i = 0; i < n_fx_params; ++i)
+        {
+            int vp = i * 5 + 1;
+            int tp = i * 5 + 2;
+            int xp = i * 5 + 3;
+            int dp = i * 5 + 4;
+            int dt = i * 5 + 5;
+
+            switch (fx->p[i].valtype)
+            {
+            case vt_float:
+                sc.params[vp] = fx->p[i].val.f;
+                break;
+            case vt_int:
+                sc.params[vp] = fx->p[i].val.i;
+                break;
+            }
+
+            sc.params[tp] = fx->p[i].temposync;
+            sc.params[xp] = fx->p[i].extend_range;
+            sc.params[dp] = fx->p[i].deactivated;
+
+            if (fx->p[i].has_deformoptions())
+                sc.params[dt] = fx->p[i].deform_type;
+        }
+    }
+
+    cb.hasData = true;
+}
+
+bool isChainPasteAvailable(const ChainClipboard &cb) { return cb.hasData; }
+
+void pasteFxChain(SurgeStorage *storage, FxStorage *onto[n_fx_per_chain], ChainClipboard &cb)
+{
+    if (!cb.hasData)
+        return;
+
+    for (int slot = 0; slot < n_fx_per_chain; ++slot)
+    {
+        auto &sc = cb.slots[slot];
+        FxStorage *buf = onto[slot];
+
+        if (sc.params.empty())
+            continue;
+
+        buf->type.val.i = (int)sc.params[0];
+        buf->user_data = sc.user_data;
+
+        Effect *t_fx = spawn_effect(buf->type.val.i, storage, buf, 0);
+
+        if (t_fx)
+        {
+            t_fx->init_ctrltypes();
+            t_fx->init_default_values();
+
+            delete t_fx;
+        }
+
+        for (int i = 0; i < n_fx_params; ++i)
+        {
+            int vp = i * 5 + 1;
+            int tp = i * 5 + 2;
+            int xp = i * 5 + 3;
+            int dp = i * 5 + 4;
+            int dt = i * 5 + 5;
+
+            switch (buf->p[i].valtype)
+            {
+            case vt_float:
+            {
+                buf->p[i].val.f = sc.params[vp];
+                if (buf->p[i].val.f < buf->p[i].val_min.f)
+                    buf->p[i].val.f = buf->p[i].val_min.f;
+                if (buf->p[i].val.f > buf->p[i].val_max.f)
+                    buf->p[i].val.f = buf->p[i].val_max.f;
+            }
+            break;
+            case vt_int:
+                buf->p[i].val.i = (int)sc.params[vp];
+                break;
+            default:
+                break;
+            }
+
+            buf->p[i].temposync = (int)sc.params[tp];
+            buf->p[i].set_extend_range((int)sc.params[xp]);
+            buf->p[i].deactivated = (int)sc.params[dp];
+
+            if (buf->p[i].has_deformoptions())
+                buf->p[i].deform_type = (int)sc.params[dt];
+        }
+    }
+    // Unlike single-slot pasteFx() we do NOT clear cb here
+    // Pasting a chain to multiple targets in sequence should work without re-copying.
+}
+
 } // namespace FxClipboard
 } // namespace Surge

--- a/src/common/FxPresetAndClipboardManager.h
+++ b/src/common/FxPresetAndClipboardManager.h
@@ -80,6 +80,62 @@ struct FxUserPreset
 
     void loadPresetOnto(const Preset &p, SurgeStorage *s, FxStorage *fxbuffer);
 };
+
+struct FxChainUserPreset
+{
+    struct Preset
+    {
+        std::string file;
+        std::string name;
+        int streamingVersion{ff_revision};
+        fs::path subPath{};
+
+        struct SlotData
+        {
+            int type{0};
+            float p[n_fx_params]{};
+            bool ts[n_fx_params]{};
+            bool er[n_fx_params]{};
+            bool da[n_fx_params]{};
+            int dt[n_fx_params]{};
+
+            std::string presetName;
+
+            // Extra attributes that go in the userdata.
+            std::string filename; // special for convolver
+            std::string userdata; // whole thing
+        };
+        SlotData slots[n_fx_per_chain];
+
+        Preset()
+        {
+            for (auto &s : slots)
+            {
+                s.type = 0;
+                for (int i = 0; i < n_fx_params; ++i)
+                {
+                    s.p[i] = 0.f;
+                    s.ts[i] = false;
+                    s.er[i] = false;
+                    s.da[i] = false;
+                    s.dt[i] = -1;
+                }
+            }
+        }
+    };
+
+    std::vector<Preset> scannedPresets;
+    bool haveScannedPresets{false};
+
+    void doPresetRescan(SurgeStorage *storage, bool forceRescan = false);
+    std::vector<Preset> getPresets() const { return scannedPresets; }
+
+    bool readFromXMLSnapshot(Preset &p, TiXmlElement *snapshotEl);
+    void saveChainPresetIn(SurgeStorage *s, const Preset::SlotData slots[n_fx_per_chain],
+                           const std::string &fn);
+    void loadPresetOnto(const Preset &p, SurgeStorage *s, FxStorage *fxbuffer[n_fx_per_chain]);
+};
+
 } // namespace Storage
 
 namespace FxClipboard
@@ -90,9 +146,28 @@ struct Clipboard
     std::vector<float> fxCopyPaste;
     std::unordered_map<std::string, std::shared_ptr<std::vector<std::uint8_t>>> user_data;
 };
+
 void copyFx(SurgeStorage *, FxStorage *from, Clipboard &cb);
 bool isPasteAvailable(const Clipboard &cb);
 void pasteFx(SurgeStorage *, FxStorage *onto, Clipboard &cb);
+
+struct ChainClipboard
+{
+    struct SlotCopy
+    {
+        std::vector<float> params;
+        std::unordered_map<std::string, std::shared_ptr<std::vector<std::uint8_t>>> user_data;
+        std::string presetName;
+    };
+    SlotCopy slots[n_fx_per_chain];
+    bool hasData{false};
+};
+
+void copyFxChain(SurgeStorage *, FxStorage *from[n_fx_per_chain],
+                 const std::string presetNames[n_fx_per_chain], ChainClipboard &cb);
+bool isChainPasteAvailable(const ChainClipboard &cb);
+void pasteFxChain(SurgeStorage *, FxStorage *onto[n_fx_per_chain], ChainClipboard &cb);
+
 } // namespace FxClipboard
 } // namespace Surge
 #endif // SURGE_XT_FXPRESETANDCLIPBOARDMANAGER_H

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -559,7 +559,17 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     }
     catch (fs::filesystem_error &e)
     {
-        reportError(e.what(), "Error Scanning FX Presets");
+        reportError(e.what(), "Error Scanning FX Presets!");
+    }
+
+    try
+    {
+        fxChainUserPreset = std::make_unique<Surge::Storage::FxChainUserPreset>();
+        fxChainUserPreset->doPresetRescan(this);
+    }
+    catch (fs::filesystem_error &e)
+    {
+        reportError(e.what(), "Error Scanning FX Chains!");
     }
 
     try
@@ -569,7 +579,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     }
     catch (fs::filesystem_error &e)
     {
-        reportError(e.what(), "Error Scanning Modulator Presets");
+        reportError(e.what(), "Error Scanning Modulator Presets!");
     }
     memoryPools = std::make_unique<Surge::Memory::SurgeMemoryPools>(this);
 }
@@ -603,6 +613,7 @@ void SurgeStorage::initializeUserDataPaths()
     userWavetablesExportPath = userWavetablesPath / "Exported";
     userWavetableScriptsPath = userWavetablesPath / "Scripted";
     userFXPath = userDataPath / "FX Presets";
+    userFXChainPath = userDataPath / "FX Chains";
     userMidiMappingsPath = userDataPath / "MIDI Mappings";
     userModulatorSettingsPath = userDataPath / "Modulator Presets";
     userSkinsPath = userDataPath / "Skins";
@@ -621,9 +632,10 @@ void SurgeStorage::createUserDirectory()
     {
         try
         {
-            for (auto &s : {userDataPath, userDefaultFilePath, userPatchesPath, userWavetablesPath,
-                            userModulatorSettingsPath, userFXPath, userWavetablesExportPath,
-                            userWavetableScriptsPath, userSkinsPath, userMidiMappingsPath})
+            for (auto &s :
+                 {userDataPath, userDefaultFilePath, userPatchesPath, userWavetablesPath,
+                  userModulatorSettingsPath, userFXPath, userFXChainPath, userWavetablesExportPath,
+                  userWavetableScriptsPath, userSkinsPath, userMidiMappingsPath})
                 fs::create_directories(s);
 
             userDataPathValid = true;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -365,6 +365,13 @@ enum fxchains
     fxc_global,
 };
 
+const char fxchain_names[n_fx_chains][NAMECHARS] = {
+    "Scene A Insert FX Chain",
+    "Scene B Insert FX Chain",
+    "Send FX Chain",
+    "Global FX Chain",
+};
+
 const char fxslot_names[n_fx_slots][NAMECHARS] = {
     "A Insert FX 1", "A Insert FX 2", "B Insert FX 1", "B Insert FX 2",
     "Send FX 1",     "Send FX 2",     "Global FX 1",   "Global FX 2",
@@ -1426,6 +1433,7 @@ struct ScenesOutputData
 };
 
 struct FxUserPreset;
+struct FxChainUserPreset;
 struct ModulatorPreset;
 } // namespace Storage
 namespace Memory
@@ -1685,6 +1693,7 @@ class alignas(16) SurgeStorage
     std::vector<int> irCategoryOrdering;
 
     std::unique_ptr<Surge::Storage::FxUserPreset> fxUserPreset;
+    std::unique_ptr<Surge::Storage::FxChainUserPreset> fxChainUserPreset;
     std::unique_ptr<Surge::Storage::ModulatorPreset> modulatorPreset;
 
     bool datapathOverriden{false};
@@ -1698,6 +1707,7 @@ class alignas(16) SurgeStorage
     fs::path userIRsPath;
     fs::path userModulatorSettingsPath;
     fs::path userFXPath;
+    fs::path userFXChainPath;
     fs::path userWavetablesExportPath;
     fs::path userWavetableScriptsPath;
     fs::path userSkinsPath;

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -123,6 +123,7 @@ using namespace Surge::ParamConfig;
 struct DroppedUserDataEntries
 {
     std::vector<int> fxPresets;
+    std::vector<int> fxChains;
     std::vector<int> midiMappings;
     std::vector<int> modulatorSettings;
     std::vector<int> patches;
@@ -132,6 +133,7 @@ struct DroppedUserDataEntries
     void clear()
     {
         fxPresets.clear();
+        fxChains.clear();
         midiMappings.clear();
         modulatorSettings.clear();
         patches.clear();
@@ -141,8 +143,8 @@ struct DroppedUserDataEntries
 
     int totalSize() const
     {
-        return fxPresets.size() + midiMappings.size() + modulatorSettings.size() + patches.size() +
-               skins.size() + wavetables.size();
+        return fxPresets.size() + fxChains.size() + midiMappings.size() + modulatorSettings.size() +
+               patches.size() + skins.size() + wavetables.size();
     }
 };
 
@@ -179,6 +181,10 @@ class DroppedUserDataHandler
             if (entry->filename.endsWithIgnoreCase(".srgfx"))
             {
                 entries.fxPresets.push_back(iEntry);
+            }
+            else if (entry->filename.endsWithIgnoreCase(".srgfxchain"))
+            {
+                entries.fxChains.push_back(iEntry);
             }
             else if (entry->filename.endsWithIgnoreCase(".srgmid"))
             {
@@ -283,6 +289,14 @@ class DroppedUserDataHandler
         for (int iEntry : entries.fxPresets)
         {
             if (!uncompressEntry(iEntry, storage->userFXPath))
+            {
+                return false;
+            }
+        }
+
+        for (int iEntry : entries.fxChains)
+        {
+            if (!uncompressEntry(iEntry, storage->userFXChainPath))
             {
                 return false;
             }
@@ -2514,7 +2528,7 @@ void SurgeGUIEditor::effectSettingsBackgroundClick(int whichScene, Surge::Widget
                                synth->storage.getPatch().isDirty = true;
                        });
 
-    fxGridMenu.showMenuAsync(popupMenuOptions(c), Surge::GUI::makeEndHoverCallback(c));
+    fxGridMenu.showMenuAsync(popupMenuOptions(nullptr, false), Surge::GUI::makeEndHoverCallback(c));
 }
 
 void SurgeGUIEditor::controlBeginEdit(Surge::GUI::IComponentTagValue *control)
@@ -3599,6 +3613,8 @@ void SurgeGUIEditor::rescanAllDataFolders()
 
     if (storage.fxUserPreset)
         storage.fxUserPreset->doPresetRescan(&storage, true);
+    if (storage.fxChainUserPreset)
+        storage.fxChainUserPreset->doPresetRescan(&storage, true);
     if (storage.modulatorPreset)
         storage.modulatorPreset->forcePresetRescan();
 
@@ -5026,6 +5042,12 @@ bool SurgeGUIEditor::onDrop(const juce::String &fname)
             oss << fmt::format("{0} FX preset{1}", sz, sz != 1 ? "s" : "");
         }
 
+        if (entries.fxChains.size() > 0)
+        {
+            auto sz = entries.fxChains.size();
+            oss << fmt::format("{0} FX chain{1}", sz, sz != 1 ? "s" : "");
+        }
+
         if (entries.midiMappings.size() > 0)
         {
             auto sz = entries.midiMappings.size();
@@ -5071,6 +5093,12 @@ bool SurgeGUIEditor::onDrop(const juce::String &fname)
             if (entries.fxPresets.size() > 0)
             {
                 storage->fxUserPreset->doPresetRescan(storage, true);
+                this->queueRebuildUI();
+            }
+
+            if (entries.fxChains.size() > 0)
+            {
+                storage->fxChainUserPreset->doPresetRescan(storage, true);
                 this->queueRebuildUI();
             }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -602,13 +602,13 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void showMidiLearnOverlay(const juce::Rectangle<int> &r);
     void hideMidiLearnOverlay();
 
+    int selectedFX[n_fx_slots];
+    std::string fxPresetName[n_fx_slots];
+
   private:
     std::function<void(SurgeGUIEditor *, bool resizeWindow)> zoom_callback;
     bool zoomInvalid = false;
     static constexpr int minimumZoom = 25;
-
-    int selectedFX[n_fx_slots];
-    std::string fxPresetName[n_fx_slots];
 
     int processRunningCheckEvery{0};
     std::unique_ptr<juce::Component> noProcessingOverlay{nullptr};

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -765,6 +765,39 @@ void FxMenu::loadSnapshot(int type, TiXmlElement *e, int idx)
     }
 }
 
+/////////////////
+
+static int fxSlotToChain(int patchSlot)
+{
+    for (int i = 0; i < n_fx_slots; ++i)
+    {
+        if (fxslot_order[i] == patchSlot)
+        {
+            return i / n_fx_per_chain; // fxchains value
+        }
+    }
+
+    return fxc_scenea; // unreachable
+}
+
+static void buildChainSlotPtrs(SurgeGUIEditor *sge, int current_fx,
+                               FxStorage *slots[n_fx_per_chain], FxStorage *bufs[n_fx_per_chain],
+                               std::string names[n_fx_per_chain])
+{
+    auto &patch = sge->synth->storage.getPatch();
+
+    for (int i = 0; i < n_fx_per_chain; ++i)
+    {
+        int idx = fxslot_order[fxSlotToChain(current_fx) * n_fx_per_chain + i];
+
+        slots[i] = &patch.fx[idx];
+        bufs[i] = &sge->synth->fxsync[idx];
+        names[i] = sge->fxPresetName[idx];
+    }
+}
+
+/////////////////
+
 void FxMenu::populateForContext(bool isCalledInEffectChooser)
 {
     auto sge = firstListenerOfType<SurgeGUIEditor>();
@@ -796,14 +829,18 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
     }
 
     auto cfx = std::string{"Current FX Slot"};
+    auto cfxc = std::string{"Current FX Chain"};
     auto helpMenuText = std::string{"FX Presets"};
     auto helpMenuScreeReaderText = helpMenuText;
+
+    const auto cur_fx = current_fx;
 
     if (cfxid >= 0 && cfxid < n_fx_slots)
     {
         if (isCalledInEffectChooser)
         {
             cfx = fxslot_longnames[cfxid];
+            cfxc = fxchain_names[fxSlotToChain(cfxid)];
             helpMenuText = cfx;
         }
 
@@ -812,6 +849,7 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
     }
 
     menu.addColumnBreak();
+
     Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(menu, "FUNCTIONS");
 
     if (addDeact)
@@ -823,6 +861,8 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
                 that->repaint();
             });
     }
+
+    menu.addSeparator();
 
     menu.addItem(Surge::GUI::toOSCase(fmt::format("Clear {}", cfx)), enableClear, false,
                  [this, cfxid, that = juce::Component::SafePointer(sge->effectChooser.get())]() {
@@ -836,26 +876,97 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
                      repaint();
                  });
 
+    menu.addItem(Surge::GUI::toOSCase(fmt::format("Clear {}", cfxc)), true, false,
+                 [this, sge, cur_fx]() { sge->enqueueFXChainClear(fxSlotToChain(cur_fx)); });
+
+    menu.addItem(Surge::GUI::toOSCase("Clear All FX Chains"), true, false,
+                 [this, sge]() { sge->enqueueFXChainClear(-1); });
+
+    menu.addSeparator();
+
+    if (fx->type.val.i != fxt_off)
+    {
+        menu.addItem(Surge::GUI::toOSCase("Save FX Preset As..."), [this]() { this->saveFX(); });
+    }
+
+    menu.addItem(Surge::GUI::toOSCase("Save FX Chain Preset As..."),
+                 [this]() { this->saveChain(); });
+
+    menu.addSeparator();
+
+    menu.addItem(Surge::GUI::toOSCase("Copy FX Preset"), [this]() { this->copyFX(); });
+
+    if (Surge::FxClipboard::isPasteAvailable(fxClipboard))
+    {
+        menu.addItem(Surge::GUI::toOSCase("Paste FX Preset"), [this]() {
+            this->pasteFX();
+            this->storage->getPatch().isDirty = true;
+        });
+    }
+
+    menu.addItem(Surge::GUI::toOSCase("Copy FX Chain"), [this]() { this->copyChain(); });
+
+    if (Surge::FxClipboard::isChainPasteAvailable(fxChainClipboard))
+    {
+        menu.addItem(Surge::GUI::toOSCase("Paste FX Chain"), [this]() {
+            this->pasteChain();
+            this->storage->getPatch().isDirty = true;
+        });
+    }
+
+    menu.addSeparator();
+
     if (sge)
     {
-        auto initSubmenu = juce::PopupMenu();
+        storage->fxChainUserPreset->doPresetRescan(storage);
+        const auto &chainPresets = storage->fxChainUserPreset->getPresets();
+        auto chainSubmenu = juce::PopupMenu();
 
-        initSubmenu.addItem(Surge::GUI::toOSCase("Clear Scene A Insert FX Chain"), true, false,
-                            [this, sge]() { sge->enqueueFXChainClear(0); });
+        if (!chainPresets.empty())
+        {
+            chainSubmenu.addSeparator();
 
-        initSubmenu.addItem(Surge::GUI::toOSCase("Clear Scene B Insert FX Chain"), true, false,
-                            [this, sge]() { sge->enqueueFXChainClear(1); });
+            // Group by subPath (folder), matching how scanExtraPresets
+            // structures user single-slot presets.
+            fs::path lastSub;
 
-        initSubmenu.addItem(Surge::GUI::toOSCase("Clear Send FX Chain"), true, false,
-                            [this, sge]() { sge->enqueueFXChainClear(2); });
+            for (const auto &cp : chainPresets)
+            {
+                if (cp.subPath != lastSub)
+                {
+                    if (!lastSub.empty())
+                        chainSubmenu.addSeparator();
+                    if (!cp.subPath.empty())
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                            chainSubmenu, path_to_string(cp.subPath));
+                    lastSub = cp.subPath;
+                }
 
-        initSubmenu.addItem(Surge::GUI::toOSCase("Clear Global FX Chain"), true, false,
-                            [this, sge]() { sge->enqueueFXChainClear(3); });
+                chainSubmenu.addItem(cp.name, [this, cp, sge, cur_fx]() {
+                    // Push undo for all slots in the chain at once.
+                    // If a per-chain undo push exists use that; otherwise
+                    // push each slot individually.
 
-        initSubmenu.addItem(Surge::GUI::toOSCase("Clear All FX Chains"), true, false,
-                            [this, sge]() { sge->enqueueFXChainClear(-1); });
+                    int chainIdx = fxSlotToChain(cur_fx);
 
-        menu.addSubMenu(Surge::GUI::toOSCase("Clear Chains"), initSubmenu);
+                    for (int i = 0; i < n_fx_per_chain; ++i)
+                        sge->undoManager()->pushFX(fxslot_order[(chainIdx * n_fx_per_chain) + i]);
+
+                    FxStorage *slots[n_fx_per_chain];
+                    FxStorage *bufs[n_fx_per_chain];
+                    std::string names[n_fx_per_chain];
+                    buildChainSlotPtrs(sge, cur_fx, slots, bufs, names);
+
+                    storage->fxChainUserPreset->loadPresetOnto(cp, storage, bufs);
+
+                    sge->synth->load_fx_needed = true;
+                    storage->getPatch().isDirty = true;
+                    sge->queueRebuildUI();
+                });
+            }
+        }
+
+        menu.addSubMenu(Surge::GUI::toOSCase("FX Chains"), chainSubmenu);
     }
 
     menu.addSeparator();
@@ -870,21 +981,6 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
     };
 
     menu.addItem(Surge::GUI::toOSCase("Refresh FX Preset List"), rsA);
-    if (fx->type.val.i != fxt_off)
-    {
-        menu.addItem(Surge::GUI::toOSCase("Save FX Preset As..."), [this]() { this->saveFX(); });
-    }
-
-    menu.addSeparator();
-
-    menu.addItem(Surge::GUI::toOSCase("Copy FX Preset"), [this]() { this->copyFX(); });
-    if (Surge::FxClipboard::isPasteAvailable(fxClipboard))
-    {
-        menu.addItem(Surge::GUI::toOSCase("Paste FX Preset"), [this]() {
-            this->pasteFX();
-            this->storage->getPatch().isDirty = true;
-        });
-    }
 
     menu.addSeparator();
 
@@ -923,6 +1019,8 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
     }
 }
 
+//////////
+
 Surge::FxClipboard::Clipboard FxMenu::fxClipboard;
 
 void FxMenu::copyFX()
@@ -959,6 +1057,101 @@ void FxMenu::saveFX()
             this);
     }
 }
+
+//////////
+
+Surge::FxClipboard::ChainClipboard FxMenu::fxChainClipboard;
+
+void FxMenu::copyChain()
+{
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+    if (!sge)
+        return;
+
+    FxStorage *slots[n_fx_per_chain];
+    FxStorage *bufs[n_fx_per_chain];
+    std::string names[n_fx_per_chain];
+
+    buildChainSlotPtrs(sge, current_fx, slots, bufs, names);
+
+    Surge::FxClipboard::copyFxChain(storage, slots, names, fxChainClipboard);
+}
+
+void FxMenu::pasteChain()
+{
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+    if (!sge)
+        return;
+
+    FxStorage *slots[n_fx_per_chain];
+    FxStorage *bufs[n_fx_per_chain];
+    std::string names[n_fx_per_chain];
+
+    buildChainSlotPtrs(sge, current_fx, slots, bufs, names);
+
+    Surge::FxClipboard::pasteFxChain(storage, bufs, fxChainClipboard);
+
+    storage->getPatch().isDirty = true;
+    sge->queueRebuildUI();
+}
+
+void FxMenu::saveChain()
+{
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+    if (!sge)
+        return;
+
+    FxStorage *slots[n_fx_per_chain];
+    FxStorage *bufs[n_fx_per_chain];
+    std::string names[n_fx_per_chain];
+
+    buildChainSlotPtrs(sge, current_fx, slots, bufs, names);
+
+    sge->promptForMiniEdit(
+        "", "Enter the FX chain name:", "Save FX Chain", juce::Point<int>{},
+        [this, sge, slots, names](const std::string &presetName) {
+            // Build SlotData array from live FxStorage + selectedName
+            Surge::Storage::FxChainUserPreset::Preset::SlotData sd[n_fx_per_chain];
+
+            for (int i = 0; i < n_fx_per_chain; ++i)
+            {
+                FxStorage *fx = slots[i];
+                sd[i].type = fx->type.val.i;
+                sd[i].presetName = names[i];
+
+                for (int p = 0; p < n_fx_params; ++p)
+                {
+                    switch (fx->p[p].valtype)
+                    {
+                    case vt_float:
+                        sd[i].p[p] = fx->p[p].val.f;
+                        break;
+                    case vt_int:
+                        sd[i].p[p] = (float)fx->p[p].val.i;
+                        break;
+                    default:
+                        break;
+                    }
+
+                    sd[i].ts[p] = fx->p[p].can_temposync() && fx->p[p].temposync;
+                    sd[i].er[p] = fx->p[p].can_extend_range() && fx->p[p].extend_range;
+                    sd[i].da[p] = fx->p[p].can_deactivate() && fx->p[p].deactivated;
+                    sd[i].dt[p] = fx->p[p].has_deformoptions() ? fx->p[p].deform_type : -1;
+                }
+
+                if (fx->user_data.contains("filename"))
+                    sd[i].filename = fx->by_key("filename").to_string();
+            }
+
+            storage->fxChainUserPreset->saveChainPresetIn(storage, sd, presetName);
+        },
+        this);
+}
+
+//////////
 
 void FxMenu::loadUserPreset(const Surge::Storage::FxUserPreset::Preset &p)
 {

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.h
@@ -235,9 +235,16 @@ struct FxMenu : public juce::Component, public XMLMenuPopulator, public WidgetBa
     void setCurrentFx(int i) { current_fx = i; }
 
     static Surge::FxClipboard::Clipboard fxClipboard;
+
     void copyFX();
     void pasteFX();
     void saveFX();
+
+    static Surge::FxClipboard::ChainClipboard fxChainClipboard;
+
+    void copyChain();
+    void pasteChain();
+    void saveChain();
 
     void loadByIndex(const std::string &name, int index) override;
     void loadUserPreset(const Surge::Storage::FxUserPreset::Preset &p);


### PR DESCRIPTION
Closes #5476

Also shuffles the Functions options around a bit for better layout.

Clear FX chains submenu is also gone, reduced to two options: clear current FX chain, and clear all FX chains.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>