### PR TITLE
Tweak verbiage across reportError()

### DIFF
--- a/resources/surge-shared/configuration.xml
+++ b/resources/surge-shared/configuration.xml
@@ -152,7 +152,7 @@
     <snapshot name="Init (Send)" p0="0.500000" p1="0.500000" p2="1.000000" p3="0.500000" p4="0.500000" p5="0.000000"
               p6="0.000000" p7="1.000000"/>
 </type>
-<sectionheader label="MULTIEFFECTS"/>
+<sectionheader label="MISCELLANEOUS"/>
 <type i="14" name="Airwindows">
     <snapshot name="Init" p0="46" p1="1.000000" p2="0.000000" p3="1.000000"/>
 </type>

--- a/src/common/FxPresetAndClipboardManager.cpp
+++ b/src/common/FxPresetAndClipboardManager.cpp
@@ -170,10 +170,10 @@ void FxUserPreset::doPresetRescan(SurgeStorage *storage, bool forceRescan)
     catch (const fs::filesystem_error &e)
     {
         std::ostringstream oss;
-        oss << "Experienced file system error when scanning user FX. " << e.what();
+        oss << "Experienced a filesystem error when scanning user FX presets!\n\n" << e.what();
 
         if (storage)
-            storage->reportError(oss.str(), "FileSystem Error");
+            storage->reportError(oss.str(), "Filesystem Error");
     }
 }
 
@@ -286,7 +286,7 @@ void FxUserPreset::saveFxIn(SurgeStorage *storage, FxStorage *fx, const std::str
             {
                 storage->reportError(std::string("Unable to open FX preset file '") +
                                          path_to_string(outputPath) + "' for writing!",
-                                     "Error");
+                                     "Write Error");
                 return;
             }
 
@@ -378,11 +378,11 @@ void FxUserPreset::saveFxIn(SurgeStorage *storage, FxStorage *fx, const std::str
     catch (const fs::filesystem_error &e)
     {
         std::ostringstream oss;
-        oss << "Exception occurred while attempting to write the preset! Most likely, "
+        oss << "Exception occurred while attempting to write the FX preset. Most likely, "
                "invalid characters or a reserved name was used to name the preset. "
-               "Please try again with a different name!\n"
-            << "Details " << e.what();
-        storage->reportError(oss.str(), "Preset Write Error");
+               "Please try again with a different name!\n\n"
+            << e.what();
+        storage->reportError(oss.str(), "Write Error");
     }
 }
 
@@ -522,9 +522,9 @@ void FxChainUserPreset::doPresetRescan(SurgeStorage *storage, bool forceRescan)
     catch (const fs::filesystem_error &e)
     {
         std::ostringstream oss;
-        oss << "Experienced file system error when scanning FX chain presets. " << e.what();
+        oss << "Experienced a filesystem error when scanning FX chain presets!\n\n" << e.what();
         if (storage)
-            storage->reportError(oss.str(), "FileSystem Error");
+            storage->reportError(oss.str(), "Filesystem Error");
     }
 }
 
@@ -624,7 +624,7 @@ void FxChainUserPreset::saveChainPresetIn(SurgeStorage *storage,
             {
                 storage->reportError(std::string("Unable to open FX chain preset file '") +
                                          path_to_string(outputPath) + "' for writing!",
-                                     "Error");
+                                     "Write Error");
                 return;
             }
 
@@ -709,11 +709,11 @@ void FxChainUserPreset::saveChainPresetIn(SurgeStorage *storage,
     catch (const fs::filesystem_error &e)
     {
         std::ostringstream oss;
-        oss << "Exception occurred while attempting to write the chain preset! "
+        oss << "Exception occurred while attempting to write the FX chain preset! "
                "Most likely, invalid characters or a reserved name was used. "
-               "Please try again with a different name!\n"
-            << "Details " << e.what();
-        storage->reportError(oss.str(), "Preset Write Error");
+               "Please try again with a different name!\n\n"
+            << e.what();
+        storage->reportError(oss.str(), "Write Error");
     }
 }
 

--- a/src/common/ModulatorPresetManager.cpp
+++ b/src/common/ModulatorPresetManager.cpp
@@ -196,11 +196,11 @@ void ModulatorPreset::savePresetToUser(const fs::path &location, SurgeStorage *s
     catch (const fs::filesystem_error &e)
     {
         std::ostringstream oss;
-        oss << "Exception occurred while attempting to write the preset! Most likely, "
+        oss << "Exception occurred while attempting to write the LFO preset! Most likely, "
                "invalid characters or a reserved name was used to name the preset. "
                "Please try again with a different name!\n"
-            << "Details " << e.what();
-        s->reportError(oss.str(), "Preset Write Error");
+            << e.what();
+        s->reportError(oss.str(), "Write Error");
     }
 }
 

--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -384,9 +384,8 @@ CREATE TABLE IF NOT EXISTS Favorites (
         if (ec != SQLITE_OK)
         {
             std::ostringstream oss;
-            oss << "An error occurred opening sqlite file '" << dbname << "'. The error was '"
-                << sqlite3_errmsg(dbh) << "'.";
-            storage->reportError(oss.str(), "Surge Patch Database Error");
+            oss << "An error occurred when opening '" << dbname << "'.\n\n" << sqlite3_errmsg(dbh);
+            storage->reportError(oss.str(), "Database Error");
             if (dbh)
             {
                 // even if opening fails we still need to close the database
@@ -488,7 +487,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
             }
             catch (const SQL::Exception &e)
             {
-                storage->reportError(e.what(), "PatchDB Setup Error");
+                storage->reportError(e.what(), "Database Setup Error");
             }
         }
 
@@ -705,7 +704,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
                                "writing up to 10 more times. "
                                "Please dismiss this error in the meantime!\n\n Attempt: "
                             << lock_retries;
-                        storage->reportError(oss.str(), "Patch Database Locked");
+                        storage->reportError(oss.str(), "Database Locked");
                         // OK so in this case, we reload doThis onto the front of the queue and
                         // sleep
                         lock_retries++;
@@ -725,12 +724,12 @@ CREATE TABLE IF NOT EXISTS Favorites (
                         {
                             storage->reportError(
                                 "Database is locked and unwritable after multiple attempts!",
-                                "Patch Database Locked");
+                                "Database Locked");
                         }
                     }
                     catch (SQL::Exception &e)
                     {
-                        storage->reportError(e.what(), "Patch DB");
+                        storage->reportError(e.what(), "Database Error");
                     }
                 }
             }
@@ -805,7 +804,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         {
             if (storage)
             {
-                storage->reportError(e.what(), "PatchDB - Load Check");
+                storage->reportError(e.what(), "Database Load Check");
             }
             return;
         }
@@ -837,7 +836,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         {
             if (storage)
             {
-                storage->reportError(e.what(), "PatchDB - Insert Patch");
+                storage->reportError(e.what(), "Database Insert Patch");
             }
             return;
         }
@@ -942,7 +941,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         {
             if (storage)
             {
-                storage->reportError(e.what(), "PatchDB - FXP Features");
+                storage->reportError(e.what(), "Database FXP Features");
             }
             return;
         }
@@ -961,7 +960,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         {
             if (storage)
             {
-                storage->reportError(e.what(), "PatchDB - FXP Features");
+                storage->reportError(e.what(), "Database FXP Features");
             }
             return;
         }
@@ -988,7 +987,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
         catch (const SQL::Exception &e)
         {
-            storage->reportError(e.what(), "PatchDB - Junk gave Junk");
+            storage->reportError(e.what(), "Database Junk Gave Junk");
         }
     }
 
@@ -1008,7 +1007,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
         catch (const SQL::Exception &e)
         {
-            storage->reportError(e.what(), "PatchDB - Junk gave Junk");
+            storage->reportError(e.what(), "Database Junk Gave Junk");
         }
     }
 
@@ -1023,7 +1022,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
         catch (const SQL::Exception &e)
         {
-            storage->reportError(e.what(), "PatchDB - Junk gave Junk");
+            storage->reportError(e.what(), "Database Junk Gave Junk");
         }
     }
     void addRootCategory(const std::string &name, CatType type)
@@ -1044,7 +1043,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
         catch (const SQL::Exception &e)
         {
-            storage->reportError(e.what(), "PatchDB - Category Query");
+            storage->reportError(e.what(), "Database Category Query");
         }
 
         try
@@ -1060,7 +1059,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
         catch (const SQL::Exception &e)
         {
-            storage->reportError(e.what(), "PatchDB - Category Root Insert");
+            storage->reportError(e.what(), "Database Category Root Insert");
         }
     }
 
@@ -1084,7 +1083,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
         catch (const SQL::Exception &e)
         {
-            storage->reportError(e.what(), "PatchDB - Category Query");
+            storage->reportError(e.what(), "Database Category Query");
         }
 
         try
@@ -1111,7 +1110,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
         catch (const SQL::Exception &e)
         {
-            storage->reportError(e.what(), "PatchDB - Category Root Insert");
+            storage->reportError(e.what(), "Database Category Root Insert");
         }
     }
 
@@ -1221,7 +1220,7 @@ std::vector<std::pair<std::string, int>> PatchDB::readAllFeatures()
     }
     catch (SQL::Exception &e)
     {
-        storage->reportError(e.what(), "PatchDB - readFeatures");
+        storage->reportError(e.what(), "Database Read Features");
     }
     return res;
 }
@@ -1246,7 +1245,7 @@ std::vector<std::string> PatchDB::readAllFeatureValueString(const std::string &f
     }
     catch (SQL::Exception &e)
     {
-        storage->reportError(e.what(), "PatchDB - readFeatures");
+        storage->reportError(e.what(), "Database Read Features");
     }
     return res;
 }
@@ -1271,7 +1270,7 @@ std::vector<int> PatchDB::readAllFeatureValueInt(const std::string &feature)
     }
     catch (SQL::Exception &e)
     {
-        storage->reportError(e.what(), "PatchDB - readFeatures");
+        storage->reportError(e.what(), "Database Read Features");
     }
     return res;
 }
@@ -1316,7 +1315,7 @@ std::vector<PatchDB::patchRecord> PatchDB::rawQueryForNameLike(const std::string
         }
         else
         {
-            storage->reportError(e.what(), "PatchDB - rawQueryForNameLike");
+            storage->reportError(e.what(), "Database Raw Query For Name Like");
         }
     }
 
@@ -1379,7 +1378,7 @@ std::vector<PatchDB::catRecord> PatchDB::internalCategories(int t, const std::st
     }
     catch (SQL::Exception &e)
     {
-        storage->reportError(e.what(), "PatchDB - Loading Categories");
+        storage->reportError(e.what(), "Database Loading Categories");
     }
 
     return res;
@@ -1428,7 +1427,7 @@ std::vector<std::string> PatchDB::readUserFavorites()
     catch (SQL::Exception &e)
     {
         // This error really doesn't matter most of the time
-        storage->reportError(e.what(), "PatchDB - Loading Favorites");
+        storage->reportError(e.what(), "Database Loading Favorites");
     }
     return std::vector<std::string>();
 }
@@ -1457,7 +1456,7 @@ PatchDB::readAllPatchPathsWithIdAndModTime()
     catch (SQL::Exception &e)
     {
         // This error really doesn't matter most of the time
-        storage->reportError(e.what(), "PatchDB - Loading Favorites");
+        storage->reportError(e.what(), "Database Loading Favorites");
     }
     return res;
 }
@@ -1589,7 +1588,7 @@ PatchDB::queryFromQueryString(const std::unique_ptr<PatchDBQueryParser::Token> &
         }
         else
         {
-            storage->reportError(e.what(), "PatchDB - rawQueryForNameLike");
+            storage->reportError(e.what(), "Database Raw Query For Name Like");
         }
     }
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1603,14 +1603,12 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
 
     if (datasize >= (1 << 22))
     {
-        auto msg = fmt::format(
-            "The patch that we attempted to load has a very large header ({:d} bytes), "
-            "which is larger than our safety threshold of 4 megabytes. This almost definitely "
-            "means that the patch header is corrupted, so Surge XT will not "
-            "proceed with loading!",
-            datasize);
+        auto msg = fmt::format("The patch has a header larger than 4 MB. This almost definitely "
+                               "means that the header is corrupted, so as a safety measure, the "
+                               "patch won't be loaded!",
+                               datasize);
 
-        storage->reportError(msg, "Patch Load Error");
+        storage->reportError(msg, "Load Error");
 
         return;
     }

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -82,9 +82,9 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     else if (samplerate < 12000 || samplerate > 48000 * 32)
     {
         std::ostringstream oss;
-        oss << "Warning: SurgeStorage constructed with invalid samplerate: " << samplerate
-            << " - resetting to 48000 until audio system tells us otherwise" << std::endl;
-        reportError(oss.str(), "Sample Rate Corrupted on Startup");
+        oss << "SurgeStorage wa constructed with invalid samplerate ()" << samplerate
+            << " Hz). It will be reset to 48000 until audio system tells us otherwise!\n";
+        reportError(oss.str(), "Initialization Error");
         setSamplerate(48000);
     }
     else
@@ -347,7 +347,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
             reportError(
                 std::string() + "Surge is unable to find the %DOCUMENTS% directory. " +
                     "Your system is misconfigured and several features including saving patches, " +
-                    "the search database and preferences will not work. " + e.what(),
+                    "patch database and storing user preferences will not work!\n\n" + e.what(),
                 "Unable to determine %DOCUMENTS%");
         }
     }
@@ -376,8 +376,9 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     if (!snapshotloader.Parse(cxmlData.c_str()))
     {
         std::cout << snapshotloader.ErrorDesc() << std::endl;
-        reportError("Cannot parse 'configuration.xml' from memory. Internal Software Error.",
-                    "Surge Incorrectly Built");
+        reportError("Cannot parse 'configuration.xml' from memory! This means that Surge XT was "
+                    "incorrectly built from source code, which should never happen.",
+                    "Internal Software Error");
     }
 
     load_midi_controllers();
@@ -396,9 +397,9 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
         {
             WindowWT.size = 0;
             std::ostringstream oss;
-            oss << "Unable to load 'windows.wt' from memory. "
-                << "This is a fatal internal software error which should never occur!";
-            reportError(oss.str(), "Resource Loading Error");
+            oss << "Unable to load 'windows.wt' from memory. This means that Surge XT was "
+                   "incorrectly built from source code, which should never happen.";
+            reportError(oss.str(), "Internal Software Error");
         }
     }
 
@@ -440,10 +441,9 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
             TiXmlElement *pdoc = TINYXML_SAFE_TO_ELEMENT(doc.FirstChild("param-doc"));
             if (!pdoc)
             {
-                reportError(
-                    "Unknown top element in paramdocumentation.xml - not a parameter documentation "
-                    "XML file!",
-                    "Error");
+                reportError("Unknown top element in paramdocumentation.xml file. The file seems "
+                            "corrupted or malformed.",
+                            "Load Error");
             }
             else
             {
@@ -559,7 +559,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     }
     catch (fs::filesystem_error &e)
     {
-        reportError(e.what(), "Error Scanning FX Presets!");
+        reportError(e.what(), "Filesystem Error");
     }
 
     try
@@ -569,7 +569,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     }
     catch (fs::filesystem_error &e)
     {
-        reportError(e.what(), "Error Scanning FX Chains!");
+        reportError(e.what(), "Filesystem Error");
     }
 
     try
@@ -579,7 +579,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
     }
     catch (fs::filesystem_error &e)
     {
-        reportError(e.what(), "Error Scanning Modulator Presets!");
+        reportError(e.what(), "Filesystem Error");
     }
     memoryPools = std::make_unique<Surge::Memory::SurgeMemoryPools>(this);
 }
@@ -651,8 +651,8 @@ void SurgeStorage::createUserDirectory()
         }
         catch (const fs::filesystem_error &e)
         {
-            reportError(std::string() + "User directory is non-writable. " + e.what(),
-                        "Unable to set up User Directory.");
+            reportError(fmt::format("User directory is non-writable.\n\n{}", e.what()),
+                        "Filesystem Error");
             userDataPathValid = false;
         }
     }
@@ -668,7 +668,7 @@ void SurgeStorage::createUserDirectory()
             }
             catch (const fs::filesystem_error &e)
             {
-                reportError(e.what(), "Unable to set up User Directory");
+                reportError(e.what(), "Filesystem Error");
                 userDataPathValid = false;
             }
         }
@@ -707,7 +707,7 @@ fs::path SurgeStorage::getOverridenUserPath()
                         path_to_string(overrideFile) + "\nis malformed (" + detail +
                         "). Falling back to the default user data folder. Use "
                         "\"Set Custom User Data Folder...\" to reconfigure.",
-                    "Custom User Data Folder Configuration Invalid");
+                    "User Data Folder Error");
     };
 
     try
@@ -744,13 +744,13 @@ fs::path SurgeStorage::getOverridenUserPath()
                         "\nno longer exists or is not a directory. Falling back to the default "
                         "user data folder. Use \"Set Custom User Data Folder...\" to set a "
                         "new location.",
-                    "Custom User Data Folder Missing");
+                    "Custom User Data Folder Error");
     }
     catch (const std::exception &e)
     {
         reportError(std::string("Error reading custom user data folder configuration: ") +
                         e.what() + ". Falling back to the default user data folder.",
-                    "Custom User Data Folder Configuration Error");
+                    "Custom User Data Folder Error");
     }
 
     return {};
@@ -799,11 +799,11 @@ void SurgeStorage::setOverridenUserPath(const fs::path *path)
     catch (const fs::filesystem_error &e)
     {
         reportError(std::string() + "Unable to save user directory override: " + e.what(),
-                    "Error Saving Override");
+                    "Filesystem Error");
     }
     catch (...)
     {
-        reportError("Unable to save user directory override", "Error Saving Override");
+        reportError("Unable to save user directory override", "Filesystem Error");
     }
 }
 
@@ -992,10 +992,10 @@ void SurgeStorage::refresh_patchlist()
         {
             std::ostringstream erross;
             erross << "Unable to determine the modification time of '" << p.path.u8string() << ". "
-                   << "This usually means the file can't be opened, or is a broken symlink, or "
-                      "some such. Underlying error: "
+                   << "This usually means the file cannot be opened, is a broken symbolic link, or "
+                      "similar.\n\n"
                    << e.what();
-            reportError(erross.str(), "Unable to Read File Time");
+            reportError(erross.str(), "File Read Error");
             p.lastModTime = 0;
         }
         auto ps = p.path.u8string();
@@ -1199,7 +1199,7 @@ void SurgeStorage::refreshPatchOrWTListAddDir(bool userDir, const fs::path &init
     catch (const fs::filesystem_error &e)
     {
         std::ostringstream oss;
-        oss << "Experienced filesystem error when building patches. " << e.what();
+        oss << "Experienced filesystem error when building patches.\n\n" << e.what();
         reportError(oss.str(), "Filesystem Error");
     }
 
@@ -1557,8 +1557,8 @@ void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *os
     {
         std::ostringstream oss;
         oss << "Unable to load file with extension " << extension
-            << "! Surge XT only supports .wav, .wt and .wtscript wavetable files!";
-        reportError(oss.str(), "Error");
+            << "!\nSurge XT only supports .wav, .wt and .wtscript wavetable files!";
+        reportError(oss.str(), "Load Error");
     }
 
     if (osc && loaded)
@@ -1581,7 +1581,7 @@ void SurgeStorage::load_wt(string filename, Wavetable *wt, OscillatorStorage *os
         {
             if (!parse_wt_metadata(metadata, osc))
             {
-                reportError("Unable to parse metadata", "WaveTable Load");
+                reportError("Unable to parse metadata", "Load Error");
                 std::cerr << metadata << std::endl;
                 osc->wavetable_script = {};
                 osc->wavetable_script_res_base = 5;
@@ -1677,7 +1677,7 @@ bool SurgeStorage::load_wt_wt(string filename, Wavetable *wt, std::string &metad
             << " If you would like, please attach the wavetable which caused this error to a new "
                "GitHub issue at "
             << stringRepository;
-        reportError(oss.str(), "Wavetable Loading Error");
+        reportError(oss.str(), "Load Error");
     }
     return wasBuilt;
 }
@@ -1731,7 +1731,7 @@ bool SurgeStorage::load_wt_wt_mem(const char *data, size_t dataSize, Wavetable *
             << " If you would like, please attach the wavetable which caused this error to a new "
                "GitHub issue at "
             << stringRepository;
-        reportError(oss.str(), "Wavetable Loading Error");
+        reportError(oss.str(), "Load Error");
     }
     return wasBuilt;
 }
@@ -1739,7 +1739,7 @@ bool SurgeStorage::load_wt_wt_mem(const char *data, size_t dataSize, Wavetable *
 bool SurgeStorage::export_wt_wt_portable(const fs::path &fname, Wavetable *wt,
                                          const std::string &metadata)
 {
-    std::string errorMessage{"Unkown error"};
+    std::string errorMessage{"Unknown error!"};
     std::filebuf wfp;
 
     if (!wfp.open(fname, std::ios::binary | std::ios::out))
@@ -1747,7 +1747,7 @@ bool SurgeStorage::export_wt_wt_portable(const fs::path &fname, Wavetable *wt,
         errorMessage = "Unable to open file " + fname.u8string() + "!";
         errorMessage += std::strerror(errno);
 
-        reportError(errorMessage, "Wavetable Export");
+        reportError(errorMessage, "Export Error");
 
         return false;
     }
@@ -3206,7 +3206,7 @@ bool SurgeStorage::resetToCurrentScaleAndMapping()
     catch (Tunings::TuningError &e)
     {
         retuneTo12TETScaleC261Mapping();
-        reportError(e.what(), "SCL/KBM Error - Resetting to standard");
+        reportError(e.what(), "SCL/KBM Error");
     }
 
     auto t = currentTuning;
@@ -3339,7 +3339,7 @@ void SurgeStorage::rescanUserMidiMappings()
     catch (const fs::filesystem_error &e)
     {
         std::ostringstream oss;
-        oss << "Experienced filesystem error when loading MIDI settings. " << e.what();
+        oss << "Experienced filesystem error when loading the MIDI mapping.\n\n" << e.what();
         reportError(oss.str(), "Filesystem Error");
     }
 }
@@ -3360,7 +3360,7 @@ void SurgeStorage::loadMidiMappingByName(std::string name)
     {
         // Invalid XML Document. Show an error?
         reportError("Unable to locate surge-midi element in XML. Not a valid MIDI mapping!",
-                    "Surge MIDI");
+                    "Load Error");
         return;
     }
 
@@ -3486,8 +3486,8 @@ void SurgeStorage::storeMidiMappingToName(std::string name)
     if (!doc.SaveFile(path_to_string(fn)))
     {
         std::ostringstream oss;
-        oss << "Unable to save MIDI settings to '" << fn.u8string() << "'!";
-        reportError(oss.str(), "Error");
+        oss << "Unable to save the MIDI mapping to '" << fn.u8string() << "'!";
+        reportError(oss.str(), "Write Error");
     }
 }
 
@@ -3558,7 +3558,7 @@ void SurgeStorage::connect_as_oddsound_main()
                     "reset the MTS-ESP system, use the 'Reinitialize MTS-ESP' option in Surge XT. "
                     "Alternatively, quit the other program and attempt re-enabling Act as MTS-ESP "
                     "source option.",
-                    "MTS-ESP Source Initialization Error");
+                    "MTS-ESP Error");
     }
     lastSentTuningUpdate = -1;
 

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -5161,7 +5161,7 @@ void SurgeSynthesizer::loadFromDawExtraState()
         }
         catch (Tunings::TuningError &e)
         {
-            storage.reportError(e.what(), "Unable to restore tuning!");
+            storage.reportError(e.what(), "Tuning Restore Error");
             storage.retuneTo12TETScale();
         }
     }
@@ -5188,7 +5188,7 @@ void SurgeSynthesizer::loadFromDawExtraState()
         }
         catch (Tunings::TuningError &e)
         {
-            storage.reportError(e.what(), "Unable to restore mapping!");
+            storage.reportError(e.what(), "Mapping Restore Error");
             storage.remapToConcertCKeyboard();
         }
     }

--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -254,8 +254,8 @@ bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, cons
         auto msg = sst::plugininfra::misc_platform::getLastSystemError();
 
         storage.reportError(std::string() + "Unable to open file '" + std::string(fxpPath) +
-                                "'. Error Is: " + msg,
-                            "Unable to open file");
+                                "'.\n\n" + msg,
+                            "Load Error");
         return false;
     }
     fxChunkSetCustom fxp;
@@ -290,9 +290,9 @@ bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, cons
         //   oss << "Synth ID is '" << q.c[0] << q.c[1] << q.c[2] << q.c[3] << "'; Surge expected
         //   'cjs3'. ";
         //}
-        oss << "This error usually occurs when you attempt to load an .fxp that belongs to another "
-               "plugin into Surge XT.";
-        storage.reportError(oss.str(), "Unknown FXP File");
+        oss << "Loaded file has unknown FXP file format. This error usually occurs when you "
+               "attempt to load an .fxp that belongs to another plugin into Surge XT.";
+        storage.reportError(oss.str(), "Load Error");
         return false;
     }
 
@@ -375,7 +375,7 @@ bool SurgeSynthesizer::loadPatchByPath(const char *fxpPath, int categoryId, cons
             }
             catch (Tunings::TuningError &e)
             {
-                storage.reportError(e.what(), "Error applying tuning!");
+                storage.reportError(e.what(), "Tuning Error");
                 storage.retuneTo12TETScaleC261Mapping();
             }
         }
@@ -625,9 +625,9 @@ void SurgeSynthesizer::savePatch(bool factoryInPlace, bool skipOverwrite)
         std::ostringstream oss;
         oss << "Exception occurred while creating category folder! Most likely, invalid characters "
                "were used to name the category. Please remove suspicious characters and try "
-               "again!\nErrMessage: "
-            << msg << "\n"
-            << "Details " << e.what();
+               "again!\nError Message: "
+            << msg << "\n\n"
+            << e.what();
         storage.reportError(oss.str(), "Path Create Error");
         return;
     }
@@ -661,8 +661,8 @@ void SurgeSynthesizer::savePatch(bool factoryInPlace, bool skipOverwrite)
         std::ostringstream oss;
         oss << "Exception occurred while attempting to write the patch! Most likely, "
                "invalid characters or a reserved name was used to name the patch. "
-               "Please try again with a different name!\n"
-            << "Details " << e.what();
+               "Please try again with a different name!\n\n"
+            << e.what();
         storage.reportError(oss.str(), "Patch Write Error");
         return;
     }
@@ -680,9 +680,8 @@ void SurgeSynthesizer::savePatchToPath(fs::path filename, bool refreshPatchList)
     {
         auto msg = sst::plugininfra::misc_platform::getLastSystemError();
 
-        storage.reportError("Unable to save the patch to '" + filename.u8string() +
-                                "'. Error is: " + msg,
-                            "Patch Save Error");
+        storage.reportError("Unable to save the patch to '" + filename.u8string() + "'. \n\n" + msg,
+                            "Patch Write Error");
 
         return;
     }

--- a/src/common/WAVFileSupport.cpp
+++ b/src/common/WAVFileSupport.cpp
@@ -585,7 +585,7 @@ std::string SurgeStorage::export_wt_wav_portable(const fs::path &fname, Wavetabl
             errorMessage = "Unable to open file " + fname.u8string() + "!";
             errorMessage += std::strerror(errno);
 
-            reportError(errorMessage, "Wavetable Export");
+            reportError(errorMessage, "Export Error");
 
             return "";
         }

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -227,7 +227,7 @@ struct LuaWTEvaluator::Details
             oss << "Failed to evaluate the generate() function!\n" << err;
 
             if (storage)
-                storage->reportError(oss.str(), "Wavetable Evaluator Runtime Error");
+                storage->reportError(oss.str(), "Wavetable Script Evaluator Error");
             else
                 std::cerr << oss.str();
         }
@@ -264,7 +264,7 @@ struct LuaWTEvaluator::Details
                 {
                     if (storage)
                         storage->reportError("Init function returned a non-table.",
-                                             "Wavetable Script Evaluator");
+                                             "Wavetable Script Evaluator Error");
                     makeEmptyState(true);
                 }
             }
@@ -277,7 +277,7 @@ struct LuaWTEvaluator::Details
                     err = "Lua error: Value is nil.";
                 oss << "Failed to evaluate init() function!\n" << err;
                 if (storage)
-                    storage->reportError(oss.str(), "Wavetable Evaluator Init Error");
+                    storage->reportError(oss.str(), "Wavetable Script Evaluator Error");
                 else
                     std::cerr << oss.str();
                 lua_pop(L, -1);
@@ -575,7 +575,7 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
     std::ifstream inFile(filename, std::ios::binary | std::ios::ate);
     if (!inFile)
     {
-        storage->reportError("Failed to load XML file.", "XML Load Error");
+        storage->reportError("Failed to load XML file.", "Load Error");
         return std::nullopt;
     }
     const auto fileSize = static_cast<size_t>(inFile.tellg());
@@ -609,8 +609,7 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
 
         if (xmlSize > bytesAfterHeader || blobSize > bytesAfterHeader - xmlSize)
         {
-            storage->reportError("Wavetable script file is truncated or corrupt.",
-                                 "XML Load Error");
+            storage->reportError("Wavetable script file is truncated or corrupt!", "Load Error");
             return std::nullopt;
         }
 
@@ -624,43 +623,42 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
     doc.Parse(xmlStr.c_str(), nullptr, TIXML_ENCODING_LEGACY);
     if (doc.Error())
     {
-        storage->reportError("Failed to parse wavetable script XML.", "XML Load Error");
+        storage->reportError("Failed to parse wavetable script XML!", "Load Error");
         return std::nullopt;
     }
 
     auto wtscript = TINYXML_SAFE_TO_ELEMENT(doc.FirstChildElement("wtscript"));
     if (!wtscript)
     {
-        storage->reportError("No root <wtscript> element found.", "XML Load Error");
+        storage->reportError("No root wtscript element found!", "Load Error");
         return std::nullopt;
     }
 
     auto wavetable_script = TINYXML_SAFE_TO_ELEMENT(wtscript->FirstChildElement("script"));
     if (!wavetable_script)
     {
-        storage->reportError("No <wavetable_script> element found.", "XML Load Error");
+        storage->reportError("No wavetable_script element found!", "Load Error");
         return std::nullopt;
     }
 
     auto b64script = wavetable_script->Attribute("lua");
     if (!b64script || std::strlen(b64script) == 0)
     {
-        storage->reportError("Empty or missing lua attribute in <wavetable_script>.",
-                             "XML Load Error");
+        storage->reportError("Empty or missing lua attribute in wavetable_script!", "Load Error");
         return std::nullopt;
     }
 
     int nframes = 0;
     if (wavetable_script->QueryIntAttribute("frames", &nframes) != TIXML_SUCCESS)
     {
-        storage->reportError("Missing or invalid frames attribute.", "XML Load Error");
+        storage->reportError("Missing or invalid frames attribute!", "Load Error");
         return std::nullopt;
     }
 
     int res_base = 0;
     if (wavetable_script->QueryIntAttribute("samples", &res_base) != TIXML_SUCCESS)
     {
-        storage->reportError("Missing or invalid samples attribute.", "XML Load Error");
+        storage->reportError("Missing or invalid samples attribute!", "Load Error");
         return std::nullopt;
     }
 

--- a/src/common/dsp/effects/ConvolutionEffect.cpp
+++ b/src/common/dsp/effects/ConvolutionEffect.cpp
@@ -75,7 +75,12 @@ ConvolutionEffect::ConvolutionEffect(SurgeStorage *storage, FxStorage *fxdata, p
 
             if (v.empty())
             {
-                storage->reportError("Error loading provided impulse response", "FX Error");
+                storage->reportError(
+                    fmt::format(
+                        "Impulse response sample at\n\n{}\n\ncould not be loaded. Perhaps it was "
+                        "renamed or moved to another location?",
+                        f),
+                    "Load Error");
             }
             else
             {
@@ -373,8 +378,9 @@ void ConvolutionEffect::prep_ir()
     s = s && convolverR_.init(hd_size, tl_size, irRsub);
     if (!s)
     {
-        storage->reportError("Error initializing the convolver, not running convolution effect",
-                             "FX Error");
+        storage->reportError(
+            "Error initializing the convolution engine. The effect will not process audio!",
+            "Convolution Error");
         return;
     }
 

--- a/src/surge-fx/FXOpenSoundControl.cpp
+++ b/src/surge-fx/FXOpenSoundControl.cpp
@@ -59,7 +59,7 @@ void FXOpenSoundControl::tryOSCStartup()
 {
     if (!storage || !sfxPtr)
     {
-        storage->reportError("synth or sfxPtr are null", "OSC startup failure");
+        storage->reportError("SurgeStorage or sfxPtr are null!", "OSC Startup Error");
         return;
     }
 
@@ -141,7 +141,7 @@ void FXOpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
 
     if (addr.empty() || addr.at(0) != '/')
     {
-        storage->reportError("Bad OSC message format.", "OSC input error");
+        storage->reportError("Bad OSC message format!", "OSC Input Error");
         return;
     }
 
@@ -166,19 +166,19 @@ void FXOpenSoundControl::oscMessageReceived(const juce::OSCMessage &message)
                 index = stoi(addr_part);
                 if (index < 1 || index > 12)
                 {
-                    storage->reportError("Bad FX parameter index. Must be 1-12.",
-                                         "OSC input error");
+                    storage->reportError("Bad FX parameter index! Must be 1-12.",
+                                         "OSC Input Error");
                     return;
                 }
             }
             catch (const std::exception &e)
             {
-                storage->reportError("Bad format for FX parameter index.", "OSC input error");
+                storage->reportError("Bad format for FX parameter index!", "OSC Input Error");
                 return;
             }
             if (!message[0].isFloat32())
             {
-                storage->reportError("Expected float value.", "OSC input error");
+                storage->reportError("Expected float value!", "OSC Input Error");
                 return;
             }
 

--- a/src/surge-fx/SurgeFXEditor.cpp
+++ b/src/surge-fx/SurgeFXEditor.cpp
@@ -742,7 +742,7 @@ juce::PopupMenu SurgefxAudioProcessorEditor::makeOSCMenu()
 
             std::string form_str =
                 "'/fx/param/<n> <val>'; replace <n> with 1 - 12 and <val> with 0.0 - 1.0 ";
-            w->processor.storage->reportError(form_str, "OSC Message Format:");
+            w->processor.storage->reportError(form_str, "OSC Message Format");
         });
 
     return oscSubMenu;

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -679,7 +679,7 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
                         "This can be avoided by setting the DAW to use fixed buffer sizes, if "
                         "possible.",
                         fmt::arg("sz", BLOCK_SIZE)),
-            "Audio Input Latency Activated", SurgeStorage::AUDIO_INPUT_LATENCY_WARNING, false);
+            "Audio Input Latency", SurgeStorage::AUDIO_INPUT_LATENCY_WARNING, false);
         inputIsLatent = true;
     }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -780,7 +780,7 @@ void SurgeGUIEditor::idle()
                        " you can probably ignore this message and continue once Surge XT catches "
                        "up.";
 
-                synth->storage.reportError(oss.str(), "Patch Loading Error");
+                synth->storage.reportError(oss.str(), "Load Error");
             }
         }
 
@@ -2016,9 +2016,9 @@ void SurgeGUIEditor::openOrRecreateEditor()
         {
             // This would only happen if we added new parameters
             synth->storage.reportError(
-                "INTERNAL ERROR: List of parameters is larger than maximum number of parameter "
+                "List of parameters is larger than maximum number of parameter "
                 "slots. Increase n_paramslots in SurgeGUIEditor.h!",
-                "Error");
+                "Internal Error");
         }
 
         Parameter *p = *iter;
@@ -2405,15 +2405,14 @@ bool SurgeGUIEditor::open(void *parent)
         auto db = Surge::GUI::SkinDB::get();
 
         std::ostringstream oss;
-        oss << "Unable to load current skin! Reverting the skin to Surge XT Classic.\n\nSkin "
-               "Error:\n"
+        oss << "Unable to load the skin! Reverting to Surge XT Classic.\n\n"
             << db->getAndResetErrorString();
 
         auto msg = std::string(oss.str());
         this->currentSkin = db->defaultSkin(&(this->synth->storage));
         this->currentSkin->reloadSkin(this->bitmapStore);
 
-        synth->storage.reportError(msg, "Skin Loading Error");
+        synth->storage.reportError(msg, "Load Error");
     }
 
     reloadFromSkin();
@@ -3369,7 +3368,7 @@ void SurgeGUIEditor::promptForUserValueEntry(Parameter *p, juce::Component *c, i
             synth->storage.reportError(
                 "This parameter does not support editing its value by text input.\n\n"
                 "Please report this to Surge Synth Team in order to fix the problem!",
-                "Error");
+                "Internal Error");
             return;
         }
 
@@ -3590,14 +3589,14 @@ void SurgeGUIEditor::setupSkinFromEntry(const Surge::GUI::SkinDB::Entry &entry)
     if (!this->currentSkin->reloadSkin(this->bitmapStore))
     {
         std::ostringstream oss;
-        oss << "Unable to load " << entry.root << entry.name
-            << " skin! Reverting the skin to Surge XT Classic.\n\nSkin Error:\n"
+        oss << "Unable to load '" << entry.root << entry.name
+            << "'! Reverting to Surge XT Classic.\n\n"
             << db->getAndResetErrorString();
 
         auto msg = std::string(oss.str());
         this->currentSkin = db->defaultSkin(&(this->synth->storage));
         this->currentSkin->reloadSkin(this->bitmapStore);
-        synth->storage.reportError(msg, "Skin Loading Error");
+        synth->storage.reportError(msg, "Load Error");
     }
     reloadFromSkin();
 }
@@ -6764,7 +6763,7 @@ void SurgeGUIEditor::exportWavetableAs(WTExportFormat exportFormat)
                 if (!this->synth->storage.export_wt_wt_portable(fsp, &oscdata.wt, metadata))
                 {
                     this->synth->storage.reportError(
-                        "Unable to save the wavetable to " + fsp.u8string(), "Wavetable Export");
+                        "Unable to save the wavetable to " + fsp.u8string(), "Export Error");
                 }
                 break;
             }
@@ -6928,7 +6927,7 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
             std::ofstream outFile(fullLocation, std::ios::binary);
             if (!outFile)
             {
-                storage->reportError("Failed to open file for writing.", "Save Error");
+                storage->reportError("Failed to open file for writing.", "Write Error");
                 return;
             }
 
@@ -6948,7 +6947,7 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
                     ZSTD_compress(compressed.data(), compBound, binn_ptr(oscmap), rawSize, 3);
                 if (ZSTD_isError(compSize))
                 {
-                    storage->reportError("Failed to compress snapshot data.", "Save Error");
+                    storage->reportError("Failed to compress snapshot data.", "Write Error");
                     return;
                 }
                 compressed.resize(compSize);
@@ -6969,7 +6968,7 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
             outFile.close();
             if (!outFile)
             {
-                storage->reportError("Failed to write file.", "Save Error");
+                storage->reportError("Failed to write file.", "Write Error");
                 return;
             }
 
@@ -7001,7 +7000,7 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
                "Most likely, invalid characters or a reserved name was used to name "
                "the script. Please try again with a different name!\n"
             << "Details " << e.what();
-        storage->reportError(oss.str(), "Script Write Error");
+        storage->reportError(oss.str(), "Write Error");
     }
 }
 

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -482,7 +482,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                 catch (Tunings::TuningError &e)
                 {
                     synth->storage.retuneTo12TETScaleC261Mapping();
-                    synth->storage.reportError(e.what(), "Loading Error");
+                    synth->storage.reportError(e.what(), "Load Error");
                 }
                 tuningChanged();
                 auto tuningLabel = path_to_string(fs::path(synth->storage.currentScale.name));
@@ -546,7 +546,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                 catch (Tunings::TuningError &e)
                 {
                     synth->storage.remapToConcertCKeyboard();
-                    synth->storage.reportError(e.what(), "Loading Error");
+                    synth->storage.reportError(e.what(), "Load Error");
                 }
                 tuningChanged();
                 auto mappingLabel = synth->storage.currentMapping.name;
@@ -601,7 +601,7 @@ juce::PopupMenu SurgeGUIEditor::makeTuningMenu(const juce::Point<int> &where, bo
                         " does not exist. It seems that your Surge factory data folder is "
                         "missing.\n\n"
                         "Please run the Surge installer to set up the factory data.",
-                    "Factory Tuning Library Folder Not Found");
+                    "Load Error");
             }
         });
 
@@ -1664,7 +1664,7 @@ juce::PopupMenu SurgeGUIEditor::makeDataMenu(const juce::Point<int> &where)
                 "The folder " + path_to_string(this->synth->storage.datapath) +
                     " does not exist. It seems that your Surge factory data folder is missing.\n\n"
                     "Please run the Surge installer to set up the factory data.",
-                "Factory Data Folder Not Found");
+                "Load Error");
         }
     });
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -514,12 +514,11 @@ void SurgeGUIEditor::refreshSkin()
     if (!currentSkin->reloadSkin(bitmapStore))
     {
         auto db = Surge::GUI::SkinDB::get();
-        std::string msg =
-            "Unable to load skin! Reverting the skin to Surge Classic XT.\n\nSkin error:\n" +
-            db->getAndResetErrorString();
+        std::string msg = "Unable to load the skin! Reverting to Surge Classic XT.\n\n" +
+                          db->getAndResetErrorString();
         currentSkin = db->defaultSkin(&(synth->storage));
         currentSkin->reloadSkin(bitmapStore);
-        synth->storage.reportError(msg, "Skin Loading Error");
+        synth->storage.reportError(msg, "Load Error");
     }
 
     reloadFromSkin();

--- a/src/surge-xt/gui/overlays/TuningOverlays.cpp
+++ b/src/surge-xt/gui/overlays/TuningOverlays.cpp
@@ -2810,7 +2810,7 @@ struct TuningControlArea : public juce::Component,
             {
                 overlay->storage->reportError(
                     "You have unapplied changes in your SCL/KBM. Please apply them before saving!",
-                    "SCL Save Error");
+                    "Notification");
                 break;
             }
             fileChooser = std::make_unique<juce::FileChooser>("Save SCL", juce::File(), "*.scl");
@@ -2836,9 +2836,8 @@ struct TuningControlArea : public juce::Component,
                     }
                     else
                     {
-                        overlay->storage->reportError("Unable to save Scala file to " +
-                                                          fsp.u8string() + "!",
-                                                      "Scala Save Error");
+                        overlay->storage->reportError(
+                            "Unable to save Scala file to " + fsp.u8string() + "!", "Write Error");
                     }
                 });
         }
@@ -2853,7 +2852,7 @@ struct TuningControlArea : public juce::Component,
                         " does not exist. It seems that your Surge factory data folder is "
                         "missing.\n\n"
                         "Please run the Surge installer to set up the factory data.",
-                    "Tuning Library Folder Not Found");
+                    "Load Error");
             }
         }
         break;
@@ -3127,7 +3126,7 @@ void TuningOverlay::onNewSCLKBM(const std::string &scl, const std::string &kbm)
     }
     catch (const Tunings::TuningError &e)
     {
-        storage->reportError(e.what(), "Error Applying Tuning");
+        storage->reportError(e.what(), "Tuning Error");
     }
 }
 

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
@@ -992,14 +992,14 @@ void CurrentFxDisplay::onDrop(const juce::String &file)
             {
                 storage->reportError(
                     fmt::format("Failed to copy impulse response from {}!", file.toStdString()),
-                    "Impulse Response Load Error");
+                    "Load Error");
                 return;
             }
             if (!cb->loadWavForConvolution(rString))
             {
                 storage->reportError(
                     fmt::format("Failed to load impulse response from {}!", file.toStdString()),
-                    "Impulse Response Load Error");
+                    "Load Error");
                 return;
             }
         }

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -882,7 +882,7 @@ void PatchSelector::showClassicMenu(bool single_category, bool userOnly)
                     " does not exist. It seems that your Surge factory patches folder is "
                     "missing.\n\n"
                     "Please run the Surge installer to set up the factory patches.",
-                "Factory Patches Folder Not Found");
+                "Load Error");
         }
     });
 
@@ -894,7 +894,7 @@ void PatchSelector::showClassicMenu(bool single_category, bool userOnly)
                     " does not exist. It seems that your Surge third party patches folder is "
                     "missing.\n\n"
                     "Please run the Surge installer to set up the third party patches.",
-                "Third Party Patches Folder Not Found");
+                "Load Error");
         }
     });
 

--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
@@ -809,7 +809,6 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
 
     auto cfxid = -1;
     auto cfxtype = 0;
-    bool addDeact = false;
     bool isDeact = false;
     bool enableClear = true;
 
@@ -821,7 +820,6 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
         {
             auto deactbm = sge->effectChooser->getDeactivatedBitmask();
 
-            addDeact = true;
             isDeact = deactbm & (1 << cfxid);
             cfxtype = sge->effectChooser->fxTypes[cfxid];
             enableClear = cfxtype != fxt_off;
@@ -852,15 +850,12 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
 
     Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(menu, "FUNCTIONS");
 
-    if (addDeact)
-    {
-        menu.addItem(
-            Surge::GUI::toOSCase(fmt::format("{} {}", (isDeact ? "Activate" : "Deactivate"), cfx)),
-            [that = juce::Component::SafePointer(sge->effectChooser.get())]() {
-                that->toggleSelectedDeactivation();
-                that->repaint();
-            });
-    }
+    menu.addItem(
+        Surge::GUI::toOSCase(fmt::format("{} {}", (isDeact ? "Activate" : "Deactivate"), cfx)),
+        [that = juce::Component::SafePointer(sge->effectChooser.get())]() {
+            that->toggleSelectedDeactivation();
+            that->repaint();
+        });
 
     menu.addSeparator();
 
@@ -1214,10 +1209,10 @@ void FxMenu::scanExtraPresets()
     {
         // really nothing to do about this other than continue without the preset
         std::ostringstream oss;
-        oss << "Experienced file system error when scanning user FX. " << e.what();
+        oss << "Experienced file system error when scanning user FX presets!\n\n" << e.what();
 
         if (storage)
-            storage->reportError(oss.str(), "FileSystem Error");
+            storage->reportError(oss.str(), "Filesystem Error");
     }
 }
 


### PR DESCRIPTION
Most often shortening the titlebar line and making it consistent depending on what the error is. In some cases adjust the verbiage and formatting of the error.