### PR TITLE
Ensure binn is the same size as the decompressed data for safety.

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1204,7 +1204,24 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
         }
         if (dr < end)
         {
-            dr += load_arbitrary_block_storage(dr, ((char *)end - dr));
+            if (streamingRevision <= 28)
+            {
+                dr += load_arbitrary_block_storage(dr, (char *)end - dr);
+            }
+            else
+            {
+                // Started putting the size in the xml so that we could tack more on to the end.
+                if (static_cast<std::size_t>((char *)end - dr) < claimedArbitraryBlockStorageSize)
+                {
+                    std::cerr << "Missing arbitrary block storage data at the end of the patch, "
+                                 "possible patch corruption."
+                              << std::endl;
+                }
+                else
+                {
+                    dr += load_arbitrary_block_storage(dr, claimedArbitraryBlockStorageSize);
+                }
+            }
         }
     }
     else
@@ -1222,6 +1239,17 @@ unsigned int SurgePatch::save_patch(void **data)
     void *xmldata = 0;
     patch_header header;
     std::vector<std::uint8_t> arbdata;
+
+    arbdata = save_arbitrary_block_storage();
+    if (arbdata.size() > std::numeric_limits<int32_t>::max())
+    {
+        claimedArbitraryBlockStorageSize = 0;
+        arbdata.clear();
+    }
+    else
+    {
+        claimedArbitraryBlockStorageSize = arbdata.size();
+    }
 
     memcpy(header.tag, "sub3", 4);
     size_t xmlsize = save_xml(&xmldata);
@@ -1249,7 +1277,6 @@ unsigned int SurgePatch::save_patch(void **data)
         }
     }
     psize += xmlsize + sizeof(patch_header);
-    arbdata = save_arbitrary_block_storage();
     psize += arbdata.size();
     if (patchptr)
         free(patchptr);
@@ -1470,10 +1497,12 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
 
     data = decompressed.data();
 
-    int sz = 0;
+    int sz = static_cast<int>(decompressedSize);
     if (!binn_is_valid_ex(data, NULL, NULL, &sz))
     {
-        std::cerr << "Failed to find binn; possibly corrupted patch." << std::endl;
+        std::cerr
+            << "Failed to find binn or it was not the reported size; possibly corrupted patch."
+            << std::endl;
         return 0;
     }
     binn *b = binn_open_ex(data, sz);
@@ -1722,6 +1751,12 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 tag = TINYXML_SAFE_TO_ELEMENT(tag->NextSiblingElement("tag"));
             }
         }
+    }
+
+    TiXmlElement *serialization = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("serialization"));
+    if (serialization)
+    {
+        serialization->QueryIntAttribute("absSize", &claimedArbitraryBlockStorageSize);
     }
 
     TiXmlElement *parameters = TINYXML_SAFE_TO_ELEMENT(patch->FirstChild("parameters"));
@@ -3803,6 +3838,9 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
 
     meta.InsertEndChild(tagsX);
     patch.InsertEndChild(meta);
+
+    TiXmlElement serialization("serialization");
+    serialization.SetAttribute("absSize", claimedArbitraryBlockStorageSize);
 
     TiXmlElement parameters("parameters");
 

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -3841,6 +3841,7 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
 
     TiXmlElement serialization("serialization");
     serialization.SetAttribute("absSize", claimedArbitraryBlockStorageSize);
+    patch.InsertEndChild(serialization);
 
     TiXmlElement parameters("parameters");
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1371,6 +1371,7 @@ class SurgePatch
     int32_t paramModulationCount{0};
     static constexpr int maxMonophonicParamModulations = 256;
     std::array<MonophonicParamModulation, maxMonophonicParamModulations> monophonicParamModulations;
+    int claimedArbitraryBlockStorageSize{0};
 };
 
 struct Patch

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -149,7 +149,7 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 // 27 -> 28 (XT 1.4.* nightlies) added corrected TX shapes to Sine oscillator
 // clang-format on
 
-const int ff_revision = 28;
+const int ff_revision = 29;
 
 const int n_scene_params = 273;
 const int n_global_params = 11 + n_fx_slots * (n_fx_params + 1); // each param plus a type

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -147,6 +147,7 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 // 26 -> 27 (XT 1.4.* nightlies) fixed OB-Xd and BP12 legacy streaming for sst-filters upgrade
 //                               fixed extendable parameters not extending in Waveshaper effect
 // 27 -> 28 (XT 1.4.* nightlies) added corrected TX shapes to Sine oscillator
+// 28 -> 29 (XT 1.4.* nightlies) save/load size of ArbitraryBlockStorage segment
 // clang-format on
 
 const int ff_revision = 29;

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -548,7 +548,7 @@ static void loadWtscriptSnapshots(const void *compData, size_t blobSize, Oscilla
     if (decompressedSize < sizeof(binn_struct))
         return;
 
-    int sz = 0;
+    int sz = decompressedSize;
     if (!binn_is_valid_ex(decompressed.data(), NULL, NULL, &sz))
         return;
 


### PR DESCRIPTION
Also allow us to tack more on to the end in the future.

Paul, before you merge this, can you verify if I should bother with the streaming revision check (and increment it, which I'll add a commit to do)? We're still on nightly, so if it's fine to *not* do it I can just hose people's IR and WT script patches (they'll need the IRs and WT scripts re-imported basically).