### PR TITLE
Refresh MSEG/Formula overlay on scene change

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -2414,6 +2414,15 @@ void SurgeGUIEditor::openOrRecreateEditor()
     sendStructureChangeIn = 120;
 
     frame->repaint();
+
+    // Also bring any torn-out overlay back to the front
+    for (const auto &ol : juceOverlays)
+    {
+        if (ol.second && ol.second->isTornOut() && ol.second->tearOutParent)
+        {
+            ol.second->tearOutParent->toFront(false);
+        }
+    }
 }
 
 void SurgeGUIEditor::close_editor()

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -214,6 +214,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void changeSelectedOsc(int value);
     void changeSelectedScene(int value);
     void closeOrRefreshWTSEditor();
+    void closeOrRefreshMSEGOrFormulaEditor();
 
     void refreshSkin();
 

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -850,8 +850,8 @@ bool SurgeGUIEditor::updateOverlayContentIfPresent(OverlayTags tag)
         {
             mseol->forceRefresh();
         }
+        break;
     }
-
     case FORMULA_EDITOR:
     {
         auto feol = dynamic_cast<Surge::Overlays::FormulaModulatorEditor *>(getOverlayIfOpen(tag));

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -419,41 +419,8 @@ void SurgeGUIEditor::changeSelectedScene(int value)
     synth->release_if_latched[synth->storage.getPatch().scene_active.val.i] = true;
     synth->storage.getPatch().scene_active.val.i = current_scene;
 
-    bool hasMSEG = isAnyOverlayPresent(MSEG_EDITOR);
-    bool hasForm = isAnyOverlayPresent(FORMULA_EDITOR);
-
-    if (hasForm || hasMSEG)
-    {
-        auto ld = &(synth->storage.getPatch()
-                        .scene[current_scene]
-                        .lfo[modsource_editor[current_scene] - ms_lfo1]);
-
-        if (ld->shape.val.i == lt_mseg && hasMSEG)
-        {
-            refreshOverlayWithOpenClose(SurgeGUIEditor::MSEG_EDITOR);
-        }
-        else if (ld->shape.val.i == lt_formula && hasForm)
-        {
-            refreshOverlayWithOpenClose(SurgeGUIEditor::FORMULA_EDITOR);
-        }
-        else if (ld->shape.val.i == lt_mseg && hasForm)
-        {
-            refreshAndMorphOverlayWithOpenClose(FORMULA_EDITOR, MSEG_EDITOR);
-        }
-        else if (ld->shape.val.i == lt_formula && hasMSEG)
-        {
-            refreshAndMorphOverlayWithOpenClose(MSEG_EDITOR, FORMULA_EDITOR);
-        }
-        else
-        {
-            if (hasForm)
-                closeOverlay(SurgeGUIEditor::FORMULA_EDITOR);
-            if (hasMSEG)
-                closeOverlay(SurgeGUIEditor::MSEG_EDITOR);
-        }
-    }
-
     closeOrRefreshWTSEditor();
+    closeOrRefreshMSEGOrFormulaEditor();
 
     refresh_mod();
 
@@ -492,6 +459,60 @@ void SurgeGUIEditor::closeOrRefreshWTSEditor()
             if (wasTornOut)
             {
                 closeOverlay(otag);
+            }
+            showOverlay(otag);
+            if (wasTornOut)
+            {
+                auto c = getOverlayWrapperIfOpen(otag);
+                if (c)
+                {
+                    c->doTearOut(tearOutLoc);
+                }
+            }
+        }
+    }
+}
+
+void SurgeGUIEditor::closeOrRefreshMSEGOrFormulaEditor()
+{
+    bool hadExtendedOverlay = false;
+    bool wasTornOut = false;
+    auto wasTornOutTag = MSEG_EDITOR;
+    juce::Point<int> tearOutLoc;
+
+    for (auto otag : {MSEG_EDITOR, FORMULA_EDITOR})
+    {
+        if (isAnyOverlayPresent(otag))
+        {
+            auto c = getOverlayWrapperIfOpen(otag);
+            if (c)
+            {
+                wasTornOut = c->isTornOut();
+                tearOutLoc = c->currentTearOutLocation();
+                wasTornOutTag = otag;
+            }
+            if (!wasTornOut)
+            {
+                closeOverlay(otag);
+            }
+            hadExtendedOverlay = true;
+        }
+    }
+
+    if (hadExtendedOverlay)
+    {
+        auto shape = synth->storage.getPatch()
+                         .scene[current_scene]
+                         .lfo[modsource_editor[current_scene] - ms_lfo1]
+                         .shape.val.i;
+
+        if (shape == lt_mseg || shape == lt_formula)
+        {
+            auto otag = (shape == lt_mseg) ? MSEG_EDITOR : FORMULA_EDITOR;
+
+            if (wasTornOut)
+            {
+                closeOverlay(wasTornOutTag);
             }
             showOverlay(otag);
             if (wasTornOut)

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -433,6 +433,18 @@ void OverlayWrapper::resized()
 
 void OverlayWrapper::doTearOut(const juce::Point<int> &showAt)
 {
+    if (isTornOut())
+    {
+        // Already torn out edge case: this happens when showOverlay restores the torn-out state on
+        // reopen and the caller then tears out again. Re-recording parentBeforeTearOut here would
+        // break tear-in so just reposition the existing window if a location was requested
+        if (showAt.x >= 0 && showAt.y >= 0)
+        {
+            tearOutParent->setTopLeftPosition(showAt.x, showAt.y);
+        }
+        return;
+    }
+
     auto rvs = juce::ScopedValueSetter(resizeRecordsSize, false);
     auto pt = std::make_pair(-1, -1);
 


### PR DESCRIPTION
- Fixes MSEG/Formula overlay not refreshing on scene change (like it does on switching modulators)
- Keep torn-out overlay windows on top after an editor rebuild
- Make `OverlayWrapper::doTearOut` re-entrant so reopening an already torn-out overlay (scene/osc/modulator switch) doesn't break re-docking using the minimize button
- Adds missing `break` in `updateOverlayContentIfPresent`

Assisted-by: Claude Opus 4.8