### PR TITLE
Defer Formula shared table wipe to the next evaluation's init()

### DIFF
--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -493,6 +493,7 @@ void SurgeSynthesizer::loadRaw(const void *data, int size, bool preset)
                                                           &(storage.getPatch().formulamods[sc][m]));
         }
     }
+    Surge::Formula::requestSharedDataWipe(&storage);
 
     storage.getPatch().isDirty = false;
 

--- a/src/common/dsp/modulators/FormulaModulationHelper.cpp
+++ b/src/common/dsp/modulators/FormulaModulationHelper.cpp
@@ -114,6 +114,9 @@ end
         }
     }
 
+    // Service any pending shared-table wipe here, immediately before init() runs below
+    wipeSharedData(storage, !is_display);
+
     // Calculate lfo_id from the element pointer
     // Requires that formulamods is a contiguous 2D array and that fs points inside it
     auto computeLfoId = [storage](const FormulaModulatorStorage *fs) {
@@ -208,21 +211,6 @@ end
             lua_pop(s.L, 2); // Pop process and init (or nil)
             stateData.knownBadFunctions.insert(s.funcName);
         }
-
-        // Wipe shared table on each script parse
-        lua_getglobal(s.L, sharedTableName);
-        if (lua_istable(s.L, -1))
-        {
-            lua_pushnil(s.L);
-            while (lua_next(s.L, -2))
-            {
-                lua_pop(s.L, 1);        // pop value
-                lua_pushvalue(s.L, -1); // duplicate the key
-                lua_pushnil(s.L);
-                lua_settable(s.L, -4); // clear the key
-            }
-        }
-        lua_pop(s.L, 1); // pop shared (or nil)
 
         // this happens here because we did parse it at least. Don't parse again until it is changed
         lua_pushstring(s.L, fs->formulaString.c_str());
@@ -452,6 +440,49 @@ end
 #endif
 
     return true;
+}
+
+void requestSharedDataWipe(SurgeStorage *storage)
+{
+    auto &stateData = *storage->formulaGlobalData;
+    stateData.audioSharedWipeRequested.store(true, std::memory_order_relaxed);
+    stateData.displaySharedWipeRequested.store(true, std::memory_order_relaxed);
+}
+
+void wipeSharedData(SurgeStorage *storage, bool onAudioThread)
+{
+#if HAS_LUA
+    auto &stateData = *storage->formulaGlobalData;
+
+    auto wipe = [](void *state) {
+        auto *L = (lua_State *)state;
+        lua_getglobal(L, sharedTableName);
+        if (lua_istable(L, -1))
+        {
+            lua_pushnil(L);
+            while (lua_next(L, -2))
+            {
+                lua_pop(L, 1);        // pop value
+                lua_pushvalue(L, -1); // duplicate the key
+                lua_pushnil(L);
+                lua_settable(L, -4); // clear the key
+            }
+        }
+        lua_pop(L, 1); // pop shared (or nil)
+    };
+
+    // Pick the flag set by the calling thread, then wipe its state if a request is pending
+    auto *requested =
+        onAudioThread ? &stateData.audioSharedWipeRequested : &stateData.displaySharedWipeRequested;
+
+    if (requested->load(std::memory_order_relaxed))
+    {
+        requested->store(false, std::memory_order_relaxed);
+        auto *state = onAudioThread ? stateData.audioState : stateData.displayState;
+        if (state)
+            wipe(state);
+    }
+#endif
 }
 
 void removeFunctionsAssociatedWith(SurgeStorage *storage, FormulaModulatorStorage *fs)

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -27,6 +27,7 @@
 #include "StringOps.h"
 #include "LuaSupport.h"
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -45,6 +46,8 @@ struct GlobalData
     std::unordered_set<std::string> knownBadFunctions; // these are functions which cause an error
     std::unordered_map<FormulaModulatorStorage *, std::unordered_set<std::string>> functionsPerFMS;
     void *audioState{nullptr}, *displayState{nullptr};
+    std::atomic<bool> audioSharedWipeRequested{false};
+    std::atomic<bool> displaySharedWipeRequested{false};
 };
 
 static constexpr int max_formula_outputs{max_lfo_indices};
@@ -105,6 +108,8 @@ void setupStorage(SurgeStorage *s);
 
 bool initEvaluatorState(EvaluatorState &s);
 bool cleanEvaluatorState(EvaluatorState &s);
+void requestSharedDataWipe(SurgeStorage *storage);
+void wipeSharedData(SurgeStorage *storage, bool onAudioThread);
 void removeFunctionsAssociatedWith(SurgeStorage *,
                                    FormulaModulatorStorage *fs); // audio thread only please
 bool prepareForEvaluation(SurgeStorage *storage, FormulaModulatorStorage *fs, EvaluatorState &s,

--- a/src/surge-testrunner/UnitTestsLUA.cpp
+++ b/src/surge-testrunner/UnitTestsLUA.cpp
@@ -1030,7 +1030,7 @@ end)FN");
         }
     }
 
-    SECTION("Shared Table Is Wiped On Script Change")
+    SECTION("Shared Table Is Wiped By requestSharedDataWipe")
     {
         SurgeStorage storage;
         FormulaModulatorStorage fs;
@@ -1067,6 +1067,7 @@ end)FN";
             REQUIRE(c.v == 0.25);
         }
         fs.setFormula(scriptB);
+        Surge::Formula::requestSharedDataWipe(&storage);
         auto secondRun = runFormula(&storage, &fs, 0.0321, 5);
         REQUIRE(!secondRun.empty());
         for (auto c : secondRun)

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -39,6 +39,7 @@
 #include "ModulatorPresetManager.h"
 #include "ModulationSource.h"
 #include "WavetableScriptEvaluator.h"
+#include "FormulaModulationHelper.h"
 #include "PatchFileHeaderStructs.h"
 
 #include "SurgeSynthEditor.h"
@@ -2811,6 +2812,7 @@ void SurgeGUIEditor::setFormulaFromUndo(int scene, int lfoid, const FormulaModul
         refresh_mod();
     }
     synth->storage.getPatch().formulamods[scene][lfoid] = val;
+    Surge::Formula::requestSharedDataWipe(&(synth->storage));
     synth->refresh_editor = true;
     if (auto ol = getOverlayIfOpenAs<Surge::Overlays::FormulaModulatorEditor>(FORMULA_EDITOR))
     {

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -33,6 +33,7 @@
 #include "AccessibleHelpers.h"
 #include "DebugHelpers.h"
 #include "ModulatorPresetManager.h"
+#include "FormulaModulationHelper.h"
 
 #include "fmt/core.h"
 
@@ -2080,6 +2081,11 @@ void SurgeGUIEditor::loadModulatorPresetFrom(const fs::path &path, int scene, in
     synth->storage.modulatorPreset->loadPresetFrom(path, &synth->storage, scene, lfoId);
 
     auto newshape = synth->storage.getPatch().scene[scene].lfo[lfoId].shape.val.i;
+
+    if (newshape == lt_formula)
+    {
+        Surge::Formula::requestSharedDataWipe(&(synth->storage));
+    }
 
     if (auto ol = getOverlayIfOpenAs<Surge::Overlays::MSEGEditor>(MSEG_EDITOR))
     {

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -2813,6 +2813,7 @@ void FormulaModulatorEditor::applyCode()
 
     editor->undoManager()->pushFormula(scene, lfo_id, *formulastorage);
     formulastorage->setFormula(mainDocument->getAllContent().toStdString());
+    Surge::Formula::requestSharedDataWipe(storage);
     storage->getPatch().isDirty = true;
     editor->forceLfoDisplayRepaint();
     updateDebuggerIfNeeded();


### PR DESCRIPTION
Formula's `shared` table is wiped on script (re)parse to give scripts a clean slate and prevent stale data carrying over. Currently that wipe lives inside a branch of `prepareForEvaluation()`, which has two problems: first, the ordering is awkward where one modulator's parse can wipe the table after another modulator has already run its `init()` and populated it. And two, it skips the wipe for cached scripts.

This PR instead sets a flag at each script-change entry point (script apply, patch load, preset load, undo), consumed before a script's `init()` runs, fixing these issues.

Assisted-by: Claude Opus 4.8