### PR TITLE
Disable the deactivated-rate ghost wave for Formula LFO display

### DIFF
--- a/scripts/misc/Formula-state-variable-test.lua
+++ b/scripts/misc/Formula-state-variable-test.lua
@@ -49,6 +49,7 @@ function init(state)
     print("tuned_key", state.tuned_key)
     print("use_amplitude", state.use_amplitude)
     print("use_envelope", state.use_envelope)
+    print("use_rate", state.use_rate)
     print("velocity", state.velocity)
     print("voice_count", state.voice_count)
     print("voice_id", state.voice_id)
@@ -110,10 +111,10 @@ function process(state)
         print("tuned_key", state.tuned_key)
         print("use_amplitude", state.use_amplitude)
         print("use_envelope", state.use_envelope)
+        print("use_rate", state.use_rate)
         print("velocity", state.velocity)
         print("voice_count", state.voice_count)
         print("voice_id", state.voice_id)
-
     end
 
     state.output = 0

--- a/src/common/dsp/modulators/FormulaModulationHelper.cpp
+++ b/src/common/dsp/modulators/FormulaModulationHelper.cpp
@@ -299,6 +299,7 @@ end
             addb("clamp_output", true);
             addb("use_amplitude", true);
             addb("use_envelope", true);
+            addb("use_rate", true);
             addb("retrigger_AEG", false);
             addb("retrigger_FEG", false);
 
@@ -348,6 +349,7 @@ end
 
         s.useAmplitude = true;
         s.useEnvelope = true;
+        s.useRate = true;
 
         {
             auto sub = Surge::LuaSupport::SGLD("prepareForEvaluation::subscriptions", s.L);
@@ -389,6 +391,21 @@ end
                     }
 
                     lua_pop(s.L, 1); // Pop use_envelope
+                }
+                {
+                    // read off the rate control
+                    auto gr = Surge::LuaSupport::SGLD("prepareForEvaluation::rateread", s.L);
+                    lua_getfield(s.L, -1, "use_rate");
+                    if (lua_isboolean(s.L, -1))
+                    {
+                        s.useRate = lua_toboolean(s.L, -1);
+                    }
+                    else if (lua_isnumber(s.L, -1))
+                    {
+                        s.useRate = (lua_tonumber(s.L, -1) != 0.0);
+                    }
+
+                    lua_pop(s.L, 1); // Pop use_rate
                 }
                 lua_pop(s.L, 1); // Pop the modulator state
             }
@@ -827,7 +844,7 @@ enum showFilter
 bool isUserDefined(std::string str)
 {
     // clang-format off
-    static constexpr std::array<std::string_view, 57> keywords = {
+    static constexpr std::array<std::string_view, 58> keywords = {
         "amplitude",     "attack",        "block_size",
         "cc_breath",     "cc_expr",       "cc_mw",
         "cc_sus",        "chan_at",       "channel",
@@ -845,8 +862,9 @@ bool isUserDefined(std::string str)
         "retrigger_FEG", "samplerate",    "scene_mode",
         "songpos",       "split_point",   "startphase",
         "sustain",       "tempo",         "tuned_key",
-        "use_amplitude", "use_envelope",  "velocity",
-        "voice_count",   "voice_id",      "subscriptions"};
+        "use_amplitude", "use_envelope",  "use_rate",
+        "velocity",      "voice_count",   "voice_id",
+        "subscriptions"};
     // clang-format on
 
     auto foundInList = std::find(keywords.begin(), keywords.end(), str) != keywords.end();

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -64,6 +64,7 @@ struct EvaluatorState
     bool isvalid = false;
     bool useAmplitude = true;
     bool useEnvelope = true;
+    bool useRate = true;
     bool isFinite = true;
 
     float del, a, h, dec, s, r;

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -584,7 +584,7 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
     LFOStorage deactivateStorage;
     bool hasFullWave = false, waveIsAmpWave = false;
 
-    if (lfodata->rate.deactivated)
+    if (lfodata->rate.deactivated && lfodata->shape.val.i != lt_formula)
     {
         hasFullWave = true;
         deactivateStorage = *lfodata;

--- a/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
+++ b/src/surge-xt/gui/widgets/LFOAndStepDisplay.cpp
@@ -584,7 +584,8 @@ void LFOAndStepDisplay::paintWaveform(juce::Graphics &g)
     LFOStorage deactivateStorage;
     bool hasFullWave = false, waveIsAmpWave = false;
 
-    if (lfodata->rate.deactivated && lfodata->shape.val.i != lt_formula)
+    if (lfodata->rate.deactivated &&
+        !(lfodata->shape.val.i == lt_formula && !tlfo->formulastate.useRate))
     {
         hasFullWave = true;
         deactivateStorage = *lfodata;


### PR DESCRIPTION
When an LFO's rate is deactivated, the waveform display draws a faint "ghost" reference wave by re-running the modulator with rate re-enabled and start_phase forced to 0. For Formula modulators this is not that useful, best case it just makes thousands of extra `process()` calls to draw the graph a second time, worst case it produces output that has no relation to what the script is doing (when the Phase slider is used for other parameters for example).