### PR TITLE
Param clumping: no root name

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -118,7 +118,7 @@ SurgeSynthProcessor::SurgeSynthProcessor()
 
     setupSurgeSynthesizerDI();
 
-    auto parent = std::make_unique<juce::AudioProcessorParameterGroup>("Root", "Root", "|");
+    auto parent = std::make_unique<juce::AudioProcessorParameterGroup>("", "", "|");
     auto macroG = std::make_unique<juce::AudioProcessorParameterGroup>("macros", "Macros", "|");
 
     for (int mn = 0; mn < n_customcontrollers; ++mn)


### PR DESCRIPTION
This avoids putting all parameter groups into a Root group in hosts like Studio One (and in Reaper it prefixes every group name with Root/ which is ugly)