### PR TITLE
Pin latest CJE, param group root gets no separator

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -118,7 +118,7 @@ SurgeSynthProcessor::SurgeSynthProcessor()
 
     setupSurgeSynthesizerDI();
 
-    auto parent = std::make_unique<juce::AudioProcessorParameterGroup>("", "", "|");
+    auto parent = std::make_unique<juce::AudioProcessorParameterGroup>("", "", "");
     auto macroG = std::make_unique<juce::AudioProcessorParameterGroup>("macros", "Macros", "|");
 
     for (int mn = 0; mn < n_customcontrollers; ++mn)


### PR DESCRIPTION
This reinstates parameter groups for CLAP and restores parity with how VST3 and AU param groups are displayed!