### PR TITLE
MSEG freehand draw (Shift+Ctrl+Alt) 

### DIFF
--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -467,7 +467,7 @@ void freehandRDP(std::span<const std::pair<float, float>> samples, float epsilon
     for (size_t i = 1; i < samples.size() - 1; ++i)
     {
         float frac = (duration > 1e-6f) ? (samples[i].first - tStart) / duration : 0.f;
-        frac = std::clamp(frac, 0.f, 1.f, frac);
+        frac = std::clamp(frac, 0.f, 1.f);
 
         float predicted;
         switch (fit.type)

--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -53,14 +53,16 @@ static float evalLinear(float frac, float v0, float v1, float cpv)
 
     if (fabs(V) > 1e-3f)
     {
-        float Q = std::max(1e-5f, std::min(1e6f, (1.f - sqrtf(disc)) / (2.f * V)));
+        float Q = std::clamp((1.f - sqrtf(disc)) / (2.f * V), 1e-5f, 1e6f);
         a = amul * 2.f * logf(Q);
     }
 
     float cpline = frac;
 
     if (fabs(a) > 1e-3f)
+    {
         cpline = (expf(a * frac) - 1.f) / (expf(a) - 1.f);
+    }
 
     // df=0 so bend3 is identity — no additional deform step needed
 
@@ -99,14 +101,16 @@ static float evalSCurve(float frac, float v0, float v1, float cpv)
 
     if (fabs(V) > 1e-3f)
     {
-        float Q = std::max(1e-5f, std::min(1e6f, (1.f - sqrtf(disc)) / (2.f * V)));
+        float Q = std::clamp((1.f - sqrtf(disc)) / (2.f * V), 1e-5f, 1e6f);
         a = amul * 2.f * logf(Q);
     }
 
     float cpline = f2;
 
     if (fabs(a) > 1e-3f)
+    {
         cpline = (expf(a * f2) - 1.f) / (expf(a) - 1.f);
+    }
 
     if (!mirrored)
         cpline *= 0.5f;
@@ -126,7 +130,9 @@ static float evalBezier(float timeAlong, float duration, float v0, float v1, flo
 
     // Guard: walk off exact midpoint to avoid degenerate quadratic
     if (fabs(cpt - duration * 0.5f) < 1e-5f)
+    {
         cpt += 1e-4f;
+    }
 
     // Convert stored on-curve point to actual Bezier control point
     float tp = duration * 0.5f;
@@ -172,8 +178,11 @@ static float maxResidual(std::span<const std::pair<float, float>> samples, float
         frac = std::clamp(frac, 0.f, 1.f);
         float predicted = eval(frac);
         float r = fabs(s.second - predicted);
+
         if (r > maxR)
+        {
             maxR = r;
+        }
     }
 
     return maxR;
@@ -183,7 +192,7 @@ static float maxResidual(std::span<const std::pair<float, float>> samples, float
 // https://en.wikipedia.org/wiki/Golden-section_search#Iterative_algorithm
 template <typename F> static float goldenSearch(F f, float lo, float hi, int iters = 30)
 {
-    constexpr float phi = 0.6180339887f; // 1/golden_ratio
+    constexpr float phi = 0.6180339887f; // 1 / golden_ratio
     float c = hi - phi * (hi - lo);
     float d = lo + phi * (hi - lo);
     float fc = f(c), fd = f(d);
@@ -209,6 +218,45 @@ template <typename F> static float goldenSearch(F f, float lo, float hi, int ite
     }
 
     return (lo + hi) * 0.5f;
+}
+
+static std::pair<float, float>
+fitBezierLeastSquares(std::span<const std::pair<float, float>> samples,
+                      std::span<const float> param, float v0, float v1, float tStart, float tEnd)
+{
+    float duration = tEnd - tStart;
+
+    // In time axis:
+    //   P0.x = 0 (local), P2.x = duration, seg_mid.x = duration/2
+    float segMidT = duration * 0.5f;
+    float numT = 0.f, denT = 0.f;
+
+    // In value axis:
+    //   P0.y = v0, P2.y = v1, seg_mid.y = (v0+v1)/2
+    float segMidV = (v0 + v1) * 0.5f;
+    float numV = 0.f, denV = 0.f;
+
+    for (size_t i = 0; i < samples.size(); ++i)
+    {
+        float u = param[i];
+        float w = 4.f * u * (1.f - u);
+
+        float localT = samples[i].first - tStart;
+        float fixedT =
+            (1.f - u) * (1.f - u) * 0.f + u * u * duration - 2.f * u * (1.f - u) * segMidT;
+        numT += w * (localT - fixedT);
+        denT += w * w;
+
+        float fixedV = (1.f - u) * (1.f - u) * v0 + u * u * v1 - 2.f * u * (1.f - u) * segMidV;
+        numV += w * (samples[i].second - fixedV);
+        denV += w * w;
+    }
+
+    float pxStored = (denT > 1e-8f) ? (numT / denT) : duration * 0.5f;
+    float pyStored = (denV > 1e-8f) ? (numV / denV) : (v0 + v1) * 0.5f;
+
+    return {(duration > 1e-6f) ? std::clamp(pxStored / duration, 0.f, 1.f) : 0.5f,
+            std::clamp(pyStored, -1.f, 1.f)};
 }
 
 // ------------------------------------------------------------
@@ -322,60 +370,7 @@ FitResult fitSegment(std::span<const std::pair<float, float>> samples, float v0,
             //   target_i = sample.x (for time) or sample.v (for value)
             //
             // Least squares: px_stored = Σ wᵢ*(targetᵢ - fixedᵢ) / Σ wᵢy
-
-            // In time axis:
-            //   P0.x = 0 (local), P2.x = duration, seg_mid.x = duration/2
-            float segMidT = duration * 0.5f;
-            float numT = 0.f, denT = 0.f;
-
-            // In value axis:
-            //   P0.y = v0, P2.y = v1, seg_mid.y = (v0+v1)/2
-            float segMidV = (v0 + v1) * 0.5f;
-            float numV = 0.f, denV = 0.f;
-
-            for (size_t i = 0; i < n; ++i)
-            {
-                float u = param[i];
-                float w = 4.f * u * (1.f - u); // coefficient of P1_stored (×2 already folded in)
-
-                // Time axis
-                float localT = samples[i].first - tStart; // 0..duration
-                float fixedT =
-                    (1.f - u) * (1.f - u) * 0.f + u * u * duration - 2.f * u * (1.f - u) * segMidT;
-                numT += w * (localT - fixedT);
-                denT += w * w;
-
-                // Value axis
-                float sampleV = samples[i].second;
-                float fixedV =
-                    (1.f - u) * (1.f - u) * v0 + u * u * v1 - 2.f * u * (1.f - u) * segMidV;
-                numV += w * (sampleV - fixedV);
-                denV += w * w;
-            }
-
-            float pxStored = (denT > 1e-8f) ? (numT / denT) : segMidT;
-            float pyStored = (denV > 1e-8f) ? (numV / denV) : segMidV;
-
-            float sampleMeanV = 0.f;
-
-            for (auto &s : samples)
-            {
-                sampleMeanV += s.second;
-            }
-
-            sampleMeanV /= samples.size();
-
-            // If mean sample is above chord mid but control point is below, flip
-            if ((sampleMeanV > segMidV) != (pyStored > segMidV))
-            {
-                pyStored = segMidV + (segMidV - pyStored);
-            }
-
-            // Convert px_stored from local time to normalised cpduration
-            float cpdurNorm = (duration > 1e-6f) ? std::clamp(pxStored / duration, 0.f, 1.f) : 0.5f;
-
-            // Clamp cpv to [-1, 1]
-            float cpv = std::clamp(pyStored, -1.f, 1.f);
+            auto [cpdurNorm, cpv] = fitBezierLeastSquares(samples, param, v0, v1, tStart, tEnd);
 
             float r = maxResidual(samples, tStart, tEnd, [&](float frac) {
                 return evalBezier(frac * duration, duration, v0, v1, cpdurNorm, cpv);

--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -32,6 +32,435 @@ namespace Surge
 namespace MSEG
 {
 
+// ------------------------------------------------------------
+// Internal helpers
+// ------------------------------------------------------------
+
+// Evaluate LINEAR shape at normalized phase frac in [0,1], cpv in [-1,1], df=0.
+static float evalLinear(float frac, float v0, float v1, float cpv)
+{
+    float V = 0.5f * cpv + 0.5f;
+    float amul = 1.f;
+
+    if (V < 0.5f)
+    {
+        amul = -1.f;
+        V = 1.f - V;
+    }
+
+    float disc = 1.f - 4.f * V * (1.f - V);
+    float a = 0.f;
+
+    if (fabs(V) > 1e-3f)
+    {
+        float Q = std::max(1e-5f, std::min(1e6f, (1.f - sqrtf(disc)) / (2.f * V)));
+        a = amul * 2.f * logf(Q);
+    }
+
+    float cpline = frac;
+
+    if (fabs(a) > 1e-3f)
+        cpline = (expf(a * frac) - 1.f) / (expf(a) - 1.f);
+
+    // df=0 so bend3 is identity — no additional deform step needed
+
+    return cpline * (v1 - v0) + v0;
+}
+
+// Evaluate SCURVE shape at normalized phase frac in [0,1], cpv in [-1,1], df=0.
+static float evalSCurve(float frac, float v0, float v1, float cpv)
+{
+    // df=0 so the adf branch is skipped; frac is used directly for the fold
+    float f2 = frac;
+    bool mirrored = false;
+
+    if (f2 > 0.5f)
+    {
+        f2 = 1.f - (f2 - 0.5f) * 2.f;
+        mirrored = true;
+    }
+    else
+    {
+        f2 = f2 * 2.f;
+    }
+
+    // Reuse LINEAR shape on the half-phase
+    float V = 0.5f * cpv + 0.5f;
+    float amul = 1.f;
+
+    if (V < 0.5f)
+    {
+        amul = -1.f;
+        V = 1.f - V;
+    }
+
+    float disc = 1.f - 4.f * V * (1.f - V);
+    float a = 0.f;
+
+    if (fabs(V) > 1e-3f)
+    {
+        float Q = std::max(1e-5f, std::min(1e6f, (1.f - sqrtf(disc)) / (2.f * V)));
+        a = amul * 2.f * logf(Q);
+    }
+
+    float cpline = f2;
+
+    if (fabs(a) > 1e-3f)
+        cpline = (expf(a * f2) - 1.f) / (expf(a) - 1.f);
+
+    if (!mirrored)
+        cpline *= 0.5f;
+    else
+        cpline = 1.f - 0.5f * cpline;
+
+    return cpline * (v1 - v0) + v0;
+}
+
+// Evaluate QUAD_BEZIER at timeAlongSegment, given segment duration and the
+// stored (on-curve) control point (cpduration normalized 0..1, cpv absolute).
+// df=0 so no pow() warp on t.
+static float evalBezier(float timeAlong, float duration, float v0, float v1, float cpdurNorm,
+                        float cpv)
+{
+    float cpt = cpdurNorm * duration;
+
+    // Guard: walk off exact midpoint to avoid degenerate quadratic
+    if (fabs(cpt - duration * 0.5f) < 1e-5f)
+        cpt += 1e-4f;
+
+    // Convert stored on-curve point to actual Bezier control point
+    float tp = duration * 0.5f;
+    float vp = (v1 - v0) * 0.5f + v0;
+    float dt = cpt - tp;
+    float dy = cpv - vp;
+    float px1 = tp + 2.f * dt; // actual control point time
+    float py1 = vp + 2.f * dy; // actual control point value
+
+    // Solve for Bezier parameter t from timeAlong
+    // (px2 - 2*px1)*t^2 + 2*px1*t - timeAlong = 0  (px0=0)
+    float px2 = duration;
+    float a = px2 - 2.f * px1;
+    float b = 2.f * px1;
+    float c = -timeAlong;
+    float disc = b * b - 4.f * a * c;
+
+    if (a == 0.f || disc < 0.f)
+    {
+        // Degenerate: fall back to linear
+        return (timeAlong / duration) * v1 + (1.f - timeAlong / duration) * v0;
+    }
+
+    float bt = (-b + sqrtf(disc)) / (2.f * a);
+    // df=0: no pow() warp
+
+    return (1.f - bt) * (1.f - bt) * v0 + 2.f * (1.f - bt) * bt * py1 + bt * bt * v1;
+}
+
+// Compute max absolute residual for a set of (time,value) samples against
+// a user-supplied eval function that takes normalized phase [0,1].
+// tStart/tEnd define the segment boundaries.
+template <typename EvalFn>
+static float maxResidual(const std::vector<std::pair<float, float>> &samples, size_t start,
+                         size_t end, float tStart, float tEnd, EvalFn eval)
+{
+    float duration = tEnd - tStart;
+    float maxR = 0.f;
+
+    for (size_t i = start; i <= end; ++i)
+    {
+        float frac = (duration > 1e-6f) ? (samples[i].first - tStart) / duration : 0.f;
+        frac = std::max(0.f, std::min(1.f, frac));
+        float predicted = eval(frac);
+        float r = fabs(samples[i].second - predicted);
+        if (r > maxR)
+            maxR = r;
+    }
+
+    return maxR;
+}
+
+// 1-D golden section search for minimum of f over [lo, hi].
+template <typename F> static float goldenSearch(F f, float lo, float hi, int iters = 30)
+{
+    constexpr float phi = 0.6180339887f; // 1/golden_ratio
+    float c = hi - phi * (hi - lo);
+    float d = lo + phi * (hi - lo);
+    float fc = f(c), fd = f(d);
+
+    for (int i = 0; i < iters; ++i)
+    {
+        if (fc < fd)
+        {
+            hi = d;
+            d = c;
+            fd = fc;
+            c = hi - phi * (hi - lo);
+            fc = f(c);
+        }
+        else
+        {
+            lo = c;
+            c = d;
+            fc = fd;
+            d = lo + phi * (hi - lo);
+            fd = f(d);
+        }
+    }
+
+    return (lo + hi) * 0.5f;
+}
+
+// ------------------------------------------------------------
+
+FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t start, size_t end,
+                     float v0, float v1, float tStart, float tEnd)
+{
+    FitResult best;
+    best.maxResidual = std::numeric_limits<float>::max();
+    float duration = tEnd - tStart;
+
+    // ---- HOLD ----
+    {
+        float r =
+            maxResidual(samples, start, end, tStart, tEnd, [&](float /*frac*/) { return v0; });
+        if (r < best.maxResidual)
+        {
+            best = {MSEGStorage::segment::HOLD, 0.f, 0.5f, r};
+        }
+    }
+
+    // ---- LINEAR ----
+    {
+        auto costFn = [&](float cpv) {
+            return maxResidual(samples, start, end, tStart, tEnd,
+                               [&](float frac) { return evalLinear(frac, v0, v1, cpv); });
+        };
+        float cpv = goldenSearch(costFn, -1.f, 1.f);
+        float r = costFn(cpv);
+
+        if (r < best.maxResidual)
+            best = {MSEGStorage::segment::LINEAR, cpv, 0.5f, r};
+    }
+
+    // ---- SCURVE ----
+    {
+        auto costFn = [&](float cpv) {
+            return maxResidual(samples, start, end, tStart, tEnd,
+                               [&](float frac) { return evalSCurve(frac, v0, v1, cpv); });
+        };
+        float cpv = goldenSearch(costFn, -1.f, 1.f);
+        float r = costFn(cpv);
+
+        if (r < best.maxResidual)
+            best = {MSEGStorage::segment::SCURVE, cpv, 0.5f, r};
+    }
+
+    // ---- QUAD_BEZIER (least-squares for on-curve control point) ----
+    {
+        // The stored control point is an on-curve point (user sees it pass through here).
+        // We fit (cpdurNorm, cpv) directly in the segment's local coordinate system.
+        //
+        // Chord-length parameterisation: tᵢ proportional to cumulative arc length.
+        size_t n = end - start + 1;
+        std::vector<float> param(n);
+        param[0] = 0.f;
+
+        for (size_t i = 1; i < n; ++i)
+        {
+            float dt = samples[start + i].first - samples[start + i - 1].first;
+            float dv = samples[start + i].second - samples[start + i - 1].second;
+            param[i] = param[i - 1] + sqrtf(dt * dt + dv * dv);
+        }
+
+        float totalLen = param[n - 1];
+
+        if (totalLen > 1e-6f)
+        {
+            for (size_t i = 0; i < n; ++i)
+                param[i] /= totalLen;
+        }
+
+        // For each sample at chord-param uᵢ, the Bezier value is:
+        //   B(uᵢ) = (1-uᵢ)² P0 + 2uᵢ(1-uᵢ) P1_actual + uᵢ² P2
+        //
+        // where P1_actual = segment_mid + 2*(P1_stored - segment_mid)
+        //                  = 2*P1_stored - segment_mid
+        //
+        // So B(uᵢ) = (1-uᵢ)² P0 + 2uᵢ(1-uᵢ)*(2*P1_stored - segment_mid) + uᵢ² P2
+        //
+        // The stored control point has two independent components: (px_stored, py_stored).
+        // Both appear linearly, so we can solve two independent 1-D weighted least squares:
+        //
+        //   weight_i = 4 * uᵢ * (1 - uᵢ)                (coefficient of P1_stored in B)
+        //   fixed_i  = (1-uᵢ)² * P0.x + uᵢ² * P2.x
+        //            - 2*uᵢ*(1-uᵢ) * seg_mid.x           (everything except P1_stored)
+        //   target_i = sample.x (for time) or sample.v (for value)
+        //
+        // Least squares: px_stored = Σ wᵢ*(targetᵢ - fixedᵢ) / Σ wᵢ²
+
+        // In time axis:
+        //   P0.x = 0 (local), P2.x = duration, seg_mid.x = duration/2
+        float segMidT = duration * 0.5f;
+        float numT = 0.f, denT = 0.f;
+
+        // In value axis:
+        //   P0.y = v0, P2.y = v1, seg_mid.y = (v0+v1)/2
+        float segMidV = (v0 + v1) * 0.5f;
+        float numV = 0.f, denV = 0.f;
+
+        for (size_t i = 0; i < n; ++i)
+        {
+            float u = param[i];
+            float w = 4.f * u * (1.f - u); // coefficient of P1_stored (×2 already folded in)
+
+            // Time axis
+            float localT = samples[start + i].first - tStart; // 0..duration
+            float fixedT =
+                (1.f - u) * (1.f - u) * 0.f + u * u * duration - 2.f * u * (1.f - u) * segMidT;
+            numT += w * (localT - fixedT);
+            denT += w * w;
+
+            // Value axis
+            float sampleV = samples[start + i].second;
+            float fixedV = (1.f - u) * (1.f - u) * v0 + u * u * v1 - 2.f * u * (1.f - u) * segMidV;
+            numV += w * (sampleV - fixedV);
+            denV += w * w;
+        }
+
+        float pxStored = (denT > 1e-8f) ? (numT / denT) : segMidT;
+        float pyStored = (denV > 1e-8f) ? (numV / denV) : segMidV;
+
+        // Convert px_stored from local time to normalised cpduration
+        float cpdurNorm =
+            (duration > 1e-6f) ? std::max(0.f, std::min(1.f, pxStored / duration)) : 0.5f;
+
+        // Clamp cpv to [-1, 1]
+        float cpv = std::max(-1.f, std::min(1.f, pyStored));
+
+        float r = maxResidual(samples, start, end, tStart, tEnd, [&](float frac) {
+            return evalBezier(frac * duration, duration, v0, v1, cpdurNorm, cpv);
+        });
+
+        if (r < best.maxResidual)
+            best = {MSEGStorage::segment::QUAD_BEZIER, cpv, cpdurNorm, r};
+    }
+
+    return best;
+}
+
+void freehandRDP(const std::vector<std::pair<float, float>> &samples, size_t start, size_t end,
+                 float epsilon, float totalGestureDuration,
+                 std::vector<MSEGStorage::segment> &result)
+{
+    if (end <= start + 1)
+    {
+        // Base case: two points — emit one segment
+        float tStart = samples[start].first;
+        float tEnd = samples[end].first;
+        float v0 = samples[start].second;
+        float v1 = samples[end].second;
+        float timeSpan = samples[end].first - samples[start].first;
+        float valueSpan = fabs(samples[end].second - samples[start].second);
+
+        // A span is "nearly vertical" if its time width is tiny relative to
+        // the whole gesture duration, regardless of its own value span
+        if (timeSpan < totalGestureDuration * 0.02f)
+        {
+            MSEGStorage::segment seg{};
+            seg.duration = timeSpan;
+            seg.v0 = samples[start].second;
+            seg.cpv = 0.f;
+            seg.cpduration = 0.5f;
+            seg.type = MSEGStorage::segment::LINEAR;
+            seg.useDeform = true;
+            seg.invertDeform = false;
+            result.push_back(seg);
+            return;
+        }
+
+        FitResult fit = fitSegment(samples, start, end, v0, v1, tStart, tEnd);
+
+        MSEGStorage::segment seg{};
+        seg.duration = tEnd - tStart;
+        seg.v0 = v0;
+        seg.cpv = fit.cpv;
+        seg.cpduration = fit.cpduration;
+        seg.type = fit.type;
+        seg.useDeform = true;
+        seg.invertDeform = false;
+
+        result.push_back(seg);
+        return;
+    }
+
+    float tStart = samples[start].first;
+    float tEnd = samples[end].first;
+    float v0 = samples[start].second;
+    float v1 = samples[end].second;
+
+    // Try fitting the entire span first
+    FitResult fit = fitSegment(samples, start, end, v0, v1, tStart, tEnd);
+
+    if (fit.maxResidual <= epsilon)
+    {
+        // Whole span fits — emit one segment
+        MSEGStorage::segment seg{};
+        seg.duration = tEnd - tStart;
+        seg.v0 = v0;
+        seg.cpv = fit.cpv;
+        seg.cpduration = fit.cpduration;
+        seg.type = fit.type;
+        seg.useDeform = true;
+        seg.invertDeform = false;
+
+        result.push_back(seg);
+        return;
+    }
+
+    // Find the sample with maximum residual against the best fit — split there
+    float maxR = 0.f;
+    size_t splitIdx = (start + end) / 2;
+    float duration = tEnd - tStart;
+
+    for (size_t i = start + 1; i < end; ++i)
+    {
+        float frac = (duration > 1e-6f) ? (samples[i].first - tStart) / duration : 0.f;
+        frac = std::max(0.f, std::min(1.f, frac));
+
+        float predicted;
+        switch (fit.type)
+        {
+        case MSEGStorage::segment::HOLD:
+            predicted = v0;
+            break;
+        case MSEGStorage::segment::LINEAR:
+            predicted = evalLinear(frac, v0, v1, fit.cpv);
+            break;
+        case MSEGStorage::segment::SCURVE:
+            predicted = evalSCurve(frac, v0, v1, fit.cpv);
+            break;
+        case MSEGStorage::segment::QUAD_BEZIER:
+            predicted = evalBezier(frac * duration, duration, v0, v1, fit.cpduration, fit.cpv);
+            break;
+        default:
+            predicted = (v1 - v0) * frac + v0;
+            break;
+        }
+
+        float r = fabs(samples[i].second - predicted);
+
+        if (r > maxR)
+        {
+            maxR = r;
+            splitIdx = i;
+        }
+    }
+
+    // Recurse on both halves
+    freehandRDP(samples, start, splitIdx, epsilon, totalGestureDuration, result);
+    freehandRDP(samples, splitIdx, end, epsilon, totalGestureDuration, result);
+}
+
 void rebuildCache(MSEGStorage *ms)
 {
     forceToConstrainedNormalForm(ms);

--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -36,95 +36,130 @@ namespace MSEG
 // Internal helpers
 // ------------------------------------------------------------
 
-// Evaluate LINEAR shape at normalized phase frac in [0,1], cpv in [-1,1], df=0.
-static float evalLinear(float frac, float v0, float v1, float cpv)
+// Evaluate LINEAR or SCURVE shape at normalized phase frac in [0,1].
+static float evalLinAndSCurve(float frac, float v0, float v1, float cpv, bool isScurve,
+                              float df = 0.f)
 {
-    float V = 0.5f * cpv + 0.5f;
-    float amul = 1.f;
+    bool scurveMirrored = false;
 
-    if (V < 0.5f)
+    if (isScurve)
     {
-        amul = -1.f;
-        V = 1.f - V;
+        /* There is a pathological case here where the deform is non-zero but very small
+         * where this results in a floating point underflow. That is, if df is e1-7 then
+         * e^df - 1 is basically the last decimal place and you get floating point rounding
+         * quantization. So treat all deforms less than 1e-4 as zero.
+         *
+         * This is totally warranted because we work in float space.
+         * Remember e^x = 1 + x + x^2/2 + ... we are in a situation where df = 1e-4
+         * and adf = 1e-3 so adf^2 = 1e-6 == 0 at floating point. Safe to ignore on
+         * the scale of values of 1. So
+         *
+         * (e^(af)-1) / (e^a - 1)
+         * (1 + af - 1) / (1 + a - 1)
+         * = f
+         *
+         * or: to floating point precision any deform below 1e-4 is the same as no
+         * deform up to errors (and those errors are not what we want on the output).
+         *
+         * See issue #3708 for an example.
+         */
+        if (fabs(df) > 1e-4)
+        {
+            auto adf = df * 10;
+            frac = (exp(adf * frac) - 1) / (exp(adf) - 1);
+        }
+
+        if (frac > 0.5)
+        {
+            frac = 1 - (frac - 0.5) * 2;
+            scurveMirrored = true;
+        }
+        else
+        {
+            frac = frac * 2;
+        }
     }
 
-    float disc = 1.f - 4.f * V * (1.f - V);
-    float a = 0.f;
+    /*
+     * Alright so we have a functional form (e^ax-1)/(e^a-1) = y;
+     * We also know that since we have vertical only motion here x = 1/2 and y is where we want
+     * to hit ( specifically since we are generating a 0,1 line and cpv is -1,1 then
+     * here we get y = 0.5 * cpv + 0.5.
+     *
+     * Fine so lets show our work. I'm going to use X and V for now
+     *
+     * (e^aX-1)/(e^a-1) = V  @ x=1/2
+     * introduce Q = e^a/2
+     * (Q - 1) / ( Q^2 - 1 ) = V
+     * Q - 1 = V Q^2 - V
+     * V Q^2 - Q + ( 1-V ) = 0
+     *
+     * OK cool we know how to solve that (for V != 0)
+     *
+     * Q = (1 +/- sqrt( 1 - 4 * V * (1-V) )) / 2 V
+     *
+     * and since Q = e^a/2
+     *
+     * a = 2 * log(Q)
+     *
+     */
 
-    if (fabs(V) > 1e-3f)
+    float V = 0.5 * cpv + 0.5;
+    float amul = 1;
+
+    if (V < 0.5)
     {
-        float Q = std::clamp((1.f - sqrtf(disc)) / (2.f * V), 1e-5f, 1e6f);
-        a = amul * 2.f * logf(Q);
+        amul = -1;
+        V = 1 - V;
     }
 
-    float cpline = frac;
+    float disc = (1 - 4 * V * (1 - V));
+    float a = 0;
 
-    if (fabs(a) > 1e-3f)
+    if (fabs(V) > 1e-3)
     {
-        cpline = (expf(a * frac) - 1.f) / (expf(a) - 1.f);
+        float Q = limit_range((1 - sqrt(disc)) / (2 * V), 0.00001f, 1000000.f);
+        a = amul * 2 * log(Q);
     }
 
-    // df=0 so bend3 is identity — no additional deform step needed
+    // OK so frac is the 0..1 line point
+    auto cpline = frac;
 
-    return cpline * (v1 - v0) + v0;
-}
-
-// Evaluate SCURVE shape at normalized phase frac in [0,1], cpv in [-1,1], df=0.
-static float evalSCurve(float frac, float v0, float v1, float cpv)
-{
-    // df=0 so the adf branch is skipped; frac is used directly for the fold
-    float f2 = frac;
-    bool mirrored = false;
-
-    if (f2 > 0.5f)
+    if (fabs(a) > 1e-3)
     {
-        f2 = 1.f - (f2 - 0.5f) * 2.f;
-        mirrored = true;
+        cpline = (exp(a * frac) - 1) / (exp(a) - 1);
+    }
+
+    if (!isScurve)
+    {
+        // This is the equivalent of LFOModulationSource.cpp::bend3
+        float dfa = -0.5f * limit_range(df, -3.f, 3.f);
+
+        float x = (2 * cpline - 1);
+        x = x - dfa * x * x + dfa;
+        x = x - dfa * x * x + dfa; // do twice because bend3 does it twice
+        cpline = 0.5 * (x + 1);
     }
     else
     {
-        f2 = f2 * 2.f;
+        if (!scurveMirrored)
+        {
+            cpline *= 0.5;
+        }
+        else
+        {
+            cpline = 1.0 - 0.5 * cpline;
+        }
     }
 
-    // Reuse LINEAR shape on the half-phase
-    float V = 0.5f * cpv + 0.5f;
-    float amul = 1.f;
-
-    if (V < 0.5f)
-    {
-        amul = -1.f;
-        V = 1.f - V;
-    }
-
-    float disc = 1.f - 4.f * V * (1.f - V);
-    float a = 0.f;
-
-    if (fabs(V) > 1e-3f)
-    {
-        float Q = std::clamp((1.f - sqrtf(disc)) / (2.f * V), 1e-5f, 1e6f);
-        a = amul * 2.f * logf(Q);
-    }
-
-    float cpline = f2;
-
-    if (fabs(a) > 1e-3f)
-    {
-        cpline = (expf(a * f2) - 1.f) / (expf(a) - 1.f);
-    }
-
-    if (!mirrored)
-        cpline *= 0.5f;
-    else
-        cpline = 1.f - 0.5f * cpline;
-
+    // cpline will still be 0..1 so now we need to transform it
     return cpline * (v1 - v0) + v0;
 }
 
 // Evaluate QUAD_BEZIER at timeAlongSegment, given segment duration and the
 // stored (on-curve) control point (cpduration normalized 0..1, cpv absolute).
-// df=0 so no pow() warp on t.
 static float evalBezier(float timeAlong, float duration, float v0, float v1, float cpdurNorm,
-                        float cpv)
+                        float cpv, float df = 0.f)
 {
     float cpt = cpdurNorm * duration;
 
@@ -157,7 +192,16 @@ static float evalBezier(float timeAlong, float duration, float v0, float v1, flo
     }
 
     float bt = (-b + sqrtf(disc)) / (2.f * a);
-    // df=0: no pow() warp
+
+    if (df < 0)
+    {
+        bt = pow(bt, 1.0 + df * 0.7);
+    }
+
+    if (df > 0)
+    {
+        bt = pow(bt, 1.0 + df * 3);
+    }
 
     return (1.f - bt) * (1.f - bt) * v0 + 2.f * (1.f - bt) * bt * py1 + bt * bt * v1;
 }
@@ -290,8 +334,9 @@ FitResult fitSegment(std::span<const std::pair<float, float>> samples, float v0,
     // ---- LINEAR ----
     {
         auto costFn = [&](float cpv) {
-            return maxResidual(samples, tStart, tEnd,
-                               [&](float frac) { return evalLinear(frac, v0, v1, cpv); });
+            return maxResidual(samples, tStart, tEnd, [&](float frac) {
+                return evalLinAndSCurve(frac, v0, v1, cpv, false);
+            });
         };
 
         // scale down the control point value depending on length of the segment
@@ -314,8 +359,9 @@ FitResult fitSegment(std::span<const std::pair<float, float>> samples, float v0,
         // ---- SCURVE ----
         {
             auto costFn = [&](float cpv) {
-                return maxResidual(samples, tStart, tEnd,
-                                   [&](float frac) { return evalSCurve(frac, v0, v1, cpv); });
+                return maxResidual(samples, tStart, tEnd, [&](float frac) {
+                    return evalLinAndSCurve(frac, v0, v1, cpv, true);
+                });
             };
             float cpv = goldenSearch(costFn, -1.f, 1.f);
             float r = costFn(cpv);
@@ -471,10 +517,10 @@ void freehandRDP(std::span<const std::pair<float, float>> samples, float epsilon
             predicted = v0;
             break;
         case MSEGStorage::segment::LINEAR:
-            predicted = evalLinear(frac, v0, v1, fit.cpv);
+            predicted = evalLinAndSCurve(frac, v0, v1, fit.cpv, false);
             break;
         case MSEGStorage::segment::SCURVE:
-            predicted = evalSCurve(frac, v0, v1, fit.cpv);
+            predicted = evalLinAndSCurve(frac, v0, v1, fit.cpv, true);
             break;
         case MSEGStorage::segment::QUAD_BEZIER:
             predicted = evalBezier(frac * duration, duration, v0, v1, fit.cpduration, fit.cpv);
@@ -744,209 +790,13 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
         }
 
         float frac = timeAlongSegment / r.duration;
-        float actualTime = frac;
-
-        /*
-         * Here is where they are the same. The S-Curve is just two copies of the
-         * deformed line, with one inverted, pushed to the next quadrant.
-         */
-        bool scurveMirrored = false;
-
-        if (r.type == MSEGStorage::segment::SCURVE)
-        {
-            /* There is a pathological case here where the deform is non-zero but very small
-             * where this results in a floating point underflow. That is, if df is e1-7 then
-             * e^df - 1 is basically the last decimal place and you get floating point rounding
-             * quantization. So treat all deforms less than 1e-4 as zero.
-             *
-             * This is totally warranted because we work in float space.
-             * Remember e^x = 1 + x + x^2/2 + ... we are in a situation where df = 1e-4
-             * and adf = 1e-3 so adf^2 = 1e-6 == 0 at floating point. Safe to ignore on
-             * the scale of values of 1. So
-             *
-             * (e^(af)-1) / (e^a - 1)
-             * (1 + af - 1) / (1 + a - 1)
-             * = f
-             *
-             * or: to floating point precision any deform below 1e-4 is the same as no
-             * deform up to errors (and those errors are not what we want on the output).
-             *
-             * See issue #3708 for an example.
-             */
-            if (fabs(df) > 1e-4)
-            {
-                // Deform moves the center point
-                auto adf = df * 10;
-                frac = (exp(adf * frac) - 1) / (exp(adf) - 1);
-            }
-
-            if (frac > 0.5)
-            {
-                frac = 1 - (frac - 0.5) * 2;
-                scurveMirrored = true;
-            }
-            else
-            {
-                frac = frac * 2;
-            }
-        }
-
-        // So we want to handle control points
-        auto cpd = r.cpv;
-
-        /*
-         * Alright so we have a functional form (e^ax-1)/(e^a-1) = y;
-         * We also know that since we have vertical only motion here x = 1/2 and y is where we want
-         * to hit ( specifically since we are generating a 0,1 line and cpv is -1,1 then
-         * here we get y = 0.5 * cpv + 0.5.
-         *
-         * Fine so lets show our work. I'm going to use X and V for now
-         *
-         * (e^aX-1)/(e^a-1) = V  @ x=1/2
-         * introduce Q = e^a/2
-         * (Q - 1) / ( Q^2 - 1 ) = V
-         * Q - 1 = V Q^2 - V
-         * V Q^2 - Q + ( 1-V ) = 0
-         *
-         * OK cool we know how to solve that (for V != 0)
-         *
-         * Q = (1 +/- sqrt( 1 - 4 * V * (1-V) )) / 2 V
-         *
-         * and since Q = e^a/2
-         *
-         * a = 2 * log(Q)
-         *
-         */
-
-        float V = 0.5 * r.cpv + 0.5;
-        float amul = 1;
-
-        if (V < 0.5)
-        {
-            amul = -1;
-            V = 1 - V;
-        }
-
-        float disc = (1 - 4 * V * (1 - V));
-        float a = 0;
-
-        if (fabs(V) > 1e-3)
-        {
-            float Q = limit_range((1 - sqrt(disc)) / (2 * V), 0.00001f, 1000000.f);
-            a = amul * 2 * log(Q);
-        }
-
-        // OK so frac is the 0,1 line point
-        auto cpline = frac;
-
-        if (fabs(a) > 1e-3)
-        {
-            cpline = (exp(a * frac) - 1) / (exp(a) - 1);
-        }
-
-        if (r.type == MSEGStorage::segment::LINEAR)
-        {
-            // This is the equivalent of LFOModulationSource.cpp::bend3
-            float dfa = -0.5f * limit_range(df, -3.f, 3.f);
-
-            float x = (2 * cpline - 1);
-            x = x - dfa * x * x + dfa;
-            x = x - dfa * x * x + dfa; // do twice because bend3 does it twice
-            cpline = 0.5 * (x + 1);
-        }
-
-        // OK and now we have to dup it if we are in s-curve
-        if (r.type == MSEGStorage::segment::SCURVE)
-        {
-            if (!scurveMirrored)
-            {
-                cpline *= 0.5;
-            }
-            else
-            {
-                cpline = 1.0 - 0.5 * cpline;
-            }
-        }
-
-        // cpline will still be 0,1 so now we need to transform it
-        res = cpline * (lv1 - lv0) + lv0;
+        bool isScurve = (r.type == MSEGStorage::segment::SCURVE);
+        res = evalLinAndSCurve(frac, lv0, lv1, r.cpv, isScurve, df);
         break;
     }
     case MSEGStorage::segment::QUAD_BEZIER:
     {
-        /*
-        ** First let's correct the control point so that the
-        ** user specified one is through the curve. This means
-        ** that the line from the center of the segment connecting
-        ** the endpoints to the control point pushes out 2x
-        */
-
-        float cpv = lcpv;
-        float cpt = r.cpduration * r.duration;
-
-        // If we are positioned exactly at the midpoint our calculation below to find time will fail
-        // so walk off a smidge
-        if (fabs(cpt - r.duration * 0.5) < 1e-5)
-        {
-            cpt += 1e-4;
-        }
-
-        // here's the midpoint along the connecting curve
-        float tp = r.duration / 2;
-        float vp = (lv1 - lv0) / 2 + lv0;
-
-        // The distance from tp,vp to cpt,cpv
-        float dt = (cpt - tp), dy = (cpv - vp);
-
-        cpv = vp + 2 * dy;
-        cpt = tp + 2 * dt;
-
-        // B = (1-t)^2 P0 + 2 t (1-t) P1 + t^2 P2
-        float ttarget = timeAlongSegment;
-        float px0 = 0, px1 = cpt, px2 = r.duration, py0 = lv0, py1 = cpv, py2 = lv1;
-
-        /*
-        ** OK so we want to find the bezier t corresponding to phase target
-        **
-        ** (1-t)^2 px0 + 2 * (1-t) t px1 + t * t px2 = ttarget;
-        **
-        ** Luckily we know px0 = 0. So
-        **
-        ** 2 * ( 1-t ) * t * px1 + t * t * px2 - ttarget = 0;
-        ** 2 * t * px1 - 2 * t^2 * px1 + t^2 * px2 - ttarget = 0;
-        ** (px2 - 2 * px1) t^2 + 2 * px1 * t - ttarget = 0;
-        **
-        */
-        float a = px2 - 2 * px1;
-        float b = 2 * px1;
-        float c = -ttarget;
-        float disc = b * b - 4 * a * c;
-
-        if (a == 0 || disc < 0)
-        {
-            // This means we have a line between v0 and nv1
-            float frac = timeAlongSegment / r.duration;
-            res = frac * lv1 + (1 - frac) * lv0;
-        }
-        else
-        {
-            float t = (-b + sqrt(b * b - 4 * a * c)) / (2 * a);
-
-            if (df < 0)
-            {
-                t = pow(t, 1.0 + df * 0.7);
-            }
-            if (df > 0)
-            {
-                t = pow(t, 1.0 + df * 3);
-            }
-
-            /*
-            ** And now evaluate the bezier in y with that t
-            */
-            res = (1 - t) * (1 - t) * py0 + 2 * (1 - t) * t * py1 + t * t * py2;
-        }
-
+        res = evalBezier(timeAlongSegment, r.duration, lv0, lv1, r.cpduration, lcpv, df);
         break;
     }
     case MSEGStorage::segment::BUMP:

--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -221,8 +221,17 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
 
     // ---- HOLD ----
     {
-        float r =
-            maxResidual(samples, start, end, tStart, tEnd, [&](float /*frac*/) { return v0; });
+        float holdV = 0.f;
+
+        for (size_t i = start; i <= end; ++i)
+        {
+            holdV += samples[i].second;
+        }
+
+        holdV /= (end - start + 1);
+
+        float r = maxResidual(samples, start, end, tStart, tEnd, [&](float) { return holdV; });
+
         if (r < best.maxResidual)
         {
             best = {MSEGStorage::segment::HOLD, 0.f, 0.5f, r};
@@ -235,114 +244,141 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
             return maxResidual(samples, start, end, tStart, tEnd,
                                [&](float frac) { return evalLinear(frac, v0, v1, cpv); });
         };
-        float cpv = goldenSearch(costFn, -1.f, 1.f);
+        float cpvRange = std::min(1.f, (float)(end - start) / 10.f);
+        float cpv = goldenSearch(costFn, -cpvRange, cpvRange);
         float r = costFn(cpv);
 
         if (r < best.maxResidual)
+        {
             best = {MSEGStorage::segment::LINEAR, cpv, 0.5f, r};
+        }
     }
 
-    // ---- SCURVE ----
-    {
-        auto costFn = [&](float cpv) {
-            return maxResidual(samples, start, end, tStart, tEnd,
-                               [&](float frac) { return evalSCurve(frac, v0, v1, cpv); });
-        };
-        float cpv = goldenSearch(costFn, -1.f, 1.f);
-        float r = costFn(cpv);
+    const bool enoughSamplesForComplex = (end - start + 1) >= 5;
 
-        if (r < best.maxResidual)
-            best = {MSEGStorage::segment::SCURVE, cpv, 0.5f, r};
-    }
-
-    // ---- QUAD_BEZIER (least-squares for on-curve control point) ----
-    {
-        // The stored control point is an on-curve point (user sees it pass through here).
-        // We fit (cpdurNorm, cpv) directly in the segment's local coordinate system.
-        //
-        // Chord-length parameterisation: tᵢ proportional to cumulative arc length.
-        size_t n = end - start + 1;
-        std::vector<float> param(n);
-        param[0] = 0.f;
-
-        for (size_t i = 1; i < n; ++i)
+    if (enoughSamplesForComplex)
+    { // ---- SCURVE ----
         {
-            float dt = samples[start + i].first - samples[start + i - 1].first;
-            float dv = samples[start + i].second - samples[start + i - 1].second;
-            param[i] = param[i - 1] + sqrtf(dt * dt + dv * dv);
+            auto costFn = [&](float cpv) {
+                return maxResidual(samples, start, end, tStart, tEnd,
+                                   [&](float frac) { return evalSCurve(frac, v0, v1, cpv); });
+            };
+            float cpv = goldenSearch(costFn, -1.f, 1.f);
+            float r = costFn(cpv);
+
+            if (r < best.maxResidual)
+            {
+                best = {MSEGStorage::segment::SCURVE, cpv, 0.5f, r};
+            }
         }
 
-        float totalLen = param[n - 1];
-
-        if (totalLen > 1e-6f)
+        // ---- QUAD_BEZIER (least-squares for on-curve control point) ----
         {
+            // The stored control point is an on-curve point (user sees it pass through here).
+            // We fit (cpdurNorm, cpv) directly in the segment's local coordinate system.
+            //
+            // Chord-length parameterisation: tᵢ proportional to cumulative arc length.
+            size_t n = end - start + 1;
+            std::vector<float> param(n);
+            param[0] = 0.f;
+
+            for (size_t i = 1; i < n; ++i)
+            {
+                float dt = samples[start + i].first - samples[start + i - 1].first;
+                float dv = samples[start + i].second - samples[start + i - 1].second;
+                param[i] = param[i - 1] + sqrtf(dt * dt + dv * dv);
+            }
+
+            float totalLen = param[n - 1];
+
+            if (totalLen > 1e-6f)
+            {
+                for (size_t i = 0; i < n; ++i)
+                    param[i] /= totalLen;
+            }
+
+            // For each sample at chord-param uᵢ, the Bezier value is:
+            //   B(uᵢ) = (1-uᵢ)² P0 + 2uᵢ(1-uᵢ) P1_actual + uᵢ² P2
+            //
+            // where P1_actual = segment_mid + 2*(P1_stored - segment_mid)
+            //                  = 2*P1_stored - segment_mid
+            //
+            // So B(uᵢ) = (1-uᵢ)² P0 + 2uᵢ(1-uᵢ)*(2*P1_stored - segment_mid) + uᵢ² P2
+            //
+            // The stored control point has two independent components: (px_stored, py_stored).
+            // Both appear linearly, so we can solve two independent 1-D weighted least squares:
+            //
+            //   weight_i = 4 * uᵢ * (1 - uᵢ)                (coefficient of P1_stored in B)
+            //   fixed_i  = (1-uᵢ)² * P0.x + uᵢ² * P2.x
+            //            - 2*uᵢ*(1-uᵢ) * seg_mid.x           (everything except P1_stored)
+            //   target_i = sample.x (for time) or sample.v (for value)
+            //
+            // Least squares: px_stored = Σ wᵢ*(targetᵢ - fixedᵢ) / Σ wᵢ²
+
+            // In time axis:
+            //   P0.x = 0 (local), P2.x = duration, seg_mid.x = duration/2
+            float segMidT = duration * 0.5f;
+            float numT = 0.f, denT = 0.f;
+
+            // In value axis:
+            //   P0.y = v0, P2.y = v1, seg_mid.y = (v0+v1)/2
+            float segMidV = (v0 + v1) * 0.5f;
+            float numV = 0.f, denV = 0.f;
+
             for (size_t i = 0; i < n; ++i)
-                param[i] /= totalLen;
+            {
+                float u = param[i];
+                float w = 4.f * u * (1.f - u); // coefficient of P1_stored (×2 already folded in)
+
+                // Time axis
+                float localT = samples[start + i].first - tStart; // 0..duration
+                float fixedT =
+                    (1.f - u) * (1.f - u) * 0.f + u * u * duration - 2.f * u * (1.f - u) * segMidT;
+                numT += w * (localT - fixedT);
+                denT += w * w;
+
+                // Value axis
+                float sampleV = samples[start + i].second;
+                float fixedV =
+                    (1.f - u) * (1.f - u) * v0 + u * u * v1 - 2.f * u * (1.f - u) * segMidV;
+                numV += w * (sampleV - fixedV);
+                denV += w * w;
+            }
+
+            float pxStored = (denT > 1e-8f) ? (numT / denT) : segMidT;
+            float pyStored = (denV > 1e-8f) ? (numV / denV) : segMidV;
+
+            float sampleMeanV = 0.f;
+
+            for (size_t i = start; i <= end; ++i)
+            {
+                sampleMeanV += samples[i].second;
+            }
+
+            sampleMeanV /= (end - start + 1);
+
+            // If mean sample is above chord mid but control point is below, flip
+            if ((sampleMeanV > segMidV) != (pyStored > segMidV))
+            {
+                pyStored = segMidV + (segMidV - pyStored);
+            }
+
+            // Convert px_stored from local time to normalised cpduration
+            float cpdurNorm =
+                (duration > 1e-6f) ? std::max(0.f, std::min(1.f, pxStored / duration)) : 0.5f;
+
+            // Clamp cpv to [-1, 1]
+            float cpv = std::max(-1.f, std::min(1.f, pyStored));
+
+            float r = maxResidual(samples, start, end, tStart, tEnd, [&](float frac) {
+                return evalBezier(frac * duration, duration, v0, v1, cpdurNorm, cpv);
+            });
+
+            if (r < best.maxResidual)
+            {
+                best = {MSEGStorage::segment::QUAD_BEZIER, cpv, cpdurNorm, r};
+            }
         }
-
-        // For each sample at chord-param uᵢ, the Bezier value is:
-        //   B(uᵢ) = (1-uᵢ)² P0 + 2uᵢ(1-uᵢ) P1_actual + uᵢ² P2
-        //
-        // where P1_actual = segment_mid + 2*(P1_stored - segment_mid)
-        //                  = 2*P1_stored - segment_mid
-        //
-        // So B(uᵢ) = (1-uᵢ)² P0 + 2uᵢ(1-uᵢ)*(2*P1_stored - segment_mid) + uᵢ² P2
-        //
-        // The stored control point has two independent components: (px_stored, py_stored).
-        // Both appear linearly, so we can solve two independent 1-D weighted least squares:
-        //
-        //   weight_i = 4 * uᵢ * (1 - uᵢ)                (coefficient of P1_stored in B)
-        //   fixed_i  = (1-uᵢ)² * P0.x + uᵢ² * P2.x
-        //            - 2*uᵢ*(1-uᵢ) * seg_mid.x           (everything except P1_stored)
-        //   target_i = sample.x (for time) or sample.v (for value)
-        //
-        // Least squares: px_stored = Σ wᵢ*(targetᵢ - fixedᵢ) / Σ wᵢ²
-
-        // In time axis:
-        //   P0.x = 0 (local), P2.x = duration, seg_mid.x = duration/2
-        float segMidT = duration * 0.5f;
-        float numT = 0.f, denT = 0.f;
-
-        // In value axis:
-        //   P0.y = v0, P2.y = v1, seg_mid.y = (v0+v1)/2
-        float segMidV = (v0 + v1) * 0.5f;
-        float numV = 0.f, denV = 0.f;
-
-        for (size_t i = 0; i < n; ++i)
-        {
-            float u = param[i];
-            float w = 4.f * u * (1.f - u); // coefficient of P1_stored (×2 already folded in)
-
-            // Time axis
-            float localT = samples[start + i].first - tStart; // 0..duration
-            float fixedT =
-                (1.f - u) * (1.f - u) * 0.f + u * u * duration - 2.f * u * (1.f - u) * segMidT;
-            numT += w * (localT - fixedT);
-            denT += w * w;
-
-            // Value axis
-            float sampleV = samples[start + i].second;
-            float fixedV = (1.f - u) * (1.f - u) * v0 + u * u * v1 - 2.f * u * (1.f - u) * segMidV;
-            numV += w * (sampleV - fixedV);
-            denV += w * w;
-        }
-
-        float pxStored = (denT > 1e-8f) ? (numT / denT) : segMidT;
-        float pyStored = (denV > 1e-8f) ? (numV / denV) : segMidV;
-
-        // Convert px_stored from local time to normalised cpduration
-        float cpdurNorm =
-            (duration > 1e-6f) ? std::max(0.f, std::min(1.f, pxStored / duration)) : 0.5f;
-
-        // Clamp cpv to [-1, 1]
-        float cpv = std::max(-1.f, std::min(1.f, pyStored));
-
-        float r = maxResidual(samples, start, end, tStart, tEnd, [&](float frac) {
-            return evalBezier(frac * duration, duration, v0, v1, cpdurNorm, cpv);
-        });
-
-        if (r < best.maxResidual)
-            best = {MSEGStorage::segment::QUAD_BEZIER, cpv, cpdurNorm, r};
     }
 
     return best;

--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -160,18 +160,18 @@ static float evalBezier(float timeAlong, float duration, float v0, float v1, flo
 // a user-supplied eval function that takes normalized phase [0,1].
 // tStart/tEnd define the segment boundaries.
 template <typename EvalFn>
-static float maxResidual(const std::vector<std::pair<float, float>> &samples, size_t start,
-                         size_t end, float tStart, float tEnd, EvalFn eval)
+static float maxResidual(std::span<const std::pair<float, float>> samples, float tStart, float tEnd,
+                         EvalFn eval)
 {
     float duration = tEnd - tStart;
     float maxR = 0.f;
 
-    for (size_t i = start; i <= end; ++i)
+    for (auto &s : samples)
     {
-        float frac = (duration > 1e-6f) ? (samples[i].first - tStart) / duration : 0.f;
-        frac = std::max(0.f, std::min(1.f, frac));
+        float frac = (duration > 1e-6f) ? (s.first - tStart) / duration : 0.f;
+        frac = std::clamp(frac, 0.f, 1.f);
         float predicted = eval(frac);
-        float r = fabs(samples[i].second - predicted);
+        float r = fabs(s.second - predicted);
         if (r > maxR)
             maxR = r;
     }
@@ -180,6 +180,7 @@ static float maxResidual(const std::vector<std::pair<float, float>> &samples, si
 }
 
 // 1-D golden section search for minimum of f over [lo, hi].
+// https://en.wikipedia.org/wiki/Golden-section_search#Iterative_algorithm
 template <typename F> static float goldenSearch(F f, float lo, float hi, int iters = 30)
 {
     constexpr float phi = 0.6180339887f; // 1/golden_ratio
@@ -212,8 +213,8 @@ template <typename F> static float goldenSearch(F f, float lo, float hi, int ite
 
 // ------------------------------------------------------------
 
-FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t start, size_t end,
-                     float v0, float v1, float tStart, float tEnd)
+FitResult fitSegment(std::span<const std::pair<float, float>> samples, float v0, float v1,
+                     float tStart, float tEnd)
 {
     FitResult best;
     best.maxResidual = std::numeric_limits<float>::max();
@@ -223,14 +224,14 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
     {
         float holdV = 0.f;
 
-        for (size_t i = start; i <= end; ++i)
+        for (auto &s : samples)
         {
-            holdV += samples[i].second;
+            holdV += s.second;
         }
 
-        holdV /= (end - start + 1);
+        holdV /= samples.size();
 
-        float r = maxResidual(samples, start, end, tStart, tEnd, [&](float) { return holdV; });
+        float r = maxResidual(samples, tStart, tEnd, [&](float) { return holdV; });
 
         if (r < best.maxResidual)
         {
@@ -241,10 +242,14 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
     // ---- LINEAR ----
     {
         auto costFn = [&](float cpv) {
-            return maxResidual(samples, start, end, tStart, tEnd,
+            return maxResidual(samples, tStart, tEnd,
                                [&](float frac) { return evalLinear(frac, v0, v1, cpv); });
         };
-        float cpvRange = std::min(1.f, (float)(end - start) / 10.f);
+
+        // scale down the control point value depending on length of the segment
+        // prevents over-exponential fits when we have sparse input data
+        // but still allows wider range for curve fitting dense spans
+        float cpvRange = std::min(1.f, (float)(samples.size() - 1) / 10.f);
         float cpv = goldenSearch(costFn, -cpvRange, cpvRange);
         float r = costFn(cpv);
 
@@ -254,13 +259,14 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
         }
     }
 
-    const bool enoughSamplesForComplex = (end - start + 1) >= 5;
+    const bool enoughSamplesForComplex = samples.size() >= 5;
 
     if (enoughSamplesForComplex)
-    { // ---- SCURVE ----
+    {
+        // ---- SCURVE ----
         {
             auto costFn = [&](float cpv) {
-                return maxResidual(samples, start, end, tStart, tEnd,
+                return maxResidual(samples, tStart, tEnd,
                                    [&](float frac) { return evalSCurve(frac, v0, v1, cpv); });
             };
             float cpv = goldenSearch(costFn, -1.f, 1.f);
@@ -278,14 +284,14 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
             // We fit (cpdurNorm, cpv) directly in the segment's local coordinate system.
             //
             // Chord-length parameterisation: tᵢ proportional to cumulative arc length.
-            size_t n = end - start + 1;
+            size_t n = samples.size();
             std::vector<float> param(n);
             param[0] = 0.f;
 
             for (size_t i = 1; i < n; ++i)
             {
-                float dt = samples[start + i].first - samples[start + i - 1].first;
-                float dv = samples[start + i].second - samples[start + i - 1].second;
+                float dt = samples[i].first - samples[i - 1].first;
+                float dv = samples[i].second - samples[i - 1].second;
                 param[i] = param[i - 1] + sqrtf(dt * dt + dv * dv);
             }
 
@@ -294,7 +300,9 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
             if (totalLen > 1e-6f)
             {
                 for (size_t i = 0; i < n; ++i)
+                {
                     param[i] /= totalLen;
+                }
             }
 
             // For each sample at chord-param uᵢ, the Bezier value is:
@@ -313,7 +321,7 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
             //            - 2*uᵢ*(1-uᵢ) * seg_mid.x           (everything except P1_stored)
             //   target_i = sample.x (for time) or sample.v (for value)
             //
-            // Least squares: px_stored = Σ wᵢ*(targetᵢ - fixedᵢ) / Σ wᵢ²
+            // Least squares: px_stored = Σ wᵢ*(targetᵢ - fixedᵢ) / Σ wᵢy
 
             // In time axis:
             //   P0.x = 0 (local), P2.x = duration, seg_mid.x = duration/2
@@ -331,14 +339,14 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
                 float w = 4.f * u * (1.f - u); // coefficient of P1_stored (×2 already folded in)
 
                 // Time axis
-                float localT = samples[start + i].first - tStart; // 0..duration
+                float localT = samples[i].first - tStart; // 0..duration
                 float fixedT =
                     (1.f - u) * (1.f - u) * 0.f + u * u * duration - 2.f * u * (1.f - u) * segMidT;
                 numT += w * (localT - fixedT);
                 denT += w * w;
 
                 // Value axis
-                float sampleV = samples[start + i].second;
+                float sampleV = samples[i].second;
                 float fixedV =
                     (1.f - u) * (1.f - u) * v0 + u * u * v1 - 2.f * u * (1.f - u) * segMidV;
                 numV += w * (sampleV - fixedV);
@@ -350,12 +358,12 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
 
             float sampleMeanV = 0.f;
 
-            for (size_t i = start; i <= end; ++i)
+            for (auto &s : samples)
             {
-                sampleMeanV += samples[i].second;
+                sampleMeanV += s.second;
             }
 
-            sampleMeanV /= (end - start + 1);
+            sampleMeanV /= samples.size();
 
             // If mean sample is above chord mid but control point is below, flip
             if ((sampleMeanV > segMidV) != (pyStored > segMidV))
@@ -364,13 +372,12 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
             }
 
             // Convert px_stored from local time to normalised cpduration
-            float cpdurNorm =
-                (duration > 1e-6f) ? std::max(0.f, std::min(1.f, pxStored / duration)) : 0.5f;
+            float cpdurNorm = (duration > 1e-6f) ? std::clamp(pxStored / duration, 0.f, 1.f) : 0.5f;
 
             // Clamp cpv to [-1, 1]
-            float cpv = std::max(-1.f, std::min(1.f, pyStored));
+            float cpv = std::clamp(pyStored, -1.f, 1.f);
 
-            float r = maxResidual(samples, start, end, tStart, tEnd, [&](float frac) {
+            float r = maxResidual(samples, tStart, tEnd, [&](float frac) {
                 return evalBezier(frac * duration, duration, v0, v1, cpdurNorm, cpv);
             });
 
@@ -384,19 +391,18 @@ FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t
     return best;
 }
 
-void freehandRDP(const std::vector<std::pair<float, float>> &samples, size_t start, size_t end,
-                 float epsilon, float totalGestureDuration,
-                 std::vector<MSEGStorage::segment> &result)
+void freehandRDP(std::span<const std::pair<float, float>> samples, float epsilon,
+                 float totalGestureDuration, std::vector<MSEGStorage::segment> &result)
 {
-    if (end <= start + 1)
+    if (samples.size() <= 2)
     {
         // Base case: two points — emit one segment
-        float tStart = samples[start].first;
-        float tEnd = samples[end].first;
-        float v0 = samples[start].second;
-        float v1 = samples[end].second;
-        float timeSpan = samples[end].first - samples[start].first;
-        float valueSpan = fabs(samples[end].second - samples[start].second);
+        float tStart = samples.front().first;
+        float tEnd = samples.back().first;
+        float v0 = samples.front().second;
+        float v1 = samples.back().second;
+        float timeSpan = samples.back().first - samples.front().first;
+        float valueSpan = fabs(samples.back().second - samples.front().second);
 
         // A span is "nearly vertical" if its time width is tiny relative to
         // the whole gesture duration, regardless of its own value span
@@ -404,7 +410,7 @@ void freehandRDP(const std::vector<std::pair<float, float>> &samples, size_t sta
         {
             MSEGStorage::segment seg{};
             seg.duration = timeSpan;
-            seg.v0 = samples[start].second;
+            seg.v0 = samples.front().second;
             seg.cpv = 0.f;
             seg.cpduration = 0.5f;
             seg.type = MSEGStorage::segment::LINEAR;
@@ -414,7 +420,7 @@ void freehandRDP(const std::vector<std::pair<float, float>> &samples, size_t sta
             return;
         }
 
-        FitResult fit = fitSegment(samples, start, end, v0, v1, tStart, tEnd);
+        FitResult fit = fitSegment(samples, v0, v1, tStart, tEnd);
 
         MSEGStorage::segment seg{};
         seg.duration = tEnd - tStart;
@@ -429,13 +435,13 @@ void freehandRDP(const std::vector<std::pair<float, float>> &samples, size_t sta
         return;
     }
 
-    float tStart = samples[start].first;
-    float tEnd = samples[end].first;
-    float v0 = samples[start].second;
-    float v1 = samples[end].second;
+    float tStart = samples.front().first;
+    float tEnd = samples.back().first;
+    float v0 = samples.front().second;
+    float v1 = samples.back().second;
 
     // Try fitting the entire span first
-    FitResult fit = fitSegment(samples, start, end, v0, v1, tStart, tEnd);
+    FitResult fit = fitSegment(samples, v0, v1, tStart, tEnd);
 
     if (fit.maxResidual <= epsilon)
     {
@@ -455,13 +461,13 @@ void freehandRDP(const std::vector<std::pair<float, float>> &samples, size_t sta
 
     // Find the sample with maximum residual against the best fit — split there
     float maxR = 0.f;
-    size_t splitIdx = (start + end) / 2;
+    size_t splitIdx = (samples.size() - 1) / 2;
     float duration = tEnd - tStart;
 
-    for (size_t i = start + 1; i < end; ++i)
+    for (size_t i = 1; i < samples.size() - 1; ++i)
     {
         float frac = (duration > 1e-6f) ? (samples[i].first - tStart) / duration : 0.f;
-        frac = std::max(0.f, std::min(1.f, frac));
+        frac = std::clamp(frac, 0.f, 1.f, frac);
 
         float predicted;
         switch (fit.type)
@@ -493,8 +499,8 @@ void freehandRDP(const std::vector<std::pair<float, float>> &samples, size_t sta
     }
 
     // Recurse on both halves
-    freehandRDP(samples, start, splitIdx, epsilon, totalGestureDuration, result);
-    freehandRDP(samples, splitIdx, end, epsilon, totalGestureDuration, result);
+    freehandRDP(samples.first(splitIdx + 1), epsilon, totalGestureDuration, result);
+    freehandRDP(samples.subspan(splitIdx), epsilon, totalGestureDuration, result);
 }
 
 void rebuildCache(MSEGStorage *ms)
@@ -905,7 +911,7 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
         float px0 = 0, px1 = cpt, px2 = r.duration, py0 = lv0, py1 = cpv, py2 = lv1;
 
         /*
-        ** OK so we want to find the bezier t corresponding to phase ttarget
+        ** OK so we want to find the bezier t corresponding to phase target
         **
         ** (1-t)^2 px0 + 2 * (1-t) t px1 + t * t px2 = ttarget;
         **

--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -209,7 +209,7 @@ static float evalBezier(float timeAlong, float duration, float v0, float v1, flo
 // Compute max absolute residual for a set of (time,value) samples against
 // a user-supplied eval function that takes normalized phase [0,1].
 // tStart/tEnd define the segment boundaries.
-template <typename EvalFn>
+template <std::invocable<float> EvalFn>
 static float maxResidual(std::span<const std::pair<float, float>> samples, float tStart, float tEnd,
                          EvalFn eval)
 {
@@ -234,7 +234,8 @@ static float maxResidual(std::span<const std::pair<float, float>> samples, float
 
 // 1-D golden section search for minimum of f over [lo, hi].
 // https://en.wikipedia.org/wiki/Golden-section_search#Iterative_algorithm
-template <typename F> static float goldenSearch(F f, float lo, float hi, int iters = 30)
+template <std::invocable<float> F>
+static float goldenSearch(F f, float lo, float hi, int iters = 30)
 {
     constexpr float phi = 0.6180339887f; // 1 / golden_ratio
     float c = hi - phi * (hi - lo);

--- a/src/common/dsp/modulators/MSEGModulationHelper.h
+++ b/src/common/dsp/modulators/MSEGModulationHelper.h
@@ -58,6 +58,28 @@ struct EvaluatorState
 
     void seed(long l) { gen = std::minstd_rand(l); }
 };
+
+struct FitResult
+{
+    MSEGStorage::segment::Type type;
+    float cpv{0.f};
+    float cpduration{0.5f};
+    float maxResidual{1e10f};
+};
+
+// Fit a single segment spanning samples[start..end] (inclusive endpoints pinned
+// to v0/v1 at absolute times tStart/tEnd).  Returns the best-fitting type and
+// its control-point values. LFO Deform is assumed as 0 throughout.
+FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t start, size_t end,
+                     float v0, float v1, float tStart, float tEnd);
+
+// Index-based Ramer-Douglas-Peucker algorithm using curve-fit residual
+// Appends fitted MSEGStorage::segment values to `result`.
+// epsilon is the max-residual tolerance in normalized value units.
+void freehandRDP(const std::vector<std::pair<float, float>> &samples, size_t start, size_t end,
+                 float epsilon, float totalGestureDuration,
+                 std::vector<MSEGStorage::segment> &result);
+
 float valueAt(int phaseIntPart, float phaseFracPart, float deform, MSEGStorage *ms,
               EvaluatorState *state, bool forceOneShot = false);
 

--- a/src/common/dsp/modulators/MSEGModulationHelper.h
+++ b/src/common/dsp/modulators/MSEGModulationHelper.h
@@ -70,15 +70,14 @@ struct FitResult
 // Fit a single segment spanning samples[start..end] (inclusive endpoints pinned
 // to v0/v1 at absolute times tStart/tEnd).  Returns the best-fitting type and
 // its control-point values. LFO Deform is assumed as 0 throughout.
-FitResult fitSegment(const std::vector<std::pair<float, float>> &samples, size_t start, size_t end,
-                     float v0, float v1, float tStart, float tEnd);
+FitResult fitSegment(std::span<const std::pair<float, float>> samples, float v0, float v1,
+                     float tStart, float tEnd);
 
 // Index-based Ramer-Douglas-Peucker algorithm using curve-fit residual
 // Appends fitted MSEGStorage::segment values to `result`.
 // epsilon is the max-residual tolerance in normalized value units.
-void freehandRDP(const std::vector<std::pair<float, float>> &samples, size_t start, size_t end,
-                 float epsilon, float totalGestureDuration,
-                 std::vector<MSEGStorage::segment> &result);
+void freehandRDP(std::span<const std::pair<float, float>> samples, float epsilon,
+                 float totalGestureDuration, std::vector<MSEGStorage::segment> &result);
 
 float valueAt(int phaseIntPart, float phaseFracPart, float deform, MSEGStorage *ms,
               EvaluatorState *state, bool forceOneShot = false);

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -2330,6 +2330,16 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         auto t = tf(event.position.getX());
         auto drawArea = getDrawArea();
         auto where = event.position.toInt();
+        mouseDownInitiation =
+            (drawArea.contains(event.position.toInt()) ? MOUSE_DOWN_IN_DRAW_AREA
+                                                       : MOUSE_DOWN_OUTSIDE_DRAW_AREA);
+
+        if (mouseDownInitiation == MOUSE_DOWN_IN_DRAW_AREA && event.mods.isShiftDown() &&
+            event.mods.isCommandDown() && event.mods.isAltDown())
+        {
+            setMouseCursor(juce::MouseCursor::PointingHandCursor);
+            return;
+        }
 
         if (drawArea.contains(where))
         {
@@ -2397,6 +2407,12 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
     {
         if (inFreehandDrag)
         {
+            /*             const auto drawArea = getDrawArea();
+
+                        if (drawArea.contains(event.position.toInt()))
+                        {
+                        } */
+
             const auto tf = pxToTime();
             const auto pv = pxToVal();
             const float t = tf(event.position.x);
@@ -2405,6 +2421,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             freehandSamples.push_back({t, v});
 
             repaint();
+
             return;
         }
 

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -2090,10 +2090,11 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         std::sort(freehandSamples.begin(), freehandSamples.end(),
                   [](const auto &a, const auto &b) { return a.first < b.first; });
 
+        static constexpr float nodeMinSpacing = 4.f; // px
         const auto drawArea = getDrawArea();
         float tMin = pxToTime()(drawArea.getX());
         float tMax = pxToTime()(drawArea.getRight());
-        float tEpsilon = ((tMax - tMin) / drawArea.getWidth()) * 5.f;
+        float tEpsilon = ((tMax - tMin) / drawArea.getWidth()) * nodeMinSpacing;
 
         float gestureStart = freehandSamples.front().first;
         float gestureEnd = freehandSamples.back().first;
@@ -2216,8 +2217,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             }
         }
 
-        // --- 3. Run RDP on each sub-range between consecutive pinned times ---
-        //        collecting all fitted segments into one vector
+        // --- 3. Run RDP on each sub-range between consecutive pinned times
+        //        collecting all fitted segments into one vector ---
         std::vector<MSEGStorage::segment> fitted;
 
         // Count how many segments currently span the gesture region
@@ -2242,8 +2243,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         {
             fitted.clear();
 
-            Surge::MSEG::freehandRDP(freehandSamples, 0, freehandSamples.size() - 1, epsilon,
-                                     totalTimeSpan, fitted);
+            Surge::MSEG::freehandRDP(freehandSamples, epsilon, totalTimeSpan, fitted);
 
             if ((int)fitted.size() <= budget)
             {
@@ -2266,8 +2266,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                 float epMid = (epLo2 + epHi2) * 0.5f;
                 std::vector<MSEGStorage::segment> candidate;
 
-                Surge::MSEG::freehandRDP(freehandSamples, 0, freehandSamples.size() - 1, epMid,
-                                         totalTimeSpan, candidate);
+                Surge::MSEG::freehandRDP(freehandSamples, epMid, totalTimeSpan, candidate);
 
                 if ((float)candidate.size() / totalTimeSpan <= 16.f || epMid >= 0.1f)
                 {

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -1503,6 +1503,9 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             juce::Path freehandPath;
             bool first = true;
 
+            std::stable_sort(freehandSamples.begin(), freehandSamples.end(),
+                             [](const auto &a, const auto &b) { return a.first < b.first; });
+
             for (auto &s : freehandSamples)
             {
                 float px = tpx(s.first);
@@ -2070,138 +2073,138 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             return;
         }
 
-        // Samples are already in MSEG (time, value) units — collected during drag.
-        // Clamp values to [-1, 1] defensively.
-        for (auto &s : freehandSamples)
-        {
-            s.second = limit_range(s.second, -1.f, 1.f);
-        }
+        // first let's make sure our values are sorted
+        std::sort(freehandSamples.begin(), freehandSamples.end(),
+                  [](const auto &a, const auto &b) { return a.first < b.first; });
+
+        const auto drawArea = getDrawArea();
+        float tMin = pxToTime()(drawArea.getX());
+        float tMax = pxToTime()(drawArea.getRight());
+        float tEpsilon = ((tMax - tMin) / drawArea.getWidth()) * 5.f;
 
         float gestureStart = freehandSamples.front().first;
         float gestureEnd = freehandSamples.back().first;
 
-        // we gestured from right to left, perhaps?
-        if (gestureEnd < gestureStart)
-        {
-            std::swap(gestureStart, gestureEnd);
-            std::reverse(freehandSamples.begin(), freehandSamples.end());
-        }
-
         gestureStart = std::max(gestureStart, 0.f);
         gestureEnd = std::min(gestureEnd, ms->totalDuration);
 
-        if (gestureEnd - gestureStart < MSEGStorage::minimumDuration)
+        if (gestureEnd - gestureStart < tEpsilon)
         {
             return;
         }
 
-        // 1. Split boundary segments if gesture starts/ends mid-segment
+        // Save loop marker times before any modifications
+        float loopStartTime = (ms->loop_start >= 0 && ms->loop_start < ms->n_activeSegments)
+                                  ? ms->segmentStart[ms->loop_start]
+                                  : -1.f;
+        float loopEndTime = (ms->loop_end >= 0 && ms->loop_end < ms->n_activeSegments)
+                                ? ms->segmentStart[ms->loop_end]
+                                : -1.f;
 
-        // splitSegment(ms, t, v) is already available in MSEGModulationHelper.
-        // We evaluate the existing MSEG at the boundary times to get the right v.
-        //
-        // Note: after each split, segmentStart[] indices shift — call rebuildCache
-        // between splits so timeToSegment() stays valid.
+        // Handle nearly-vertical gesture globally
+        float totalTimeSpan = gestureEnd - gestureStart;
+        float totalValueSpan = fabs(freehandSamples.back().second - freehandSamples.front().second);
+
+        // --- 1. Split at gesture boundaries ---
+        for (float t : {gestureStart, gestureEnd})
         {
-            int seg = Surge::MSEG::timeToSegment(ms, gestureStart);
-
-            if (seg >= 0 &&
-                fabs(gestureStart - ms->segmentStart[seg]) > MSEGStorage::minimumDuration &&
-                fabs(gestureStart - ms->segmentEnd[seg]) > MSEGStorage::minimumDuration)
+            int seg = Surge::MSEG::timeToSegment(ms, t);
+            if (seg >= 0 && fabs(t - ms->segmentStart[seg]) > tEpsilon &&
+                fabs(t - ms->segmentEnd[seg]) > tEpsilon)
             {
-                // Evaluate existing curve at gestureStart for continuity
-                float v = freehandSamples.front().second; // use gesture's own start value
-                Surge::MSEG::splitSegment(ms, gestureStart, v);
+                float v = freehandSamples.front().second;
+                float bestDist = std::numeric_limits<float>::max();
+                for (auto &s : freehandSamples)
+                {
+                    float d = fabs(s.first - t);
+                    if (d < bestDist)
+                    {
+                        bestDist = d;
+                        v = s.second;
+                    }
+                }
+                Surge::MSEG::splitSegment(ms, t, v);
                 Surge::MSEG::rebuildCache(ms);
             }
         }
 
-        {
-            int seg = Surge::MSEG::timeToSegment(ms, gestureEnd);
+        // Count original segments in gesture region
+        int originalInteriorCount = 0;
 
-            if (seg >= 0 &&
-                fabs(gestureEnd - ms->segmentStart[seg]) > MSEGStorage::minimumDuration &&
-                fabs(gestureEnd - ms->segmentEnd[seg]) > MSEGStorage::minimumDuration)
+        for (int i = 0; i < ms->n_activeSegments; ++i)
+        {
+            if (ms->segmentStart[i] >= gestureStart - tEpsilon &&
+                ms->segmentStart[i] < gestureEnd - tEpsilon)
             {
-                float v = freehandSamples.back().second;
-                Surge::MSEG::splitSegment(ms, gestureEnd, v);
-                Surge::MSEG::rebuildCache(ms);
+                originalInteriorCount++;
             }
         }
 
-        // 2. After both splits, find left and right boundary indices
+        // --- 2. Delete all segments strictly inside gesture region ---
+        bool deleted = true;
 
-        int leftIdx = Surge::MSEG::timeToSegment(ms, gestureStart + MSEGStorage::minimumDuration);
-        int rightIdx = Surge::MSEG::timeToSegment(ms, gestureEnd + MSEGStorage::minimumDuration);
-
-        // Segments leftIdx .. rightIdx-1 are the interior ones to remove
-        // Shift rightIdx..n_activeSegments-1 left to fill the gap
-        int interiorCount = rightIdx - leftIdx;
-
-        for (int i = rightIdx; i < ms->n_activeSegments; ++i)
+        while (deleted)
         {
-            ms->segments[i - interiorCount + 1] = ms->segments[i];
+            deleted = false;
+            for (int i = 0; i < ms->n_activeSegments; ++i)
+            {
+                float segStart = ms->segmentStart[i];
+
+                if (segStart <= gestureStart + tEpsilon)
+                {
+                    continue;
+                }
+
+                if (segStart >= gestureEnd - tEpsilon)
+                {
+                    continue;
+                }
+
+                // Delete this interior non-pinned segment
+                // Find left neighbor and extend it to cover the gap
+                if (i > 0)
+                {
+                    ms->segments[i - 1].duration += ms->segments[i].duration;
+                    for (int j = i; j < ms->n_activeSegments - 1; ++j)
+                    {
+                        ms->segments[j] = ms->segments[j + 1];
+                    }
+                    ms->n_activeSegments--;
+                    Surge::MSEG::rebuildCache(ms);
+                    deleted = true;
+                    break;
+                }
+            }
         }
 
-        ms->n_activeSegments -= (interiorCount - 1); // keep one placeholder
-        ms->segments[leftIdx].duration = gestureEnd - gestureStart;
-        ms->segments[leftIdx].v0 = freehandSamples.front().second;
+        // --- 3. Run RDP on each sub-range between consecutive pinned times ---
+        //        collecting all fitted segments into one vector
+        std::vector<MSEGStorage::segment> fitted;
 
-        Surge::MSEG::rebuildCache(ms);
-
-        // 3. Find the left boundary node index after cleanup
-
-        int leftSeg = Surge::MSEG::timeToSegment(ms, gestureStart);
-
-        if (leftSeg < 0)
-        {
-            leftSeg = 0;
-        }
-
-        // The boundary node values (after splits) are our pinned P0/P2.
-        float v0 = ms->segments[leftSeg].v0;
-        float v1 = ms->segments[leftSeg].nv1;
-
-        // 4. Run RDP + fit with node-budget binary search
-
-        // Maximum nodes we can insert = (128 - existing segments outside gesture) - 1
-        // (we replace the single remaining inside segment with N fitted ones)
+        // Count how many segments currently span the gesture region
         int budget = max_msegs - ms->n_activeSegments + 1;
         budget = std::max(1, budget);
 
-        std::vector<MSEGStorage::segment> fitted;
+        // binary search on epsilon
+        float epLo = 0.f, epHi = 2.f;
+        float gestureValueRange = 0.f;
 
-        // Binary search on epsilon: start with a small epsilon, widen if over budget.
-        float epLo = 0.f;
-        float epHi = 2.f; // max possible residual in [-1,1] value space
-        float epsilon = 0.01f;
+        for (auto &s : freehandSamples)
+        {
+            gestureValueRange =
+                std::max(gestureValueRange, fabs(s.second - freehandSamples.front().second));
+        }
+
+        gestureValueRange =
+            std::max(gestureValueRange, 0.1f); // minimum range to avoid division issues
+
+        float epsilon = std::max(0.05f, gestureValueRange * 0.05f); // 5% of gesture value range
 
         for (int iter = 0; iter < 16; ++iter)
         {
             fitted.clear();
-
-            // Before running RDP — detect nearly vertical gesture
-            float totalTimeSpan = freehandSamples.back().first - freehandSamples.front().first;
-            float totalValueSpan =
-                fabs(freehandSamples.back().second - freehandSamples.front().second);
-
-            if (totalValueSpan > 0.f && totalTimeSpan / totalValueSpan < 0.1f)
-            {
-                fitted.clear();
-                MSEGStorage::segment seg{};
-                seg.duration = totalTimeSpan;
-                seg.v0 = freehandSamples.front().second;
-                seg.cpv = 0.f;
-                seg.cpduration = 0.5f;
-                seg.type = MSEGStorage::segment::LINEAR;
-                fitted.push_back(seg);
-            }
-            else
-            {
-                Surge::MSEG::freehandRDP(freehandSamples, 0, freehandSamples.size() - 1, epsilon,
-                                         totalTimeSpan, fitted);
-            }
-
+            Surge::MSEG::freehandRDP(freehandSamples, 0, freehandSamples.size() - 1, epsilon,
+                                     totalTimeSpan, fitted);
             if ((int)fitted.size() <= budget)
             {
                 break;
@@ -2211,71 +2214,83 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             epsilon = (epsilon + epHi) * 0.5f;
         }
 
-        // If still over budget (shouldn't happen but be safe), keep only `budget` segments
-        if ((int)fitted.size() > budget)
+        // density-based widening
+        float nodesPerUnit = (float)fitted.size() / totalTimeSpan;
+
+        if (nodesPerUnit > 16.f)
         {
-            fitted.resize(budget);
+            float epLo2 = epsilon, epHi2 = 0.1f;
+
+            for (int iter = 0; iter < 16; ++iter)
+            {
+                float epMid = (epLo2 + epHi2) * 0.5f;
+                std::vector<MSEGStorage::segment> candidate;
+                Surge::MSEG::freehandRDP(freehandSamples, 0, freehandSamples.size() - 1, epMid,
+                                         totalTimeSpan, candidate);
+
+                if ((float)candidate.size() / totalTimeSpan <= 16.f || epMid >= 0.1f)
+                {
+                    fitted = candidate;
+                    break;
+                }
+
+                epLo2 = epMid;
+            }
         }
 
-        // 5. Write fitted segments directly into ms->segments[]
+        // --- 4. Write fitted segments directly into ms->segments[] ---
+        int leftIdx = Surge::MSEG::timeToSegment(ms, gestureStart + tEpsilon);
 
-        // ...shifting any segments after the gesture region to make room, then fix up the right
-        // boundary node value and rebuild.
-
-        // After deletion loop, leftSeg is the index where gesture starts.
-        // Direct write — no splitSegment calls for insertion.
+        if (leftIdx < 0)
+        {
+            leftIdx = 0;
+        }
 
         int newCount = (int)fitted.size();
-        int oldTotal = ms->n_activeSegments;
+        int segsAfter = ms->n_activeSegments - leftIdx - 1;
 
-        // Number of segments after the gesture region
-        int rightSeg = leftSeg + 1; // after deletion there's exactly one segment spanning gesture
-        int segsAfter = oldTotal - rightSeg;
+        segsAfter = std::max(0, segsAfter);
 
-        // Check total won't exceed max_msegs
-        // (binary search already ensured fitted.size() <= budget, but be safe)
-        int newTotal = leftSeg + newCount + segsAfter;
+        int newTotal = leftIdx + newCount + segsAfter;
 
         if (newTotal > max_msegs)
         {
-            newCount = max_msegs - leftSeg - segsAfter;
+            newCount = max_msegs - leftIdx - segsAfter;
             fitted.resize(newCount);
         }
 
-        // Shift segments after the gesture region to make room
-        // Work backwards to avoid overwriting
+        // Shift segments after gesture region
         for (int i = segsAfter - 1; i >= 0; --i)
         {
-            ms->segments[leftSeg + newCount + i] = ms->segments[rightSeg + i];
+            ms->segments[leftIdx + newCount + i] = ms->segments[leftIdx + 1 + i];
         }
 
-        // Write fitted segments directly
+        // Write fitted segments
         for (int i = 0; i < newCount; ++i)
         {
-            ms->segments[leftSeg + i] = fitted[i];
+            ms->segments[leftIdx + i] = fitted[i];
         }
 
-        ms->n_activeSegments = leftSeg + newCount + segsAfter;
+        ms->n_activeSegments = leftIdx + newCount + segsAfter;
 
-        // Fix up the right boundary: first segment after gesture must start at gestureEnd value
-        if (leftSeg + newCount < ms->n_activeSegments)
+        // Fix right boundary v0
+        if (leftIdx + newCount < ms->n_activeSegments)
         {
-            ms->segments[leftSeg + newCount].v0 = freehandSamples.back().second;
+            ms->segments[leftIdx + newCount].v0 = freehandSamples.back().second;
         }
 
-        // how many extra segments we inserted (fitted count minus the 1 we deleted)
-        int indexDelta = newCount - interiorCount;
+        // --- 5. Remap loop markers by saved time positions ---
+        int indexDelta = newCount - originalInteriorCount;
 
-        // loop_start/end inside gesture region: remap to nearest boundary
-        if (ms->loop_start >= leftIdx && ms->loop_start < rightIdx)
-            ms->loop_start = leftIdx + newCount - 1;
-        else if (ms->loop_start >= rightIdx)
+        if (ms->loop_start >= leftIdx + originalInteriorCount)
+        {
             ms->loop_start += indexDelta;
+        }
 
-        if (ms->loop_end >= leftIdx && ms->loop_end < rightIdx)
-            ms->loop_end = leftIdx + newCount - 1;
-        else if (ms->loop_end >= rightIdx)
+        if (ms->loop_end >= leftIdx + originalInteriorCount)
+        {
             ms->loop_end += indexDelta;
+        }
 
         Surge::MSEG::rebuildCache(ms);
         pushToUndo();
@@ -2407,18 +2422,30 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
     {
         if (inFreehandDrag)
         {
-            /*             const auto drawArea = getDrawArea();
-
-                        if (drawArea.contains(event.position.toInt()))
-                        {
-                        } */
-
+            const auto drawArea = getDrawArea();
             const auto tf = pxToTime();
             const auto pv = pxToVal();
-            const float t = tf(event.position.x);
-            const float v = limit_range(pv(event.position.y), -1.f, 1.f);
+            const float tMin = tf(drawArea.getX());
+            const float tMax = tf(drawArea.getRight());
+            const float pixelInTime = (tMax - tMin) / drawArea.getWidth();
+            const float minTimeDelta = pixelInTime * 4.f; // at least 4 pixels apart in time
+
+            float t = std::max(0.f, std::min(tf(event.position.x), ms->totalDuration));
+            float v = limit_range(pv(event.position.y), -1.f, 1.f);
 
             freehandSamples.push_back({t, v});
+
+            std::sort(freehandSamples.begin(), freehandSamples.end(),
+                      [](const auto &a, const auto &b) { return a.first < b.first; });
+
+            // Remove samples that are too close in time to their predecessor
+            for (auto it = freehandSamples.begin() + 1; it != freehandSamples.end();)
+            {
+                if (fabs(it->first - std::prev(it)->first) < minTimeDelta)
+                    it = freehandSamples.erase(it);
+                else
+                    ++it;
+            }
 
             repaint();
 

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -35,6 +35,7 @@
 #include "widgets/NumberField.h"
 #include "widgets/Switch.h"
 #include "overlays/TypeinParamEditor.h"
+#include <algorithm>
 #include <set>
 #include "widgets/MenuCustomComponents.h"
 
@@ -312,7 +313,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         }
     }
 
-    // This little struct acts as a SmapGuard so that Shift-drags can (un)reset snap
+    // This little struct acts as a SnapGuard so that Shift-drags can (un)reset snap
     struct SnapGuard
     {
         SnapGuard(MSEGCanvas *c) : c(c)
@@ -1485,12 +1486,44 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         g.setColour(skin->getColor(Colors::MSEGEditor::Curve));
         g.strokePath(path, strokeStyle, tfpath);
 
-        if (hlpathUsed)
+        if (hlpathUsed && !inFreehandDrag)
         {
             strokeStyle = juce::PathStrokeType(1.5 * pathScale, juce::PathStrokeType::beveled,
                                                juce::PathStrokeType::butt);
             g.setColour(skin->getColor(Colors::MSEGEditor::CurveHighlight));
             g.strokePath(highlightPath, strokeStyle, tfpath);
+        }
+
+        // Draw freehand gesture overlay
+        if (inFreehandDrag && freehandSamples.size() >= 2)
+        {
+            auto tpx = timeToPx();
+            auto vpx = valToPx();
+
+            juce::Path freehandPath;
+            bool first = true;
+
+            for (auto &s : freehandSamples)
+            {
+                float px = tpx(s.first);
+                float py = vpx(s.second);
+
+                if (first)
+                {
+                    freehandPath.startNewSubPath(px, py);
+                    first = false;
+                }
+                else
+                {
+                    freehandPath.lineTo(px, py);
+                }
+            }
+
+            auto strokeStyle = juce::PathStrokeType(
+                0.75f * pathScale, juce::PathStrokeType::beveled, juce::PathStrokeType::butt);
+
+            g.setColour(skin->getColor(Colors::MSEGEditor::CurveHighlight).withAlpha(0.6f));
+            g.strokePath(freehandPath, strokeStyle);
         }
 
         for (const auto &h : hotzones)
@@ -1646,6 +1679,10 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
     bool cursorResetPosition = false;
     bool inDrag = false;
     bool inDrawDrag = false;
+    bool inFreehandDrag = false;
+
+    std::vector<std::pair<float, float>> freehandSamples;
+
     enum
     {
         NOT_MOUSE_DOWN,
@@ -1671,6 +1708,15 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             {
                 mouseDownInitiation = MOUSE_DOWN_IN_DRAW_AREA;
             }
+        }
+
+        // Start freehand drawing - fun! :)
+        if (mouseDownInitiation == MOUSE_DOWN_IN_DRAW_AREA && e.mods.isShiftDown() &&
+            e.mods.isCommandDown() && e.mods.isAltDown())
+        {
+            inFreehandDrag = true;
+            freehandSamples.clear();
+            return;
         }
 
         if (e.mods.isPopupMenu())
@@ -1953,6 +1999,13 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         inDrag = false;
         inDrawDrag = false;
 
+        if (inFreehandDrag && !freehandSamples.empty())
+        {
+            commitFreehandGesture();
+            freehandSamples.clear();
+            inFreehandDrag = false;
+        }
+
         if (lasso)
         {
             lasso->endLasso();
@@ -2008,6 +2061,228 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         return;
     }
 
+    void commitFreehandGesture()
+    {
+        prepareForUndo();
+
+        if (freehandSamples.size() < 2)
+        {
+            return;
+        }
+
+        // Samples are already in MSEG (time, value) units — collected during drag.
+        // Clamp values to [-1, 1] defensively.
+        for (auto &s : freehandSamples)
+        {
+            s.second = limit_range(s.second, -1.f, 1.f);
+        }
+
+        float gestureStart = freehandSamples.front().first;
+        float gestureEnd = freehandSamples.back().first;
+
+        // we gestured from right to left, perhaps?
+        if (gestureEnd < gestureStart)
+        {
+            std::swap(gestureStart, gestureEnd);
+            std::reverse(freehandSamples.begin(), freehandSamples.end());
+        }
+
+        gestureStart = std::max(gestureStart, 0.f);
+        gestureEnd = std::min(gestureEnd, ms->totalDuration);
+
+        if (gestureEnd - gestureStart < MSEGStorage::minimumDuration)
+        {
+            return;
+        }
+
+        // 1. Split boundary segments if gesture starts/ends mid-segment
+
+        // splitSegment(ms, t, v) is already available in MSEGModulationHelper.
+        // We evaluate the existing MSEG at the boundary times to get the right v.
+        //
+        // Note: after each split, segmentStart[] indices shift — call rebuildCache
+        // between splits so timeToSegment() stays valid.
+        {
+            int seg = Surge::MSEG::timeToSegment(ms, gestureStart);
+
+            if (seg >= 0 &&
+                fabs(gestureStart - ms->segmentStart[seg]) > MSEGStorage::minimumDuration &&
+                fabs(gestureStart - ms->segmentEnd[seg]) > MSEGStorage::minimumDuration)
+            {
+                // Evaluate existing curve at gestureStart for continuity
+                float v = freehandSamples.front().second; // use gesture's own start value
+                Surge::MSEG::splitSegment(ms, gestureStart, v);
+                Surge::MSEG::rebuildCache(ms);
+            }
+        }
+
+        {
+            int seg = Surge::MSEG::timeToSegment(ms, gestureEnd);
+
+            if (seg >= 0 &&
+                fabs(gestureEnd - ms->segmentStart[seg]) > MSEGStorage::minimumDuration &&
+                fabs(gestureEnd - ms->segmentEnd[seg]) > MSEGStorage::minimumDuration)
+            {
+                float v = freehandSamples.back().second;
+                Surge::MSEG::splitSegment(ms, gestureEnd, v);
+                Surge::MSEG::rebuildCache(ms);
+            }
+        }
+
+        // 2. After both splits, find left and right boundary indices
+
+        int leftIdx = Surge::MSEG::timeToSegment(ms, gestureStart + MSEGStorage::minimumDuration);
+        int rightIdx = Surge::MSEG::timeToSegment(ms, gestureEnd + MSEGStorage::minimumDuration);
+
+        // Segments leftIdx .. rightIdx-1 are the interior ones to remove
+        // Shift rightIdx..n_activeSegments-1 left to fill the gap
+        int interiorCount = rightIdx - leftIdx;
+
+        for (int i = rightIdx; i < ms->n_activeSegments; ++i)
+        {
+            ms->segments[i - interiorCount + 1] = ms->segments[i];
+        }
+
+        ms->n_activeSegments -= (interiorCount - 1); // keep one placeholder
+        ms->segments[leftIdx].duration = gestureEnd - gestureStart;
+        ms->segments[leftIdx].v0 = freehandSamples.front().second;
+
+        Surge::MSEG::rebuildCache(ms);
+
+        // 3. Find the left boundary node index after cleanup
+
+        int leftSeg = Surge::MSEG::timeToSegment(ms, gestureStart);
+
+        if (leftSeg < 0)
+        {
+            leftSeg = 0;
+        }
+
+        // The boundary node values (after splits) are our pinned P0/P2.
+        float v0 = ms->segments[leftSeg].v0;
+        float v1 = ms->segments[leftSeg].nv1;
+
+        // 4. Run RDP + fit with node-budget binary search
+
+        // Maximum nodes we can insert = (128 - existing segments outside gesture) - 1
+        // (we replace the single remaining inside segment with N fitted ones)
+        int budget = max_msegs - ms->n_activeSegments + 1;
+        budget = std::max(1, budget);
+
+        std::vector<MSEGStorage::segment> fitted;
+
+        // Binary search on epsilon: start with a small epsilon, widen if over budget.
+        float epLo = 0.f;
+        float epHi = 2.f; // max possible residual in [-1,1] value space
+        float epsilon = 0.01f;
+
+        for (int iter = 0; iter < 16; ++iter)
+        {
+            fitted.clear();
+
+            // Before running RDP — detect nearly vertical gesture
+            float totalTimeSpan = freehandSamples.back().first - freehandSamples.front().first;
+            float totalValueSpan =
+                fabs(freehandSamples.back().second - freehandSamples.front().second);
+
+            if (totalValueSpan > 0.f && totalTimeSpan / totalValueSpan < 0.1f)
+            {
+                fitted.clear();
+                MSEGStorage::segment seg{};
+                seg.duration = totalTimeSpan;
+                seg.v0 = freehandSamples.front().second;
+                seg.cpv = 0.f;
+                seg.cpduration = 0.5f;
+                seg.type = MSEGStorage::segment::LINEAR;
+                fitted.push_back(seg);
+            }
+            else
+            {
+                Surge::MSEG::freehandRDP(freehandSamples, 0, freehandSamples.size() - 1, epsilon,
+                                         totalTimeSpan, fitted);
+            }
+
+            if ((int)fitted.size() <= budget)
+            {
+                break;
+            }
+
+            epLo = epsilon;
+            epsilon = (epsilon + epHi) * 0.5f;
+        }
+
+        // If still over budget (shouldn't happen but be safe), keep only `budget` segments
+        if ((int)fitted.size() > budget)
+        {
+            fitted.resize(budget);
+        }
+
+        // 5. Write fitted segments directly into ms->segments[]
+
+        // ...shifting any segments after the gesture region to make room, then fix up the right
+        // boundary node value and rebuild.
+
+        // After deletion loop, leftSeg is the index where gesture starts.
+        // Direct write — no splitSegment calls for insertion.
+
+        int newCount = (int)fitted.size();
+        int oldTotal = ms->n_activeSegments;
+
+        // Number of segments after the gesture region
+        int rightSeg = leftSeg + 1; // after deletion there's exactly one segment spanning gesture
+        int segsAfter = oldTotal - rightSeg;
+
+        // Check total won't exceed max_msegs
+        // (binary search already ensured fitted.size() <= budget, but be safe)
+        int newTotal = leftSeg + newCount + segsAfter;
+
+        if (newTotal > max_msegs)
+        {
+            newCount = max_msegs - leftSeg - segsAfter;
+            fitted.resize(newCount);
+        }
+
+        // Shift segments after the gesture region to make room
+        // Work backwards to avoid overwriting
+        for (int i = segsAfter - 1; i >= 0; --i)
+        {
+            ms->segments[leftSeg + newCount + i] = ms->segments[rightSeg + i];
+        }
+
+        // Write fitted segments directly
+        for (int i = 0; i < newCount; ++i)
+        {
+            ms->segments[leftSeg + i] = fitted[i];
+        }
+
+        ms->n_activeSegments = leftSeg + newCount + segsAfter;
+
+        // Fix up the right boundary: first segment after gesture must start at gestureEnd value
+        if (leftSeg + newCount < ms->n_activeSegments)
+        {
+            ms->segments[leftSeg + newCount].v0 = freehandSamples.back().second;
+        }
+
+        // how many extra segments we inserted (fitted count minus the 1 we deleted)
+        int indexDelta = newCount - interiorCount;
+
+        // loop_start/end inside gesture region: remap to nearest boundary
+        if (ms->loop_start >= leftIdx && ms->loop_start < rightIdx)
+            ms->loop_start = leftIdx + newCount - 1;
+        else if (ms->loop_start >= rightIdx)
+            ms->loop_start += indexDelta;
+
+        if (ms->loop_end >= leftIdx && ms->loop_end < rightIdx)
+            ms->loop_end = leftIdx + newCount - 1;
+        else if (ms->loop_end >= rightIdx)
+            ms->loop_end += indexDelta;
+
+        Surge::MSEG::rebuildCache(ms);
+        pushToUndo();
+        modelChanged();
+        repaint();
+    }
+
     void showCursorAt(const juce::Point<float> &w) { cursorHideOrigin = w.toInt(); }
     void showCursorAt(const juce::Point<int> &w) { cursorHideOrigin = w; }
 
@@ -2043,6 +2318,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
     void mouseMagnify(const juce::MouseEvent &event, float scaleFactor) override
     {
+
         auto pii = event.position.toInt();
         zoom(pii, -(1.f - scaleFactor) * 4);
         return;
@@ -2119,6 +2395,19 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
     void mouseDrag(const juce::MouseEvent &event) override
     {
+        if (inFreehandDrag)
+        {
+            const auto tf = pxToTime();
+            const auto pv = pxToVal();
+            const float t = tf(event.position.x);
+            const float v = limit_range(pv(event.position.y), -1.f, 1.f);
+
+            freehandSamples.push_back({t, v});
+
+            repaint();
+            return;
+        }
+
         if (lasso)
         {
             lasso->dragLasso(event);

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -822,7 +822,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         auto tpx = timeToPx();
         float maxt = drawDuration();
 
-        // draw loop area
+        // draw looped area of the axis
         if (ms->loopMode != MSEGStorage::ONESHOT && ms->editMode != MSEGStorage::LFO)
         {
             int ls = (ms->loop_start >= 0 ? ms->loop_start : 0);
@@ -1135,7 +1135,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         auto tpx = timeToPx();
         auto pxt = pxToTime();
 
-        // Now draw the loop region
+        // Draw the loop region fill
         if (ms->loopMode != MSEGStorage::LoopMode::ONESHOT && ms->editMode != MSEGStorage::LFO)
         {
             int ls = (ms->loop_start >= 0 ? ms->loop_start : 0);
@@ -1157,18 +1157,6 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
                 g.setColour(cf);
                 g.fillRect(loopRect);
-
-                auto cb = skin->getColor(Colors::MSEGEditor::Loop::RegionBorder);
-                g.setColour(cb);
-
-                if (oldpxe > drawArea.getX() && oldpxe <= drawArea.getRight())
-                {
-                    g.drawLine(pxe - 0.5, drawArea.getY(), pxe - 0.5, drawArea.getBottom(), 1);
-                }
-                if (oldpxs >= drawArea.getX() && oldpxs < drawArea.getRight())
-                {
-                    g.drawLine(pxs - 0.5, drawArea.getY(), pxs - 0.5, drawArea.getBottom(), 1);
-                }
             }
         }
 
@@ -1474,6 +1462,31 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         }
 
         drawAxis(g);
+
+        // draw the loop region borders
+        if (ms->loopMode != MSEGStorage::LoopMode::ONESHOT && ms->editMode != MSEGStorage::LFO)
+        {
+            int ls = (ms->loop_start >= 0 ? ms->loop_start : 0);
+            int le = (ms->loop_end >= 0 ? ms->loop_end : ms->n_activeSegments - 1);
+
+            float pxs = tpx(ms->segmentStart[ls]);
+            float pxe = tpx(ms->segmentEnd[le]);
+
+            if (!(pxs > drawArea.getRight() || pxe < drawArea.getX()))
+            {
+                auto cb = skin->getColor(Colors::MSEGEditor::Loop::RegionBorder);
+                g.setColour(cb);
+
+                if (pxe > drawArea.getX() && pxe <= drawArea.getRight())
+                {
+                    g.drawLine(pxe - 0.5, drawArea.getY(), pxe - 0.5, drawArea.getBottom(), 1);
+                }
+                if (pxs >= drawArea.getX() && pxs < drawArea.getRight())
+                {
+                    g.drawLine(pxs - 0.5, drawArea.getY(), pxs - 0.5, drawArea.getBottom(), 1);
+                }
+            }
+        }
 
         // draw segment curve
         auto strokeStyle = juce::PathStrokeType(0.75 * pathScale, juce::PathStrokeType::beveled,
@@ -2093,6 +2106,29 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             return;
         }
 
+        // snap gesture boundaries to existing nodes if close enough
+        auto snapToNearestNode = [&](float t, bool isEnd = false) -> float {
+            for (int i = 0; i < ms->n_activeSegments; ++i)
+            {
+                if (fabs(ms->segmentStart[i] - t) < tEpsilon)
+                {
+                    if (isEnd)
+                        freehandSamples.push_back({ms->segmentStart[i], ms->segments[i].v0});
+                    else
+                        freehandSamples.insert(freehandSamples.begin(),
+                                               {ms->segmentStart[i], ms->segments[i].v0});
+                    return ms->segmentStart[i];
+                }
+            }
+
+            return t;
+        };
+
+        gestureStart = snapToNearestNode(gestureStart);
+        gestureEnd = snapToNearestNode(gestureEnd, true);
+
+        float totalTimeSpan = gestureEnd - gestureStart;
+
         // Save loop marker times before any modifications
         float loopStartTime = (ms->loop_start >= 0 && ms->loop_start < ms->n_activeSegments)
                                   ? ms->segmentStart[ms->loop_start]
@@ -2101,42 +2137,30 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                                 ? ms->segmentStart[ms->loop_end]
                                 : -1.f;
 
-        // Handle nearly-vertical gesture globally
-        float totalTimeSpan = gestureEnd - gestureStart;
-        float totalValueSpan = fabs(freehandSamples.back().second - freehandSamples.front().second);
-
         // --- 1. Split at gesture boundaries ---
         for (float t : {gestureStart, gestureEnd})
         {
             int seg = Surge::MSEG::timeToSegment(ms, t);
+
             if (seg >= 0 && fabs(t - ms->segmentStart[seg]) > tEpsilon &&
                 fabs(t - ms->segmentEnd[seg]) > tEpsilon)
             {
                 float v = freehandSamples.front().second;
                 float bestDist = std::numeric_limits<float>::max();
+
                 for (auto &s : freehandSamples)
                 {
                     float d = fabs(s.first - t);
+
                     if (d < bestDist)
                     {
                         bestDist = d;
                         v = s.second;
                     }
                 }
+
                 Surge::MSEG::splitSegment(ms, t, v);
                 Surge::MSEG::rebuildCache(ms);
-            }
-        }
-
-        // Count original segments in gesture region
-        int originalInteriorCount = 0;
-
-        for (int i = 0; i < ms->n_activeSegments; ++i)
-        {
-            if (ms->segmentStart[i] >= gestureStart - tEpsilon &&
-                ms->segmentStart[i] < gestureEnd - tEpsilon)
-            {
-                originalInteriorCount++;
             }
         }
 
@@ -2146,6 +2170,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         while (deleted)
         {
             deleted = false;
+
             for (int i = 0; i < ms->n_activeSegments; ++i)
             {
                 float segStart = ms->segmentStart[i];
@@ -2160,18 +2185,32 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                     continue;
                 }
 
-                // Delete this interior non-pinned segment
                 // Find left neighbor and extend it to cover the gap
                 if (i > 0)
                 {
                     ms->segments[i - 1].duration += ms->segments[i].duration;
+
                     for (int j = i; j < ms->n_activeSegments - 1; ++j)
                     {
                         ms->segments[j] = ms->segments[j + 1];
                     }
+
                     ms->n_activeSegments--;
+
+                    if (ms->loop_start > i)
+                    {
+                        ms->loop_start--;
+                    }
+
+                    if (ms->loop_end > i)
+                    {
+                        ms->loop_end--;
+                    }
+
                     Surge::MSEG::rebuildCache(ms);
+
                     deleted = true;
+
                     break;
                 }
             }
@@ -2186,8 +2225,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         budget = std::max(1, budget);
 
         // binary search on epsilon
-        float epLo = 0.f, epHi = 2.f;
-        float gestureValueRange = 0.f;
+        float epLo{0.f}, epHi{2.f}, gestureValueRange{0.f};
 
         for (auto &s : freehandSamples)
         {
@@ -2195,16 +2233,18 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                 std::max(gestureValueRange, fabs(s.second - freehandSamples.front().second));
         }
 
-        gestureValueRange =
-            std::max(gestureValueRange, 0.1f); // minimum range to avoid division issues
+        // minimum range to avoid division issues
+        gestureValueRange = std::max(gestureValueRange, 0.1f);
 
         float epsilon = std::max(0.05f, gestureValueRange * 0.05f); // 5% of gesture value range
 
         for (int iter = 0; iter < 16; ++iter)
         {
             fitted.clear();
+
             Surge::MSEG::freehandRDP(freehandSamples, 0, freehandSamples.size() - 1, epsilon,
                                      totalTimeSpan, fitted);
+
             if ((int)fitted.size() <= budget)
             {
                 break;
@@ -2225,6 +2265,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             {
                 float epMid = (epLo2 + epHi2) * 0.5f;
                 std::vector<MSEGStorage::segment> candidate;
+
                 Surge::MSEG::freehandRDP(freehandSamples, 0, freehandSamples.size() - 1, epMid,
                                          totalTimeSpan, candidate);
 
@@ -2280,14 +2321,14 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         }
 
         // --- 5. Remap loop markers by saved time positions ---
-        int indexDelta = newCount - originalInteriorCount;
+        int indexDelta = newCount - 1;
 
-        if (ms->loop_start >= leftIdx + originalInteriorCount)
+        if (ms->loop_start >= leftIdx + 1)
         {
             ms->loop_start += indexDelta;
         }
 
-        if (ms->loop_end >= leftIdx + originalInteriorCount)
+        if (ms->loop_end >= leftIdx + 1)
         {
             ms->loop_end += indexDelta;
         }
@@ -2299,6 +2340,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
     }
 
     void showCursorAt(const juce::Point<float> &w) { cursorHideOrigin = w.toInt(); }
+
     void showCursorAt(const juce::Point<int> &w) { cursorHideOrigin = w; }
 
     void guaranteeCursorShown()

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -1516,9 +1516,6 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             juce::Path freehandPath;
             bool first = true;
 
-            std::stable_sort(freehandSamples.begin(), freehandSamples.end(),
-                             [](const auto &a, const auto &b) { return a.first < b.first; });
-
             for (auto &s : freehandSamples)
             {
                 float px = tpx(s.first);
@@ -2469,9 +2466,9 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             const float tMin = tf(drawArea.getX());
             const float tMax = tf(drawArea.getRight());
             const float pixelInTime = (tMax - tMin) / drawArea.getWidth();
-            const float minTimeDelta = pixelInTime * 4.f; // at least 4 pixels apart in time
+            const float minTimeDelta = pixelInTime * 2.f; // at least 2 pixels apart in time
 
-            float t = std::max(0.f, std::min(tf(event.position.x), ms->totalDuration));
+            float t = std::clamp(tf(event.position.x), 0.f, ms->totalDuration);
             float v = limit_range(pv(event.position.y), -1.f, 1.f);
 
             freehandSamples.push_back({t, v});


### PR DESCRIPTION
Closes #6469. 

Inspired by the same feature in UVI Falcon. We're trying to fit more curve types, Falcon only does linear piecewise fitting, we're using hold, linear, S-curve and Bezier. 

Hold Shift+Ctrl+Alt to initiate the freehand draw in MSEG. 

Also fixes a long-standing bug where loop start/end vertical lines would be occluded by gridlines, if loop points were snapping to the grid. 

Needs two things fixed subsequently but we can do that in separate PRs.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>