### PR TITLE
Add Find and Goto line to the Lua editors' Prelude tabs

### DIFF
--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -776,6 +776,11 @@ bool CodeEditorSearch::keyPressed(const juce::KeyPress &key, juce::Component *or
 
 void CodeEditorSearch::replaceResults(bool all)
 {
+    if (ed->isReadOnly())
+    {
+        return;
+    }
+
     if (resultTotal > 0)
     {
         resultHasChanged = true;
@@ -1053,6 +1058,28 @@ void SurgeCodeEditorComponent::mouseDrag(const juce::MouseEvent &event)
 
 bool SurgeCodeEditorComponent::keyPressed(const juce::KeyPress &key)
 {
+    // Prelude find
+    if (search != nullptr && key.getModifiers().isCommandDown() && key.isKeyCode('F'))
+    {
+        if (gotoLine != nullptr)
+        {
+            gotoLine->hide();
+        }
+        search->show();
+        search->showReplace(false);
+        return true;
+    }
+
+    // Prelude go to line
+    if (gotoLine != nullptr && key.getModifiers().isCommandDown() && key.isKeyCode('G'))
+    {
+        if (search != nullptr)
+        {
+            search->hide();
+        }
+        gotoLine->show();
+        return true;
+    }
 
     // update search results
     if (search != nullptr)
@@ -1164,6 +1191,11 @@ void SurgeCodeEditorComponent::addPopupMenuItems(juce::PopupMenu &menuToAddTo,
     if (search == nullptr)
     {
         find.setEnabled(false);
+        replace.setEnabled(false);
+    }
+
+    if (isReadOnly())
+    {
         replace.setEnabled(false);
     }
 
@@ -2751,6 +2783,8 @@ FormulaModulatorEditor::FormulaModulatorEditor(SurgeGUIEditor *ed, SurgeStorage 
     preludeDisplay->setScrollbarThickness(8);
     preludeDisplay->setTitle("Formula Modulator Prelude Code");
     preludeDisplay->setDescription("Formula Modulator Prelude Code");
+    preludeDisplay->setSearch(*search);
+    preludeDisplay->setGotoLine(*gotoLine);
 
     EditorColors::setColorsFromSkin(preludeDisplay.get(), skin);
 
@@ -2875,16 +2909,38 @@ void FormulaModulatorEditor::resized()
 
 void FormulaModulatorEditor::showModulatorCode()
 {
+    const bool keepFocus = hasKeyboardFocus(true);
+
+    search->hide();
+    gotoLine->hide();
     preludeDisplay->setVisible(false);
     mainEditor->setVisible(true);
+    search->setEditor(*mainEditor);
+    gotoLine->setEditor(*mainEditor);
     getEditState().codeOrPrelude = 0;
+
+    if (keepFocus)
+    {
+        mainEditor->grabKeyboardFocus();
+    }
 }
 
 void FormulaModulatorEditor::showPreludeCode()
 {
+    const bool keepFocus = hasKeyboardFocus(true);
+
+    search->hide();
+    gotoLine->hide();
     preludeDisplay->setVisible(true);
     mainEditor->setVisible(false);
+    search->setEditor(*preludeDisplay);
+    gotoLine->setEditor(*preludeDisplay);
     getEditState().codeOrPrelude = 1;
+
+    if (keepFocus)
+    {
+        preludeDisplay->grabKeyboardFocus();
+    }
 }
 
 void FormulaModulatorEditor::updateDebuggerIfNeeded()
@@ -3812,6 +3868,9 @@ WavetableScriptEditor::WavetableScriptEditor(SurgeGUIEditor *ed, SurgeStorage *s
     preludeDisplay->setScrollbarThickness(8);
     preludeDisplay->setTitle("Wavetable Prelude Code");
     preludeDisplay->setDescription("Wavetable Prelude Code");
+    preludeDisplay->setSearch(*search);
+    preludeDisplay->setGotoLine(*gotoLine);
+
     EditorColors::setColorsFromSkin(preludeDisplay.get(), skin);
 
     controlArea = std::make_unique<WavetableScriptControlArea>(this, editor);
@@ -3948,16 +4007,38 @@ void WavetableScriptEditor::resized()
 
 void WavetableScriptEditor::showModulatorCode()
 {
+    const bool keepFocus = hasKeyboardFocus(true);
+
+    search->hide();
+    gotoLine->hide();
     preludeDisplay->setVisible(false);
     mainEditor->setVisible(true);
+    search->setEditor(*mainEditor);
+    gotoLine->setEditor(*mainEditor);
     getEditState().codeOrPrelude = 0;
+
+    if (keepFocus)
+    {
+        mainEditor->grabKeyboardFocus();
+    }
 }
 
 void WavetableScriptEditor::showPreludeCode()
 {
+    const bool keepFocus = hasKeyboardFocus(true);
+
+    search->hide();
+    gotoLine->hide();
     preludeDisplay->setVisible(true);
     mainEditor->setVisible(false);
+    search->setEditor(*preludeDisplay);
+    gotoLine->setEditor(*preludeDisplay);
     getEditState().codeOrPrelude = 1;
+
+    if (keepFocus)
+    {
+        preludeDisplay->grabKeyboardFocus();
+    }
 }
 
 void WavetableScriptEditor::rerenderFromUIState()

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -1156,11 +1156,19 @@ void SurgeCodeEditorComponent::performPopupMenuAction(int menuItemID)
 void SurgeCodeEditorComponent::addPopupMenuItems(juce::PopupMenu &menuToAddTo,
                                                  const juce::MouseEvent *mouseClickEvent)
 {
-    juce::CodeEditorComponent::addPopupMenuItems(menuToAddTo, mouseClickEvent);
+    if (isReadOnly())
+    {
+        menuToAddTo.addItem(juce::StandardApplicationCommandIDs::copy, "Copy",
+                            !getHighlightedRegion().isEmpty());
+        menuToAddTo.addItem(juce::StandardApplicationCommandIDs::selectAll, "Select All");
+    }
+    else
+    {
+        juce::CodeEditorComponent::addPopupMenuItems(menuToAddTo, mouseClickEvent);
+    }
 
 #if MAC
     std::string commandStr = u8"\U00002318";
-
 #else
     std::string commandStr = "Ctrl";
 #endif
@@ -1193,19 +1201,17 @@ void SurgeCodeEditorComponent::addPopupMenuItems(juce::PopupMenu &menuToAddTo,
         find.setEnabled(false);
         replace.setEnabled(false);
     }
+    menuToAddTo.addItem(find);
 
-    if (isReadOnly())
+    if (!isReadOnly())
     {
-        replace.setEnabled(false);
+        menuToAddTo.addItem(replace);
     }
 
     if (gotoLine == nullptr)
     {
         gotoline.setEnabled(false);
     }
-
-    menuToAddTo.addItem(find);
-    menuToAddTo.addItem(replace);
     menuToAddTo.addItem(gotoline);
 }
 
@@ -2775,6 +2781,7 @@ FormulaModulatorEditor::FormulaModulatorEditor(SurgeGUIEditor *ed, SurgeStorage 
 
     preludeDocument = std::make_unique<juce::CodeDocument>();
     preludeDocument->insertText(0, Surge::LuaSupport::getFormulaPrelude());
+    preludeDocument->clearUndoHistory();
 
     preludeDisplay =
         std::make_unique<SurgeCodeEditorComponent>(*preludeDocument, tokenizer.get(), skin);
@@ -3860,6 +3867,7 @@ WavetableScriptEditor::WavetableScriptEditor(SurgeGUIEditor *ed, SurgeStorage *s
 
     preludeDocument = std::make_unique<juce::CodeDocument>();
     preludeDocument->insertText(0, Surge::LuaSupport::getWTSEPrelude());
+    preludeDocument->clearUndoHistory();
 
     preludeDisplay =
         std::make_unique<SurgeCodeEditorComponent>(*preludeDocument, tokenizer.get(), skin);

--- a/src/surge-xt/gui/overlays/LuaEditors.h
+++ b/src/surge-xt/gui/overlays/LuaEditors.h
@@ -151,6 +151,7 @@ class TextfieldPopup : public juce::Component,
     void setButtonOffsetAtRow(int row, int offset);
 
     void setTextWidth(int w);
+    void setEditor(juce::CodeEditorComponent &editor) { ed = &editor; }
     virtual void show();
     virtual void hide();
 };
@@ -392,7 +393,7 @@ struct WavetableScriptEditor : public CodeEditorContainerWithApply, public Refre
 
     std::unique_ptr<Surge::WavetableScript::LuaWTEvaluator> evaluator;
     std::unique_ptr<juce::CodeDocument> preludeDocument;
-    std::unique_ptr<juce::CodeEditorComponent> preludeDisplay;
+    std::unique_ptr<SurgeCodeEditorComponent> preludeDisplay;
     std::unique_ptr<WavetableScriptControlArea> controlArea;
     std::unique_ptr<WavetablePreviewComponent> rendererComponent;
 


### PR DESCRIPTION
- Switches Prelude tab to SurgeCodeEditorComponent and handle keybinds for find and go to line
- Grey out replace in the Prelude's context menu
- Also keeps keyboard focus when switching components/tabs

Assisted-By: Claude Opus 4.8