### PR TITLE
String oscillator: rename "Scene A In" to "Scene A"

### DIFF
--- a/src/common/dsp/oscillators/StringOscillator.cpp
+++ b/src/common/dsp/oscillators/StringOscillator.cpp
@@ -85,7 +85,7 @@ std::string stringosc_excitation_name(int i)
     case StringOscillator::constant_audioin:
         return "Audio In";
     case StringOscillator::constant_scene_a_in:
-        return "Scene A In";
+        return "Scene A";
     }
     return "Unknown";
 }


### PR DESCRIPTION
Because that's how it should read logically. The exciter is scene A, not scene A input.