### PR TITLE
Add option to detach sustain pedal from voicing

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2132,6 +2132,7 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
 
     // Default hardclip value
     storage->hardclipMode = SurgeStorage::HARDCLIP_TO_18DBFS;
+    storage->useSustainAsModulatorOnly = false;
 
     for (int sc = 0; sc < n_scenes; ++sc)
     {
@@ -2206,6 +2207,19 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             if (tam->QueryIntAttribute("v", &tv) == TIXML_SUCCESS)
             {
                 storage->setTuningApplicationMode((SurgeStorage::TuningApplicationMode)(tv));
+            }
+        }
+
+        auto *dspv =
+            TINYXML_SAFE_TO_ELEMENT(nonparamconfig->FirstChild("detachSustainPedalFromVoicing"));
+
+        if (dspv)
+        {
+            bool tv;
+
+            if (tam->QueryBoolAttribute("v", &tv) == TIXML_SUCCESS)
+            {
+                storage->useSustainAsModulatorOnly.store(tv);
             }
         }
 
@@ -3990,6 +4004,11 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
         tam.SetAttribute("v", (int)(storage->tuningApplicationMode));
     }
     nonparamconfig.InsertEndChild(tam);
+
+    TiXmlElement dspv("detachSustainPedalFromVoicing");
+    dspv.SetAttribute("v", (int)(storage->useSustainAsModulatorOnly));
+
+    nonparamconfig.InsertEndChild(dspv);
 
     patch.InsertEndChild(nonparamconfig);
 

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2232,6 +2232,8 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
             Surge::FxClipboard::copyFx(this, &getPatch().fx[sl], *(clipboard_scenefx[i]));
         }
 
+        clipboard_useSustainAsModulatorOnly = useSustainAsModulatorOnly.load();
+
         clipboard_primode = getPatch().scene[scene].monoVoicePriorityMode;
         clipboard_envmode = getPatch().scene[scene].monoVoiceEnvelopeMode;
     }
@@ -2530,6 +2532,8 @@ void SurgeStorage::clipboard_paste(
                 updateFxInSlot(clipboard_scenefx[i], sl);
             }
         }
+
+        useSustainAsModulatorOnly.store(clipboard_useSustainAsModulatorOnly);
 
         getPatch().scene[scene].monoVoicePriorityMode = clipboard_primode;
         getPatch().scene[scene].monoVoiceEnvelopeMode = clipboard_envmode;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1792,6 +1792,8 @@ class alignas(16) SurgeStorage
     std::atomic<bool> mapChannelToOctave; // When other midi modes come along, clean this up.
     std::atomic<bool> transposeByTuningPeriod{false};
 
+    std::atomic<bool> useSustainAsModulatorOnly{false};
+
     bool mpeEnabled{false};
 
     int oscPortIn{DEFAULT_OSC_PORT_IN};
@@ -2005,6 +2007,9 @@ class alignas(16) SurgeStorage
         clipboard_wtSnapshots;
 
     char clipboard_modulator_names[n_lfos][max_lfo_indices][CUSTOM_CONTROLLER_LABEL_SIZE + 1];
+
+    bool clipboard_useSustainAsModulatorOnly = false;
+
     MonoVoicePriorityMode clipboard_primode = NOTE_ON_LATEST_RETRIGGER_HIGHEST;
     MonoVoiceEnvelopeMode clipboard_envmode = RESTART_FROM_ZERO;
 

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2191,6 +2191,11 @@ void SurgeSynthesizer::channelController(char channel, int cc, int value)
                 ->set_target(fval);
         }
 
+        if (storage.useSustainAsModulatorOnly)
+        {
+            break;
+        }
+
         sustainpedalCC = value;
         hasUpdatedMidiCC = true;
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -1019,6 +1019,15 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                 contextMenu.addSeparator();
             }
 
+            if (modsource == ms_sustain)
+            {
+                auto &opt = synth->storage.useSustainAsModulatorOnly;
+                contextMenu.addItem(Surge::GUI::toOSCase("Detach Sustain Pedal from Voicing"), true,
+                                    opt.load(), [&opt]() { opt.store(!opt.load()); });
+
+                contextMenu.addSeparator();
+            }
+
             int n_total_md = synth->storage.getPatch().param_ptr.size();
             const int max_md = 4096;
 


### PR DESCRIPTION
Closes #6506

Right-click the Sustain modbutton to show this option. It is global for the instance and stores in the patch (not the DAW extra state).