### PR TITLE
A few updates to the Modern oscillator!

### DIFF
--- a/resources/surge-shared/configuration.xml
+++ b/resources/surge-shared/configuration.xml
@@ -8,13 +8,13 @@
               retrigger="0"/>
 </type>
 <type i="8" name="Modern">
-    <snapshot name="Sawtooth" p0="1.0" p1="0.0" p2="0.0" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1"
+    <snapshot name="Sawtooth" p0="1.0" p1="0.0" p1_deactivated="1" p2="0.0" p2_deactivated="1" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1"
               retrigger="0"/>
-    <snapshot name="Square" p0="0.0" p1="1.0" p2="0.0" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1"
+    <snapshot name="Square" p0="0.0" p0_deactivated="1" p1="1.0" p2="0.0" p2_deactivated="1" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1"
               retrigger="0"/>
-    <snapshot name="Triangle" p0="0.0" p1="0.0" p2="1.0" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1"
+    <snapshot name="Triangle" p0="0.0" p0_deactivated="1" p1="0.0" p1_deactivated="1" p2="1.0" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1"
               retrigger="0"/>
-    <snapshot name="Sine" p0="0.0" p1="0.0" p2="1.0" p2_deform_type="2" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0"
+    <snapshot name="Sine" p0="0.0" p0_deactivated="1" p1="0.0" p1_deactivated="1" p2="1.0" p2_deform_type="2" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0"
               p6="1" retrigger="0"/>
 </type>
 <separator/>

--- a/resources/surge-shared/configuration.xml
+++ b/resources/surge-shared/configuration.xml
@@ -8,14 +8,14 @@
               retrigger="0"/>
 </type>
 <type i="8" name="Modern">
-    <snapshot name="Sawtooth" p0="1.0" p1="0.0" p1_deactivated="1" p2="0.0" p2_deactivated="1" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1"
-              retrigger="0"/>
-    <snapshot name="Square" p0="0.0" p0_deactivated="1" p1="1.0" p2="0.0" p2_deactivated="1" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1"
-              retrigger="0"/>
-    <snapshot name="Triangle" p0="0.0" p0_deactivated="1" p1="0.0" p1_deactivated="1" p2="1.0" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1"
-              retrigger="0"/>
-    <snapshot name="Sine" p0="0.0" p0_deactivated="1" p1="0.0" p1_deactivated="1" p2="1.0" p2_deform_type="2" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0"
-              p6="1" retrigger="0"/>
+    <snapshot name="Sawtooth" p0="1.0" p1="0.0" p1_deactivated="1" p2="0.0" p2_deactivated="1" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1" retrigger="0"/>
+    <snapshot name="Square" p0="0.0" p0_deactivated="1" p1="1.0" p2="0.0" p2_deactivated="1" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1" retrigger="0"/>
+    <snapshot name="Triangle" p0="0.0" p0_deactivated="1" p1="0.0" p1_deactivated="1" p2="1.0" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1" retrigger="0"/>
+    <snapshot name="Sine" p0="0.0" p0_deactivated="1" p1="0.0" p1_deactivated="1" p2="1.0" p2_deform_type="2" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1" retrigger="0"/>
+    <snapshot name="Saw + Square" p0="0.5" p1="-0.5" p2="0.0" p2_deactivated="1" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1" retrigger="0"/>
+    <snapshot name="Saw + Square + Sub 1" p0="0.5" p1="-0.5" p2="1.0" p2_deform_type="1024" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1" retrigger="0"/>
+    <snapshot name="Saw + Square + Sub 2" p0="0.5" p1="-0.5" p2="1.0" p2_deform_type="5120" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1" retrigger="0"/>
+    <snapshot name="All" p0="1.0" p1="-0.5" p2="0.5" p3="0.5" p4="0.0" p5="0.1" p5_extend_range="0" p6="1" retrigger="0"/>
 </type>
 <separator/>
 <type i="2" name="Wavetable" retrigger="0" p0_extend_range="1" p5_extend_range="0"/>

--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -349,6 +349,7 @@ bool Parameter::can_deactivate() const
     case ct_wstype:
     case ct_filtertype:
     case ct_amplitude_clipper:
+    case ct_modern_trimix:
         return true;
     }
     return false;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -149,6 +149,7 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 // 27 -> 28 (XT 1.4.* nightlies) added corrected TX shapes to Sine oscillator
 // 28 -> 29 (XT 1.4.* nightlies) save/load size of ArbitraryBlockStorage segment
 // 29 -> 30 (XT 1.4.* nightlies) reordered Phaser LFO waveforms and added a Saw shape (sst-effects upgrade)
+//                               Modern oscillator can now disable waveforms 2 and 3 to save CPU
 // clang-format on
 
 const int ff_revision = 30;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3262,6 +3262,15 @@ bool SurgeSynthesizer::loadOscalgos()
                         }
                     }
 
+                    lbl = fmt::format("p{:d}_deactivated", k);
+
+                    if (e->QueryIntAttribute(lbl.c_str(), &j) == TIXML_SUCCESS)
+                    {
+                        osc_st.p[k].deactivated = j;
+                        for (const auto &it : audioThreadParamListeners)
+                            (it.second)(oname, j, sx);
+                    }
+
                     lbl = fmt::format("p{:d}_deform_type", k);
 
                     if (e->QueryIntAttribute(lbl.c_str(), &j) == TIXML_SUCCESS)

--- a/src/common/dsp/oscillators/ModernOscillator.cpp
+++ b/src/common/dsp/oscillators/ModernOscillator.cpp
@@ -308,10 +308,25 @@ void ModernOscillator::init(float pitch, bool is_display, bool nonzero_init_drif
 template <ModernOscillator::mo_multitypes mtype, bool subOctave, bool FM>
 void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float fmdepthV)
 {
-    float submul = 1;
+    const bool sawActive = !oscdata->p[mo_saw_mix].deactivated;
+    const bool pulseActive = !oscdata->p[mo_pulse_mix].deactivated;
+    const bool thirdActive = !oscdata->p[mo_tri_mix].deactivated;
+    const bool needSaw = sawActive || pulseActive;
+    int numUnisonVoices = n_unison;
+
+    float submul = 1.f;
+
     if (subOctave)
     {
-        submul = 0.5;
+        const bool subdowntwo =
+            oscdata->p[mo_tri_mix].deform_type & ModernOscillator::mo_submask::mo_subdowntwo;
+
+        submul = 0.5f - (0.25f * subdowntwo);
+
+        if (!needSaw)
+        {
+            numUnisonVoices = 1;
+        }
     }
 
     float ud = oscdata->p[mo_unison_detune].get_extended(
@@ -319,14 +334,15 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
     pitchlag.startValue(pitch);
     sync.newValue(std::max(0.f, localcopy[oscdata->p[mo_sync].param_id_in_scene].f));
 
-    float absOff = 0;
+    float absOff = 0.f;
+
     if (oscdata->p[mo_unison_detune].absolute)
     {
         absOff = ud * 16;
         ud = 0;
     }
 
-    for (int u = 0; u < n_unison; ++u)
+    for (int u = 0; u < numUnisonVoices; ++u)
     {
         auto dval = driftLFO[u].next();
         auto lfodetune = drift * dval;
@@ -343,15 +359,16 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
     auto subdt = drift * driftLFO[0].val();
 
     subdpbase.newValue(std::min(0.5, pitch_to_dphase(pitchlag.v + subdt) * submul));
-    subdpsbase.newValue(std::min(0.5, pitch_to_dphase(pitchlag.v + subdt + sync.v) * submul));
+    subdspbase.newValue(std::min(0.5, pitch_to_dphase(pitchlag.v + subdt + sync.v) * submul));
     sync.process();
 
     // Let people modulate outside the sliders a bit. but not catastrophically
-    sawmix.newValue(0.5 *
+    sawmix.newValue(sawActive * 0.5 *
                     limit_range(localcopy[oscdata->p[mo_saw_mix].param_id_in_scene].f, -2.f, 2.f));
     sqrmix.newValue(
-        0.5 * limit_range(localcopy[oscdata->p[mo_pulse_mix].param_id_in_scene].f, -2.f, 2.f));
-    trimix.newValue(0.5 *
+        pulseActive * 0.5 *
+        limit_range(localcopy[oscdata->p[mo_pulse_mix].param_id_in_scene].f, -2.f, 2.f));
+    trimix.newValue(thirdActive * 0.5 *
                     limit_range(localcopy[oscdata->p[mo_tri_mix].param_id_in_scene].f, -2.f, 2.f));
 
     // Since we always use this multiplied by 2, put the mul here to save it later
@@ -366,7 +383,7 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
     // numerical path; away from sync the turnaround-gated shortcut is exact.
     bool syncActive = sync.v > 1e-4;
 
-    bool subsyncskip =
+    const bool subsyncskip =
         oscdata->p[mo_tri_mix].deform_type & ModernOscillator::mo_submask::mo_subskipsync;
 
     for (int i = 0; i < BLOCK_SIZE_OS; ++i)
@@ -383,7 +400,7 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
         // back to a [0,1) phase offset for the second saw of the pulse.
         double pwHalf = pwidth.v * 0.5;
 
-        for (int u = 0; u < n_unison; ++u)
+        for (int u = 0; u < numUnisonVoices; ++u)
         {
             auto dp = dpbase[u].v;
             auto dsp = dspbase[u].v;
@@ -425,9 +442,22 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
                 {
                     double p = (phs[s] - 0.5) * 2;
                     double p3 = p * p * p;
-                    sB[s] = (p3 - p) * dpwOneOverSix;
 
-                    if (subOctave)
+                    if (needSaw)
+                    {
+                        sB[s] = (p3 - p) * dpwOneOverSix;
+
+                        double pwp = p + pwidth.v;
+                        pwp += (pwp > 1) * -2;
+                        oB[s] = (pwp * pwp * pwp - pwp) * dpwOneOverSix;
+                    }
+                    else
+                    {
+                        sB[s] = 0.0;
+                        oB[s] = 0.0;
+                    }
+
+                    if (subOctave || !thirdActive)
                     {
                         tB[s] = 0.0;
                     }
@@ -451,10 +481,6 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
                         double Q = 1 - (tp < 0) * 2;
                         tB[s] = (2.0 + tp * tp * (3.0 - 2.0 * Q * tp)) * dpwOneOverSix;
                     }
-
-                    double pwp = p + pwidth.v;
-                    pwp += (pwp > 1) * -2;
-                    oB[s] = (pwp * pwp * pwp - pwp) * dpwOneOverSix;
                 }
 
                 double saw = sB[0] + sB[2] - 2.0 * sB[1];
@@ -467,20 +493,26 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
             }
             else
             {
-                // Saw: analytic away from the wrap, numerical near it. Each helper
-                // returns the final component value (1/(4 dsp^2) scale folded in).
-                double sawv = dpwSawComp(pfm, dsp, false);
+                double sawv = 0.0, sqrv = 0.0;
 
-                // Pulse = saw(phase) - saw(phase + width); the second saw turns
-                // around at a different phase so it gates independently.
-                double poff = pfm + pwHalf;
-                poff -= (poff >= 1.0);
-                double sqrv = dpwSawComp(poff, dsp, false) - sawv;
+                if (needSaw)
+                {
+                    // Saw: analytic away from the wrap, numerical near it. Each helper
+                    // returns the final component value (1/(4 dsp^2) scale folded in).
+                    sawv = dpwSawComp(pfm, dsp, false);
+
+                    // Pulse = saw(phase) - saw(phase + width); the second saw turns
+                    // around at a different phase so it gates independently.
+                    double poff = pfm + pwHalf;
+                    poff -= (poff >= 1.0);
+                    sqrv = dpwSawComp(poff, dsp, false) - sawv;
+                }
 
                 // Triangle / square analytically; sine stays numerical inside the
                 // helper. Sub-octave moves the multitype to the sub, so it's zero
                 // here (matching the original triBuff = 0 in that case).
-                double triv = subOctave ? 0.0 : dpwMultiComp<mtype>(pfm, dsp, false);
+                double triv =
+                    (subOctave || !thirdActive) ? 0.0 : dpwMultiComp<mtype>(pfm, dsp, false);
 
                 res = sawmix.v * sawv + trimix.v * triv + sqrmix.v * sqrv;
             }
@@ -510,7 +542,7 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
                      * forward and then difference over the new phase. WHat we should really do is
                      * figure out continuous generators with sync in but ugh that's super hard and
                      * it is late in the 1.9 cycle. So instead what we do is a little compensating
-                     * turnover where we linearly itnerpolate the prior phase forward one sample
+                     * turnover where we linearly interpolate the prior phase forward one sample
                      * (that is sTurnVal) and then average it into the next sample. Resetting
                      * sTurnFrac above means this only happens at the turnover sample. Only do this
                      * if sync is on of course
@@ -531,10 +563,10 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
             dspbase[u].process();
         }
 
-        if (subOctave)
+        if (subOctave && thirdActive)
         {
             auto dp = subdpbase.v;
-            auto dsp = ((1 - subsyncskip) * subdpsbase.v) + (subsyncskip * dp);
+            auto dsp = ((1 - subsyncskip) * subdspbase.v) + (subsyncskip * dp);
 
             // FM can be large, so wrap the base phase into [0,1) before the
             // turnaround-gated helper (which assumes a small backward stencil).
@@ -556,7 +588,9 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
             }
 
             if (subsphase > 1)
+            {
                 subsphase -= floor(subsphase);
+            }
         }
 
         output[i] = vL;
@@ -568,7 +602,7 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
         pwidth.process();
         fmdepth.process();
         subdpbase.process();
-        subdpsbase.process();
+        subdspbase.process();
     }
 
     if (!stereo)
@@ -670,13 +704,28 @@ static struct ModernTriName : public ParameterDynamicNameFunction
     }
 } dpwTriName;
 
+static struct ModernDynamicDeact : public ParameterDynamicDeactivationFunction
+{
+    bool getValue(const Parameter *p) const override
+    {
+        auto oscs = &(p->storage->getPatch().scene[p->scene - 1].osc[p->ctrlgroup_entry]);
+        return oscs->p[ModernOscillator::mo_pulse_mix].deactivated;
+    }
+
+    Parameter *getPrimaryDeactivationDriver(const Parameter *p) const override
+    {
+        auto oscs = &(p->storage->getPatch().scene[p->scene - 1].osc[p->ctrlgroup_entry]);
+        return &(oscs->p[ModernOscillator::mo_pulse_mix]);
+    }
+} moDynamicDeact;
+
 void ModernOscillator::init_ctrltypes()
 {
     oscdata->p[mo_saw_mix].set_name("Sawtooth");
-    oscdata->p[mo_saw_mix].set_type(ct_percent_bipolar);
+    oscdata->p[mo_saw_mix].set_type(ct_percent_bipolar_deactivatable);
 
     oscdata->p[mo_pulse_mix].set_name("Pulse");
-    oscdata->p[mo_pulse_mix].set_type(ct_percent_bipolar);
+    oscdata->p[mo_pulse_mix].set_type(ct_percent_bipolar_deactivatable);
 
     oscdata->p[mo_tri_mix].set_name("--DYNAMIC-NAME--");
     oscdata->p[mo_tri_mix].set_type(ct_modern_trimix);
@@ -685,6 +734,7 @@ void ModernOscillator::init_ctrltypes()
     oscdata->p[mo_pulse_width].set_name("Width");
     oscdata->p[mo_pulse_width].set_type(ct_percent);
     oscdata->p[mo_pulse_width].val_default.f = 0.5;
+    oscdata->p[mo_pulse_width].dynamicDeactivation = &moDynamicDeact;
 
     oscdata->p[mo_sync].set_name("Sync");
     oscdata->p[mo_sync].set_type(ct_syncpitch);
@@ -698,11 +748,25 @@ void ModernOscillator::init_ctrltypes()
 void ModernOscillator::init_default_values()
 {
     oscdata->p[mo_saw_mix].val.f = 0.5;
+    oscdata->p[mo_saw_mix].deactivated = false;
+    oscdata->p[mo_pulse_mix].val.f = 0.0;
+    oscdata->p[mo_pulse_mix].deactivated = false;
     oscdata->p[mo_tri_mix].val.f = 0.0;
     oscdata->p[mo_tri_mix].deform_type = 0;
-    oscdata->p[mo_pulse_mix].val.f = 0.0;
+    oscdata->p[mo_tri_mix].deactivated = false;
     oscdata->p[mo_pulse_width].val.f = 0.5;
     oscdata->p[mo_sync].val.f = 0.0;
     oscdata->p[mo_unison_detune].val.f = 0.2;
     oscdata->p[mo_unison_voices].val.i = 1;
+}
+
+void ModernOscillator::handleStreamingMismatches(int streamingRevision,
+                                                 int currentSynthStreamingRevision)
+{
+    if (streamingRevision <= 29)
+    {
+        oscdata->p[mo_saw_mix].deactivated = false;
+        oscdata->p[mo_pulse_mix].deactivated = false;
+        oscdata->p[mo_tri_mix].deactivated = false;
+    }
 }

--- a/src/common/dsp/oscillators/ModernOscillator.cpp
+++ b/src/common/dsp/oscillators/ModernOscillator.cpp
@@ -306,15 +306,12 @@ void ModernOscillator::init(float pitch, bool is_display, bool nonzero_init_drif
 }
 
 template <ModernOscillator::mo_multitypes mtype, bool subOctave, bool FM>
-void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float fmdepthV)
+void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float FMdepth,
+                                    bool sawActive, bool pulseActive, bool thirdActive,
+                                    bool needSaw)
 {
-    const bool sawActive = !oscdata->p[mo_saw_mix].deactivated;
-    const bool pulseActive = !oscdata->p[mo_pulse_mix].deactivated;
-    const bool thirdActive = !oscdata->p[mo_tri_mix].deactivated;
-    const bool needSaw = sawActive || pulseActive;
-    int numUnisonVoices = n_unison;
-
     float submul = 1.f;
+    int numUnisonVoices = n_unison;
 
     if (subOctave)
     {
@@ -376,7 +373,7 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
                                     0.01f, 0.99f));
     pitchlag.process();
 
-    double fv = 16 * fmdepthV * fmdepthV * fmdepthV;
+    double fv = 16 * FMdepth * FMdepth * FMdepth;
     fmdepth.newValue(fv);
 
     // Sync (turnover compensation and reset discontinuities) forces the full
@@ -443,19 +440,11 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
                     double p = (phs[s] - 0.5) * 2;
                     double p3 = p * p * p;
 
-                    if (needSaw)
-                    {
-                        sB[s] = (p3 - p) * dpwOneOverSix;
+                    sB[s] = (p3 - p) * dpwOneOverSix;
 
-                        double pwp = p + pwidth.v;
-                        pwp += (pwp > 1) * -2;
-                        oB[s] = (pwp * pwp * pwp - pwp) * dpwOneOverSix;
-                    }
-                    else
-                    {
-                        sB[s] = 0.0;
-                        oB[s] = 0.0;
-                    }
+                    double pwp = p + pwidth.v;
+                    pwp += (pwp > 1) * -2;
+                    oB[s] = (pwp * pwp * pwp - pwp) * dpwOneOverSix;
 
                     if (subOctave || !thirdActive)
                     {
@@ -495,18 +484,15 @@ void ModernOscillator::process_sblk(float pitch, float drift, bool stereo, float
             {
                 double sawv = 0.0, sqrv = 0.0;
 
-                if (needSaw)
-                {
-                    // Saw: analytic away from the wrap, numerical near it. Each helper
-                    // returns the final component value (1/(4 dsp^2) scale folded in).
-                    sawv = dpwSawComp(pfm, dsp, false);
+                // Saw: analytic away from the wrap, numerical near it. Each helper
+                // returns the final component value (1/(4 dsp^2) scale folded in).
+                sawv = dpwSawComp(pfm, dsp, false);
 
-                    // Pulse = saw(phase) - saw(phase + width); the second saw turns
-                    // around at a different phase so it gates independently.
-                    double poff = pfm + pwHalf;
-                    poff -= (poff >= 1.0);
-                    sqrv = dpwSawComp(poff, dsp, false) - sawv;
-                }
+                // Pulse = saw(phase) - saw(phase + width); the second saw turns
+                // around at a different phase so it gates independently.
+                double poff = pfm + pwHalf;
+                poff -= (poff >= 1.0);
+                sqrv = dpwSawComp(poff, dsp, false) - sawv;
 
                 // Triangle / square analytically; sine stays numerical inside the
                 // helper. Sub-octave moves the multitype to the sub, so it's zero
@@ -642,25 +628,37 @@ void ModernOscillator::process_block(float pitch, float drift, bool stereo, bool
         subOct = true;
     }
 
+    const bool sawActive = !oscdata->p[mo_saw_mix].deactivated;
+    const bool pulseActive = !oscdata->p[mo_pulse_mix].deactivated;
+    const bool thirdActive = !oscdata->p[mo_tri_mix].deactivated;
+    const bool needSaw = sawActive || pulseActive;
+
     if (!FM)
     {
         switch (multitype)
         {
         case momt_sine:
             if (subOct)
-                return process_sblk<momt_sine, true, false>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_sine, true, false>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
             else
-                return process_sblk<momt_sine, false, false>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_sine, false, false>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
         case momt_square:
             if (subOct)
-                return process_sblk<momt_square, true, false>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_square, true, false>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
             else
-                return process_sblk<momt_square, false, false>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_square, false, false>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
+
         case momt_triangle:
             if (subOct)
-                return process_sblk<momt_triangle, true, false>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_triangle, true, false>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
             else
-                return process_sblk<momt_triangle, false, false>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_triangle, false, false>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
         }
     }
     else
@@ -669,19 +667,26 @@ void ModernOscillator::process_block(float pitch, float drift, bool stereo, bool
         {
         case momt_sine:
             if (subOct)
-                return process_sblk<momt_sine, true, true>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_sine, true, true>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
             else
-                return process_sblk<momt_sine, false, true>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_sine, false, true>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
         case momt_square:
             if (subOct)
-                return process_sblk<momt_square, true, true>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_square, true, true>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
             else
-                return process_sblk<momt_square, false, true>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_square, false, true>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
+
         case momt_triangle:
             if (subOct)
-                return process_sblk<momt_triangle, true, true>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_triangle, true, true>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
             else
-                return process_sblk<momt_triangle, false, true>(pitch, drift, stereo, fmdepthV);
+                return process_sblk<momt_triangle, false, true>(
+                    pitch, drift, stereo, fmdepthV, sawActive, pulseActive, thirdActive, needSaw);
         }
     }
 }

--- a/src/common/dsp/oscillators/ModernOscillator.h
+++ b/src/common/dsp/oscillators/ModernOscillator.h
@@ -49,6 +49,7 @@ class ModernOscillator : public Oscillator
     {
         mo_subone = 1U << 10,
         mo_subskipsync = 1U << 11,
+        mo_subdowntwo = 1U << 12,
     };
 
     static constexpr int sigbuf_len = 6;
@@ -65,18 +66,22 @@ class ModernOscillator : public Oscillator
         }
     }
 
-    virtual void init(float pitch, bool is_display = false, bool nonzero_init_drift = true);
-    virtual void init_ctrltypes(int scene, int oscnum) { init_ctrltypes(); };
-    virtual void init_ctrltypes();
-    virtual void init_default_values();
+    virtual void init(float pitch, bool is_display = false,
+                      bool nonzero_init_drift = true) override;
+    virtual void init_ctrltypes(int scene, int oscnum) override { init_ctrltypes(); };
+    virtual void init_ctrltypes() override;
+    virtual void init_default_values() override;
     virtual void process_block(float pitch, float drift = 0.f, bool stereo = false, bool FM = false,
-                               float FMdepth = 0.f);
+                               float FMdepth = 0.f) override;
 
     template <mo_multitypes mtype, bool subOctave, bool FM>
     void process_sblk(float pitch, float drift = 0.f, bool stereo = false, float FMdepth = 0.f);
 
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
+
     lag<double, true> sawmix, trimix, sqrmix, pwidth, sync, dpbase[MAX_UNISON], dspbase[MAX_UNISON],
-        subdpbase, subdpsbase, detune, pitchlag, fmdepth;
+        subdpbase, subdspbase, detune, pitchlag, fmdepth;
 
     // character filter
     Surge::Oscillator::CharacterFilter<double> charFilt;

--- a/src/common/dsp/oscillators/ModernOscillator.h
+++ b/src/common/dsp/oscillators/ModernOscillator.h
@@ -75,7 +75,9 @@ class ModernOscillator : public Oscillator
                                float FMdepth = 0.f) override;
 
     template <mo_multitypes mtype, bool subOctave, bool FM>
-    void process_sblk(float pitch, float drift = 0.f, bool stereo = false, float FMdepth = 0.f);
+    void process_sblk(float pitch, float drift = 0.f, bool stereo = false, float FMdepth = 0.f,
+                      bool sawActive = true, bool pulseActive = true, bool thirdActive = true,
+                      bool needSaw = true);
 
     virtual void handleStreamingMismatches(int streamingRevision,
                                            int currentSynthStreamingRevision) override;

--- a/src/surge-testrunner/UnitTestsGOLDEN.cpp
+++ b/src/surge-testrunner/UnitTestsGOLDEN.cpp
@@ -141,6 +141,7 @@ Oscillator *setupModern(const ModernConfig &c, float pitch,
     auto o = spawn_osc(ot_modern, storage, osc, storage->getPatch().scenedata[0],
                        storage->getPatch().scenedataOrig[0], oscbuffer);
     o->init_ctrltypes();
+    o->init_default_values();
     o->init_extra_config();
 
     // Configure the Parameter objects directly (types set by init_ctrltypes above).

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2344,87 +2344,6 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
 
                         break;
                     }
-                    case ct_modern_trimix:
-                    {
-                        contextMenu.addSeparator();
-
-                        std::vector<int> waves = {ModernOscillator::mo_multitypes::momt_triangle,
-                                                  ModernOscillator::mo_multitypes::momt_sine,
-                                                  ModernOscillator::mo_multitypes::momt_square};
-
-                        bool isChecked = false;
-
-                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
-                                                                                        "WAVEFORM");
-
-                        for (int m : waves)
-                        {
-                            isChecked = ((p->deform_type & 0x0F) == m);
-
-                            contextMenu.addItem(
-                                mo_multitype_names[m], true, isChecked, [this, isChecked, p, m]() {
-                                    undoManager()->pushParameterChange(p->id, p, p->val);
-                                    update_deform_type(p, (p->deform_type & 0xFFF0) | m);
-                                    if (!isChecked)
-                                    {
-                                        synth->storage.getPatch().isDirty = true;
-                                    }
-                                    synth->refresh_editor = true;
-                                });
-                        }
-
-                        int subosc = ModernOscillator::mo_submask::mo_subone;
-
-                        isChecked = (p->deform_type & subosc);
-
-                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
-                            contextMenu, "SUB-OSCILLATOR");
-
-                        contextMenu.addItem(
-                            Surge::GUI::toOSCase("Enabled"), true, isChecked, [p, subosc, this]() {
-                                auto usubosc = subosc;
-                                int usubskipsync =
-                                    p->deform_type & ModernOscillator::mo_submask::mo_subskipsync;
-
-                                if (p->deform_type & subosc)
-                                {
-                                    usubosc = 0;
-                                }
-
-                                undoManager()->pushParameterChange(p->id, p, p->val);
-                                update_deform_type(p,
-                                                   (p->deform_type & 0xF) | usubosc | usubskipsync);
-
-                                synth->storage.getPatch().isDirty = true;
-                                synth->refresh_editor = true;
-                            });
-
-                        int subskipsync = ModernOscillator::mo_submask::mo_subskipsync;
-
-                        isChecked = (p->deform_type & subskipsync);
-
-                        contextMenu.addItem(
-                            Surge::GUI::toOSCase("Disable Hardsync"), true, isChecked,
-                            [p, subskipsync, this]() {
-                                auto usubskipsync = subskipsync;
-                                int usubosc =
-                                    p->deform_type & ModernOscillator::mo_submask::mo_subone;
-
-                                if (p->deform_type & subskipsync)
-                                {
-                                    usubskipsync = 0;
-                                }
-
-                                undoManager()->pushParameterChange(p->id, p, p->val);
-                                update_deform_type(p,
-                                                   (p->deform_type & 0xF) | usubosc | usubskipsync);
-
-                                synth->storage.getPatch().isDirty = true;
-                                synth->refresh_editor = true;
-                            });
-
-                        break;
-                    }
                     case ct_alias_mask:
                     {
                         contextMenu.addSeparator();
@@ -2918,6 +2837,126 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                             p, true, juceEditor->processor.SCT_EX_ENABLE, (float)!p->deactivated,
                             .0, .0, "");
                     });
+                }
+
+                // special casing this for Modern osc so that we don't have two "Enabled" menu
+                // entries close together
+                if (p->has_deformoptions())
+                {
+                    switch (p->ctrltype)
+                    {
+                    case ct_modern_trimix:
+                    {
+                        contextMenu.addSeparator();
+
+                        std::vector<int> waves = {ModernOscillator::mo_multitypes::momt_triangle,
+                                                  ModernOscillator::mo_multitypes::momt_sine,
+                                                  ModernOscillator::mo_multitypes::momt_square};
+
+                        bool isChecked = false;
+
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu,
+                                                                                        "WAVEFORM");
+
+                        for (int m : waves)
+                        {
+                            isChecked = ((p->deform_type & 0x0F) == m);
+
+                            contextMenu.addItem(
+                                mo_multitype_names[m], true, isChecked, [this, isChecked, p, m]() {
+                                    undoManager()->pushParameterChange(p->id, p, p->val);
+                                    update_deform_type(p, (p->deform_type & 0xFFF0) | m);
+                                    if (!isChecked)
+                                    {
+                                        synth->storage.getPatch().isDirty = true;
+                                    }
+                                    synth->refresh_editor = true;
+                                });
+                        }
+
+                        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(
+                            contextMenu, "SUB-OSCILLATOR");
+
+                        const int subosc = ModernOscillator::mo_submask::mo_subone;
+
+                        isChecked = (p->deform_type & subosc);
+
+                        contextMenu.addItem(
+                            Surge::GUI::toOSCase("Enabled"), true, isChecked, [p, subosc, this]() {
+                                auto usubosc = subosc;
+                                const int usubskipsync =
+                                    p->deform_type & ModernOscillator::mo_submask::mo_subskipsync;
+                                const int usubdowntwo =
+                                    p->deform_type & ModernOscillator::mo_submask::mo_subdowntwo;
+
+                                if (p->deform_type & subosc)
+                                {
+                                    usubosc = 0;
+                                }
+
+                                undoManager()->pushParameterChange(p->id, p, p->val);
+                                update_deform_type(p, (p->deform_type & 0xF) | usubosc |
+                                                          usubdowntwo | usubskipsync);
+
+                                synth->storage.getPatch().isDirty = true;
+                                synth->refresh_editor = true;
+                            });
+
+                        const int subdowntwo = ModernOscillator::mo_submask::mo_subdowntwo;
+
+                        isChecked = (p->deform_type & subdowntwo);
+
+                        contextMenu.addItem(
+                            Surge::GUI::toOSCase("Two Octaves Down"), true, isChecked,
+                            [p, subdowntwo, this]() {
+                                auto usubdowntwo = subdowntwo;
+                                const int usubosc =
+                                    p->deform_type & ModernOscillator::mo_submask::mo_subone;
+                                const int usubskipsync =
+                                    p->deform_type & ModernOscillator::mo_submask::mo_subskipsync;
+
+                                if (p->deform_type & subdowntwo)
+                                {
+                                    usubdowntwo = 0;
+                                }
+
+                                undoManager()->pushParameterChange(p->id, p, p->val);
+                                update_deform_type(p, (p->deform_type & 0xF) | usubosc |
+                                                          usubdowntwo | usubskipsync);
+
+                                synth->storage.getPatch().isDirty = true;
+                                synth->refresh_editor = true;
+                            });
+
+                        const int subskipsync = ModernOscillator::mo_submask::mo_subskipsync;
+
+                        isChecked = (p->deform_type & subskipsync);
+
+                        contextMenu.addItem(
+                            Surge::GUI::toOSCase("Disable Hardsync"), true, isChecked,
+                            [p, subskipsync, this]() {
+                                auto usubskipsync = subskipsync;
+                                const int usubosc =
+                                    p->deform_type & ModernOscillator::mo_submask::mo_subone;
+                                const int usubdowntwo =
+                                    p->deform_type & ModernOscillator::mo_submask::mo_subdowntwo;
+
+                                if (p->deform_type & subskipsync)
+                                {
+                                    usubskipsync = 0;
+                                }
+
+                                undoManager()->pushParameterChange(p->id, p, p->val);
+                                update_deform_type(p, (p->deform_type & 0xF) | usubosc |
+                                                          usubdowntwo | usubskipsync);
+
+                                synth->storage.getPatch().isDirty = true;
+                                synth->refresh_editor = true;
+                            });
+
+                        break;
+                    }
+                    }
                 }
 
                 int n_ms = 0;


### PR DESCRIPTION
- We can now disable each of the waveforms to save some CPU (except in Saw case, if Saw is disabled but Pulse isn't then saw still runs because it's needed)
- We can tune the suboscillator two octaves down
- Dynamic deactivation is used to gray out Width along with Pulse slider