### PR TITLE
Formula: Use double for songpos

### DIFF
--- a/src/common/dsp/modulators/FormulaModulationHelper.cpp
+++ b/src/common/dsp/modulators/FormulaModulationHelper.cpp
@@ -241,8 +241,8 @@ end
         if (lua_isfunction(s.L, -2))
         {
             // CALL HERE
-            auto addn = [&s](const char *q, float f) {
-                lua_pushnumber(s.L, f);
+            auto addn = [&s](const char *q, double d) {
+                lua_pushnumber(s.L, d);
                 lua_setfield(s.L, -2, q);
             };
 
@@ -583,8 +583,8 @@ void valueAt(int phaseIntPart, float phaseFracPart, SurgeStorage *storage,
     }
     lua_getglobal(s->L, s->stateName);
 
-    auto addn = [s](const char *q, float f) {
-        lua_pushnumber(s->L, f);
+    auto addn = [s](const char *q, double d) {
+        lua_pushnumber(s->L, d);
         lua_setfield(s->L, -2, q);
     };
 

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -69,7 +69,8 @@ struct EvaluatorState
 
     float del, a, h, dec, s, r;
     float rate, amp, phase, deform;
-    float tempo, songpos;
+    float tempo;
+    double songpos;
 
     bool retrigger_AEG, retrigger_FEG;
 


### PR DESCRIPTION
LuaJIT numbers are doubles and `storage.songpos` is a double but gets added as a float, making it lose enough precision after running a few hours that it no longer increments every block.