### PR TITLE
Add a "Never Move Keyboard Focus" workflow option

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -369,6 +369,10 @@ std::string defaultKeyToString(DefaultKey k)
         r = "focusModEditorAfterAddModulationFrom";
         break;
 
+    case NeverMoveKeyboardFocus:
+        r = "neverMoveKeyboardFocus";
+        break;
+
     case IgnoreMIDIProgramChange_Deprecated:
         r = "ignoreMidiProgramChange";
         break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -90,6 +90,7 @@ enum DefaultKey
     UseNarratorAnnouncementsForPatchTypeahead,
     ExpandModMenusWithSubMenus,
     FocusModEditorAfterAddModulationFrom,
+    NeverMoveKeyboardFocus,
     ShowVirtualKeyboard_Plugin,
     ShowVirtualKeyboard_Standalone,
     VirtualKeyboardClickSetsVelocity,

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -406,6 +406,11 @@ SurgeGUIEditor::SurgeGUIEditor(SurgeSynthEditor *jEd, SurgeSynthesizer *synth)
     Surge::GUI::setHostRequiresShowCursor(juce::PluginHostType().isLogic() ||
                                           juce::PluginHostType().isGarageBand());
 
+    // Mirror the "never move keyboard focus" preference into the GUI layer so
+    // deep widget code can honor it without needing a storage reference.
+    Surge::GUI::setNeverMoveKeyboardFocus(Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::NeverMoveKeyboardFocus, false));
+
     currentSkin = Surge::GUI::SkinDB::get()->defaultSkin(&(this->synth->storage));
 
     // init the size of the plugin
@@ -665,7 +670,7 @@ void SurgeGUIEditor::idle()
             if (!(alert && alert->isVisible()))
             {
                 componentToFocusAfterAlertDismissal->setWantsKeyboardFocus(true);
-                componentToFocusAfterAlertDismissal->grabKeyboardFocus();
+                Surge::GUI::grabKeyboardFocusIfAllowed(componentToFocusAfterAlertDismissal);
             }
         }
 
@@ -2409,7 +2414,7 @@ void SurgeGUIEditor::openOrRecreateEditor()
 
     if (!somethingHasFocus && patchSelector && patchSelector->isShowing())
     {
-        patchSelector->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(patchSelector.get());
     }
 
     sendStructureChangeIn = 120;
@@ -3213,7 +3218,14 @@ void SurgeGUIEditor::setRecommendedAccessibility()
                                            Surge::Storage::ExpandModMenusWithSubMenus, true);
     Surge::Storage::updateUserDefaultValue(
         &(this->synth->storage), Surge::Storage::FocusModEditorAfterAddModulationFrom, true);
-    oss << "Expanded Modulation Menus and Modulation Focus.";
+    oss << "Expanded Modulation Menus and Modulation Focus; ";
+
+    // Accessibility relies on Surge moving keyboard focus, so make sure the
+    // "never move keyboard focus" preference is off.
+    Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                           Surge::Storage::NeverMoveKeyboardFocus, false);
+    Surge::GUI::setNeverMoveKeyboardFocus(false);
+    oss << "Keyboard focus movement on.";
 
     enqueueAccessibleAnnouncement(oss.str());
 }
@@ -6082,7 +6094,7 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
                     // So now focus the first element of focusThis
                     if (focusThis->getWantsKeyboardFocus())
                     {
-                        focusThis->grabKeyboardFocus();
+                        Surge::GUI::grabKeyboardFocusIfAllowed(focusThis);
 
                         return true;
                     }
@@ -6091,7 +6103,7 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
                     {
                         if (c->getWantsKeyboardFocus() && c->isShowing())
                         {
-                            c->grabKeyboardFocus();
+                            Surge::GUI::grabKeyboardFocusIfAllowed(c);
 
                             return true;
                         }
@@ -6133,7 +6145,7 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
                         {
                             if (c->getWantsKeyboardFocus() && c->isShowing())
                             {
-                                c->grabKeyboardFocus();
+                                Surge::GUI::grabKeyboardFocusIfAllowed(c);
 
                                 return true;
                             }

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -1379,6 +1379,17 @@ juce::PopupMenu SurgeGUIEditor::makeWorkflowMenu(const juce::Point<int> &where)
 
     wfMenu.addSubMenu(str, kbfMenu);
 
+    bool neverMoveFocus = Surge::Storage::getUserDefaultValue(
+        &(this->synth->storage), Surge::Storage::NeverMoveKeyboardFocus, false);
+
+    wfMenu.addItem(Surge::GUI::toOSCase("Never Move Keyboard Focus"), true, neverMoveFocus,
+                   [this, neverMoveFocus]() {
+                       Surge::Storage::updateUserDefaultValue(
+                           &(this->synth->storage), Surge::Storage::NeverMoveKeyboardFocus,
+                           !neverMoveFocus);
+                       Surge::GUI::setNeverMoveKeyboardFocus(!neverMoveFocus);
+                   });
+
 #if WINDOWS
     wfMenu.addSeparator();
 

--- a/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorOverlays.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "SurgeGUIEditor.h"
+#include "SurgeGUIUtils.h"
 
 #include "overlays/ModulationEditor.h"
 #include "overlays/PatchDBViewer.h"
@@ -555,7 +556,7 @@ void SurgeGUIEditor::showOverlay(OverlayTags olt,
 
     if (wantsInitialKeyboardFocus)
     {
-        getOverlayIfOpen(olt)->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(getOverlayIfOpen(olt));
     }
 }
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -3690,7 +3690,7 @@ void SurgeGUIEditor::valueChanged(Surge::GUI::IComponentTagValue *control)
                 refresh_mod();
 
                 if (lfoRateSlider)
-                    lfoRateSlider->grabKeyboardFocus();
+                    Surge::GUI::grabKeyboardFocusIfAllowed(lfoRateSlider);
             }
             else if (cms->getMouseMode() == Surge::Widgets::ModulationSourceButton::HAMBURGER)
             {

--- a/src/surge-xt/gui/SurgeGUIUtils.cpp
+++ b/src/surge-xt/gui/SurgeGUIUtils.cpp
@@ -38,6 +38,16 @@ static bool hostRequiresShowCursor{false};
 void setHostRequiresShowCursor(bool b) { hostRequiresShowCursor = b; }
 bool getHostRequiresShowCursor() { return hostRequiresShowCursor; }
 
+static bool neverMoveKeyboardFocus{false};
+void setNeverMoveKeyboardFocus(bool b) { neverMoveKeyboardFocus = b; }
+bool getNeverMoveKeyboardFocus() { return neverMoveKeyboardFocus; }
+
+void grabKeyboardFocusIfAllowed(juce::Component *c)
+{
+    if (c && !neverMoveKeyboardFocus)
+        c->grabKeyboardFocus();
+}
+
 bool showCursor(SurgeStorage *storage)
 {
     if (hostRequiresShowCursor)

--- a/src/surge-xt/gui/SurgeGUIUtils.h
+++ b/src/surge-xt/gui/SurgeGUIUtils.h
@@ -51,6 +51,17 @@ bool getIsStandalone();
 void setHostRequiresShowCursor(bool);
 bool getHostRequiresShowCursor();
 
+// User preference (NeverMoveKeyboardFocus): when true Surge never actively
+// grabs keyboard focus, so hosts/workflows that find focus stealing disruptive
+// keep their keyboard focus. Off by default. Mirrored here from the user
+// default by SurgeGUIEditor so deep widget code can honor it without a storage.
+void setNeverMoveKeyboardFocus(bool);
+bool getNeverMoveKeyboardFocus();
+
+// Grabs keyboard focus on c unless the user asked us to never move focus. Call
+// this instead of juce::Component::grabKeyboardFocus() everywhere in the GUI.
+void grabKeyboardFocusIfAllowed(juce::Component *c);
+
 } // namespace GUI
 } // namespace Surge
 

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -27,6 +27,7 @@
 #include "SurgeImage.h"
 #include "OverlayUtils.h"
 #include "SurgeGUIEditor.h"
+#include "SurgeGUIUtils.h"
 
 namespace Surge
 {
@@ -181,7 +182,7 @@ void Alert::visibilityChanged()
 {
     if (isVisible())
     {
-        grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(this);
     }
 }
 

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -22,6 +22,7 @@
 
 #include "LuaEditors.h"
 
+#include "SurgeGUIUtils.h"
 #include "LuaSupport.h"
 #include "RuntimeFont.h"
 #include "SkinColors.h"
@@ -234,7 +235,7 @@ void TextfieldPopup::show()
     setVisible(true);
     if (textfield[0]->isShowing())
     {
-        textfield[0]->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(textfield[0].get());
     }
 }
 
@@ -393,14 +394,14 @@ bool GotoLine::keyPressed(const juce::KeyPress &key, juce::Component *originatin
     if (key.getKeyCode() == key.returnKey)
     {
         hide();
-        ed->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(ed);
     }
     else if (key.getKeyCode() == key.escapeKey)
     {
         hide();
         ed->moveCaretTo(startCaretPosition, false);
         ed->scrollToLine(startScroll);
-        ed->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(ed);
     }
     else
     {
@@ -698,7 +699,7 @@ void CodeEditorSearch::show()
     search(true);
     if (textfield[0]->isShowing())
     {
-        textfield[0]->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(textfield[0].get());
     }
     ed->repaint(); // force update selection color
 }
@@ -722,14 +723,14 @@ bool CodeEditorSearch::keyPressed(const juce::KeyPress &key, juce::Component *or
     {
         if (originatingComponent == textfield[0].get())
         {
-            textfield[1]->grabKeyboardFocus();
+            Surge::GUI::grabKeyboardFocusIfAllowed(textfield[1].get());
             textfield[1]->moveCaretToEnd();
             textfield[1]->moveCaretToStartOfLine(false);
             textfield[1]->moveCaretToEndOfLine(true);
         }
         else
         {
-            textfield[0]->grabKeyboardFocus();
+            Surge::GUI::grabKeyboardFocusIfAllowed(textfield[0].get());
             textfield[0]->moveCaretToStartOfLine(false);
             textfield[0]->moveCaretToEndOfLine(true);
         }
@@ -973,7 +974,7 @@ void CodeEditorSearch::showReplace(bool showReplaceRow)
         showRows(2);
         if (textfield[1]->isShowing())
         {
-            textfield[1]->grabKeyboardFocus();
+            Surge::GUI::grabKeyboardFocusIfAllowed(textfield[1].get());
         }
 
         textfield[1]->moveCaretToStartOfLine(false);
@@ -986,7 +987,7 @@ void CodeEditorSearch::showReplace(bool showReplaceRow)
         showRows(1);
         if (textfield[0]->isShowing())
         {
-            textfield[0]->grabKeyboardFocus();
+            Surge::GUI::grabKeyboardFocusIfAllowed(textfield[0].get());
         }
 
         textfield[0]->moveCaretToStartOfLine(false);
@@ -1840,7 +1841,7 @@ bool CodeEditorContainerWithApply::keyPressed(const juce::KeyPress &key, juce::C
             if (auto *k = getCurrentlyFocusedComponent())
             {
                 k->giveAwayKeyboardFocus();
-                olw->grabKeyboardFocus();
+                Surge::GUI::grabKeyboardFocusIfAllowed(olw);
                 return true;
             }
 
@@ -2861,7 +2862,7 @@ void FormulaModulatorEditor::applyCode()
     editor->repaintFrame();
     setApplyEnabled(false);
     if (mainEditor->isShowing())
-        mainEditor->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(mainEditor.get());
 
     if (debugPanel->isOpen)
         debugPanel->initializeLfoDebugger();
@@ -2928,7 +2929,7 @@ void FormulaModulatorEditor::showModulatorCode()
 
     if (keepFocus)
     {
-        mainEditor->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(mainEditor.get());
     }
 }
 
@@ -2946,7 +2947,7 @@ void FormulaModulatorEditor::showPreludeCode()
 
     if (keepFocus)
     {
-        preludeDisplay->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(preludeDisplay.get());
     }
 }
 
@@ -3952,7 +3953,7 @@ void WavetableScriptEditor::applyCode()
     editor->repaintFrame();
     setApplyEnabled(false);
     if (mainEditor->isShowing())
-        mainEditor->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(mainEditor.get());
 
     repaint();
 }
@@ -4027,7 +4028,7 @@ void WavetableScriptEditor::showModulatorCode()
 
     if (keepFocus)
     {
-        mainEditor->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(mainEditor.get());
     }
 }
 
@@ -4045,7 +4046,7 @@ void WavetableScriptEditor::showPreludeCode()
 
     if (keepFocus)
     {
-        preludeDisplay->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(preludeDisplay.get());
     }
 }
 

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -3860,7 +3860,7 @@ void MSEGControlRegion::hvSnapTypein(bool isH)
     typeinEditor->setBounds(r);
 
     typeinEditor->setVisible(true);
-    typeinEditor->grabKeyboardFocus();
+    Surge::GUI::grabKeyboardFocusIfAllowed(typeinEditor.get());
 
     typeinEditor->callback = [w = juce::Component::SafePointer(this), isH](auto s) {
         auto sn = std::clamp(std::atoi(s.c_str()), 1, 32);

--- a/src/surge-xt/gui/overlays/MiniEdit.cpp
+++ b/src/surge-xt/gui/overlays/MiniEdit.cpp
@@ -185,7 +185,7 @@ void MiniEdit::doReturnFocus()
 {
     if (returnFocusComp)
     {
-        returnFocusComp->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(returnFocusComp);
     }
     returnFocusComp = nullptr;
 }

--- a/src/surge-xt/gui/overlays/MiniEdit.h
+++ b/src/surge-xt/gui/overlays/MiniEdit.h
@@ -24,6 +24,7 @@
 #define SURGE_SRC_SURGE_XT_GUI_OVERLAYS_MINIEDIT_H
 
 #include "SkinSupport.h"
+#include "SurgeGUIUtils.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -68,7 +69,7 @@ struct MiniEdit : public juce::Component,
 
     void textEditorEscapeKeyPressed(juce::TextEditor &editor) override;
     void textEditorReturnKeyPressed(juce::TextEditor &editor) override;
-    void grabFocus() { typein->grabKeyboardFocus(); }
+    void grabFocus() { Surge::GUI::grabKeyboardFocusIfAllowed(typein.get()); }
 
     juce::Component *returnFocusComp{nullptr};
     void setFocusReturnTarget(juce::Component *c) { returnFocusComp = c; }

--- a/src/surge-xt/gui/overlays/ModulationEditor.cpp
+++ b/src/surge-xt/gui/overlays/ModulationEditor.cpp
@@ -566,7 +566,7 @@ struct ModulationListContents : public juce::Component, public Surge::GUI::SkinC
                 contents->editor->viewport->setViewPosition(0, 0);
             }
             if (surgeLikeSlider->isShowing())
-                surgeLikeSlider->grabKeyboardFocus();
+                Surge::GUI::grabKeyboardFocusIfAllowed(surgeLikeSlider.get());
         }
         bool firstInSort{false}, hasFollower{false};
         bool isTop{false}, isAfterTop{false}, isLast{false};
@@ -1703,7 +1703,7 @@ void ModulationSideControls::doAdd()
     addSourceW->setLabels({"Select Source"});
     addTargetW->setLabels({"Select Target"});
     addTargetW->setEnabled(false);
-    addSourceW->grabKeyboardFocus();
+    Surge::GUI::grabKeyboardFocusIfAllowed(addSourceW.get());
     repaint();
 }
 

--- a/src/surge-xt/gui/overlays/OpenSoundControlSettings.cpp
+++ b/src/surge-xt/gui/overlays/OpenSoundControlSettings.cpp
@@ -181,7 +181,7 @@ void OpenSoundControlSettings::shownInParent()
 {
     if (inPort && inPort->isShowing())
     {
-        inPort->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(inPort.get());
     }
 }
 

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -27,6 +27,7 @@
 #include "OverlayComponent.h"
 #include "widgets/MainFrame.h"
 #include "SurgeJUCELookAndFeel.h"
+#include "SurgeGUIUtils.h"
 
 namespace Surge
 {
@@ -794,7 +795,7 @@ void OverlayWrapper::onClose()
             [w = juce::Component::SafePointer(pc)]() {
                 if (!w)
                     return;
-                w->grabKeyboardFocus();
+                Surge::GUI::grabKeyboardFocusIfAllowed(w);
             });
     }
     else

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -272,7 +272,7 @@ void PatchStoreDialog::shownInParent()
 {
     if (nameEd->isShowing() && isVisible())
     {
-        nameEd->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(nameEd.get());
     }
 }
 
@@ -388,7 +388,7 @@ void PatchStoreDialog::resized()
 
     if (isVisible())
     {
-        nameEd->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(nameEd.get());
     }
 
     if (showTagsField)

--- a/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
+++ b/src/surge-xt/gui/overlays/TypeinParamEditor.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "TypeinParamEditor.h"
+#include "SurgeGUIUtils.h"
 #include "RuntimeFont.h"
 #include "SurgeGUIEditor.h"
 #include "AccessibleHelpers.h"
@@ -249,13 +250,13 @@ void TypeinParamEditor::textEditorEscapeKeyPressed(juce::TextEditor &te)
     setVisible(false);
 }
 
-void TypeinParamEditor::grabFocus() { textEd->grabKeyboardFocus(); }
+void TypeinParamEditor::grabFocus() { Surge::GUI::grabKeyboardFocusIfAllowed(textEd.get()); }
 
 void TypeinParamEditor::doReturnFocus()
 {
     if (returnFocusComp)
     {
-        returnFocusComp->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(returnFocusComp);
     }
     returnFocusComp = nullptr;
 }

--- a/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
+++ b/src/surge-xt/gui/widgets/CurrentFxDisplay.cpp
@@ -11,6 +11,7 @@
 #include "SurgeGUIEditor.h"
 #include "SurgeJUCEHelpers.h"
 #include "SurgeGUIEditorTags.h"
+#include "SurgeGUIUtils.h"
 #include "dsp/effects/ConditionerEffect.h"
 #include "dsp/effects/ConvolutionEffect.h"
 
@@ -812,7 +813,7 @@ void CurrentFxDisplay::convolutionLayout()
 
     if (had_focus)
     {
-        menu->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(menu.get());
         had_focus = false;
     }
 }

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -495,7 +495,7 @@ void MultiSwitch::updateAccessibleStateOnUserValueChange()
     {
         return;
     }
-    selectionComponents[getIntegerValue()]->grabKeyboardFocus();
+    Surge::GUI::grabKeyboardFocusIfAllowed(selectionComponents[getIntegerValue()].get());
 }
 
 template <> struct DiscreteAHRange<MultiSwitch>

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -1345,7 +1345,7 @@ void PatchSelector::toggleTypeAheadSearch(bool b)
         typeAhead->setVisible(true);
         typeAhead->setEnabled(enable);
 
-        typeAhead->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(typeAhead.get());
         typeAhead->selectAll();
 
         if (!enable)
@@ -1403,7 +1403,7 @@ void PatchSelector::enableTypeAheadIfReady()
 
     if (enable)
     {
-        typeAhead->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(typeAhead.get());
         typeAhead->selectAll();
         typeAhead->searchAndShowListBox();
     }

--- a/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
+++ b/src/surge-xt/gui/widgets/TypeAheadTextEditor.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "TypeAheadTextEditor.h"
+#include "SurgeGUIUtils.h"
 #include "MainFrame.h"
 #include "AccessibleHelpers.h"
 
@@ -299,7 +300,7 @@ void TypeAhead::dismissWithValue(int providerIdx, const std::string &s,
 
         if (isVisible())
         {
-            grabKeyboardFocus();
+            Surge::GUI::grabKeyboardFocusIfAllowed(this);
         }
     }
 
@@ -317,7 +318,7 @@ void TypeAhead::dismissWithoutValue()
     lbox->setVisible(false);
 
     if (isShowing())
-        grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(this);
 
     for (auto l : taList)
     {
@@ -474,7 +475,7 @@ bool TypeAhead::keyPressed(const juce::KeyPress &press)
             lbox->setSelectedRows(lastSelectedRow);
         }
 
-        lbox->grabKeyboardFocus();
+        Surge::GUI::grabKeyboardFocusIfAllowed(lbox.get());
 
         return true;
     }


### PR DESCRIPTION
Some hosts and workflows are disrupted when Surge grabs keyboard focus while editing parameters or opening overlays, stealing focus away from the host. Add a user option, off by default, that makes Surge never actively move keyboard focus. All focus grabs now route through a single gate that honors the preference.

The careful focus handling for accessible users is preserved: the option defaults off, and enabling the recommended accessibility settings forces it off so keyboard focus movement stays on.

The option lives in the Workflow menu.

Closes #8215
Closes #8350

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>