### PR TITLE
Formula: Add dynamic names for LFO sliders

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -2080,7 +2080,10 @@ bool Parameter::supportsDynamicName() const
     switch (ctrltype)
     {
     case ct_modern_trimix:
+    case ct_lfoamplitude:
+    case ct_lfodeform:
     case ct_lfophaseshuffle:
+    case ct_lforate_deactivatable:
     case ct_percent:
     case ct_percent_bipolar:
     case ct_percent_bipolar_deactivatable:

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -694,16 +694,21 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
 
             auto &fs = p->storage->getPatch().formulamods[p->scene - 1][cge];
 
+            if (!fs.labels)
+            {
+                return nullptr;
+            }
+
             switch (p->ctrltype)
             {
             case ct_lfoamplitude:
-                return &fs.labelAmplitude;
+                return &fs.labels->amplitude;
             case ct_lfodeform:
-                return &fs.labelDeform;
+                return &fs.labels->deform;
             case ct_lfophaseshuffle:
-                return &fs.labelPhase;
+                return &fs.labels->phase;
             case ct_lforate_deactivatable:
-                return &fs.labelRate;
+                return &fs.labels->rate;
             default:
                 return nullptr;
             }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -677,40 +677,75 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
     // Assign the dynamic name handlers
     static struct : public ParameterDynamicNameFunction
     {
+        const std::string *formulaLabel(const Parameter *p) const
+        {
+            if (!p || !p->storage)
+            {
+                return nullptr;
+            }
+
+            auto cge = p->ctrlgroup_entry - ms_lfo1;
+            auto &lf = p->storage->getPatch().scene[p->scene - 1].lfo[cge];
+
+            if (lf.shape.val.i != lt_formula)
+            {
+                return nullptr;
+            }
+
+            auto &fs = p->storage->getPatch().formulamods[p->scene - 1][cge];
+
+            switch (p->ctrltype)
+            {
+            case ct_lfoamplitude:
+                return &fs.labelAmplitude;
+            case ct_lfodeform:
+                return &fs.labelDeform;
+            case ct_lfophaseshuffle:
+                return &fs.labelPhase;
+            case ct_lforate_deactivatable:
+                return &fs.labelRate;
+            default:
+                return nullptr;
+            }
+        }
+
         const char *getName(const Parameter *p) const override
         {
             static char res[TXT_SIZE];
 
-            if (p && p->storage)
+            // Check for Formula script-set label for the four main LFO sliders
+            auto l = formulaLabel(p);
+            if (l && !l->empty())
             {
-                auto cge = p->ctrlgroup_entry - ms_lfo1;
-                auto lf = &(p->storage->getPatch().scene[p->scene - 1].lfo[cge]);
-                auto tp = lf->shape.val.i;
+                snprintf(res, TXT_SIZE, "%s", l->c_str());
+                return res;
+            }
 
-                switch (tp)
+            // Phase slider has a dynamic default for the Step Sequencer
+            if (p->ctrltype == ct_lfophaseshuffle)
+            {
+                if (p->storage)
                 {
-                case lt_stepseq:
-                    if (lf->rate.deactivated)
-                    {
-                        snprintf(res, TXT_SIZE, "Phase");
-                    }
-                    else
+                    auto cge = p->ctrlgroup_entry - ms_lfo1;
+                    auto &lf = p->storage->getPatch().scene[p->scene - 1].lfo[cge];
+                    if (lf.shape.val.i == lt_stepseq && !lf.rate.deactivated)
                     {
                         snprintf(res, TXT_SIZE, "Shuffle");
                     }
-                    break;
-                default:
-                    snprintf(res, TXT_SIZE, "Phase");
-                    break;
+                    else
+                    {
+                        snprintf(res, TXT_SIZE, "Phase");
+                    }
                 }
+                else
+                {
+                    snprintf(res, TXT_SIZE, "Phase/Shuffle");
+                }
+                return res;
             }
-            else
-            {
-                snprintf(res, TXT_SIZE, "Phase/Shuffle");
-            }
-            return res;
+            return p->dispname;
         }
-    } lfoPhaseName;
+    } lfoSliderName;
 
     // Assign the dynamic deactivation handlers
     static struct OscAudioInDeact : public ParameterDynamicDeactivationFunction
@@ -774,9 +809,12 @@ SurgePatch::SurgePatch(SurgeStorage *storage)
 
         for (int lf = 0; lf < n_lfos; ++lf)
         {
-            scene[sc].lfo[lf].start_phase.dynamicName = &lfoPhaseName;
             scene[sc].lfo[lf].start_phase.dynamicDeactivation = &lfoRatePhaseDeact;
             scene[sc].lfo[lf].rate.dynamicDeactivation = &lfoRatePhaseDeact;
+            scene[sc].lfo[lf].start_phase.dynamicName = &lfoSliderName;
+            scene[sc].lfo[lf].rate.dynamicName = &lfoSliderName;
+            scene[sc].lfo[lf].deform.dynamicName = &lfoSliderName;
+            scene[sc].lfo[lf].magnitude.dynamicName = &lfoSliderName;
 
             auto *curr = &(scene[sc].lfo[lf].delay), *end = &(scene[sc].lfo[lf].release);
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -963,6 +963,8 @@ struct FormulaModulatorStorage
     std::string formulaString = "";
     size_t formulaHash = 0;
 
+    std::string labelAmplitude = "", labelDeform = "", labelPhase = "", labelRate = "";
+
     // these values stream so don't change the numerical equivalents
     enum Interpreter
     {

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -963,7 +963,11 @@ struct FormulaModulatorStorage
     std::string formulaString = "";
     size_t formulaHash = 0;
 
-    std::string labelAmplitude = "", labelDeform = "", labelPhase = "", labelRate = "";
+    struct Labels
+    {
+        std::string amplitude, deform, phase, rate;
+    };
+    std::shared_ptr<Labels> labels;
 
     // these values stream so don't change the numerical equivalents
     enum Interpreter

--- a/src/common/dsp/modulators/FormulaModulationHelper.cpp
+++ b/src/common/dsp/modulators/FormulaModulationHelper.cpp
@@ -128,6 +128,15 @@ end
     };
     s.lfo_id = computeLfoId(fs);
 
+    // Reset the dynamic slider labels on every display script eval
+    if (is_display)
+    {
+        fs->labelAmplitude = "";
+        fs->labelDeform = "";
+        fs->labelPhase = "";
+        fs->labelRate = "";
+    }
+
     // OK so now evaluate the formula. This is a mistake - the loading and
     // compiling can be expensive so lets look it up by hash first
     auto h = fs->formulaHash;
@@ -406,6 +415,31 @@ end
                     }
 
                     lua_pop(s.L, 1); // Pop use_rate
+                }
+
+                // Display only, optional labels table for setting LFO slider dynamic names
+                if (is_display)
+                {
+                    auto gl = Surge::LuaSupport::SGLD("prepareForEvaluation::labelsread", s.L);
+
+                    lua_getfield(s.L, -1, "labels");
+                    if (lua_istable(s.L, -1))
+                    {
+                        auto readLabel = [&s](const char *key, std::string &dest) {
+                            lua_getfield(s.L, -1, key);
+                            if (lua_isstring(s.L, -1))
+                            {
+                                dest = lua_tostring(s.L, -1);
+                            }
+                            lua_pop(s.L, 1); // Pop the value
+                        };
+
+                        readLabel("amplitude", fs->labelAmplitude);
+                        readLabel("deform", fs->labelDeform);
+                        readLabel("phase", fs->labelPhase);
+                        readLabel("rate", fs->labelRate);
+                    }
+                    lua_pop(s.L, 1); // Pop labels (table or non-table)
                 }
                 lua_pop(s.L, 1); // Pop the modulator state
             }
@@ -843,27 +877,27 @@ enum showFilter
 bool isUserDefined(std::string str)
 {
     // clang-format off
-    static constexpr std::array<std::string_view, 58> keywords = {
+    static constexpr std::array<std::string_view, 59> keywords = {
         "amplitude",     "attack",        "block_size",
         "cc_breath",     "cc_expr",       "cc_mw",
         "cc_sus",        "chan_at",       "channel",
         "clamp_output",  "cycle",         "decay",
         "deform",        "delay",         "highest_key",
         "hold",          "intphase",      "is_rendering_to_ui",
-        "is_voice",      "key",           "latest_key",
-        "lfo_id",        "lowest_key",    "macros",
-        "mpe_bend",      "mpe_bendrange", "mpe_enabled",
-        "mpe_pressure",  "mpe_timbre",    "output",
-        "pb",            "pb_range_dn",   "pb_range_up",
-        "phase",         "play_mode",     "poly_at",
-        "poly_limit",    "rate",          "rel_velocity",
-        "release",       "released",      "retrigger_AEG",
-        "retrigger_FEG", "samplerate",    "scene_mode",
-        "songpos",       "split_point",   "startphase",
-        "sustain",       "tempo",         "tuned_key",
-        "use_amplitude", "use_envelope",  "use_rate",
-        "velocity",      "voice_count",   "voice_id",
-        "subscriptions"};
+        "is_voice",      "key",           "labels",
+        "latest_key",    "lfo_id",        "lowest_key",
+        "macros",        "mpe_bend",      "mpe_bendrange",
+        "mpe_enabled",   "mpe_pressure",  "mpe_timbre",
+        "output",        "pb",            "pb_range_dn",
+        "pb_range_up",   "phase",         "play_mode",
+        "poly_at",       "poly_limit",    "rate",
+        "rel_velocity",  "release",       "released",
+        "retrigger_AEG", "retrigger_FEG", "samplerate",
+        "scene_mode",    "songpos",       "split_point",
+        "startphase",    "sustain",       "tempo",
+        "tuned_key",     "use_amplitude", "use_envelope",
+        "use_rate",      "velocity",      "voice_count",
+        "voice_id",      "subscriptions"};
     // clang-format on
 
     auto foundInList = std::find(keywords.begin(), keywords.end(), str) != keywords.end();

--- a/src/common/dsp/modulators/FormulaModulationHelper.cpp
+++ b/src/common/dsp/modulators/FormulaModulationHelper.cpp
@@ -131,10 +131,7 @@ end
     // Reset the dynamic slider labels on every display script eval
     if (is_display)
     {
-        fs->labelAmplitude = "";
-        fs->labelDeform = "";
-        fs->labelPhase = "";
-        fs->labelRate = "";
+        fs->labels.reset();
     }
 
     // OK so now evaluate the formula. This is a mistake - the loading and
@@ -425,6 +422,7 @@ end
                     lua_getfield(s.L, -1, "labels");
                     if (lua_istable(s.L, -1))
                     {
+                        auto labels = std::make_shared<FormulaModulatorStorage::Labels>();
                         auto readLabel = [&s](const char *key, std::string &dest) {
                             lua_getfield(s.L, -1, key);
                             if (lua_isstring(s.L, -1))
@@ -434,10 +432,11 @@ end
                             lua_pop(s.L, 1); // Pop the value
                         };
 
-                        readLabel("amplitude", fs->labelAmplitude);
-                        readLabel("deform", fs->labelDeform);
-                        readLabel("phase", fs->labelPhase);
-                        readLabel("rate", fs->labelRate);
+                        readLabel("amplitude", labels->amplitude);
+                        readLabel("deform", labels->deform);
+                        readLabel("phase", labels->phase);
+                        readLabel("rate", labels->rate);
+                        fs->labels = labels;
                     }
                     lua_pop(s.L, 1); // Pop labels (table or non-table)
                 }


### PR DESCRIPTION
Makes it possible to optionally set the names of the four main LFO sliders from Lua for Formula modulators. Only works from the `init()` block during display script evals. Custom names are used inside the UI, modulation matrix and slider context menus.

Example use:

```lua
function init(state)
    state.labels = { rate = "Slider A", phase = "Slider B", deform = "Slider C",  amplitude = "Slider D" }
    return state
end
```

Assisted-By: Claude Opus 4.8