### PR TITLE
Defensive wavetable loading and display changes

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1456,38 +1456,51 @@ void SurgeStorage::perform_queued_wtloads()
     {
         for (int o = 0; o < n_oscs; o++)
         {
-            if (patch.scene[sc].osc[o].wt.queue_id != -1)
+            // A malformed wavetable must never let an exception escape into the
+            // audio thread; catch here so a bad load can't terminate the process.
+            try
             {
-                if (patch.scene[sc].osc[o].wt.everBuilt)
-                    patch.isDirty = true;
-                load_wt(patch.scene[sc].osc[o].wt.queue_id, &patch.scene[sc].osc[o].wt,
-                        &patch.scene[sc].osc[o]);
-                patch.scene[sc].osc[o].wt.force_refresh_display = false;
-                patch.scene[sc].osc[o].wt.refresh_display = true;
-            }
-            else if (patch.scene[sc].osc[o].wt.queue_filename[0])
-            {
-                if (!(uses_wavetabledata(patch.scene[sc].osc[o].type.val.i)))
+                if (patch.scene[sc].osc[o].wt.queue_id != -1)
                 {
-                    patch.scene[sc].osc[o].queue_type = ot_wavetable;
+                    if (patch.scene[sc].osc[o].wt.everBuilt)
+                        patch.isDirty = true;
+                    load_wt(patch.scene[sc].osc[o].wt.queue_id, &patch.scene[sc].osc[o].wt,
+                            &patch.scene[sc].osc[o]);
+                    patch.scene[sc].osc[o].wt.force_refresh_display = false;
+                    patch.scene[sc].osc[o].wt.refresh_display = true;
                 }
-                int wtidx = -1, ct = 0;
-                for (const auto &wti : wt_list)
+                else if (patch.scene[sc].osc[o].wt.queue_filename[0])
                 {
-                    if (path_to_string(wti.path) == patch.scene[sc].osc[0].wt.queue_filename)
+                    if (!(uses_wavetabledata(patch.scene[sc].osc[o].type.val.i)))
                     {
-                        wtidx = ct;
+                        patch.scene[sc].osc[o].queue_type = ot_wavetable;
                     }
-                    ct++;
-                }
+                    int wtidx = -1, ct = 0;
+                    for (const auto &wti : wt_list)
+                    {
+                        if (path_to_string(wti.path) == patch.scene[sc].osc[0].wt.queue_filename)
+                        {
+                            wtidx = ct;
+                        }
+                        ct++;
+                    }
 
-                patch.scene[sc].osc[o].wt.current_id = wtidx;
-                load_wt(patch.scene[sc].osc[o].wt.queue_filename, &patch.scene[sc].osc[o].wt,
-                        &patch.scene[sc].osc[o]);
-                patch.scene[sc].osc[o].wt.force_refresh_display = true;
-                patch.scene[sc].osc[o].wt.refresh_display = true;
-                if (patch.scene[sc].osc[o].wt.everBuilt)
-                    patch.isDirty = true;
+                    patch.scene[sc].osc[o].wt.current_id = wtidx;
+                    load_wt(patch.scene[sc].osc[o].wt.queue_filename, &patch.scene[sc].osc[o].wt,
+                            &patch.scene[sc].osc[o]);
+                    patch.scene[sc].osc[o].wt.force_refresh_display = true;
+                    patch.scene[sc].osc[o].wt.refresh_display = true;
+                    if (patch.scene[sc].osc[o].wt.everBuilt)
+                        patch.isDirty = true;
+                }
+            }
+            catch (const std::exception &e)
+            {
+                // Clear the queue so we don't retry the bad load every block
+                patch.scene[sc].osc[o].wt.queue_id = -1;
+                patch.scene[sc].osc[o].wt.queue_filename = "";
+                reportError(std::string("Unable to load wavetable: ") + e.what(),
+                            "Wavetable Load Error");
             }
         }
     }

--- a/src/common/WAVFileSupport.cpp
+++ b/src/common/WAVFileSupport.cpp
@@ -482,7 +482,9 @@ bool SurgeStorage::load_wt_wav_portable(std::string fn, Wavetable *wt, std::stri
             windowSize = windowSize / 2;
 
         wh.n_samples = windowSize;
-        wh.n_tables = (int)(sample_length / windowSize);
+        // Clamp so BuildWT stays within the fixed-size tables. Samples are built
+        // with AppendSilence, which adds 3 frames, so leave room for those.
+        wh.n_tables = std::min(max_subtables - 3, (int)(sample_length / windowSize));
     }
 
     int channels = 1;

--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -173,6 +173,16 @@ bool Wavetable::BuildWT(void *wdata, wt_header &wh, bool AppendSilence)
     n_tables = mech::endian_read_int16LE(wh.n_tables);
     size = mech::endian_read_int32LE(wh.n_samples);
 
+    // Reject malformed/oversized headers before writing into the fixed-size
+    // TableF32WeakPointers[max_mipmap_levels][max_subtables] arrays; otherwise a
+    // bogus frame or sample count is an out-of-bounds write. The false return is
+    // surfaced as a load error by load_wt_wt / load_wt_wt_mem.
+    if (size <= 0 || size > max_wtable_size ||
+        n_tables + (AppendSilence ? 3u : 0u) > (unsigned)max_subtables)
+    {
+        return false;
+    }
+
     size_t req_size = RequiredWTSize(size, n_tables);
 
     if (req_size > dataSizes)

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -1869,6 +1869,10 @@ struct WaveTable3DEditor : public juce::Component,
 
     void paint(juce::Graphics &g) override
     {
+        // The audio thread can rebuild and reallocate the wavetable underneath us
+        // (BuildWT), so hold the wt lock while we read it, like the 2D display does.
+        std::lock_guard<std::mutex> wtLock(storage->waveTableDataMutex);
+
         auto &wt = oscdata->wt;
         wt_size = wt.size;
         wt_nframes = wt.n_tables;


### PR DESCRIPTION
Harden the wavetable load and display paths against malformed files and threading races:

- Guard the wavetable file load on the audio thread so a bad file reports an error instead of terminating the plugin
- Reject oversized or malformed wavetable headers before writing into the fixed-size frame tables, and clamp the WAV sample frame count
- Lock the wavetable data mutex while the 3D display reads the table, as the 2D display already does

Addresses #7926.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>