### PR TITLE
Remap Phaser LFO waveform for the new sst-effects ordering

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -469,6 +469,7 @@ bool Parameter::is_discrete_selection() const
     case ct_airwindows_fx:
     case ct_flangermode:
     case ct_fxlfowave:
+    case ct_fxlfowave_extended:
     case ct_distortion_waveshape:
     case ct_reson_mode:
     case ct_vocoder_bandcount:
@@ -1168,6 +1169,12 @@ void Parameter::set_type(int ctrltype)
         valtype = vt_int;
         val_min.i = 0;
         val_max.i = 5; // sin, tri, saw, s&g, s&h, square
+        val_default.i = 0;
+        break;
+    case ct_fxlfowave_extended:
+        valtype = vt_int;
+        val_min.i = 0;
+        val_max.i = 6; // sin, tri, ramp, saw, square, noise, s&h
         val_default.i = 0;
         break;
     case ct_twist_engine:
@@ -4140,6 +4147,34 @@ std::string Parameter::get_display(bool external, float ef) const
                 break;
             case 5:
                 txt = "Square";
+                break;
+            }
+        }
+        break;
+        case ct_fxlfowave_extended:
+        {
+            switch (i)
+            {
+            case 0:
+                txt = "Sine";
+                break;
+            case 1:
+                txt = "Triangle";
+                break;
+            case 2:
+                txt = "Ramp";
+                break;
+            case 3:
+                txt = "Saw";
+                break;
+            case 4:
+                txt = "Square";
+                break;
+            case 5:
+                txt = "Noise";
+                break;
+            case 6:
+                txt = "Sample & Hold";
                 break;
             }
         }

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -157,6 +157,7 @@ enum ctrltypes
     ct_flangerpitch,
     ct_flangermode,
     ct_fxlfowave,
+    ct_fxlfowave_extended, // Phaser waveform: adds Saw, so 7 values instead of 6
     ct_flangervoices,
     ct_flangerspacing,
     ct_filter_feedback,

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -148,9 +148,10 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 //                               fixed extendable parameters not extending in Waveshaper effect
 // 27 -> 28 (XT 1.4.* nightlies) added corrected TX shapes to Sine oscillator
 // 28 -> 29 (XT 1.4.* nightlies) save/load size of ArbitraryBlockStorage segment
+// 29 -> 30 (XT 1.4.* nightlies) reordered Phaser LFO waveforms and added a Saw shape (sst-effects upgrade)
 // clang-format on
 
-const int ff_revision = 29;
+const int ff_revision = 30;
 
 const int n_scene_params = 273;
 const int n_global_params = 11 + n_fx_slots * (n_fx_params + 1); // each param plus a type

--- a/src/common/dsp/effects/PhaserEffect.cpp
+++ b/src/common/dsp/effects/PhaserEffect.cpp
@@ -21,6 +21,8 @@
  */
 #include "PhaserEffect.h"
 
+#include <cmath>
+
 #include "globals.h"
 #include "sst/basic-blocks/mechanics/block-ops.h"
 #include "sst/basic-blocks/dsp/MidSide.h"
@@ -49,7 +51,7 @@ void PhaserEffect::init_ctrltypes()
     Effect::init_ctrltypes();
 
     fxdata->p[ph_mod_wave].set_name("Waveform");
-    fxdata->p[ph_mod_wave].set_type(ct_fxlfowave);
+    fxdata->p[ph_mod_wave].set_type(ct_fxlfowave_extended);
     fxdata->p[ph_mod_rate].set_name("Rate");
     fxdata->p[ph_mod_rate].set_type(ct_lforate_deactivatable);
     fxdata->p[ph_mod_depth].set_name("Depth");
@@ -95,6 +97,57 @@ void PhaserEffect::init_ctrltypes()
     fxdata->p[ph_spread].dynamicDeactivation = &phGroupDeact;
 
     configureControlsFromFXMetadata();
+}
+
+void PhaserEffect::handleStreamingMismatches(int streamingRevision,
+                                             int currentSynthStreamingRevision)
+{
+    // These early fixups predate the move to sst-effects and were lost in that
+    // port; restore them so very old patches load as they used to.
+    if (streamingRevision <= 13)
+    {
+        fxdata->p[ph_stages].val.i = 4;
+        fxdata->p[ph_width].val.f = 0.f;
+    }
+
+    if (streamingRevision <= 15)
+    {
+        fxdata->p[ph_mod_wave].val.i = 1;
+        fxdata->p[ph_mod_rate].deactivated = false;
+    }
+
+    if (streamingRevision <= 17)
+    {
+        fxdata->p[ph_tone].val.f = 0.f;
+        fxdata->p[ph_tone].deactivated = true;
+    }
+
+    if (streamingRevision < 30)
+    {
+        // sst-effects reordered the Phaser LFO waveforms and added a Saw (its own
+        // streaming version 1 -> 2), decoupled from the Surge stream. Surge
+        // revisions before 30 stored the old ordering, so remap the values.
+        remapLegacyWaveform(fxdata);
+    }
+}
+
+void PhaserEffect::remapLegacyWaveform(FxStorage *fxdata)
+{
+    // Bridge Surge's FxStorage to the sst-effects streaming-version-1 -> 2 remapper,
+    // which reorders the LFO waveforms and forces Stereo on for the wrapped shapes.
+    float p[n_fx_params];
+    for (int i = 0; i < n_fx_params; ++i)
+        p[i] = (fxdata->p[i].valtype == vt_int) ? (float)fxdata->p[i].val.i : fxdata->p[i].val.f;
+
+    remapParametersForStreamingVersion(1, p);
+
+    for (int i = 0; i < n_fx_params; ++i)
+    {
+        if (fxdata->p[i].valtype == vt_int)
+            fxdata->p[i].val.i = (int)std::round(p[i]);
+        else
+            fxdata->p[i].val.f = p[i];
+    }
 }
 
 const char *PhaserEffect::group_label(int id)

--- a/src/common/dsp/effects/PhaserEffect.h
+++ b/src/common/dsp/effects/PhaserEffect.h
@@ -40,8 +40,14 @@ class PhaserEffect
     virtual ~PhaserEffect() = default;
 
     virtual void init_ctrltypes() override;
+    virtual void handleStreamingMismatches(int streamingRevision,
+                                           int currentSynthStreamingRevision) override;
     virtual const char *group_label(int id) override;
     virtual int group_label_ypos(int id) override;
+
+    // Apply the sst-effects LFO waveform reorder (streaming version 1 -> 2) to a
+    // Surge FxStorage. Shared by the synth patch stream and the surge-fx plugin.
+    static void remapLegacyWaveform(FxStorage *fxdata);
 };
 
 #endif // SURGE_SRC_COMMON_DSP_EFFECTS_PHASEREFFECT_H

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -25,6 +25,7 @@
 #include "SurgeFXEditor.h"
 #include "DebugHelpers.h"
 #include "UserDefaults.h"
+#include "PhaserEffect.h"
 #include <fmt/core.h>
 
 #if LINUX
@@ -527,7 +528,7 @@ juce::AudioProcessorEditor *SurgefxAudioProcessor::createEditor()
 void SurgefxAudioProcessor::getStateInformation(juce::MemoryBlock &destData)
 {
     std::unique_ptr<juce::XmlElement> xml(new juce::XmlElement("surgefx"));
-    xml->setAttribute("streamingVersion", (int)2);
+    xml->setAttribute("streamingVersion", (int)3);
 
     for (int i = 0; i < n_fx_params; ++i)
     {
@@ -588,7 +589,7 @@ void SurgefxAudioProcessor::setStateInformation(const void *data, int sizeInByte
         if (xmlState->hasTagName("surgefx"))
         {
             auto streamingVersion = xmlState->getIntAttribute("streamingVersion", (int)2);
-            if (streamingVersion > 2 || streamingVersion < 0)
+            if (streamingVersion > 3 || streamingVersion < 0)
                 streamingVersion = 1; // assume some corrupted ancient session
 
             effectNum = xmlState->getIntAttribute("fxt", fxt_delay);
@@ -609,7 +610,7 @@ void SurgefxAudioProcessor::setStateInformation(const void *data, int sizeInByte
                     float v = xmlState->getDoubleAttribute(nm, 0.0);
                     fxstorage->p[fx_param_remap[i]].set_value_f01(v);
                 }
-                else if (streamingVersion == 2)
+                else if (streamingVersion >= 2)
                 {
                     auto &spar = fxstorage->p[fx_param_remap[i]];
                     nm = fmt::format("fxp_{:d}", i);
@@ -652,6 +653,14 @@ void SurgefxAudioProcessor::setStateInformation(const void *data, int sizeInByte
                     int pf = xmlState->getIntAttribute(nm, 0);
                     paramFeaturesCache[i] = pf;
                 }
+            }
+
+            // sst-effects reordered the Phaser LFO waveforms and added a Saw shape,
+            // decoupled from this plugin's stream. Sessions before v3 stored the old
+            // ordering, so remap them with the shared sst-effects remapper.
+            if (streamingVersion < 3 && effectNum == fxt_phaser)
+            {
+                PhaserEffect::remapLegacyWaveform(fxstorage);
             }
 
             resetFxParams(true);


### PR DESCRIPTION
The sst-effects Phaser gained a Saw shape and reordered its LFO waveforms, growing the parameter from 6 to 7 values. Its per-effect streaming version is decoupled from the Surge stream, so bump the Surge revision one last time and remap old Phaser waveforms on load. Also restore the legacy Phaser streaming fixups that were lost when the effect moved to sst-effects, and apply the same remap to the standalone surge-fx plugin.

Addresses #8378 

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>