### PR TITLE
Filter Analysis: allow starting node drag on the edge of graph's rectangle

### DIFF
--- a/src/surge-xt/gui/overlays/FilterAnalysis.cpp
+++ b/src/surge-xt/gui/overlays/FilterAnalysis.cpp
@@ -158,7 +158,8 @@ void FilterAnalysis::onSkinChanged()
 
 void FilterAnalysis::paint(juce::Graphics &g)
 {
-    auto &fs = editor->getPatch().scene[editor->current_scene].filterunit[whichFilter];
+    auto &sc = editor->getPatch().scene[editor->current_scene];
+    auto &fs = sc.filterunit[whichFilter];
 
     constexpr auto dbRange = GRAPH_MAX_DB - GRAPH_MIN_DB;
 
@@ -171,16 +172,18 @@ void FilterAnalysis::paint(juce::Graphics &g)
         return (float)height * (GRAPH_MAX_DB - db) / dbRange;
     };
 
-    std::string nm, snm;
+    std::array<std::string, n_filterunits_per_scene> nm, snm, label;
 
-    nm = fs.type.get_display();
-    snm = fs.subtype.get_display();
-
-    auto label = fmt::format("{}", nm);
-
-    if (sst::filters::fut_subcount[fs.type.val.i] > 0)
+    for (int i = 0; i < n_filterunits_per_scene; i++)
     {
-        label = fmt::format("{} ({})", nm, snm);
+        nm[i] = sc.filterunit[i].type.get_display();
+        snm[i] = sc.filterunit[i].subtype.get_display();
+        label[i] = fmt::format("{}", nm[i]);
+
+        if (sst::filters::fut_subcount[fs.type.val.i] > 0)
+        {
+            label[i] = fmt::format("{} ({})", nm[i], snm[i]);
+        }
     }
 
     g.fillAll(skin->getColor(Colors::MSEGEditor::Background));
@@ -427,11 +430,24 @@ void FilterAnalysis::paint(juce::Graphics &g)
         g.drawText(txt2, readout, juce::Justification::centredLeft);
     }
 
-    const auto txtr = lb.withTrimmedTop(1).withHeight(17);
+    auto txtr = lb.withTrimmedTop(1).withHeight(17).withWidth((lb.getWidth() / 2) - 4).withLeft(48);
 
-    g.setColour(skin->getColor(Colors::Waveshaper::Preview::Text));
     g.setFont(skin->getFont(Fonts::Waveshaper::Preview::Title));
-    g.drawText(label, txtr, juce::Justification::centred);
+
+    for (int i = 0; i < n_filterunits_per_scene; i++)
+    {
+        g.setColour((i == whichFilter) ? skin->getColor(Colors::MSEGEditor::Curve)
+                                       : skin->getColor(Colors::Waveshaper::Preview::Text));
+
+        if (i == 1)
+        {
+            txtr = txtr.withRightX(lb.getWidth() - 48);
+        }
+
+        g.drawFittedText(
+            label[i], txtr,
+            (i == 0) ? juce::Justification::centredLeft : juce::Justification::centredRight, 1);
+    }
 }
 
 bool FilterAnalysis::shouldRepaintOnParamChange(const SurgePatch &patch, Parameter *p)
@@ -496,13 +512,13 @@ void FilterAnalysis::selectFilter(int which)
 void FilterAnalysis::resized()
 {
     auto t = getTransform().inverted();
-    auto h = getHeight();
     auto w = getWidth();
+    auto h = getHeight();
 
     t.transformPoint(w, h);
 
-    f1Button->setBounds(2, 2, 40, 15);
-    f2Button->setBounds(w - 42, 2, 40, 15);
+    f1Button->setBounds(4, 2, 40, 15);
+    f2Button->setBounds(w - 44, 2, 40, 15);
 
     catchUpStore = evaluator->outboundUpdates - 1; // because we need to rebuild the path
 }

--- a/src/surge-xt/gui/overlays/FilterAnalysis.cpp
+++ b/src/surge-xt/gui/overlays/FilterAnalysis.cpp
@@ -186,7 +186,7 @@ void FilterAnalysis::paint(juce::Graphics &g)
     g.fillAll(skin->getColor(Colors::MSEGEditor::Background));
 
     const auto lb = getLocalBounds();
-    const auto dRect = lb.withTrimmedTop(18).reduced(4);
+    const auto dRect = getDrawRegion();
     const auto width = dRect.getWidth();
     const auto height = dRect.getHeight();
     const auto labelHeight = 9;
@@ -507,31 +507,26 @@ void FilterAnalysis::resized()
     catchUpStore = evaluator->outboundUpdates - 1; // because we need to rebuild the path
 }
 
+juce::Rectangle<int> FilterAnalysis::getDrawRegion()
+{
+    return getLocalBounds().withTrimmedTop(18).reduced(4);
+}
+
 void FilterAnalysis::mouseDrag(const juce::MouseEvent &event)
 {
-    auto dRect = getLocalBounds().transformedBy(getTransform().inverted());
+    const auto dRect = getDrawRegion();
+    const auto width = dRect.getWidth() - 1;
+    const auto height = dRect.getHeight() - 1;
 
-    float rx0 = dRect.getX();
-    float rx1 = dRect.getX() + dRect.getWidth() - 1;
-    float ry0 = dRect.getY();
-    float ry1 = dRect.getY() + dRect.getHeight() - 1;
+    auto mousePoint = event.position - dRect.getPosition().toFloat();
 
-    juce::Point<float> mousePoint =
-        event.getPosition()
-            .transformedBy(
-                juce::AffineTransform().translated(dRect.getX(), dRect.getY()).inverted())
-            .toFloat();
+    mousePoint.setX(std::clamp(mousePoint.getX(), 0.f, (float)width));
+    mousePoint.setY(std::clamp(mousePoint.getY(), 0.f, (float)height));
 
-    mousePoint.setX(std::clamp(mousePoint.getX(), rx0, rx1));
-    mousePoint.setY(std::clamp(mousePoint.getY(), ry0, ry1));
-
-    if (isPressed && dRect.contains(mousePoint.toInt()))
+    if (isPressed)
     {
         auto &ss = editor->getPatch().scene[editor->current_scene];
         auto &fs = ss.filterunit[whichFilter];
-
-        auto width = dRect.getWidth() - 1;
-        auto height = dRect.getHeight() - 1;
 
         auto xNorm = mousePoint.x / (float)width;
         auto freq = std::pow(GRAPH_MAX_FREQ / GRAPH_MIN_FREQ, xNorm) * GRAPH_MIN_FREQ;
@@ -539,7 +534,6 @@ void FilterAnalysis::mouseDrag(const juce::MouseEvent &event)
         float cutoff =
             limit_range(12.0f * std::log2(freq / 440.0f), fs.cutoff.val_min.f, fs.cutoff.val_max.f);
         float resonance = limit01((height - mousePoint.y) / (float)height);
-        float f = fs.cutoff.value_to_normalized(cutoff);
 
         fs.cutoff.val.f = cutoff;
         fs.resonance.val.f = resonance;
@@ -547,6 +541,8 @@ void FilterAnalysis::mouseDrag(const juce::MouseEvent &event)
         // assert if filter cutoff or resonance params are not assigned in SurgeGUIEditor.cpp
         jassert(editor->filterCutoffSlider[whichFilter] != nullptr);
         jassert(editor->filterResonanceSlider[whichFilter] != nullptr);
+
+        float f = fs.cutoff.value_to_normalized(cutoff);
 
         editor->filterCutoffSlider[whichFilter]->asControlValueInterface()->setValue(f);
         editor->filterCutoffSlider[whichFilter]->setQuantitizedDisplayValue(f);
@@ -577,11 +573,11 @@ void FilterAnalysis::mouseDrag(const juce::MouseEvent &event)
 // just by clicking anywhere in the graph, no mouse movement required
 void FilterAnalysis::mouseDown(const juce::MouseEvent &event)
 {
-    const auto lb = getLocalBounds().transformedBy(getTransform().inverted());
-    auto dRect = lb.withTrimmedTop(18).reduced(4);
+    auto dRect = getDrawRegion();
     auto where = event.position;
+    const bool withinHotzone = hotzone.contains(where);
 
-    if (dRect.contains(where.toInt()))
+    if (dRect.contains(where.toInt()) || withinHotzone)
     {
         isPressed = true;
 

--- a/src/surge-xt/gui/overlays/FilterAnalysis.cpp
+++ b/src/surge-xt/gui/overlays/FilterAnalysis.cpp
@@ -427,7 +427,7 @@ void FilterAnalysis::paint(juce::Graphics &g)
         g.drawText(txt2, readout, juce::Justification::centredLeft);
     }
 
-    const auto txtr = lb.withHeight(15);
+    const auto txtr = lb.withTrimmedTop(1).withHeight(17);
 
     g.setColour(skin->getColor(Colors::Waveshaper::Preview::Text));
     g.setFont(skin->getFont(Fonts::Waveshaper::Preview::Title));

--- a/src/surge-xt/gui/overlays/FilterAnalysis.h
+++ b/src/surge-xt/gui/overlays/FilterAnalysis.h
@@ -57,6 +57,8 @@ struct FilterAnalysis : public OverlayComponent, Surge::GUI::SkinConsumingCompon
     void repushData();
     void forceDataRefresh() override { repushData(); }
 
+    juce::Rectangle<int> getDrawRegion();
+
     juce::Rectangle<float> hotzone;
     juce::Point<int> cursorHideOrigin;
 


### PR DESCRIPTION
Previously, if the cutoff/resonance node/hotzone was right on the edge of the graph, so that half of the node was drawn outside of the graph's rectangle, clicking in that outer half would change the mouse cursor (correctly), but wouldn't actually initiate the drag, because in mouseDown() we only tested for within dRect but didn't take hotzone into account.

Also, clean up the code some with getDrawArea() method that does the rectangle trimming in one place that is then used in paint(), mouseDown() and mouseDrag().

Also, show names of both filters in headers, accenting the currently selected one with the same color used for the plot curve.