### PR TITLE
Remove overzealous rescaling of MSEG cpduration

### DIFF
--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -1316,14 +1316,7 @@ void extendTo(MSEGStorage *ms, float t, float nv)
 
     if (ms->endpointMode == MSEGStorage::EndpointMode::LOCKED)
     {
-        // The first point has to match where I just clicked. Adjust it and its control point
-        float cpdratio = 0.5;
-
-        if (ms->segments[0].duration > 0)
-        {
-            cpdratio = ms->segments[0].cpduration / ms->segments[0].duration;
-        }
-
+        // The first point has to match where I just clicked. Adjust it
         float cpvratio = 0.5;
 
         if (ms->segments[0].nv1 != ms->segments[0].v0)
@@ -1333,7 +1326,6 @@ void extendTo(MSEGStorage *ms, float t, float nv)
         }
 
         ms->segments[0].v0 = nv;
-        ms->segments[0].cpduration = cpdratio * ms->segments[0].duration;
         ms->segments[0].cpv =
             (ms->segments[0].nv1 - ms->segments[0].v0) * cpvratio + ms->segments[0].v0;
     }
@@ -1438,7 +1430,6 @@ void unsplitSegment(MSEGStorage *ms, float t, bool wrapTime)
         return;
     }
 
-    float cpdratio = ms->segments[prior].cpduration / ms->segments[prior].duration;
     float cpvratio = 0.5;
 
     if (ms->segments[prior].nv1 != ms->segments[prior].v0)
@@ -1449,7 +1440,7 @@ void unsplitSegment(MSEGStorage *ms, float t, bool wrapTime)
 
     ms->segments[prior].duration += ms->segments[idx].duration;
     ms->segments[prior].nv1 = ms->segments[idx].nv1;
-    ms->segments[prior].cpduration = cpdratio * ms->segments[prior].duration;
+    ms->segments[prior].cpduration = ms->segments[prior].duration;
 
     for (int i = idx; i < ms->n_activeSegments - 1; ++i)
     {
@@ -2017,13 +2008,6 @@ void adjustDurationShiftingSubsequent(MSEGStorage *ms, int idx, float dx, float 
 
     if (idx >= 0)
     {
-        auto rcv = 0.5;
-
-        if (ms->segments[idx].duration > 0)
-        {
-            rcv = ms->segments[idx].cpduration / ms->segments[idx].duration;
-        }
-
         float prior = ms->segments[idx].duration;
 
         adjustDurationInternal(ms, idx, dx, snap);
@@ -2031,8 +2015,6 @@ void adjustDurationShiftingSubsequent(MSEGStorage *ms, int idx, float dx, float 
         float after = ms->segments[idx].duration;
 
         durationChange = after - prior;
-
-        ms->segments[idx].cpduration = ms->segments[idx].duration * rcv;
     }
 
     if (ms->editMode == MSEGStorage::LFO)
@@ -2101,25 +2083,13 @@ void adjustDurationConstantTotalDuration(MSEGStorage *ms, int idx, float dx, flo
 
     if (prior >= 0)
     {
-        auto rcv = 0.5;
-
-        if (ms->segments[prior].duration > 0)
-        {
-            rcv = ms->segments[prior].cpduration / ms->segments[prior].duration;
-        }
-
         adjustDurationInternal(ms, prior, dx, snap, csum);
-        ms->segments[prior].cpduration = ms->segments[prior].duration * rcv;
         pd = ms->segments[prior].duration;
     }
 
     if (next < ms->n_activeSegments)
     {
-        auto rcv = ms->segments[next].cpduration / ms->segments[next].duration;
-
-        // offsetDuration( ms->segments[next].duration, -dx );
         ms->segments[next].duration = csum - pd;
-        ms->segments[next].cpduration = ms->segments[next].duration * rcv;
     }
 
     rebuildCache(ms);

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -499,7 +499,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                         if (isLast)
                         {
                             Surge::MSEG::adjustDurationShiftingSubsequent(this->ms, prior, dx,
-                                                                          ms->hSnap, longestMSEG);
+                                                                          ms->hSnap, max_msegs);
                         }
                         else
                         {
@@ -510,7 +510,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                     else
                     {
                         Surge::MSEG::adjustDurationShiftingSubsequent(this->ms, prior, dx,
-                                                                      ms->hSnap, longestMSEG);
+                                                                      ms->hSnap, max_msegs);
                     }
                     break;
                 case SINGLE:
@@ -756,7 +756,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                             }
 
                             Surge::MSEG::adjustDurationShiftingSubsequent(
-                                ms, ms->n_activeSegments - 1, dx / tscale, ms->hSnap, longestMSEG);
+                                ms, ms->n_activeSegments - 1, dx / tscale, ms->hSnap, max_msegs);
                         }
                     });
 
@@ -3268,14 +3268,14 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             actionsMenu.addSeparator();
 
             actionsMenu.addItem(Surge::GUI::toOSCase("Double Duration"), isActive, false, [this]() {
-                Surge::MSEG::scaleDurations(this->ms, 2.0, longestMSEG);
+                Surge::MSEG::scaleDurations(this->ms, 2.0, max_msegs);
                 pushToUndo();
                 modelChanged();
                 zoomToFull();
             });
 
             actionsMenu.addItem(Surge::GUI::toOSCase("Half Duration"), isActive, false, [this]() {
-                Surge::MSEG::scaleDurations(this->ms, 0.5, longestMSEG);
+                Surge::MSEG::scaleDurations(this->ms, 0.5, max_msegs);
                 pushToUndo();
                 modelChanged();
                 zoomToFull();
@@ -3510,7 +3510,6 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         repaint();
     }
 
-    static constexpr int longestMSEG = 128;
     static constexpr int longestSmallZoom = 32;
 
     void applyZoomPanConstraints(int activeSegment = -1, bool specialEndpoint = false)
@@ -3529,8 +3528,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         {
             auto bd = std::max(ms->totalDuration, 1.f);
             auto longest = bd * 2;
-            if (longest > longestMSEG)
-                longest = longestMSEG;
+            if (longest > max_msegs)
+                longest = max_msegs;
             if (longest < longestSmallZoom)
                 longest = longestSmallZoom;
             if (ms->axisWidth > longest)


### PR DESCRIPTION
Previously, if your cp x was 0.25 and your segment was 1 grid unit long (for example), and you extended that segment to be 2 grid units long, cp x would be rescaled to 0.5 instead of staying at 0.25.

This PR makes sure cp x stays put in all these situations where it was overzealously rescaled in MSEGModulationHelper.

Also, replace longestMSEG static constexpr with max_msegs from SurgeStorage (which is 256 now).