### PR TITLE
Minor Keyboard Tweaks

### DIFF
--- a/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
@@ -45,6 +45,7 @@ constexpr int kTypein2DChooser = -1;
 
 // matches MSEGCanvas::TimeEdit
 constexpr int kTimeEditShift = 1;
+constexpr int kTimeEditDraw = 2;
 
 // the CP hotzone existence condition from MSEGCanvas::recalcHotZones
 constexpr float kMinCPDuration = 0.01f;
@@ -179,15 +180,16 @@ float MSEGAccessibleKeyboardHandler::xStep(const juce::ModifierKeys &mods) const
 
 float MSEGAccessibleKeyboardHandler::yStep(const juce::ModifierKeys &mods) const
 {
-    float b = ms->vSnap > 0 ? ms->vSnap : ms->vSnapDefault;
-    if (b <= 0)
-        b = 0.025f;
-    b *= unipolarFactor();
-    if (mods.isShiftDown())
-        b *= 0.25f;
     if (mods.isCommandDown())
-        b *= 4.f;
-    return b;
+    {
+        float b = ms->vSnap > 0 ? ms->vSnap : ms->vSnapDefault;
+        if (b <= 0)
+            b = 0.025f;
+        return b * unipolarFactor();
+    }
+    // fixed steps, without the unipolar factor, so the announced value always
+    // changes by exactly the step
+    return mods.isShiftDown() ? 0.01f : 0.05f;
 }
 
 float MSEGAccessibleKeyboardHandler::xSnapFor(const juce::ModifierKeys &mods) const
@@ -195,9 +197,14 @@ float MSEGAccessibleKeyboardHandler::xSnapFor(const juce::ModifierKeys &mods) co
     return mods.isShiftDown() ? 0.f : ms->hSnap;
 }
 
+// value moves only quantize with Ctrl held, which engages the vertical snap
+// division whether or not the snap checkbox is on
 float MSEGAccessibleKeyboardHandler::ySnapFor(const juce::ModifierKeys &mods) const
 {
-    return mods.isShiftDown() ? 0.f : ms->vSnap * unipolarFactor();
+    if (!mods.isCommandDown())
+        return 0.f;
+    float b = ms->vSnap > 0 ? ms->vSnap : ms->vSnapDefault;
+    return std::max(b, 0.f) * unipolarFactor();
 }
 
 float MSEGAccessibleKeyboardHandler::curveValueAt(float t) const
@@ -376,7 +383,7 @@ void MSEGAccessibleKeyboardHandler::nudgeNodeX(int node, float dx, float snap, b
     }
     else
     {
-        // per the accessibility spec, Draw movement mode nudges like Single
+        // Draw mode never reaches here; processCursorKey refuses time moves
         if (cb.getTimeEditMode && cb.getTimeEditMode() == kTimeEditShift)
             Surge::MSEG::adjustDurationShiftingSubsequent(ms, node - 1, dx, snap, max_msegs);
         else
@@ -400,7 +407,7 @@ void MSEGAccessibleKeyboardHandler::nudgeNodeX(int node, float dx, float snap, b
     }
 }
 
-void MSEGAccessibleKeyboardHandler::nudgeControlPoint(int seg, float dx, float dy)
+void MSEGAccessibleKeyboardHandler::nudgeControlPoint(int seg, float dx, float dy, float ySnapRes)
 {
     auto &s = ms->segments[seg];
 
@@ -434,7 +441,7 @@ void MSEGAccessibleKeyboardHandler::nudgeControlPoint(int seg, float dx, float d
     if (dy != 0)
     {
         float before = s.cpv;
-        s.cpv = std::clamp(s.cpv + dy, -1.f, 1.f);
+        s.cpv = quantizeValue(std::clamp(s.cpv + dy, -1.f, 1.f), ySnapRes);
         Surge::MSEG::constrainControlPointAt(ms, seg);
 
         inFlightEdit = true;
@@ -752,7 +759,7 @@ bool MSEGAccessibleKeyboardHandler::groupNudgeX(float dx, float snap)
     return changed;
 }
 
-bool MSEGAccessibleKeyboardHandler::groupNudgeCP(float dx, float dy)
+bool MSEGAccessibleKeyboardHandler::groupNudgeCP(float dx, float dy, float ySnapRes)
 {
     auto sel = cb.getSelection ? cb.getSelection() : std::vector<int>();
     auto N = ms->n_activeSegments;
@@ -773,7 +780,7 @@ bool MSEGAccessibleKeyboardHandler::groupNudgeCP(float dx, float dy)
         if (dx != 0)
             s.cpduration += dx / std::max(s.duration, 0.001f);
         if (dy != 0)
-            s.cpv = std::clamp(s.cpv + dy, -1.f, 1.f);
+            s.cpv = quantizeValue(std::clamp(s.cpv + dy, -1.f, 1.f), ySnapRes);
         Surge::MSEG::constrainControlPointAt(ms, i);
 
         if (std::fabs(s.cpduration - beforeX) > 1e-7 || std::fabs(s.cpv - beforeY) > 1e-7)
@@ -933,7 +940,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
             {
                 if (cb.prepareForUndo)
                     cb.prepareForUndo();
-                if (groupNudgeCP(dx, 0.f) && cb.pushToUndo)
+                if (groupNudgeCP(dx, 0.f, 0.f) && cb.pushToUndo)
                     cb.pushToUndo();
                 return true;
             }
@@ -950,9 +957,18 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
             if (cb.prepareForUndo)
                 cb.prepareForUndo();
             auto before = ms->segments[seg].cpduration;
-            nudgeControlPoint(seg, dx, 0.f);
+            nudgeControlPoint(seg, dx, 0.f, 0.f);
             if (std::fabs(ms->segments[seg].cpduration - before) > 1e-7 && cb.pushToUndo)
                 cb.pushToUndo();
+            return true;
+        }
+
+        // Draw mode disables node time movement for the mouse (timeConstraint
+        // is a no-op), so match it here; control points above stay movable
+        if (cb.getTimeEditMode && cb.getTimeEditMode() == kTimeEditDraw)
+        {
+            if (cb.announce)
+                cb.announce("Horizontal movement is disabled while Draw is on");
             return true;
         }
 
@@ -984,7 +1000,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
             {
                 if (cb.prepareForUndo)
                     cb.prepareForUndo();
-                if (groupNudgeCP(0.f, dy) && cb.pushToUndo)
+                if (groupNudgeCP(0.f, dy, ySnapFor(mods)) && cb.pushToUndo)
                     cb.pushToUndo();
                 return true;
             }
@@ -1001,7 +1017,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
             if (cb.prepareForUndo)
                 cb.prepareForUndo();
             auto before = ms->segments[seg].cpv;
-            nudgeControlPoint(seg, 0.f, dy);
+            nudgeControlPoint(seg, 0.f, dy, ySnapFor(mods));
             if (std::fabs(ms->segments[seg].cpv - before) > 1e-7 && cb.pushToUndo)
                 cb.pushToUndo();
             return true;

--- a/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
@@ -168,14 +168,14 @@ float MSEGAccessibleKeyboardHandler::unipolarFactor() const
 
 float MSEGAccessibleKeyboardHandler::xStep(const juce::ModifierKeys &mods) const
 {
-    float b = ms->hSnap > 0 ? ms->hSnap : ms->hSnapDefault;
-    if (b <= 0)
-        b = 0.05f;
-    if (mods.isShiftDown())
-        b *= 0.25f;
     if (mods.isCommandDown())
-        b *= 4.f;
-    return b;
+    {
+        float b = ms->hSnap > 0 ? ms->hSnap : ms->hSnapDefault;
+        if (b <= 0)
+            b = 0.05f;
+        return b;
+    }
+    return mods.isShiftDown() ? 0.01f : 0.05f;
 }
 
 float MSEGAccessibleKeyboardHandler::yStep(const juce::ModifierKeys &mods) const
@@ -192,9 +192,14 @@ float MSEGAccessibleKeyboardHandler::yStep(const juce::ModifierKeys &mods) const
     return mods.isShiftDown() ? 0.01f : 0.05f;
 }
 
+// time moves only quantize with Ctrl held, which engages the horizontal snap
+// division whether or not the snap checkbox is on
 float MSEGAccessibleKeyboardHandler::xSnapFor(const juce::ModifierKeys &mods) const
 {
-    return mods.isShiftDown() ? 0.f : ms->hSnap;
+    if (!mods.isCommandDown())
+        return 0.f;
+    float b = ms->hSnap > 0 ? ms->hSnap : ms->hSnapDefault;
+    return std::max(b, 0.f);
 }
 
 // value moves only quantize with Ctrl held, which engages the vertical snap
@@ -358,9 +363,20 @@ void MSEGAccessibleKeyboardHandler::nudgeNodeY(int node, float dy, float snapRes
     }
 }
 
+// adjustDurationInternal snaps relative to dragDuration, a mouse-drag
+// accumulator the mouse path stashes on mouseDown; refresh it so keyboard
+// snap moves are relative to the node's actual time
+void MSEGAccessibleKeyboardHandler::refreshSnapDragState()
+{
+    for (int i = 0; i < ms->n_activeSegments; ++i)
+        ms->segments[i].dragDuration = ms->segments[i].duration;
+}
+
 void MSEGAccessibleKeyboardHandler::nudgeNodeX(int node, float dx, float snap, bool announceResult)
 {
     auto N = ms->n_activeSegments;
+
+    refreshSnapDragState();
 
     if (node <= 0)
     {
@@ -701,6 +717,8 @@ bool MSEGAccessibleKeyboardHandler::groupNudgeX(float dx, float snap)
 {
     auto sel = cb.getSelection ? cb.getSelection() : std::vector<int>();
     auto N = ms->n_activeSegments;
+
+    refreshSnapDragState();
 
     std::sort(sel.begin(), sel.end());
     if (dx > 0)

--- a/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.h
+++ b/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.h
@@ -124,11 +124,11 @@ struct MSEGAccessibleKeyboardHandler
     void resetCP();
     void nudgeNodeX(int node, float dx, float snap, bool announceResult);
     void nudgeNodeY(int node, float dy, float snapRes, bool announceResult);
-    void nudgeControlPoint(int seg, float dx, float dy);
+    void nudgeControlPoint(int seg, float dx, float dy, float ySnapRes);
     // return whether anything actually moved, so the caller can push undo
     bool groupNudgeX(float dx, float snap);
     bool groupNudgeY(float dy, float snapRes);
-    bool groupNudgeCP(float dx, float dy);
+    bool groupNudgeCP(float dx, float dy, float ySnapRes);
     void groupDelete(bool removeSegment);
 
     float xStep(const juce::ModifierKeys &mods) const;

--- a/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.h
+++ b/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.h
@@ -122,6 +122,7 @@ struct MSEGAccessibleKeyboardHandler
     void addNode(bool append);
     void deleteNode(bool removeSegment);
     void resetCP();
+    void refreshSnapDragState();
     void nudgeNodeX(int node, float dx, float snap, bool announceResult);
     void nudgeNodeY(int node, float dy, float snapRes, bool announceResult);
     void nudgeControlPoint(int seg, float dx, float dy, float ySnapRes);
@@ -134,7 +135,7 @@ struct MSEGAccessibleKeyboardHandler
     float xStep(const juce::ModifierKeys &mods) const;
     float yStep(const juce::ModifierKeys &mods) const;
     float unipolarFactor() const;
-    // 0 (no quantize) for fine Shift moves so the fine step isn't rounded away
+    // 0 (no quantize) unless Ctrl is held, which snaps regardless of the checkbox
     float xSnapFor(const juce::ModifierKeys &mods) const;
     float ySnapFor(const juce::ModifierKeys &mods) const;
 


### PR DESCRIPTION
This addresses feedback from @mkruselj from Discord regarding the accessible MSEG editor work:
* CTRL+up/down snaps regardless of whether vertical snap is on or off
* bare up/down moves by 0.05 per press
* SHIFT+up/down move by 0.01 per press
* Keyboard navigation now respects the constraints of the move switch being set to draw, accessible announcement if X axis movement is attempted
*

Assisted by Claude Fable 5.