### PR TITLE
Fix for MSEG loop start misdraw in an edge case

### DIFF
--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -1275,7 +1275,8 @@ void insertAtIndex(MSEGStorage *ms, int insertIndex)
 
     // Handle the loops. We have just inserted at index so if start or end
     // is later we need to push them out
-    if (ms->loop_start != MSEGStorage::kLoopPointUnset && ms->loop_start >= insertIndex)
+    if (ms->loop_start != MSEGStorage::kLoopPointUnset && ms->loop_start >= insertIndex &&
+        ms->loop_start != ms->n_activeSegments)
     {
         ms->loop_start++;
     }
@@ -1318,6 +1319,9 @@ void insertBefore(MSEGStorage *ms, float t)
 
 void extendTo(MSEGStorage *ms, float t, float nv)
 {
+    std::cout << "extendTo ENTRY: n_activeSegments=" << ms->n_activeSegments
+              << " loop_start=" << ms->loop_start << " loop_end=" << ms->loop_end << std::endl;
+
     if (ms->editMode == MSEGStorage::LFO)
     {
         return;
@@ -1347,6 +1351,9 @@ void extendTo(MSEGStorage *ms, float t, float nv)
             ms->loop_end = ms->n_activeSegments - 2;
         }
     }
+
+    std::cout << "extendTo EXIT:  n_activeSegments=" << ms->n_activeSegments
+              << " loop_start=" << ms->loop_start << " loop_end=" << ms->loop_end << std::endl;
 
     auto sn = ms->n_activeSegments - 1;
 

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -1546,6 +1546,12 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             float pxs = tpx(ms->segmentStart[ls]);
             float pxe = tpx(ms->segmentEnd[le]);
 
+            // one-past-end sentinel: loop start is pinned at the current envelope end
+            if (ls >= ms->n_activeSegments)
+            {
+                pxs = tpx(ms->segmentEnd[ms->n_activeSegments - 1]);
+            }
+
             if (!(pxs > drawArea.getRight() || pxe < drawArea.getX()))
             {
                 auto cb = skin->getColor(Colors::MSEGEditor::Loop::RegionBorder);
@@ -2022,8 +2028,11 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         }
 
         auto drawArea = getDrawArea();
+        const auto inDrawArea =
+            (drawArea.contains(event.position.toInt()) ? MOUSE_DOWN_IN_DRAW_AREA
+                                                       : MOUSE_DOWN_OUTSIDE_DRAW_AREA);
 
-        if (drawArea.contains(where))
+        if (inDrawArea)
         {
             auto tf = pxToTime();
             auto pv = pxToVal();
@@ -2916,9 +2925,12 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
             reset = true;
 
-            if (h.zoneSubType == hotzone::SEGMENT_CONTROL)
+            switch (h.zoneSubType)
+            {
+            case hotzone::SEGMENT_CONTROL:
             {
                 auto nextCursor = juce::MouseCursor::NormalCursor;
+
                 switch (h.segmentDirection)
                 {
                 case hotzone::VERTICAL_ONLY:
@@ -2933,11 +2945,22 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                 }
 
                 setMouseCursor(nextCursor);
-            }
 
-            if (h.zoneSubType == hotzone::SEGMENT_ENDPOINT)
+                break;
+            }
+            case hotzone::SEGMENT_ENDPOINT:
             {
                 setMouseCursor(juce::MouseCursor::UpDownLeftRightResizeCursor);
+                break;
+            }
+            case hotzone::LOOP_START:
+            case hotzone::LOOP_END:
+            {
+                setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
+                break;
+            }
+            default:
+                break;
             }
         }
 


### PR DESCRIPTION
This fixes the following repro case:

1. Default MSEG state
2. Set loop start to grid unit 3, so it's at the same place as loop end
3. Double-click last node to delete it
4. Add new node at the end by double-click

Result is that loop boundary border for loop start is incorrectly painted. In the X axis ruler at the bottom the triangular loop start/end markers are painted correctly.

Also, add left-right cursor when hovering over loop start/end markers in the horizontal axis.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>