### PR TITLE
A number of MSEG UX improvements

### DIFF
--- a/src/common/SkinModel.h
+++ b/src/common/SkinModel.h
@@ -112,7 +112,8 @@ enum NumberfieldControlModes
     MSEG_SNAP_H,
     MSEG_SNAP_V,
     WTSE_RESOLUTION,
-    WTSE_FRAMES
+    WTSE_FRAMES,
+    MSEG_NODE_SELECT
 };
 }
 

--- a/src/common/dsp/modulators/MSEGModulationHelper.cpp
+++ b/src/common/dsp/modulators/MSEGModulationHelper.cpp
@@ -1095,7 +1095,7 @@ float valueAt(int ip, float fup, float df, MSEGStorage *ms, EvaluatorState *es, 
         if (df < 0.f)
             k += abs(df) * 9.f;
         else if (df > 0.f)
-            k -= df * 2.999999f;
+            k -= df * 2.999f;
 
         // exponential charge formula
         float curve = (1.0f - exp(-k * localFrac)) / (1.0f - exp(-k));

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -495,15 +495,21 @@ void SurgeJUCELookAndFeel::drawToggleButton(Graphics &g, ToggleButton &button,
 {
     auto tickWidth = jmin(15.0f, (float)button.getHeight() * 0.75f) * 1.2f;
 
-    drawTickBox(g, button, 2.0f, ((float)button.getHeight() - tickWidth) * 0.5f, tickWidth,
-                tickWidth, button.getToggleState(), button.isEnabled(),
-                shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+    juce::Rectangle<float> tickBounds(2.f, ((float)button.getHeight() - tickWidth) * 0.5f,
+                                      tickWidth, tickWidth);
 
-    g.setColour(button.findColour(ToggleButton::textColourId));
-    g.setFont(skin->fontManager->getLatoAtSize(9));
+    g.setColour(button.findColour(ToggleButton::tickColourId));
 
     if (!button.isEnabled())
         g.setOpacity(0.5f);
+
+    g.drawRoundedRectangle(tickBounds, 4.0f, 1.0f);
+
+    if (button.getToggleState())
+        g.fillRoundedRectangle(tickBounds, 4.0f);
+
+    g.setColour(button.findColour(ToggleButton::textColourId));
+    g.setFont(skin->fontManager->getLatoAtSize(9));
 
     g.drawFittedText(
         button.getButtonText(),

--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -79,7 +79,7 @@ struct MSEGControlRegion : public juce::Component,
     MSEGControlRegion(MSEGCanvas *c, SurgeStorage *storage, LFOStorage *lfos, MSEGStorage *ms,
                       MSEGEditor::State *eds, Surge::GUI::Skin::ptr_t skin,
                       std::shared_ptr<SurgeImageStore> b, SurgeGUIEditor *sge)
-        : juce::Component("MSEG Control Region")
+        : juce::Component("MSEG Settings")
     {
         setSkin(skin, b);
         this->ms = ms;
@@ -89,8 +89,8 @@ struct MSEGControlRegion : public juce::Component,
         this->storage = storage;
         this->sge = sge;
         setAccessible(true);
-        setTitle("Controls");
-        setDescription("Controls");
+        setTitle("MSEG Settings");
+        setDescription("MSEG Settings");
         // Accessibility grouping only. A keyboardFocusContainer here would wall the
         // widgets off from the overlay's tab order while the region itself never
         // takes focus, leaving them unreachable by tab.
@@ -108,6 +108,11 @@ struct MSEGControlRegion : public juce::Component,
         tag_horizontal_value,
         tag_loop_mode,
         tag_edit_mode,
+        tag_node_select,
+        tag_deform_use,
+        tag_deform_invert,
+        tag_trigger_filter_eg,
+        tag_trigger_amp_eg,
     };
 
     std::unique_ptr<Surge::Overlays::TypeinLambdaEditor> typeinEditor;
@@ -123,9 +128,40 @@ struct MSEGControlRegion : public juce::Component,
     std::unique_ptr<Surge::Widgets::Switch> hSnapButton, vSnapButton;
     std::unique_ptr<Surge::Widgets::MultiSwitch> loopMode, editMode, movementMode;
     std::unique_ptr<Surge::Widgets::NumberField> hSnapSize, vSnapSize;
+    std::unique_ptr<Surge::Widgets::NumberField> nodeSelect;
+    std::unique_ptr<juce::ToggleButton> deformUseButton, deformInvertButton, triggerFilterButton,
+        triggerAmpButton;
+    std::unique_ptr<juce::Label> deformUseLabel, deformInvertLabel, triggerFilterLabel,
+        triggerAmpLabel;
     std::vector<std::unique_ptr<juce::Label>> labels;
 
     void hvSnapTypein(bool isH);
+
+    // Mirrors MSEGCanvas::isSceneMSEG(). Duplicated rather than routed through
+    // canvas because canvas is nullptr during the constructor's initial
+    // rebuild(), while lfodata is always valid on MSEGControlRegion.
+    bool isSceneMSEG() const { return lfodata->shape.ctrlgroup_entry >= ms_slfo1; }
+
+    // Which segment indices the trigger/deform checkboxes currently act on:
+    // either the single kbdHandler cursor node, or every node in the active
+    // lasso/keyboard selection. Always non-empty.
+    std::vector<int> activeNodeSelection() const;
+
+    // Node whose current settings the checkboxes should display when the
+    // selection has more than one member: the selected node spanning the
+    // longest segment duration. Lassos never produce disjoint selections
+    // (a new shift+drag replaces rather than adds), so "longest segment" is
+    // a stable, cheap proxy for "most recently touched."
+    int representativeNodeForSelection(const std::vector<int> &sel) const;
+
+    // Refreshes nodeSelect and the footer checkboxes from the current cursor
+    // state. Called after rebuild() and whenever the canvas reports a selection
+    // or cursor change.
+    void refreshNodeControls();
+
+    // Shared onClick handler for the footer trigger/deform toggle buttons.
+    // Applies the clicked button's new state to every node in the active selection.
+    void toggleButtonClicked(int tag);
 
     MSEGStorage *ms = nullptr;
     MSEGEditor::State *eds = nullptr;
@@ -140,7 +176,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
     MSEGCanvas(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, MSEGEditor::State *eds,
                Surge::GUI::Skin::ptr_t skin, std::shared_ptr<SurgeImageStore> b,
                SurgeGUIEditor *sge)
-        : juce::Component("MSEG Canvas")
+        : juce::Component("MSEG Display")
     {
         setSkin(skin, b);
         this->storage = storage;
@@ -152,8 +188,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         handleDrawable = b->getImage(IDB_MSEG_NODES);
         timeEditMode = (MSEGCanvas::TimeEdit)eds->timeEditMode;
         setOpaque(true);
-        setTitle("MSEG Display and Edit Canvas");
-        setDescription("MSEG Display and Edit Canvas");
+        setTitle("MSEG Display/Editor");
+        setDescription("MSEG Display/Editor");
         setAccessible(true);
         setupAccessibleKeyboard();
     };
@@ -1444,47 +1480,17 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             }
             else
             {
-                bool useDottedPath = false; // use juce::Path and dotted. Slow AF on windows
-                bool useSolidPath = false;  // use juce::Path and solid. Fastest, but no dots
-                bool useHand = !(useDottedPath || useSolidPath); // Hand roll the lines. Fast enough
-
                 g.setColour(secondaryHGridColor);
 
-                if (useHand)
+                float x = drawArea.getX() - ticklen;
+                float xe = drawArea.getRight();
+
+                if (val != -1.f)
                 {
-                    float x = drawArea.getX() - ticklen;
-                    float xe = drawArea.getRight();
-
-                    if (val != -1.f)
+                    while (x < xe)
                     {
-                        while (x < xe)
-                        {
-                            g.drawLine(x, v, std::min(xe, x + 2), v, 0.5);
-                            x += 5;
-                        }
-                    }
-                }
-                else
-                {
-                    float dashLength[2] = {2.f, 5.f}; // 2 px dash 5 px gap
-                    auto dotted = juce::Path();
-                    auto markerLine = juce::Path();
-                    auto st = juce::PathStrokeType(0.5, juce::PathStrokeType::beveled,
-                                                   juce::PathStrokeType::butt);
-
-                    markerLine.startNewSubPath(drawArea.getX() - ticklen, v);
-                    markerLine.lineTo(drawArea.getRight(), v);
-
-                    // Can be any even size if you change the '2' below
-                    st.createDashedStroke(dotted, markerLine, dashLength, 2);
-
-                    if (useDottedPath)
-                    {
-                        g.strokePath(dotted, st);
-                    }
-                    else
-                    {
-                        g.strokePath(markerLine, st);
+                        g.drawLine(x, v, std::min(xe, x + 2), v, 0.5);
+                        x += 5;
                     }
                 }
             }
@@ -1623,6 +1629,18 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
         using type = MSEGStorage::segment::Type;
 
+        // recalcHotZones tags the trailing "end of the whole MSEG" hotzone
+        // (added once, only for the last segment) with the same
+        // associatedSegment as that segment's own start-node hotzone - see
+        // the two rectForPoint(..., SEGMENT_ENDPOINT, ...) calls there. That
+        // makes the two indistinguishable by associatedSegment alone. By
+        // construction order the start-node hotzone always comes first for a
+        // given associatedSegment, so the second SEGMENT_ENDPOINT occurrence
+        // is always the trailing one; treat it as node index
+        // associatedSegment+1 for cursor/selection matching below instead of
+        // colliding with the start node.
+        std::set<int> seenSegmentStartHotzone;
+
         for (const auto &h : hotzones)
         {
             if (h.type == hotzone::MOUSABLE_NODE)
@@ -1634,7 +1652,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
                 if (h.active)
                 {
-                    offy = isMouseDown ? 1 : 0;
+                    offy = 1;
                     showValue = isMouseDown;
                 }
 
@@ -1645,10 +1663,43 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                 }
 
                 if (h.zoneSubType == hotzone::SEGMENT_CONTROL)
+                {
                     offx = 1;
+                }
+                else
+                {
+                    int nodeIndex = h.associatedSegment;
 
-                if (!inZoomLasso && lassoSelector && lassoSelector->contains(h.associatedSegment))
-                    offy = 2;
+                    if (h.zoneSubType == hotzone::SEGMENT_ENDPOINT)
+                    {
+                        if (seenSegmentStartHotzone.count(h.associatedSegment))
+                        {
+                            nodeIndex = h.associatedSegment + 1;
+                        }
+                        else
+                        {
+                            seenSegmentStartHotzone.insert(h.associatedSegment);
+                        }
+                    }
+
+                    // we only want nodes to show they're selected, not control points
+                    // less visual distraction!
+                    if (!inZoomLasso && lassoSelector &&
+                        lassoSelector->contains(h.associatedSegment))
+                        offy = 2;
+                    else if (kbdHandler &&
+                             kbdHandler->mode == MSEGAccessibleKeyboardHandler::Mode::CURSOR &&
+                             !(lassoSelector && lassoSelector->items.getNumSelected() > 0) &&
+                             nodeIndex == kbdHandler->index)
+                    {
+                        // the keyboard cursor / footer "current node" NumberField
+                        // selection shares the same selected look as a lasso pick,
+                        // and applies regardless of where keyboard focus currently
+                        // sits so dragging the NumberField reads correctly even
+                        // when the canvas itself isn't focused
+                        offy = 2;
+                    }
+                }
 
                 auto r = h.rect;
 
@@ -1784,24 +1835,18 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             }
         }
 
-        paintKeyboardCursor(g);
-    }
-
-    void paintKeyboardCursor(juce::Graphics &g)
-    {
-        if (!hasKeyboardFocus(false))
-            return;
-
-        const float handleRadius = 6.5f; // matches recalcHotZones
-        auto valpx = valToPx();
-        auto tpx = timeToPx();
-        auto pos = kbdHandler->cursorPosition();
-        auto cx = tpx(pos.first);
-        auto cy = valpx(pos.second);
-
-        g.setColour(skin->getColor(Colors::MSEGEditor::CurveHighlight));
-        g.drawEllipse(cx - handleRadius - 2, cy - handleRadius - 2, 2 * (handleRadius + 2),
-                      2 * (handleRadius + 2), 2.f);
+        // Keyboard cursor visualization is now unified into the offy=2
+        // selected-node look above (see the MOUSABLE_NODE loop), instead of
+        // a separate ellipse overlay here.
+        //
+        // NOTE: this assumes kbdHandler->index always addresses one of the
+        // hotzones iterated above (i.e. index < ms->n_activeSegments). If the
+        // cursor can ever rest on the final endpoint (index == numNodes()),
+        // that position won't have a matching hotzone in this loop and will
+        // draw no highlight at all, silently regressing the old always-drawn
+        // ellipse. Flagging rather than guessing: MSEGEditorAccessibleKeyboard.cpp
+        // isn't available to me, so I can't confirm whether index ever reaches
+        // that value. Worth a quick check before this ships.
     }
 
     juce::Point<int> mouseDownOrigin, lastPanZoomMousePos, cursorHideOrigin;
@@ -1828,6 +1873,25 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         prepareForUndo();
 
         const auto drawArea = getDrawArea();
+
+        auto updateSelectedSegment = [this, drawArea](juce::Point<float> where,
+                                                      const bool gotLastHZ = false) {
+            if (drawArea.contains(where.toInt()) && kbdHandler && !gotLastHZ)
+            {
+                auto pxt = pxToTime();
+                auto t = pxt(where.getX());
+                int seg = (t < 0)                    ? 0
+                          : (t >= ms->totalDuration) ? std::max(0, ms->n_activeSegments - 1)
+                                                     : Surge::MSEG::timeToSegment(ms, t);
+
+                kbdHandler->setCursorNode(seg, false);
+
+                if (controlregion)
+                {
+                    controlregion->refreshNodeControls();
+                }
+            }
+        };
 
         mouseDownInitiation =
             (drawArea.contains(e.position.toInt()) ? MOUSE_DOWN_IN_DRAW_AREA
@@ -1857,6 +1921,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             if (mouseDownInitiation)
             {
                 openPopup(e.position);
+
+                updateSelectedSegment(e.position, false);
             }
 
             return;
@@ -1909,6 +1975,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             if (clearLasso)
             {
                 lassoSelector.reset(nullptr);
+                if (controlregion)
+                    controlregion->refreshNodeControls();
             }
             repaint();
         }
@@ -1960,9 +2028,22 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         inDrag = true;
 
         bool gotHZ = false;
+        bool gotLastHZ = false;
+
+        std::set<int> seenSegmentStartHotzone;
 
         for (auto &h : hotzones)
         {
+            int nodeIndex = h.associatedSegment;
+
+            if (h.type == hotzone::MOUSABLE_NODE && h.zoneSubType == hotzone::SEGMENT_ENDPOINT)
+            {
+                if (seenSegmentStartHotzone.count(h.associatedSegment))
+                    nodeIndex = h.associatedSegment + 1;
+                else
+                    seenSegmentStartHotzone.insert(h.associatedSegment);
+            }
+
             if (h.rect.contains(where) && h.type == hotzone::MOUSABLE_NODE)
             {
                 gotHZ = true;
@@ -1972,12 +2053,21 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                 h.active = true;
                 h.dragging = true;
 
+                if (h.zoneSubType == hotzone::SEGMENT_ENDPOINT && kbdHandler)
+                {
+                    gotLastHZ = true;
+                    kbdHandler->setCursorNode(nodeIndex, false);
+
+                    if (controlregion)
+                    {
+                        controlregion->refreshNodeControls();
+                    }
+                }
+
                 repaint();
 
-                /*
-                 * Activate temporary snap. Note this is also handled similarly in
-                 * onMouseMoved so if you change ctrl/alt here change it there too
-                 */
+                // Activate temporary snap. Note this is also handled similarly in
+                // onMouseMoved so if you change ctrl/alt here change it there too
                 bool c = e.mods.isCommandDown();
                 bool a = e.mods.isAltDown();
 
@@ -2012,6 +2102,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             // Lin doesn't cursor hide so this hand is bad there
             setMouseCursor(juce::MouseCursor::DraggingHandCursor);
         }
+
+        updateSelectedSegment(where, gotLastHZ);
 
         return;
     }
@@ -2180,6 +2272,11 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             if (lassoSelector && lassoSelector->items.getNumSelected() == 0)
             {
                 lassoSelector.reset(nullptr);
+            }
+
+            if (controlregion)
+            {
+                controlregion->refreshNodeControls();
             }
 
             return;
@@ -2912,6 +3009,29 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                 hoveredSegment = -1;
                 repaint();
             }
+        }
+
+        bool anyActiveChanged = false;
+
+        for (auto &h : hotzones)
+        {
+            if (h.type != hotzone::MOUSABLE_NODE)
+            {
+                continue;
+            }
+
+            bool nowActive = h.rect.contains(where.toFloat());
+
+            if (nowActive != h.active)
+            {
+                h.active = nowActive;
+                anyActiveChanged = true;
+            }
+        }
+
+        if (anyActiveChanged)
+        {
+            repaint();
         }
 
         bool reset = false;
@@ -3819,6 +3939,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                                             !this->ms->segments[tts].retriggerFEG;
                                         pushToUndo();
                                         modelChanged();
+                                        if (controlregion)
+                                            controlregion->refreshNodeControls();
                                     });
 
                 triggerMenu.addItem(Surge::GUI::toOSCase("Amp EG"), true,
@@ -3827,6 +3949,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                                             !this->ms->segments[tts].retriggerAEG;
                                         pushToUndo();
                                         modelChanged();
+                                        if (controlregion)
+                                            controlregion->refreshNodeControls();
                                     });
 
                 triggerMenu.addSeparator();
@@ -3836,6 +3960,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                     this->ms->segments[tts].retriggerAEG = false;
                     pushToUndo();
                     modelChanged();
+                    if (controlregion)
+                        controlregion->refreshNodeControls();
                 });
 
                 triggerMenu.addItem(Surge::GUI::toOSCase("All"), [this, tts]() {
@@ -3843,6 +3969,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                     this->ms->segments[tts].retriggerAEG = true;
                     pushToUndo();
                     modelChanged();
+                    if (controlregion)
+                        controlregion->refreshNodeControls();
                 });
 
                 contextMenu.addSubMenu("Trigger", triggerMenu);
@@ -3851,7 +3979,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             auto settingsMenu = juce::PopupMenu();
 
             settingsMenu.addItem(
-                Surge::GUI::toOSCase("Link Start and End Nodes"), true,
+                Surge::GUI::toOSCase("Link Edge Nodes"), true,
                 (ms->endpointMode == MSEGStorage::EndpointMode::LOCKED), [this]() {
                     pushToUndo();
                     if (this->ms->endpointMode == MSEGStorage::EndpointMode::LOCKED)
@@ -3868,12 +3996,14 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
             settingsMenu.addSeparator();
 
-            settingsMenu.addItem(Surge::GUI::toOSCase("Deform Applied to Segment"), true,
+            settingsMenu.addItem(Surge::GUI::toOSCase("Use Deform for Segment"), true,
                                  ms->segments[tts].useDeform, [this, tts]() {
                                      this->ms->segments[tts].useDeform =
                                          !this->ms->segments[tts].useDeform;
                                      pushToUndo();
                                      modelChanged();
+                                     if (controlregion)
+                                         controlregion->refreshNodeControls();
                                  });
 
             settingsMenu.addItem(Surge::GUI::toOSCase("Invert Deform Value"), true,
@@ -3882,6 +4012,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                                          !this->ms->segments[tts].invertDeform;
                                      pushToUndo();
                                      modelChanged();
+                                     if (controlregion)
+                                         controlregion->refreshNodeControls();
                                  });
 
             contextMenu.addSubMenu("Settings", settingsMenu);
@@ -3911,6 +4043,11 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
         onModelChanged();
 
         kbdHandler->revalidateCursor(!kbdHandler->inFlightEdit);
+
+        if (controlregion)
+        {
+            controlregion->refreshNodeControls();
+        }
 
         repaint();
     }
@@ -4129,7 +4266,11 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             }
             repaint();
         };
-        cbk.repaint = [this]() { repaint(); };
+        cbk.repaint = [this]() {
+            repaint();
+            if (controlregion)
+                controlregion->refreshNodeControls();
+        };
     }
 
     bool keyPressed(const juce::KeyPress &key) override
@@ -4145,6 +4286,8 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
     {
         kbdHandler->revalidateCursor(false);
         kbdHandler->announceFocus();
+        if (controlregion)
+            controlregion->refreshNodeControls();
         repaint();
     }
 
@@ -4256,6 +4399,25 @@ void MSEGControlRegion::valueChanged(Surge::GUI::IComponentTagValue *p)
             ms->hSnap = ms->hSnapDefault;
         if (canvas)
             canvas->repaint();
+        break;
+    }
+    case tag_node_select:
+    {
+        if (canvas && canvas->kbdHandler)
+        {
+            int v = nodeSelect->getIntValue();
+
+            // top value (== nodeCount) is the "Multi" slot: dragging into it
+            // has no node to select, so just leave the existing selection
+            // (if any) alone and refresh the display back to whatever it
+            // should read.
+            if (v < nodeSelect->nodeCount)
+            {
+                canvas->kbdHandler->setCursorNode(v, false);
+                canvas->repaint();
+            }
+        }
+        refreshNodeControls();
         break;
     }
     default:
@@ -4495,6 +4657,135 @@ void MSEGControlRegion::hvSnapTypein(bool isH)
     };
 }
 
+std::vector<int> MSEGControlRegion::activeNodeSelection() const
+{
+    if (canvas && canvas->kbdHandler)
+    {
+        auto sel = canvas->kbdHandler->cb.getSelection();
+        if (!sel.empty())
+            return sel;
+
+        return {canvas->kbdHandler->index};
+    }
+    return {0};
+}
+
+int MSEGControlRegion::representativeNodeForSelection(const std::vector<int> &sel) const
+{
+    // Lassos never produce disjoint selections (a new shift+drag replaces
+    // rather than extends one), so picking the node with the longest segment
+    // duration is a stable proxy for "the node most recently touched."
+    int best = sel.empty() ? 0 : sel.front();
+    float bestDuration = -1.f;
+
+    for (auto i : sel)
+    {
+        if (i < 0 || i >= ms->n_activeSegments)
+            continue;
+
+        if (ms->segments[i].duration > bestDuration)
+        {
+            bestDuration = ms->segments[i].duration;
+            best = i;
+        }
+    }
+    return best;
+}
+
+void MSEGControlRegion::toggleButtonClicked(int tag)
+{
+    if (!canvas)
+        return;
+
+    auto sel = activeNodeSelection();
+
+    canvas->prepareForUndo();
+
+    for (auto i : sel)
+    {
+        if (i < 0 || i >= ms->n_activeSegments)
+            continue;
+
+        switch (tag)
+        {
+        case tag_deform_use:
+            ms->segments[i].useDeform = deformUseButton->getToggleState();
+            break;
+        case tag_deform_invert:
+            ms->segments[i].invertDeform = deformInvertButton->getToggleState();
+            break;
+        case tag_trigger_filter_eg:
+            ms->segments[i].retriggerFEG = triggerFilterButton->getToggleState();
+            break;
+        case tag_trigger_amp_eg:
+            ms->segments[i].retriggerAEG = triggerAmpButton->getToggleState();
+            break;
+        default:
+            break;
+        }
+    }
+
+    canvas->pushToUndo();
+    canvas->modelChanged();
+    canvas->repaint();
+}
+
+void MSEGControlRegion::refreshNodeControls()
+{
+    bool haveCanvas = (canvas && canvas->kbdHandler);
+    int nodeCount = haveCanvas ? canvas->kbdHandler->numNodes() : ms->n_activeSegments;
+
+    if (nodeSelect)
+    {
+        nodeSelect->setNodeCount(nodeCount);
+
+        auto sel = haveCanvas ? canvas->kbdHandler->cb.getSelection() : std::vector<int>();
+
+        if (sel.size() > 1)
+        {
+            // dragging past the last real node reads as "Multi"; land exactly
+            // on that slot to reflect an existing multi-node selection
+            nodeSelect->setIntValue(nodeCount, true);
+        }
+        else
+        {
+            int cur = haveCanvas ? canvas->kbdHandler->index : 0;
+            nodeSelect->setIntValue(cur, true);
+        }
+    }
+
+    auto sel = activeNodeSelection();
+    int rep = representativeNodeForSelection(sel);
+
+    bool haveRep = (rep >= 0 && rep < ms->n_activeSegments);
+
+    if (!isSceneMSEG())
+    {
+        if (triggerFilterButton)
+        {
+            triggerFilterButton->setToggleState(haveRep && ms->segments[rep].retriggerFEG,
+                                                juce::dontSendNotification);
+        }
+        if (triggerAmpButton)
+        {
+            triggerAmpButton->setToggleState(haveRep && ms->segments[rep].retriggerAEG,
+                                             juce::dontSendNotification);
+        }
+    }
+
+    if (deformUseButton)
+    {
+        deformUseButton->setToggleState(haveRep && ms->segments[rep].useDeform,
+                                        juce::dontSendNotification);
+    }
+
+    if (deformInvertButton)
+    {
+        deformInvertButton->setToggleState(haveRep && ms->segments[rep].invertDeform,
+                                           juce::dontSendNotification);
+    }
+}
+
 void MSEGControlRegion::rebuild()
 {
     removeAllChildren();
@@ -4512,7 +4803,7 @@ void MSEGControlRegion::rebuild()
 
     // movement modes
     {
-        int segWidth = 110;
+        int segWidth = 104;
         int marginPos = xpos + margin;
         int btnWidth = 94;
         int ypos = 1;
@@ -4565,12 +4856,12 @@ void MSEGControlRegion::rebuild()
         movementMode->setupAccessibility();
         // this value centers the loop mode and snap sections against the MSEG editor width
         // if more controls are to be added to that center section, reduce this value
-        xpos += 173;
+        xpos += segWidth;
     }
 
     // edit mode
     {
-        int segWidth = 107;
+        int segWidth = 100;
         int btnWidth = 90;
         int ypos = 1;
 
@@ -4616,7 +4907,7 @@ void MSEGControlRegion::rebuild()
 
     // loop mode
     {
-        int segWidth = 110;
+        int segWidth = 104;
         int btnWidth = 94;
         int ypos = 1;
 
@@ -4771,7 +5062,128 @@ void MSEGControlRegion::rebuild()
         vSnapSize->setDescription("Vertical Snap Grid, divisions per unit");
         vSnapSize->setExplicitFocusOrder(70);
         addAndMakeVisible(*vSnapSize);
+
+        xpos += segWidth;
     }
+
+    // selected node
+    {
+        int segWidth = 46;
+        int editWidth = 32;
+        int ypos = 1;
+
+        auto mml = std::make_unique<juce::Label>();
+        mml->setText("Selected", juce::dontSendNotification);
+        mml->setFont(labelFont);
+        mml->setColour(juce::Label::textColourId, skin->getColor(Colors::MSEGEditor::Text));
+        mml->setBounds(xpos - 1, ypos, segWidth, labelHeight);
+        addAndMakeVisible(*mml);
+        labels.push_back(std::move(mml));
+
+        ypos += margin + labelHeight;
+
+        nodeSelect = std::make_unique<Surge::Widgets::NumberField>();
+        nodeSelect->setTag(tag_node_select);
+        nodeSelect->setControlMode(Surge::Skin::Parameters::MSEG_NODE_SELECT);
+        nodeSelect->addListener(this);
+        nodeSelect->setStorage(storage);
+        nodeSelect->setSkin(skin, associatedBitmapStore);
+        nodeSelect->setBounds(xpos + 5, ypos, editWidth, numfieldHeight);
+        auto nsImages =
+            skin->standardHoverAndHoverOnForIDB(IDB_MSEG_SNAPVALUE_NUMFIELD, associatedBitmapStore);
+        nodeSelect->setBackgroundDrawable(nsImages[0]);
+        nodeSelect->setHoverBackgroundDrawable(nsImages[1]);
+        nodeSelect->setTextColour(skin->getColor(Colors::MSEGEditor::NumberField::Text));
+        nodeSelect->setHoverTextColour(skin->getColor(Colors::MSEGEditor::NumberField::TextHover));
+        nodeSelect->setTitle("Selected Node");
+        nodeSelect->setDescription("Selected Node");
+        nodeSelect->setExplicitFocusOrder(80);
+        addAndMakeVisible(*nodeSelect);
+
+        xpos += segWidth;
+    }
+
+    // checkboxes
+    const bool showTrigger = !isSceneMSEG();
+    const int boxW = 12, boxH = 12;
+    const int rowH = 14;
+    int ypos = 1;
+
+    auto makeToggleRow = [&](std::unique_ptr<juce::ToggleButton> &btn,
+                             std::unique_ptr<juce::Label> &lbl, const std::string &title, int tag,
+                             int colXOffset, int colWidth) {
+        auto boxRect = juce::Rectangle<int>(xpos + colXOffset, ypos, boxW + 2, boxH);
+        auto labelRect =
+            juce::Rectangle<int>(xpos + colXOffset + boxW + 1, ypos - 1, colWidth - boxW, rowH);
+
+        lbl = std::make_unique<juce::Label>();
+        lbl->setText(Surge::GUI::toOSCase(title), juce::dontSendNotification);
+        lbl->setFont(editFont);
+        lbl->setColour(juce::Label::textColourId, skin->getColor(Colors::MSEGEditor::Text));
+        lbl->setColour(juce::Label::backgroundColourId, juce::Colours::transparentBlack);
+        lbl->setBounds(labelRect);
+        addAndMakeVisible(*lbl);
+
+        btn = std::make_unique<juce::ToggleButton>();
+        btn->setButtonText("");
+        btn->setTitle(title);
+        btn->setDescription(title);
+        btn->setBounds(boxRect);
+        btn->setAlwaysOnTop(true);
+        btn->onClick = [this, tag]() { this->toggleButtonClicked(tag); };
+        addAndMakeVisible(*btn);
+    };
+
+    // deform
+    {
+        int segWidth = 87;
+
+        auto mml = std::make_unique<juce::Label>();
+        mml->setText("Deform", juce::dontSendNotification);
+        mml->setFont(labelFont);
+        mml->setColour(juce::Label::textColourId, skin->getColor(Colors::MSEGEditor::Text));
+        mml->setBounds(xpos, ypos, segWidth, labelHeight);
+        addAndMakeVisible(*mml);
+        labels.push_back(std::move(mml));
+
+        ypos += margin + labelHeight;
+
+        int useColWidth = 40, invertColWidth = segWidth - useColWidth;
+
+        makeToggleRow(deformUseButton, deformUseLabel, "Use", tag_deform_use, 0, useColWidth);
+        makeToggleRow(deformInvertButton, deformInvertLabel, "Invert", tag_deform_invert,
+                      useColWidth - 3, invertColWidth);
+
+        xpos += segWidth;
+    }
+
+    // trigger EG
+    if (showTrigger)
+    {
+        int segWidth = 94;
+        ypos = 1;
+
+        auto mml = std::make_unique<juce::Label>();
+        mml->setText("Trigger EG", juce::dontSendNotification);
+        mml->setFont(labelFont);
+        mml->setColour(juce::Label::textColourId, skin->getColor(Colors::MSEGEditor::Text));
+        mml->setBounds(xpos, ypos, segWidth, labelHeight);
+        addAndMakeVisible(*mml);
+        labels.push_back(std::move(mml));
+
+        ypos += margin + labelHeight;
+
+        const int filterColWidth = 44, ampColWidth = segWidth - filterColWidth;
+
+        makeToggleRow(triggerFilterButton, triggerFilterLabel, "Filter", tag_trigger_filter_eg, 0,
+                      filterColWidth);
+        makeToggleRow(triggerAmpButton, triggerAmpLabel, "Amp", tag_trigger_amp_eg,
+                      filterColWidth - 1, ampColWidth);
+
+        xpos += segWidth;
+    }
+
+    refreshNodeControls();
 }
 
 MSEGEditor::MSEGEditor(SurgeStorage *storage, LFOStorage *lfodata, MSEGStorage *ms, State *eds,

--- a/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
@@ -120,6 +120,25 @@ float quantizeValue(float v, float snapResolution)
 }
 } // namespace
 
+void MSEGAccessibleKeyboardHandler::setCursorNode(int node, bool announceResult)
+{
+    if (mode == Mode::SELECTION)
+    {
+        // dragging the footer NumberField always collapses to a single node
+        exitSelection();
+    }
+
+    // placeCursorOnNode is the same primitive Tab/Shift+Tab and mouse-driven
+    // focus already use to move the cursor (clamping, rememberedTime, and
+    // cb.repaint are all handled there).
+    placeCursorOnNode(node);
+
+    if (announceResult)
+    {
+        announceCursor();
+    }
+}
+
 int MSEGAccessibleKeyboardHandler::numNodes() const { return ms->n_activeSegments + 1; }
 
 float MSEGAccessibleKeyboardHandler::nodeTime(int i) const
@@ -144,7 +163,7 @@ bool MSEGAccessibleKeyboardHandler::controlPointUsable(int seg) const
 
 bool MSEGAccessibleKeyboardHandler::controlPointIs2D(int seg) const
 {
-    auto t = ms->segments[seg].type;
+    const auto t = ms->segments[seg].type;
     return t == MSEGStorage::segment::QUAD_BEZIER || t == MSEGStorage::segment::BROWNIAN ||
            (t >= MSEGStorage::segment::RATCHET_1 && t <= MSEGStorage::segment::RATCHET_8);
 }

--- a/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
@@ -987,7 +987,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
             if (!controlPointUsable(seg))
             {
                 if (cb.announce)
-                    cb.announce("No control point on this segment");
+                    cb.announce("No control point for this segment type!");
                 return true;
             }
 
@@ -1005,7 +1005,8 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
         if (cb.getTimeEditMode && cb.getTimeEditMode() == kTimeEditDraw)
         {
             if (cb.announce)
-                cb.announce("Horizontal movement is disabled while Draw is on");
+                cb.announce(
+                    "Horizontal movement is disabled while Draw movement mode is selected!");
             return true;
         }
 
@@ -1047,7 +1048,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
             if (!controlPointUsable(seg))
             {
                 if (cb.announce)
-                    cb.announce("No control point on this segment");
+                    cb.announce("No control point for this segment type!");
                 return true;
             }
 
@@ -1080,7 +1081,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
 
     if (kc == juce::KeyPress::homeKey || kc == juce::KeyPress::endKey)
     {
-        auto pre = std::string(hasSelection() ? "Selection cleared. " : "");
+        auto pre = std::string(hasSelection() ? "Selection cleared!" : "");
         if (!pre.empty())
             clearSelection();
 
@@ -1108,7 +1109,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
             return true;
         }
 
-        auto pre = std::string(hasSelection() ? "Selection cleared. " : "");
+        auto pre = std::string(hasSelection() ? "Selection cleared!" : "");
         if (!pre.empty())
             clearSelection();
 
@@ -1127,7 +1128,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
             if (!controlPointUsable(seg))
             {
                 if (cb.announce)
-                    cb.announce("No control point on this segment");
+                    cb.announce("No control point for this segment type!");
                 return true;
             }
 
@@ -1141,13 +1142,13 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
             if (ms->endpointMode == MSEGStorage::EndpointMode::LOCKED)
             {
                 if (cb.announce)
-                    cb.announce("Editing start node value, linked endpoints");
+                    cb.announce("Editing start node value, linked edge nodes");
                 if (cb.showTypein)
                     cb.showTypein(0, kTypeinValue);
             }
             else if (cb.announce)
             {
-                cb.announce("No type-in for the final node, use arrow keys");
+                cb.announce("No type-in for the final node, use arrow keys!");
             }
         }
         else if (cb.showTypein)
@@ -1185,7 +1186,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
         if (hasSelection())
         {
             if (cb.announce)
-                cb.announce("Clear the selection first to add a node");
+                cb.announce("Clear the selection first to add a node!");
             return true;
         }
         addNode(mods.isShiftDown());

--- a/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.h
+++ b/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.h
@@ -96,6 +96,12 @@ struct MSEGAccessibleKeyboardHandler
     void announceFocus();
     void announceEditorState();
 
+    // Externally driven cursor placement (e.g. from the "current node"
+    // NumberField in the footer). Exits any active selection, moves the
+    // cursor to node, and optionally announces the move for accessibility
+    // parity with keyboard-driven navigation.
+    void setCursorNode(int node, bool announceResult);
+
     // geometry of the cursor for the canvas's visual highlight
     int numNodes() const;
     float nodeTime(int i) const;

--- a/src/surge-xt/gui/widgets/NumberField.cpp
+++ b/src/surge-xt/gui/widgets/NumberField.cpp
@@ -70,6 +70,12 @@ std::string NumberField::valueToDisplay() const
         oss << respt;
     }
     break;
+    case Skin::Parameters::MSEG_NODE_SELECT:
+        if (iValue >= nodeCount)
+            oss << "Multi";
+        else
+            oss << (iValue + 1);
+        break;
     default:
         if (extended)
             return fmt::format("{:.2f}", (float)(iValue / 100.0));
@@ -149,8 +155,24 @@ void NumberField::setControlMode(Surge::Skin::Parameters::NumberfieldControlMode
         iMin = 1;
         iMax = 256;
         break;
+    case Skin::Parameters::MSEG_NODE_SELECT:
+        iMin = 0;
+        iMax = nodeCount; // top value == nodeCount reads as "Multi"
+        break;
     }
     bounceToInt();
+}
+
+void NumberField::setNodeCount(int n)
+{
+    nodeCount = std::max(0, n);
+    if (controlMode == Skin::Parameters::MSEG_NODE_SELECT)
+    {
+        iMax = nodeCount;
+        iValue = limit_range(iValue, iMin, iMax);
+        bounceToInt();
+        repaint();
+    }
 }
 
 void NumberField::mouseDown(const juce::MouseEvent &event)

--- a/src/surge-xt/gui/widgets/NumberField.h
+++ b/src/surge-xt/gui/widgets/NumberField.h
@@ -61,11 +61,12 @@ struct NumberField : public juce::Component,
     }
     float getValue() const override { return value; }
     int getIntValue() const { return iValue; }
-    void setIntValue(int v)
+    void setIntValue(int v, const bool silent = false)
     {
         value = Parameter::intScaledToFloat(v, iMax, iMin);
         bounceToInt();
-        notifyValueChanged();
+        if (!silent)
+            notifyValueChanged();
         repaint();
     }
 
@@ -87,6 +88,13 @@ struct NumberField : public juce::Component,
     void setControlMode(Surge::Skin::Parameters::NumberfieldControlModes n,
                         bool isExtended = false);
     Surge::Skin::Parameters::NumberfieldControlModes getControlMode() const { return controlMode; }
+
+    // MSEG_NODE_SELECT only: how many selectable nodes currently exist in the
+    // MSEG. iMax tracks nodeCount, so the field's top value (iMax) is one past
+    // the last real node index and reads as "Multi" in valueToDisplay. Callers
+    // update this whenever the segment count changes (rebuild, add/delete node).
+    int nodeCount{1};
+    void setNodeCount(int n);
 
     enum MouseMode
     {


### PR DESCRIPTION
Add widgets to MSEG footer to select a particular node and adjust its deform and envelope trigger options (this for voice MSEG only of course).

These widgets are synchronized with accessible keyboard navigation and update when selected node is changed either via mouse or keyboard.

Removed tacked-on keyboard focus circle and used graphics assets for nodes that we already have (use the same state as when we click on a node with the mouse).

Hovered node graphics asset was never used because we never updated h.active in mouseMove(), now we do and it's a lot better!

Renamed "Link Start and End Nodes" to "Link Edge Nodes".

Renamed "Deform Applied to Segment" to "Use Deform for Segment".

Fix squiggly deform for ratchet segment type (floating point precision thing? anyways it should have stopped at linear but it didn't, now it does).

Removed dead code for dashed line painting.

Fixed the bug where clicking the second to last node selected the last node alongside.

Changed how we paint the ToggleButton in LookAndFeel - filled roundrect instead of a ticked roundrect. This allows us to make smaller tickboxes without the tick itself looking too tiny.

Adjusted verbiage of some accessible announcements.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>