### PR TITLE
Tweak the look of tickboxes

### DIFF
--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -493,7 +493,8 @@ void SurgeJUCELookAndFeel::drawToggleButton(Graphics &g, ToggleButton &button,
                                             bool shouldDrawButtonAsHighlighted,
                                             bool shouldDrawButtonAsDown)
 {
-    auto tickWidth = jmin(15.0f, (float)button.getHeight() * 0.75f) * 1.2f;
+    const auto tickWidth = jmin(15.0f, (float)button.getHeight() * 0.75f) * 1.2f;
+    constexpr auto rectRadius = 2.f;
 
     juce::Rectangle<float> tickBounds(2.f, ((float)button.getHeight() - tickWidth) * 0.5f,
                                       tickWidth, tickWidth);
@@ -503,10 +504,12 @@ void SurgeJUCELookAndFeel::drawToggleButton(Graphics &g, ToggleButton &button,
     if (!button.isEnabled())
         g.setOpacity(0.5f);
 
-    g.drawRoundedRectangle(tickBounds, 4.0f, 1.0f);
+    g.drawRoundedRectangle(tickBounds, rectRadius, 1.0f);
+
+    g.setColour(button.findColour(ToggleButton::tickColourId).withAlpha(0.666f));
 
     if (button.getToggleState())
-        g.fillRoundedRectangle(tickBounds, 4.0f);
+        g.fillRoundedRectangle(tickBounds.reduced(2.f), rectRadius * 0.5f);
 
     g.setColour(button.findColour(ToggleButton::textColourId));
     g.setFont(skin->fontManager->getLatoAtSize(9));

--- a/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
+++ b/src/surge-xt/gui/overlays/KeyBindingsOverlay.cpp
@@ -178,8 +178,9 @@ struct KeyBindingsListRow : public juce::Component
     void resized() override
     {
         auto r = getLocalBounds().reduced(2);
-        auto a1 = r.withWidth(r.getHeight() * 1.5);
-        auto at = r.withTrimmedLeft(r.getHeight() * 1.5);
+        const auto h = r.getHeight() * 0.7;
+        auto a1 = r.withSizeKeepingCentre(h + 2, h).withX(r.getX() + 4);
+        auto at = r.withTrimmedLeft(r.getHeight());
         auto a2 = at.withTrimmedRight(120);
         auto a3 = at.withTrimmedLeft(at.getWidth() - 120);
 

--- a/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
+++ b/src/surge-xt/gui/overlays/PatchStoreDialog.cpp
@@ -446,31 +446,27 @@ void PatchStoreDialog::resized()
         int boxW = 17;
         int boxY = checkboxRowY + (checkboxRowH - boxH) / 2;
 
-        auto tuningBox = juce::Rectangle<int>(margin, boxY, boxW, boxH);
-        auto tuningLabel = juce::Rectangle<int>(margin + boxW, checkboxRowY,
-                                                halfW - (margin + boxW + margin), checkboxRowH);
+        auto box1 = juce::Rectangle<int>(margin, boxY, boxW, boxH);
+        auto label1 = juce::Rectangle<int>(margin + boxW, checkboxRowY,
+                                           halfW - (margin + boxW + margin), checkboxRowH);
 
-        auto snapBox = juce::Rectangle<int>(halfW + margin, boxY, boxW, boxH);
-        auto snapLabel = juce::Rectangle<int>(halfW + margin + boxW, checkboxRowY,
-                                              halfW - (margin + boxW + margin), checkboxRowH);
+        auto box2 = juce::Rectangle<int>(halfW + margin, boxY, boxW, boxH);
+        auto label2 = juce::Rectangle<int>(halfW + margin + boxW, checkboxRowY,
+                                           halfW - (margin + boxW + margin), checkboxRowH);
 
-        storeTuningLabel->setVisible(true);
-        storeTuningLabel->setBounds(tuningLabel);
-        storeTuningLabel->setEnabled(showTuning);
-        storeTuningLabel->setAlpha(showTuning ? 1.0f : 0.5f);
-        storeTuningButton->setVisible(true);
-        storeTuningButton->setEnabled(showTuning);
-        storeTuningButton->setAlpha(showTuning ? 1.0f : 0.5f);
-        storeTuningButton->setBounds(tuningBox);
+        storeTuningLabel->setVisible(showTuning);
+        storeTuningLabel->setBounds(label1);
+
+        storeTuningLabel->setVisible(showTuning);
+        storeTuningButton->setVisible(showTuning);
+        storeTuningButton->setBounds(box1);
 
         storeSnapshotsLabel->setVisible(true);
-        storeSnapshotsLabel->setBounds(snapLabel);
-        storeSnapshotsLabel->setEnabled(hasSnapshots);
-        storeSnapshotsLabel->setAlpha(hasSnapshots ? 1.0f : 0.5f);
-        storeSnapshotsButton->setVisible(true);
+        storeSnapshotsLabel->setBounds(showTuning ? label2 : label1);
+        storeSnapshotsLabel->setVisible(hasSnapshots);
+        storeSnapshotsButton->setVisible(hasSnapshots);
         storeSnapshotsButton->setEnabled(hasSnapshots);
-        storeSnapshotsButton->setAlpha(hasSnapshots ? 1.0f : 0.5f);
-        storeSnapshotsButton->setBounds(snapBox);
+        storeSnapshotsButton->setBounds(showTuning ? box2 : box1);
     }
     else
     {


### PR DESCRIPTION
Affects patch save dialog, MSEG editor, keyboard shortcuts editor.

Also, in patch save dialog, hide the WTSE snapshot checkbox completely if we have a tuning to save. Only show checkboxes that apply. If we don't have a tuning to save but we do have WTSE snapshots to save, then that checkbox will take the place of Save Tuning checkbox, too.