### PR TITLE
Add some more MSEG keybinds

### DIFF
--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -84,37 +84,25 @@ struct MSEGControlRegion : public juce::Component,
         : juce::Component("MSEG Settings")
     {
         setSkin(skin, b);
+
         this->ms = ms;
         this->eds = eds;
         this->lfodata = lfos;
         this->canvas = c;
         this->storage = storage;
         this->sge = sge;
+
         setAccessible(true);
         setTitle("MSEG Settings");
         setDescription("MSEG Settings");
+        setWantsKeyboardFocus(true);
+
         // Accessibility grouping only. A keyboardFocusContainer here would wall the
         // widgets off from the overlay's tab order while the region itself never
         // takes focus, leaving them unreachable by tab.
         setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
-        rebuild();
-    };
 
-    enum ControlTags
-    {
-        tag_segment_nodeedit_mode = 1231231, // Just to push outside any ID range
-        tag_segment_movement_mode,
-        tag_vertical_snap,
-        tag_vertical_value,
-        tag_horizontal_snap,
-        tag_horizontal_value,
-        tag_loop_mode,
-        tag_edit_mode,
-        tag_node_select,
-        tag_deform_use,
-        tag_deform_invert,
-        tag_trigger_filter_eg,
-        tag_trigger_amp_eg,
+        rebuild();
     };
 
     std::unique_ptr<Surge::Overlays::TypeinLambdaEditor> typeinEditor;
@@ -171,6 +159,8 @@ struct MSEGControlRegion : public juce::Component,
     LFOStorage *lfodata = nullptr;
     SurgeStorage *storage = nullptr;
     SurgeGUIEditor *sge = nullptr;
+
+    bool keyPressed(const juce::KeyPress &key) override;
 };
 
 struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComponent
@@ -4355,6 +4345,116 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
             if (controlregion)
                 controlregion->refreshNodeControls();
         };
+        cbk.toggleOrRotate = [this](int tag) -> std::string {
+            if (!controlregion)
+                return "";
+
+            bool toggleState = false;
+
+            switch (tag)
+            {
+            case tag_segment_movement_mode:
+            {
+                int m = (timeEditMode + 1) % 3;
+
+                timeEditMode = (TimeEdit)m;
+                eds->timeEditMode = m;
+                controlregion->movementMode->setValue(float(m) / 2.f);
+
+                recalcHotZones(juce::Point<int>(0, 0));
+
+                controlregion->repaint();
+                repaint();
+
+                return controlregion->movementMode->accessibleCellLabels[m];
+            }
+            case tag_edit_mode:
+            {
+                int m = ms->editMode;
+                const auto editMode = (MSEGStorage::EditMode)!m;
+
+                prepareForUndo();
+                pushToUndo();
+
+                Surge::MSEG::modifyEditMode(this->ms, editMode);
+
+                controlregion->editMode->setValue(!m);
+
+                // zoom to fit
+                ms->axisStart = 0.f;
+                ms->axisWidth = editMode ? 1.f : ms->envelopeModeDuration;
+
+                modelChanged(0, false);
+
+                repaint();
+                controlregion->repaint();
+
+                return controlregion->editMode->accessibleCellLabels[m];
+            }
+            case tag_loop_mode:
+            {
+                prepareForUndo();
+                pushToUndo();
+
+                if (ms->loopMode == MSEGStorage::LoopMode::ONESHOT)
+                    ms->loopMode = MSEGStorage::LoopMode::LOOP;
+                else if (ms->loopMode == MSEGStorage::LoopMode::LOOP)
+                    ms->loopMode = MSEGStorage::LoopMode::GATED_LOOP;
+                else
+                    ms->loopMode = MSEGStorage::LoopMode::ONESHOT;
+
+                const auto m = (float)ms->loopMode - 1.f;
+                controlregion->loopMode->setValue(m / 2.f);
+
+                modelChanged();
+
+                repaint();
+                controlregion->repaint();
+
+                return controlregion->loopMode->accessibleCellLabels[(int)m];
+            }
+            case tag_deform_use:
+            {
+                toggleState = !controlregion->deformUseButton->getToggleState();
+                controlregion->deformUseButton->setToggleState(toggleState,
+                                                               juce::dontSendNotification);
+                controlregion->toggleButtonClicked(tag);
+                controlregion->repaint();
+                break;
+            }
+            case tag_deform_invert:
+            {
+                toggleState = !controlregion->deformInvertButton->getToggleState();
+                controlregion->deformInvertButton->setToggleState(toggleState,
+                                                                  juce::dontSendNotification);
+                controlregion->toggleButtonClicked(tag);
+                controlregion->repaint();
+                break;
+            }
+            case tag_trigger_filter_eg:
+            {
+                toggleState = !controlregion->triggerFilterButton->getToggleState();
+                controlregion->triggerFilterButton->setToggleState(toggleState,
+                                                                   juce::dontSendNotification);
+                controlregion->toggleButtonClicked(tag);
+                controlregion->repaint();
+                break;
+            }
+            case tag_trigger_amp_eg:
+            {
+                toggleState = !controlregion->triggerAmpButton->getToggleState();
+                controlregion->triggerAmpButton->setToggleState(toggleState,
+                                                                juce::dontSendNotification);
+                controlregion->toggleButtonClicked(tag);
+                controlregion->repaint();
+                break;
+            }
+            break;
+            }
+
+            // multibuttons return early so this is fine for toggles
+            return toggleState ? "enabled" : "disabled";
+        };
     }
 
     bool keyPressed(const juce::KeyPress &key) override
@@ -4397,6 +4497,18 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
                 }));
     }
 };
+
+bool MSEGControlRegion::keyPressed(const juce::KeyPress &key)
+{
+    if (canvas && canvas->kbdHandler)
+    {
+        if (hasKeyboardFocus(false))
+        {
+            return canvas->kbdHandler->processKey(key);
+        }
+    }
+    return false;
+}
 
 void MSEGControlRegion::valueChanged(Surge::GUI::IComponentTagValue *p)
 {

--- a/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.cpp
@@ -501,7 +501,7 @@ void MSEGAccessibleKeyboardHandler::addNode(bool append)
     if (N >= max_msegs)
     {
         if (cb.announce)
-            cb.announce(fmt::format("Maximum {} segments reached", max_msegs));
+            cb.announce("Maximum number of segments reached!");
         return;
     }
 
@@ -518,6 +518,8 @@ void MSEGAccessibleKeyboardHandler::addNode(bool append)
         if (step <= 0)
             step = 0.125f;
 
+        clearSelection();
+
         if (cb.prepareForUndo)
             cb.prepareForUndo();
         Surge::MSEG::extendTo(ms, ms->totalDuration + step, ms->segments[N - 1].nv1);
@@ -530,6 +532,7 @@ void MSEGAccessibleKeyboardHandler::addNode(bool append)
         inFlightEdit = false;
 
         placeCursorOnNode(numNodes() - 1);
+
         if (cb.announce)
             cb.announce("Added " + nodeAnnouncement(index));
     }
@@ -547,6 +550,8 @@ void MSEGAccessibleKeyboardHandler::addNode(bool append)
 
         auto t = ms->segmentStart[seg] + s.duration * 0.5f;
 
+        clearSelection();
+
         if (cb.prepareForUndo)
             cb.prepareForUndo();
         Surge::MSEG::splitSegment(ms, t, curveValueAt(t));
@@ -559,6 +564,7 @@ void MSEGAccessibleKeyboardHandler::addNode(bool append)
         inFlightEdit = false;
 
         placeCursorOnNode(seg + 1);
+
         if (cb.announce)
             cb.announce("Added " + nodeAnnouncement(index));
     }
@@ -588,6 +594,8 @@ void MSEGAccessibleKeyboardHandler::deleteNode(bool removeSegment)
     }
 
     auto t = nodeTime(index);
+
+    clearSelection();
 
     if (cb.prepareForUndo)
         cb.prepareForUndo();
@@ -901,22 +909,27 @@ void MSEGAccessibleKeyboardHandler::revalidateCursor(bool announceIfMoved)
     auto N = ms->n_activeSegments;
     auto oldIndex = index;
 
-    if (index > N)
+    if (index > N || N != lastN)
     {
         // resolve to the node nearest where the cursor last was in time
         int best = 0;
         float bestDist = std::numeric_limits<float>::max();
+
         for (int i = 0; i <= N; ++i)
         {
             auto d = std::fabs(nodeTime(i) - rememberedTime);
+
             if (d < bestDist)
             {
                 bestDist = d;
                 best = i;
             }
         }
+
         index = best;
     }
+
+    lastN = N;
 
     if (cb.getSelection && cb.setSelection)
     {
@@ -1181,7 +1194,7 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
         return true;
     }
 
-    if (c == 'a')
+    if (c == 'n')
     {
         if (hasSelection())
         {
@@ -1208,6 +1221,59 @@ bool MSEGAccessibleKeyboardHandler::processCursorKey(const juce::KeyPress &key)
     if (c == 'i')
     {
         announceEditorState();
+        return true;
+    }
+
+    if (c == 'm')
+    {
+        if (cb.toggleOrRotate)
+            cb.announce("Movement mode set to: " + cb.toggleOrRotate(tag_segment_movement_mode));
+        return true;
+    }
+
+    if (c == 't')
+    {
+        if (cb.toggleOrRotate)
+            cb.announce("Edit mode set to: " + cb.toggleOrRotate(tag_edit_mode));
+        return true;
+    }
+
+    if (c == 'l')
+    {
+        if (cb.toggleOrRotate)
+            cb.announce("Loop mode set to: " + cb.toggleOrRotate(tag_loop_mode));
+        return true;
+    }
+
+    if (c == 'd')
+    {
+        if (cb.toggleOrRotate)
+            cb.announce("Use deform is " + cb.toggleOrRotate(tag_deform_use) +
+                        " for current selection.");
+        return true;
+    }
+
+    if (c == 'v')
+    {
+        if (cb.toggleOrRotate)
+            cb.announce("Invert deform is " + cb.toggleOrRotate(tag_deform_invert) +
+                        " for current selection.");
+        return true;
+    }
+
+    if (c == 'f')
+    {
+        if (cb.toggleOrRotate)
+            cb.announce("Trigger Filter EG is " + cb.toggleOrRotate(tag_trigger_filter_eg) +
+                        " for current selection.");
+        return true;
+    }
+
+    if (c == 'a')
+    {
+        if (cb.toggleOrRotate)
+            cb.announce("Trigger Amp EG is " + cb.toggleOrRotate(tag_trigger_amp_eg) +
+                        " for current selection.");
         return true;
     }
 

--- a/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.h
+++ b/src/surge-xt/gui/overlays/MSEGEditorAccessibleKeyboard.h
@@ -38,6 +38,23 @@ namespace Surge
 namespace Overlays
 {
 
+enum MSEGControlTags
+{
+    tag_segment_nodeedit_mode = 1231231,
+    tag_segment_movement_mode,
+    tag_vertical_snap,
+    tag_vertical_value,
+    tag_horizontal_snap,
+    tag_horizontal_value,
+    tag_loop_mode,
+    tag_edit_mode,
+    tag_node_select,
+    tag_deform_use,
+    tag_deform_invert,
+    tag_trigger_filter_eg,
+    tag_trigger_amp_eg,
+};
+
 /*
  * The keyboard model for the accessible MSEG editor. A cursor always sits on a
  * node; Tab and Shift+Tab step it along the MSEG, the four arrow keys move the
@@ -72,6 +89,7 @@ struct MSEGAccessibleKeyboardHandler
         std::function<std::vector<int>()> getSelection;
         std::function<void(const std::vector<int> &)> setSelection;
         std::function<void()> repaint;
+        std::function<std::string(int)> toggleOrRotate;
     };
 
     SurgeStorage *storage{nullptr};
@@ -80,6 +98,7 @@ struct MSEGAccessibleKeyboardHandler
     Callbacks cb;
 
     int index{0};
+    int lastN{-1};
     float rememberedTime{0.f};
     Mode mode{Mode::CURSOR};
     // the node selection mode started on; the selection is always the


### PR DESCRIPTION
Alt+A (add node) is changed to Alt+N
Alt+M rotates through movement modes (single/shift/draw) Alt+T toggles between edit modes (envelope/LFO)
Alt+L rotates between loop modes (off/on/gate)
Alt+D toggles Use Deform
Alt+V toggles Invert Deform
Alt+F toggles Trigger Filter EG
Alt+A toggles Trigger Amp EG

Also, keybinds now work from MSEG footer area, not just the canvas!