### PR TITLE
LuaEditors: Control group focus navigation and accessibility

### DIFF
--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -1060,8 +1060,43 @@ void SurgeCodeEditorComponent::mouseDrag(const juce::MouseEvent &event)
     repaint();
 }
 
+// Hand the control group focus keys to the overlay wrapper, which owns that navigation,
+// before the code editor takes them as text input.
+static bool handleControlGroupFocusKey(juce::Component *from, const juce::KeyPress &key)
+{
+    auto *container = from->findParentComponentOfClass<CodeEditorContainerWithApply>();
+    auto *wrapper = from->findParentComponentOfClass<OverlayWrapper>();
+
+    if (!container || !wrapper)
+    {
+        return false;
+    }
+
+    auto *sge = container->editor;
+
+    if (!sge || !sge->keyMapManager || !sge->getUseKeyboardShortcuts())
+    {
+        return false;
+    }
+
+    auto action = sge->keyMapManager->matches(key);
+
+    if (!action.has_value() || (*action != Surge::GUI::FOCUS_NEXT_CONTROL_GROUP &&
+                                *action != Surge::GUI::FOCUS_PRIOR_CONTROL_GROUP))
+    {
+        return false;
+    }
+
+    return wrapper->keyPressed(key);
+}
+
 bool SurgeCodeEditorComponent::keyPressed(const juce::KeyPress &key)
 {
+    if (handleControlGroupFocusKey(this, key))
+    {
+        return true;
+    }
+
     // Prelude find
     if (search != nullptr && key.getModifiers().isCommandDown() && key.isKeyCode('F'))
     {
@@ -2559,6 +2594,46 @@ struct FormulaControlArea : public juce::Component,
         }
     }
 
+    static constexpr int debugBtnWidth = 60, debugBtnMargin = 2;
+
+    // The debugger row is anchored to the right edge, so Show/Hide moves inward to make
+    // room for Init and Step when the debugger is open.
+    int debuggerRowStart() const
+    {
+        int shown = overlay->debugPanel->isOpen ? 3 : 1;
+
+        return getWidth() - 10 - (shown * debugBtnWidth) - ((shown - 1) * debugBtnMargin);
+    }
+
+    // Set the button text and its accessible name, notifying the screen reader ourselves
+    // since setTitle() does not.
+    void updateShowButtonText(bool isOpen)
+    {
+        const auto title = isOpen ? "Hide Debugger" : "Show Debugger";
+
+        showS->setLabels({isOpen ? "Hide" : "Show"});
+        showS->setTitle(title);
+        showS->setDescription(title);
+
+        if (auto *h = showS->getAccessibilityHandler())
+        {
+            h->notifyAccessibilityEvent(juce::AccessibilityEvent::titleChanged);
+        }
+    }
+
+    // Place the debugger buttons on open and close, which rebuild() does not cover since
+    // the control area bounds stay the same.
+    void positionDebuggerRow()
+    {
+        int bpos = debuggerRowStart();
+
+        for (auto *b : {showS.get(), initS.get(), stepS.get()})
+        {
+            b->setTopLeftPosition(bpos, b->getY());
+            bpos += debugBtnWidth + debugBtnMargin;
+        }
+    }
+
     void rebuild()
     {
         int labelHeight = 12;
@@ -2591,7 +2666,10 @@ struct FormulaControlArea : public juce::Component,
             codeS->setDraggable(true);
             codeS->setValue(overlay->getEditState().codeOrPrelude);
             codeS->setSkin(skin, associatedBitmapStore);
+            codeS->setAccessibleCellLabels({"Editor", "Prelude"});
+            codeS->setExplicitFocusOrder(10);
             addAndMakeVisible(*codeS);
+            codeS->setupAccessibility();
 
             btnWidth = 60;
 
@@ -2610,23 +2688,24 @@ struct FormulaControlArea : public juce::Component,
             applyS->setDraggable(true);
             applyS->setSkin(skin, associatedBitmapStore);
             applyS->setEnabled(false);
+            applyS->setExplicitFocusOrder(20);
             addAndMakeVisible(*applyS);
         }
 
-        // Debugger Controls from the left
+        // Debugger controls, reading Show/Hide, Init, Step from left to right
         {
             debugL = newL("Debugger");
             debugL->setBounds(getWidth() - 24 - 100, 1, 100, labelHeight);
             debugL->setJustificationType(juce::Justification::centredRight);
             addAndMakeVisible(*debugL);
 
-            int btnWidth = 60;
-            int bpos = getWidth() - 10 - btnWidth;
+            int bpos = debuggerRowStart();
             int ypos = 1 + labelHeight + margin;
 
-            auto ma = [&](const std::string &label, const std::string title, tags tag) {
+            auto ma = [&](const std::string &label, const std::string title, tags tag,
+                          int focusOrder) {
                 auto res = std::make_unique<Surge::Widgets::MultiSwitchSelfDraw>();
-                auto btnrect = juce::Rectangle<int>(bpos, ypos - 1, btnWidth, buttonHeight);
+                auto btnrect = juce::Rectangle<int>(bpos, ypos - 1, debugBtnWidth, buttonHeight);
 
                 res->setBounds(btnrect);
                 res->setStorage(overlay->storage);
@@ -2641,24 +2720,24 @@ struct FormulaControlArea : public juce::Component,
                 res->setDraggable(false);
                 res->setSkin(skin, associatedBitmapStore);
                 res->setValue(0);
+                res->setExplicitFocusOrder(focusOrder);
                 return res;
             };
 
             auto isOpen = overlay->debugPanel->isOpen;
             showS = ma(isOpen ? "Hide" : "Show", isOpen ? "Hide Debugger" : "Show Debugger",
-                       tag_debugger_show);
+                       tag_debugger_show, 30);
             addAndMakeVisible(*showS);
-            bpos -= btnWidth + margin;
+            bpos += debugBtnWidth + debugBtnMargin;
 
-            stepS = ma("Step", "Step Debugger", tag_debugger_step);
-            stepS->setVisible(isOpen);
-            addChildComponent(*stepS);
-            bpos -= btnWidth + margin;
-
-            initS = ma("Init", "Init Debugger", tag_debugger_init);
+            initS = ma("Init", "Init Debugger", tag_debugger_init, 40);
             initS->setVisible(isOpen);
             addChildComponent(*initS);
-            bpos -= btnWidth + margin;
+            bpos += debugBtnWidth + debugBtnMargin;
+
+            stepS = ma("Step", "Step Debugger", tag_debugger_step, 50);
+            stepS->setVisible(isOpen);
+            addChildComponent(*stepS);
         }
     }
 
@@ -2727,19 +2806,22 @@ struct FormulaControlArea : public juce::Component,
             if (overlay->debugPanel->isOpen)
             {
                 overlay->debugPanel->setOpen(false);
-                showS->setLabels({"Show"});
+                updateShowButtonText(false);
                 stepS->setVisible(false);
                 initS->setVisible(false);
             }
             else
             {
                 overlay->debugPanel->setOpen(true);
-                showS->setLabels({"Hide"});
+                updateShowButtonText(true);
                 stepS->setVisible(true);
                 initS->setVisible(true);
+                overlay->debugPanel->initializeLfoDebugger();
             }
+            positionDebuggerRow();
             repaint();
         }
+        break;
         case tag_debugger_init:
             overlay->debugPanel->initializeLfoDebugger();
             break;
@@ -2920,8 +3002,6 @@ void FormulaModulatorEditor::resized()
 
 void FormulaModulatorEditor::showModulatorCode()
 {
-    const bool keepFocus = hasKeyboardFocus(true);
-
     search->hide();
     gotoLine->hide();
     preludeDisplay->setVisible(false);
@@ -2929,17 +3009,10 @@ void FormulaModulatorEditor::showModulatorCode()
     search->setEditor(*mainEditor);
     gotoLine->setEditor(*mainEditor);
     getEditState().codeOrPrelude = 0;
-
-    if (keepFocus)
-    {
-        Surge::GUI::grabKeyboardFocusIfAllowed(mainEditor.get());
-    }
 }
 
 void FormulaModulatorEditor::showPreludeCode()
 {
-    const bool keepFocus = hasKeyboardFocus(true);
-
     search->hide();
     gotoLine->hide();
     preludeDisplay->setVisible(true);
@@ -2947,11 +3020,13 @@ void FormulaModulatorEditor::showPreludeCode()
     search->setEditor(*preludeDisplay);
     gotoLine->setEditor(*preludeDisplay);
     getEditState().codeOrPrelude = 1;
+}
 
-    if (keepFocus)
-    {
-        Surge::GUI::grabKeyboardFocusIfAllowed(preludeDisplay.get());
-    }
+std::vector<juce::Component *> FormulaModulatorEditor::getGroupNavigationComponents()
+{
+    auto *code = mainEditor->isVisible() ? mainEditor.get() : preludeDisplay.get();
+
+    return {code, controlArea.get()};
 }
 
 void FormulaModulatorEditor::updateDebuggerIfNeeded()
@@ -3434,8 +3509,10 @@ struct WavetableScriptControlArea : public juce::Component,
             codeS->setDraggable(true);
             codeS->setValue(overlay->getEditState().codeOrPrelude);
             codeS->setSkin(skin, associatedBitmapStore);
+            codeS->setAccessibleCellLabels({"Editor", "Prelude"});
             codeS->setExplicitFocusOrder(20);
             addAndMakeVisible(*codeS);
+            codeS->setupAccessibility();
 
             renderModeS = std::make_unique<Surge::Widgets::MultiSwitchSelfDraw>();
             xpos += btnWidth + 7;
@@ -3501,8 +3578,7 @@ struct WavetableScriptControlArea : public juce::Component,
             currentFrameN->setTextColour(skin->getColor(Colors::MSEGEditor::NumberField::Text));
             currentFrameN->setHoverTextColour(
                 skin->getColor(Colors::MSEGEditor::NumberField::TextHover));
-            renderModeS->setAccessible(false);
-            currentFrameN->setExplicitFocusOrder(50);
+            currentFrameN->setWantsKeyboardFocus(false);
             addAndMakeVisible(*currentFrameN);
 
             framesL = newL("Frames");
@@ -4049,8 +4125,6 @@ void WavetableScriptEditor::resized()
 
 void WavetableScriptEditor::showModulatorCode()
 {
-    const bool keepFocus = hasKeyboardFocus(true);
-
     search->hide();
     gotoLine->hide();
     preludeDisplay->setVisible(false);
@@ -4058,17 +4132,10 @@ void WavetableScriptEditor::showModulatorCode()
     search->setEditor(*mainEditor);
     gotoLine->setEditor(*mainEditor);
     getEditState().codeOrPrelude = 0;
-
-    if (keepFocus)
-    {
-        Surge::GUI::grabKeyboardFocusIfAllowed(mainEditor.get());
-    }
 }
 
 void WavetableScriptEditor::showPreludeCode()
 {
-    const bool keepFocus = hasKeyboardFocus(true);
-
     search->hide();
     gotoLine->hide();
     preludeDisplay->setVisible(true);
@@ -4076,11 +4143,13 @@ void WavetableScriptEditor::showPreludeCode()
     search->setEditor(*preludeDisplay);
     gotoLine->setEditor(*preludeDisplay);
     getEditState().codeOrPrelude = 1;
+}
 
-    if (keepFocus)
-    {
-        Surge::GUI::grabKeyboardFocusIfAllowed(preludeDisplay.get());
-    }
+std::vector<juce::Component *> WavetableScriptEditor::getGroupNavigationComponents()
+{
+    auto *code = mainEditor->isVisible() ? mainEditor.get() : preludeDisplay.get();
+
+    return {code, controlArea.get()};
 }
 
 void WavetableScriptEditor::rerenderFromUIState()

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -3508,7 +3508,7 @@ struct WavetableScriptControlArea : public juce::Component,
             renderModeS->setValue(overlay->rendererComponent->mode);
             renderModeS->setSkin(skin, associatedBitmapStore);
             renderModeS->setAccessible(false);
-            renderModeS->setExplicitFocusOrder(30);
+            renderModeS->setWantsKeyboardFocus(false);
             addAndMakeVisible(*renderModeS);
 
             applyS = std::make_unique<Surge::Widgets::MultiSwitchSelfDraw>();
@@ -3528,7 +3528,7 @@ struct WavetableScriptControlArea : public juce::Component,
             applyS->setDraggable(true);
             applyS->setSkin(skin, associatedBitmapStore);
             applyS->setEnabled(false);
-            applyS->setExplicitFocusOrder(40);
+            applyS->setExplicitFocusOrder(30);
             addAndMakeVisible(*applyS);
 
             auto images = skin->standardHoverAndHoverOnForIDB(IDB_MSEG_SNAPVALUE_NUMFIELD,
@@ -3586,7 +3586,7 @@ struct WavetableScriptControlArea : public juce::Component,
                 }
                 return false;
             };
-            framesN->setExplicitFocusOrder(60);
+            framesN->setExplicitFocusOrder(40);
             addAndMakeVisible(*framesN);
 
             resolutionL = newL("Samples");
@@ -3610,7 +3610,7 @@ struct WavetableScriptControlArea : public juce::Component,
             resolutionN->setTextColour(skin->getColor(Colors::MSEGEditor::NumberField::Text));
             resolutionN->setHoverTextColour(
                 skin->getColor(Colors::MSEGEditor::NumberField::TextHover));
-            resolutionN->setExplicitFocusOrder(70);
+            resolutionN->setExplicitFocusOrder(50);
             addAndMakeVisible(*resolutionN);
 
             generateS = std::make_unique<Surge::Widgets::MultiSwitchSelfDraw>();
@@ -3629,7 +3629,7 @@ struct WavetableScriptControlArea : public juce::Component,
             generateS->setDraggable(false);
             generateS->setSkin(skin, associatedBitmapStore);
             generateS->setEnabled(true);
-            generateS->setExplicitFocusOrder(80);
+            generateS->setExplicitFocusOrder(60);
             addAndMakeVisible(*generateS);
         }
     }

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -2594,17 +2594,6 @@ struct FormulaControlArea : public juce::Component,
         }
     }
 
-    static constexpr int debugBtnWidth = 60, debugBtnMargin = 2;
-
-    // The debugger row is anchored to the right edge, so Show/Hide moves inward to make
-    // room for Init and Step when the debugger is open.
-    int debuggerRowStart() const
-    {
-        int shown = overlay->debugPanel->isOpen ? 3 : 1;
-
-        return getWidth() - 10 - (shown * debugBtnWidth) - ((shown - 1) * debugBtnMargin);
-    }
-
     // Set the button text and its accessible name, notifying the screen reader ourselves
     // since setTitle() does not.
     void updateShowButtonText(bool isOpen)
@@ -2618,19 +2607,6 @@ struct FormulaControlArea : public juce::Component,
         if (auto *h = showS->getAccessibilityHandler())
         {
             h->notifyAccessibilityEvent(juce::AccessibilityEvent::titleChanged);
-        }
-    }
-
-    // Place the debugger buttons on open and close, which rebuild() does not cover since
-    // the control area bounds stay the same.
-    void positionDebuggerRow()
-    {
-        int bpos = debuggerRowStart();
-
-        for (auto *b : {showS.get(), initS.get(), stepS.get()})
-        {
-            b->setTopLeftPosition(bpos, b->getY());
-            bpos += debugBtnWidth + debugBtnMargin;
         }
     }
 
@@ -2692,20 +2668,21 @@ struct FormulaControlArea : public juce::Component,
             addAndMakeVisible(*applyS);
         }
 
-        // Debugger controls, reading Show/Hide, Init, Step from left to right
+        // Debugger Controls from the left
         {
             debugL = newL("Debugger");
             debugL->setBounds(getWidth() - 24 - 100, 1, 100, labelHeight);
             debugL->setJustificationType(juce::Justification::centredRight);
             addAndMakeVisible(*debugL);
 
-            int bpos = debuggerRowStart();
+            int btnWidth = 60;
+            int bpos = getWidth() - 10 - btnWidth;
             int ypos = 1 + labelHeight + margin;
 
             auto ma = [&](const std::string &label, const std::string title, tags tag,
                           int focusOrder) {
                 auto res = std::make_unique<Surge::Widgets::MultiSwitchSelfDraw>();
-                auto btnrect = juce::Rectangle<int>(bpos, ypos - 1, debugBtnWidth, buttonHeight);
+                auto btnrect = juce::Rectangle<int>(bpos, ypos - 1, btnWidth, buttonHeight);
 
                 res->setBounds(btnrect);
                 res->setStorage(overlay->storage);
@@ -2728,16 +2705,17 @@ struct FormulaControlArea : public juce::Component,
             showS = ma(isOpen ? "Hide" : "Show", isOpen ? "Hide Debugger" : "Show Debugger",
                        tag_debugger_show, 30);
             addAndMakeVisible(*showS);
-            bpos += debugBtnWidth + debugBtnMargin;
-
-            initS = ma("Init", "Init Debugger", tag_debugger_init, 40);
-            initS->setVisible(isOpen);
-            addChildComponent(*initS);
-            bpos += debugBtnWidth + debugBtnMargin;
+            bpos -= btnWidth + margin;
 
             stepS = ma("Step", "Step Debugger", tag_debugger_step, 50);
             stepS->setVisible(isOpen);
             addChildComponent(*stepS);
+            bpos -= btnWidth + margin;
+
+            initS = ma("Init", "Init Debugger", tag_debugger_init, 40);
+            initS->setVisible(isOpen);
+            addChildComponent(*initS);
+            bpos -= btnWidth + margin;
         }
     }
 
@@ -2818,7 +2796,6 @@ struct FormulaControlArea : public juce::Component,
                 initS->setVisible(true);
                 overlay->debugPanel->initializeLfoDebugger();
             }
-            positionDebuggerRow();
             repaint();
         }
         break;

--- a/src/surge-xt/gui/overlays/LuaEditors.h
+++ b/src/surge-xt/gui/overlays/LuaEditors.h
@@ -336,6 +336,8 @@ struct FormulaModulatorEditor : public CodeEditorContainerWithApply, public Refr
 
     void updateDebuggerIfNeeded();
 
+    std::vector<juce::Component *> getGroupNavigationComponents() override;
+
     std::unique_ptr<juce::CodeDocument> preludeDocument;
     std::unique_ptr<SurgeCodeEditorComponent> preludeDisplay;
     std::unique_ptr<FormulaControlArea> controlArea;
@@ -385,6 +387,8 @@ struct WavetableScriptEditor : public CodeEditorContainerWithApply,
     void applyCodeToOsc();
 
     void rerenderFromUIState();
+
+    std::vector<juce::Component *> getGroupNavigationComponents() override;
 
     void timerCallback() override;
     void pollGenJobs();

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -321,33 +321,58 @@ bool MultiSwitch::keyPressed(const juce::KeyPress &key)
         return true;
     }
 
-    bool doit =
-        action != Increase || action != Decrease || (rows * columns == 1 && action == Return);
+    const auto cells = rows * columns;
 
-    if (!doit)
-        return false;
-
-    int dir = 1;
-    if (action == Decrease)
-    {
-        dir = -1;
-    }
-
-    auto iv = limit_range(getIntegerValue() + dir, 0, rows * columns - 1);
-
-    if (rows * columns == 1)
+    // Press a one cell switch on any of the edit keys.
+    if (cells == 1)
     {
         setValue(0);
+        notifyValueChangedWithBeginEnd();
+        repaint();
+
+        return true;
     }
-    else
+
+    auto iv = getIntegerValue();
+
+    switch (action)
     {
-        _DBGCOUT << "Setting integer value to " << iv << " " << 1.f * iv / (rows * columns - 1)
-                 << std::endl;
-        setValue(1.f * iv / (rows * columns - 1));
+    case Increase: // Up
+        iv = limit_range(iv + 1, 0, cells - 1);
+        break;
+    case Decrease: // Down
+        iv = limit_range(iv - 1, 0, cells - 1);
+        break;
+    case ToMax: // Home
+        iv = 0;
+        break;
+    case ToMin: // End
+        iv = cells - 1;
+        break;
+    case Return:
+    {
+        // Select the cell focus is on, or step to the next option, wrapping at the end.
+        auto focused = -1;
+
+        for (int i = 0; i < (int)selectionComponents.size(); ++i)
+        {
+            if (selectionComponents[i]->hasKeyboardFocus(false))
+            {
+                focused = i;
+            }
+        }
+
+        iv = (focused >= 0 && focused != iv) ? focused : (iv + 1) % cells;
     }
-    notifyBeginEdit();
-    notifyValueChanged();
-    notifyEndEdit();
+    break;
+    default:
+        return false;
+    }
+
+    // _DBGCOUT << "Setting integer value to " << iv << " " << 1.f * iv / (cells - 1) << std::endl;
+
+    setValue(1.f * iv / (cells - 1));
+    notifyValueChangedWithBeginEnd();
     repaint();
 
     return true;


### PR DESCRIPTION
Formula and Wavetable Script editors:

- Alt+. / Alt+, now move keyboard focus between the visible code display and the control area
- Code selection switches announce their options to a screen reader instead of a bare value
- Removed the tab switch editor focus grabs in `showModulatorCode` / `showPreludeCode`, which
  the switch accessibility cells now override
- Explicit focus orders for the Formula control area
- Debugger Init and Step come after Show/Hide in the tab order
- Show/Hide no longer re-initializes the debugger when closing (missing break)
- Wavetable View and Display Mode are no longer reachable by Tab

MultiSwitch:

- Fixed an always-true condition and refactored to a switch case
- Home and End go to the first and last option instead of End just incrementing
- Return selects the focused cell, or steps to the next option and wraps

Assisted-by: Claude Opus 4.8