### PR TITLE
Attempt to fix FX plugin resetting state on UI open in Renoise

### DIFF
--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -54,7 +54,7 @@ SurgefxAudioProcessor::SurgefxAudioProcessor()
 
     setLatencySamples(nonLatentBlockMode ? 0 : BLOCK_SIZE);
 
-    effectNum = fxt_off;
+    effectNum = fxt_delay;
 
     fxstorage = &(storage->getPatch().fx[0]);
     audio_thread_surge_effect.reset();
@@ -211,7 +211,7 @@ void SurgefxAudioProcessor::prepareToPlay(double sr, int samplesPerBlock)
 
     setLatencySamples(nonLatentBlockMode ? 0 : BLOCK_SIZE);
 
-    if (effectNum == fxt_off)
+    if (!hasLoadedFxType.load())
     {
         resetFxType(fxt_delay, true);
     }
@@ -748,6 +748,11 @@ void SurgefxAudioProcessor::resetFxType(int type, bool updateJuceParams)
     output_position = -1;
     effectNum = type;
     fxstorage->type.val.i = effectNum;
+
+    if (type != fxt_off)
+    {
+        hasLoadedFxType.store(true);
+    }
 
     for (int i = 0; i < n_fx_params; ++i)
         fxstorage->p[i].set_type(ct_none);

--- a/src/surge-fx/SurgeFXProcessor.h
+++ b/src/surge-fx/SurgeFXProcessor.h
@@ -427,6 +427,7 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
     int storage_id_start, storage_id_end;
 
     int effectNum;
+    std::atomic<bool> hasLoadedFxType{false};
 
     int fx_param_remap[n_fx_params];
     std::string group_names[n_fx_params];


### PR DESCRIPTION
`effectNum` was a plain int, read on `prepareToPlay()` (potentially audio thread) and written on `setStateInformation()` (message thread) without synchronization. `prepareToPlay()` used `effectNum == fxt_off` to detect "no state loaded yet" and, if true, force-reset to the default Delay effect. On some hosts (observed: Renoise on Linux) opening the plugin editor triggers a second `prepareToPlay()` call that can race ahead of `setStateInformation()`'s write, reading the stale `fxt_off` sentinel and stomping the just-restored effect type/params back to Delay defaults - even though generic parameter views (which read `fxstorage`/`fxParams` directly, bypassing this path) showed the correct values.

Replace the `effectNum`-as-sentinel check with an explicit `std::atomic<bool> hasLoadedFxType`, set inside `resetFxType()` whenever a real (non-off) effect type is established. `prepareToPlay()` now checks this flag instead of racing on `effectNum` directly.

Also construct the processor directly into `fxt_delay` rather than `fxt_off,` since `fxt_off` is not a user-reachable effect type and previously relied on `prepareToPlay()`'s fallback to correct it after the fact - this was a regression source for standalone/fresh instances under the new flag-based check.

Addresses #8267

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>