### PR TITLE
Overlays: One tab stop per MultiSwitch, fix focus highlight

### DIFF
--- a/src/surge-xt/gui/AccessibleHelpers.h
+++ b/src/surge-xt/gui/AccessibleHelpers.h
@@ -619,6 +619,114 @@ struct HasAccessibleSubComponentForFocus
     virtual juce::Component *getCurrentAccessibleSelectionComponent() = 0;
 };
 
+/*
+ * Stock JUCE tab ordering, except that a widget owning accessible sub components
+ * (e.g. a MultiSwitch and its per cell overlay buttons) is a single tab stop on its
+ * current selection instead of the owner followed by every one of its cells. This is
+ * what MainFrame's GlobalKeyboardTraverser gives the main UI. Any component which calls
+ * setFocusContainerType(keyboardFocusContainer) should hand this out from
+ * createKeyboardFocusTraverser(), otherwise JUCE gives you a tab stop for the owner and
+ * one more for each of its cells.
+ */
+struct SelectionCollapsingKeyboardFocusTraverser : public juce::KeyboardFocusTraverser
+{
+    // The stop that stands in for c, if c owns one. Null when c owns no sub components,
+    // or owns them but hasn't built them yet (a MultiSwitch without setupAccessibility).
+    static juce::Component *selectionOf(juce::Component *c)
+    {
+        if (auto sub = dynamic_cast<HasAccessibleSubComponentForFocus *>(c))
+        {
+            return sub->getCurrentAccessibleSelectionComponent();
+        }
+
+        return nullptr;
+    }
+
+    // Map any component onto the stop which represents it, so traversal still works when
+    // focus sits on an owner (control group navigation grabs those directly) or on a cell
+    // which is no longer the selected one.
+    static juce::Component *collapse(juce::Component *c)
+    {
+        if (!c)
+        {
+            return nullptr;
+        }
+
+        if (auto sel = selectionOf(c))
+        {
+            return sel;
+        }
+
+        // A sub component is represented by its owner's selection. An owner which returns
+        // itself delegates to nothing, so leave its children alone.
+        if (auto parent = c->getParentComponent())
+        {
+            auto sel = selectionOf(parent);
+
+            if (sel && sel != parent)
+            {
+                return sel;
+            }
+        }
+
+        return c;
+    }
+
+    std::vector<juce::Component *> getAllComponents(juce::Component *parentComponent) override
+    {
+        auto components = juce::KeyboardFocusTraverser::getAllComponents(parentComponent);
+
+        // An owner steps aside for its selection, and so do that owner's other cells.
+        components.erase(std::remove_if(components.begin(), components.end(),
+                                        [](auto c) { return collapse(c) != c; }),
+                         components.end());
+
+        return components;
+    }
+
+    juce::Component *getNextComponent(juce::Component *current) override
+    {
+        return step(current, +1);
+    }
+
+    juce::Component *getPreviousComponent(juce::Component *current) override
+    {
+        return step(current, -1);
+    }
+
+    juce::Component *step(juce::Component *current, int dir)
+    {
+        if (!current)
+        {
+            return nullptr;
+        }
+
+        auto container = current->findKeyboardFocusContainer();
+
+        if (!container)
+        {
+            return nullptr;
+        }
+
+        auto components = getAllComponents(container);
+        auto pos = std::find(components.begin(), components.end(), collapse(current));
+
+        // Off the ends, or focus somewhere we don't represent: JUCE wraps to the first or
+        // last stop of the container for us.
+        if (pos == components.end())
+        {
+            return nullptr;
+        }
+
+        if (dir > 0)
+        {
+            return (std::next(pos) == components.end()) ? nullptr : *std::next(pos);
+        }
+
+        return (pos == components.begin()) ? nullptr : *std::prev(pos);
+    }
+};
+
 } // namespace Widgets
 } // namespace Surge
 

--- a/src/surge-xt/gui/overlays/LuaEditors.cpp
+++ b/src/surge-xt/gui/overlays/LuaEditors.cpp
@@ -2586,6 +2586,12 @@ struct FormulaControlArea : public juce::Component,
         setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
     }
 
+    // One tab stop per switch, on its selected cell.
+    std::unique_ptr<juce::ComponentTraverser> createKeyboardFocusTraverser() override
+    {
+        return std::make_unique<Surge::Widgets::SelectionCollapsingKeyboardFocusTraverser>();
+    }
+
     void resized() override
     {
         if (skin)
@@ -3418,6 +3424,12 @@ struct WavetableScriptControlArea : public juce::Component,
         setTitle("Controls");
         setDescription("Controls");
         setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
+    }
+
+    // One tab stop per switch, on its selected cell.
+    std::unique_ptr<juce::ComponentTraverser> createKeyboardFocusTraverser() override
+    {
+        return std::make_unique<Surge::Widgets::SelectionCollapsingKeyboardFocusTraverser>();
     }
 
     void resized() override

--- a/src/surge-xt/gui/overlays/OverlayWrapper.cpp
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.cpp
@@ -28,6 +28,7 @@
 #include "widgets/MainFrame.h"
 #include "SurgeJUCELookAndFeel.h"
 #include "SurgeGUIUtils.h"
+#include "AccessibleHelpers.h"
 
 namespace Surge
 {
@@ -819,6 +820,11 @@ bool OverlayWrapper::keyPressed(const juce::KeyPress &key)
 OverlayComponent *OverlayWrapper::getPrimaryChildAsOverlayComponent()
 {
     return dynamic_cast<OverlayComponent *>(primaryChild.get());
+}
+
+std::unique_ptr<juce::ComponentTraverser> OverlayWrapper::createKeyboardFocusTraverser()
+{
+    return std::make_unique<Surge::Widgets::SelectionCollapsingKeyboardFocusTraverser>();
 }
 
 void OverlayWrapper::onSkinChanged()

--- a/src/surge-xt/gui/overlays/OverlayWrapper.h
+++ b/src/surge-xt/gui/overlays/OverlayWrapper.h
@@ -157,12 +157,12 @@ struct OverlayWrapper : public juce::Component,
     /*
      * All overlays should use default focus order not the wonky tag first and
      * then description and so on order for the main frame (which is laying out controls
-     * in a differently structured way).
+     * in a differently structured way). We do collapse a widget owning accessible sub
+     * components onto its selection the way the main frame does, so a MultiSwitch is one
+     * tab stop rather than the switch plus every cell. Out of line since the traverser
+     * lives in AccessibleHelpers.h, which includes us by way of SurgeGUIEditor.h.
      */
-    std::unique_ptr<juce::ComponentTraverser> createKeyboardFocusTraverser() override
-    {
-        return std::make_unique<juce::KeyboardFocusTraverser>();
-    }
+    std::unique_ptr<juce::ComponentTraverser> createKeyboardFocusTraverser() override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OverlayWrapper);
 };

--- a/src/surge-xt/gui/widgets/MultiSwitch.cpp
+++ b/src/surge-xt/gui/widgets/MultiSwitch.cpp
@@ -529,6 +529,11 @@ juce::Component *MultiSwitch::getCurrentAccessibleSelectionComponent()
 
 void MultiSwitch::updateAccessibleStateOnUserValueChange()
 {
+    // Move the focus highlight onto the cell we just selected. JUCE only reports focus
+    // entering and leaving the switch, not moving between our own cells, so without this
+    // the highlight stays on whichever cell tab first landed on.
+    updateFocusHover();
+
     if (isAlwaysAccessibleMomentary())
         return;
 

--- a/src/surge-xt/gui/widgets/MultiSwitch.h
+++ b/src/surge-xt/gui/widgets/MultiSwitch.h
@@ -101,13 +101,35 @@ struct MultiSwitch : public juce::Component,
     void startHover(const juce::Point<float> &) override;
     void endHover() override;
 
-    void focusGained(juce::Component::FocusChangeType cause) override
+    void focusGained(juce::Component::FocusChangeType cause) override { updateFocusHover(); }
+
+    void focusLost(juce::Component::FocusChangeType cause) override { updateFocusHover(); }
+
+    // Keyboard focus lands on a cell, not on us, so track the cells too. Without this the
+    // switch unhighlights the moment focus moves into one of its own cells.
+    void focusOfChildComponentChanged(juce::Component::FocusChangeType cause) override
     {
-        // fixme - probably use the location of the current element
-        startHover(valueToCoordinate(getValue()));
+        updateFocusHover();
     }
 
-    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
+    void updateFocusHover()
+    {
+        // While the pointer is here it owns the highlight
+        if (isMouseOverOrDragging(true))
+        {
+            return;
+        }
+
+        if (hasKeyboardFocus(true))
+        {
+            // fixme - probably use the location of the current element
+            startHover(valueToCoordinate(getValue()));
+        }
+        else
+        {
+            endHover();
+        }
+    }
 
     bool keyPressed(const juce::KeyPress &key) override;
     Surge::GUI::WheelAccumulationHelper wheelHelper;


### PR DESCRIPTION
Tabbing in an overlay stopped on a MultiSwitch and then on every one of its cells.
The main UI collapses those to the checked cell already, via MainFrame's traverser; overlays used the stock JUCE one.

- Add SelectionCollapsingKeyboardFocusTraverser, handed out by OverlayWrapper
- Any keyboardFocusContainer shadows the wrapper's traverser and needs its own
  (Currently: FormulaControlArea, WavetableScriptControlArea, TuningControlArea)
- MultiSwitch: keep the highlight while a cell holds focus, and move it with the
  selection on keyboard edits

Assisted-by: Claude Opus 5

