### PR TITLE
Alert boxes: Accessibility and fixes

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -4074,7 +4074,8 @@ void SurgeGUIEditor::alertBox(const std::string &title, const std::string &promp
     alert->setDescription(title);
     alert->setWindowTitle(title);
 
-    addAndMakeVisibleWithTracking(frame.get(), *alert);
+    // Added hidden and shown at the end, so it grabs focus onto a fully configured dialog.
+    addComponentWithTracking(frame.get(), *alert);
 
     alert->setLabel(prompt);
 
@@ -6019,7 +6020,8 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
                     fmt::format("You have used a keyboard shortcut to load another patch,\n"
                                 "which will discard any changes made so far.\n\n"
                                 "Do you want to proceed?"),
-                    Surge::Storage::PromptToActivateCategoryAndPatchOnKeypress, [this, action]() {
+                    Surge::Storage::PromptToActivateCategoryAndPatchOnKeypress,
+                    [this, action]() {
                         closeOverlay(SAVE_PATCH);
 
                         auto insideCategory = Surge::Storage::getUserDefaultValue(
@@ -6027,7 +6029,8 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
 
                         loadPatchWithDirtyCheck(action == KeyboardActions::NEXT_PATCH, false,
                                                 insideCategory);
-                    });
+                    },
+                    STOP_ASKING);
             }
             case KeyboardActions::PREV_CATEGORY:
             case KeyboardActions::NEXT_CATEGORY:
@@ -6037,11 +6040,13 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
                     fmt::format("You have used a keyboard shortcut to select another category,\n"
                                 "which will discard any changes made so far.\n\n"
                                 "Do you want to proceed?"),
-                    Surge::Storage::PromptToActivateCategoryAndPatchOnKeypress, [this, action]() {
+                    Surge::Storage::PromptToActivateCategoryAndPatchOnKeypress,
+                    [this, action]() {
                         closeOverlay(SAVE_PATCH);
 
                         loadPatchWithDirtyCheck(action == KeyboardActions::NEXT_CATEGORY, true);
-                    });
+                    },
+                    STOP_ASKING);
             }
 
             // TODO: UPDATE WHEN ADDING MORE OSCILLATORS
@@ -6864,12 +6869,13 @@ void SurgeGUIEditor::globalFocusChanged(juce::Component *fc)
 
 bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(
     const ::std::string &title, const std::string &msg, Surge::Storage::DefaultKey dontAskAgainKey,
-    std::function<void()> okCallback, std::string ynMessage, AskAgainStates askAgainDef)
+    std::function<void()> okCallback, DontAskAgainMeans dontAskAgainMeans, std::string ynMessage,
+    AskAgainStates askAgainDef)
 {
     auto bypassed =
         Surge::Storage::getUserDefaultValue(&(synth->storage), dontAskAgainKey, askAgainDef);
 
-    if (bypassed == NEVER)
+    if (bypassed == NEVER && dontAskAgainMeans == REMEMBER_ANSWER)
     {
         return false;
     }
@@ -6884,7 +6890,7 @@ bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(
     alert->setSkin(currentSkin, bitmapStore);
     alert->setDescription(title);
     alert->setWindowTitle(title);
-    addAndMakeVisibleWithTracking(frame.get(), *alert);
+    addComponentWithTracking(frame.get(), *alert);
     alert->setLabel(msg);
     alert->addDontAskAgainButtonAndSetText(ynMessage);
     alert->setOkCancelButtonTexts("OK", "Cancel");
@@ -6895,10 +6901,12 @@ bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(
         }
         okCallback();
     };
-    alert->onCancelForToggleState = [this, dontAskAgainKey](bool dontAskAgain) {
+    alert->onCancelForToggleState = [this, dontAskAgainKey, dontAskAgainMeans](bool dontAskAgain) {
         if (dontAskAgain)
         {
-            Surge::Storage::updateUserDefaultValue(&(synth->storage), dontAskAgainKey, NEVER);
+            Surge::Storage::updateUserDefaultValue(&(synth->storage), dontAskAgainKey,
+                                                   (dontAskAgainMeans == STOP_ASKING) ? ALWAYS
+                                                                                      : NEVER);
         }
     };
     alert->setBounds(0, 0, getWindowSizeX(), getWindowSizeY());
@@ -6922,7 +6930,7 @@ void SurgeGUIEditor::loadPatchWithDirtyCheck(bool increment, bool isCategory, bo
 
                 synth->jogPatchOrCategory(increment, isCategory, insideCategory);
             },
-            "Don't ask me again", ALWAYS);
+            STOP_ASKING, "Don't ask me again", ALWAYS);
     }
     else
     {

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -967,6 +967,14 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         NEVER = 100
     };
 
+    // What ticking "Don't ask me again" records: REMEMBER_ANSWER stores the button pressed,
+    // STOP_ASKING runs the action unprompted from then on whichever button was pressed.
+    enum DontAskAgainMeans
+    {
+        REMEMBER_ANSWER,
+        STOP_ASKING
+    };
+
     // sometimes we need to return focus to a specific component after an Alert dialog is dismissed
     // currently used by KeyBindingsOverlay
     juce::Component::SafePointer<juce::Component> componentToFocusAfterAlertDismissal{nullptr};
@@ -975,6 +983,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool promptForOKCancelWithDontAskAgain(const ::std::string &title, const std::string &msg,
                                            Surge::Storage::DefaultKey dontAskAgainKey,
                                            std::function<void()> okCallback,
+                                           DontAskAgainMeans dontAskAgainMeans = REMEMBER_ANSWER,
                                            std::string ynMessage = "Don't ask me again",
                                            AskAgainStates askAgainDefault = DUNNO);
 

--- a/src/surge-xt/gui/overlays/Alert.cpp
+++ b/src/surge-xt/gui/overlays/Alert.cpp
@@ -57,8 +57,10 @@ Alert::Alert(uint16_t extraH)
 {
     extraHeight = extraH;
     setAccessible(true);
-    setFocusContainerType(juce::Component::FocusContainerType::focusContainer);
-    setWantsKeyboardFocus(true);
+
+    // Keep Tab inside the dialog. Focus goes to a child, never the container itself.
+    setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
+    setWantsKeyboardFocus(false);
 
     labelComponent = std::make_unique<MultiLineSkinLabel>();
     labelComponent->setTitle("Message");
@@ -137,7 +139,15 @@ void Alert::resized()
 
     if (dontAskAgainButton)
     {
-        dontAskAgainButton->setBounds(buttonRow.translated(10, 0));
+        auto checkbox = buttonRow.translated(10, 0);
+        auto tickWidth = juce::roundToInt(juce::jmin(15.f, btnHeight * 0.75f) * 1.2f);
+        auto textWidth = skin ? SST_STRING_WIDTH_INT(skin->fontManager->getLatoAtSize(9),
+                                                     dontAskAgainButton->getButtonText())
+                              : 0;
+        auto width =
+            juce::jmin(tickWidth + 12 + textWidth, okButton->getX() - checkbox.getX() - margin);
+
+        dontAskAgainButton->setBounds(checkbox.withWidth(width));
     }
 }
 
@@ -152,37 +162,45 @@ void Alert::onSkinChanged()
 
 void Alert::buttonClicked(juce::Button *button)
 {
+    // A callback can raise a second alert, which destroys us mid-callback, so hide first, copy the
+    // callback onto the stack and touch no members after invoking it.
+    const bool isOk = (button == okButton.get());
+    const bool isCancel = (button == cancelButton.get());
+
+    if (!isOk && !isCancel)
+    {
+        return;
+    }
+
+    setVisible(false);
+
     if (!dontAskAgainButton)
     {
-        if (button == okButton.get() && onOk)
+        auto cb = isOk ? onOk : onCancel;
+
+        if (cb)
         {
-            onOk();
-        }
-        else if (button == cancelButton.get() && onCancel)
-        {
-            onCancel();
+            cb();
         }
     }
     else
     {
-        if (button == okButton.get() && onOkForToggleState)
+        auto cb = isOk ? onOkForToggleState : onCancelForToggleState;
+        const bool dontAskAgain = dontAskAgainButton->getToggleState();
+
+        if (cb)
         {
-            onOkForToggleState(dontAskAgainButton->getToggleState());
-        }
-        else if (button == cancelButton.get() && onCancelForToggleState)
-        {
-            onCancelForToggleState(dontAskAgainButton->getToggleState());
+            cb(dontAskAgain);
         }
     }
-
-    setVisible(false);
 }
 
 void Alert::visibilityChanged()
 {
     if (isVisible())
     {
-        Surge::GUI::grabKeyboardFocusIfAllowed(this);
+        // Focus the message so a screen reader announces the prompt on open.
+        Surge::GUI::grabKeyboardFocusIfAllowed(labelComponent.get());
     }
 }
 


### PR DESCRIPTION
- Tab now stays inside the dialog instead of escaping into the UI behind it
- Focus lands on the message, so screen readers announce the prompt
- "Don't ask me again" checkbox no longer covers the OK/Cancel buttons and eats their clicks
- Fixed a crash when the Confirm Patch Change dialog opens the Confirm Patch Loading dialog through a callback
- Fixed a rare condition where ticking "don't ask me again" and then cancelling would permanently disable the patch/category jog keybinds

Assisted-by: Claude Opus 5