### PR TITLE
Implement host-side context menus in FX plugin

### DIFF
--- a/src/surge-fx/SurgeFXEditor.cpp
+++ b/src/surge-fx/SurgeFXEditor.cpp
@@ -354,6 +354,22 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
             fxParamSliders[i].setTextValue(processor.getParamValue(i).c_str());
         };
 
+        fxParamSliders[i].onPopupMenu = [this, i]() {
+            if (auto *param = processor.getHostParameterForFxSlot(i))
+            {
+                if (auto *hostContext = getHostContext())
+                {
+                    if (auto menuInfo = hostContext->getContextMenuForParameter(param))
+                    {
+                        auto menu = menuInfo->getEquivalentPopupMenu();
+
+                        menu = modifyHostMenu(menu, i);
+                        menu.showMenuAsync(juce::PopupMenu::Options{});
+                    }
+                }
+            }
+        };
+
         fxParamSliders[i].onDragStart = [i, this]() {
             this->processor.setUserEditingFXParam(i, true);
         };
@@ -469,6 +485,59 @@ SurgefxAudioProcessorEditor::SurgefxAudioProcessorEditor(SurgefxAudioProcessor &
 
     idleTimer = std::make_unique<IdleTimer>(this);
     idleTimer->startTimer(1000 / 25);
+}
+
+juce::PopupMenu SurgefxAudioProcessorEditor::modifyHostMenu(juce::PopupMenu menu, const int idx)
+{
+    auto newMenu = juce::PopupMenu();
+
+    newMenu.addSectionHeader(
+        fmt::format("{} {}", fxParamDisplay[idx].getGroup(), fxParamDisplay[idx].getName()));
+
+    newMenu.addSeparator();
+
+    // make things look a bit nicer for our friends from Image-Line
+    if (juce::PluginHostType().isFruityLoops())
+    {
+        auto it = juce::PopupMenu::MenuItemIterator(menu);
+
+        while (it.next())
+        {
+            auto txt = it.getItem().text;
+
+            if (txt.startsWithChar('-'))
+            {
+                it.getItem().isSectionHeader = true;
+                it.getItem().text = txt.fromFirstOccurrenceOf("-", false, false);
+            }
+
+            newMenu.addItem(it.getItem());
+        }
+    }
+
+    // we really don't need that parameter name repeated in Reaper...
+    if (juce::PluginHostType().isReaper())
+    {
+        auto it = juce::PopupMenu::MenuItemIterator(menu);
+
+        while (it.next())
+        {
+            auto txt = it.getItem().text;
+            bool include = true;
+
+            if (txt.startsWithChar('[') && txt.endsWithChar(']'))
+            {
+                include = it.next();
+            }
+
+            if (include)
+            {
+                newMenu.addItem(it.getItem());
+            }
+        }
+    }
+
+    return newMenu;
 }
 
 SurgefxAudioProcessorEditor::~SurgefxAudioProcessorEditor()

--- a/src/surge-fx/SurgeFXEditor.h
+++ b/src/surge-fx/SurgeFXEditor.h
@@ -123,10 +123,27 @@ class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor,
 
     int defaultPresetIndexForCurrentType() const { return currentPresets.empty() ? -1 : 0; }
 
+    std::vector<juce::Component *> accessibleOrderWeakRefs;
+    std::unique_ptr<juce::ComponentTraverser> createFocusTraverser() override;
+
   private:
     struct AccSlider : public juce::Slider
     {
         AccSlider() { setWantsKeyboardFocus(true); }
+
+        void mouseDown(const juce::MouseEvent &e) override
+        {
+            if (e.mods.isPopupMenu() && onPopupMenu)
+            {
+                onPopupMenu();
+                return;
+            }
+
+            juce::Slider::mouseDown(e);
+        }
+
+        std::function<void()> onPopupMenu;
+
         juce::String getTextFromValue(double v) override
         {
             // std::cout << "GTFV " << v << std::endl;
@@ -136,19 +153,26 @@ class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor,
         }
 
         juce::String tv;
+
         void setTextValue(juce::String s)
         {
             tv = s;
+
             if (auto *handler = getAccessibilityHandler())
             {
                 handler->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
             }
         }
+
         bool keyPressed(const juce::KeyPress &key) override
         {
             float amt = 0.05;
+
             if (key.getModifiers().isShiftDown())
+            {
                 amt = 0.01;
+            }
+
             if (key.getKeyCode() == juce::KeyPress::upKey)
             {
                 setValue(std::clamp(getValue() + amt, 0., 1.),
@@ -193,6 +217,7 @@ class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor,
     void resetLabels();
 
     juce::PopupMenu makeOSCMenu();
+    juce::PopupMenu modifyHostMenu(juce::PopupMenu menu, const int idx);
 
     std::unique_ptr<SurgeLookAndFeel> surgeLookFeel;
     std::unique_ptr<juce::Label> fxNameLabel;
@@ -214,17 +239,12 @@ class SurgefxAudioProcessorEditor : public juce::AudioProcessorEditor,
         void timerCallback() override;
         SurgefxAudioProcessorEditor *ed;
     };
+
     void idle();
+
     std::unique_ptr<IdleTimer> idleTimer;
     bool priorValid{true};
 
-  public:
-    std::vector<juce::Component *> accessibleOrderWeakRefs;
-
-  public:
-    std::unique_ptr<juce::ComponentTraverser> createFocusTraverser() override;
-
-  private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SurgefxAudioProcessorEditor)
 };
 

--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -840,7 +840,7 @@ void SurgefxAudioProcessor::resetFxParams(bool updateJuceParams)
         updateJuceParamsFromStorage();
     }
 
-    updateHostDisplay();
+    updateHostDisplay(juce::AudioProcessorListener::ChangeDetails{}.withParameterInfoChanged(true));
     resettingFx = false;
 }
 

--- a/src/surge-fx/SurgeFXProcessor.h
+++ b/src/surge-fx/SurgeFXProcessor.h
@@ -355,6 +355,16 @@ class SurgefxAudioProcessor : public juce::AudioProcessor,
 
     sst::filters::HalfRate::HalfRateFilter halfbandIN{6, true};
 
+    juce::AudioProcessorParameter *getHostParameterForFxSlot(int i)
+    {
+        if (i < 0 || i >= n_fx_params || !getParamEnabled(i))
+        {
+            return nullptr;
+        }
+
+        return fxParams[i];
+    }
+
   private:
     template <typename T, typename F> struct FXAudioParameter : public T
     {

--- a/src/surge-fx/SurgeLookAndFeel.h
+++ b/src/surge-fx/SurgeLookAndFeel.h
@@ -374,6 +374,10 @@ class SurgeFXParamDisplay : public juce::Component
         overlayEditor->onReturnKey = [this]() { processOverlay(); };
         addChildComponent(*overlayEditor);
     }
+
+    std::string getGroup() { return group; };
+    std::string getName() { return name; };
+
     virtual void setGroup(std::string grp)
     {
         group = grp;


### PR DESCRIPTION
Also send trigger parameter name update change for hosts, so that parameters change their name when loading a different effect.