### PR TITLE
Fix a MSEG editor crash

### DIFF
--- a/src/surge-xt/gui/overlays/MSEGEditor.cpp
+++ b/src/surge-xt/gui/overlays/MSEGEditor.cpp
@@ -3736,7 +3736,7 @@ struct MSEGCanvas : public juce::Component, public Surge::GUI::SkinConsumingComp
 
         auto ecomp = std::make_unique<Surge::Widgets::MenuTitleHelpComponent>("", hurl);
 
-        contextMenu.addCustomItem(-1, std::move(ecomp), nullptr, ecomp->getTitle());
+        contextMenu.addCustomItem(-1, std::move(ecomp), nullptr, "");
 
         contextMenu.addSeparator();
 


### PR DESCRIPTION
Fixing a use-after-free which clang was sensitive about (due to order of evaluation).