### PR TITLE
Patch load: fix confirmation dialogs

### DIFF
--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -200,9 +200,6 @@ std::string defaultKeyToString(DefaultKey k)
     case PromptToActivateShortcutsOnAccKeypress:
         r = "promptToActivateShortcutsOnAccKeypress";
         break;
-    case PromptToActivateCategoryAndPatchOnKeypress:
-        r = "promptToActivateCategoryAndPatchOnKeypress";
-        break;
     case PromptToLoadOverDirtyPatch:
         r = "promptToLoadOverDirtyPatch";
         break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -120,7 +120,6 @@ enum DefaultKey
     LastPatchPath,
 
     PromptToActivateShortcutsOnAccKeypress,
-    PromptToActivateCategoryAndPatchOnKeypress,
 
     TuningPolarGraphMode,
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -6015,38 +6015,18 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
             case KeyboardActions::PREV_PATCH:
             case KeyboardActions::NEXT_PATCH:
             {
-                return promptForOKCancelWithDontAskAgain(
-                    "Confirm Patch Change",
-                    fmt::format("You have used a keyboard shortcut to load another patch,\n"
-                                "which will discard any changes made so far.\n\n"
-                                "Do you want to proceed?"),
-                    Surge::Storage::PromptToActivateCategoryAndPatchOnKeypress,
-                    [this, action]() {
-                        closeOverlay(SAVE_PATCH);
+                auto insideCategory = Surge::Storage::getUserDefaultValue(
+                    &(this->synth->storage), Surge::Storage::PatchJogWraparound, 1);
 
-                        auto insideCategory = Surge::Storage::getUserDefaultValue(
-                            &(this->synth->storage), Surge::Storage::PatchJogWraparound, 1);
-
-                        loadPatchWithDirtyCheck(action == KeyboardActions::NEXT_PATCH, false,
-                                                insideCategory);
-                    },
-                    STOP_ASKING);
+                loadPatchWithDirtyCheck(action == KeyboardActions::NEXT_PATCH, false,
+                                        insideCategory);
+                return true;
             }
             case KeyboardActions::PREV_CATEGORY:
             case KeyboardActions::NEXT_CATEGORY:
             {
-                return promptForOKCancelWithDontAskAgain(
-                    "Confirm Category Change",
-                    fmt::format("You have used a keyboard shortcut to select another category,\n"
-                                "which will discard any changes made so far.\n\n"
-                                "Do you want to proceed?"),
-                    Surge::Storage::PromptToActivateCategoryAndPatchOnKeypress,
-                    [this, action]() {
-                        closeOverlay(SAVE_PATCH);
-
-                        loadPatchWithDirtyCheck(action == KeyboardActions::NEXT_CATEGORY, true);
-                    },
-                    STOP_ASKING);
+                loadPatchWithDirtyCheck(action == KeyboardActions::NEXT_CATEGORY, true);
+                return true;
             }
 
             // TODO: UPDATE WHEN ADDING MORE OSCILLATORS
@@ -6474,7 +6454,7 @@ bool SurgeGUIEditor::keyPressed(const juce::KeyPress &key, juce::Component *orig
             "\nWould you like to enable it?\n\n"
             "You can change this option later in the Workflow menu.",
             Surge::Storage::DefaultKey::PromptToActivateShortcutsOnAccKeypress,
-            [this]() { toggleUseKeyboardShortcuts(); });
+            [this]() { toggleUseKeyboardShortcuts(); }, RECORDS_ANSWER, "Don't ask me again");
     }
 
     return false;
@@ -6869,13 +6849,16 @@ void SurgeGUIEditor::globalFocusChanged(juce::Component *fc)
 
 bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(
     const ::std::string &title, const std::string &msg, Surge::Storage::DefaultKey dontAskAgainKey,
-    std::function<void()> okCallback, DontAskAgainMeans dontAskAgainMeans, std::string ynMessage,
-    AskAgainStates askAgainDef)
+    std::function<void()> okCallback, DontAskAgainMeans dontAskAgainMeans,
+    const std::string &ynMessage, AskAgainStates askAgainDef)
 {
     auto bypassed =
         Surge::Storage::getUserDefaultValue(&(synth->storage), dontAskAgainKey, askAgainDef);
 
-    if (bypassed == NEVER && dontAskAgainMeans == REMEMBER_ANSWER)
+    // Older defaults files can hold NEVER against a DISABLES_CONFIRMATION key, which would
+    // suppress the action entirely. Only RECORDS_ANSWER honours it, so those fall through and
+    // prompt.
+    if (bypassed == NEVER && dontAskAgainMeans == RECORDS_ANSWER)
     {
         return false;
     }
@@ -6902,11 +6885,10 @@ bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(
         okCallback();
     };
     alert->onCancelForToggleState = [this, dontAskAgainKey, dontAskAgainMeans](bool dontAskAgain) {
-        if (dontAskAgain)
+        // Cancel must not switch the confirmation off.
+        if (dontAskAgain && dontAskAgainMeans == RECORDS_ANSWER)
         {
-            Surge::Storage::updateUserDefaultValue(&(synth->storage), dontAskAgainKey,
-                                                   (dontAskAgainMeans == STOP_ASKING) ? ALWAYS
-                                                                                      : NEVER);
+            Surge::Storage::updateUserDefaultValue(&(synth->storage), dontAskAgainKey, NEVER);
         }
     };
     alert->setBounds(0, 0, getWindowSizeX(), getWindowSizeY());
@@ -6915,7 +6897,7 @@ bool SurgeGUIEditor::promptForOKCancelWithDontAskAgain(
     return false;
 }
 
-void SurgeGUIEditor::loadPatchWithDirtyCheck(bool increment, bool isCategory, bool insideCategory)
+void SurgeGUIEditor::loadPatchWithDirtyCheck(std::function<void()> loadAction)
 {
     if (synth->storage.getPatch().isDirty)
     {
@@ -6924,20 +6906,22 @@ void SurgeGUIEditor::loadPatchWithDirtyCheck(bool increment, bool isCategory, bo
             fmt::format("The currently loaded patch has unsaved changes.\n"
                         "Loading a new patch will discard any such changes.\n\n"
                         "Do you want to proceed?"),
-            Surge::Storage::PromptToLoadOverDirtyPatch,
-            [this, increment, isCategory, insideCategory]() {
-                closeOverlay(SAVE_PATCH);
-
-                synth->jogPatchOrCategory(increment, isCategory, insideCategory);
-            },
-            STOP_ASKING, "Don't ask me again", ALWAYS);
+            Surge::Storage::PromptToLoadOverDirtyPatch, loadAction, DISABLES_CONFIRMATION,
+            "Don't ask me again", ALWAYS);
     }
     else
     {
+        loadAction();
+    }
+}
+
+void SurgeGUIEditor::loadPatchWithDirtyCheck(bool increment, bool isCategory, bool insideCategory)
+{
+    loadPatchWithDirtyCheck([this, increment, isCategory, insideCategory]() {
         closeOverlay(SAVE_PATCH);
 
         synth->jogPatchOrCategory(increment, isCategory, insideCategory);
-    }
+    });
 }
 
 void SurgeGUIEditor::enqueueAccessibleAnnouncement(const std::string &s)

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -544,6 +544,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         synth->processAudioThreadOpsWhenAudioEngineUnavailable();
     }
 
+    void loadPatchWithDirtyCheck(std::function<void()> loadAction);
     void loadPatchWithDirtyCheck(bool increment, bool isCategory, bool insideCategory = false);
 
     void openMacroRenameDialog(const int ccid, const juce::Point<int> where,
@@ -968,12 +969,12 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
         NEVER = 100
     };
 
-    // What ticking "Don't ask me again" records: REMEMBER_ANSWER stores the button pressed,
-    // STOP_ASKING runs the action unprompted from then on whichever button was pressed.
+    // What ticking the checkbox does at each call site: RECORDS_ANSWER stores the button pressed
+    // for reuse, DISABLES_CONFIRMATION switches the prompt off.
     enum DontAskAgainMeans
     {
-        REMEMBER_ANSWER,
-        STOP_ASKING
+        RECORDS_ANSWER,
+        DISABLES_CONFIRMATION
     };
 
     // sometimes we need to return focus to a specific component after an Alert dialog is dismissed
@@ -984,8 +985,8 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     bool promptForOKCancelWithDontAskAgain(const ::std::string &title, const std::string &msg,
                                            Surge::Storage::DefaultKey dontAskAgainKey,
                                            std::function<void()> okCallback,
-                                           DontAskAgainMeans dontAskAgainMeans = REMEMBER_ANSWER,
-                                           std::string ynMessage = "Don't ask me again",
+                                           DontAskAgainMeans dontAskAgainMeans,
+                                           const std::string &ynMessage,
                                            AskAgainStates askAgainDefault = DUNNO);
 
   private:

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -902,7 +902,7 @@ bool PatchSelector::optionallyAddFavorites(juce::PopupMenu &p, bool addColumnBre
         for (auto idx : favs)
         {
             subMenu.addItem(juce::CharPointer_UTF8(storage->patch_list[idx].name.c_str()),
-                            [this, idx]() { this->loadPatch(idx, true); });
+                            [this, idx]() { this->loadPatchWithDirtyCheck(idx, true); });
         }
 
         subMenu.addSeparator();
@@ -918,7 +918,7 @@ bool PatchSelector::optionallyAddFavorites(juce::PopupMenu &p, bool addColumnBre
         for (auto idx : favs)
         {
             p.addItem(juce::CharPointer_UTF8(storage->patch_list[idx].name.c_str()),
-                      [this, idx]() { this->loadPatch(idx, true); });
+                      [this, idx]() { this->loadPatchWithDirtyCheck(idx, true); });
         }
         p.addSeparator();
         p.addItem(Surge::GUI::toOSCase("Export favorites to..."), [this]() { exportFavorites(); });
@@ -1114,7 +1114,7 @@ bool PatchSelector::populatePatchMenuForCategory(int c, juce::PopupMenu &context
 
             bool isFav = storage->patch_list[p].isFavorite;
             auto item = juce::PopupMenu::Item(name).setEnabled(true).setTicked(thisCheck).setAction(
-                [this, p]() { this->loadPatch(p); });
+                [this, p]() { this->loadPatchWithDirtyCheck(p); });
 
             if (thisCheck)
                 item.setID(ID_TO_PRESELECT_MENU_ITEMS);
@@ -1195,6 +1195,20 @@ bool PatchSelector::populatePatchMenuForCategory(int c, juce::PopupMenu &context
 }
 
 void PatchSelector::loadPatch(int id) { loadPatch(id, false); }
+
+void PatchSelector::loadPatchWithDirtyCheck(int id, bool fromFavorites)
+{
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+    if (sge)
+    {
+        sge->loadPatchWithDirtyCheck([this, id, fromFavorites]() { loadPatch(id, fromFavorites); });
+    }
+    else
+    {
+        loadPatch(id, fromFavorites);
+    }
+}
 
 void PatchSelector::loadPatch(int id, bool fromFavorites)
 {

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -157,6 +157,7 @@ struct PatchSelector : public juce::Component,
 
     void loadPatch(int id);
     void loadPatch(int id, bool fromFavorites);
+    void loadPatchWithDirtyCheck(int id, bool fromFavorites = false);
     void loadInitPatch();
     int sel_id = 0, enqueue_sel_id = 0;
 


### PR DESCRIPTION
Follow up from: #8496

- Fixes keyboard patch/category jog taking a different path from the patch selector's jog buttons, going through an extra "Confirm Patch Change" dialog
- Fixes that dialog firing on every press regardless of dirty state
- Fixes a second dialog being raised for the same keypress
- Fixes the keypress being reported as unhandled whenever the dialog appeared
- Fixes selecting a patch from the menu loading over unsaved changes without prompting
- Fixes ticking "Don't ask me again" and pressing Cancel switching the confirmation off entirely. Tick + OK and the Workflow menu item still do
- Retires the now-unused `promptToActivateCategoryAndPatchOnKeypress` default, the Workflow menu item is now the only exposed control for the confirmation. Stored values for the retired key are ignored on read

Assisted-by: Claude Opus 5