### PR TITLE
Receiving All Sound Off does what it should

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4640,8 +4640,8 @@ void SurgeSynthesizer::process()
 
         if (masterfade < 0.0001f)
         {
-            releaseScene(0);
-            releaseScene(1);
+            stopSound();
+
             approachingAllSoundOff = false;
         }
     }


### PR DESCRIPTION
Previously we didn't suspend the effects when receiving All Sound Off. Now we do.

Won't affect FL Studio (sadly) since it only sends All Notes Off, but some other DAWs will behave properly at least.

Closes #8375