### PR TITLE
Canonicalize portable factory and user data paths

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -196,6 +196,9 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
         "Surge Synth Team", "Surge XT", true);
     userDataPath = getOverridenUserPath();
 
+    bool isFactoryPortable{false};
+    bool isUserPortable{false};
+
 #if MAC
     if (!hasSuppliedDataPath)
     {
@@ -238,6 +241,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
             {
                 datapath = std::move(portable);
                 founddir = true;
+                isFactoryPortable = true;
             }
 
             cp = cp.parent_path();
@@ -279,10 +283,12 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
         if (fs::is_directory(portable))
         {
             userDataPath = std::move(portable);
+            isUserPortable = true;
         }
 
         up = up.parent_path();
     }
+
     if (userDataPath.empty())
     {
         userDataPath = calculateStandardUserDataPath(sxt);
@@ -303,6 +309,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
             if (fs::is_directory(portable))
             {
                 datapath = std::move(portable);
+                isFactoryPortable = true;
             }
 
             cp = cp.parent_path();
@@ -333,6 +340,7 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
         if (fs::is_directory(portable))
         {
             userDataPath = std::move(portable);
+            isUserPortable = true;
         }
 
         cp = cp.parent_path();
@@ -355,6 +363,34 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
         }
     }
 #endif
+
+    // Canonicalize now, once, so every downstream consumer (PatchDB path keys,
+    // refreshPatchlistAddDir, userDataPath-derived paths, etc.) sees a stable,
+    // symlink-resolved string regardless of which portable-mode symlink (if any)
+    // or install location was used to find it. This matters in particular because
+    // the patch DB caches patches by raw path string (see
+    // PatchDB::readAllPatchPathsWithIdAndModTime), so two different plugin formats
+    // resolving the same real folder through different symlinks would otherwise
+    // produce different cache keys and force a full patch-library rescan.
+    auto canonicalizeIfPresent = [this](fs::path &p, const bool doIt) {
+        if (p.empty() || !doIt)
+        {
+            return;
+        }
+
+        try
+        {
+            p = fs::weakly_canonical(p);
+        }
+        catch (const fs::filesystem_error &e)
+        {
+            // leave p as-is; downstream is_directory/existence checks will
+            // surface any real problem
+        }
+    };
+
+    canonicalizeIfPresent(datapath, isFactoryPortable);
+    canonicalizeIfPresent(userDataPath, isUserPortable);
 
     initializeUserDataPaths();
 


### PR DESCRIPTION
Previously, if we loaded CLAP then VST3 and had a symlink to factory and/or user data paths, and clicked the magnifier button after each instantiation, we would get a long "Updating patch database" countdown always, which made no sense.

Well, it didn't make sense to me as a user, but it makes sense code-wise, because portable paths are scanned from the plugin binary as the basepath, so for VST3 and CLAP we actually get different final paths, and autorefreshing the patch database is predicated solely on the path.

By canonicalizing the detected portable paths, we remove this annoyance because what the path resolves to will be the actual path to the symlinked folder, not based relative to the plugin binary, but absolute to the drive the data folders are on.