### PR TITLE
Fix regression caused by #8465

### DIFF
--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1039,8 +1039,8 @@ void SurgeGUIEditor::idle()
         {
             if (synth->vu_peak[0] != vu->getValue())
             {
-                vuInvalid = true;
                 vu->setValue(synth->vu_peak[0]);
+                vuInvalid = true;
             }
 
             if (synth->vu_peak[1] != vu->getValueR())
@@ -1069,11 +1069,11 @@ void SurgeGUIEditor::idle()
                 {
                     vuInvalid = true;
                 }
+            }
 
-                if (vuInvalid)
-                {
-                    vu->repaint();
-                }
+            if (vuInvalid)
+            {
+                vu->repaint();
             }
         }
 

--- a/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorValueCallbacks.cpp
@@ -2109,11 +2109,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(Surge::GUI::IComponentTagValue *c
                         }
                         else if (p->ctrlgroup == cg_LFO)
                         {
-                            if (a >= ms_lfo1 && a <= ms_lfo1 + n_lfos_voice)
+                            if (a >= ms_lfo1 && a < ms_lfo1 + n_lfos_voice)
                             {
                                 prefix = "Voice LFO " + std::to_string(a - ms_lfo1 + 1);
                             }
-                            else if (a >= ms_slfo1 && a <= ms_slfo1 + n_lfos_scene)
+                            else if (a >= ms_slfo1 && a < ms_slfo1 + n_lfos_scene)
                             {
                                 prefix = "Scene LFO " + std::to_string(a - ms_slfo1 + 1);
                             }


### PR DESCRIPTION
Move the VU meter repaint block outside of showCPU block.

Also, fix an off-by-one indexing for Disable/Enable Tempo Sync for all LFO params menu entries.

Addresses #8462