### PR TITLE
Fix crash when copying a smaller wavetable after a larger one

### DIFF
--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -137,8 +137,8 @@ void Wavetable::Copy(Wavetable *wt)
         allocPointers(wt->dataSizes);
     }
 
-    memcpy(TableF32Data, wt->TableF32Data, dataSizes * sizeof(float));
-    memcpy(TableI16Data, wt->TableI16Data, dataSizes * sizeof(short));
+    memcpy(TableF32Data, wt->TableF32Data, wt->dataSizes * sizeof(float));
+    memcpy(TableI16Data, wt->TableI16Data, wt->dataSizes * sizeof(short));
 
     for (int i = 0; i < max_mipmap_levels; i++)
     {


### PR DESCRIPTION
`Wavetable::Copy` grows the destination to fit the source, then memcpy's `dataSizes` elements, its own buffer length, not the source's.

Steps to reproduce, generate a full size WT using the WT Script Editor (default script suffices) and do Copy from Osc, switch to second oscillator and Copy Osc with Sine HQ loaded and it seg faults.