### PR TITLE
Do not assume XML attributes are present when reading a patch

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1814,8 +1814,16 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
 
             while (tag)
             {
-                std::string tagName = tag->Attribute("tag");
-                tags.emplace_back(tagName);
+                // Attribute returns null when it isn't there, and patches arrive
+                // from other people, so a <tag/> without one would build a
+                // std::string from nullptr rather than simply having no name.
+                const char *tagName = tag->Attribute("tag");
+
+                if (tagName)
+                {
+                    tags.emplace_back(tagName);
+                }
+
                 tag = TINYXML_SAFE_TO_ELEMENT(tag->NextSiblingElement("tag"));
             }
         }

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -494,15 +494,20 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
                         int g = 0;
                         if (pchild->QueryIntAttribute("group", &g) == TIXML_SUCCESS)
                         {
-                            std::string help_url = pchild->Attribute("help_url");
+                            // Attribute returns null for one that isn't present, and
+                            // an entry can carry its group without carrying a URL
+                            const char *hu = pchild->Attribute("help_url");
+                            std::string help_url = hu ? hu : "";
                             if (help_url.size() > 0)
                                 helpURL_controlgroup[g] = help_url;
                         }
                     }
                     else if (strcmp(pchild->Value(), "param") == 0)
                     {
-                        std::string id = pchild->Attribute("id");
-                        std::string help_url = pchild->Attribute("help_url");
+                        const char *idA = pchild->Attribute("id");
+                        const char *huA = pchild->Attribute("help_url");
+                        std::string id = idA ? idA : "";
+                        std::string help_url = huA ? huA : "";
                         int t = 0;
                         if (help_url.size() > 0)
                         {
@@ -519,8 +524,10 @@ SurgeStorage::SurgeStorage(const SurgeStorage::SurgeStorageConfig &config) : oth
                     }
                     else if (strcmp(pchild->Value(), "special") == 0)
                     {
-                        std::string id = pchild->Attribute("id");
-                        std::string help_url = pchild->Attribute("help_url");
+                        const char *idA = pchild->Attribute("id");
+                        const char *huA = pchild->Attribute("help_url");
+                        std::string id = idA ? idA : "";
+                        std::string help_url = huA ? huA : "";
                         if (help_url.size() > 0)
                         {
                             helpURL_specials[id] = help_url;

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -904,4 +904,26 @@ TEST_CASE("XML Direct", "[io]")
         std::string test{"<patch><parameters/></patch>"};
         surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
     }
+
+    SECTION("Tag without its attribute")
+    {
+        // TiXmlElement::Attribute returns null for an attribute that isn't there,
+        // so a <tag/> carrying no tag built a std::string from nullptr. Patches
+        // come from other people, so this is reachable by opening one.
+        auto surge = Surge::Headless::createSurge(44100);
+        std::string test{"<patch><meta><tags><tag/></tags></meta></patch>"};
+        surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
+        REQUIRE(surge->storage.getPatch().tags.empty());
+    }
+
+    SECTION("Tags mixing named and unnamed")
+    {
+        // one malformed entry shouldn't cost the patch its other tags
+        auto surge = Surge::Headless::createSurge(44100);
+        std::string test{"<patch><meta><tags>"
+                         "<tag tag=\"bass\"/><tag/><tag tag=\"lead\"/>"
+                         "</tags></meta></patch>"};
+        surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
+        REQUIRE(surge->storage.getPatch().tags.size() == 2);
+    }
 }


### PR DESCRIPTION
`TiXmlElement::Attribute` returns null for an attribute that isn't there. Most of the readers already account for that — `FxUserPreset::readFromXMLSnapshot` bails when `name` is missing, and the `meta` and `label` reads check before using what they got — but a few build a `std::string` straight from the result.

### The one that matters

`SurgePatch.cpp`, reading the patch tag list:

```cpp
std::string tagName = tag->Attribute("tag");
```

A `<tag/>` element carrying no `tag` attribute constructs a `std::string` from `nullptr`. Patches are shared, downloaded and hand edited, so opening someone else's patch is enough to reach this. A malformed entry is now skipped and the patch keeps its remaining tags, rather than one bad entry taking the whole load down.

### The same shape elsewhere

`SurgeStorage.cpp` reads `help_url` and `id` the same way in three places while parsing the configuration. An entry can legitimately carry its `group` or `id` without carrying a URL, so those are read as optional now too.

### Testing

Two cases added to `TEST_CASE("XML Direct", "[io]")`, which already exists with the comment *"we want to make sure it doesn't nuke surge with garbage"* — this is a piece of garbage it didn't yet cover. One case feeds a bare `<tag/>`, the other mixes named and unnamed tags to check a malformed entry doesn't cost the patch its good ones.

I checked they fail without the fix rather than only passing with it. Reverting the two sources and keeping the tests gives:

```
UnitTestsIO.cpp:908: FAILED:
due to a fatal error condition:
  SIGSEGV - Segmentation violation signal
```

With the fix, `[io]` is green at 5463 assertions in 10 test cases, and the full runner is green at **5702164 assertions in 126 test cases**. `clang-format` clean.

Related: same class of thing as surge-synthesizer/sst-plugininfra#84, which was the user defaults reader.

---

Assisted-By: Claude Code (Claude Opus 5) — I used it to sweep the call sites and draft the patch; the analysis, the both-ways check and the review of it are mine.

X: [@manuaudiomix](https://x.com/manuaudiomix)
