### PR TITLE
Bound the extraoscdata indices and count taken from a patch

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2778,6 +2778,14 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 int sos = std::atoi(lkid->Attribute("osc"));
                 int ssc = std::atoi(lkid->Attribute("scene"));
 
+                // These index scene[n_scenes] and osc[n_oscs] and they come
+                // straight out of the file, so a patch naming a scene or
+                // oscillator we don't have would write outside the patch.
+                if (sos < 0 || sos >= n_oscs || ssc < 0 || ssc >= n_scenes)
+                {
+                    continue;
+                }
+
                 if (lkid->Attribute("wavetable_display_name"))
                 {
                     scene[ssc].osc[sos].wavetable_display_name =
@@ -2828,7 +2836,11 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
 
                 if (lkid->QueryIntAttribute("extra_n", &ti) == TIXML_SUCCESS)
                 {
-                    ec->nData = ti;
+                    // extra_n is the bound for the writes below and it comes from
+                    // the file, so it has to be held inside the array it indexes.
+                    ec->nData = std::max(
+                        0,
+                        std::min(ti, (int)OscillatorStorage::ExtraConfigurationData::max_config));
 
                     for (int qq = 0; qq < ec->nData; ++qq)
                     {

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2781,7 +2781,7 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 // These index scene[n_scenes] and osc[n_oscs] and they come
                 // straight out of the file, so a patch naming a scene or
                 // oscillator we don't have would write outside the patch.
-                if (sos < 0 || sos >= n_oscs || ssc < 0 || ssc >= n_scenes)
+                if (!within_range(0, ssc, n_scenes - 1) || !within_range(0, sos, n_oscs - 1))
                 {
                     continue;
                 }
@@ -2838,9 +2838,8 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                 {
                     // extra_n is the bound for the writes below and it comes from
                     // the file, so it has to be held inside the array it indexes.
-                    ec->nData = std::max(
-                        0,
-                        std::min(ti, (int)OscillatorStorage::ExtraConfigurationData::max_config));
+                    ec->nData = limit_range(
+                        ti, 0, (int)OscillatorStorage::ExtraConfigurationData::max_config);
 
                     for (int qq = 0; qq < ec->nData; ++qq)
                     {
@@ -2956,6 +2955,12 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             mi = v;
         }
 
+        if (!within_range(0, sc, n_scenes - 1) || !within_range(0, mi, n_lfos - 1))
+        {
+            p = TINYXML_SAFE_TO_ELEMENT(p->NextSibling("mseg"));
+            continue;
+        }
+
         auto *ms = &(msegs[sc][mi]);
 
         msegFromXMLElement(ms, p, userPrefRestoreMSEGFromPatch);
@@ -3006,6 +3011,12 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
         if (p->QueryIntAttribute("i", &v) == TIXML_SUCCESS)
         {
             mi = v;
+        }
+
+        if (!within_range(0, sc, n_scenes - 1) || !within_range(0, mi, n_lfos - 1))
+        {
+            p = TINYXML_SAFE_TO_ELEMENT(p->NextSibling("formula"));
+            continue;
         }
 
         auto *fs = &(formulamods[sc][mi]);
@@ -3110,11 +3121,14 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
         {
             int lfo, idx, scene;
 
+            const char *lv = lb->Attribute("v");
+
             if (lb->QueryIntAttribute("lfo", &lfo) == TIXML_SUCCESS &&
                 lb->QueryIntAttribute("idx", &idx) == TIXML_SUCCESS &&
-                lb->QueryIntAttribute("scene", &scene) == TIXML_SUCCESS)
-                strxcpy(LFOBankLabel[scene][lfo][idx], lb->Attribute("v"),
-                        CUSTOM_CONTROLLER_LABEL_SIZE);
+                lb->QueryIntAttribute("scene", &scene) == TIXML_SUCCESS && lv &&
+                within_range(0, scene, n_scenes - 1) && within_range(0, lfo, n_lfos - 1) &&
+                within_range(0, idx, max_lfo_indices - 1))
+                strxcpy(LFOBankLabel[scene][lfo][idx], lv, CUSTOM_CONTROLLER_LABEL_SIZE);
             lb = TINYXML_SAFE_TO_ELEMENT(lb->NextSibling("label"));
         }
     }

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -939,8 +939,7 @@ TEST_CASE("XML Direct", "[io]")
         surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
 
         auto &ec = surge->storage.getPatch().scene[0].osc[0].extraConfig;
-        REQUIRE(ec.nData >= 0);
-        REQUIRE(ec.nData <= (int)OscillatorStorage::ExtraConfigurationData::max_config);
+        REQUIRE(ec.nData == (int)OscillatorStorage::ExtraConfigurationData::max_config);
     }
 
     SECTION("extraoscdata with a negative extra_n")
@@ -952,7 +951,40 @@ TEST_CASE("XML Direct", "[io]")
         surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
 
         auto &ec = surge->storage.getPatch().scene[0].osc[0].extraConfig;
-        REQUIRE(ec.nData >= 0);
+        REQUIRE(ec.nData == 0);
+    }
+
+    SECTION("msegs with out of range scene and index")
+    {
+        auto surge = Surge::Headless::createSurge(44100);
+        std::string test{"<patch><parameters/><msegs>"
+                         "<mseg scene=\"99\" i=\"99\"/><mseg scene=\"-1\" i=\"-1\"/>"
+                         "</msegs></patch>"};
+        surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
+        SUCCEED("an out of range mseg scene or index did not write outside the patch");
+    }
+
+    SECTION("formulae with out of range scene and index")
+    {
+        auto surge = Surge::Headless::createSurge(44100);
+        std::string test{"<patch><parameters/><formulae>"
+                         "<formula scene=\"99\" i=\"99\"/><formula scene=\"-1\" i=\"-1\"/>"
+                         "</formulae></patch>"};
+        surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
+        SUCCEED("an out of range formula scene or index did not write outside the patch");
+    }
+
+    SECTION("lfo bank labels with out of range indices or no value")
+    {
+        // three indices and the label text all come from the file
+        auto surge = Surge::Headless::createSurge(44100);
+        std::string test{"<patch><parameters/><lfobanklabels>"
+                         "<label scene=\"99\" lfo=\"99\" idx=\"99\" v=\"x\"/>"
+                         "<label scene=\"-1\" lfo=\"-1\" idx=\"-1\" v=\"x\"/>"
+                         "<label scene=\"0\" lfo=\"0\" idx=\"0\"/>"
+                         "</lfobanklabels></patch>"};
+        surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
+        SUCCEED("out of range label indices and a missing value were both discarded");
     }
 
     SECTION("extraoscdata with out of range scene and osc")

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -926,4 +926,45 @@ TEST_CASE("XML Direct", "[io]")
         surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
         REQUIRE(surge->storage.getPatch().tags.size() == 2);
     }
+
+    SECTION("extraoscdata with an oversized extra_n")
+    {
+        // extra_n is the loop bound for writes into a fixed max_config array and
+        // it arrives from the file, so a patch could ask us to write far past the
+        // end of it. Patches get shared and downloaded, so opening one is enough.
+        auto surge = Surge::Headless::createSurge(44100);
+        std::string test{"<patch><parameters/><extraoscdata>"
+                         "<od osc=\"0\" scene=\"0\" extra_n=\"100000\"/>"
+                         "</extraoscdata></patch>"};
+        surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
+
+        auto &ec = surge->storage.getPatch().scene[0].osc[0].extraConfig;
+        REQUIRE(ec.nData >= 0);
+        REQUIRE(ec.nData <= (int)OscillatorStorage::ExtraConfigurationData::max_config);
+    }
+
+    SECTION("extraoscdata with a negative extra_n")
+    {
+        auto surge = Surge::Headless::createSurge(44100);
+        std::string test{"<patch><parameters/><extraoscdata>"
+                         "<od osc=\"0\" scene=\"0\" extra_n=\"-5\"/>"
+                         "</extraoscdata></patch>"};
+        surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
+
+        auto &ec = surge->storage.getPatch().scene[0].osc[0].extraConfig;
+        REQUIRE(ec.nData >= 0);
+    }
+
+    SECTION("extraoscdata with out of range scene and osc")
+    {
+        // scene and osc index fixed arrays of n_scenes and n_oscs, and both come
+        // from the file without being checked against those bounds.
+        auto surge = Surge::Headless::createSurge(44100);
+        std::string test{"<patch><parameters/><extraoscdata>"
+                         "<od osc=\"99\" scene=\"99\" extra_n=\"1\"/>"
+                         "<od osc=\"-1\" scene=\"-1\" extra_n=\"1\"/>"
+                         "</extraoscdata></patch>"};
+        surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
+        SUCCEED("an out of range scene or osc index did not write outside the patch");
+    }
 }


### PR DESCRIPTION
The `extraoscdata` block reads three numbers out of the patch and uses all three without checking them against what they index. Patches get shared, downloaded and hand edited, so opening someone else's patch is enough to reach every one of these.

### `osc` and `scene`

They index `osc[n_oscs]` and `scene[n_scenes]`, and both come from the file:

```cpp
int sos = std::atoi(lkid->Attribute("osc"));
int ssc = std::atoi(lkid->Attribute("scene"));
...
auto ec = &(scene[ssc].osc[sos].extraConfig);
```

A patch naming an oscillator or scene we don't have writes outside the patch object. A negative index does the same in the other direction.

### `extra_n`

This is the one I'd look at first. It's the loop bound for writes into `ExtraConfigurationData::data`, which is a fixed `max_config` floats:

```cpp
ec->nData = ti;                                  // straight from the file

for (int qq = 0; qq < ec->nData; ++qq)
{
    if (lkid->QueryDoubleAttribute(attr, &tf) == TIXML_SUCCESS)
        ec->data[qq] = tf;
    else
        ec->data[qq] = 0.f;                      // writes even with no attribute
}
```

Because the `else` branch writes too, `extra_n` on its own decides how far past the end of that array we go — no `extra_data_N` attributes are needed at all. A negative value was also stored unchanged, leaving `nData` negative in the patch.

### The change

Entries whose `osc` or `scene` is outside range are skipped, and `extra_n` is held inside the array it indexes.

### Testing

Three cases added to `TEST_CASE("XML Direct", "[io]")`, which already exists to check `load_xml` copes with garbage.

Worth mentioning for anyone extending that test case: `load_xml` returns before `extraoscdata` if the patch has no `<parameters>` element, so a test patch needs one or it silently never reaches this code. My first attempt at these tests passed against the unfixed build for exactly that reason.

Once they actually reach it, the unfixed build gives:

```
UnitTestsIO.cpp:933: FAILED:
  REQUIRE( ec.nData >= 0 )
with expansion:
  -5 >= 0

UnitTestsIO.cpp:936: FAILED:
due to a fatal error condition:
  SIGSEGV - Segmentation violation signal
```

With the fix, `[io]` is green at 5468 assertions in 10 test cases and the full runner is green at **5702780 assertions in 126 test cases**. `clang-format` clean.

### A note on how I'm reporting this

There's no `SECURITY.md` and private vulnerability reporting is turned off for the repo, so there was no private channel to use and I've written this as an ordinary bug report. It is a bounded, attacker-influenced write reachable from a shared file, so you may want to treat it with more urgency than the other two I've sent today, and it might be worth enabling private reporting on the repo for next time.

Sits alongside #8523, which was the null-attribute reads in the same loader. They don't overlap.

---

Assisted-By: Claude Code (Claude Opus 5) — I used it to trace the loader and draft the patch; the analysis, the both-ways check and the review of it are mine.

X: [@manuaudiomix](https://x.com/manuaudiomix)
