### PR TITLE
Make the MatrixVerb vibrato seeds well defined

### DIFF
--- a/libs/airwindows/src/MatrixVerb.cpp
+++ b/libs/airwindows/src/MatrixVerb.cpp
@@ -69,23 +69,26 @@ MatrixVerb::MatrixVerb(audioMasterCallback audioMaster) :
 	depthG = 0.002146;
 	depthH = 0.002088;
 	//the individual vibrato rates for the delays
-	vibAL = rand()*-2147483647;
-	vibBL = rand()*-2147483647;
-	vibCL = rand()*-2147483647;
-	vibDL = rand()*-2147483647;
-	vibEL = rand()*-2147483647;
-	vibFL = rand()*-2147483647;
-	vibGL = rand()*-2147483647;
-	vibHL = rand()*-2147483647;
+	//rand() * -2147483647 is an int multiply which overflows for any rand()
+	//above 1, and signed overflow is undefined. 2147483649u is -2147483647
+	//as unsigned, so this wraps identically but is defined.
+	vibAL = (int)(rand() * 2147483649u);
+	vibBL = (int)(rand() * 2147483649u);
+	vibCL = (int)(rand() * 2147483649u);
+	vibDL = (int)(rand() * 2147483649u);
+	vibEL = (int)(rand() * 2147483649u);
+	vibFL = (int)(rand() * 2147483649u);
+	vibGL = (int)(rand() * 2147483649u);
+	vibHL = (int)(rand() * 2147483649u);
 	
-	vibAR = rand()*-2147483647;
-	vibBR = rand()*-2147483647;
-	vibCR = rand()*-2147483647;
-	vibDR = rand()*-2147483647;
-	vibER = rand()*-2147483647;
-	vibFR = rand()*-2147483647;
-	vibGR = rand()*-2147483647;
-	vibHR = rand()*-2147483647;
+	vibAR = (int)(rand() * 2147483649u);
+	vibBR = (int)(rand() * 2147483649u);
+	vibCR = (int)(rand() * 2147483649u);
+	vibDR = (int)(rand() * 2147483649u);
+	vibER = (int)(rand() * 2147483649u);
+	vibFR = (int)(rand() * 2147483649u);
+	vibGR = (int)(rand() * 2147483649u);
+	vibHR = (int)(rand() * 2147483649u);
 	
 	
 	A = 1.0;


### PR DESCRIPTION
### What

`MatrixVerb`'s constructor seeds sixteen vibrato members with

```cpp
vibAL = rand()*-2147483647;
```

`rand()` returns `int` and `-2147483647` is `int`, so this is an int multiply that overflows for any `rand()` result above 1. Signed overflow is undefined behaviour, and a UBSan build reports all sixteen of them while the effect is being constructed — which happens whenever a patch using MatrixVerb loads:

```
libs/airwindows/src/MatrixVerb.cpp:72:16: runtime error: signed integer overflow:
216250703 * -2147483647 cannot be represented in type 'int'
    #0 MatrixVerb::MatrixVerb::MatrixVerb(int) MatrixVerb.cpp:72
    #3 (anonymous namespace)::create<MatrixVerb::MatrixVerb>(int, double, int)
    #4 AirWindowsEffect::setupSubFX(int, bool) AirWindowsEffect.cpp:288
    #5 AirWindowsEffect::updateAfterReload() AirWindowsEffect.cpp:309
    #6 SurgeSynthesizer::loadFx(bool, bool) SurgeSynthesizer.cpp:3181
    #7 SurgeSynthesizer::loadRaw(void const*, int, bool) SurgeSynthesizerIO.cpp:478
```

### The change

`2147483649u` is `-2147483647` reinterpreted as unsigned, so the multiply wraps exactly the way it does today, but unsigned overflow is defined rather than undefined.

I deliberately did **not** switch to a floating multiply (`* -2147483647.0`), even though that is arguably what the expression is reaching for, because it would change the values. This way the bits are identical.

### Why this is safe

Two independent reasons:

1. **The values are unchanged.** I compared both forms across the whole `int` range at `-O2`, striding by a prime: 215330 values, zero differences in the resulting `double`.
2. **The values are never read.** All sixteen `vib*` members are assigned in this constructor and appear nowhere else in `MatrixVerb.cpp` — the only other mentions are their declarations in `MatrixVerb.h`. So MatrixVerb cannot sound different either way.

`[fx]` stays green at 3202892 assertions across 9 cases.

I kept the surrounding tab style since this is vendored and the format check only covers `src`, so the diff stays minimal against upstream. Happy to just delete the sixteen dead assignments instead if you would rather — that is the other reasonable reading, I went with the smaller diff.

### Verification

- The trace above is from an ASan/UBSan build of `surge-testrunner` on `[io]`, before the change.
- The replacement expression compiled with `-fsanitize=undefined` reports nothing; the original reports the overflow. 
- Bit-for-bit comparison as described above.

Assisted-By: Claude Code (Claude Opus 5) — X: manuaudiomix
