### PR TITLE
Fix two undefined behaviour reports in src/

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -1572,9 +1572,12 @@ void SurgeSynthesizer::releaseNotePostHoldCheck(int scene, char channel, char ke
                          * velocity here is our release velocity. So grab the prior notes
                          * velocity since it is the best we have at this point.
                          */
-                        auto priorNoteVel =
-                            std::clamp((char)(v->modsources[ms_velocity]->get_output(0) * 128),
-                                       (char)0, (char)127);
+                        // get_output is normalised, so a full velocity note scales to
+                        // exactly 128, which does not fit in a char. Clamping after the
+                        // conversion is too late to help, so clamp while it is still an
+                        // int and narrow the result.
+                        auto priorNoteVel = (char)std::clamp(
+                            (int)(v->modsources[ms_velocity]->get_output(0) * 128), 0, 127);
                         v->uber_release();
 
                         // confirm that no notes are active

--- a/src/common/dsp/modulators/FormulaModulationHelper.h
+++ b/src/common/dsp/modulators/FormulaModulationHelper.h
@@ -56,7 +56,7 @@ using Surge::LuaSupport::sharedTableName;
 
 struct EvaluatorState
 {
-    bool released;
+    bool released{false};
     char funcName[TXT_SIZE];
     char funcNameInit[TXT_SIZE];
     char stateName[TXT_SIZE];
@@ -80,7 +80,7 @@ struct EvaluatorState
     int lfo_id{0};
 
     // voice features
-    bool isVoice, mpeenabled;
+    bool isVoice{false}, mpeenabled{false};
     int key{60}, channel{0}, velocity{0}, releasevelocity{0}, mpebendrange{24};
     int64_t voiceOrderAtCreate{1L};
     float polyat{0}, mpebend{0}, mpetimbre{0}, mpepressure{0}, tunedkey{0};


### PR DESCRIPTION
Two unrelated UBSan findings from a sanitizer build of `surge-testrunner`, kept as separate commits so you can take one without the other.

### 1. Uninitialised bools in `EvaluatorState`

`released`, `isVoice` and `mpeenabled` are the only three bools in the struct without a default member initialiser. Every other one has `= false`, `{false}` or `= true`.

They do get assigned from `LFOModulationSource` when a voice is driving the modulator, but `prepareForEvaluation` and the debug row builder read them on paths that reach neither assignment:

```
FormulaModulationHelper.cpp:284:19: runtime error: load of value 87,
which is not a valid value for type 'bool'
    #0 Surge::Formula::prepareForEvaluation(...) FormulaModulationHelper.cpp:284
    #1 runFormula(...) UnitTestsLUA.cpp:444
```

Seven sites report — `.cpp:284, 293, 303, 304, 677, 682, 695` — and they line up exactly with the reads of these three members (`is_display` sits right beside them at :305 and is not reported, because it *is* initialised).

This is worth more than tidiness: a `bool` holding neither 0 nor 1 is undefined, and `if (b)` and `if (!b)` can both be taken. `isVoice` gates whether `key`, `velocity`, `channel` and friends are published to the formula at all, so a garbage read decides which variables a formula modulator can see.

`false` is what every sibling defaults to and what the assigning paths use for a non-voice state.

### 2. Velocity narrowed before it is clamped

```cpp
std::clamp((char)(v->modsources[ms_velocity]->get_output(0) * 128), (char)0, (char)127)
```

`get_output` is normalised, so a full velocity note scales to exactly `128`, and the cast to `char` happens *before* the clamp — the clamp is bounding a value that has already overflowed.

```
SurgeSynthesizer.cpp:1576:46: runtime error: 128 is outside the range of
representable values of type 'char'
    #0 SurgeSynthesizer::releaseNotePostHoldCheck(int, char, char, char, int)
    #1 SurgeSynthesizer::releaseNote(char, char, char, int)
```

Compiling that expression standalone against the fixed form, with a full velocity input:

| | `-O0` | `-O1` / `-O2` / `-O3` |
|---|---|---|
| current | **0** | **128** |
| clamp-then-narrow | 127 | 127 |

So a note released at full velocity hands on either `0` or a `128` that a signed char cannot represent and that slips past the clamp. Clamping as an `int` and narrowing the result gives `127` everywhere.

### Verification

Both proven in each direction on an ASan/UBSan build, each tag run on its own:

| | before | after |
|---|---|---|
| `[formula]` | 7 UBSan reports | 0, green at 16956 assertions / 10 cases |
| `[midi]` | 1 UBSan report | 0, green at 7493 assertions / 14 cases |

Reverting just the two source changes and rebuilding brings all 8 reports back, so the tests are tied to the fixes rather than passing incidentally.

The full suite also now runs to completion under ASan/UBSan — **5676633 assertions across 127 cases** — which it could not do before, because it was aborting on an out-of-bounds read in the vendored Clouds code (surge-synthesizer/eurorack#4).

Assisted-By: Claude Code (Claude Opus 5) — X: manuaudiomix
