### PR TITLE
Bound the patch and wavetable readers by the data they were given

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1176,11 +1176,30 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
     assert(data);
     void *end = (char *)data + datasize;
     patch_header *ph = (patch_header *)data;
-    ph->xmlsize = mech::endian_read_int32LE(ph->xmlsize);
 
     if (!memcmp(ph->tag, "sub3", 4))
     {
+        // Reading the rest of the header needs the rest of the header to be there.
+        // datasize only had to clear four bytes to get this far, and these reads
+        // endian swap in place, so a truncated patch both reads and writes past the
+        // end of the caller's buffer.
+        if (datasize < (int)sizeof(patch_header))
+        {
+            return;
+        }
+
+        ph->xmlsize = mech::endian_read_int32LE(ph->xmlsize);
+
         char *dr = (char *)data + sizeof(patch_header);
+
+        // xmlsize is a count from the file and dr is stepped forward by it, so bound
+        // it to what the buffer actually holds rather than forming a pointer outside
+        // the allocation.
+        if (ph->xmlsize > (unsigned int)(datasize - (int)sizeof(patch_header)))
+        {
+            return;
+        }
+
         load_xml(dr, ph->xmlsize, preset);
         dr += ph->xmlsize;
 
@@ -1191,8 +1210,26 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
                 ph->wtsize[sc][osc] = mech::endian_read_int32LE(ph->wtsize[sc][osc]);
                 if (ph->wtsize[sc][osc])
                 {
+                    // The header has to fit, not merely begin before the end. dr can
+                    // land exactly on end, which the old "wth > end" let through, and
+                    // the header was read anyway.
+                    if (dr + sizeof(wt_header) > (char *)end)
+                        return;
+
                     wt_header *wth = (wt_header *)dr;
-                    if (wth > end)
+
+                    // BuildWT sizes the block it copies from the counts inside this
+                    // header rather than from wtsize, so the frames it is about to
+                    // read have to be present as well. It rejects counts beyond
+                    // max_wtable_size / max_subtables, which keeps this product from
+                    // running away.
+                    const size_t sampleWidth = (mech::endian_read_int16LE(wth->flags) & wtf_int16)
+                                                   ? sizeof(short)
+                                                   : sizeof(float);
+                    const size_t wtBytes = sampleWidth * mech::endian_read_int16LE(wth->n_tables) *
+                                           mech::endian_read_int32LE(wth->n_samples);
+
+                    if (wtBytes > (size_t)((char *)end - dr - sizeof(wt_header)))
                         return;
 
                     scene[sc].osc[osc].wt.queue_id = -1;

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1179,10 +1179,7 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
 
     if (!memcmp(ph->tag, "sub3", 4))
     {
-        // Reading the rest of the header needs the rest of the header to be there.
-        // datasize only had to clear four bytes to get this far, and these reads
-        // endian swap in place, so a truncated patch both reads and writes past the
-        // end of the caller's buffer.
+        // the reads below swap in place, so require the whole header first
         if (datasize < (int)sizeof(patch_header))
         {
             return;
@@ -1192,9 +1189,7 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
 
         char *dr = (char *)data + sizeof(patch_header);
 
-        // xmlsize is a count from the file and dr is stepped forward by it, so bound
-        // it to what the buffer actually holds rather than forming a pointer outside
-        // the allocation.
+        // xmlsize comes from the file; keep dr inside the buffer
         if (ph->xmlsize > (unsigned int)(datasize - (int)sizeof(patch_header)))
         {
             return;
@@ -1210,19 +1205,13 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
                 ph->wtsize[sc][osc] = mech::endian_read_int32LE(ph->wtsize[sc][osc]);
                 if (ph->wtsize[sc][osc])
                 {
-                    // The header has to fit, not merely begin before the end. dr can
-                    // land exactly on end, which the old "wth > end" let through, and
-                    // the header was read anyway.
+                    // the header has to fit, not merely begin before the end
                     if (dr + sizeof(wt_header) > (char *)end)
                         return;
 
                     wt_header *wth = (wt_header *)dr;
 
-                    // BuildWT sizes the block it copies from the counts inside this
-                    // header rather than from wtsize, so the frames it is about to
-                    // read have to be present as well. It rejects counts beyond
-                    // max_wtable_size / max_subtables, which keeps this product from
-                    // running away.
+                    // BuildWT copies per these counts, not wtsize, so the frames must be here
                     const size_t sampleWidth = (mech::endian_read_int16LE(wth->flags) & wtf_int16)
                                                    ? sizeof(short)
                                                    : sizeof(float);

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1683,17 +1683,48 @@ bool SurgeStorage::load_wt_wt(string filename, Wavetable *wt, std::string &metad
         return false;
     }
 
+    auto reportWavetableNotBuilt = [this, &wh]() {
+        std::ostringstream oss;
+        oss << "Wavetable could not be built, which means it has too many frames or samples per "
+               "frame.\n"
+            << " You have provided " << wh.n_tables << " frames with " << wh.n_samples
+            << "samples per frame, while the limit is " << max_subtables << " frames and "
+            << max_wtable_size << " samples per frame.\n"
+            << "In some cases, Surge XT detects this situation inconsistently, which can lead to a "
+               "potentially volatile state\n."
+            << "It is recommended to restart Surge XT and not load "
+               "the problematic wavetable again.\n\n"
+            << " If you would like, please attach the wavetable which caused this error to a new "
+               "GitHub issue at "
+            << stringRepository;
+        reportError(oss.str(), "Load Error");
+    };
+
+    const auto nTables = mech::endian_read_int16LE(wh.n_tables);
+    const auto nSamples = mech::endian_read_int32LE(wh.n_samples);
+
+    // BuildWT applies exactly these bounds, but only after we have allocated a buffer
+    // sized from them, and n_samples is a 32 bit count straight out of the file. A
+    // corrupt or hostile wavetable can therefore ask for hundreds of terabytes and the
+    // allocation below throws std::bad_alloc before the check is ever reached. Nothing
+    // on the way in from load_wt catches it. Reject the header first; the file was going
+    // to be refused anyway, so this only changes how it is refused.
+    if (nSamples <= 0 || nSamples > max_wtable_size || (unsigned)nTables > (unsigned)max_subtables)
+    {
+        reportWavetableNotBuilt();
+
+        return false;
+    }
+
     size_t ds;
 
     if (mech::endian_read_int16LE(wh.flags) & wtf_int16)
     {
-        ds = sizeof(short) * mech::endian_read_int16LE(wh.n_tables) *
-             mech::endian_read_int32LE(wh.n_samples);
+        ds = sizeof(short) * nTables * nSamples;
     }
     else
     {
-        ds = sizeof(float) * mech::endian_read_int16LE(wh.n_tables) *
-             mech::endian_read_int32LE(wh.n_samples);
+        ds = sizeof(float) * nTables * nSamples;
     }
 
     const std::unique_ptr<char[]> data{new char[ds]};
@@ -1733,20 +1764,7 @@ bool SurgeStorage::load_wt_wt(string filename, Wavetable *wt, std::string &metad
 
     if (!wasBuilt)
     {
-        std::ostringstream oss;
-        oss << "Wavetable could not be built, which means it has too many frames or samples per "
-               "frame.\n"
-            << " You have provided " << wh.n_tables << " frames with " << wh.n_samples
-            << "samples per frame, while the limit is " << max_subtables << " frames and "
-            << max_wtable_size << " samples per frame.\n"
-            << "In some cases, Surge XT detects this situation inconsistently, which can lead to a "
-               "potentially volatile state\n."
-            << "It is recommended to restart Surge XT and not load "
-               "the problematic wavetable again.\n\n"
-            << " If you would like, please attach the wavetable which caused this error to a new "
-               "GitHub issue at "
-            << stringRepository;
-        reportError(oss.str(), "Load Error");
+        reportWavetableNotBuilt();
     }
     return wasBuilt;
 }

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1703,12 +1703,7 @@ bool SurgeStorage::load_wt_wt(string filename, Wavetable *wt, std::string &metad
     const auto nTables = mech::endian_read_int16LE(wh.n_tables);
     const auto nSamples = mech::endian_read_int32LE(wh.n_samples);
 
-    // BuildWT applies exactly these bounds, but only after we have allocated a buffer
-    // sized from them, and n_samples is a 32 bit count straight out of the file. A
-    // corrupt or hostile wavetable can therefore ask for hundreds of terabytes and the
-    // allocation below throws std::bad_alloc before the check is ever reached. Nothing
-    // on the way in from load_wt catches it. Reject the header first; the file was going
-    // to be refused anyway, so this only changes how it is refused.
+    // BuildWT applies these same bounds, but only after the buffer is allocated from them
     if (nSamples <= 0 || nSamples > max_wtable_size || (unsigned)nTables > (unsigned)max_subtables)
     {
         reportWavetableNotBuilt();

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -83,6 +83,55 @@ TEST_CASE("We Can Read Wavetables", "[io]")
     }
 }
 
+TEST_CASE("Wavetable headers are range checked before allocating", "[io]")
+{
+    // A .wt header is tag[4], n_samples (uint32), n_tables (uint16), flags (uint16),
+    // packed. BuildWT rejects counts beyond max_wtable_size / max_subtables, but the
+    // buffer is sized from those same counts and allocated before it ever gets there,
+    // so a header claiming the maximum of each asks for hundreds of terabytes.
+    auto writeWt = [](const std::string &name, uint32_t nSamples, uint16_t nTables,
+                      uint16_t flags) {
+        auto p = fs::temp_directory_path() / name;
+        std::ofstream o(p, std::ios::binary);
+
+        o.write("vawt", 4);
+        for (int i = 0; i < 4; ++i)
+            o.put((char)((nSamples >> (8 * i)) & 0xFF));
+        for (int i = 0; i < 2; ++i)
+            o.put((char)((nTables >> (8 * i)) & 0xFF));
+        for (int i = 0; i < 2; ++i)
+            o.put((char)((flags >> (8 * i)) & 0xFF));
+
+        return p;
+    };
+
+    auto surge = Surge::Headless::createSurge(44100);
+    REQUIRE(surge.get());
+
+    auto *wt = &(surge->storage.getPatch().scene[0].osc[0].wt);
+    std::string md;
+
+    SECTION("a float wavetable claiming the maximum of both counts")
+    {
+        auto f = writeWt("surge_wt_huge_f32.wt", 0x7FFFFFFF, 0x7FFF, 0);
+        bool loaded{true};
+
+        REQUIRE_NOTHROW(loaded = surge->storage.load_wt_wt(path_to_string(f), wt, md));
+        REQUIRE(!loaded);
+        fs::remove(f);
+    }
+
+    SECTION("the same header on the int16 path")
+    {
+        auto f = writeWt("surge_wt_huge_i16.wt", 0x7FFFFFFF, 0x7FFF, wtf_int16);
+        bool loaded{true};
+
+        REQUIRE_NOTHROW(loaded = surge->storage.load_wt_wt(path_to_string(f), wt, md));
+        REQUIRE(!loaded);
+        fs::remove(f);
+    }
+}
+
 TEST_CASE("All Factory Wavetables Are Loadable", "[io]")
 {
     auto surge = Surge::Headless::createSurge(44100, true);

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -132,6 +132,71 @@ TEST_CASE("Wavetable headers are range checked before allocating", "[io]")
     }
 }
 
+TEST_CASE("Truncated patches are refused before they are read", "[io]")
+{
+    // patch_header is tag[4] + xmlsize + wtsize[2][3], 32 bytes, but load_patch only
+    // required datasize > 4 before reading all of it - and the reads endian swap in
+    // place, so they write to the caller's buffer too. Patches arrive as .fxp files
+    // and as DAW session state, so every one of these is reachable input.
+    auto build = [](size_t sz, uint32_t xmlsize, uint32_t wt00) {
+        char *b = (char *)malloc(sz);
+
+        memset(b, 0, sz);
+        memcpy(b, "sub3", 4);
+
+        for (int i = 0; i < 4 && (size_t)(4 + i) < sz; ++i)
+            b[4 + i] = (char)((xmlsize >> (8 * i)) & 0xFF);
+        for (int i = 0; i < 4 && (size_t)(8 + i) < sz; ++i)
+            b[8 + i] = (char)((wt00 >> (8 * i)) & 0xFF);
+
+        return b;
+    };
+
+    auto surge = Surge::Headless::createSurge(44100);
+    REQUIRE(surge.get());
+
+    SECTION("a patch shorter than its own header")
+    {
+        char *b = build(8, 0, 0);
+
+        REQUIRE_NOTHROW(surge->loadRaw(b, 8, false));
+        free(b);
+    }
+
+    SECTION("a wavetable header sitting exactly at the end")
+    {
+        // xmlsize of 0 leaves dr on end, which the old start-pointer check allowed
+        char *b = build(32, 0, 64);
+
+        REQUIRE_NOTHROW(surge->loadRaw(b, 32, false));
+        free(b);
+    }
+
+    SECTION("a wavetable header whose frames are not present")
+    {
+        // BuildWT sizes its copy from the header's own counts, not from wtsize, so a
+        // header claiming 4096 samples reads 16k out of a buffer holding 16 bytes
+        const size_t sz = 32 + 12 + 16;
+        char *b = build(sz, 0, 12 + 16);
+        char *w = b + 32;
+
+        memcpy(w, "vawt", 4);
+
+        uint32_t nsamples = 4096;
+        uint16_t ntables = 1, flags = 0;
+
+        for (int i = 0; i < 4; ++i)
+            w[4 + i] = (char)((nsamples >> (8 * i)) & 0xFF);
+        for (int i = 0; i < 2; ++i)
+            w[8 + i] = (char)((ntables >> (8 * i)) & 0xFF);
+        for (int i = 0; i < 2; ++i)
+            w[10 + i] = (char)((flags >> (8 * i)) & 0xFF);
+
+        REQUIRE_NOTHROW(surge->loadRaw(b, (int)sz, false));
+        free(b);
+    }
+}
+
 TEST_CASE("All Factory Wavetables Are Loadable", "[io]")
 {
     auto surge = Surge::Headless::createSurge(44100, true);

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -85,10 +85,7 @@ TEST_CASE("We Can Read Wavetables", "[io]")
 
 TEST_CASE("Wavetable headers are range checked before allocating", "[io]")
 {
-    // A .wt header is tag[4], n_samples (uint32), n_tables (uint16), flags (uint16),
-    // packed. BuildWT rejects counts beyond max_wtable_size / max_subtables, but the
-    // buffer is sized from those same counts and allocated before it ever gets there,
-    // so a header claiming the maximum of each asks for hundreds of terabytes.
+    // the buffer is sized from the header counts, so range check them first
     auto writeWt = [](const std::string &name, uint32_t nSamples, uint16_t nTables,
                       uint16_t flags) {
         auto p = fs::temp_directory_path() / name;
@@ -134,10 +131,7 @@ TEST_CASE("Wavetable headers are range checked before allocating", "[io]")
 
 TEST_CASE("Truncated patches are refused before they are read", "[io]")
 {
-    // patch_header is tag[4] + xmlsize + wtsize[2][3], 32 bytes, but load_patch only
-    // required datasize > 4 before reading all of it - and the reads endian swap in
-    // place, so they write to the caller's buffer too. Patches arrive as .fxp files
-    // and as DAW session state, so every one of these is reachable input.
+    // load_patch read the whole 32 byte header after checking only datasize > 4
     auto build = [](size_t sz, uint32_t xmlsize, uint32_t wt00) {
         char *b = (char *)malloc(sz);
 
@@ -174,8 +168,7 @@ TEST_CASE("Truncated patches are refused before they are read", "[io]")
 
     SECTION("a wavetable header whose frames are not present")
     {
-        // BuildWT sizes its copy from the header's own counts, not from wtsize, so a
-        // header claiming 4096 samples reads 16k out of a buffer holding 16 bytes
+        // BuildWT copies per the header counts, not wtsize: 16k out of 16 bytes
         const size_t sz = 32 + 12 + 16;
         char *b = build(sz, 0, 12 + 16);
         char *w = b + 32;


### PR DESCRIPTION
Two commits, kept separate. Both are the same shape: a reader taking a size from the file and using it before checking it against the buffer it actually has. Everything here is reachable from ordinary input — `.wt` and `.fxp` files get downloaded, and `loadRaw` is also what restores DAW session state.

---

## 1. `load_wt_wt` sizes an allocation from an unchecked header

```cpp
ds = sizeof(float) * mech::endian_read_int16LE(wh.n_tables) *
     mech::endian_read_int32LE(wh.n_samples);

const std::unique_ptr<char[]> data{new char[ds]};
```

`BuildWT` applies `max_wtable_size` (4096) and `max_subtables` (512) to those same counts — but thirty lines later, after the buffer exists. A header claiming the maximum of each works out to roughly **281 TB**, so `new[]` throws `std::bad_alloc` first, and nothing on the path from `load_wt` catches it.

```
due to unexpected exception with message:
  std::bad_alloc
```

Applying the same bounds before computing `ds` only changes *how* the file is refused — it was going to fail `BuildWT` anyway — so the error the user sees is unchanged. The message moved into a lambda so both the early bail and the `BuildWT` failure report it.

`load_wt_wt_mem` is unaffected; it already bounds `ds` by the size of the buffer it was handed.

---

## 2. `load_patch` reads past the end three different ways

**The header itself.** `patch_header` is 32 bytes; the only check was `datasize <= 4`. And because the reads endian-swap in place through a cast-away `const`, this writes out of bounds as well as reading:

```
heap-buffer-overflow ... WRITE of size 4
  #0 SurgePatch::load_patch(void const*, int, bool) SurgePatch.cpp:1191
  #1 SurgeSynthesizer::loadRaw(void const*, int, bool)
located 0 bytes after 8-byte region
```

**The embedded wavetable header.** Guarded with `if (wth > end)`, which only asks whether it *starts* past the end. A header landing exactly on `end` passes and is read:

```
  #0 Wavetable::BuildWT(void*, wt_header&, bool) Wavetable.cpp:172
  #1 SurgePatch::load_patch(...) SurgePatch.cpp:1206
located 10 bytes after 32-byte region
```

**The frames.** `BuildWT` sizes its copy from the counts inside that header, not from `wtsize`, so a header claiming 4096 samples reads 16k out of whatever remains:

```
READ of size 16384
  #1 sst::basic_blocks::mechanics::endian_copyblock32LE endian-ops.h:111
  #2 Wavetable::BuildWT(void*, wt_header&, bool) Wavetable.cpp:257
located 0 bytes after 60-byte region
```

Worth noting that bounding by `wtsize` does **not** fix that third one — the test sets `wtsize` to exactly the bytes remaining and `BuildWT` still overruns, because it trusts its own header over the chunk size. The check has to use the same product `BuildWT` will use.

I looked at reusing `load_wt_wt_mem` here, since it already performs all three of these checks. It can't be dropped in as-is: it requires the `vawt` tag, and `save_patch` does `memset(wth[sc][osc].tag, 0, 4)`, so every existing patch would be rejected. Happy to consolidate them properly if you'd rather have one implementation — it would need the tag check made optional.

---

### One change that is defensive rather than a fix

I also bounded `xmlsize` by the remaining bytes before stepping `dr` over it. No sanitizer report came out of that one and I could not produce a case that misbehaves — `load_xml` copes. But `dr` is advanced by a count straight from the file, and forming a pointer outside the allocation is undefined regardless of what is checked afterwards. Say the word and I'll drop it.

### Verification

Every case above was proven in both directions — reverting only the source change and rebuilding brings each report back:

| case | before | after |
|---|---|---|
| `.wt` float / int16 header at max counts | `std::bad_alloc` | refused, load error |
| patch shorter than its header | OOB write | refused |
| wt header exactly at `end` | OOB read | refused |
| wt frames not present | 16k OOB read | refused |
| huge `xmlsize` | *no report* | *no report* |

- `All Patches Are Loadable` green under ASan — every factory patch still loads through the new guards.
- `All Factory Wavetables Are Loadable` unchanged at **1839 assertions**, so all 919 factory tables still load.
- `[io]` green, no sanitizer output.

Assisted-By: Claude Code (Claude Opus 5) — X: manuaudiomix
