### PR TITLE
Do not size the arbdata buffer from the size the frame claims

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1542,6 +1542,22 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
         // Same for the rest of these "return 0"s.
         return 0;
     }
+    // decompressedSize is what the zstd frame header claims, not anything measured, so
+    // a few bytes of crafted header can ask for terabytes. DynArray constructs its
+    // elements, so the pages are touched rather than merely reserved and the process is
+    // killed outright - there is no bad_alloc to catch. The largest block the factory
+    // content produces is about 3.6 MB, so this ceiling is roughly two orders of
+    // magnitude of headroom over real patches.
+    static constexpr std::uint64_t maxArbitraryBlockStorageSize{256 * 1024 * 1024};
+
+    if (decompressedSize > maxArbitraryBlockStorageSize)
+    {
+        std::cerr << "Arbitrary block storage claims " << decompressedSize
+                  << " bytes, which is beyond what a patch should carry; possibly corrupted patch."
+                  << std::endl;
+        return 0;
+    }
+
     sst::cpputils::DynArray<std::uint8_t> decompressed(decompressedSize);
     decompressedSize = ZSTD_decompress(decompressed.data(), decompressedSize, data, remainder);
     if (ZSTD_isError(decompressedSize))

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1542,12 +1542,7 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
         // Same for the rest of these "return 0"s.
         return 0;
     }
-    // decompressedSize is what the zstd frame header claims, not anything measured, so
-    // a few bytes of crafted header can ask for terabytes. DynArray constructs its
-    // elements, so the pages are touched rather than merely reserved and the process is
-    // killed outright - there is no bad_alloc to catch. The largest block the factory
-    // content produces is about 3.6 MB, so this ceiling is roughly two orders of
-    // magnitude of headroom over real patches.
+    // cap the declared size; real patches top out around 3.6 MB
     static constexpr std::uint64_t maxArbitraryBlockStorageSize{256 * 1024 * 1024};
 
     if (decompressedSize > maxArbitraryBlockStorageSize)

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1486,6 +1486,9 @@ bool SurgePatch::readOscSnapshotsFromBinn(binn *oscmap, OscillatorStorage &osc,
     return any;
 }
 
+// the largest arbdata block we will write, and so the largest we will read back
+static constexpr std::uint64_t maxArbitraryBlockStorageSize{256 * 1024 * 1024};
+
 std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
 {
     binn *map = binn_object();
@@ -1520,6 +1523,15 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
     // Now compress it with zstd
     auto size = binn_size(map);
     void *ptr = binn_ptr(map);
+
+    if (static_cast<std::uint64_t>(size) > maxArbitraryBlockStorageSize)
+    {
+        std::cerr << "Arbitrary block storage is " << size
+                  << " bytes, which is beyond what a patch can carry; not writing it." << std::endl;
+        binn_free(map);
+        return {};
+    }
+
     auto compressedSize = ZSTD_compressBound(size);
     std::vector<std::uint8_t> buf(compressedSize);
     compressedSize = ZSTD_compress(buf.data(), compressedSize, ptr, size, 3);
@@ -1542,9 +1554,6 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
         // Same for the rest of these "return 0"s.
         return 0;
     }
-    // cap the declared size; real patches top out around 3.6 MB
-    static constexpr std::uint64_t maxArbitraryBlockStorageSize{256 * 1024 * 1024};
-
     if (decompressedSize > maxArbitraryBlockStorageSize)
     {
         std::cerr << "Arbitrary block storage claims " << decompressedSize

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1546,6 +1546,20 @@ std::vector<std::uint8_t> SurgePatch::save_arbitrary_block_storage()
     // Now compress it with zstd
     auto size = binn_size(map);
     void *ptr = binn_ptr(map);
+
+    if (static_cast<std::uint64_t>(size) > maxArbitraryBlockStorageSize)
+    {
+        storage->reportError(
+            fmt::format("This patch carries {} bytes of impulse responses and wavetable "
+                        "snapshots, which is more than the {} MB a patch can hold. The patch "
+                        "will be saved without them, so they will not be there when it is "
+                        "loaded again!",
+                        size, maxArbitraryBlockStorageSize / (1024 * 1024)),
+            "Patch Write Error");
+        binn_free(map);
+        return {};
+    }
+
     auto compressedSize = ZSTD_compressBound(size);
     std::vector<std::uint8_t> buf(compressedSize);
     compressedSize = ZSTD_compress(buf.data(), compressedSize, ptr, size, 3);
@@ -1568,6 +1582,19 @@ unsigned int SurgePatch::load_arbitrary_block_storage(const void *data, std::siz
         // Same for the rest of these "return 0"s.
         return 0;
     }
+
+    if (decompressedSize > maxArbitraryBlockStorageSize)
+    {
+        storage->reportError(
+            fmt::format("This patch claims to carry {} bytes of impulse responses and wavetable "
+                        "snapshots, which is more than the {} MB a patch can hold. This almost "
+                        "definitely means that the patch is corrupted, so as a safety measure "
+                        "they will not be loaded!",
+                        decompressedSize, maxArbitraryBlockStorageSize / (1024 * 1024)),
+            "Load Error");
+        return 0;
+    }
+
     sst::cpputils::DynArray<std::uint8_t> decompressed(decompressedSize);
     decompressedSize = ZSTD_decompress(decompressed.data(), decompressedSize, data, remainder);
     if (ZSTD_isError(decompressedSize))

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -677,6 +677,9 @@ struct MidiChannelState
     float timbre;
 };
 
+// the largest block a patch or wtscript will write, and so the largest we will read back
+constexpr std::uint64_t maxArbitraryBlockStorageSize{256 * 1024 * 1024};
+
 // Arbitrary block storage helpers.
 // Arbitrary block storage can be used to save/load arbitrary blocks from the
 // patch and is available in particular places like the FX storage. An arbitrary block storage is

--- a/src/common/dsp/WavetableScriptEvaluator.cpp
+++ b/src/common/dsp/WavetableScriptEvaluator.cpp
@@ -546,11 +546,24 @@ LuaWTEvaluator::populateWavetable(const std::function<bool()> &canceled, bool pr
 
 #if HAS_LUA
 static void loadWtscriptSnapshots(const void *compData, size_t blobSize, SurgeStorage *storage,
-                                  OscillatorStorage *oscdata)
+                                  OscillatorStorage *oscdata, std::string *errorOut)
 {
     auto decompressedSize = ZSTD_getFrameContentSize(compData, blobSize);
     if (decompressedSize == ZSTD_CONTENTSIZE_UNKNOWN || decompressedSize == ZSTD_CONTENTSIZE_ERROR)
         return;
+
+    // the size is a claim in the frame header, not a measurement, so bound it before allocating
+    if (decompressedSize > maxArbitraryBlockStorageSize)
+    {
+        emitError(errorOut, storage,
+                  fmt::format("This wavetable script claims to carry {} bytes of snapshots, which "
+                              "is more than the {} MB a file can hold. This almost definitely "
+                              "means that the file is corrupted, so as a safety measure they will "
+                              "not be loaded!",
+                              decompressedSize, maxArbitraryBlockStorageSize / (1024 * 1024)),
+                  "Load Error");
+        return;
+    }
 
     std::vector<std::uint8_t> decompressed(decompressedSize);
     decompressedSize = ZSTD_decompress(decompressed.data(), decompressedSize, compData, blobSize);
@@ -627,7 +640,7 @@ LuaWTEvaluator::parseWtscript(const fs::path &filename, SurgeStorage *storage,
         }
 
         const void *compData = fileData.data() + xmlOffset + xmlSize;
-        loadWtscriptSnapshots(compData, blobSize, storage, oscdata);
+        loadWtscriptSnapshots(compData, blobSize, storage, oscdata, errorOut);
     }
 
     // Parse only the XML portion

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -85,11 +85,7 @@ TEST_CASE("We Can Read Wavetables", "[io]")
 
 TEST_CASE("Arbitrary block storage does not trust its declared size", "[io]")
 {
-    // The decompressed size in a zstd frame header is a claim, not a measurement, and
-    // load_arbitrary_block_storage sized its buffer from it directly. DynArray
-    // constructs its elements, so an absurd claim touches the pages rather than just
-    // reserving them and the process is killed - there is no bad_alloc to catch.
-    // Patches arrive as .fxp files and as DAW session state.
+    // the zstd header's declared size is a claim, so dont size the buffer from it
     auto frameClaiming = [](uint64_t claimed) {
         std::vector<unsigned char> f{0x28, 0xB5, 0x2F, 0xFD}; // zstd magic
         f.push_back(0xE0);                                    // single segment, 8 byte size field

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -83,6 +83,39 @@ TEST_CASE("We Can Read Wavetables", "[io]")
     }
 }
 
+TEST_CASE("Arbitrary block storage does not trust its declared size", "[io]")
+{
+    // The decompressed size in a zstd frame header is a claim, not a measurement, and
+    // load_arbitrary_block_storage sized its buffer from it directly. DynArray
+    // constructs its elements, so an absurd claim touches the pages rather than just
+    // reserving them and the process is killed - there is no bad_alloc to catch.
+    // Patches arrive as .fxp files and as DAW session state.
+    auto frameClaiming = [](uint64_t claimed) {
+        std::vector<unsigned char> f{0x28, 0xB5, 0x2F, 0xFD}; // zstd magic
+        f.push_back(0xE0);                                    // single segment, 8 byte size field
+
+        for (int i = 0; i < 8; ++i)
+            f.push_back((unsigned char)((claimed >> (8 * i)) & 0xFF));
+
+        for (unsigned char c : {0x09, 0x00, 0x00}) // one raw block, last, one byte
+            f.push_back(c);
+        f.push_back(0x41);
+
+        return f;
+    };
+
+    auto surge = Surge::Headless::createSurge(44100);
+    REQUIRE(surge.get());
+
+    // ~17.6 TB. The largest block the factory patches produce is about 3.6 MB.
+    auto f = frameClaiming(0x0000100000000000ULL);
+    unsigned int consumed{1};
+
+    REQUIRE_NOTHROW(consumed =
+                        surge->storage.getPatch().load_arbitrary_block_storage(f.data(), f.size()));
+    REQUIRE(consumed == 0);
+}
+
 TEST_CASE("All Factory Wavetables Are Loadable", "[io]")
 {
     auto surge = Surge::Headless::createSurge(44100, true);

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -178,6 +178,22 @@ bool loadTestWav(const fs::path &p, std::string &md, std::string *error = nullpt
 
     return loaded;
 }
+
+// a zstd frame whose header declares `claimed` bytes while carrying one
+std::vector<unsigned char> zstdFrameClaiming(uint64_t claimed)
+{
+    std::vector<unsigned char> f{0x28, 0xB5, 0x2F, 0xFD}; // zstd magic
+    f.push_back(0xE0);                                    // single segment, 8 byte size field
+
+    for (int i = 0; i < 8; ++i)
+        f.push_back((unsigned char)((claimed >> (8 * i)) & 0xFF));
+
+    for (unsigned char c : {0x09, 0x00, 0x00}) // one raw block, last, one byte
+        f.push_back(c);
+    f.push_back(0x41);
+
+    return f;
+}
 } // namespace
 
 TEST_CASE("WAV with a zero channel count", "[io]")
@@ -423,6 +439,20 @@ TEST_CASE("Truncated patches are refused before they are read", "[io]")
     }
 }
 
+TEST_CASE("Arbitrary block storage does not trust its declared size", "[io]")
+{
+    auto surge = Surge::Headless::createSurge(44100);
+    REQUIRE(surge.get());
+
+    // ~17.6 TB, against a cap of 256 MB
+    auto f = zstdFrameClaiming(0x0000100000000000ULL);
+    unsigned int consumed{1};
+
+    REQUIRE_NOTHROW(consumed =
+                        surge->storage.getPatch().load_arbitrary_block_storage(f.data(), f.size()));
+    REQUIRE(consumed == 0);
+}
+
 TEST_CASE("All Factory Wavetables Are Loadable", "[io]")
 {
     auto surge = Surge::Headless::createSurge(44100, true);
@@ -476,6 +506,57 @@ TEST_CASE("All Factory .wtscript Files Validate", "[io]")
         REQUIRE(la->loadWtscriptForTesting(p.path, &surge->storage, oscdata));
         REQUIRE(oscdata->wavetable_display_name != "");
     }
+}
+
+TEST_CASE("Wavetable script snapshots do not trust their declared size", "[io]")
+{
+    auto surge = Surge::Headless::createSurge(44100, true);
+    REQUIRE(surge.get());
+
+    // a real factory script, so the snapshot blob is the only suspect part
+    fs::path src;
+    for (const auto &p : surge->storage.wt_list)
+    {
+        if (p.path.extension() == ".wtscript" && surge->storage.wt_category[p.category].isFactory)
+        {
+            src = p.path;
+            break;
+        }
+    }
+    REQUIRE(!src.empty());
+
+    std::ifstream in(src, std::ios::binary | std::ios::ate);
+    REQUIRE(in);
+    std::vector<char> xml(static_cast<std::size_t>(in.tellg()));
+    in.seekg(0);
+    in.read(xml.data(), xml.size());
+    in.close();
+
+    auto blob = zstdFrameClaiming(0x0000100000000000ULL); // ~17.6 TB, against a cap of 256 MB
+    auto f = fs::temp_directory_path() / "surge_wtscript_huge_snapshot.wtscript";
+
+    {
+        std::ofstream o(f, std::ios::binary);
+        o.write("wts1", 4);
+
+        for (auto v : {(uint32_t)xml.size(), (uint32_t)blob.size()})
+            for (int i = 0; i < 4; ++i)
+                o.put((char)((v >> (8 * i)) & 0xFF));
+
+        o.write(xml.data(), xml.size());
+        o.write((const char *)blob.data(), blob.size());
+    }
+
+    auto la = std::make_unique<Surge::WavetableScript::LuaWTEvaluator>();
+    auto oscdata = &(surge->storage.getPatch().scene[0].osc[0]);
+    bool loaded{false};
+
+    // the script still loads, the snapshot blob is the only thing refused
+    REQUIRE_NOTHROW(loaded = la->loadWtscriptForTesting(f, &surge->storage, oscdata));
+    REQUIRE(loaded);
+    REQUIRE(!oscdata->wtSnapshots[0]);
+
+    fs::remove(f);
 }
 #endif
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -7315,6 +7315,17 @@ void SurgeGUIEditor::saveWavetableScript(const fs::path &location, SurgeStorage 
             const auto freeOscmap = sst::cpputils::make_scope_guard([&] { binn_free(oscmap); });
             bool hasSnapshots = SurgePatch::writeOscSnapshotsToBinn(oscmap, *oscdata);
 
+            if (hasSnapshots &&
+                static_cast<std::uint64_t>(binn_size(oscmap)) > maxArbitraryBlockStorageSize)
+            {
+                storage->reportError(
+                    fmt::format("This wavetable script carries {} bytes of snapshots, which is "
+                                "more than the {} MB a file can hold.",
+                                binn_size(oscmap), maxArbitraryBlockStorageSize / (1024 * 1024)),
+                    "Write Error");
+                return;
+            }
+
             doc.InsertEndChild(wtscript);
 
             // Serialize XML to a string


### PR DESCRIPTION
### What

`load_arbitrary_block_storage` asks zstd how large the block decompresses to, and allocates that straight away:

```cpp
auto decompressedSize = ZSTD_getFrameContentSize(data, remainder);
...
sst::cpputils::DynArray<std::uint8_t> decompressed(decompressedSize);
```

That number is a **claim in the frame header**, not a measurement, and it is independent of how many bytes were actually supplied. Sixteen bytes of hand-written zstd header can declare 17.6 TB.

### The failure mode is a process kill, not an exception

`DynArray` constructs its elements, so the pages are touched rather than merely reserved. The allocation does not fail cleanly — the OS kills the process:

```
NEUTERED exit=137 (137 = SIGKILL) output_lines=0
```

No `bad_alloc`, no output, nothing to catch. A DAW loading such a patch loses the session, and patches arrive both as `.fxp` files and as restored session state.

Both call sites bound the *compressed* input they hand in — `(char *)end - dr`, or `claimedArbitraryBlockStorageSize` after checking it against the remaining bytes — but neither bounds what the frame claims to expand to. `streamingRevision` and `absSize` both come from the patch XML, so which of the two paths runs is attacker-chosen as well.

### The ceiling

Picking a number here is a judgement call, so I measured instead of guessing. Instrumenting `load_arbitrary_block_storage` and loading the whole factory set: **128 patches carry arbitrary block storage, and the largest decompresses to 3,649,380 bytes** — about 3.5 MB.

256 MB leaves roughly two orders of magnitude of headroom over anything the factory content produces, while keeping a corrupt header from taking the process down. It is a `static constexpr` with a comment explaining where the number came from — very happy to move it if you would rather it were tighter, or drawn from something else.

### Verification

- Against the unfixed loader the new test dies with **SIGKILL**, so the proof here is the exit code rather than a failed assertion — reverting only `SurgePatch.cpp` and rebuilding reproduces it every time.
- With the fix it returns 0 and reports a corrupt patch, which is what the surrounding code already does for the other "we can't read this" cases.
- `All Patches Are Loadable` green, `[io]` green at 5444 assertions across 11 cases.

This is independent of #8528 — different function, different failure mode — so I kept it on its own branch rather than widening that one again.

Assisted-By: Claude Code (Claude Opus 5) — X: manuaudiomix
