### PR TITLE
Validate patch data: missing tempoOnSave crashes, unvalidated modrouting indices

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2176,17 +2176,8 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                         t.destination_id = i;
                     }
 
-                    //  Every field here comes from the file and every one of them is used
-                    //  as an array subscript later on, mostly on the audio thread:
-                    //  source_id indexes modsources[] and modsource_doprocess[],
-                    //  source_scene indexes scene[], source_index reaches
-                    //  ModulationSource::get_output(), which bounds it from above but not
-                    //  below, so a negative index reads voutput[-n]; and destination_id
-                    //  indexes globaldata[]. Drop a routing that would land
-                    //  outside any of those rather than storing it for the engine to
-                    //  dereference. Note the destination bound differs by list: a global
-                    //  routing's destination_id is an index into param_ptr, which is larger
-                    //  than globaldata.
+                    //  make sure returned indices are in bounds of sources and targets
+                    //  before applying
                     const int maxDestinationId = (sceneId != 0) ? n_scene_params : n_global_params;
 
                     if (t.source_id <= 0 || t.source_id >= n_modsources || t.source_scene < 0 ||

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2176,7 +2176,35 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                         t.destination_id = i;
                     }
 
-                    modlist->push_back(t);
+                    //  Every field here comes from the file and every one of them is used
+                    //  as an array subscript later on, mostly on the audio thread:
+                    //  source_id indexes modsources[] and modsource_doprocess[],
+                    //  source_scene indexes scene[], source_index reaches
+                    //  ModulationSource::get_output(), which bounds it from above but not
+                    //  below, so a negative index reads voutput[-n]; and destination_id
+                    //  indexes globaldata[]. Drop a routing that would land
+                    //  outside any of those rather than storing it for the engine to
+                    //  dereference. Note the destination bound differs by list: a global
+                    //  routing's destination_id is an index into param_ptr, which is larger
+                    //  than globaldata.
+                    const int maxDestinationId = (sceneId != 0) ? n_scene_params : n_global_params;
+
+                    if (t.source_id <= 0 || t.source_id >= n_modsources || t.source_scene < 0 ||
+                        t.source_scene >= n_scenes || t.source_index < 0 || t.destination_id < 0 ||
+                        t.destination_id >= maxDestinationId)
+                    {
+                        std::ostringstream oss;
+
+                        oss << "Dropped an out of range modulation routing while loading the "
+                            << "patch: source " << t.source_id << ", scene " << t.source_scene
+                            << ", index " << t.source_index << ", destination " << t.destination_id
+                            << ".";
+                        storage->reportError(oss.str(), "Patch Load Error");
+                    }
+                    else
+                    {
+                        modlist->push_back(t);
+                    }
                 }
 
                 mr = TINYXML_SAFE_TO_ELEMENT(mr->NextSibling("modrouting"));

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -3194,7 +3194,9 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
     }
     else
     {
-        if (tos->QueryDoubleAttribute("v", &d) != TIXML_SUCCESS)
+        //  The element is optional even in a revision that is supposed to carry it, so
+        //  a patch that simply omits it must not be dereferenced here.
+        if (!tos || tos->QueryDoubleAttribute("v", &d) != TIXML_SUCCESS)
         {
             d = 120.0;
         }


### PR DESCRIPTION
Two crashes reachable by editing a single element in an ordinary `.fxp`. Both verified against `resources/test-data/Voice Oooh.fxp` with an ASan/UBSan build of `surge-xt-cli`.

## 1 — Missing `<tempoOnSave>` crashes the loader

`SurgePatch.cpp` assumes any patch claiming revision ≥ 23 carries the element, and `TINYXML_SAFE_TO_ELEMENT` returns `nullptr` when it doesn't. Delete that one element and load:

```
SurgePatch.cpp:3197:18: runtime error: member call on null pointer of type 'TiXmlElement'
AddressSanitizer: SEGV on unknown address 0x0000000000b8
```

Falls back to the 120 bpm default already used when the attribute is present but unreadable.

## 2 — `<modrouting>` fields are unvalidated all the way to the subscript

Every field of a routing is read from the file and every one is later used as an array index, mostly on the audio thread:

| field | indexes | bound |
|---|---|---|
| `source_id` | `scene[].modsources[]`, `modsource_doprocess[]` | `n_modsources` |
| `source_scene` | `scene[]` | `n_scenes` |
| `source_index` | `ModulationSource::get_output()` | tests `which < vecsize`, never `which >= 0` |
| `destination_id` | `globaldata[]` | `n_global_params` |

**Give `character` a routing.** It's a global *post*-parameter, so `destination_id` becomes its `param_ptr` index — 765 — while `globaldata` has 219 entries:

```
SurgeSynthesizer.cpp:4513:9: runtime error: index 765 out of bounds for type 'pdata[219]'
```

That's a read-modify-write past the end of `globaldata`, on the audio thread, every block. It gets past the `type == vt_float` filter because `hasStreamedType` is false when the `type` attribute is absent, and the filter never consults `modulateable`.

**Put a wild source on any global parameter:**

```
Assertion failed: ((id > 0) && (id < n_modsources)),
  function prepareModsourceDoProcess, SurgeSynthesizer.cpp, line 3652
```

That assert is the only thing between the patch and `modsource_doprocess[id] = true` — and CMake's default Release flags are `-O3 -DNDEBUG`, which compiles it out. I checked: nothing in `CMakeLists.txt` or `cmake/` overrides that.

### The fix

Validate the four fields once where the routing is built, rather than at each of the many subscripts. Out-of-range routings are dropped with a reported error naming the offending values.

Two details worth flagging for review:

- The destination bound **differs by list** — a global routing's `destination_id` indexes `param_ptr`, which is larger than `globaldata`. That asymmetry is the actual root cause of the 765 case.
- For `source_index` I added **only the missing lower bound**, since `get_output()` already bounds it from above. `ModulationSource::vecsize` is `protected`, so checking the upper bound here would mean widening its visibility for no benefit.

## Verification

- All three inputs now load with no sanitizer report, and the dropped routing is named in the error.
- The **14 factory `.fxp` files under `resources/`** load with **zero routings dropped** and no behaviour change — that was the regression I was most worried about, since a wrong bound here would silently strip legitimate modulation.
- Control: the unmodified patch produces no error before or after.

One caveat on scope. This validates at the load boundary; it does not change the many consumers that still subscript these values unchecked, and it doesn't touch `isValidModulation()`, which only rejects source 0. If you'd rather have the bounds asserted at the consumers too, or the routing clamped rather than dropped, say which and I'll rework it.
