### PR TITLE
Sanitize non-ASCII characters in the build hostname

### DIFF
--- a/cmake/versiontools.cmake
+++ b/cmake/versiontools.cmake
@@ -55,6 +55,11 @@ endif ()
 
 cmake_host_system_information(RESULT SURGE_BUILD_FQDN QUERY FQDN)
 
+# The FQDN is embedded verbatim into a C string literal in version.cpp.in.
+# Hostnames legitimately contain non-ASCII characters, which MSVC rejects
+# in a narrow literal, so replace anything outside printable ASCII.
+string(REGEX REPLACE "[^ -~]" "_" SURGE_BUILD_FQDN "${SURGE_BUILD_FQDN}")
+
 message(STATUS "Setting up surge version")
 message(STATUS "  git hash is ${GIT_COMMIT_HASH} and branch is ${GIT_BRANCH}")
 message(STATUS "  buildhost is ${SURGE_BUILD_FQDN}")


### PR DESCRIPTION
### Problem

Surge does not build on Windows/MSVC when the machine's hostname contains non-ASCII characters.

`cmake/versiontools.cmake` reads the hostname with `cmake_host_system_information(... QUERY FQDN)` and `version.cpp.in` embeds it verbatim into a narrow C string literal:

```c
const char* Build::BuildHost = "@SURGE_BUILD_FQDN@";
```

On a machine named `ThinkPadLluís` the generated `version.cpp` contains a byte MSVC cannot interpret in that literal, and the build fails during `surge-common`:

```
version.cpp(26,35): error C2001: newline in constant
version.cpp(27,4): error C2143: syntax error: missing ';' before 'const'
version.cpp(1,1): error C2220: the following warning is treated as an error
```

Hostnames with accents, umlauts or CJK characters are perfectly ordinary, so this is reachable by anyone building on Windows with a localized machine name.

### Fix

Replace anything outside printable ASCII with an underscore, immediately after the FQDN is queried. `SURGE_BUILD_FQDN` only feeds the `BuildHost` display string, so degrading it is harmless — the above host reports as `ThinkPadLlu_s`.

### Testing

Verified locally on Windows 11 / MSVC 19.44 with VS 2022:

- before: `surge-testrunner` fails to build with the errors above
- after: `version.cpp` generates a valid literal and `surge-testrunner` builds and runs clean

Found while investigating #7570.
