### PR TITLE
FX plugin: force parameter name refresh in processor ctor

### DIFF
--- a/src/surge-fx/SurgeFXProcessor.cpp
+++ b/src/surge-fx/SurgeFXProcessor.cpp
@@ -142,6 +142,10 @@ SurgefxAudioProcessor::SurgefxAudioProcessor()
         fxBaseParams[i]->addListener(this);
     }
 
+    // Force an initial update of the JUCE parameter mutable names and storage values
+    updateJuceParamsFromStorage();
+    updateHostDisplay(juce::AudioProcessorListener::ChangeDetails{}.withParameterInfoChanged(true));
+
     for (int i = 0; i < n_fx_params + 1; ++i)
     {
         changedParams[i] = false;


### PR DESCRIPTION
The plugin instantiated with generic names and was only using correct parameter names when loading a preset or a different effect.