### PR TITLE
Fix pitch ramp in String oscillator when changing scene tuning

### DIFF
--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -516,7 +516,8 @@ void SurgeVoice::switch_toggled()
 
     // scenepbpitch is pitch state but without state.pkey, so that it can be used to add
     // scene pitch/octave, pitch bend and associated modulations to non-keytracked oscillators
-    state.scenepbpitch = pb;
+    state.scenepbpitch = pb + localcopy[pitch_id].f * (scene->pitch.extend_range ? 12.f : 1.f) +
+                         (octaveSize * localcopy[octave_id].i);
     state.pitch = state.pkey + state.scenepbpitch;
 
     modsources[ms_keytrack]->set_output(0, (state.pitch - (float)scene->keytrack_root.val.i) *
@@ -1702,11 +1703,10 @@ void SurgeVoice::retriggerOSCWithIndependentAttacks()
         {
             // This matches the override in ::process_block
             float ktrkroot = 60;
-            auto usep = noteShiftFromPitchParam((scene->osc[i].keytrack.val.b
-                                                     ? state.getPitch(storage)
-                                                     : ktrkroot + state.scenepbpitch) +
-                                                    octaveSize * scene->osc[i].octave.val.i,
-                                                0);
+            auto usep = noteShiftFromPitchParam(
+                (scene->osc[i].keytrack.val.b ? state.pitch : ktrkroot + state.scenepbpitch) +
+                    octaveSize * scene->osc[i].octave.val.i,
+                0);
 
             /*
              * This is awfully special case but it's the best solution

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -1703,10 +1703,11 @@ void SurgeVoice::retriggerOSCWithIndependentAttacks()
         {
             // This matches the override in ::process_block
             float ktrkroot = 60;
-            auto usep = noteShiftFromPitchParam(
-                (scene->osc[i].keytrack.val.b ? state.pitch : ktrkroot + state.scenepbpitch) +
-                    octaveSize * scene->osc[i].octave.val.i,
-                0);
+            auto usep = noteShiftFromPitchParam((scene->osc[i].keytrack.val.b
+                                                     ? state.getPitch(storage)
+                                                     : ktrkroot + state.scenepbpitch) +
+                                                    octaveSize * scene->osc[i].octave.val.i,
+                                                0);
 
             /*
              * This is awfully special case but it's the best solution


### PR DESCRIPTION
`switch_toggled()` (runs at voice construction, right before the initial `osc[i]->init(usep, ...)` call):

```cpp
float pb = modsources[ms_pitchbend]->get_output(0);
if (pb > 0) pb *= ...
else pb *= ...
state.scenepbpitch = pb;                          // <-- ONLY pitch bend
state.pitch = state.pkey + state.scenepbpitch;
```
`process_block()` (runs every block afterward):
```cpp
state.scenepbpitch = pb + localcopy[pitch_id].f * (scene->pitch.extend_range ? 12.f : 1.f) +
                     (octaveSize * localcopy[octave_id].i);   // <-- scene Pitch AND scene Octave included
state.pitch = state.pkey + state.scenepbpitch;
```
`switch_toggled()`'s version of `scenepbpitch` silently drops the scene Pitch and Octave contribution entirely. Since `switch_toggled()` is what seeds the initial `osc[i]->init(usep, ...)` call for a brand-new voice (comment at the top of the constructor: "`switch_toggled()` comes last since it creates and activates the oscillators"), the String oscillator's `tap[0].startValue(pitchmult_inv)` gets seeded from a pitch that's missing the scene octave offset. The very next `process_block()` recomputes `scenepbpitch` correctly (now including octave), passes the correct pitch into `StringOscillator::process_block_internal()`, which calls `tap[0].newValue(pitchmult_inv)` - and the lag smoother glides from the wrong (octave-less) seed up to the correct pitch.

Scene octave = 0 → the missing term is 0 → no discrepancy → no audible ramp.
Scene octave = 3 → seed is 3 octaves flat, corrects itself over the smoother's time constant → audible ramp.

Per-osc octave/pitch never shows this because that offset (`octaveSize * scene->osc[i].octave.val.i`) is added identically in both `switch_toggled()` (line ~556) and `process_block()` (lines ~1080 etc.) — no mismatch possible there.


Closes #6985!


Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>