### PR TITLE
Fix loss of audio when Tape effect is loaded and Surge is oversampled in host

### DIFF
--- a/src/common/dsp/effects/chowdsp/tape/LossFilter.cpp
+++ b/src/common/dsp/effects/chowdsp/tape/LossFilter.cpp
@@ -50,7 +50,7 @@ void LossFilter::prepare(float sampleRate, int blockSize)
 
     for (int i = 0; i < 2; ++i)
     {
-        filters[i] = std::make_unique<FIRFilter>(order);
+        filters[i] = std::make_unique<FIRFilter>(curOrder);
         filters[i]->reset();
         filters[i]->setCoefs(currentCoefs.data());
     }


### PR DESCRIPTION
### Problem

The Tape effect's wet signal drops dramatically (up to ~80 dB) when running at sample rates significantly above 44.1/48kHz — for example when Reaper's per-plugin oversampling is set to 192k or above. Only the Hysteresis and Loss sections are affected; Degrade is not.

### Root cause

In `LossFilter::prepare()`, the FIR filter length is scaled for the current sample rate:

```cpp
fsFactor = fs / 44100.0f;
curOrder = int(order * fsFactor);
currentCoefs.resize(curOrder);
```

`currentCoefs` (the designed filter coefficients) is sized to `curOrder`. However, the actual `FIRFilter` objects are constructed with the original, unscaled `order`:

```cpp
filters[i] = std::make_unique<FIRFilter>(order);   // should be curOrder
filters[i]->setCoefs(currentCoefs.data());
```

`FIRFilter::setCoefs()` copies exactly `order` elements from `coefs`. At 44.1/48kHz, `curOrder ≈ order`, so the truncation is negligible. At higher rates `curOrder` grows well past `order` (e.g. 208 vs. 48 at 192kHz), so the filter is built from only the first `order` coefficients of a much longer designed response — the resulting filter no longer resembles the intended one and its gain collapses.

### Fix

Construct the filters with `curOrder` instead of `order`:

```cpp
filters[i] = std::make_unique<FIRFilter>(curOrder);
```

### Verification

Reproduced standalone outside the plugin by feeding a 1kHz sine through `FIRFilter` built the buggy way vs. the fixed way, using coefficients generated by the real `calcCoefs()` at several sample rates:

| fs | order | curOrder | buggy output | fixed output |
|---|---|---|---|---|
| 44100 | 48 | 48 | 0.00 dB | 0.00 dB |
| 48000 | 48 | 52 | 0.00 dB | 0.00 dB |
| 96000 | 48 | 104 | **-56.6 dB** | 0.00 dB |
| 176400 | 48 | 192 | **-77.5 dB** | 0.00 dB |
| 192000 | 48 | 208 | **-79.6 dB** | 0.00 dB |

Confirmed fixed in-plugin under Reaper with 192k FX oversampling enabled, both when Tape is loaded before and after enabling oversampling.

### Note

The Hysteresis section's internal 2x oversampling and RK4 solver were checked and are stable/sample-rate-independent by construction — they were not part of the issue. This was purely the `LossFilter` FIR sizing bug; Hysteresis being audibly affected too was presumably just a byproduct of the overall wet path collapsing (bypassing Loss alone doesn't reinitialize the chain).


Fixes #6834!

Assisted-By: Claude Opus 5 <noreply@anthropic.com>