### PR TITLE
Start BLIT oscillators mid-cycle instead of delaying their first impulse

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ Daniel Hatadi <https://github.com/dhatadi>
 Yashas Hebbarabailu <https://github.com/y-hbb>
 Bill Allen <https://github.com/bwanab>
 Manu Arimaka <https://github.com/manuaudio>
+Lluís Estapé <https://github.com/lluisestape-upc>

--- a/src/common/dsp/oscillators/ClassicOscillator.cpp
+++ b/src/common/dsp/oscillators/ClassicOscillator.cpp
@@ -256,7 +256,25 @@ void ClassicOscillator::init(float pitch, bool is_display, bool nonzero_init_dri
             */
             double detune = oscdata->p[co_unison_detune].get_extended(localcopy[id_detune].f) *
                             (detune_bias * float(i) + detune_offset);
-            float t = storage->note_to_pitch_inv_tuningctr(detune);
+
+            /*
+            ** Mirror ::convolute's non-absolute t, sync included, so a synced voice is seeded
+            ** from the period it will actually run at. The absolute branch is deliberately
+            ** left alone: its formula is samplerate dependent and known to be odd (see the
+            ** comment in ::convolute), so seeding from the unsynced period there keeps the
+            ** existing behaviour rather than baking the oddity into a second place.
+            */
+            float t;
+
+            if (oscdata->p[co_unison_detune].absolute)
+            {
+                t = storage->note_to_pitch_inv_tuningctr(detune);
+            }
+            else
+            {
+                float sync = min((float)l_sync.v, (12 + 72 + 72) - pitch);
+                t = storage->note_to_pitch_inv_tuningctr(detune + sync);
+            }
 
             float pw = limit_range(l_pw.v, 0.001f, 0.999f);
             float pw2 = 2.f * l_pw2.v;

--- a/src/common/dsp/oscillators/ClassicOscillator.cpp
+++ b/src/common/dsp/oscillators/ClassicOscillator.cpp
@@ -232,21 +232,103 @@ void ClassicOscillator::init(float pitch, bool is_display, bool nonzero_init_dri
             oscstate[i] = 0.f;
             syncstate[i] = 0.f;
             last_level[i] = 0.f;
+            start_level[i] = 0.f;
+            dc_uni[i] = 0.f;
+            state[i] = 0;
+            pwidth[i] = limit_range(l_pw.v, 0.001f, 0.999f);
+            pwidth2[i] = 2.f * l_pw2.v;
         }
         else
         {
-            double drand = (double)storage->rand_01();
+            /*
+            ** Start the voice at a random point inside the cycle, carrying the state it
+            ** would have had if it had been running, rather than delaying its first impulse
+            ** by a random amount. Seeding oscstate with a positive value and nothing else
+            ** leaves the buffers empty, so the voice is simply silent until the first
+            ** ::convolute fires - a delay of up to a full cycle. See issue #7570.
+            **
+            ** ::convolute walks a four segment cycle whose durations sum to 2 * t, tracking
+            ** the waveform as last_level (the level at the end of the current segment) and
+            ** dc_uni (the slope across it). So: pick a uniform point in the cycle, replay
+            ** that bookkeeping up to the segment holding it, and hand the voice over ready
+            ** for the next ::convolute. State 0 sets the level absolutely rather than
+            ** incrementally, so replaying from a zero level lands on the right answer.
+            */
             double detune = oscdata->p[co_unison_detune].get_extended(localcopy[id_detune].f) *
                             (detune_bias * float(i) + detune_offset);
-            double st = 0.5 * drand * storage->note_to_pitch_inv_tuningctr(detune);
-            oscstate[i] = st;
-            syncstate[i] = st;
-            last_level[i] = 0.f;
+            float t = storage->note_to_pitch_inv_tuningctr(detune);
+
+            float pw = limit_range(l_pw.v, 0.001f, 0.999f);
+            float pw2 = 2.f * l_pw2.v;
+            float wf = l_shape.v;
+            float sub = l_sub.v;
+
+            // These mirror the rate computation at the end of ::convolute
+            float seg[4] = {t * pw * pw2, t * (1.f - pw) * (2.f - pw2), t * pw * (2.f - pw2),
+                            t * (1.f - pw) * pw2};
+            float cycle = seg[0] + seg[1] + seg[2] + seg[3];
+
+            // One draw per voice, as before, so the rest of the random sequence is unchanged
+            float phase = storage->rand_01() * cycle;
+
+            // mech::rcp, not a division, to match how ::convolute computes this
+            float dcu = (1.f + wf) * (1.f - sub) * mech::rcp(t);
+            float level = 0.f, lvl_start = 0.f, acc = 0.f;
+            int s = 0;
+
+            for (int step = 0; step < 4; ++step)
+            {
+                float g;
+
+                switch (s)
+                {
+                case 0:
+                {
+                    float tg =
+                        ((1 + wf) * 0.5f + (1 - pw) * (-wf)) * (1 - sub) + 0.5f * sub * (2.f - pw2);
+                    g = tg - level;
+                    break;
+                }
+                case 1:
+                    g = wf * (1.f - sub) - sub;
+                    break;
+                case 2:
+                    g = 1.f - sub;
+                    break;
+                default:
+                    g = wf * (1.f - sub) + sub;
+                    break;
+                }
+
+                lvl_start = level + g;
+                level = lvl_start - seg[s] * dcu;
+
+                if (acc + seg[s] > phase)
+                {
+                    break;
+                }
+
+                acc += seg[s];
+                s = (s + 1) & 3;
+            }
+
+            float elapsed = phase - acc;
+            float frac = (seg[s] > 0.f) ? (elapsed / seg[s]) : 0.f;
+
+            oscstate[i] = seg[s] - elapsed;
+            syncstate[i] = oscstate[i];
+            last_level[i] = level;
+
+            // The level runs linearly from just after the impulse to last_level
+            start_level[i] = lvl_start + (level - lvl_start) * frac;
+
+            dc_uni[i] = dcu;
+            dcbuffer[bufpos + FIRoffset] += dcu;
+            state[i] = (s + 1) & 3;
+            pwidth[i] = pw;
+            pwidth2[i] = pw2;
         }
 
-        dc_uni[i] = 0.f;
-        state[i] = 0.f;
-        pwidth[i] = limit_range(l_pw.v, 0.001f, 0.999f);
         driftLFO[i].init(nonzero_init_drift);
     }
 }
@@ -614,6 +696,34 @@ void ClassicOscillator::process_block(float pitch0, float drift, bool stereo, bo
                                       storage->note_to_pitch_inv(pitch));
     // This must be a real division, reciprocal approximation is not precise enough
     pitchmult = 1.f / pitchmult_inv;
+
+    /*
+    ** ::init chose a start phase for each voice but could not seed the shared integrator,
+    ** because how much level a voice contributes depends on the stereo flag, which only
+    ** arrives here. Do it on the first block, before anything is generated. See issue #7570.
+    */
+    if (first_run)
+    {
+        float sL = 0.f, sR = 0.f;
+
+        for (int u = 0; u < n_unison; u++)
+        {
+            float v = start_level[u] * out_attenuation;
+
+            if (stereo)
+            {
+                sL += v * panL[u];
+                sR += v * panR[u];
+            }
+            else
+            {
+                sL += v;
+            }
+        }
+
+        osc_out = SIMD_MM(set1_ps)(sL);
+        osc_outR = SIMD_MM(set1_ps)(sR);
+    }
 
     int k, l;
 

--- a/src/common/dsp/oscillators/ClassicOscillator.cpp
+++ b/src/common/dsp/oscillators/ClassicOscillator.cpp
@@ -303,7 +303,10 @@ void ClassicOscillator::init(float pitch, bool is_display, bool nonzero_init_dri
                 lvl_start = level + g;
                 level = lvl_start - seg[s] * dcu;
 
-                if (acc + seg[s] > phase)
+                // >=, not >: rand_01() can return 1.0f, so phase can equal cycle. With >
+                // the loop would fall out with s wrapped back to 0 and a stale start_level;
+                // >= breaks at the last segment with frac == 1, which is the correct end.
+                if (acc + seg[s] >= phase)
                 {
                     break;
                 }

--- a/src/common/dsp/oscillators/ClassicOscillator.h
+++ b/src/common/dsp/oscillators/ClassicOscillator.h
@@ -56,6 +56,10 @@ class ClassicOscillator : public AbstractBlitOscillator
     bool first_run;
     float dc, dc_uni[MAX_UNISON], elapsed_time[MAX_UNISON], last_level[MAX_UNISON],
         pwidth[MAX_UNISON], pwidth2[MAX_UNISON];
+    // Output level each voice starts at, from the phase ::init picked for it. The shared
+    // integrator is seeded from these on the first ::process_block, which is the first
+    // point at which the stereo flag is known.
+    float start_level[MAX_UNISON];
     template <bool is_init> void update_lagvals();
     float pitch;
     lipol_ps li_hpf, li_DC;

--- a/src/common/dsp/oscillators/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/oscillators/SampleAndHoldOscillator.cpp
@@ -109,21 +109,41 @@ void SampleAndHoldOscillator::init(float pitch, bool is_display, bool nonzero_in
         {
             oscstate[i] = 0;
             syncstate[i] = 0;
+            last_level[i] = 0.0;
+            start_level[i] = 0.f;
+            pwidth[i] = limit_range(l_pw.v, 0.001, 0.999);
         }
         else
         {
-            double drand = (double)storage->rand_01();
+            /*
+            ** Start partway through a held value rather than delaying the first step by a
+            ** random amount, which is what seeding oscstate does and is the bug in #7570.
+            **
+            ** Unlike the Classic oscillator there is no level to reconstruct: the held
+            ** value is random by construction, so any draw from the same range is as
+            ** correct as any other. Pick one, and put the voice partway through the
+            ** segment holding it.
+            **
+            ** Two draws per voice, matching the previous code, which also drew twice and
+            ** discarded the second - so the rest of the random sequence is unchanged.
+            */
             double detune = oscdata->p[shn_unison_detune].get_extended(localcopy[id_detune].f) *
                             (detune_bias * float(i) + detune_offset);
-            double st = drand * storage->note_to_pitch_tuningctr(detune) * 0.5;
-            drand = (double)storage->rand_01();
-            double ot = drand * storage->note_to_pitch_tuningctr(detune);
-            oscstate[i] = st;
-            syncstate[i] = st;
+            float phase = storage->rand_01();
+            float level = storage->rand_01() - 0.5f;
+
+            // l_pw is a lag<double> in this oscillator, unlike the Classic one
+            float pw = (float)limit_range(l_pw.v, 0.001, 0.999);
+            // convolute uses the inverted form; state 0 runs for t * pwidth
+            float seg = storage->note_to_pitch_inv_tuningctr(detune) * pw;
+
+            oscstate[i] = seg * (1.f - phase);
+            syncstate[i] = oscstate[i];
+            last_level[i] = level;
+            start_level[i] = level;
+            pwidth[i] = pw;
         }
         state[i] = 0;
-        last_level[i] = 0.0;
-        pwidth[i] = limit_range(l_pw.v, 0.001, 0.999);
         driftLFO[i].init(nonzero_init_drift);
     }
 
@@ -380,6 +400,39 @@ void SampleAndHoldOscillator::process_block(float pitch0, float drift, bool ster
     pitchmult_inv =
         max(1.0, storage->dsamplerate_os * (1 / 8.175798915) * storage->note_to_pitch_inv(pitch));
     pitchmult = 1.f / pitchmult_inv;
+
+    /*
+    ** ::init chose a held value and a phase for each voice but could not seed the shared
+    ** integrator, since a voice's contribution depends on the stereo flag, which only
+    ** arrives here. Do it on the first block, before anything is generated. See #7570.
+    **
+    ** Unlike ClassicOscillator this class never cleared first_run, since nothing here
+    ** read it before, so clear it right away rather than at the end of the block.
+    */
+    if (first_run)
+    {
+        first_run = false;
+
+        float sL = 0.f, sR = 0.f;
+
+        for (int u = 0; u < n_unison; u++)
+        {
+            float v = start_level[u] * out_attenuation;
+
+            if (stereo)
+            {
+                sL += v * panL[u];
+                sR += v * panR[u];
+            }
+            else
+            {
+                sL += v;
+            }
+        }
+
+        osc_out = SIMD_MM(set1_ps)(sL);
+        osc_outR = SIMD_MM(set1_ps)(sR);
+    }
     // This must be a real division, reciprocal-approximation is not precise enough
     int k, l;
 

--- a/src/common/dsp/oscillators/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/oscillators/SampleAndHoldOscillator.cpp
@@ -134,8 +134,22 @@ void SampleAndHoldOscillator::init(float pitch, bool is_display, bool nonzero_in
 
             // l_pw is a lag<double> in this oscillator, unlike the Classic one
             float pw = (float)limit_range(l_pw.v, 0.001, 0.999);
+
+            // As in ClassicOscillator: mirror ::convolute's non-absolute t, sync included,
+            // and leave the absolute branch seeded from the unsynced period.
+            float t;
+
+            if (oscdata->p[shn_unison_detune].absolute)
+            {
+                t = storage->note_to_pitch_inv_tuningctr(detune);
+            }
+            else
+            {
+                t = storage->note_to_pitch_inv_tuningctr(detune + l_sync.v);
+            }
+
             // convolute uses the inverted form; state 0 runs for t * pwidth
-            float seg = storage->note_to_pitch_inv_tuningctr(detune) * pw;
+            float seg = t * pw;
 
             oscstate[i] = seg * (1.f - phase);
             syncstate[i] = oscstate[i];

--- a/src/common/dsp/oscillators/SampleAndHoldOscillator.h
+++ b/src/common/dsp/oscillators/SampleAndHoldOscillator.h
@@ -66,6 +66,10 @@ class SampleAndHoldOscillator : public AbstractBlitOscillator
     bool first_run;
     float dc, dc_uni[MAX_UNISON], elapsed_time[MAX_UNISON], last_level[MAX_UNISON],
         last_level2[MAX_UNISON], pwidth[MAX_UNISON];
+    // Level each voice is holding when it starts, from the phase ::init picked for it. The
+    // shared integrator is seeded from these on the first ::process_block, which is where
+    // the stereo flag first arrives.
+    float start_level[MAX_UNISON];
     float pitch;
     lag<double> FMdepth, l_pw, l_shape, l_smooth, l_sub, l_sync;
     int id_pw, id_shape, id_smooth, id_sub, id_sync, id_detune;

--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -339,7 +339,15 @@ void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
                 last_tableipol = tableid;
             }
         }
+    }
 
+    // The mipmap level depends only on pitch, but ::init cannot compute it (pitchmult_inv
+    // is not available there), and with retrigger off a voice starts at a random state and
+    // so skips the state == 0 block above on its first convolute. Recompute it on first_run
+    // too, otherwise the voice runs the un-mipmapped table for its first partial cycle - a
+    // note-on CPU spike rather than an audible artifact. See issue #7570.
+    if (state[voice] == 0 || first_run)
+    {
         int ts = oscdata->wt.size;
         float a = oscdata->wt.dt * pitchmult_inv;
 
@@ -791,6 +799,8 @@ void WavetableOscillator::process_block(float pitch0, float drift, bool stereo, 
             }
         }
     }
+
+    first_run = false;
 }
 
 void WavetableOscillator::handleStreamingMismatches(int streamingRevision,

--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -130,14 +130,24 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
             if (oscdata->retrigger.val.b || is_display)
             {
                 oscstate[i] = 0.f;
+                state[i] = 0;
             }
             else
             {
-                float drand = storage->rand_01();
-                oscstate[i] = drand;
+                /*
+                ** Start at a random position in the table rather than delaying the first
+                ** step by a random amount, which is what seeding oscstate does and is the
+                ** bug in #7570. Unlike the Classic oscillator this one emits pure steps
+                ** with no DC ramp between them, so firing immediately from a random table
+                ** index puts the voice at the right level with the usual band limiting,
+                ** and there is no integrator state to prime.
+                **
+                ** One draw per voice, as before, so the rest of the random sequence is
+                ** unchanged. convolute masks state against the mipmapped table size.
+                */
+                oscstate[i] = 0.f;
+                state[i] = (int)(storage->rand_01() * oscdata->wt.size) & (oscdata->wt.size - 1);
             }
-
-            state[i] = 0;
         }
 
         last_level[i] = 0.0;

--- a/src/surge-testrunner/UnitTestsDSP.cpp
+++ b/src/surge-testrunner/UnitTestsDSP.cpp
@@ -703,49 +703,78 @@ TEST_CASE("Reverb1 White Noise Blast", "[dsp]")
 
 TEST_CASE("Oscillator Onset", "[dsp]") // See issue 7570
 {
+    /*
+    ** An oscillator should start making sound immediately, whether or not retrigger is on.
+    **
+    ** The BLIT oscillators used to seed oscstate with a positive random value when
+    ** retrigger was off, which leaves the buffers empty and the voice silent until the
+    ** first convolute fires. That is a delay of up to a full cycle rather than a random
+    ** start phase: at MIDI 60 it reached 169 oversampled samples for Classic and 337 for
+    ** Wavetable, and it scales with the period, so a bass note could lose several
+    ** milliseconds off the front of its attack.
+    */
+    constexpr int maxOnset{16};
+    constexpr int nTrials{50};
+    constexpr int nBlocks{32}; // enough to cover the old worst case even at MIDI 24
+
     for (const auto &rt : {true, false})
     {
         for (const auto &ot :
              {ot_classic, ot_wavetable, ot_window, ot_sine, ot_twist, ot_shnoise, ot_FM2, ot_FM3})
         {
-            auto surge = Surge::Headless::createSurge(44100, ot == ot_wavetable || ot == ot_window);
-            auto storage = &surge->storage;
-
-            auto oscstorage = &(storage->getPatch().scene[0].osc[0]);
-
-            unsigned char oscbuffer alignas(16)[oscillator_buffer_size];
-
-            oscstorage->retrigger.val.b = rt;
-
-            auto o = spawn_osc(ot, storage, oscstorage, storage->getPatch().scenedata[0],
-                               storage->getPatch().scenedataOrig[0], oscbuffer);
-            o->init_ctrltypes();
-            o->init_default_values();
-            o->init_extra_config();
-
-            o->init(60);
-
-            int itUntilBigger{0};
-            bool continueChecking{true};
-
-            for (int j = 0; j < 10 && continueChecking; ++j)
+            for (const auto &note : {24, 60, 96})
             {
-                o->process_block(60, 0, true, false, 0);
-                for (int i = 0; i < BLOCK_SIZE_OS && continueChecking; ++i)
+                auto surge =
+                    Surge::Headless::createSurge(44100, ot == ot_wavetable || ot == ot_window);
+                auto storage = &surge->storage;
+
+                auto oscstorage = &(storage->getPatch().scene[0].osc[0]);
+
+                unsigned char oscbuffer alignas(16)[oscillator_buffer_size];
+
+                oscstorage->retrigger.val.b = rt;
+
+                auto o = spawn_osc(ot, storage, oscstorage, storage->getPatch().scenedata[0],
+                                   storage->getPatch().scenedataOrig[0], oscbuffer);
+                o->init_ctrltypes();
+                o->init_default_values();
+                o->init_extra_config();
+
+                int worstOnset{0};
+
+                for (int trial = 0; trial < nTrials; ++trial)
                 {
-                    itUntilBigger++;
-                    if (std::fabs(o->output[i]) > 1e-6)
+                    o->init(note);
+
+                    int onset{nBlocks * BLOCK_SIZE_OS}, n{0};
+                    bool found{false};
+
+                    for (int j = 0; j < nBlocks && !found; ++j)
                     {
-                        continueChecking = false;
-                        break;
+                        o->process_block(note, 0, true, false, 0);
+
+                        for (int i = 0; i < BLOCK_SIZE_OS; ++i, ++n)
+                        {
+                            if (std::fabs(o->output[i]) > 1e-6)
+                            {
+                                onset = n;
+                                found = true;
+                                break;
+                            }
+                        }
                     }
+
+                    worstOnset = std::max(worstOnset, onset);
                 }
+
+                o->~Oscillator();
+
+                INFO("Oscillator " << osc_type_names[ot] << " at note " << note
+                                   << " with retrigger " << (rt ? "on" : "off")
+                                   << " has a worst case onset of " << worstOnset
+                                   << " oversampled samples");
+                REQUIRE(worstOnset <= maxOnset);
             }
-            o->~Oscillator();
-            /*std::cout << "Onset Delay for " << osc_type_names[ot] << " with retrig=" << rt << " is
-               "
-                      << (continueChecking ? "Unknown" : std::to_string(itUntilBigger))
-                      << std::endl;*/
         }
     }
 }


### PR DESCRIPTION
Fixes #7570.

### The problem

With retrigger off, the three `AbstractBlitOscillator` subclasses seeded `oscstate` with a positive random value:

```cpp
double st = 0.5 * drand * storage->note_to_pitch_inv_tuningctr(detune);
oscstate[i] = st;
```

`oscstate` is remaining phase space, not phase. With the buffers freshly memset and `last_level` and `dc_uni` at zero, there is nothing to emit until the first `convolute` fires, so the voice is simply silent for `oscstate * period` samples. That is a random *delay*, not a random start phase.

Measured onset delay before this change, in oversampled samples, 300 inits per point:

| Oscillator | MIDI 24 | MIDI 60 | MIDI 96 |
|---|---|---|---|
| Classic | 665.6 | 82.8 | 10.0 |
| Wavetable | 1263.1 | 167.5 | 21.7 |
| S&H Noise | 655.4 | 81.5 | 9.9 |

It halves per octave, as a fixed fraction of a cycle should. At MIDI 24 that is 7.5 ms off the front of the attack on average, and up to about 15 ms worst case.

### The change

Each oscillator starts mid-cycle instead, but the right way to do that differs by oscillator, so the three are not the same patch:

- **Classic** has a four segment cycle summing to `2 * t`, with the waveform tracked as `last_level` plus a `dc_uni` ramp. `init` picks a uniform point in the cycle and replays that bookkeeping up to the segment holding it. State 0 sets the level absolutely rather than incrementally, so replaying from zero lands on the right answer. It seeds `last_level`, `dc_uni`, `dcbuffer`, `state`, `pwidth`/`pwidth2` and `oscstate`. The `dc_uni` slope is computed with `mech::rcp(t)` rather than `/ t`, to match `convolute` exactly. The value is otherwise carried forward as `olddc` on the next call, so a mismatch would only differ over the first partial segment, but keeping them identical avoids the confusion.
- **Wavetable** emits pure steps with no DC ramp, so it just starts at a random table index with `oscstate` at zero. The first `convolute` then fires immediately and steps to the correct level *through the existing sinc convolution*, so the onset is band limited and no integrator state needs priming at all.
- **S&H Noise** holds a random value by construction, so there is no level to reconstruct. It draws one, and starts partway through the segment holding it.

Classic and S&H both need the shared integrator seeded with the level their voices start at. That depends on the stereo flag, which `init` does not receive, so it happens on the first `process_block` behind the existing `first_run` flag, which until now was written but never read.

Worth a second look when reviewing: the two classes did not treat that flag the same way. `ClassicOscillator` already cleared it at the end of `process_block`, but `SampleAndHoldOscillator` only ever set it in the constructor, so this change clears it there as soon as it has been used.

Each oscillator makes the same number of RNG draws as before, so the rest of the random sequence is unchanged.

### Testing

The `Oscillator Onset` regtest from #7571 now asserts rather than just computing a number. It covers all eight oscillator types at MIDI 24, 60 and 96 with retrigger both on and off, and requires a worst case onset of at most 16 oversampled samples.

- It **fails on master**, at `Classic at note 24 with retrigger off`, the first case it reaches.
- It passes with this change, and every oscillator lands at 1 to 2 samples with retrigger off, matching or beating the retrigger-on path.

The whole test runner passes on both platforms I have:

| | test cases | assertions |
|---|---|---|
| Windows, MSVC, Release | 108 | 5,660,060 |
| Linux (WSL2), Clang, Debug + ASan/UBSan | 108 | 5,680,582 |

ASan reports nothing. UBSan reports one pre-existing issue unrelated to this change: a misaligned `int16_t` load in `sst-basic-blocks`, reached from `Wavetable::BuildWT` while parsing patch wavetables. Happy to open that separately if it is not already known.

### What I would like eyes on

Starting at an arbitrary phase means starting at an arbitrary level, so a step at note-on is unavoidable. The question is whether it is bigger than what the waveform does anyway.

At the bare oscillator, MIDI 36, worst of 16 note-ons. The jump at sample 0 is measured from silence, since the buffers start empty:

| Oscillator | retrigger on | retrigger off | its own largest step while running |
|---|---|---|---|
| Classic | 0.0007 | **1.24** | 0.45 |
| Wavetable | 0.0000 | 0.0013 | 0.0044 |
| S&H Noise | 0.0003 | 0.45 | 0.45 |

Only Classic exceeds its own normal behaviour, by about 2.7x. Wavetable is effectively perfect because its opening step goes through `convolute` and comes out band limited. S&H matches its own step size by construction. It is a staircase, so starting on a stair is in character.

Classic is the one that seeds `osc_out` directly, so its opening step is a raw discontinuity rather than a band limited one.

At the synth output it looks better. Init patch, Classic, fastest amp attack and full sustain so nothing masks the onset, worst of 16 note-ons:

| | largest step in the first 200 samples | largest step while running |
|---|---|---|
| retrigger on | 0.10 | 0.22 |
| retrigger off | 0.20 | 0.22 |

So by the time it reaches the output the onset step no longer exceeds the waveform's own edges.

It is still visible, though. Captured in a DAW, a note-on with retrigger off starts with a single sample step to an arbitrary level, where retrigger on ramps up from zero. It did not sound like anything in play testing, at any tempo or register I tried, but I would rather flag it than quietly file it as fixed.

If you do want it gone, the direction I would try is routing Classic's opening level through the sinc convolution the way Wavetable does, though the DC ramp makes that less straightforward.
