### PR TITLE
Properly fix Drive/Output extend range in Waveshaper effect

### DIFF
--- a/src/common/dsp/effects/WaveShaperEffect.cpp
+++ b/src/common/dsp/effects/WaveShaperEffect.cpp
@@ -81,7 +81,7 @@ void WaveShaperEffect::process(float *dataL, float *dataR)
 {
     mix.set_target_smoothed(clamp01(*pd_float[ws_mix]));
     boost.set_target_smoothed(
-        db_to_amp(fxdata->p[ws_postboost].get_extended(fxdata->p[ws_postboost].val.f)));
+        db_to_amp_unbound(fxdata->p[ws_postboost].get_extended(fxdata->p[ws_postboost].val.f)));
 
     /*
      * OK so what's all this? Well the network of halfbands and so on
@@ -100,7 +100,7 @@ void WaveShaperEffect::process(float *dataL, float *dataR)
     const auto scalef = 3.f, oscalef = 1.f / 3.f, hbfComp = 2.f;
 
     auto x = scalef * fxdata->p[ws_drive].get_extended(fxdata->p[ws_drive].val.f);
-    auto dnv = limit_range(powf(2.f, x / 18.f), 0.f, 8.f);
+    auto dnv = db_to_amp_unbound(x);
     drive.newValue(dnv);
     bias.newValue(clamp1bp(*pd_float[ws_bias]));
 

--- a/src/common/dsp/utilities/DSPUtils.h
+++ b/src/common/dsp/utilities/DSPUtils.h
@@ -47,5 +47,6 @@ inline float linear_to_amp(float x) { return powf(std::clamp(x, 0.0000000001f, 1
 inline float amp_to_db(float x) { return std::clamp((float)(18.f * log2(x)), -192.f, 96.f); }
 
 inline float db_to_amp(float x) { return std::clamp(powf(2.f, x / 18.f), 0.f, 2.f); }
+inline float db_to_amp_unbound(float x) { return std::max(powf(2.f, x / 18.f), 0.f); }
 
 #endif // SURGE_SRC_COMMON_DSP_UTILITIES_DSPUTILS_H


### PR DESCRIPTION
`db_to_amp()` was clamping its output to [0, 2]. Added `db_to_amp_unbound()` which only clamps the bottom to 0, upper end is not clamped.

We already have streaming version handler for sv < 27 which belongs to 1.4 nightlies, so we're just rolling this fix in.

Fixes #6445