### PR TITLE
Fix stuck note when a context menu eats VKB's key up

### DIFF
--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -358,6 +358,11 @@ void SurgeSynthEditor::setVKBLayout(const std::string layout)
  * none of them is physically down it can only ever emit note offs, never note ons. Under that
  * guard it is a no-op when nothing is stale and a release when something is, which makes the
  * VKB self healing regardless of who ate the key up.
+ *
+ * Note that the guard has to ask isKeyCurrentlyDown rather than KeyPress::isCurrentlyDown.
+ * The latter also requires the live modifier flags to match those on the KeyPress, and ours
+ * are bound bare, so merely holding Ctrl, Shift or Alt would make every held note look
+ * released and we would cut it out from under the player.
  */
 void SurgeSynthEditor::resyncVKBHeldKeys()
 {
@@ -368,7 +373,7 @@ void SurgeSynthEditor::resyncVKBHeldKeys()
 
     for (const auto &k : vkbBoundKeys)
     {
-        if (k.isCurrentlyDown())
+        if (juce::KeyPress::isKeyCurrentlyDown(k.getKeyCode()))
         {
             return;
         }

--- a/src/surge-xt/SurgeSynthEditor.cpp
+++ b/src/surge-xt/SurgeSynthEditor.cpp
@@ -308,6 +308,7 @@ void SurgeSynthEditor::setVKBLayout(const std::string layout)
     if (search != vkbLayouts.end())
     {
         keyboard->clearKeyMappings();
+        vkbBoundKeys.clear();
 
         unsigned int n = 0;
 
@@ -331,14 +332,49 @@ void SurgeSynthEditor::setVKBLayout(const std::string layout)
             if (i < 128)
             {
                 keyboard->setKeyPressForNote((juce::KeyPress)i, n);
+                vkbBoundKeys.emplace_back((juce::KeyPress)i);
             }
 #else
             keyboard->setKeyPressForNote((juce::KeyPress)i, n);
+            vkbBoundKeys.emplace_back((juce::KeyPress)i);
 #endif
 
             n++;
         }
     }
+}
+
+/*
+ * juce::MidiKeyboardComponent tracks the QWERTY keys it has sent note ons for in a private
+ * bitset which it only reconciles from two places: keyStateChanged, which is event driven,
+ * and focusLost. We deliberately set wantsKeyboardFocus false on the VKB and feed it through
+ * our own KeyListener instead, so focusLost never fires for it and that safety net is gone.
+ *
+ * That means any window which swallows key events - a context menu entering modal state, a
+ * typein taking focus, alt-tabbing away - can eat the key up, leaving the bitset marked down
+ * and the note stuck with no event ever coming to clear it.
+ *
+ * So poll. keyStateChanged rescans every bound key against the real OS key state, and when
+ * none of them is physically down it can only ever emit note offs, never note ons. Under that
+ * guard it is a no-op when nothing is stale and a release when something is, which makes the
+ * VKB self healing regardless of who ate the key up.
+ */
+void SurgeSynthEditor::resyncVKBHeldKeys()
+{
+    if (vkbBoundKeys.empty())
+    {
+        return;
+    }
+
+    for (const auto &k : vkbBoundKeys)
+    {
+        if (k.isCurrentlyDown())
+        {
+            return;
+        }
+    }
+
+    keyboard->keyStateChanged(false);
 }
 
 void SurgeSynthEditor::handleAsyncUpdate() {}
@@ -364,6 +400,8 @@ void SurgeSynthEditor::paint(juce::Graphics &g)
 void SurgeSynthEditor::idle()
 {
     sge->idle();
+
+    resyncVKBHeldKeys();
 
     if (processor.surge->refresh_vkb)
     {

--- a/src/surge-xt/SurgeSynthEditor.h
+++ b/src/surge-xt/SurgeSynthEditor.h
@@ -81,6 +81,12 @@ class SurgeSynthEditor : public juce::AudioProcessorEditor,
 
     void setVKBLayout(const std::string layout);
 
+    // The KeyPresses setVKBLayout actually bound onto the VKB, which is a subset of the chosen
+    // layout, since accessible keys and (on Linux) keycodes >= 128 get filtered out. Used by
+    // resyncVKBHeldKeys to know which keys to poll.
+    std::vector<juce::KeyPress> vkbBoundKeys;
+    void resyncVKBHeldKeys();
+
     void reapplySurgeComponentColours();
 
     struct IdleTimer : juce::Timer


### PR DESCRIPTION
The VKB has `wantsKeyboardFocus()` false so that it receives QWERTY input no
matter what else is focused, with key events fed to it through
SurgeSynthEditor's `KeyListener`. But that also means JUCE never calls
`focusLost()` on it, and `focusLost()` is where `MidiKeyboardComponent`
releases the keys it believes are held. Its `keysPressed` bitset is
otherwise only reconciled from `keyStateChanged()`, which is event driven.

So if a context menu enters modal state while a key is held, the key up
goes to the menu instead. The bitset stays marked down and no further event
ever arrives to clear it, so the note hangs until you press and release
that key again.

Poll for it in the editor `idle()` instead. `keyStateChanged()` rescans
every bound key against the real OS key state, so calling it at a moment
when none of them is physically down can only ever emit note offs, never
note ons. That makes the VKB self-healing regardless of who swallowed the
key up, which also covers Alt-tabbing away and hiding the VKB mid-note.

Fixes #5480

Assisted-By: Claude Opus 5 <noreply@anthropic.com>