### PR TITLE
Allow wavetable oneshot, looping and re-slicing to be changed at runtime

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1229,7 +1229,25 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
                     void *d = (void *)((char *)dr + sizeof(wt_header));
 
                     storage->waveTableDataMutex.lock();
-                    scene[sc].osc[osc].wt.BuildWT(d, *wth, false);
+                    const bool wtBuilt = scene[sc].osc[osc].wt.BuildWT(d, *wth, false);
+
+                    if (!wtBuilt)
+                    {
+                        // The header passed the bounds checks above, so this is a frame or
+                        // sample count BuildWT itself rejects. Say so rather than carrying
+                        // on: an oscillator left with no wavetable at all reads garbage,
+                        // and trips the assert in save_patch if the patch is saved again.
+                        std::cerr << "Wavetable in scene " << (char)('A' + sc) << " oscillator "
+                                  << (osc + 1) << " could not be built; possible patch corruption."
+                                  << std::endl;
+
+                        if (!scene[sc].osc[osc].wt.everBuilt)
+                        {
+                            // Nothing usable was ever here, so queue the default rather
+                            // than leaving the oscillator pointing at an empty table
+                            scene[sc].osc[osc].wt.queue_id = 0;
+                        }
+                    }
 
                     // The osc's WT was just replaced by the loaded patch so invalidate any
                     // in-progress WT script job for it. Bump inside the mutex so the worker's

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1254,7 +1254,11 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
 
                     storage->waveTableDataMutex.unlock();
 
-                    if (hadName && scene[sc].osc[osc].wt.current_id < 0)
+                    // A re-sliced table no longer matches the file it was named after, so
+                    // don't re-attach it to that wt_list entry: doing so would make undo
+                    // reload the pristine file and silently discard the edit.
+                    if (hadName && scene[sc].osc[osc].wt.current_id < 0 &&
+                        !(scene[sc].osc[osc].wt.flags & wtf_user_modified))
                     {
                         for (int i = 0;
                              i < storage->wt_list.size() && scene[sc].osc[osc].wt.current_id < 0;

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1510,7 +1510,8 @@ void SurgeStorage::perform_queued_wtloads()
                 // first and any in-progress WT script generate skips its stale publish. The bump
                 // takes its own lock scope because load_wt takes waveTableDataMutex internally.
                 if (patch.scene[sc].osc[o].wt.queue_id != -1 ||
-                    patch.scene[sc].osc[o].wt.queue_filename[0])
+                    patch.scene[sc].osc[o].wt.queue_filename[0] ||
+                    patch.scene[sc].osc[o].wt.queue_reslice)
                 {
                     std::lock_guard<std::mutex> lk(waveTableDataMutex);
                     wtGenPublishToken[sc * n_oscs + o]++;
@@ -1549,12 +1550,42 @@ void SurgeStorage::perform_queued_wtloads()
                     if (patch.scene[sc].osc[o].wt.everBuilt)
                         patch.isDirty = true;
                 }
+                else if (patch.scene[sc].osc[o].wt.queue_reslice)
+                {
+                    auto &wt = patch.scene[sc].osc[o].wt;
+
+                    wt.queue_reslice = false;
+
+                    bool ok;
+                    {
+                        std::lock_guard<std::mutex> lk(waveTableDataMutex);
+                        ok = wt.Reslice(wt.reslice_size, wt.reslice_frames, wt.reslice_flags);
+                    }
+
+                    if (ok)
+                    {
+                        // The table no longer matches the file it came from, so detach it.
+                        // wavetable_display_name is deliberately left alone: it is what the
+                        // oscillator keeps showing, and it is what stops the patch loader
+                        // falling back to "(Patch Wavetable)".
+                        wt.current_id = -1;
+                        wt.current_filename = "";
+                        wt.force_refresh_display = true;
+                        wt.refresh_display = true;
+                        patch.isDirty = true;
+                    }
+
+                    wt.reslice_size = -1;
+                    wt.reslice_frames = -1;
+                    wt.reslice_flags = 0;
+                }
             }
             catch (const std::exception &e)
             {
                 // Clear the queue so we don't retry the bad load every block
                 patch.scene[sc].osc[o].wt.queue_id = -1;
                 patch.scene[sc].osc[o].wt.queue_filename = "";
+                patch.scene[sc].osc[o].wt.queue_reslice = false;
                 reportError(std::string("Unable to load wavetable: ") + e.what(),
                             "Wavetable Load Error");
             }
@@ -1842,7 +1873,9 @@ bool SurgeStorage::export_wt_wt_portable(const fs::path &fname, Wavetable *wt,
 
     wth.n_samples = wt->size;
     wth.n_tables = wt->n_tables;
-    wth.flags = wt->flags;
+    // wtf_user_modified describes this session's edit history, not the file, and older
+    // Surge builds know nothing about the bit - so don't write it out.
+    wth.flags = wt->flags & ~wtf_user_modified;
     if (!metadata.empty())
         wth.flags |= wtf_has_metadata;
 

--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -172,19 +172,27 @@ bool Wavetable::BuildWT(void *wdata, wt_header &wh, bool AppendSilence)
 {
     assert(wdata);
 
-    flags = mech::endian_read_int16LE(wh.flags);
-    n_tables = mech::endian_read_int16LE(wh.n_tables);
-    size = mech::endian_read_int32LE(wh.n_samples);
+    const auto newFlags = mech::endian_read_int16LE(wh.flags);
+    const auto newTables = mech::endian_read_int16LE(wh.n_tables);
+    const int newSize = mech::endian_read_int32LE(wh.n_samples);
 
     // Reject malformed/oversized headers before writing into the fixed-size
     // TableF32WeakPointers[max_mipmap_levels][max_subtables] arrays; otherwise a
     // bogus frame or sample count is an out-of-bounds write. The false return is
     // surfaced as a load error by load_wt_wt / load_wt_wt_mem.
-    if (size <= 0 || size > max_wtable_size ||
-        n_tables + (AppendSilence ? 3u : 0u) > (unsigned)max_subtables)
+    //
+    // Validate before assigning any of it: a rejected header must leave an
+    // already-built wavetable alone, rather than leaving it describing itself with
+    // counts its buffers do not have.
+    if (newSize <= 0 || newSize > max_wtable_size ||
+        newTables + (AppendSilence ? 3u : 0u) > (unsigned)max_subtables)
     {
         return false;
     }
+
+    flags = newFlags;
+    n_tables = newTables;
+    size = newSize;
 
     size_t req_size = RequiredWTSize(size, n_tables);
 

--- a/src/common/dsp/Wavetable.cpp
+++ b/src/common/dsp/Wavetable.cpp
@@ -28,6 +28,8 @@
 #include "sst/basic-blocks/mechanics/endian-ops.h"
 
 #include <bit>
+#include <algorithm>
+#include <cstring>
 
 namespace mech = sst::basic_blocks::mechanics;
 
@@ -125,6 +127,7 @@ void Wavetable::Copy(Wavetable *wt)
     size = wt->size;
     size_po2 = wt->size_po2;
     flags = wt->flags;
+    data_n_tables = wt->data_n_tables;
     dt = wt->dt;
     n_tables = wt->n_tables;
 
@@ -191,6 +194,7 @@ bool Wavetable::BuildWT(void *wdata, wt_header &wh, bool AppendSilence)
     }
 
     int wdata_tables = n_tables;
+    data_n_tables = wdata_tables;
 
     if (AppendSilence)
     {
@@ -280,6 +284,136 @@ bool Wavetable::BuildWT(void *wdata, wt_header &wh, bool AppendSilence)
 
     everBuilt = true;
     return true;
+}
+
+int Wavetable::SourceFrameCount() const
+{
+    if (!everBuilt || size <= 0 || n_tables == 0)
+    {
+        return 0;
+    }
+
+    int nf = (data_n_tables > 0) ? data_n_tables : (int)n_tables;
+    nf = std::min(nf, (int)n_tables);
+
+    if (flags & wtf_is_sample)
+    {
+        // On a sample, trailing silence is padding: either the three frames BuildWT
+        // appends, or however many of those survived a patch round-trip (which rebuilds
+        // with AppendSilence false, so they arrive as ordinary data). Dropping them here
+        // is what keeps a re-slice from growing the table by three frames every time.
+        while (nf > 1)
+        {
+            const float *f = TableF32WeakPointers[0][nf - 1];
+
+            if (!f)
+            {
+                break;
+            }
+
+            bool silent = true;
+
+            for (int i = 0; i < size && silent; ++i)
+            {
+                silent = (f[i] == 0.f);
+            }
+
+            if (!silent)
+            {
+                break;
+            }
+
+            nf--;
+        }
+    }
+
+    return nf;
+}
+
+std::vector<float> Wavetable::FlattenSource() const
+{
+    const int nf = SourceFrameCount();
+
+    if (nf < 1)
+    {
+        return {};
+    }
+
+    std::vector<float> out((size_t)nf * (size_t)size, 0.f);
+
+    for (int j = 0; j < nf; ++j)
+    {
+        if (const float *f = TableF32WeakPointers[0][j])
+        {
+            memcpy(out.data() + (size_t)j * (size_t)size, f, size * sizeof(float));
+        }
+    }
+
+    return out;
+}
+
+bool Wavetable::Reslice(int newSize, int newFrames, int newFlags)
+{
+    if (!everBuilt)
+    {
+        return false;
+    }
+
+    const auto src = FlattenSource();
+
+    if (src.empty())
+    {
+        return false;
+    }
+
+    const bool asSample = (newFlags & wtf_is_sample) != 0;
+    // BuildWT appends three silent frames for a sample, and they have to fit too
+    const int cap = asSample ? (max_subtables - 3) : max_subtables;
+
+    int sz = (newSize > 0) ? newSize : size;
+
+    sz = std::clamp(sz, min_reslice_size, max_wtable_size);
+    // BuildWT derives size_po2 with bit_width and both oscillators mask with size - 1,
+    // so a non-power-of-two frame size is not representable. Round down to one.
+    sz = 1 << (std::bit_width((unsigned int)sz) - 1);
+
+    if (newFrames > 0)
+    {
+        // Frame count is the free variable: shrink the frame size until the requested
+        // count fits in the samples we have, rather than refusing the request.
+        while ((size_t)newFrames * (size_t)sz > src.size() && sz > min_reslice_size)
+        {
+            sz >>= 1;
+        }
+    }
+
+    const int fit = (int)(src.size() / (size_t)sz);
+
+    if (fit < 1)
+    {
+        return false;
+    }
+
+    int frames = (newFrames > 0) ? newFrames : fit;
+
+    // Samples past the last whole frame are truncated, which is the whole point
+    frames = std::min({frames, fit, cap});
+
+    if (frames < 1)
+    {
+        return false;
+    }
+
+    wt_header wh;
+
+    memset(&wh, 0, sizeof(wt_header));
+    wh.n_samples = sz;
+    wh.n_tables = (unsigned short)frames;
+    // We hand BuildWT float data, so the encoding bits from the original load do not
+    // describe it any more. Metadata belongs to the file, not to this table.
+    wh.flags = (unsigned short)(newFlags & ~(wtf_int16 | wtf_int16_is_16 | wtf_has_metadata));
+
+    return BuildWT((void *)src.data(), wh, asSample);
 }
 
 void Wavetable::MipMapWT()

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -22,6 +22,7 @@
 #ifndef SURGE_SRC_COMMON_DSP_WAVETABLE_H
 #define SURGE_SRC_COMMON_DSP_WAVETABLE_H
 #include <string>
+#include <vector>
 #include <StringOps.h>
 const int max_wtable_size = 4096;
 const int max_subtables = 512;
@@ -50,9 +51,36 @@ class Wavetable
 
     void allocPointers(size_t newSize);
 
+    // Smallest frame size the runtime re-slicer will produce. BuildWT copes with anything
+    // down to 1, but below this a "frame" stops being a waveform in any useful sense, and
+    // the auto-shrink in Reslice would happily grind all the way to the bottom.
+    static constexpr int min_reslice_size = 16;
+
+    // Recover the source samples this wavetable was built from, by concatenating its top
+    // mipmap level. Sample-mode tables carry trailing silent frames - either the three
+    // BuildWT appends, or however many survived a patch round-trip - so those are trimmed
+    // back off, which keeps repeated re-slices from accumulating padding.
+    std::vector<float> FlattenSource() const;
+
+    // Frames of real content, i.e. n_tables minus any trailing silent padding. For a
+    // wavetable this is just n_tables; for a sample it is the count worth showing the user,
+    // since the padding is an implementation detail of BuildWT.
+    int SourceFrameCount() const;
+
+    // Rebuild in place at a new frame size and/or frame count. newSize <= 0 keeps the
+    // current frame size; newFrames <= 0 derives the largest frame count the samples
+    // support. If newFrames does not fit at the requested frame size the size is halved
+    // until it does (down to min_reslice_size), and any samples past the last whole frame
+    // are truncated. Returns false and leaves the wavetable untouched if the request
+    // cannot be satisfied.
+    bool Reslice(int newSize, int newFrames, int newFlags);
+
   public:
     bool everBuilt = false;
     int size;
+    // Frames actually populated from the build data, excluding any silence BuildWT
+    // appended. FlattenSource needs this because n_tables counts the padding.
+    int data_n_tables{0};
     unsigned int n_tables;
     int size_po2;
     int flags;
@@ -71,15 +99,24 @@ class Wavetable
     std::string queue_filename;
     std::string current_filename;
     int frame_size_if_absent{-1};
+
+    // Runtime re-slice request. Set from the UI thread, consumed on the audio thread in
+    // SurgeStorage::perform_queued_wtloads so the rebuild lands on a block boundary, the
+    // same way a queued wavetable load does.
+    bool queue_reslice{false};
+    int reslice_size{-1};
+    int reslice_frames{-1};
+    int reslice_flags{0};
 };
 
 enum wtflags
 {
     wtf_is_sample = 1,
     wtf_loop_sample = 2,
-    wtf_int16 = 4,           // If this is set we have int16 in range 0-2^15
-    wtf_int16_is_16 = 8,     // and in this case, range 0-2^16 if with above
-    wtf_has_metadata = 0x10, // null term xml at end of file
+    wtf_int16 = 4,            // If this is set we have int16 in range 0-2^15
+    wtf_int16_is_16 = 8,      // and in this case, range 0-2^16 if with above
+    wtf_has_metadata = 0x10,  // null term xml at end of file
+    wtf_user_modified = 0x20, // re-sliced at runtime, so it no longer matches its source
 };
 
 #endif // SURGE_SRC_COMMON_DSP_WAVETABLE_H

--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -73,7 +73,9 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
 
     if (oscdata->wt.flags & wtf_is_sample)
     {
-        sampleloop = n_unison;
+        // An explicit loop flag overrides the unison-count-as-play-count behavior rather
+        // than adding to it, so a looped sample ignores the voice count entirely.
+        sampleloop = (oscdata->wt.flags & wtf_loop_sample) ? infinite_sampleloop : n_unison;
         n_unison = 1;
     }
 
@@ -308,7 +310,7 @@ void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
             tableid++;
             if (tableid > oscdata->wt.n_tables - paddingLoop)
             {
-                if (sampleloop < 7)
+                if (sampleloop < infinite_sampleloop)
                     sampleloop--;
 
                 if (sampleloop > 0)

--- a/src/common/dsp/oscillators/WavetableOscillator.h
+++ b/src/common/dsp/oscillators/WavetableOscillator.h
@@ -91,6 +91,11 @@ class WavetableOscillator : public AbstractBlitOscillator
     int FMdelay;
     int nointerp;
     float FMmul_inv;
+    // Play count for sample-mode playback, counted down each time the sample wraps. It is
+    // seeded from the unison voice count, which for samples has always doubled as "play the
+    // sample this many times"; at this value or above it stops counting down and the sample
+    // loops forever, which is what wtf_loop_sample pins it to.
+    static constexpr int infinite_sampleloop = 7;
     int sampleloop;
 
     pdata *unmodulatedLocalcopy;

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -31,6 +31,7 @@
 
 #include "UnitTestUtilities.h"
 #include "WavetableScriptEvaluator.h"
+#include "dsp/oscillators/WavetableOscillator.h"
 
 #include <chrono>
 #include <thread>
@@ -1421,4 +1422,345 @@ TEST_CASE("XML Direct", "[io]")
         surge->storage.getPatch().load_xml(test.c_str(), test.size(), false);
         SUCCEED("an out of range scene or osc index did not write outside the patch");
     }
+}
+
+namespace
+{
+// A wavetable with entirely distinct, never-zero samples, so a re-slice can be checked for
+// exact content preservation and the trailing-silence trim has nothing to latch on to.
+void buildRampWT(Wavetable *wt, int frames, int frameSize)
+{
+    std::vector<float> data((size_t)frames * frameSize);
+
+    for (size_t i = 0; i < data.size(); ++i)
+    {
+        data[i] = (float)(i + 1) / (float)data.size();
+    }
+
+    wt_header wh;
+
+    memset(&wh, 0, sizeof(wt_header));
+    wh.n_samples = frameSize;
+    wh.n_tables = frames;
+    wh.flags = 0;
+
+    REQUIRE(wt->BuildWT(data.data(), wh, false));
+}
+
+// The ramp above is all positive, which the wavetable oscillator's integrator turns into a
+// long lived offset - no good for asking whether a voice has actually gone quiet. This one
+// is zero mean per frame.
+void buildSineWT(Wavetable *wt, int frames, int frameSize)
+{
+    std::vector<float> data((size_t)frames * frameSize);
+
+    for (int f = 0; f < frames; ++f)
+    {
+        for (int k = 0; k < frameSize; ++k)
+        {
+            data[(size_t)f * frameSize + k] = std::sin(2.0 * M_PI * k / (double)frameSize);
+        }
+    }
+
+    wt_header wh;
+
+    memset(&wh, 0, sizeof(wt_header));
+    wh.n_samples = frameSize;
+    wh.n_tables = frames;
+    wh.flags = 0;
+
+    REQUIRE(wt->BuildWT(data.data(), wh, false));
+}
+} // namespace
+
+TEST_CASE("Wavetables Can Be Resliced At Runtime", "[io]")
+{
+    SECTION("Frame size drives frame count")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        const auto before = wt.FlattenSource();
+        REQUIRE(before.size() == 512);
+
+        REQUIRE(wt.Reslice(32, -1, wt.flags));
+        REQUIRE(wt.size == 32);
+        REQUIRE(wt.n_tables == 16);
+        REQUIRE(wt.SourceFrameCount() == 16);
+
+        // Same samples, just cut up differently
+        REQUIRE(wt.FlattenSource() == before);
+
+        REQUIRE(wt.Reslice(16, -1, wt.flags));
+        REQUIRE(wt.size == 16);
+        REQUIRE(wt.n_tables == 32);
+        REQUIRE(wt.FlattenSource() == before);
+    }
+
+    SECTION("A non-power-of-two frame size rounds down")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        REQUIRE(wt.Reslice(60, -1, wt.flags));
+        REQUIRE(wt.size == 32);
+        REQUIRE(wt.n_tables == 16);
+    }
+
+    SECTION("A frame size below the floor clamps rather than failing")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        REQUIRE(wt.Reslice(2, -1, wt.flags));
+        REQUIRE(wt.size == Wavetable::min_reslice_size);
+    }
+
+    SECTION("Reducing the frame count truncates the tail")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        const auto before = wt.FlattenSource();
+
+        REQUIRE(wt.Reslice(-1, 5, wt.flags));
+        REQUIRE(wt.size == 64);
+        REQUIRE(wt.n_tables == 5);
+
+        const auto after = wt.FlattenSource();
+        REQUIRE(after.size() == 320);
+        REQUIRE(std::equal(after.begin(), after.end(), before.begin()));
+    }
+
+    SECTION("Growing the frame count past the sample budget shrinks the frame size")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        // 20 frames will not fit at 64, nor at 32, but does at 16
+        REQUIRE(wt.Reslice(-1, 20, wt.flags));
+        REQUIRE(wt.size == 16);
+        REQUIRE(wt.n_tables == 20);
+        REQUIRE(wt.FlattenSource().size() == 320);
+    }
+
+    SECTION("A frame count that cannot be reached even at the floor is capped")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        // 512 samples at the 16 sample floor is 32 frames, so 400 is unreachable
+        REQUIRE(wt.Reslice(-1, 400, wt.flags));
+        REQUIRE(wt.size == Wavetable::min_reslice_size);
+        REQUIRE(wt.n_tables == 32);
+    }
+
+    SECTION("Sample mode round trips without accumulating padding")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        const auto before = wt.FlattenSource();
+
+        REQUIRE(wt.Reslice(-1, -1, wt.flags | wtf_is_sample));
+        REQUIRE(wt.flags & wtf_is_sample);
+        // BuildWT appends three silent frames for a sample
+        REQUIRE(wt.n_tables == 11);
+        // ...which SourceFrameCount and FlattenSource both see through
+        REQUIRE(wt.SourceFrameCount() == 8);
+        REQUIRE(wt.FlattenSource() == before);
+
+        // Toggling sample mode repeatedly must not grow the table each time
+        for (int i = 0; i < 4; ++i)
+        {
+            REQUIRE(wt.Reslice(-1, -1, wt.flags & ~wtf_is_sample));
+            REQUIRE(wt.n_tables == 8);
+            REQUIRE(wt.FlattenSource() == before);
+
+            REQUIRE(wt.Reslice(-1, -1, wt.flags | wtf_is_sample));
+            REQUIRE(wt.n_tables == 11);
+            REQUIRE(wt.FlattenSource() == before);
+        }
+    }
+
+    SECTION("A sample leaves room for the padding inside max_subtables")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        REQUIRE(wt.Reslice(-1, max_subtables, wt.flags | wtf_is_sample));
+        REQUIRE(wt.n_tables <= max_subtables);
+        REQUIRE(wt.SourceFrameCount() <= max_subtables - 3);
+    }
+
+    SECTION("The encoding flags are cleared, since we rebuild from float")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+        wt.flags |= wtf_int16 | wtf_int16_is_16;
+
+        REQUIRE(wt.Reslice(32, -1, wt.flags));
+        REQUIRE((wt.flags & wtf_int16) == 0);
+        REQUIRE((wt.flags & wtf_int16_is_16) == 0);
+    }
+
+    SECTION("An unbuilt wavetable refuses to reslice")
+    {
+        Wavetable wt;
+        REQUIRE(!wt.Reslice(64, -1, 0));
+    }
+}
+
+TEST_CASE("Queued Wavetable Reslices Run On The Audio Thread", "[io]")
+{
+    auto surge = Surge::Headless::createSurge(44100);
+    REQUIRE(surge.get());
+
+    auto *osc = &(surge->storage.getPatch().scene[0].osc[0]);
+    osc->queue_type = ot_wavetable;
+
+    // Let the startup wavetable load settle, so the reslice is the only thing queued
+    for (int i = 0; i < 5; ++i)
+        surge->process();
+
+    auto &wt = osc->wt;
+    REQUIRE(wt.queue_id == -1);
+    REQUIRE(wt.queue_filename.empty());
+
+    buildRampWT(&wt, 8, 64);
+    wt.current_id = 3;
+    osc->wavetable_display_name = "Some Wavetable";
+
+    wt.reslice_size = 32;
+    wt.reslice_frames = -1;
+    wt.reslice_flags = wt.flags | wtf_user_modified;
+    wt.queue_reslice = true;
+
+    surge->storage.perform_queued_wtloads();
+
+    REQUIRE(!wt.queue_reslice);
+    REQUIRE(wt.size == 32);
+    REQUIRE(wt.n_tables == 16);
+
+    // Detached from the wt_list entry, but the name it was loaded under is kept
+    REQUIRE(wt.current_id == -1);
+    REQUIRE(wt.flags & wtf_user_modified);
+    REQUIRE(osc->wavetable_display_name == "Some Wavetable");
+    REQUIRE(wt.refresh_display);
+}
+
+TEST_CASE("A Resliced Wavetable Survives A Patch Round Trip", "[io]")
+{
+    auto surge = Surge::Headless::createSurge(44100);
+    REQUIRE(surge.get());
+
+    auto *osc = &(surge->storage.getPatch().scene[0].osc[0]);
+    osc->type.val.i = ot_wavetable;
+
+    // The headless storage has no wavetable library, so stand one entry up by hand. The
+    // patch loader re-attaches a nameless-id wavetable to the list entry its display name
+    // matches, and this is the entry a re-sliced table must NOT be re-attached to.
+    Patch entry;
+    entry.name = "Reslice Test WT";
+    entry.path = "reslice-test.wt";
+    surge->storage.wt_list.push_back(entry);
+
+    osc->wavetable_display_name = entry.name;
+
+    auto &wt = osc->wt;
+    buildRampWT(&wt, 8, 64);
+    REQUIRE(wt.Reslice(32, -1, wt.flags | wtf_is_sample | wtf_loop_sample | wtf_user_modified));
+
+    const auto expected = wt.FlattenSource();
+    const auto expectedTables = wt.n_tables;
+
+    void *data = nullptr;
+    auto sz = surge->storage.getPatch().save_patch(&data);
+    REQUIRE(sz > 0);
+    surge->storage.getPatch().load_patch(data, sz, false);
+
+    auto &rt = surge->storage.getPatch().scene[0].osc[0].wt;
+
+    REQUIRE(rt.size == 32);
+    REQUIRE(rt.n_tables == expectedTables);
+    REQUIRE(rt.flags & wtf_is_sample);
+    REQUIRE(rt.flags & wtf_loop_sample);
+    REQUIRE(rt.flags & wtf_user_modified);
+    // Still detached, so undo restores the edit rather than reloading the original file
+    REQUIRE(rt.current_id == -1);
+
+    // ...whereas without the modified bit the same patch does get re-attached, which is
+    // what the bit exists to suppress
+    rt.flags &= ~wtf_user_modified;
+
+    void *plain = nullptr;
+    auto psz = surge->storage.getPatch().save_patch(&plain);
+    REQUIRE(psz > 0);
+    surge->storage.getPatch().load_patch(plain, psz, false);
+
+    REQUIRE(surge->storage.getPatch().scene[0].osc[0].wt.current_id == 0);
+
+    // The patch blob is int16, so this is a lossy but faithful round trip
+    const auto got = rt.FlattenSource();
+    REQUIRE(got.size() == expected.size());
+
+    for (size_t i = 0; i < got.size(); ++i)
+    {
+        REQUIRE(got[i] == Approx(expected[i]).margin(1e-3));
+    }
+}
+
+TEST_CASE("Looped Samples Keep Sounding", "[dsp]")
+{
+    auto playAndMeasureTail = [](bool loop) {
+        auto surge = Surge::Headless::createSurge(44100);
+        REQUIRE(surge.get());
+
+        auto *osc = &(surge->storage.getPatch().scene[0].osc[0]);
+        osc->queue_type = ot_wavetable;
+
+        for (int i = 0; i < 5; ++i)
+            surge->process();
+
+        auto &wt = osc->wt;
+        buildSineWT(&wt, 8, 1024);
+
+        int flags = wt.flags | wtf_is_sample;
+
+        if (loop)
+        {
+            flags |= wtf_loop_sample;
+        }
+
+        REQUIRE(wt.Reslice(-1, -1, flags));
+
+        // A one voice unison seeds sampleloop with 1, so an unlooped sample plays once and
+        // stops. Without pinning it the unison count would be doing the looping for us.
+        osc->p[WavetableOscillator::wt_unison_voices].val.i = 1;
+
+        surge->playNote(0, 60, 127, 0);
+
+        float tail = 0;
+
+        for (int q = 0; q < 200; ++q)
+        {
+            surge->process();
+
+            if (q > 100)
+            {
+                for (int s = 0; s < BLOCK_SIZE; ++s)
+                    tail += fabs(surge->output[0][s]);
+            }
+        }
+
+        return tail;
+    };
+
+    const auto oneShot = playAndMeasureTail(false);
+    const auto looped = playAndMeasureTail(true);
+
+    // Eight frames at 261 Hz is about 1300 samples, so by block 100 an unlooped sample is
+    // long finished and only the DC blocker's decay is left
+    REQUIRE(looped > 1.f);
+    REQUIRE(oneShot < looped * 0.01f);
 }

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -32,6 +32,10 @@
 #include "UnitTestUtilities.h"
 #include "WavetableScriptEvaluator.h"
 #include "dsp/oscillators/WavetableOscillator.h"
+#include "PatchFileHeaderStructs.h"
+#include "sst/basic-blocks/mechanics/endian-ops.h"
+
+namespace mech = sst::basic_blocks::mechanics;
 
 #include <chrono>
 #include <thread>
@@ -1763,4 +1767,97 @@ TEST_CASE("Looped Samples Keep Sounding", "[dsp]")
     // long finished and only the DC blocker's decay is left
     REQUIRE(looped > 1.f);
     REQUIRE(oneShot < looped * 0.01f);
+}
+
+TEST_CASE("A Rejected Wavetable Header Leaves The Wavetable Alone", "[io]")
+{
+    SECTION("BuildWT keeps the previous table on a bad header")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        const auto before = wt.FlattenSource();
+
+        wt_header wh;
+
+        memset(&wh, 0, sizeof(wt_header));
+        wh.n_samples = max_wtable_size * 2;
+        wh.n_tables = 1;
+        wh.flags = 0;
+
+        std::vector<float> junk((size_t)wh.n_samples, 0.5f);
+
+        REQUIRE(!wt.BuildWT(junk.data(), wh, false));
+
+        // Crucially it does not now claim a size its buffers cannot back
+        REQUIRE(wt.size == 64);
+        REQUIRE(wt.n_tables == 8);
+        REQUIRE(wt.everBuilt);
+        REQUIRE(wt.FlattenSource() == before);
+    }
+
+    SECTION("Too many frames is rejected the same way")
+    {
+        Wavetable wt;
+        buildRampWT(&wt, 8, 64);
+
+        wt_header wh;
+
+        memset(&wh, 0, sizeof(wt_header));
+        wh.n_samples = 64;
+        wh.n_tables = max_subtables + 1;
+        wh.flags = 0;
+
+        std::vector<float> junk((size_t)wh.n_samples * wh.n_tables, 0.5f);
+
+        REQUIRE(!wt.BuildWT(junk.data(), wh, false));
+        REQUIRE(wt.size == 64);
+        REQUIRE(wt.n_tables == 8);
+    }
+}
+
+TEST_CASE("A Patch With An Unbuildable Wavetable Does Not Leave The Oscillator Empty", "[io]")
+{
+    auto surge = Surge::Headless::createSurge(44100);
+    REQUIRE(surge.get());
+
+    auto *osc = &(surge->storage.getPatch().scene[0].osc[0]);
+    osc->type.val.i = ot_wavetable;
+
+    // Big enough that a corrupted header still claims fewer bytes than the blob holds,
+    // so it gets past the size guard in load_patch and reaches BuildWT
+    buildRampWT(&osc->wt, 16, 2048);
+
+    void *data = nullptr;
+    auto sz = surge->storage.getPatch().save_patch(&data);
+    REQUIRE(sz > 0);
+
+    // Take a copy, since save_patch owns its buffer and we are about to scribble on it
+    std::vector<char> blob((char *)data, (char *)data + sz);
+
+    auto *ph = (sst::io::patch_header *)blob.data();
+    const auto xmlsize = mech::endian_read_int32LE(ph->xmlsize);
+    auto *wth = (wt_header *)(blob.data() + sizeof(sst::io::patch_header) + xmlsize);
+
+    REQUIRE(mech::endian_read_int32LE(wth->n_samples) == 2048);
+
+    // A frame size BuildWT must refuse
+    wth->n_samples = mech::endian_write_int32LE(max_wtable_size * 2);
+    wth->n_tables = mech::endian_write_int16LE(1);
+
+    surge->storage.getPatch().load_patch(blob.data(), (int)blob.size(), false);
+
+    auto &rt = surge->storage.getPatch().scene[0].osc[0].wt;
+
+    // Either the previous table survived or a default was queued, but the oscillator is
+    // never left describing a table it does not have
+    REQUIRE(rt.size != max_wtable_size * 2);
+    REQUIRE((rt.everBuilt || rt.queue_id == 0));
+
+    surge->storage.perform_queued_wtloads();
+    REQUIRE(rt.everBuilt);
+
+    // And it can still be saved without tripping the assert in save_patch
+    void *again = nullptr;
+    REQUIRE(surge->storage.getPatch().save_patch(&again) > 0);
 }

--- a/src/surge-xt/gui/UndoManager.cpp
+++ b/src/surge-xt/gui/UndoManager.cpp
@@ -237,6 +237,18 @@ struct UndoManagerImpl
         {
             res += pt->estimateUserDataSize();
         }
+        if (auto pt = std::get_if<UndoWavetable>(&a))
+        {
+            // The variant only holds a pointer, so without this a stack of wavetable undos
+            // is invisible to maxUndoStackMem while really costing megabytes apiece: the
+            // weak pointer arrays are over 100k on their own, before the sample data.
+            res += pt->wavetable_script.size();
+
+            if (pt->wt)
+            {
+                res += sizeof(Wavetable) + pt->wt->dataSizes * (sizeof(float) + sizeof(short));
+            }
+        }
         return res;
     }
 
@@ -444,14 +456,17 @@ struct UndoManagerImpl
 
     void doCleanup()
     {
-        while (undoStackMem > maxUndoStackMem)
+        // Now that a wavetable record is accounted for honestly, a single one can be a
+        // sizeable fraction of the budget on its own - so these have to stop at empty
+        // rather than trusting the budget to be reachable by evicting.
+        while (undoStackMem > maxUndoStackMem && !undoStack.empty())
         {
             auto r = undoStack.front();
             undoStackMem -= actionSize(r.action);
             freeAction(r.action);
             undoStack.pop_front();
         }
-        while (redoStackMem > maxRedoStackMem)
+        while (redoStackMem > maxRedoStackMem && !redoStack.empty())
         {
             auto r = redoStack.front();
             redoStackMem -= actionSize(r.action);

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -728,17 +728,109 @@ void OscillatorWaveformDisplay::createWTMenuItems(juce::PopupMenu &contextMenu, 
             createOpenScriptEditorMenu(contextMenu);
 #endif
 
-            Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "INFO");
-
-            // These are enabled simply so they show up in the screen reader
-            contextMenu.addItem(
-                Surge::GUI::toOSCase(fmt::format("Number of Frames: {}", oscdata->wt.n_tables)),
-                true, false, nullptr);
-            contextMenu.addItem(
-                Surge::GUI::toOSCase(fmt::format("Frame Length: {} samples", oscdata->wt.size)),
-                true, false, nullptr);
+            createWTShapeMenu(contextMenu);
         }
     }
+}
+
+void OscillatorWaveformDisplay::createWTShapeMenu(juce::PopupMenu &contextMenu)
+{
+    auto &wt = oscdata->wt;
+    const int frames = wt.SourceFrameCount();
+    const int totalSamples = frames * wt.size;
+
+    // The window oscillator shares the wavetable but ignores wtf_is_sample entirely, so
+    // oneshot playback is only offered where it does something. Frame size and frame count
+    // still are, since the window oscillator reads both.
+    if (oscdata->type.val.i == ot_wavetable)
+    {
+        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "SHAPE");
+
+        const bool isSample = (wt.flags & wtf_is_sample) != 0;
+
+        contextMenu.addItem(Surge::GUI::toOSCase("Play as Oneshot"), true, isSample,
+                            [this, isSample]() {
+                                auto f = oscdata->wt.flags;
+
+                                if (isSample)
+                                {
+                                    // Looping is meaningless back in wavetable playback
+                                    f &= ~(wtf_is_sample | wtf_loop_sample);
+                                }
+                                else
+                                {
+                                    f |= wtf_is_sample;
+                                }
+
+                                queueWavetableReslice(-1, -1, f);
+                            });
+
+        contextMenu.addItem(
+            Surge::GUI::toOSCase("Loop Oneshot"), isSample, (wt.flags & wtf_loop_sample) != 0,
+            [this]() { queueWavetableReslice(-1, -1, oscdata->wt.flags ^ wtf_loop_sample); });
+
+        contextMenu.addSeparator();
+    }
+
+    Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "INFO");
+
+    auto framesAction = [this, frames]() {
+        sge->promptForMiniEdit(
+            std::to_string(frames), "Enter the number of frames:", "Number of Frames",
+            juce::Point<int>{},
+            [this](const std::string &s) {
+                int n = 0;
+
+                try
+                {
+                    n = std::stoi(s);
+                }
+                catch (const std::exception &)
+                {
+                    return;
+                }
+
+                if (n > 0)
+                {
+                    queueWavetableReslice(-1, n, oscdata->wt.flags);
+                }
+            },
+            this);
+    };
+
+    contextMenu.addItem(Surge::GUI::toOSCase(fmt::format("Number of Frames: {}...", frames)), true,
+                        false, framesAction);
+
+    juce::PopupMenu sizeMenu;
+
+    for (int sz = Wavetable::min_reslice_size; sz <= max_wtable_size; sz <<= 1)
+    {
+        // Offer only frame sizes the samples can actually fill at least one frame of
+        if (sz > totalSamples)
+        {
+            break;
+        }
+
+        sizeMenu.addItem(std::to_string(sz), true, sz == wt.size,
+                         [this, sz]() { queueWavetableReslice(sz, -1, oscdata->wt.flags); });
+    }
+
+    contextMenu.addSubMenu(Surge::GUI::toOSCase(fmt::format("Frame Length: {} samples", wt.size)),
+                           sizeMenu);
+}
+
+void OscillatorWaveformDisplay::queueWavetableReslice(int newSize, int newFrames, int newFlags)
+{
+    sge->undoManager()->pushWavetable(scene, oscInScene);
+
+    auto &wt = oscdata->wt;
+
+    wt.reslice_size = newSize;
+    wt.reslice_frames = newFrames;
+    // Mark the table as diverged from its source before the audio thread rebuilds it, so
+    // patch reload does not re-attach it to the wt_list entry it was named after.
+    wt.reslice_flags = newFlags | wtf_user_modified;
+    wt.queue_reslice = true;
 }
 
 void OscillatorWaveformDisplay::createWTLoadMenu(juce::PopupMenu &contextMenu)

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -744,30 +744,31 @@ void OscillatorWaveformDisplay::createWTShapeMenu(juce::PopupMenu &contextMenu)
     // still are, since the window oscillator reads both.
     if (oscdata->type.val.i == ot_wavetable)
     {
-        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "SHAPE");
+        Surge::Widgets::MenuCenteredBoldLabel::addToMenuAsSectionHeader(contextMenu, "PLAYBACK");
 
         const bool isSample = (wt.flags & wtf_is_sample) != 0;
+        const bool isSampleLooped = isSample && (wt.flags & wtf_loop_sample) != 0;
+        const bool isSampleOneshot = isSample && !isSampleLooped;
 
-        contextMenu.addItem(Surge::GUI::toOSCase("Play as Oneshot"), true, isSample,
+        contextMenu.addItem(Surge::GUI::toOSCase("Play as Wavetable"), true, !isSample,
                             [this, isSample]() {
                                 auto f = oscdata->wt.flags;
-
-                                if (isSample)
-                                {
-                                    // Looping is meaningless back in wavetable playback
-                                    f &= ~(wtf_is_sample | wtf_loop_sample);
-                                }
-                                else
-                                {
-                                    f |= wtf_is_sample;
-                                }
-
+                                // Looping is meaningless back in wavetable playback
+                                f &= ~(wtf_is_sample | wtf_loop_sample);
                                 queueWavetableReslice(-1, -1, f);
                             });
 
-        contextMenu.addItem(
-            Surge::GUI::toOSCase("Loop Oneshot"), isSample, (wt.flags & wtf_loop_sample) != 0,
-            [this]() { queueWavetableReslice(-1, -1, oscdata->wt.flags ^ wtf_loop_sample); });
+        contextMenu.addItem(Surge::GUI::toOSCase("Play as Oneshot Sample"), true, isSampleOneshot,
+                            [this]() {
+                                auto f = oscdata->wt.flags | wtf_is_sample;
+                                queueWavetableReslice(-1, -1, f);
+                            });
+
+        contextMenu.addItem(Surge::GUI::toOSCase("Play as Looped Sample"), true, isSampleLooped,
+                            [this]() {
+                                auto f = oscdata->wt.flags | wtf_is_sample | wtf_loop_sample;
+                                queueWavetableReslice(-1, -1, f);
+                            });
 
         contextMenu.addSeparator();
     }
@@ -798,7 +799,7 @@ void OscillatorWaveformDisplay::createWTShapeMenu(juce::PopupMenu &contextMenu)
             this);
     };
 
-    contextMenu.addItem(Surge::GUI::toOSCase(fmt::format("Number of Frames: {}...", frames)), true,
+    contextMenu.addItem(Surge::GUI::toOSCase(fmt::format("Number of Frames: {}", frames)), true,
                         false, framesAction);
 
     juce::PopupMenu sizeMenu;

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.h
@@ -121,6 +121,8 @@ struct OscillatorWaveformDisplay : public juce::Component,
     void createWTLoadMenu(juce::PopupMenu &contextMenu);
     void createWTExportMenu(juce::PopupMenu &contextMenu);
     void createWTRenameMenu(juce::PopupMenu &contextMenu);
+    void createWTShapeMenu(juce::PopupMenu &contextMenu);
+    void queueWavetableReslice(int newSize, int newFrames, int newFlags);
     void createOpenScriptEditorMenu(juce::PopupMenu &contextMenu);
     void refreshWavetablesMenu(juce::PopupMenu &contextMenu);
 


### PR DESCRIPTION
The .wt format carries metadata saying whether a wavetable should play back as a wavetable or as a sample, and how it is cut into frames, but none of it could be changed once loaded - and for a WAV or a patch wavetable it could not be expressed at all. This adds a runtime path for all of it, hung off the oscillator display's context menu.

`Wavetable::Reslice()` rebuilds a table in place from its own contents: the top mipmap level is flattened back into the sample stream it was built from, then handed to `BuildWT()` with a new frame size, frame count and flag set. That works for every wavetable regardless of where it came from - file, patch blob or Lua script - and re-slicing a script's output is a legitimate effect in its own right, so the menu never regenerates. Script resolution stays where it already lives, in the script editor.

Frame size is a power of two between 16 and 4096, since both oscillators mask with size - 1. Frame count is a free integer: when the requested count will not fit at the current frame size the size is halved until it does, and samples past the last whole frame are truncated, so growing the count past what the table holds works the way you would expect.

Sample mode is handled by `SourceFrameCount`, which sees through the three silent frames `BuildWT()` appends - and through however many of those survived a patch round trip, since load_patch rebuilds with `AppendSilence` false and they arrive as ordinary data. Without that, every toggle would grow the table.

`wtf_loop_sample` was declared but never read. It now pins `sampleloop` to the value at which it stops counting down, overriding rather than extending the long-standing behaviour where the unison voice count doubles as a play count for samples. Existing patches do not set the flag, so they are unaffected.

A re-sliced table no longer matches the file it came from, so it detaches: `current_id` is cleared, which makes undo capture the full wavetable rather than reloading the original, while `wavetable_display_name` is deliberately left alone so the oscillator keeps showing the name it was loaded under instead of falling back to `"(Patch Wavetable)"`. The new `wtf_user_modified` bit records this acrossa patch round trip, so `load_patch()` does not re-attach the table to the `wt_list` entry its name matches. The bit is masked out of .wt export.

The rebuild is queued and performed in `perform_queued_wtloads()`, on the audio thread at a block boundary, the same way a queued wavetable load is.

Unison on samples is deliberately left out: `tableid`, `last_tableid` and `sampleloop` are scalars shared across unison voices, so letting more than one voice run would need them promoted to per-voice arrays. That is a separate change coming in a separate PR.

Assisted-By: Claude Opus 5 <noreply@anthropic.com>