### PR TITLE
Let unison voices mean unison on samples, not a play count

### DIFF
--- a/src/common/Parameter.cpp
+++ b/src/common/Parameter.cpp
@@ -985,6 +985,7 @@ void Parameter::set_type(int ctrltype)
         val_default.i = 0;
         break;
     case ct_osccount:
+    case ct_osccount_or_playcount:
         valtype = vt_int;
         val_min.i = 1;
         val_max.i = 16;
@@ -2101,6 +2102,8 @@ bool Parameter::supportsDynamicName() const
     case ct_pitch_extendable_very_low_minval:
     case ct_freq_audible_very_low_minval:
     case ct_tape_drive:
+    case ct_oscspread:
+    case ct_osccount_or_playcount:
         return true;
     default:
         break;
@@ -3855,6 +3858,33 @@ std::string Parameter::get_display(bool external, float ef) const
         case ct_osccount:
             txt = fmt::format("{:d} voice{:s}", i, (i > 1 ? "s" : ""));
             break;
+        case ct_osccount_or_playcount:
+        {
+            // On the wavetable data oscillators this count doubles as a sample play count
+            // when wtf_unison_is_loop_count is set. Reach the oscillator the same way the
+            // dynamic name does rather than through user_data, which Morph already owns.
+            bool asPlays = false;
+
+            if (storage && scene > 0 && scene <= n_scenes && ctrlgroup == cg_OSC &&
+                ctrlgroup_entry >= 0 && ctrlgroup_entry < n_oscs)
+            {
+                const auto &wtf =
+                    storage->getPatch().scene[scene - 1].osc[ctrlgroup_entry].wt.flags;
+
+                asPlays = (wtf & wtf_is_sample) && (wtf & wtf_unison_is_loop_count);
+            }
+
+            if (asPlays)
+            {
+                txt = fmt::format("{:d}x", i);
+            }
+            else
+            {
+                txt = fmt::format("{:d} voice{:s}", i, (i > 1 ? "s" : ""));
+            }
+
+            break;
+        }
         case ct_fxtype:
             txt = fx_type_shortnames[limit_range(i, 0, (int)n_fx_types - 1)];
             break;
@@ -4491,6 +4521,7 @@ bool Parameter::can_be_nondestructively_modulated() const
     case ct_bool_retrigger:
     case ct_osctype:
     case ct_osccount:
+    case ct_osccount_or_playcount:
     case ct_pitch_octave:
     case ct_wt2window:
     case ct_ringmod_sineoscmode:

--- a/src/common/Parameter.h
+++ b/src/common/Parameter.h
@@ -127,6 +127,10 @@ enum ctrltypes
     ct_wstype,
     ct_wt2window,
     ct_osccount,
+    // Same range and streaming as ct_osccount, but on the two wavetable-data oscillators
+    // the count doubles as a sample play count when wtf_unison_is_loop_count is set, so it
+    // needs a dynamic name and a display that reads "nx" rather than "voices".
+    ct_osccount_or_playcount,
     ct_oscspread,
     ct_oscspread_bipolar,
     ct_scenemode,

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -1296,8 +1296,7 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
                     // collapsed to one voice. Record that on load so these patches keep
                     // playing the way they always have; a table arriving without the flag
                     // from here on gets real unison instead.
-                    if (streamingRevision <= 30 &&
-                        scene[sc].osc[osc].type.val.i == ot_wavetable &&
+                    if (streamingRevision <= 30 && scene[sc].osc[osc].type.val.i == ot_wavetable &&
                         (scene[sc].osc[osc].wt.flags & wtf_is_sample))
                     {
                         scene[sc].osc[osc].wt.flags |= wtf_unison_is_loop_count;
@@ -1307,10 +1306,7 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
                         // The count now means what it says across its whole range, so the
                         // patches that were relying on that need the loop flag to keep
                         // sustaining.
-                        if (scene[sc]
-                                .osc[osc]
-                                .p[WavetableOscillator::wt_unison_voices]
-                                .val.i >= 7)
+                        if (scene[sc].osc[osc].p[WavetableOscillator::wt_unison_voices].val.i >= 7)
                         {
                             scene[sc].osc[osc].wt.flags |= wtf_loop_sample;
                         }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -27,6 +27,7 @@
 
 #include "SurgeStorage.h"
 #include "Oscillator.h"
+#include "WavetableOscillator.h"
 #include "SurgeParamConfig.h"
 #include "Effect.h"
 #include "MSEGModulationHelper.h"
@@ -1287,6 +1288,31 @@ void SurgePatch::load_patch(const void *data, int datasize, bool preset)
                             {
                                 scene[sc].osc[osc].wt.current_id = i;
                             }
+                        }
+                    }
+
+                    // Before wtf_unison_is_loop_count existed, a sample in the Wavetable
+                    // oscillator always read the unison voice count as a play count and
+                    // collapsed to one voice. Record that on load so these patches keep
+                    // playing the way they always have; a table arriving without the flag
+                    // from here on gets real unison instead.
+                    if (streamingRevision <= 30 &&
+                        scene[sc].osc[osc].type.val.i == ot_wavetable &&
+                        (scene[sc].osc[osc].wt.flags & wtf_is_sample))
+                    {
+                        scene[sc].osc[osc].wt.flags |= wtf_unison_is_loop_count;
+
+                        // The old countdown stopped decrementing at 7, so any voice count
+                        // from there up looped forever rather than playing that many times.
+                        // The count now means what it says across its whole range, so the
+                        // patches that were relying on that need the loop flag to keep
+                        // sustaining.
+                        if (scene[sc]
+                                .osc[osc]
+                                .p[WavetableOscillator::wt_unison_voices]
+                                .val.i >= 7)
+                        {
+                            scene[sc].osc[osc].wt.flags |= wtf_loop_sample;
                         }
                     }
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -150,9 +150,10 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 // 28 -> 29 (XT 1.4.* nightlies) save/load size of ArbitraryBlockStorage segment
 // 29 -> 30 (XT 1.4.* nightlies) reordered Phaser LFO waveforms and added a Saw shape (sst-effects upgrade)
 //                               Modern oscillator can now disable waveforms 2 and 3 to save CPU
+// 30 -> 31 (XT 1.4.* nightlies) Unison Voices parameter can change to Loop Count for Wavetable oscillator (old patches handled for wtf_loop_sample)
 // clang-format on
 
-const int ff_revision = 30;
+const int ff_revision = 31;
 
 const int n_scene_params = 273;
 const int n_global_params = 11 + n_fx_slots * (n_fx_params + 1); // each param plus a type

--- a/src/common/dsp/Oscillator.cpp
+++ b/src/common/dsp/Oscillator.cpp
@@ -41,6 +41,49 @@
 
 using namespace std;
 
+namespace Surge
+{
+namespace Oscillator
+{
+
+/*
+ * Shared by the Wavetable and Window oscillators - see OscillatorCommonFunctions.h. Both
+ * hooks answer the same question: is this oscillator's wavetable a sample whose unison
+ * count has been repurposed as a play count?
+ */
+static bool unisonIsPlayCount(const Parameter *p)
+{
+    if (!p->storage || p->scene < 1 || p->scene > n_scenes || p->ctrlgroup != cg_OSC ||
+        p->ctrlgroup_entry < 0 || p->ctrlgroup_entry >= n_oscs)
+    {
+        return false;
+    }
+
+    const auto &flags = p->storage->getPatch().scene[p->scene - 1].osc[p->ctrlgroup_entry].wt.flags;
+
+    return (flags & wtf_is_sample) && (flags & wtf_unison_is_loop_count);
+}
+
+const char *SampleUnisonDynamicName::getName(const Parameter *p) const
+{
+    if (p->ctrltype == ct_oscspread)
+        return unisonIsPlayCount(p) ? "N/A" : "Unison Detune";
+    else
+        return unisonIsPlayCount(p) ? "Loop Count" : "Unison Voices";
+}
+
+bool SampleUnisonDetuneDeact::getValue(const Parameter *p) const
+{
+    // In play count mode the oscillator runs a single voice, so there is nothing to detune
+    return unisonIsPlayCount(p);
+}
+
+SampleUnisonDynamicName sampleUnisonDynamicName;
+SampleUnisonDetuneDeact sampleUnisonDetuneDeact;
+
+} // namespace Oscillator
+} // namespace Surge
+
 Oscillator *spawn_osc(int osctype, SurgeStorage *storage, OscillatorStorage *oscdata,
                       pdata *localcopy, pdata *localcopyUnmod, unsigned char *onto)
 {

--- a/src/common/dsp/Wavetable.h
+++ b/src/common/dsp/Wavetable.h
@@ -117,6 +117,11 @@ enum wtflags
     wtf_int16_is_16 = 8,      // and in this case, range 0-2^16 if with above
     wtf_has_metadata = 0x10,  // null term xml at end of file
     wtf_user_modified = 0x20, // re-sliced at runtime, so it no longer matches its source
+    // When set, the unison voice count is read as a sample play count instead, and the
+    // oscillator collapses to a single voice. This is how samples have always behaved, so
+    // the bit is set on patches predating it; a fresh load leaves it clear and gets real
+    // unison, with wtf_loop_sample deciding whether the sample repeats forever.
+    wtf_unison_is_loop_count = 0x40,
 };
 
 #endif // SURGE_SRC_COMMON_DSP_WAVETABLE_H

--- a/src/common/dsp/oscillators/OscillatorCommonFunctions.h
+++ b/src/common/dsp/oscillators/OscillatorCommonFunctions.h
@@ -37,6 +37,28 @@ template <typename valtype>
 using CharacterFilter = sst::basic_blocks::dsp::CharacterFilter<valtype, SurgeStorage>;
 
 template <typename valtype> using UnisonSetup = sst::basic_blocks::dsp::UnisonSetup<valtype>;
+
+/*
+ * The Wavetable and Window oscillators share a unison voices parameter whose meaning flips
+ * with wtf_unison_is_loop_count: when that flag is set on a sample, the count is a play
+ * count and the oscillator collapses to one voice. Both the parameter label and the unison
+ * detune control have to follow the flag, and neither is a parameter, so the two hooks below
+ * read the oscillator's wavetable flags directly. They are shared rather than duplicated per
+ * oscillator because the two behave identically here; the instances live in Oscillator.cpp.
+ */
+struct SampleUnisonDynamicName : public ParameterDynamicNameFunction
+{
+    const char *getName(const Parameter *p) const override;
+};
+
+struct SampleUnisonDetuneDeact : public ParameterDynamicDeactivationFunction
+{
+    bool getValue(const Parameter *p) const override;
+};
+
+extern SampleUnisonDynamicName sampleUnisonDynamicName;
+extern SampleUnisonDetuneDeact sampleUnisonDetuneDeact;
+
 } // namespace Oscillator
 } // namespace Surge
 

--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -71,12 +71,25 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
 
     n_unison = limit_range(oscdata->p[wt_unison_voices].val.i, 1, MAX_UNISON);
 
+    int playcount = 1;
+
     if (oscdata->wt.flags & wtf_is_sample)
     {
-        // An explicit loop flag overrides the unison-count-as-play-count behavior rather
-        // than adding to it, so a looped sample ignores the voice count entirely.
-        sampleloop = (oscdata->wt.flags & wtf_loop_sample) ? infinite_sampleloop : n_unison;
-        n_unison = 1;
+        if (oscdata->wt.flags & wtf_unison_is_loop_count)
+        {
+            // The voice count is a play count instead, so the oscillator runs one voice.
+            // This is how samples behaved before the flag existed, which is why old patches
+            // get it set on load.
+            playcount = n_unison;
+            n_unison = 1;
+        }
+
+        // An explicit loop flag overrides the count rather than adding to it, so a looped
+        // sample ignores it entirely
+        if (oscdata->wt.flags & wtf_loop_sample)
+        {
+            playcount = infinite_sampleloop;
+        }
     }
 
     if (is_display)
@@ -108,12 +121,14 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
     }
 
     shape *= ((float)oscdata->wt.n_tables - 1.f + nointerp) * 0.99999f;
-    tableipol = modff(shape, &intpart);
+    float t_ipol = modff(shape, &intpart);
     if (deformType != XT_134_EARLIER)
-        tableipol = shape;
-    tableid = limit_range((int)intpart, 0, std::max((int)oscdata->wt.n_tables - 2 + nointerp, 0));
-    last_tableipol = tableipol;
-    last_tableid = tableid;
+        t_ipol = shape;
+    int t_id = limit_range((int)intpart, 0, std::max((int)oscdata->wt.n_tables - 2 + nointerp, 0));
+    // Note last_tableipol deliberately keeps the morph-derived value below even though
+    // tableipol is zeroed for a sample, which is what the original scalar code did
+    float t_last_ipol = t_ipol;
+    last_tableid = t_id;
 
     selectDeform();
 
@@ -122,8 +137,20 @@ void WavetableOscillator::init(float pitch, bool is_display, bool nonzero_init_d
 
     if (oscdata->wt.flags & wtf_is_sample)
     {
-        tableipol = 0.f;
-        tableid -= 1;
+        // Morph is the start point offset for a sample: the frame it lands on is where
+        // playback begins, and the -1 is what the first advance in convolute() cancels out
+        t_ipol = 0.f;
+        t_id -= 1;
+    }
+
+    // Broadcast to every voice, not just the sounding ones, so nothing is ever read
+    // uninitialized if the unison count changes underneath us
+    for (int i = 0; i < MAX_UNISON; i++)
+    {
+        tableipol[i] = t_ipol;
+        last_tableipol[i] = t_last_ipol;
+        tableid[i] = t_id;
+        sampleloop[i] = playcount;
     }
 
     for (int i = 0; i < n_unison; i++)
@@ -164,8 +191,11 @@ void WavetableOscillator::init_ctrltypes()
     oscdata->p[wt_skewh].set_type(ct_percent_bipolar);
     oscdata->p[wt_unison_detune].set_name("Unison Detune");
     oscdata->p[wt_unison_detune].set_type(ct_oscspread);
+    oscdata->p[wt_unison_detune].dynamicDeactivation = &Surge::Oscillator::sampleUnisonDetuneDeact;
+    oscdata->p[wt_unison_detune].dynamicName = &Surge::Oscillator::sampleUnisonDynamicName;
     oscdata->p[wt_unison_voices].set_name("Unison Voices");
-    oscdata->p[wt_unison_voices].set_type(ct_osccount);
+    oscdata->p[wt_unison_voices].set_type(ct_osccount_or_playcount);
+    oscdata->p[wt_unison_voices].dynamicName = &Surge::Oscillator::sampleUnisonDynamicName;
 }
 
 void WavetableOscillator::init_default_values()
@@ -307,19 +337,19 @@ void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
 
         if (oscdata->wt.flags & wtf_is_sample)
         {
-            tableid++;
-            if (tableid > oscdata->wt.n_tables - paddingLoop)
+            tableid[voice]++;
+            if (tableid[voice] > (int)oscdata->wt.n_tables - paddingLoop)
             {
-                if (sampleloop < infinite_sampleloop)
-                    sampleloop--;
+                if (sampleloop[voice] < infinite_sampleloop)
+                    sampleloop[voice]--;
 
-                if (sampleloop > 0)
+                if (sampleloop[voice] > 0)
                 {
-                    tableid = 0;
+                    tableid[voice] = 0;
                 }
                 else
                 {
-                    tableid = oscdata->wt.n_tables - paddingEnd;
+                    tableid[voice] = oscdata->wt.n_tables - paddingEnd;
                     oscstate[voice] = 100000000000.f; // rather large number
                     return;
                 }
@@ -327,8 +357,8 @@ void WavetableOscillator::convolute(int voice, bool FM, bool stereo)
 
             if (deformType != XT_134_EARLIER)
             {
-                tableipol = tableid;
-                last_tableipol = tableid;
+                tableipol[voice] = tableid[voice];
+                last_tableipol[voice] = tableid[voice];
             }
         }
 
@@ -555,7 +585,8 @@ float WavetableOscillator::getMorph()
 */
 float WavetableOscillator::deformLegacy(float block_pos, int voice)
 {
-    float tblip_ipol = (1 - block_pos) * last_tableipol + block_pos * tableipol;
+    float tblip_ipol =
+        (1 - block_pos) * last_tableipol[voice] + block_pos * tableipol[voice];
 
     // in Continuous Morph mode tblip_ipol gives us position between current and next frame
     // when not in Continuous Morph mode, we don't interpolate so this position should be
@@ -564,16 +595,18 @@ float WavetableOscillator::deformLegacy(float block_pos, int voice)
 
     // that 1 - nointerp makes sure we don't read the table off memory, keeps us bounded
     // and since it gets multiplied by lipol, in morph mode ends up being zero - no sweat!
-    return (oscdata->wt.TableF32WeakPointers[mipmap[voice]][tableid][state[voice]] *
+    return (oscdata->wt.TableF32WeakPointers[mipmap[voice]][tableid[voice]][state[voice]] *
             (1.f - lipol)) +
-           (oscdata->wt.TableF32WeakPointers[mipmap[voice]][tableid + 1 - nointerp][state[voice]] *
+           (oscdata->wt
+                .TableF32WeakPointers[mipmap[voice]][tableid[voice] + 1 - nointerp][state[voice]] *
             lipol);
 }
 
 float WavetableOscillator::deformContinuous(float block_pos, int voice)
 {
     block_pos = nointerp ? 1 : block_pos;
-    float tblip_ipol = (1 - block_pos) * last_tableipol + block_pos * tableipol;
+    float tblip_ipol =
+        (1 - block_pos) * last_tableipol[voice] + block_pos * tableipol[voice];
 
     int tempTableId = floor(tblip_ipol);
     int targetTableId = min((int)(tempTableId + 1), (int)(oscdata->wt.n_tables - 1));
@@ -589,7 +622,7 @@ float WavetableOscillator::deformContinuous(float block_pos, int voice)
 float WavetableOscillator::deformMorph(float block_pos, int voice)
 {
 
-    float frames[2] = {(last_tableipol), (tableipol)};
+    float frames[2] = {(last_tableipol[voice]), (tableipol[voice])};
     for (int i = 0; i < 2; i++)
     {
         int actualFrame = floor(frames[i]);
@@ -636,32 +669,56 @@ void WavetableOscillator::process_block(float pitch0, float drift, bool stereo, 
     l_hskew.process();
     l_clip.process();
 
-    if ((oscdata->wt.n_tables == 1) ||
-        (tableid >=
-         oscdata->wt.n_tables)) // TableID-range may have changed in the meantime, check it!
+    // TableID-range may have changed in the meantime, check it! In sample mode the voices
+    // carry independent frame indices, so every sounding one has to be checked and reset,
+    // not just the first: a voice left pointing past a table that shrank underneath us
+    // reads out of bounds in the deform functions.
+    //
+    // The cast to int matters. n_tables is unsigned, so the old comparison promoted the
+    // frame index and a sample sitting at the -1 that init() seeds - which is what the
+    // first advance in convolute() cancels out - looked enormous and got reset to 0 before
+    // it ever played. That skipped frame 0 whenever Morph put the start point there.
+    bool outOfRange = (oscdata->wt.n_tables == 1);
+
+    for (int i = 0; i < n_unison && !outOfRange; i++)
     {
-        tableipol = 0.f;
-        tableid = 0;
+        outOfRange = (tableid[i] >= (int)oscdata->wt.n_tables);
+    }
+
+    if (outOfRange)
+    {
         last_tableid = 0;
-        last_tableipol = 0.f;
+
+        for (int i = 0; i < MAX_UNISON; i++)
+        {
+            tableipol[i] = 0.f;
+            last_tableipol[i] = 0.f;
+            tableid[i] = 0;
+        }
     }
     else if (oscdata->wt.flags & wtf_is_sample)
     {
-        if (deformType == XT_134_EARLIER)
+        for (int i = 0; i < n_unison; i++)
         {
-            tableipol = 0.f;
-            last_tableipol = 0.f;
-        }
-        else
-        {
-            tableipol = tableid;
-            last_tableipol = tableid;
+            if (deformType == XT_134_EARLIER)
+            {
+                tableipol[i] = 0.f;
+                last_tableipol[i] = 0.f;
+            }
+            else
+            {
+                tableipol[i] = tableid[i];
+                last_tableipol[i] = tableid[i];
+            }
         }
     }
     else
     {
-        last_tableipol = tableipol;
-        last_tableid = tableid;
+        // Morph mode is identical for every voice, so work it out once on locals and
+        // broadcast. Doing it this way rather than having the deform functions pick an
+        // index keeps the branch out of the per-sample read in convolute().
+        float t_last_ipol = tableipol[0];
+        last_tableid = tableid[0];
 
         float shape;
         float intpart;
@@ -669,34 +726,41 @@ void WavetableOscillator::process_block(float pitch0, float drift, bool stereo, 
         shape = getMorph();
 
         shape *= ((float)oscdata->wt.n_tables - 1.f + nointerp) * 0.99999f;
-        tableipol = deformType == XT_134_EARLIER ? modff(shape, &intpart) : shape;
+        float t_ipol = deformType == XT_134_EARLIER ? modff(shape, &intpart) : shape;
         modff(shape, &intpart);
-        tableid = limit_range((int)intpart, 0, (int)oscdata->wt.n_tables - 2 + nointerp);
+        int t_id = limit_range((int)intpart, 0, (int)oscdata->wt.n_tables - 2 + nointerp);
 
         selectDeform();
 
         if (deformType == XT_134_EARLIER)
         {
-            if (tableid > last_tableid)
+            if (t_id > last_tableid)
             {
-                if (last_tableipol != 1.f)
+                if (t_last_ipol != 1.f)
                 {
-                    tableid = last_tableid;
-                    tableipol = 1.f;
+                    t_id = last_tableid;
+                    t_ipol = 1.f;
                 }
                 else
-                    last_tableipol = 0.0f;
+                    t_last_ipol = 0.0f;
             }
-            else if (tableid < last_tableid)
+            else if (t_id < last_tableid)
             {
-                if (last_tableipol != 0.f)
+                if (t_last_ipol != 0.f)
                 {
-                    tableid = last_tableid;
-                    tableipol = 0.f;
+                    t_id = last_tableid;
+                    t_ipol = 0.f;
                 }
                 else
-                    last_tableipol = 1.0f;
+                    t_last_ipol = 1.0f;
             }
+        }
+
+        for (int i = 0; i < MAX_UNISON; i++)
+        {
+            tableipol[i] = t_ipol;
+            last_tableipol[i] = t_last_ipol;
+            tableid[i] = t_id;
         }
     }
 

--- a/src/common/dsp/oscillators/WavetableOscillator.cpp
+++ b/src/common/dsp/oscillators/WavetableOscillator.cpp
@@ -585,8 +585,7 @@ float WavetableOscillator::getMorph()
 */
 float WavetableOscillator::deformLegacy(float block_pos, int voice)
 {
-    float tblip_ipol =
-        (1 - block_pos) * last_tableipol[voice] + block_pos * tableipol[voice];
+    float tblip_ipol = (1 - block_pos) * last_tableipol[voice] + block_pos * tableipol[voice];
 
     // in Continuous Morph mode tblip_ipol gives us position between current and next frame
     // when not in Continuous Morph mode, we don't interpolate so this position should be
@@ -605,8 +604,7 @@ float WavetableOscillator::deformLegacy(float block_pos, int voice)
 float WavetableOscillator::deformContinuous(float block_pos, int voice)
 {
     block_pos = nointerp ? 1 : block_pos;
-    float tblip_ipol =
-        (1 - block_pos) * last_tableipol[voice] + block_pos * tableipol[voice];
+    float tblip_ipol = (1 - block_pos) * last_tableipol[voice] + block_pos * tableipol[voice];
 
     int tempTableId = floor(tblip_ipol);
     int targetTableId = min((int)(tempTableId + 1), (int)(oscdata->wt.n_tables - 1));

--- a/src/common/dsp/oscillators/WavetableOscillator.h
+++ b/src/common/dsp/oscillators/WavetableOscillator.h
@@ -85,18 +85,27 @@ class WavetableOscillator : public AbstractBlitOscillator
     int mipmap[MAX_UNISON], mipmap_ofs[MAX_UNISON];
     lag<float> FMdepth, hpf_coeff, integrator_mult, l_hskew, l_vskew, l_clip, l_shape;
     float formant_t, formant_last, pitch_last, pitch_t;
-    float tableipol, last_tableipol;
+    // Frame position, per unison voice. In morph mode every voice holds the same value and
+    // the block-rate code broadcasts it to all of them, which keeps the per-sample deform
+    // read - it sits in the innermost audio loop - a plain [voice] index with no branch. In
+    // sample mode the voices walk through the table independently.
+    float tableipol[MAX_UNISON], last_tableipol[MAX_UNISON];
     float hskew, last_hskew;
-    int id_shape, id_vskew, id_hskew, id_clip, id_detune, id_formant, tableid, last_tableid;
+    int id_shape, id_vskew, id_hskew, id_clip, id_detune, id_formant;
+    int tableid[MAX_UNISON];
+    // Read only by the pre-1.4 morph clamp and the init/reset paths, never in sample mode,
+    // so this one stays shared
+    int last_tableid;
     int FMdelay;
     int nointerp;
     float FMmul_inv;
-    // Play count for sample-mode playback, counted down each time the sample wraps. It is
-    // seeded from the unison voice count, which for samples has always doubled as "play the
-    // sample this many times"; at this value or above it stops counting down and the sample
-    // loops forever, which is what wtf_loop_sample pins it to.
-    static constexpr int infinite_sampleloop = 7;
-    int sampleloop;
+    // Play count for sample-mode playback, per voice, counted down each time the sample
+    // wraps. wtf_loop_sample means "never stop" and is represented by the sentinel below:
+    // at that value the countdown is skipped entirely. The sentinel sits above MAX_UNISON
+    // deliberately, so that when wtf_unison_is_loop_count makes the unison voice count
+    // double as the play count, the whole 1..MAX_UNISON range stays a literal play count.
+    static constexpr int infinite_sampleloop = MAX_UNISON + 1;
+    int sampleloop[MAX_UNISON];
 
     pdata *unmodulatedLocalcopy;
     FeatureDeform deformType;

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -1738,8 +1738,9 @@ TEST_CASE("Looped Samples Keep Sounding", "[dsp]")
 
         REQUIRE(wt.Reslice(-1, -1, flags));
 
-        // A one voice unison seeds sampleloop with 1, so an unlooped sample plays once and
-        // stops. Without pinning it the unison count would be doing the looping for us.
+        // Without wtf_unison_is_loop_count the play count is 1 whatever the unison voices
+        // are, so an unlooped sample plays once and stops. Pinned to a single voice anyway,
+        // so that this measures the loop flag rather than the unison spread.
         osc->p[WavetableOscillator::wt_unison_voices].val.i = 1;
 
         surge->playNote(0, 60, 127, 0);
@@ -1860,4 +1861,232 @@ TEST_CASE("A Patch With An Unbuildable Wavetable Does Not Leave The Oscillator E
     // And it can still be saved without tripping the assert in save_patch
     void *again = nullptr;
     REQUIRE(surge->storage.getPatch().save_patch(&again) > 0);
+}
+
+TEST_CASE("The Sample Unison Mode Flag Round Trips", "[io]")
+{
+    auto surge = Surge::Headless::createSurge(44100);
+    REQUIRE(surge.get());
+
+    auto *osc = &(surge->storage.getPatch().scene[0].osc[0]);
+    osc->type.val.i = ot_wavetable;
+
+    auto &wt = osc->wt;
+    buildRampWT(&wt, 8, 64);
+    REQUIRE(wt.Reslice(-1, -1,
+                       wt.flags | wtf_is_sample | wtf_unison_is_loop_count | wtf_user_modified));
+
+    SECTION("through a .wt file")
+    {
+        auto f = fs::temp_directory_path() / "surge_unison_mode_flag.wt";
+        REQUIRE(surge->storage.export_wt_wt_portable(f, &wt, ""));
+
+        Wavetable back;
+        std::string md;
+        REQUIRE(surge->storage.load_wt_wt(path_to_string(f), &back, md));
+
+        REQUIRE(back.flags & wtf_is_sample);
+        // The mode says how the file should play, so unlike wtf_user_modified - which only
+        // records this session's edit history - it belongs in the exported file
+        REQUIRE(back.flags & wtf_unison_is_loop_count);
+        REQUIRE(!(back.flags & wtf_user_modified));
+
+        fs::remove(f);
+    }
+
+    SECTION("through a patch")
+    {
+        void *data = nullptr;
+        auto sz = surge->storage.getPatch().save_patch(&data);
+        REQUIRE(sz > 0);
+        surge->storage.getPatch().load_patch(data, sz, false);
+
+        REQUIRE(surge->storage.getPatch().scene[0].osc[0].wt.flags & wtf_unison_is_loop_count);
+    }
+
+    SECTION("and stays clear through a patch when it started clear")
+    {
+        REQUIRE(wt.Reslice(-1, -1, wt.flags & ~wtf_unison_is_loop_count));
+
+        void *data = nullptr;
+        auto sz = surge->storage.getPatch().save_patch(&data);
+        REQUIRE(sz > 0);
+        surge->storage.getPatch().load_patch(data, sz, false);
+
+        // A current revision patch must not pick the flag up from the migration
+        REQUIRE(!(surge->storage.getPatch().scene[0].osc[0].wt.flags & wtf_unison_is_loop_count));
+    }
+}
+
+TEST_CASE("Old Patches Keep Reading Unison Voices As A Sample Play Count", "[io]")
+{
+    // save_patch stamps the current ff_revision into the patch XML. Rewriting it in place is
+    // what puts the loader on the pre-flag migration path; both numbers are the same width,
+    // so the xml size recorded in the patch header stays correct.
+    auto downgradeRevision = [](void *data, size_t sz) {
+        const std::string from = "revision=\"" + std::to_string(ff_revision) + "\"";
+        const std::string to = "revision=\"30\"";
+
+        REQUIRE(from.size() == to.size());
+
+        char *p = (char *)data;
+
+        for (size_t i = 0; i + from.size() <= sz; ++i)
+        {
+            if (memcmp(p + i, from.c_str(), from.size()) == 0)
+            {
+                memcpy(p + i, to.c_str(), to.size());
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    auto roundTripAsOldPatch = [&](int oscType, int extraFlags, int unisonVoices) {
+        auto surge = Surge::Headless::createSurge(44100);
+        REQUIRE(surge.get());
+
+        auto *osc = &(surge->storage.getPatch().scene[0].osc[0]);
+        osc->type.val.i = oscType;
+        osc->p[WavetableOscillator::wt_unison_voices].val.i = unisonVoices;
+
+        buildRampWT(&osc->wt, 8, 64);
+        REQUIRE(osc->wt.Reslice(-1, -1, osc->wt.flags | extraFlags));
+
+        void *data = nullptr;
+        auto sz = surge->storage.getPatch().save_patch(&data);
+        REQUIRE(sz > 0);
+        REQUIRE(downgradeRevision(data, sz));
+
+        surge->storage.getPatch().load_patch(data, sz, false);
+
+        return surge->storage.getPatch().scene[0].osc[0].wt.flags;
+    };
+
+    SECTION("a sample gets the flag, so the count keeps meaning plays")
+    {
+        const auto flags = roundTripAsOldPatch(ot_wavetable, wtf_is_sample, 3);
+
+        REQUIRE(flags & wtf_is_sample);
+        REQUIRE(flags & wtf_unison_is_loop_count);
+        // Three plays was three plays then and is three plays now, so nothing pins it
+        REQUIRE(!(flags & wtf_loop_sample));
+    }
+
+    SECTION("a voice count of seven or more also gets the loop flag")
+    {
+        // The old countdown stopped decrementing at 7, so these patches were looping forever
+        // rather than playing nine times. Only the loop flag preserves that now that the
+        // whole range is a literal count.
+        const auto flags = roundTripAsOldPatch(ot_wavetable, wtf_is_sample, 9);
+
+        REQUIRE(flags & wtf_unison_is_loop_count);
+        REQUIRE(flags & wtf_loop_sample);
+    }
+
+    SECTION("seven is the boundary")
+    {
+        REQUIRE(roundTripAsOldPatch(ot_wavetable, wtf_is_sample, 7) & wtf_loop_sample);
+        REQUIRE(!(roundTripAsOldPatch(ot_wavetable, wtf_is_sample, 6) & wtf_loop_sample));
+    }
+
+    SECTION("a wavetable that is not a sample is left alone")
+    {
+        const auto flags = roundTripAsOldPatch(ot_wavetable, 0, 9);
+
+        REQUIRE(!(flags & wtf_unison_is_loop_count));
+        REQUIRE(!(flags & wtf_loop_sample));
+    }
+
+    SECTION("the window oscillator is left alone, since it never played samples")
+    {
+        const auto flags = roundTripAsOldPatch(ot_window, wtf_is_sample, 9);
+
+        REQUIRE(!(flags & wtf_unison_is_loop_count));
+        REQUIRE(!(flags & wtf_loop_sample));
+    }
+}
+
+TEST_CASE("Sample Play Count Covers The Whole Unison Range", "[dsp]")
+{
+    // Eight frames at note 60 works out at roughly 40 to 50 blocks per play, so sixteen
+    // plays finish around block 665 and land well inside the 1200 blocks below.
+    //
+    // Note that "stopped" is not "silent": the oscillator feeds a leaky integrator, so a
+    // finished sample leaves an exponential tail that is still around 1e-2 a hundred blocks
+    // later. The checks below therefore measure a stopped voice against one that is
+    // genuinely still sounding in the same window, rather than against zero.
+    auto energyIn = [](int voices, int extraFlags, int fromBlock, int toBlock) {
+        auto surge = Surge::Headless::createSurge(44100);
+        REQUIRE(surge.get());
+
+        auto *osc = &(surge->storage.getPatch().scene[0].osc[0]);
+        osc->queue_type = ot_wavetable;
+
+        for (int i = 0; i < 5; ++i)
+            surge->process();
+
+        auto &wt = osc->wt;
+        buildSineWT(&wt, 8, 1024);
+        REQUIRE(wt.Reslice(-1, -1, wt.flags | wtf_is_sample | extraFlags));
+
+        osc->p[WavetableOscillator::wt_unison_voices].val.i = voices;
+
+        surge->playNote(0, 60, 127, 0);
+
+        float e = 0;
+
+        for (int q = 0; q < 1200; ++q)
+        {
+            surge->process();
+
+            if (q >= fromBlock && q < toBlock)
+            {
+                for (int s = 0; s < BLOCK_SIZE; ++s)
+                    e += fabs(surge->output[0][s]);
+            }
+        }
+
+        return e;
+    };
+
+    SECTION("a count of two stops after two plays")
+    {
+        const auto stopped = energyIn(2, wtf_unison_is_loop_count, 150, 250);
+        const auto sounding = energyIn(9, wtf_unison_is_loop_count, 150, 250);
+
+        REQUIRE(energyIn(2, wtf_unison_is_loop_count, 0, 40) > 1.f);
+        REQUIRE(sounding > 1.f);
+        REQUIRE(stopped < sounding * 0.01f);
+    }
+
+    SECTION("a count above six is a count, not a licence to loop forever")
+    {
+        // The regression guard. The old countdown stopped decrementing at 7, so nine plays
+        // used to sustain indefinitely; they now end around block 390.
+        REQUIRE(energyIn(9, wtf_unison_is_loop_count, 150, 250) > 1.f);
+        REQUIRE(energyIn(9, wtf_unison_is_loop_count, 1100, 1200) <
+                energyIn(9, wtf_unison_is_loop_count | wtf_loop_sample, 1100, 1200) * 0.001f);
+    }
+
+    SECTION("the top of the range is still a count")
+    {
+        REQUIRE(energyIn(16, wtf_unison_is_loop_count, 400, 500) > 1.f);
+        REQUIRE(energyIn(16, wtf_unison_is_loop_count, 1100, 1200) <
+                energyIn(16, wtf_unison_is_loop_count | wtf_loop_sample, 1100, 1200) * 0.001f);
+    }
+
+    SECTION("the loop flag overrides the count entirely")
+    {
+        REQUIRE(energyIn(2, wtf_unison_is_loop_count | wtf_loop_sample, 1100, 1200) > 1.f);
+    }
+
+    SECTION("without the flag the count is unison and the sample plays once")
+    {
+        // Nine voices, but nine voices - so it is finished long before nine plays would be
+        REQUIRE(energyIn(9, 0, 0, 40) > 1.f);
+        REQUIRE(energyIn(9, 0, 150, 250) <
+                energyIn(9, wtf_unison_is_loop_count, 150, 250) * 0.01f);
+    }
 }

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -2086,7 +2086,6 @@ TEST_CASE("Sample Play Count Covers The Whole Unison Range", "[dsp]")
     {
         // Nine voices, but nine voices - so it is finished long before nine plays would be
         REQUIRE(energyIn(9, 0, 0, 40) > 1.f);
-        REQUIRE(energyIn(9, 0, 150, 250) <
-                energyIn(9, wtf_unison_is_loop_count, 150, 250) * 0.01f);
+        REQUIRE(energyIn(9, 0, 150, 250) < energyIn(9, wtf_unison_is_loop_count, 150, 250) * 0.01f);
     }
 }

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -755,8 +755,7 @@ void OscillatorWaveformDisplay::createWTShapeMenu(juce::PopupMenu &contextMenu)
                                 auto f = oscdata->wt.flags;
                                 // Looping and the play count reading of the unison voices
                                 // parameter are both meaningless back in wavetable playback
-                                f &= ~(wtf_is_sample | wtf_loop_sample |
-                                       wtf_unison_is_loop_count);
+                                f &= ~(wtf_is_sample | wtf_loop_sample | wtf_unison_is_loop_count);
                                 queueWavetableReslice(-1, -1, f);
                                 this->sge->queue_refresh = true;
                             });

--- a/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
+++ b/src/surge-xt/gui/widgets/OscillatorWaveformDisplay.cpp
@@ -753,22 +753,46 @@ void OscillatorWaveformDisplay::createWTShapeMenu(juce::PopupMenu &contextMenu)
         contextMenu.addItem(Surge::GUI::toOSCase("Play as Wavetable"), true, !isSample,
                             [this, isSample]() {
                                 auto f = oscdata->wt.flags;
-                                // Looping is meaningless back in wavetable playback
-                                f &= ~(wtf_is_sample | wtf_loop_sample);
+                                // Looping and the play count reading of the unison voices
+                                // parameter are both meaningless back in wavetable playback
+                                f &= ~(wtf_is_sample | wtf_loop_sample |
+                                       wtf_unison_is_loop_count);
                                 queueWavetableReslice(-1, -1, f);
+                                this->sge->queue_refresh = true;
                             });
 
         contextMenu.addItem(Surge::GUI::toOSCase("Play as Oneshot Sample"), true, isSampleOneshot,
                             [this]() {
                                 auto f = oscdata->wt.flags | wtf_is_sample;
+                                f &= ~wtf_loop_sample;
                                 queueWavetableReslice(-1, -1, f);
+                                this->sge->queue_refresh = true;
                             });
 
         contextMenu.addItem(Surge::GUI::toOSCase("Play as Looped Sample"), true, isSampleLooped,
                             [this]() {
                                 auto f = oscdata->wt.flags | wtf_is_sample | wtf_loop_sample;
+                                f &= ~wtf_unison_is_loop_count;
                                 queueWavetableReslice(-1, -1, f);
+                                this->sge->queue_refresh = true;
                             });
+
+        // On a sample the unison voices parameter can be read as a play count instead,
+        // which is how samples behaved before this was selectable. It only means anything
+        // in sample playback and not looped, so it is only offered there.
+        if (isSampleOneshot)
+        {
+            contextMenu.addSeparator();
+
+            const bool isPlayCount = (wt.flags & wtf_unison_is_loop_count) != 0;
+
+            contextMenu.addItem(Surge::GUI::toOSCase("Use Unison Voices as Loop Count"), true,
+                                isPlayCount, [this]() {
+                                    auto f = oscdata->wt.flags ^ wtf_unison_is_loop_count;
+                                    queueWavetableReslice(-1, -1, f);
+                                    this->sge->queue_refresh = true;
+                                });
+        }
 
         contextMenu.addSeparator();
     }


### PR DESCRIPTION
For as long as the wavetable oscillator has had sample playback, the unison voice count has doubled as a play count: a sample forced `n_unison` to 1 and used the parameter to decide how many times to play. That made real unison unavailable on samples, and it capped the useful count at six, since the countdown stopped decrementing at 7 and anything from there up looped forever.

`wtf_unison_is_loop_count` makes it a choice. Set, the count is a play count and the oscillator collapses to one voice, exactly as before. Clear - which is what a table loaded from here on gets - unison is real unison and the sample plays once, unless `wtf_loop_sample` says otherwise. The loop flag is now the sole authority for "forever", so the whole 1 to 16 range is a literal play count and the sentinel sits above `MAX_UNISON` where it cannot collide with one.

Real unison on samples needs per-voice frame state, so `tableid`, `tableipol`, `last_tableipol` and `sampleloop` are arrays now. Morph mode is identical across voices, so the block-rate code works it out on locals and broadcasts, rather than having the deform functions pick an index - that call sits in the innermost audio loop and does not need a branch for this. `last_tableid` stays shared: it is read only by the pre-1.4 morph clamp and the init paths, never in sample mode.

The check that catches a wavetable being swapped under a sounding voice now tests and resets every voice. With independent frame indices, resetting only the first would leave the others pointing past a table that shrank, which the deform functions then read out of bounds.

That check also gains a cast, which fixes a bug of its own. `n_tables` is unsigned, so the comparison promoted the frame index, and the -1 that `init()` seeds for a sample - the one the first advance in `convolute()` cancels out - looked enormous and was reset to 0 before it ever played. Morph is the start point offset for a sample, so frame 0 was silently skipped whenever Morph pointed at it.

Old patches are migrated on load, which is what the `ff_revision` bump is for. A sample in the wavetable oscillator gets the flag so the count keeps meaning plays, and one with 7 or more voices also gets `wtf_loop_sample`, since sustaining is what those patches were actually doing. The window oscillator is left alone - it has never played samples at all.

The parameter follows the flag. `ct_osccount_or_playcount` is `ct_osccount` with a dynamic name and a display that reads i.e. "3x" rather than "3 voices", and Unison Detune deactivates dynamically in play count mode, where there is only one voice to detune. Both hooks are written to be shared, so the Window oscillator can pick them up when it learns to play samples.

Assisted-By: Claude Opus 5 <noreply@anthropic.com>