### PR TITLE
Add periodic timestamped patch backups

### DIFF
--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -663,6 +663,7 @@ void SurgeStorage::initializeUserDataPaths()
     userMidiMappingsPath = userDataPath / "MIDI Mappings";
     userModulatorSettingsPath = userDataPath / "Modulator Presets";
     userSkinsPath = userDataPath / "Skins";
+    userBackupsPath = userDataPath / "Backups";
 }
 
 void SurgeStorage::createUserDirectory()

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1766,6 +1766,9 @@ class alignas(16) SurgeStorage
     fs::path userWavetablesExportPath;
     fs::path userWavetableScriptsPath;
     fs::path userSkinsPath;
+    // Timestamped periodic patch backups. Deliberately a sibling of userPatchesPath rather than
+    // a child, so refresh_patchlist() never scans it and backups stay out of the patch database.
+    fs::path userBackupsPath;
     fs::path userMidiMappingsPath;
     fs::path extraThirdPartyWavetablesPath; // used by rack
     fs::path extraUserWavetablesPath;       // used by rack

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4347,7 +4347,8 @@ void loadPatchInBackgroundThread(SurgeSynthesizer *sy)
         }
         else
         {
-            synth->loadPatchByPath(synth->patchid_file, -1, path_to_string(ppath).c_str(),
+            // The stem, not the whole path: this is the name the patch will be displayed under.
+            synth->loadPatchByPath(synth->patchid_file, -1, path_to_string(ppath.stem()).c_str(),
                                    asPreset);
         }
     }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -4326,6 +4326,7 @@ void loadPatchInBackgroundThread(SurgeSynthesizer *sy)
     if (synth->has_patchid_file)
     {
         ppath = string_to_path(synth->patchid_file);
+        const auto asPreset = synth->patchid_file_isPreset.exchange(true);
         synth->has_patchid_file = false;
         had_patchid_file = true;
         synth->stopSound();
@@ -4346,7 +4347,8 @@ void loadPatchInBackgroundThread(SurgeSynthesizer *sy)
         }
         else
         {
-            synth->loadPatchByPath(synth->patchid_file, -1, path_to_string(ppath).c_str());
+            synth->loadPatchByPath(synth->patchid_file, -1, path_to_string(ppath).c_str(),
+                                   asPreset);
         }
     }
 
@@ -4398,6 +4400,7 @@ void SurgeSynthesizer::processAudioThreadOpsWhenAudioEngineUnavailable(bool dang
         {
             auto p(string_to_path(patchid_file));
             auto s = path_to_string(p.stem());
+            const auto asPreset = patchid_file_isPreset.exchange(true);
             has_patchid_file = false;
 
             int ptid = -1, ct = 0;
@@ -4417,7 +4420,7 @@ void SurgeSynthesizer::processAudioThreadOpsWhenAudioEngineUnavailable(bool dang
             }
             else
             {
-                loadPatchByPath(patchid_file, -1, s.c_str());
+                loadPatchByPath(patchid_file, -1, s.c_str(), asPreset);
                 storage.lastLoadedPatch = p;
             }
             patchid_file[0] = 0;

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -34,6 +34,7 @@ struct QuadFilterChainState;
 #include <list>
 #include <utility>
 #include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <bitset>
 #include <vector>
@@ -72,6 +73,31 @@ class alignas(16) SurgeSynthesizer
 
     std::atomic<bool> audio_processing_active;
     std::atomic<bool> patchChanged{false};
+
+    /*
+     * Is the host transport actually rolling? Distinct from time_data.isPlaying, which the
+     * standalone deliberately pins to true so formula modulators keep running. This one is
+     * only ever set from a real host playhead and stays false in standalone and when no
+     * playhead is available, which is exactly what the periodic patch backup wants: skip
+     * backups while a DAW is playing, but always allow them in standalone.
+     */
+    std::atomic<bool> transportRunning{false};
+
+    /*
+     * Bookkeeping for the periodic patch backups. This lives on the synth rather than on the
+     * editor because the editor is constructed afresh every time the plugin window is opened,
+     * so editor-side state would restart the interval, forget which patch was last backed up,
+     * and re-report a failed backup, on every single open and close.
+     *
+     * Seeding the timer here at construction is also what keeps a window opened right after
+     * the plugin is instantiated from immediately writing a backup.
+     *
+     * Message thread only - the editor idle is the only thing that touches these.
+     */
+    std::chrono::steady_clock::time_point lastPatchBackupTime{std::chrono::steady_clock::now()};
+    size_t lastPatchBackupHash{0};
+    bool anyPatchBackupWritten{false};
+    bool patchBackupsFailed{false};
 
     // methods
   public:
@@ -485,6 +511,16 @@ class alignas(16) SurgeSynthesizer
     bool process_input;
     std::atomic<bool> has_patchid_file;
     char patchid_file[FILENAME_MAX];
+
+    /*
+     * Whether the queued patchid_file should be loaded as a preset. That is what makes
+     * loadPatchByPath keep the caller supplied name and drop the name, category, master
+     * volume and FX bypass carried in the file - right for dropping an arbitrary fxp into a
+     * running session, wrong when restoring something Surge itself wrote, such as a periodic
+     * patch backup, where that streamed metadata is the whole point. Consumed and reset to
+     * true by whichever load path picks the file up.
+     */
+    std::atomic<bool> patchid_file_isPreset{true};
     std::atomic<int> patchid_queue;
 
     // updated in audio thread, read from UI, so have assignments be atomic

--- a/src/common/UserDefaults.cpp
+++ b/src/common/UserDefaults.cpp
@@ -142,6 +142,12 @@ std::string defaultKeyToString(DefaultKey k)
     case AppendOriginalPatchBy:
         r = "appendOriginalPatchBy";
         break;
+    case EnablePatchBackups:
+        r = "enablePatchBackups";
+        break;
+    case PatchBackupInterval:
+        r = "patchBackupInterval";
+        break;
     case ModWindowShowsValues:
         r = "modWindowShowsValues";
         break;

--- a/src/common/UserDefaults.h
+++ b/src/common/UserDefaults.h
@@ -71,6 +71,9 @@ enum DefaultKey
     InitialPatchCategoryType,
     AppendOriginalPatchBy,
 
+    EnablePatchBackups,
+    PatchBackupInterval,
+
     OverrideTuningOnPatchLoad,
     OverrideMappingOnPatchLoad,
     OverrideTempoOnPatchLoad,

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -1861,3 +1861,46 @@ TEST_CASE("A Patch With An Unbuildable Wavetable Does Not Leave The Oscillator E
     void *again = nullptr;
     REQUIRE(surge->storage.getPatch().save_patch(&again) > 0);
 }
+
+TEST_CASE("Load Patch By Path Preset Semantics", "[io]")
+{
+    /*
+     * loadPatchByPath defaults to treating the file as a preset, which deliberately throws away
+     * the name and category streamed in the patch and keeps whatever the caller passed. That is
+     * right for dropping an arbitrary fxp onto a running session, and wrong for restoring a
+     * periodic patch backup, which is Surge's own patch coming home.
+     */
+    auto path = fs::temp_directory_path() / "surge_test_preset_semantics.fxp";
+
+    auto src = Surge::Headless::createSurge(44100);
+    REQUIRE(src);
+
+    src->storage.getPatch().name = "Plus Minus";
+    src->storage.getPatch().category = "Malfunction/Leads";
+    src->savePatchToPath(path, false);
+
+    SECTION("Not As Preset Restores Streamed Name And Category")
+    {
+        auto surge = Surge::Headless::createSurge(44100);
+        REQUIRE(surge);
+
+        REQUIRE(surge->loadPatchByPath(path_to_string(path).c_str(), -1, "Plus Minus (23-16-20)",
+                                       false));
+
+        REQUIRE(surge->storage.getPatch().name == "Plus Minus");
+        REQUIRE(surge->storage.getPatch().category == "Malfunction/Leads");
+    }
+
+    SECTION("As Preset Keeps The Caller Supplied Name")
+    {
+        auto surge = Surge::Headless::createSurge(44100);
+        REQUIRE(surge);
+
+        REQUIRE(surge->loadPatchByPath(path_to_string(path).c_str(), -1, "Plus Minus (23-16-20)"));
+
+        REQUIRE(surge->storage.getPatch().name == "Plus Minus (23-16-20)");
+        REQUIRE(surge->storage.getPatch().category == "Drag & Drop");
+    }
+
+    fs::remove(path);
+}

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -792,6 +792,7 @@ void SurgeSynthProcessor::processBlockPlayhead()
         playhead->getCurrentPosition(cp);
         surge->time_data.tempo = cp.bpm;
         surge->time_data.isPlaying = cp.isPlaying;
+        surge->transportRunning = cp.isPlaying || cp.isRecording;
 
         // isRecording should always imply isPlaying but better safe than sorry
         if (cp.isPlaying || cp.isRecording)
@@ -823,6 +824,10 @@ void SurgeSynthProcessor::processBlockPlayhead()
 
         // Formula modulator only, in standalone the transport is always set running.
         surge->time_data.isPlaying = (wrapperType == wrapperType_Standalone);
+
+        // ...but the real transport is not running, since there is no host playhead here.
+        // Periodic patch backups read this, so in standalone they are never transport gated.
+        surge->transportRunning = false;
 
         surge->resetStateFromTimeData();
     }

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -509,6 +509,8 @@ SurgeGUIEditor::SurgeGUIEditor(SurgeSynthEditor *jEd, SurgeSynthesizer *synth)
 
 SurgeGUIEditor::~SurgeGUIEditor()
 {
+    closePatchBackup();
+
     juce::PopupMenu::dismissAllActiveMenus();
     juce::Desktop::getInstance().removeFocusChangeListener(this);
     synth->removeModulationAPIListener(this);
@@ -566,6 +568,8 @@ void SurgeGUIEditor::idle()
         slowIdleCounter = 0;
         juceEditor->getSurgeLookAndFeel()->updateDarkIfNeeded();
     }
+
+    idlePatchBackup();
 
     if (needsModUpdate)
     {
@@ -3074,6 +3078,222 @@ SurgeGUIEditor::findWtPreview(int scene, int osc,
         return nullptr;
     }
     return &e.frames;
+}
+
+std::chrono::steady_clock::duration SurgeGUIEditor::patchBackupInterval()
+{
+    const auto mins = std::clamp(Surge::Storage::getUserDefaultValue(
+                                     &(synth->storage), Surge::Storage::PatchBackupInterval, 5),
+                                 1, 30);
+
+    return std::chrono::minutes(mins);
+}
+
+void SurgeGUIEditor::idlePatchBackup()
+{
+    if (synth->patchBackupsFailed)
+    {
+        return;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+
+    if (!Surge::Storage::getUserDefaultValue(&(synth->storage), Surge::Storage::EnablePatchBackups,
+                                             false))
+    {
+        // Keep re-arming while the option is off, so that switching backups on starts a full fresh
+        // interval rather than dumping a backup immediately.
+        synth->lastPatchBackupTime = now;
+
+        return;
+    }
+
+    // Nothing to protect if the patch is saved, and we stay out of the way while a host transport
+    // is rolling. Neither case re-arms the timer, so once the condition clears the backup happens
+    // promptly instead of waiting out another full interval.
+    if (!synth->storage.getPatch().isDirty || synth->transportRunning)
+    {
+        return;
+    }
+
+    if (now - synth->lastPatchBackupTime < patchBackupInterval())
+    {
+        return;
+    }
+
+    synth->lastPatchBackupTime = now;
+
+    savePatchBackup(false);
+}
+
+void SurgeGUIEditor::closePatchBackup()
+{
+    if (synth->patchBackupsFailed)
+    {
+        return;
+    }
+
+    if (!Surge::Storage::getUserDefaultValue(&(synth->storage), Surge::Storage::EnablePatchBackups,
+                                             false))
+    {
+        return;
+    }
+
+    if (!synth->storage.getPatch().isDirty || synth->transportRunning)
+    {
+        return;
+    }
+
+    /*
+     * Closing the window stops the interval, so grab the work on the way out regardless of how
+     * long it has been - otherwise tweaking for four minutes and then closing the window loses the
+     * lot if the host later goes down. Nothing runs away here: the hash check in savePatchBackup
+     * throws the file away unless the patch actually changed since the last backup.
+     */
+    synth->lastPatchBackupTime = std::chrono::steady_clock::now();
+
+    // Quiet, because the editor is already being torn down and there is nothing left for an error
+    // dialog to sit on top of.
+    savePatchBackup(true);
+}
+
+void SurgeGUIEditor::savePatchBackup(bool quiet)
+{
+    auto &storage = synth->storage;
+    auto &patch = storage.getPatch();
+
+    void *data{nullptr};
+    const auto datasize = patch.save_patch(&data);
+
+    if (!data || datasize == 0)
+    {
+        return;
+    }
+
+    // FNV-1a over the streamed patch. isDirty is sticky once set, so without this a patch left
+    // dirty but untouched would produce an identical backup file every single interval.
+    size_t hash{0xcbf29ce484222325ULL};
+
+    for (unsigned int i = 0; i < datasize; ++i)
+    {
+        hash ^= (size_t)(unsigned char)((const char *)data)[i];
+        hash *= 0x100000001b3ULL;
+    }
+
+    if (synth->anyPatchBackupWritten && hash == synth->lastPatchBackupHash)
+    {
+        return;
+    }
+
+    // Patch name and a single category level are free text, so scrub anything the filesystem
+    // rejects. Path separators matter most: left in, they would silently reshape the tree.
+    auto scrub = [](const std::string &in, const std::string &ifEmpty) {
+        static const std::string illegal{'<', '>', ':', '"', '/', '\\', '|', '?', '*'};
+        std::string r;
+
+        for (const auto &c : in)
+        {
+            if ((unsigned char)c >= 0x20 && illegal.find(c) == std::string::npos)
+            {
+                r += c;
+            }
+        }
+
+        // Windows silently strips these from the end of a path component
+        while (!r.empty() && (r.back() == '.' || r.back() == ' '))
+        {
+            r.pop_back();
+        }
+
+        return r.empty() ? ifEmpty : r;
+    };
+
+    const auto now = juce::Time::getCurrentTime();
+    auto dir = storage.userBackupsPath / string_to_path(now.formatted("%Y-%m-%d").toStdString());
+
+    /*
+     * A patch category can itself be nested - third party patches live at, say, Malfunction/Leads
+     * - and the category is carried around as one string with separators in it. Mirror those as
+     * real directories instead of scrubbing the separators out, which would flatten the example
+     * above into a single MalfunctionLeads folder.
+     */
+    std::string level;
+    bool anyLevel = false;
+
+    for (const auto &c : patch.category + "/")
+    {
+        if (c != '/' && c != '\\')
+        {
+            level += c;
+
+            continue;
+        }
+
+        if (!level.empty())
+        {
+            dir /= string_to_path(scrub(level, "Unsorted"));
+            anyLevel = true;
+            level.clear();
+        }
+    }
+
+    if (!anyLevel)
+    {
+        dir /= string_to_path("Unsorted");
+    }
+
+    const auto stamp = " (" + now.formatted("%H-%M-%S").toStdString() + ")";
+    const auto file = dir / string_to_path(scrub(patch.name, "Unnamed") + stamp + ".fxp");
+
+    try
+    {
+        fs::create_directories(dir);
+    }
+    catch (const fs::filesystem_error &e)
+    {
+        synth->patchBackupsFailed = true;
+
+        if (!quiet)
+        {
+            storage.reportError(
+                std::string("Unable to create the patch backups folder. Patch backups "
+                            "are disabled for the rest of this session.\n\n") +
+                    e.what(),
+                "Patch Backup Error");
+        }
+
+        return;
+    }
+
+    /*
+     * Stamp the timestamp into the streamed patch name too, so that a restored backup announces
+     * itself as one and says when it was taken - the patch browser reads the name out of the file,
+     * not out of the file name. Only for the duration of the write, since the patch being edited
+     * keeps its own name. This has to happen after the hash above: with the timestamp in the
+     * stream every serialization would differ from the last, and duplicate suppression would never
+     * fire again.
+     */
+    const auto liveName = patch.name;
+
+    patch.name = liveName + stamp;
+
+    // false means don't refresh the patch list: this must not renumber patchid, retarget the
+    // current category, or clear isDirty. It just streams the patch out to disk.
+    synth->savePatchToPath(file, false);
+
+    patch.name = liveName;
+
+    if (!fs::exists(file))
+    {
+        // savePatchToPath has already reported the write failure, so just latch here rather than
+        // putting that same dialog in front of the user again on every interval.
+        synth->patchBackupsFailed = true;
+
+        return;
+    }
+
+    synth->lastPatchBackupHash = hash;
+    synth->anyPatchBackupWritten = true;
 }
 
 void SurgeGUIEditor::idleWtGenService()

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -56,6 +56,7 @@
 #include <cstdarg>
 #include <bitset>
 #include <future>
+#include <chrono>
 #include "UndoManager.h"
 
 class SurgeSynthEditor;
@@ -384,6 +385,24 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void pollWtGenJobs();
     void idleWtGenService();
 
+    /*
+     * Periodic timestamped patch backups (see Surge::Storage::EnablePatchBackups). Driven from
+     * idle(), so backups only ever happen with the UI open - which is the point, since a patch
+     * nobody is editing has nothing worth backing up. The timer, the last written hash and the
+     * failure latch all live on the synth so that they survive the window being closed and
+     * reopened; see SurgeSynthesizer::lastPatchBackupTime.
+     */
+    void idlePatchBackup();
+
+    // Closing the window stops the interval, so capture the work on the way out. Called from the
+    // destructor, hence the quiet backup: there is no UI left to report a failure on.
+    void closePatchBackup();
+
+    void savePatchBackup(bool quiet);
+
+    // The configured backup interval, clamped to what the menu allows.
+    std::chrono::steady_clock::duration patchBackupInterval();
+
     // Message-thread-only cache of the newest preview filmstrip per (scene, osc), filled by the
     // response pollers (the overlay's pollGenJobs and the drop/menu tail; OSC generates complete
     // on the OSC thread and don't fill it). A hit requires every generation input to match, so
@@ -533,12 +552,15 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     float getModulationF01FromString(long tag, const std::string &s);
     std::string getAccessibleModulationVoiceover(long tag);
 
-    void queuePatchFileLoad(const std::string &file)
+    // isPreset false restores the name, category, master volume and FX bypass streamed in the
+    // file instead of dropping them, which is what a periodic patch backup wants.
+    void queuePatchFileLoad(const std::string &file, bool isPreset = true)
     {
         {
             std::lock_guard<std::mutex> mg(synth->patchLoadSpawnMutex);
             undoManager()->pushPatch();
             strncpy(synth->patchid_file, file.c_str(), FILENAME_MAX);
+            synth->patchid_file_isPreset = isPreset;
             synth->has_patchid_file = true;
         }
         synth->processAudioThreadOpsWhenAudioEngineUnavailable();

--- a/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditorMenuStructures.cpp
@@ -1126,6 +1126,40 @@ juce::PopupMenu SurgeGUIEditor::makePatchDefaultsMenu(const juce::Point<int> &wh
                                  !appendOGPatchBy);
                          });
 
+    auto patchBackupMenu = juce::PopupMenu();
+
+    bool enablePatchBackups = Surge::Storage::getUserDefaultValue(
+        &(synth->storage), Surge::Storage::EnablePatchBackups, false);
+
+    patchBackupMenu.addItem(Surge::GUI::toOSCase("Enable Patch Backups"), true, enablePatchBackups,
+                            [this, enablePatchBackups]() {
+                                Surge::Storage::updateUserDefaultValue(
+                                    &(this->synth->storage), Surge::Storage::EnablePatchBackups,
+                                    !enablePatchBackups);
+                            });
+
+    int backupInterval = std::clamp(Surge::Storage::getUserDefaultValue(
+                                        &(synth->storage), Surge::Storage::PatchBackupInterval, 5),
+                                    1, 30);
+
+    auto backupStr = fmt::format("Change Backup Save Interval (Current: {} {})", backupInterval,
+                                 backupInterval == 1 ? "Minute" : "Minutes");
+
+    patchBackupMenu.addItem(Surge::GUI::toOSCase(backupStr), [this, where, backupInterval]() {
+        promptForMiniEdit(
+            std::to_string(backupInterval),
+            "Enter a number of minutes (1 to 30):", "Backup Save Interval", where,
+            [this](const std::string &s) {
+                auto val = std::clamp(std::atoi(s.c_str()), 1, 30);
+
+                Surge::Storage::updateUserDefaultValue(&(this->synth->storage),
+                                                       Surge::Storage::PatchBackupInterval, val);
+            },
+            mainMenu);
+    });
+
+    patchDefMenu.addSubMenu(Surge::GUI::toOSCase("Patch Backups"), patchBackupMenu);
+
     patchDefMenu.addSeparator();
 
     if (Surge::GUI::getIsStandalone())

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -32,6 +32,7 @@
 #include "fmt/core.h"
 #include "SurgeJUCEHelpers.h"
 #include "AccessibleHelpers.h"
+#include "sst/plugininfra/strnatcmp.h"
 
 /*
  * It is an arbitrary number that we set as an ID for patch menu items.
@@ -835,7 +836,18 @@ void PatchSelector::showClassicMenu(bool single_category, bool userOnly)
         }
     });
 
+    // Only offered once periodic backups have actually written something, so people who never
+    // turned the option on don't get a menu entry pointing at a folder that isn't there.
+    if (fs::is_directory(storage->userBackupsPath))
+    {
+        contextMenu.addItem(Surge::GUI::toOSCase("Open Backups Folder..."), [this]() {
+            Surge::GUI::openFileOrFolder(this->storage->userBackupsPath);
+        });
+    }
+
     contextMenu.addSeparator();
+
+    populateBackupsMenu(contextMenu);
 
     if (tutorialCat >= 0)
     {
@@ -1045,6 +1057,155 @@ void PatchSelector::importFavorites()
     sge->fileChooser->launchAsync(juce::FileBrowserComponent::canSelectFiles, importCallback);
 }
 
+/*
+ * Fills in one level of the periodic patch backups tree: the backups sitting directly in dir, then
+ * a submenu per subdirectory. It recurses because a patch category can itself be nested, as third
+ * party patches are - Malfunction/Leads and the like - and the backup writer mirrors those levels
+ * as real directories. Sorted the same way the rest of the patch browser is, so that backups read
+ * like every other menu here rather than in reverse.
+ *
+ * added counts what went in. The return says whether the backup currently loaded is somewhere in
+ * this branch, so the caller can tick and preselect its way down to it.
+ */
+static bool addBackupsFromDir(const fs::path &dir, juce::PopupMenu &into, SurgeGUIEditor *sge,
+                              const fs::path &loaded, int &added)
+{
+    std::vector<fs::path> files, subdirs;
+
+    try
+    {
+        for (const auto &f : fs::directory_iterator(dir))
+        {
+            if (fs::is_directory(f))
+            {
+                subdirs.push_back(f.path());
+            }
+            else if (_stricmp(path_to_string(f.path().extension()).c_str(), ".fxp") == 0)
+            {
+                files.push_back(f.path());
+            }
+        }
+    }
+    catch (const fs::filesystem_error &)
+    {
+        return false;
+    }
+
+    auto byName = [](const fs::path &a, const fs::path &b) {
+        return strnatcasecmp(path_to_string(a.filename()).c_str(),
+                             path_to_string(b.filename()).c_str()) < 0;
+    };
+
+    std::sort(files.begin(), files.end(), byName);
+    std::sort(subdirs.begin(), subdirs.end(), byName);
+
+    bool anyChecked = false;
+
+    for (const auto &f : files)
+    {
+        auto name = path_to_string(f.stem());
+
+        // storage->lastLoadedPatch is set to the file path by both file load paths, so this is
+        // how a backup - which has no patch list entry to point at - gets its checkmark.
+        const bool isLoaded = !loaded.empty() && f == loaded;
+
+        anyChecked |= isLoaded;
+
+        // Loading a backup is a patch load like any other, so it warns over unsaved changes and
+        // lands on the undo stack (queuePatchFileLoad pushes it). Not as a preset though: a backup
+        // is Surge's own patch coming home, so the name and category it carries are the right ones.
+        auto item = juce::PopupMenu::Item(juce::CharPointer_UTF8(name.c_str()))
+                        .setEnabled(true)
+                        .setTicked(isLoaded)
+                        .setAction([sge, f]() {
+                            sge->loadPatchWithDirtyCheck(
+                                [sge, f]() { sge->queuePatchFileLoad(f.u8string(), false); });
+                        });
+
+        if (isLoaded)
+        {
+            item.setID(ID_TO_PRESELECT_MENU_ITEMS);
+        }
+
+        into.addItem(item);
+
+        if (++added % 32 == 0)
+        {
+            into.addColumnBreak();
+        }
+    }
+
+    for (const auto &d : subdirs)
+    {
+        juce::PopupMenu sub;
+        int inSub = 0;
+        const bool checkedKid = addBackupsFromDir(d, sub, sge, loaded, inSub);
+
+        if (inSub > 0)
+        {
+            auto name = path_to_string(d.filename());
+
+            if (checkedKid)
+            {
+                into.addSubMenu(juce::CharPointer_UTF8(name.c_str()), sub, true, nullptr, true,
+                                ID_TO_PRESELECT_MENU_ITEMS);
+                anyChecked = true;
+            }
+            else
+            {
+                into.addSubMenu(juce::CharPointer_UTF8(name.c_str()), sub);
+            }
+
+            added++;
+        }
+    }
+
+    return anyChecked;
+}
+
+bool PatchSelector::populateBackupsMenu(juce::PopupMenu &contextMenu)
+{
+    auto sge = firstListenerOfType<SurgeGUIEditor>();
+
+    if (!sge)
+    {
+        return false;
+    }
+
+    /*
+     * The backups folder deliberately lives outside the patch library, so it is never walked by
+     * refresh_patchlist() and never lands in the patch database. That keeps timestamped backups
+     * out of the categories and out of patch search, at the price of having to list the folder
+     * live, here, every time the menu opens.
+     */
+    if (!fs::is_directory(storage->userBackupsPath))
+    {
+        return false;
+    }
+
+    juce::PopupMenu backupsMenu;
+    int total = 0;
+    const bool anyChecked = addBackupsFromDir(storage->userBackupsPath, backupsMenu, sge,
+                                              storage->lastLoadedPatch, total);
+
+    if (total == 0)
+    {
+        return false;
+    }
+
+    if (anyChecked)
+    {
+        contextMenu.addSubMenu(Surge::GUI::toOSCase("Backups"), backupsMenu, true, nullptr, true,
+                               ID_TO_PRESELECT_MENU_ITEMS);
+    }
+    else
+    {
+        contextMenu.addSubMenu(Surge::GUI::toOSCase("Backups"), backupsMenu);
+    }
+
+    return true;
+}
+
 bool PatchSelector::populatePatchMenuForCategory(int c, juce::PopupMenu &contextMenu,
                                                  bool single_category, int &main_e, bool rootCall)
 {
@@ -1106,7 +1267,11 @@ bool PatchSelector::populatePatchMenuForCategory(int c, juce::PopupMenu &context
 
             bool thisCheck = false;
 
-            if (p == current_patch)
+            // current_category is -1 when the loaded patch came from a file rather than from the
+            // patch list - a periodic backup, a Load Patch from File, a drag and drop - in which
+            // case current_patch still points at whatever was loaded before it. Ticking that would
+            // claim we are sitting on a patch we are not.
+            if (p == current_patch && current_category >= 0)
             {
                 thisCheck = true;
                 amIChecked = true;

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -666,24 +666,33 @@ void PatchSelector::showClassicMenu(bool single_category, bool userOnly)
         sge->getShortcutDescription(Surge::GUI::KeyboardActions::INITIALIZE_PATCH),
         [this]() { loadInitPatch(); });
 
-    contextMenu.addItem(Surge::GUI::toOSCase("Set Current Patch as Default"), [this]() {
-        Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::InitialPatchName,
-                                               storage->patch_list[current_patch].name);
+    // Loading a patch straight off disk leaves current_category at -1 and current_patch stale,
+    // since such a patch has no entry in the patch list to point at. There is nothing sensible to
+    // store as the default patch in that case, so grey the item out rather than indexing the
+    // category vector at -1.
+    const bool canSetDefaultPatch =
+        current_patch >= 0 && current_patch < storage->patch_list.size() && current_category >= 0 &&
+        current_category < storage->patch_category.size();
 
-        Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::InitialPatchCategory,
-                                               storage->patch_category[current_category].name);
+    contextMenu.addItem(
+        Surge::GUI::toOSCase("Set Current Patch as Default"), canSetDefaultPatch, false, [this]() {
+            Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::InitialPatchName,
+                                                   storage->patch_list[current_patch].name);
 
-        Surge::Storage::updateUserDefaultValue(
-            storage, Surge::Storage::InitialPatchCategoryType,
-            storage->patch_category[current_category].isFactory ? "Factory" : "User");
+            Surge::Storage::updateUserDefaultValue(storage, Surge::Storage::InitialPatchCategory,
+                                                   storage->patch_category[current_category].name);
 
-        storage->initPatchName = Surge::Storage::getUserDefaultValue(
-            storage, Surge::Storage::InitialPatchName, "Init Saw");
-        storage->initPatchCategory = Surge::Storage::getUserDefaultValue(
-            storage, Surge::Storage::InitialPatchCategory, "Templates");
-        storage->initPatchCategoryType = Surge::Storage::getUserDefaultValue(
-            storage, Surge::Storage::InitialPatchCategoryType, "Factory");
-    });
+            Surge::Storage::updateUserDefaultValue(
+                storage, Surge::Storage::InitialPatchCategoryType,
+                storage->patch_category[current_category].isFactory ? "Factory" : "User");
+
+            storage->initPatchName = Surge::Storage::getUserDefaultValue(
+                storage, Surge::Storage::InitialPatchName, "Init Saw");
+            storage->initPatchCategory = Surge::Storage::getUserDefaultValue(
+                storage, Surge::Storage::InitialPatchCategory, "Templates");
+            storage->initPatchCategoryType = Surge::Storage::getUserDefaultValue(
+                storage, Surge::Storage::InitialPatchCategoryType, "Factory");
+        });
 
     contextMenu.addSeparator();
 

--- a/src/surge-xt/gui/widgets/PatchSelector.h
+++ b/src/surge-xt/gui/widgets/PatchSelector.h
@@ -200,6 +200,13 @@ struct PatchSelector : public juce::Component,
     bool populatePatchMenuForCategory(int index, juce::PopupMenu &contextMenu, bool single_category,
                                       int &main_e, bool rootCall);
 
+    /*
+     * Builds the periodic patch backups submenu straight off disk, since backups are kept out of
+     * patch_list and the patch database on purpose. Returns false, adding nothing, when there are
+     * no backups to show.
+     */
+    bool populateBackupsMenu(juce::PopupMenu &contextMenu);
+
     // a little transparent button to alow ally and focus over find and fav
     struct TB;
     std::unique_ptr<TB> searchButton, favoriteButton;


### PR DESCRIPTION
Surge could lose an unsaved patch to a crash or a host going down with no recovery path at all. This adds an opt-in periodic backup that streams the current patch to `User Data/Backups` whenever it is dirty.

The backup writer reuses `savePatchToPath()` with `refreshPatchList = false`, so it writes a normal fxp without renumbering `patchid`, retargeting the current category, or clearing `isDirty`. Backups are laid out as:

```
Backups/YYYY-MM-DD/<Category>/<PatchName> (HH-MM-SS).fxp
```

with patch name and category scrubbed of characters the filesystem rejects. A category can itself be nested, as third party patches are, and those levels are mirrored as real directories rather than flattened into one name. The timestamp also goes into the streamed patch name, so a restored backup says what it is and when it was taken rather than looking like the patch it came from.

The interval timer runs off the editor `idle()`, which means backups only happen with the UI open. Two further gates keep the folder useful: the patch has to be dirty, and the host transport has to be stopped. `isDirty` is sticky once set, so the serialized patch is also hashed - before the timestamp goes into the name, or every serialization would differ from the last - and an unchanged patch does not produce a second identical file. Neither the dirty nor the transport gate re-arms the timer, so a backup happens promptly once the condition clears rather than waiting out another full interval.

The timer, the hash and the failure latch live on the synth rather than on the editor, because the editor is constructed afresh every time the plugin window is opened. Editor-side state would restart the interval, forget what was last backed up, and re-report a failed backup on every open and close - so someone who reopens the window regularly would never get a backup at all. Seeding the timer at synth construction is also what stops a window opened right after instantiation from writing one immediately.

Closing the window stops the interval, so the editor destructor takes a backup on the way out whenever the patch is dirty, which covers tweaking for a few minutes and then closing the window. The hash check keeps that from producing duplicates when nothing has actually changed.

Transport state needed a new `SurgeSynthesizer::transportRunning` atomic rather than `time_data.isPlaying`, because the standalone deliberately pins `isPlaying = true` so formula modulators keep running. `transportRunning` is only ever set from a real host playhead, so backups are never transport gated in standalone.

The backups folder is a sibling of `User Data/Patches`, not a child, so `refresh_patchlist()` never walks it and backups stay out of the patch browser categories and out of the patch database. To keep them reachable anyway, the patch browser grows a Backups submenu built live off disk when the menu opens, above Tutorials, plus an Open Backups Folder entry alongside the other folder shortcuts. It walks the tree recursively, so nested categories show up as nested submenus, and it natural sorts each level the way the rest of the patch browser does. The loaded backup is ticked and preselected through `lastLoadedPatch`, and since a file loaded patch leaves `current_category` at -1, the patch list side of the menu now stops ticking whatever stale entry `patchid` still points at - it was claiming a database patch was loaded when a backup was. Loading goes through the usual dirty check and lands on the undo stack like any other patch load.

Backups do have to be loaded as a restore rather than as a preset, though. `loadPatchByPath` defaults forceIsPreset to true, which throws away the name,
category, master volume and FX bypass streamed in the file and keeps whatever name the caller passed - correct for dropping an arbitrary fxp onto a running session, but it left a restored backup sitting in a Drag & Drop category and named after its own file, and resaving it kept that. So the queued file load carries the flag through to both load paths, and the backups menu asks for a restore. Everything else keeps the existing preset behavior, which the new test in UnitTestsIO pins down in both directions.

Both settings live in Main Menu > Patch Settings > Patch Backups. Off by default, with a five minute default interval clamped to one to thirty minutes. Retention is left to the user.

The two trailing commits are pre-existing bugs uncovered along the way and are independently rebase-mergeable.


Closes #7217

Assisted-By: Claude Opus 5 <noreply@anthropic.com>