### PR TITLE
Clear unreachable routings when an LFO leaves the formula shape

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3974,6 +3974,44 @@ int SurgeSynthesizer::getMaxModulationIndex(int scene, modsources modsource) con
     return 1;
 }
 
+std::vector<std::pair<int, int>> SurgeSynthesizer::getModulationsFromSource(int modsourceScene,
+                                                                            modsources modsource,
+                                                                            int minIndex) const
+{
+    std::vector<std::pair<int, int>> res;
+
+    auto collect = [&](const std::vector<ModulationRouting> &ml, int idBase, int listScene) {
+        for (const auto &mr : ml)
+        {
+            if (mr.source_id != modsource || mr.source_index < minIndex)
+            {
+                continue;
+            }
+
+            // A global routing carries its originating scene explicitly, since the target
+            // parameter has none; a scene level one is implied by the list it lives in. See #2285
+            if (listScene < 0 ? mr.source_scene != modsourceScene : listScene != modsourceScene)
+            {
+                continue;
+            }
+
+            res.emplace_back(mr.destination_id + idBase, mr.source_index);
+        }
+    };
+
+    collect(storage.getPatch().modulation_global, 0, -1);
+
+    for (int sc = 0; sc < n_scenes; ++sc)
+    {
+        auto idBase = storage.getPatch().scene_start[sc];
+
+        collect(storage.getPatch().scene[sc].modulation_voice, idBase, sc);
+        collect(storage.getPatch().scene[sc].modulation_scene, idBase, sc);
+    }
+
+    return res;
+}
+
 void SurgeSynthesizer::clearModulation(long ptag, modsources modsource, int modsourceScene,
                                        int index, bool clearEvenIfInvalid)
 {

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -361,6 +361,14 @@ class alignas(16) SurgeSynthesizer
     int getMaxModulationIndex(int scene, modsources modsource) const;
     std::vector<int> getModulationIndicesBetween(long ptag, modsources modsource,
                                                  int modsourceScene) const;
+    /*
+     * Enumerate every routing which originates from a given modulation source in a given
+     * scene, as (destination parameter tag, source index) pairs. Optionally restricted to
+     * routings at or above minIndex, which is what a modulator losing outputs needs - see
+     * getMaxModulationIndex - so the now unreachable routings can be cleared. See #6705.
+     */
+    std::vector<std::pair<int, int>>
+    getModulationsFromSource(int modsourceScene, modsources modsource, int minIndex = 0) const;
     ModulationRouting *getModRouting(long ptag, modsources modsource, int modsourceScene,
                                      int index) const;
 

--- a/src/surge-testrunner/UnitTestsMOD.cpp
+++ b/src/surge-testrunner/UnitTestsMOD.cpp
@@ -1435,3 +1435,84 @@ TEST_CASE("Mod LFO Is Well Behaved", "[mod]")
         }
     }
 }
+
+TEST_CASE("Enumerate Modulations From A Source", "[mod]")
+{
+    // getModulationsFromSource is what lets us find the routings which become unreachable
+    // when a modulator loses outputs, as happens when an LFO leaves the formula shape. See #6705
+    auto indicesOf = [](const std::vector<std::pair<int, int>> &v) {
+        std::vector<int> res;
+        for (const auto &[ptag, idx] : v)
+            res.push_back(idx);
+        std::sort(res.begin(), res.end());
+        return res;
+    };
+
+    SECTION("Scene Level Routings Are Found And Filtered By Index")
+    {
+        auto surge = Surge::Headless::createSurge(44100);
+        REQUIRE(surge);
+
+        surge->storage.getPatch().scene[0].lfo[0].shape.val.i = lt_formula;
+
+        auto cutoff = surge->storage.getPatch().scene[0].filterunit[0].cutoff.id;
+        auto reso = surge->storage.getPatch().scene[0].filterunit[0].resonance.id;
+
+        REQUIRE(surge->setModDepth01(cutoff, ms_lfo1, 0, 0, 0.1));
+        REQUIRE(surge->setModDepth01(reso, ms_lfo1, 0, 2, 0.2));
+        REQUIRE(surge->setModDepth01(cutoff, ms_lfo1, 0, 5, 0.3));
+
+        REQUIRE(indicesOf(surge->getModulationsFromSource(0, ms_lfo1)) ==
+                std::vector<int>{0, 2, 5});
+
+        // Now switch off formula, the way the editor does before it prunes: only the routing
+        // above the three outputs a non-formula LFO has should survive the filter
+        surge->storage.getPatch().scene[0].lfo[0].shape.val.i = lt_sine;
+
+        auto beyond =
+            surge->getModulationsFromSource(0, ms_lfo1, surge->getMaxModulationIndex(0, ms_lfo1));
+
+        REQUIRE(indicesOf(beyond) == std::vector<int>{5});
+        REQUIRE(beyond[0].first == cutoff);
+
+        // A different modulator, and the same modulator in the other scene, are not ours
+        REQUIRE(surge->getModulationsFromSource(0, ms_lfo2).empty());
+        REQUIRE(surge->getModulationsFromSource(1, ms_lfo1).empty());
+    }
+
+    SECTION("Scenes Are Kept Distinct")
+    {
+        auto surge = Surge::Headless::createSurge(44100);
+        REQUIRE(surge);
+
+        REQUIRE(surge->setModDepth01(surge->storage.getPatch().scene[0].filterunit[0].cutoff.id,
+                                     ms_lfo1, 0, 1, 0.1));
+        REQUIRE(surge->setModDepth01(surge->storage.getPatch().scene[1].filterunit[0].cutoff.id,
+                                     ms_lfo1, 1, 4, 0.2));
+
+        REQUIRE(indicesOf(surge->getModulationsFromSource(0, ms_lfo1)) == std::vector<int>{1});
+        REQUIRE(indicesOf(surge->getModulationsFromSource(1, ms_lfo1)) == std::vector<int>{4});
+    }
+
+    SECTION("Global Routings Carry Their Originating Scene")
+    {
+        auto surge = Surge::Headless::createSurge(44100);
+        REQUIRE(surge);
+
+        Surge::Test::setFX(surge, 0, fxt_combulator);
+
+        auto fxp = surge->storage.getPatch().fx[0].p[2].id;
+
+        // A scene LFO modulating an FX parameter is the case which needs source_scene, see #2285
+        REQUIRE(surge->setModDepth01(fxp, ms_slfo1, 1, 3, 0.1));
+        REQUIRE(surge->storage.getPatch().modulation_global.size() == 1);
+
+        REQUIRE(surge->getModulationsFromSource(0, ms_slfo1).empty());
+
+        auto fromB = surge->getModulationsFromSource(1, ms_slfo1);
+
+        REQUIRE(fromB.size() == 1);
+        REQUIRE(fromB[0].first == fxp);
+        REQUIRE(fromB[0].second == 3);
+    }
+}

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -1514,8 +1514,14 @@ void SurgeGUIEditor::setModsourceSelected(modsources ms, int ms_idx)
     modsource_editor[current_scene] = modsource;
 
     modsource_index = ms_idx;
-    // FIXME: assumed scene LFOs are always listed after all voice LFOs in the enum
-    modsource_index_cache[current_scene][ms_idx - ms_lfo1] = ms_idx;
+
+    // The cache is keyed by LFO, so it is the modulator which picks the slot, not the output
+    // index. Any other modulator - a macro, velocity - has no slot here at all
+    if (ms >= ms_lfo1 && ms <= ms_slfo6)
+    {
+        // FIXME: assumed scene LFOs are always listed after all voice LFOs in the enum
+        modsource_index_cache[current_scene][ms - ms_lfo1] = ms_idx;
+    }
 
     if (gui_modsrc[modsource])
     {
@@ -2925,10 +2931,9 @@ void SurgeGUIEditor::setModulationFromUndo(int paramId, modsources ms, int scene
 void SurgeGUIEditor::pushModulationToUndoRedo(int paramId, modsources ms, int scene, int idx,
                                               Surge::GUI::UndoManager::Target which)
 {
-    undoManager()->pushModulationChange(
-        paramId, synth->storage.getPatch().param_ptr[paramId], ms, scene, idx,
-        synth->getModDepth01(paramId, ms, scene, idx),
-        synth->isModulationMuted(paramId, modsource, current_scene, modsource_index), which);
+    undoManager()->pushModulationChange(paramId, synth->storage.getPatch().param_ptr[paramId], ms,
+                                        scene, idx, synth->getModDepth01(paramId, ms, scene, idx),
+                                        synth->isModulationMuted(paramId, ms, scene, idx), which);
 }
 //------------------------------------------------------------------------------------------------
 

--- a/src/surge-xt/gui/SurgeGUIEditor.cpp
+++ b/src/surge-xt/gui/SurgeGUIEditor.cpp
@@ -5467,22 +5467,67 @@ void SurgeGUIEditor::swapFX(int source, int target, SurgeSynthesizer::FXReorderM
     effectChooser->setDeactivatedBitmask(synth->storage.getPatch().fx_disable.val.i);
 }
 
+/*
+ * The output index of an LFO lives in two places which have to agree: the editor's own
+ * modsource_index, which is what drives assignment, the mod rings and the infowindows, and
+ * the DAW extra state, which is what the modulator button reads back in setModList. Letting
+ * those diverge is what made the button show one output while we assigned to another. See #6705.
+ */
+void SurgeGUIEditor::setLFOModulationIndex(int scene, int lfoid, int index)
+{
+    synth->storage.getPatch().dawExtraState.editor.modulationSourceButtonState[scene][lfoid].index =
+        index;
+
+    auto ms = (modsources)(ms_lfo1 + lfoid);
+
+    // Everything below is live editor state, so it only applies when this is what's on screen
+    if (scene != current_scene || modsource != ms)
+    {
+        return;
+    }
+
+    modsource_index = index;
+
+    if (gui_modsrc[ms])
+    {
+        gui_modsrc[ms]->modlistIndex = index;
+        gui_modsrc[ms]->repaint();
+    }
+
+    if (lfoDisplay)
+    {
+        lfoDisplay->setModIndex(index);
+    }
+}
+
 void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)
 {
+    auto lfoid = modsource - ms_lfo1;
+
     if (prior != curr)
     {
-        auto lfoid = modsource - ms_lfo1;
-        auto id = synth->storage.getPatch().scene[current_scene].lfo[lfoid].shape.id;
-        auto pd = pdata();
-        pd.i = prior;
-        undoManager()->pushParameterChange(
-            id, &(synth->storage.getPatch().scene[current_scene].lfo[lfoid].shape), pd);
+        auto &lfodata = synth->storage.getPatch().scene[current_scene].lfo[lfoid];
+
+        if (prior == lt_formula)
+        {
+            // Leaving formula takes us from max_formula_outputs outputs down to three, so the
+            // routings above that are about to be cleared. Push them alongside the shape so
+            // that the whole gesture comes back in a single undo. See #6705
+            undoManager()->pushLFOShape(current_scene, lfoid, prior, modsource_index);
+        }
+        else
+        {
+            auto pd = pdata();
+            pd.i = prior;
+            undoManager()->pushParameterChange(lfodata.shape.id, &(lfodata.shape), pd);
+        }
+
         synth->storage.getPatch().isDirty = true;
 
         // Clear phase extend range when leaving step sequencer
         if (prior == lt_stepseq && curr != lt_stepseq)
         {
-            auto &phase = synth->storage.getPatch().scene[current_scene].lfo[lfoid].start_phase;
+            auto &phase = lfodata.start_phase;
             if (phase.extend_range)
             {
                 phase.set_extend_range(false);
@@ -5494,22 +5539,25 @@ void SurgeGUIEditor::lfoShapeChanged(int prior, int curr)
     // Currently only formula is indexed
     if (prior == lt_formula && curr != lt_formula)
     {
-        auto lfoid = modsource - ms_lfo1;
         modsource_index_cache[current_scene][lfoid] = modsource_index;
-        modsource_index = 0;
-        lfoDisplay->setModIndex(modsource_index);
+        setLFOModulationIndex(current_scene, lfoid, 0);
+
+        // The outputs above the new maximum are unreachable now - a non-formula LFO simply
+        // never writes them - so drop those routings rather than leaving them in the patch
+        // where they show up in menus and do nothing
+        auto maxIndex = synth->getMaxModulationIndex(current_scene, modsource);
+
+        for (const auto &[ptag, idx] :
+             synth->getModulationsFromSource(current_scene, modsource, maxIndex))
+        {
+            synth->clearModulation(ptag, modsource, current_scene, idx, true);
+        }
+
         needs_refresh = true;
     }
     else if (curr == lt_formula && prior != lt_formula)
     {
-        auto lfoid = modsource - ms_lfo1;
-        modsource_index = modsource_index_cache[current_scene][lfoid];
-        if (gui_modsrc[modsource])
-        {
-            gui_modsrc[modsource]->modlistIndex = modsource_index;
-            gui_modsrc[modsource]->repaint();
-        }
-        lfoDisplay->setModIndex(modsource_index);
+        setLFOModulationIndex(current_scene, lfoid, modsource_index_cache[current_scene][lfoid]);
         needs_refresh = true;
     }
 

--- a/src/surge-xt/gui/SurgeGUIEditor.h
+++ b/src/surge-xt/gui/SurgeGUIEditor.h
@@ -552,6 +552,7 @@ class SurgeGUIEditor : public Surge::GUI::IComponentTagValue::Listener,
     void openLFORenameDialog(const int lfo_id, const juce::Point<int> where, juce::Component *r);
 
     void lfoShapeChanged(int prior, int curr);
+    void setLFOModulationIndex(int scene, int lfoid, int index);
     void broadcastMSEGState();
     int msegIsOpenFor = -1, msegIsOpenInScene = -1;
     bool showMSEGEditorOnNextIdleOrOpen = false;

--- a/src/surge-xt/gui/UndoManager.cpp
+++ b/src/surge-xt/gui/UndoManager.cpp
@@ -176,6 +176,20 @@ struct UndoManagerImpl
         std::vector<UndoParam> undoParamValues;
         std::variant<bool, MSEGStorage, StepSequencerStorage, FormulaModulatorStorage> extraStorage;
     };
+    /*
+     * Switching an LFO off the formula shape drops it from max_formula_outputs outputs
+     * down to three, so we clear the routings which can no longer be reached. Recording
+     * them next to the shape - the way UndoOscillator and UndoFX record the modulations
+     * they blow away - keeps the whole gesture a single undo. See #6705.
+     */
+    struct UndoLFOShape
+    {
+        int scene;
+        int lfoid;
+        int shape;
+        int modIndex;
+        std::vector<UndoModulation> undoModulations;
+    };
     struct UndoRename
     {
         bool isMacro;
@@ -207,7 +221,8 @@ struct UndoManagerImpl
     // to undo.
     typedef std::variant<UndoParam, UndoModulation, UndoOscillator, UndoOscillatorExtraConfig,
                          UndoWavetable, UndoFX, UndoStep, UndoMSEG, UndoFormula, UndoRename,
-                         UndoMacro, UndoTuning, UndoPatch, UndoFullLFO, UndoFilterAnalysisMovement>
+                         UndoMacro, UndoTuning, UndoPatch, UndoFullLFO, UndoFilterAnalysisMovement,
+                         UndoLFOShape>
         UndoAction;
     struct UndoRecord
     {
@@ -236,6 +251,10 @@ struct UndoManagerImpl
         if (auto pt = std::get_if<UndoFX>(&a))
         {
             res += pt->estimateUserDataSize();
+        }
+        if (auto pt = std::get_if<UndoLFOShape>(&a))
+        {
+            res += pt->undoModulations.size() * sizeof(UndoModulation);
         }
         if (auto pt = std::get_if<UndoWavetable>(&a))
         {
@@ -316,6 +335,11 @@ struct UndoManagerImpl
             // No way to generate these other than discretely
             return false;
         }
+        if (auto pa = std::get_if<UndoLFOShape>(&a))
+        {
+            // A shape change is a discrete gesture, so never compress two of them together
+            return false;
+        }
         return false;
     }
 
@@ -383,6 +407,11 @@ struct UndoManagerImpl
         if (auto pa = std::get_if<UndoFullLFO>(&a))
         {
             return fmt::format("FullLFO[]");
+        }
+        if (auto pa = std::get_if<UndoLFOShape>(&a))
+        {
+            return fmt::format("LFOShape[scene={},lfoid={},shape={},nmods={}]", pa->scene,
+                               pa->lfoid, pa->shape, pa->undoModulations.size());
         }
         return "UNK";
     }
@@ -778,6 +807,36 @@ struct UndoManagerImpl
             pushRedo(r);
     }
 
+    void pushLFOShape(int scene, int lfoid, int shape, int modIndex,
+                      UndoManager::Target to = UndoManager::UNDO)
+    {
+        auto r = UndoLFOShape();
+        r.scene = scene;
+        r.lfoid = lfoid;
+        r.shape = shape;
+        r.modIndex = modIndex;
+
+        auto ms = (modsources)(ms_lfo1 + lfoid);
+
+        // Record every routing out of this modulator, not just the ones about to be cleared,
+        // so that undo and redo can both simply restore the recorded set wholesale
+        for (const auto &[ptag, idx] : synth->getModulationsFromSource(scene, ms))
+        {
+            auto mr = UndoModulation();
+            auto *p = synth->storage.getPatch().param_ptr[ptag];
+
+            populateUndoModulation(ptag, p, ms, scene, idx,
+                                   synth->getModDepth01(ptag, ms, scene, idx),
+                                   synth->isModulationMuted(ptag, ms, scene, idx), mr);
+            r.undoModulations.push_back(mr);
+        }
+
+        if (to == UndoManager::UNDO)
+            pushUndo(r);
+        else
+            pushRedo(r);
+    }
+
     void pushFormula(int scene, int lfoid, const FormulaModulatorStorage &pushValue,
                      UndoManager::Target to = UndoManager::UNDO)
     {
@@ -1011,6 +1070,43 @@ struct UndoManagerImpl
             auto ann = fmt::format("{} Oscillator Wavetable in Scene {} Oscillator {}", verb,
                                    (char)('A' + p->scene), p->oscNum + 1);
             editor->enqueueAccessibleAnnouncement(ann);
+            return true;
+        }
+        if (auto p = std::get_if<UndoLFOShape>(&q))
+        {
+            auto ms = (modsources)(ms_lfo1 + p->lfoid);
+            auto lf = &(editor->getPatch().scene[p->scene].lfo[p->lfoid]);
+
+            pushLFOShape(p->scene, p->lfoid, lf->shape.val.i,
+                         editor->getPatch()
+                             .dawExtraState.editor.modulationSourceButtonState[p->scene][p->lfoid]
+                             .index,
+                         opposite);
+            auto g = SelfPushGuard(this);
+
+            auto pd = pdata();
+            pd.i = p->shape;
+            editor->setParamFromUndo(lf->shape.id, pd);
+
+            // The shape decides how many outputs are reachable, so restore the recorded set
+            // of routings wholesale rather than trying to work out which ones to put back
+            for (const auto &[ptag, idx] : synth->getModulationsFromSource(p->scene, ms))
+            {
+                synth->clearModulation(ptag, ms, p->scene, idx, true);
+            }
+
+            for (const auto &qp : p->undoModulations)
+            {
+                editor->setModulationFromUndo(qp.paramId, qp.ms, qp.scene, qp.index, qp.val,
+                                              qp.muted);
+            }
+
+            editor->setLFOModulationIndex(p->scene, p->lfoid, p->modIndex);
+
+            auto ann = fmt::format("{} Modulator Shape, Scene {} Modulator {}", verb,
+                                   (char)('A' + p->scene), p->lfoid + 1);
+            editor->enqueueAccessibleAnnouncement(ann);
+
             return true;
         }
         if (auto p = std::get_if<UndoFullLFO>(&q))
@@ -1333,6 +1429,11 @@ void UndoManager::pushMacroChange(int macroid, float val) { impl->pushMacroChang
 void UndoManager::pushPatch() { impl->pushPatch(); }
 
 void UndoManager::pushFullLFO(int scene, int lfoid) { impl->pushFullLFO(scene, lfoid); }
+
+void UndoManager::pushLFOShape(int scene, int lfoid, int shape, int modIndex)
+{
+    impl->pushLFOShape(scene, lfoid, shape, modIndex);
+}
 
 void UndoManager::pushWavetable(int scene, int oscnum) { impl->pushWavetable(scene, oscnum); };
 void UndoManager::pushOscillatorExtraConfig(int scene, int oscnum)

--- a/src/surge-xt/gui/UndoManager.h
+++ b/src/surge-xt/gui/UndoManager.h
@@ -63,6 +63,7 @@ struct UndoManager
     void pushStepSequencer(int scene, int lfoid, const StepSequencerStorage &pushValue);
     void pushMSEG(int scene, int lfoid, const MSEGStorage &pushValue);
     void pushFullLFO(int scene, int lfoid);
+    void pushLFOShape(int scene, int lfoid, int shape, int modIndex);
     void pushFormula(int scene, int lfoid, const FormulaModulatorStorage &pushValue);
     void pushFX(int fxslot);
 


### PR DESCRIPTION
A formula LFO has `max_formula_outputs` outputs; every other shape has three. Switching away from formula left any routing above the third output in the patch, where it did nothing - a non-formula LFO never writes those slots of output_multi - but still showed up in menus as "LFO 3.8" and survived save and load.

Worse, the output index was tracked in two places which the shape change only half updated. `lfoShapeChanged` reset the editor's `modsource_index` to
zero, but `setupAlternates()` then ran and `ModulationSourceButton::setModList()` restored the button's index from the DAW extra state and clamped it to the new maximum. So the button read "LFO 3" while assignment, the mod rings and the infowindows all used output one.

Fix both. `setLFOModulationIndex()` is now the single place which moves an LFO's output index, keeping the editor state, the button and the DAW extra state in agreement. On leaving formula we then clear the routings at or above the new maximum, the way an oscillator or FX type change clears the modulations it invalidates.

Those routings come back in a single undo press: `UndoLFOShape` records them alongside the shape, mirroring how `UndoOscillator` and `UndoFX` record what they blow away, and undo and redo both restore the recorded set wholesale rather than trying to work out which routings to put back.

Second commit fixes a bug found along the way, this PR should be rebase-merged.

Fixes #6705

Assisted-By: Claude Opus 5 <noreply@anthropic.com>