### PR TITLE
Show macro modulations of FX parameters in the macro menu

### DIFF
--- a/src/common/ModulationSource.h
+++ b/src/common/ModulationSource.h
@@ -221,6 +221,26 @@ inline bool canModulateMonophonicTarget(modsources ms)
     return isScenelevel(ms) || ms == ms_aftertouch;
 }
 
+/*
+ * Does this modulator have a separate instance per scene? Voice and scene LFOs and the
+ * envelopes do; macros, MIDI controllers and the like are single objects shared by both
+ * scenes. Only modulators for which this is true need ModulationRouting::source_scene to
+ * disambiguate a routing onto a global (FX) target. See #2285 and #8053.
+ */
+inline bool isModulatorDistinctPerScene(modsources ms)
+{
+    if (ms >= ms_lfo1 && ms <= ms_slfo6)
+        return true;
+
+    if (ms == ms_ampeg || ms == ms_filtereg)
+        return true;
+
+    if (ms == ms_lowest_key || ms == ms_highest_key || ms == ms_latest_key)
+        return true;
+
+    return false;
+}
+
 inline bool isCustomController(modsources ms) { return (ms >= ms_ctrl1) && (ms <= ms_ctrl8); }
 
 inline bool isEnvelope(modsources ms) { return (ms == ms_ampeg) || (ms == ms_filtereg); }

--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -2218,6 +2218,15 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
                             // Explicitly set scene to A. See #2285
                             t.source_scene = 0;
                         }
+
+                        // source_scene only disambiguates modulators which exist once per
+                        // scene. Streams written before #4960 tagged macros and MIDI
+                        // controllers with whichever scene happened to be active, which then
+                        // hides the routing from that modulator's menu. See #8053.
+                        if (!isModulatorDistinctPerScene((modsources)t.source_id))
+                        {
+                            t.source_scene = 0;
+                        }
                     }
 
                     int muted = 0;

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2870,7 +2870,9 @@ void SurgeStorage::clipboard_paste(
                 ModulationRouting m;
                 m.source_id = ms;
                 m.source_index = clipboard_modulation_global[i].source_index;
-                m.source_scene = scene; /* clipboard_modulation_global[i].source_scene; */
+                // Only per-scene modulators carry a meaningful source_scene on a global
+                // target; stamping the paste scene onto a macro hides it. See #8053.
+                m.source_scene = isModulatorDistinctPerScene(ms) ? scene : 0;
                 m.depth = clipboard_modulation_global[i].depth;
                 m.destination_id = clipboard_modulation_global[i].destination_id;
 
@@ -2917,7 +2919,8 @@ void SurgeStorage::clipboard_paste(
                 ModulationRouting m;
                 m.source_id = clipboard_modulation_global[i].source_id;
                 m.source_index = clipboard_modulation_global[i].source_index;
-                m.source_scene = scene; /* clipboard_modulation_global[i].source_scene; */
+                // See #8053; a macro's global routing is not scene tagged.
+                m.source_scene = isModulatorDistinctPerScene((modsources)m.source_id) ? scene : 0;
                 m.depth = clipboard_modulation_global[i].depth;
                 m.destination_id = clipboard_modulation_global[i].destination_id;
 

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -2421,42 +2421,65 @@ void SurgeStorage::clipboard_copy(int type, int scene, int entry, modsources ms)
 
             if (type & cp_scene)
             {
+                assert(scene < 2);
+
+                // Which insert FX slot of this scene does this parameter belong to, if any?
+                auto insertSlotOfScene = [](const Parameter *dpar, int scene) {
+                    if (dpar->ctrlgroup != cg_FX)
+                    {
+                        return -1;
+                    }
+
+                    for (int q = 0; q < n_fx_per_chain; ++q)
+                    {
+                        if (dpar->ctrlgroup_entry == fxslot_order[q + scene * n_fx_per_chain])
+                        {
+                            return q;
+                        }
+                    }
+
+                    return -1;
+                };
+
                 n = getPatch().modulation_global.size();
                 for (int i = 0; i < n; i++)
                 {
-                    if (getPatch().modulation_global[i].source_scene != scene)
+                    const auto &mg = getPatch().modulation_global[i];
+                    auto dpar = getPatch().param_ptr[mg.destination_id];
+                    auto slot = insertSlotOfScene(dpar, scene);
+
+                    // What ties a global routing to a scene is the modulator when that
+                    // modulator exists once per scene, but the destination when it is
+                    // shared, since a macro belongs to neither scene. See #8053.
+                    if (isModulatorDistinctPerScene((modsources)mg.source_id))
+                    {
+                        if (mg.source_scene != scene)
+                        {
+                            continue;
+                        }
+                    }
+                    else if (slot < 0)
                     {
                         continue;
                     }
 
                     ModulationRouting m;
-                    m.source_id = getPatch().modulation_global[i].source_id;
-                    m.source_index = getPatch().modulation_global[i].source_index;
-                    m.source_scene = getPatch().modulation_global[i].source_scene;
-                    m.depth = getPatch().modulation_global[i].depth;
+                    m.source_id = mg.source_id;
+                    m.source_index = mg.source_index;
+                    m.source_scene = mg.source_scene;
+                    m.depth = mg.depth;
+                    m.destination_id = mg.destination_id;
 
-                    auto did = getPatch().modulation_global[i].destination_id;
-                    auto dpar = getPatch().param_ptr[did];
-                    if (dpar->ctrlgroup == cg_FX)
+                    if (slot >= 0)
                     {
-                        assert(scene < 2);
-                        for (int q = 0; q < n_fx_per_chain; ++q)
-                        {
-                            auto srcSl = fxslot_order[q + scene * 4];
-                            auto tgtSl = fxslot_order[q + (1 - scene) * 4];
-                            if (dpar->ctrlgroup_entry == srcSl)
-                            {
-                                int64_t d0 =
-                                    getPatch().fx[tgtSl].p[0].id - getPatch().fx[srcSl].p[0].id;
-                                m.destination_id =
-                                    getPatch().modulation_global[i].destination_id + d0;
-                            }
-                        }
+                        // move it onto the matching insert slot of the other scene
+                        auto srcSl = fxslot_order[slot + scene * n_fx_per_chain];
+                        auto tgtSl = fxslot_order[slot + (1 - scene) * n_fx_per_chain];
+
+                        m.destination_id +=
+                            getPatch().fx[tgtSl].p[0].id - getPatch().fx[srcSl].p[0].id;
                     }
-                    else
-                    {
-                        m.destination_id = getPatch().modulation_global[i].destination_id;
-                    }
+
                     clipboard_modulation_global.push_back(m);
                 }
             }

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -3446,16 +3446,7 @@ bool SurgeSynthesizer::loadOscalgos()
 
 bool SurgeSynthesizer::isModulatorDistinctPerScene(modsources modsource) const
 {
-    if (modsource >= ms_lfo1 && modsource <= ms_slfo6)
-        return true;
-
-    if (modsource == ms_ampeg || modsource == ms_filtereg)
-        return true;
-
-    if (modsource == ms_lowest_key || modsource == ms_highest_key || modsource == ms_latest_key)
-        return true;
-
-    return false;
+    return ::isModulatorDistinctPerScene(modsource);
 }
 
 bool SurgeSynthesizer::isValidModulation(long ptag, modsources modsource) const

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -1394,6 +1394,54 @@ TEST_CASE("Global Modulation Routings Are Not Scene Tagged For Shared Modulators
             }
         }
     }
+
+    SECTION("Copying Scene B Carries Its Macro To FX Routings")
+    {
+        // the copy side of the same confusion: a macro routing onto a scene B insert FX
+        // is not scene tagged, so asking for source_scene == 1 found nothing at all
+        auto surge = Surge::Headless::createSurge(44100);
+
+        // a reverb in the matching insert slot of both scenes, which is the state a real
+        // scene paste arrives at once the UI has copied the FX across too
+        for (auto slot : {fxslot_ains1, fxslot_bins1})
+        {
+            auto *pt = &(surge->storage.getPatch().fx[slot].type);
+
+            surge->setParameter01(surge->idForParameter(pt),
+                                  1.f * float(fxt_reverb) / (pt->val_max.i - pt->val_min.i), false);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                surge->process();
+            }
+        }
+
+        auto pidx = -1;
+
+        for (int i = 0; i < n_fx_params && pidx < 0; ++i)
+        {
+            if (surge->storage.getPatch().fx[fxslot_bins1].p[i].modulateable)
+            {
+                pidx = i;
+            }
+        }
+
+        REQUIRE(pidx >= 0);
+
+        auto *bfxp = &(surge->storage.getPatch().fx[fxslot_bins1].p[pidx]);
+
+        REQUIRE(surge->setModDepth01(bfxp->id, ms_ctrl7, 0, 0, 0.5));
+
+        auto isValid = [&surge](int id, modsources ms) { return surge->isValidModulation(id, ms); };
+
+        surge->storage.clipboard_copy(cp_scene, 1, -1);
+        surge->storage.clipboard_paste(cp_scene, 0, -1, ms_original, isValid);
+
+        // it should have landed on the matching slot of scene A's insert chain
+        auto *afxp = &(surge->storage.getPatch().fx[fxslot_ains1].p[pidx]);
+
+        REQUIRE(surge->isAnyActiveModulation(afxp->id, ms_ctrl7, 0));
+    }
 }
 
 TEST_CASE("XML Direct", "[io]")

--- a/src/surge-testrunner/UnitTestsIO.cpp
+++ b/src/surge-testrunner/UnitTestsIO.cpp
@@ -1279,6 +1279,123 @@ TEST_CASE("Mono Voice Priority Streams", "[io]")
     }
 }
 
+TEST_CASE("Global Modulation Routings Are Not Scene Tagged For Shared Modulators", "[io][mod]")
+{
+    // Macros and MIDI controllers are a single object shared by both scenes, so
+    // ModulationRouting::source_scene carries no information for them. Streams written
+    // before #4960 tagged a macro to FX routing with whichever scene happened to be
+    // active. That routing still sounds, and the Modulation List still shows it, but the
+    // macro's own context menu asks for scene A only and so never finds it. See #8053.
+
+    auto fromto = [](std::shared_ptr<SurgeSynthesizer> src,
+                     std::shared_ptr<SurgeSynthesizer> dest) {
+        void *d = nullptr;
+        auto sz = src->saveRaw(&d);
+
+        dest->loadRaw(d, sz, false);
+    };
+
+    // put a reverb in A Insert FX 1 and hand back the index of a param we can modulate
+    auto reverbInAIns1 = [](std::shared_ptr<SurgeSynthesizer> s) {
+        auto *pt = &(s->storage.getPatch().fx[fxslot_ains1].type);
+
+        s->setParameter01(s->idForParameter(pt),
+                          1.f * float(fxt_reverb) / (pt->val_max.i - pt->val_min.i), false);
+
+        for (int i = 0; i < 10; ++i)
+        {
+            s->process();
+        }
+
+        for (int i = 0; i < n_fx_params; ++i)
+        {
+            if (s->storage.getPatch().fx[fxslot_ains1].p[i].modulateable)
+            {
+                return i;
+            }
+        }
+
+        FAIL("no modulateable param in the reverb");
+
+        return 0;
+    };
+
+    SECTION("A Macro To FX Routing Tagged Scene B Loads As Scene A")
+    {
+        auto src = Surge::Headless::createSurge(44100);
+        auto dest = Surge::Headless::createSurge(44100);
+
+        auto pidx = reverbInAIns1(src);
+        auto *fxp = &(src->storage.getPatch().fx[fxslot_ains1].p[pidx]);
+
+        // this is what a pre-#4960 stream contained
+        REQUIRE(src->setModDepth01(fxp->id, ms_ctrl7, 1, 0, 0.5));
+
+        // and this is the bug: the macro menu always asks for scene A
+        REQUIRE_FALSE(src->isAnyActiveModulation(fxp->id, ms_ctrl7, 0));
+
+        fromto(src, dest);
+
+        auto *dfxp = &(dest->storage.getPatch().fx[fxslot_ains1].p[pidx]);
+
+        REQUIRE(dest->isAnyActiveModulation(dfxp->id, ms_ctrl7, 0));
+        REQUIRE(dest->getModDepth01(dfxp->id, ms_ctrl7, 0, 0) == Approx(0.5).margin(1e-5));
+
+        for (const auto &mg : dest->storage.getPatch().modulation_global)
+        {
+            if (!isModulatorDistinctPerScene((modsources)mg.source_id))
+            {
+                REQUIRE(mg.source_scene == 0);
+            }
+        }
+    }
+
+    SECTION("A Scene LFO To FX Routing Keeps Its Scene")
+    {
+        // the flip side; scene LFOs really do exist once per scene, so #2285 still holds
+        auto src = Surge::Headless::createSurge(44100);
+        auto dest = Surge::Headless::createSurge(44100);
+
+        auto pidx = reverbInAIns1(src);
+        auto *fxp = &(src->storage.getPatch().fx[fxslot_ains1].p[pidx]);
+
+        REQUIRE(src->setModDepth01(fxp->id, ms_slfo1, 1, 0, 0.5));
+
+        fromto(src, dest);
+
+        auto *dfxp = &(dest->storage.getPatch().fx[fxslot_ains1].p[pidx]);
+
+        REQUIRE(dest->isAnyActiveModulation(dfxp->id, ms_slfo1, 1));
+        REQUIRE_FALSE(dest->isAnyActiveModulation(dfxp->id, ms_slfo1, 0));
+    }
+
+    SECTION("Pasting A Scene Does Not Scene Tag A Macro Routing")
+    {
+        // copying scene A onto scene B used to stamp the paste scene onto every global
+        // routing it carried across, which recreated the bug in a current build
+        auto surge = Surge::Headless::createSurge(44100);
+
+        auto pidx = reverbInAIns1(surge);
+        auto *fxp = &(surge->storage.getPatch().fx[fxslot_ains1].p[pidx]);
+
+        REQUIRE(surge->setModDepth01(fxp->id, ms_ctrl7, 0, 0, 0.5));
+        REQUIRE(surge->isAnyActiveModulation(fxp->id, ms_ctrl7, 0));
+
+        auto isValid = [&surge](int id, modsources ms) { return surge->isValidModulation(id, ms); };
+
+        surge->storage.clipboard_copy(cp_scene, 0, -1);
+        surge->storage.clipboard_paste(cp_scene, 1, -1, ms_original, isValid);
+
+        for (const auto &mg : surge->storage.getPatch().modulation_global)
+        {
+            if (!isModulatorDistinctPerScene((modsources)mg.source_id))
+            {
+                REQUIRE(mg.source_scene == 0);
+            }
+        }
+    }
+}
+
 TEST_CASE("XML Direct", "[io]")
 {
     // This is not a public API but we want to make sure it


### PR DESCRIPTION
Fixes #8053.

### What was wrong

`ModulationRouting::source_scene` was added in #4960 to disambiguate a routing onto a global (FX) target when the modulator exists once per scene — LFOs and envelopes. Macros and MIDI controllers are a *single object aliased into both scenes* (`SurgeSynthesizer.cpp:196-200`), so the field carries no information for them.

Every global lookup compares it anyway (`getModulationIndicesBetween`, `getModRouting`, `getModDepth`, `clearModulation`, `setModDepth01`), and the modulator context menu always asks for scene A because `isModulatorDistinctPerScene()` is false for a macro. So a macro→FX routing tagged scene B is invisible in that menu — while still sounding, and still listed in the Modulation List, which reads the routing vectors directly.

Two ways patches end up in that state:

- **Streams written before #4960** tagged these with whichever scene happened to be active. j5v's patch on the issue has exactly four such routings from Macro 7 onto `fx8_p1` / `fx15_p1` / `fx15_p4` / `fx15_p7`, all `source_scene="1"`, which is precisely what his screenshot shows missing. **Seven factory patches** are affected: *Pipe Organ Flutes & Reeds*, *Solo Violin*, *String Cello*, *String Contrabass*, *Violin Section*, *Massive Pad 1*, *Musical Pulses*.
- **Copy Scene A → Paste Scene B in a current build**, because the paste stamped the target scene onto every global routing it carried across.

### The fix

Promote `isModulatorDistinctPerScene` to a free function beside the other modulator predicates in `ModulationSource.h` (it was already a pure function of the enum) and use it to force `source_scene` to zero for shared modulators, both when a routing is unstreamed and when one is pasted. Unstreaming normalizes older patches on load, so the field is only ever non-zero for modulators it actually describes, and no version gate is needed — a correctly streamed patch already has zero there.

Note this does rewrite patch data on load, so an affected patch changes on the user's next save. That seemed clearly preferable to teaching six read sites to special-case the field and leaving the bad data to round-trip.

### Second commit

`Carry macro to FX modulations when copying a scene` is the copy side of the same confusion and is separable — it can be dropped without affecting the fix above.

Scene copy picked the global routings belonging to a scene by comparing `source_scene`, so a macro routing onto scene B's insert FX was never collected and copying scene B lost it. It now decides by the modulator for a per-scene modulator and by the destination FX slot for a shared one.

That commit also fixes an uninitialized read: a routing onto a *send* or *global* FX parameter took the `cg_FX` branch but matched no insert slot, so the clipboard entry was pushed with an unset `destination_id`, which the scene paste then wrote into `modulation_global` with no validity check.

### Testing

New `TEST_CASE("Global Modulation Routings Are Not Scene Tagged For Shared Modulators", "[io][mod]")` with four sections: the legacy stream normalizing on load, a scene LFO correctly *keeping* its scene tag (so #2285 still holds), the paste path, and the copy path. Each bug section was verified to fail with the fix reverted.

Assisted-By: Claude Opus 5 <noreply@anthropic.com>