### PR TITLE
Make PatchDB patch indexing robust against vanishing files

### DIFF
--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -652,7 +652,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         int lock_retries{0};
         while (keepRunning)
         {
-            std::vector<EnQAble *> doThis;
+            std::vector<std::unique_ptr<EnQAble>> doThis;
             {
                 std::unique_lock<std::mutex> lk(qLock);
 
@@ -671,7 +671,10 @@ CREATE TABLE IF NOT EXISTS Favorites (
                     const auto &e = (pathQ.size() < transChunkSize)
                                         ? pathQ.end()
                                         : pathQ.begin() + transChunkSize;
-                    std::copy(b, e, std::back_inserter(doThis));
+                    for (auto it = b; it != e; ++it)
+                    {
+                        doThis.emplace_back(*it);
+                    }
                     pathQ.erase(b, e);
                 }
             }
@@ -688,10 +691,10 @@ CREATE TABLE IF NOT EXISTS Favorites (
                     {
                         SQL::TxnGuard tg(dbh);
 
-                        for (auto *p : doThis)
+                        for (auto &p : doThis)
                         {
                             p->go(*this);
-                            delete p;
+                            p.reset();
                         }
 
                         tg.end();
@@ -713,10 +716,17 @@ CREATE TABLE IF NOT EXISTS Favorites (
                         {
                             {
                                 std::unique_lock<std::mutex> lk(qLock);
-                                std::reverse(doThis.begin(), doThis.end());
-                                for (auto p : doThis)
+                                /*
+                                 * Only the TxnGuard constructor throws this, so nothing in the
+                                 * chunk has run yet. Skip any consumed item anyway, so that this
+                                 * stays correct if that ever stops being true.
+                                 */
+                                for (auto it = doThis.rbegin(); it != doThis.rend(); ++it)
                                 {
-                                    pathQ.push_front(p);
+                                    if (*it)
+                                    {
+                                        pathQ.push_front(it->release());
+                                    }
                                 }
                             }
                             std::this_thread::sleep_for(std::chrono::seconds(lock_retries * 3));
@@ -732,6 +742,24 @@ CREATE TABLE IF NOT EXISTS Favorites (
                     {
                         storage->reportError(e.what(), "Database Error");
                     }
+                    catch (const std::exception &e)
+                    {
+                        /*
+                         * Historically only SQL exceptions were caught here, so anything else
+                         * thrown by a work item escaped this function and the thread lambda
+                         * entirely, which terminates the process. A file vanishing under a
+                         * filesystem call is the obvious way to provoke that (#6973), but
+                         * whatever the cause, losing the whole application over one bad patch
+                         * file is never the right answer.
+                         */
+                        storage->reportError(e.what(), "Patch Database Error");
+                    }
+                    catch (...)
+                    {
+                        storage->reportError(
+                            "An unknown error occurred while updating the patch database.",
+                            "Patch Database Error");
+                    }
                 }
             }
         }
@@ -739,35 +767,152 @@ CREATE TABLE IF NOT EXISTS Favorites (
 
     void parseFXPIntoDB(const EnQPatch &p)
     {
-        sqlite3_stmt *insertStmt = nullptr, *insfeatureStmt = nullptr, *dropIdStmt = nullptr;
+        /*
+         * This runs on the patch database worker thread and the file we are pointed at can
+         * vanish underneath us at any moment (#6973): a rename, a file sync client, or a
+         * second Surge instance can remove it between any two statements here.
+         *
+         * So do all of the file IO first, into local state, and only touch the database once
+         * a complete and valid patch is in hand. A file which disappears mid-parse then
+         * leaves the database exactly as it was, instead of having its existing rows dropped
+         * and replaced by a stub row with no features and no search string.
+         *
+         * For the same reason use the non-throwing filesystem overloads, and don't bother
+         * with an fs::exists() pre-check: it cannot close the race, it only widens the window
+         * between the check and the use.
+         */
+        std::error_code ec;
+        auto qtime = fs::last_write_time(p.path, ec);
 
-        if (!fs::exists(p.path))
+        if (ec)
         {
 #if TRACE_DB
-            std::cout << "    - Warning: Non existent " << path_to_string(p.path) << std::endl;
+            std::cout << "    - Warning: Unstattable " << path_to_string(p.path) << std::endl;
 #endif
             return;
         }
-        // Check with
-        auto qtime = fs::last_write_time(p.path);
+
         int64_t qtimeInt =
             std::chrono::duration_cast<std::chrono::seconds>(qtime.time_since_epoch()).count();
 
-        bool patchLoaded = false;
+        std::ifstream stream(p.path, std::ios::in | std::ios::binary);
+
+        if (!stream.is_open())
+        {
+#if TRACE_DB
+            std::cout << "    - Warning: Unopenable " << path_to_string(p.path) << std::endl;
+#endif
+            return;
+        }
+
+        std::vector<char> fxChunk;
+        fxChunk.resize(sizeof(sst::io::fxChunkSetCustom));
+        stream.read(fxChunk.data(), fxChunk.size());
+
+        if (!stream)
+        {
+            return;
+        }
+
+        auto *fxp = (sst::io::fxChunkSetCustom *)(fxChunk.data());
+
+        if ((mech::endian_read_int32BE(fxp->chunkMagic) != 'CcnK') ||
+            (mech::endian_read_int32BE(fxp->fxMagic) != 'FPCh') ||
+            (mech::endian_read_int32BE(fxp->fxID) != 'cjs3'))
+        {
+            return;
+        }
+
+        std::vector<char> patchHeaderChunk;
+        patchHeaderChunk.resize(sizeof(sst::io::patch_header));
+        stream.read(patchHeaderChunk.data(), patchHeaderChunk.size());
+
+        if (!stream)
+        {
+            return;
+        }
+
+        auto *ph = (sst::io::patch_header *)(patchHeaderChunk.data());
+        auto xmlSz = mech::endian_read_int32LE(ph->xmlsize);
+
+        if (memcmp(ph->tag, "sub3", 4) != 0 || xmlSz < 0 || xmlSz > 1024 * 1024 * 1024)
+        {
+            std::cerr << "Skipping invalid patch : [" << p.path.u8string() << "]" << std::endl;
+            return;
+        }
+
+        std::string xmlData;
+        xmlData.resize(xmlSz);
+        stream.read(xmlData.data(), xmlData.size());
+
+        if (!stream)
+        {
+            return;
+        }
+
+        auto features = extractFeaturesFromXML(xmlData.data());
+
+        /*
+         * The patch has been read in full and is valid, so assemble the search string. The
+         * tags contribute to it, which is why this waits until the features are extracted.
+         */
+        std::ostringstream searchName;
+        searchName << p.name << " ";
+
+        if (storage)
+        {
+            auto pTmp = p.path.parent_path();
+            std::vector<fs::path> parentFiles;
+            int maxItForSafety{0};
+            while ((pTmp != storage->userPatchesPath) &&
+                   (pTmp != storage->datapath / "patches_factory") &&
+                   (pTmp != storage->datapath / "patches_3rdparty") && !pTmp.empty() &&
+                   (pTmp != pTmp.root_directory()) && maxItForSafety < 10)
+            {
+                parentFiles.push_back(pTmp.filename());
+                pTmp = pTmp.parent_path();
+                maxItForSafety++;
+            }
+
+            if (pTmp == storage->datapath / "patches_3rdparty")
+            {
+                parentFiles.erase(parentFiles.end() - 1);
+            }
+
+            for (const auto &pf : parentFiles)
+            {
+                searchName << pf.u8string() << " ";
+            }
+        }
+
+        for (const auto &f : features)
+        {
+            if (std::get<0>(f) == "TAG")
+            {
+                searchName << " " << std::get<3>(f);
+            }
+        }
+
+        const auto sns = searchName.str();
+        const auto path = p.path.u8string();
+
+        /*
+         * From here on it is database work only, and no further failure can leave a patch
+         * half described. Since the search string is known up front the row goes in complete,
+         * which also retires the separate UPDATE that used to finish the job afterwards.
+         */
         std::vector<int> dropIds;
+
         try
         {
             auto exists = SQL::Statement(
                 dbh, "SELECT id, last_write_time from Patches WHERE Patches.Path LIKE ?1");
-            const auto path(p.path.u8string());
             exists.bind(1, path);
 
             // Drop all the ones with this path independent of time if I'm adding
             while (exists.step())
             {
-                auto id = exists.col_int(0);
-                auto t = exists.col_int64(1);
-                dropIds.push_back(id);
+                dropIds.push_back(exists.col_int(0));
             }
 
             exists.finalize();
@@ -810,21 +955,20 @@ CREATE TABLE IF NOT EXISTS Favorites (
             return;
         }
 
-        if (patchLoaded)
-            return;
-
         int64_t patchid = -1;
+
         try
         {
             auto ins = SQL::Statement(dbh, "INSERT INTO PATCHES ( \"path\", \"name\", "
-                                           "\"category\", \"category_type\", \"last_write_time\" ) "
-                                           "VALUES ( ?1, ?2, ?3, ?4, ?5 )");
-            const auto path(p.path.u8string());
+                                           "\"category\", \"category_type\", \"last_write_time\", "
+                                           "\"search_over\" ) "
+                                           "VALUES ( ?1, ?2, ?3, ?4, ?5, ?6 )");
             ins.bind(1, path);
             ins.bind(2, p.name);
             ins.bind(3, p.catname);
             ins.bind(4, (int)p.type);
             ins.bindi64(5, qtimeInt);
+            ins.bind(6, sns);
 
             ins.step();
 
@@ -842,84 +986,15 @@ CREATE TABLE IF NOT EXISTS Favorites (
             return;
         }
 
-        std::ostringstream searchName;
-        searchName << p.name << " ";
-
-        if (storage)
-        {
-            auto pTmp = p.path.parent_path();
-            std::vector<fs::path> parentFiles;
-            int maxItForSafety{0};
-            while ((pTmp != storage->userPatchesPath) &&
-                   (pTmp != storage->datapath / "patches_factory") &&
-                   (pTmp != storage->datapath / "patches_3rdparty") && !pTmp.empty() &&
-                   (pTmp != pTmp.root_directory()) && maxItForSafety < 10)
-            {
-                parentFiles.push_back(pTmp.filename());
-                pTmp = pTmp.parent_path();
-                maxItForSafety++;
-            }
-
-            if (pTmp == storage->datapath / "patches_3rdparty")
-            {
-                parentFiles.erase(parentFiles.end() - 1);
-            }
-
-            for (const auto &pf : parentFiles)
-            {
-                searchName << pf.u8string() << " ";
-            }
-        }
-
-        std::ifstream stream(p.path, std::ios::in | std::ios::binary);
-
-        std::vector<char> fxChunk;
-        fxChunk.resize(sizeof(sst::io::fxChunkSetCustom));
-        stream.read(fxChunk.data(), fxChunk.size());
-        if (!stream)
-        {
-            return;
-        }
-
-        auto *fxp = (sst::io::fxChunkSetCustom *)(fxChunk.data());
-        if ((mech::endian_read_int32BE(fxp->chunkMagic) != 'CcnK') ||
-            (mech::endian_read_int32BE(fxp->fxMagic) != 'FPCh') ||
-            (mech::endian_read_int32BE(fxp->fxID) != 'cjs3'))
-        {
-            return;
-        }
-
-        std::vector<char> patchHeaderChunk;
-        patchHeaderChunk.resize(sizeof(sst::io::patch_header));
-        stream.read(patchHeaderChunk.data(), patchHeaderChunk.size());
-        if (!stream)
-        {
-            return;
-        }
-        auto *ph = (sst::io::patch_header *)(patchHeaderChunk.data());
-        auto xmlSz = mech::endian_read_int32LE(ph->xmlsize);
-
-        if (memcmp(ph->tag, "sub3", 4) != 0 || xmlSz < 0 || xmlSz > 1024 * 1024 * 1024)
-        {
-            std::cerr << "Skipping invalid patch : [" << p.path.u8string() << "]" << std::endl;
-            return;
-        }
-
-        std::string xmlData;
-        xmlData.resize(xmlSz);
-        stream.read(xmlData.data(), xmlData.size());
-        if (!stream)
-            return;
         try
         {
             auto ins =
                 SQL::Statement(dbh, "INSERT INTO PATCHFEATURE ( \"patch_id\", \"feature\", "
                                     "\"feature_type\", \"feature_ivalue\", \"feature_svalue\" ) "
                                     "VALUES ( ?1, ?2, ?3, ?4, ?5 )");
-            auto feat = extractFeaturesFromXML(xmlData.data());
-            for (const auto &f : feat)
+
+            for (const auto &f : features)
             {
-                const auto &ftype = std::get<0>(f);
                 ins.bindi64(1, patchid);
                 ins.bind(2, std::get<0>(f));
                 ins.bind(3, (int)std::get<1>(f));
@@ -930,31 +1005,8 @@ CREATE TABLE IF NOT EXISTS Favorites (
 
                 ins.clearBindings();
                 ins.reset();
-                if (ftype == "TAG")
-                {
-                    searchName << " " << std::get<3>(f);
-                }
             }
 
-            ins.finalize();
-        }
-        catch (const SQL::Exception &e)
-        {
-            if (storage)
-            {
-                storage->reportError(e.what(), "Database FXP Features");
-            }
-            return;
-        }
-
-        auto sns = searchName.str();
-        try
-        {
-            auto ins = SQL::Statement(dbh, "UPDATE PATCHES SET search_over=?1 WHERE id=?2");
-            ins.bind(1, sns);
-            ins.bind(2, patchid);
-
-            ins.step();
             ins.finalize();
         }
         catch (const SQL::Exception &e)

--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -344,6 +344,13 @@ CREATE TABLE IF NOT EXISTS Favorites (
         void go(WriterWorker &w) override { w.erasePatch(id); }
     };
 
+    struct EnQDeleteByPath : public EnQAble
+    {
+        std::string path;
+        EnQDeleteByPath(const std::string &p) : path(p) {}
+        void go(WriterWorker &w) override { w.erasePatchByPath(path); }
+    };
+
     struct EnQCategory : public EnQAble
     {
         std::string name;
@@ -1064,6 +1071,32 @@ CREATE TABLE IF NOT EXISTS Favorites (
         }
     }
 
+    /*
+     * Removing a patch file is something we know about at the moment it happens, so say so
+     * directly rather than making a subsequent full rescan diff the directory tree against
+     * the database in order to rediscover it.
+     */
+    void erasePatchByPath(const std::string &path)
+    {
+        try
+        {
+            auto feat = SQL::Statement(dbh, "DELETE FROM PatchFeature WHERE patch_id IN "
+                                            "(SELECT id FROM Patches WHERE path = ?1)");
+            feat.bind(1, path);
+            feat.step();
+            feat.finalize();
+
+            auto there = SQL::Statement(dbh, "DELETE FROM Patches WHERE path = ?1");
+            there.bind(1, path);
+            there.step();
+            there.finalize();
+        }
+        catch (const SQL::Exception &e)
+        {
+            storage->reportError(e.what(), "Database Erase By Path");
+        }
+    }
+
     void addDebug(const std::string &m)
     {
         try
@@ -1448,6 +1481,12 @@ void PatchDB::erasePatchByID(int id)
 {
     prepareForWrites();
     worker->enqueueWorkItem(new WriterWorker::EnQDelete(id));
+}
+
+void PatchDB::erasePatchByPath(const std::string &path)
+{
+    prepareForWrites();
+    worker->enqueueWorkItem(new WriterWorker::EnQDeleteByPath(path));
 }
 
 std::vector<std::string> PatchDB::readUserFavorites()

--- a/src/common/PatchDB.cpp
+++ b/src/common/PatchDB.cpp
@@ -26,6 +26,7 @@
 #include <iterator>
 #include <chrono>
 #include <functional>
+#include <cstring>
 
 #include "sqlite3.h"
 #include "SurgeStorage.h"
@@ -898,7 +899,7 @@ CREATE TABLE IF NOT EXISTS Favorites (
         auto *ph = (sst::io::patch_header *)(patchHeaderChunk.data());
         auto xmlSz = mech::endian_read_int32LE(ph->xmlsize);
 
-        if (!memcpy(ph->tag, "sub3", 4) || xmlSz < 0 || xmlSz > 1024 * 1024 * 1024)
+        if (memcmp(ph->tag, "sub3", 4) != 0 || xmlSz < 0 || xmlSz > 1024 * 1024 * 1024)
         {
             std::cerr << "Skipping invalid patch : [" << p.path.u8string() << "]" << std::endl;
             return;

--- a/src/common/PatchDB.h
+++ b/src/common/PatchDB.h
@@ -117,6 +117,11 @@ struct PatchDB
     void addDebugMessage(const std::string &debug);
     void setUserFavorite(const std::string &path, bool isIt);
     void erasePatchByID(int id);
+    /*
+     * Drop every row for a path. Use this when you have just removed the file
+     * yourself, so the database follows without needing a full rescan to notice.
+     */
+    void erasePatchByPath(const std::string &path);
     void doAfterCurrentQueueDrained(std::function<void()> op);
 
     /*

--- a/src/surge-xt/gui/widgets/PatchSelector.cpp
+++ b/src/surge-xt/gui/widgets/PatchSelector.cpp
@@ -732,48 +732,59 @@ void PatchSelector::showClassicMenu(bool single_category, bool userOnly)
         if (isUser)
         {
             contextMenu.addItem(Surge::GUI::toOSCase("Rename Patch..."), [this, sge]() {
-                sge->showOverlay(
-                    SurgeGUIEditor::SAVE_PATCH, [this](Overlays::OverlayComponent *co) {
-                        auto psd = dynamic_cast<Surge::Overlays::PatchStoreDialog *>(co);
-                        if (!psd)
+                sge->showOverlay(SurgeGUIEditor::SAVE_PATCH, [this](
+                                                                 Overlays::OverlayComponent *co) {
+                    auto psd = dynamic_cast<Surge::Overlays::PatchStoreDialog *>(co);
+                    if (!psd)
+                        return;
+                    psd->setIsRename(true);
+                    psd->setEnclosingParentTitle("Rename Patch");
+                    const auto priorPath = storage->patch_list[current_patch].path;
+                    psd->onOK = [this, priorPath]() {
+                        /*
+                         * The save above has already queued the new path for indexing, so
+                         * queueing the removal of the old one behind it is correctly ordered
+                         * by construction. That means we can remove the file immediately
+                         * instead of waiting for the indexer to drain first, and we don't
+                         * need a full rescan for the database to notice it is gone.
+                         */
+                        try
+                        {
+                            fs::remove(priorPath);
+                        }
+                        catch (const fs::filesystem_error &e)
+                        {
+                            std::ostringstream oss;
+                            oss << "Experienced filesystem error while renaming patch " << e.what();
+                            storage->reportError(oss.str(), "Filesystem Error");
                             return;
-                        psd->setIsRename(true);
-                        psd->setEnclosingParentTitle("Rename Patch");
-                        const auto priorPath = storage->patch_list[current_patch].path;
-                        psd->onOK = [this, priorPath]() {
-                            /*
-                             * OK so the database doesn't like deleting files while it is indexing.
-                             * We should fix this (#6793) but for now put the delete action at the
-                             * end of the db processing thread. BUT that will run on the patchdb
-                             * thread so bounce it from here to there and then back here.
-                             */
-                            auto nextStep = [this, priorPath]() {
-                                auto doDelete = [this, priorPath]() {
-                                    fs::remove(priorPath);
-                                    storage->refresh_patchlist();
-                                    storage->initializePatchDb(true);
-                                };
-                                juce::MessageManager::getInstance()->callAsync(doDelete);
-                            };
-                            storage->patchDB->doAfterCurrentQueueDrained(nextStep);
-                        };
-                    });
+                        }
+
+                        storage->patchDB->erasePatchByPath(priorPath.u8string());
+                        storage->refresh_patchlist();
+                    };
+                });
             });
 
             contextMenu.addItem(Surge::GUI::toOSCase("Delete Patch"), [this, sge]() {
                 auto onOk = [this]() {
+                    const auto path = storage->patch_list[current_patch].path;
+
                     try
                     {
-                        fs::remove(storage->patch_list[current_patch].path);
-                        storage->refresh_patchlist();
-                        storage->initializePatchDb(true);
+                        fs::remove(path);
                     }
                     catch (const fs::filesystem_error &e)
                     {
                         std::ostringstream oss;
                         oss << "Experienced filesystem error while deleting patch " << e.what();
                         storage->reportError(oss.str(), "Filesystem Error");
+                        return;
                     }
+
+                    // Tell the database directly rather than making it rescan to find out
+                    storage->patchDB->erasePatchByPath(path.u8string());
+                    storage->refresh_patchlist();
                     isUser = false;
                 };
 


### PR DESCRIPTION
`parseFXPIntoDB` runs on the patch database worker thread, and the file it is pointed at can disappear at any moment: a rename, a file sync client, or a second Surge instance can remove it between any two statements. It handled that badly in two distinct ways.

**It could take the process down.** The mtime was read with the throwing `fs::last_write_time` overload, guarded only by an `fs::exists()` call three lines earlier, so a file removed in that window raised `std::filesystem_error`. The worker loop caught only SQL exceptions, so that escaped `loadQueueFunction` and the thread lambda entirely and hit `std::terminate`. This is the mechanism behind #6959.

**It wrote to the database before it had proven it could read the file.** The old order dropped the existing rows for the path and inserted the new `Patches` row, and only then opened the stream, validated the magic and read the XML. All five failure paths after that insert were bare returns, so a file which went away mid-parse left behind a row with no features and a null search string, and a merely transient read failure destroyed a good patch's existing index entry and replaced it with that stub.

So the parse is now strictly read-then-write: all the file IO happens first into local state, and the database is only touched once a complete and valid patch is in hand. Any file-side failure returns having changed nothing, which is the correct outcome since a genuinely deleted file gets reaped by the directory scan instead. Because the search string is known before the insert, the row now goes in complete and the trailing `UPDATE search_over` is gone.

Alongside that: the non-throwing filesystem overloads are used and the `fs::exists()` pre-check is dropped, since it could never close the race and only widened it; the worker loop gets catch-all arms so no future stray exception can kill the application over one bad patch file; and the queue chunk is held by `unique_ptr` so an exception part way through it no longer leaks the items that had not run yet.

This does not make the index transactionally correct against a concurrently changing filesystem. A file deleted just after its transaction commits still leaves a stale row until the next rescan. Closing that properly needs a filesystem watcher or an mtime revalidation pass, which does not seem worth it. What this does is reduce the failure from "crash or corrupt the index" to "one stale row until the next scan".

Fixes #6973

## Also on this branch

**Tell PatchDB when a patch file is deleted instead of rescanning.** Removing a patch file is something the UI knows about as it happens, but the database could only find out via a full `initializePatchDb(true)` rescan that diffs the whole patch tree in order to rediscover the one path we just deleted ourselves. That indirection is why the rename in #6975 had to defer its `fs::remove` until the indexer drained, and bounce the work from the GUI thread to the patch database thread and back.

A new `erasePatchByPath` work item says so directly. Since it is enqueued behind the indexing that `savePatch` has already queued for the new file, the ordering the drain was buying comes for free, so the rename can delete the old file immediately and drop the round trip entirely. Deleting a patch takes the same path, so neither operation forces a full re-index any more. `doAfterCurrentQueueDrained` and `waitForJobsOutstandingComplete` have no callers left, but are kept deliberately as reasonable primitives to have on hand.

The rename's `fs::remove` is also now guarded the way the delete already was, and both operations stop on a filesystem error rather than continuing to update state as though the file had gone away.

**Fix broken patch header tag check.** `parseFXPIntoDB` used `memcpy` where `memcmp` was intended, so the `"sub3"` header check never fired and in fact overwrote the tag rather than comparing it. This is a pre-existing bug that the restructuring merely happens to touch, so it is first on the branch and cherry-picks on its own.

## Testing

Unit tests pass and the standalone builds and links. The rename and delete flows are GUI driven and no test covers the indexer, so the ordering was verified by reading rather than exercised end to end in the running app.

Assisted-By: Claude Opus 5 <noreply@anthropic.com>
