### PR TITLE
Publish our tuning as soon as we become an MTS-ESP source

### DIFF
--- a/src/common/SurgePatch.cpp
+++ b/src/common/SurgePatch.cpp
@@ -3814,18 +3814,21 @@ void SurgePatch::load_xml(const void *data, int datasize, bool is_preset)
             }
 
             auto mts_main = TINYXML_SAFE_TO_ELEMENT(de->FirstChild("oddsound_mts_active_as_main"));
+            dawExtraState.oddsoundMTSActiveAsMain = false;
+
             if (mts_main)
             {
                 int tv;
 
                 if (mts_main->QueryIntAttribute("v", &tv) == TIXML_SUCCESS)
                 {
-                    if (tv)
-                    {
-#ifndef SURGE_SKIP_ODDSOUND_MTS
-                        storage->connect_as_oddsound_main();
-#endif
-                    }
+                    /*
+                     * Stage this like every other bit of DAW extra state rather than
+                     * connecting here. The scale and mapping are still being read at this
+                     * point, so registering as a source now would broadcast 12-TET to the
+                     * whole session and only correct itself once the tuning lands.
+                     */
+                    dawExtraState.oddsoundMTSActiveAsMain = (tv != 0);
                 }
             }
 
@@ -4645,7 +4648,7 @@ unsigned int SurgePatch::save_xml(void **data) // allocates mem, must be freed b
 
         // Revision 21 adds MTS as main
         TiXmlElement oam("oddsound_mts_active_as_main");
-        oam.SetAttribute("v", (int)(storage->oddsound_mts_active_as_main));
+        oam.SetAttribute("v", dawExtraState.oddsoundMTSActiveAsMain ? 1 : 0);
         dawExtraXML.InsertEndChild(oam);
 
         /*

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -3405,13 +3405,11 @@ bool SurgeStorage::resetToCurrentScaleAndMapping()
     }
 
 #ifndef SURGE_SKIP_ODDSOUND_MTS
+    // This can run on the audio thread, so when there is a UI to do it for us we let
+    // the tuningUpdates counter carry the news and publish from the idle loop instead
     if (oddsound_mts_active_as_main && !uiThreadChecksTunings)
     {
-        for (int i = 0; i < 128; ++i)
-        {
-            MTS_SetNoteTuning(currentTuning.frequencyForMidiNote(i), i);
-        }
-        MTS_SetScaleName(currentTuning.scale.description.c_str());
+        publish_tuning_as_oddsound_main();
     }
     tuningUpdates++;
 #endif
@@ -3731,16 +3729,14 @@ void SurgeStorage::connect_as_oddsound_main()
                     "source option.",
                     "MTS-ESP Error");
     }
-    lastSentTuningUpdate = -1;
-
-    if (!uiThreadChecksTunings && oddsound_mts_active_as_main)
-    {
-        for (int i = 0; i < 128; ++i)
-        {
-            MTS_SetNoteTuning(currentTuning.frequencyForMidiNote(i), i);
-        }
-        MTS_SetScaleName(currentTuning.scale.description.c_str());
-    }
+    /*
+     * MTS_RegisterMaster() starts the session off at 12-TET, so publish our own tuning
+     * right here rather than leaving the session mistuned until the next UI idle tick.
+     * Deferring to the UI is only needed where a retune can arrive on the audio thread;
+     * becoming a source is a deliberate act which never does.
+     */
+    lastSentTuningUpdate = tuningUpdates;
+    publish_tuning_as_oddsound_main();
 }
 void SurgeStorage::disconnect_as_oddsound_main()
 {
@@ -3754,13 +3750,24 @@ void SurgeStorage::send_tuning_update()
         return;
 
     lastSentTuningUpdate = tuningUpdates;
+    publish_tuning_as_oddsound_main();
+}
+
+void SurgeStorage::publish_tuning_as_oddsound_main()
+{
     if (!oddsound_mts_active_as_main)
+    {
         return;
+    }
+
+    double freqs[128];
 
     for (int i = 0; i < 128; ++i)
     {
-        MTS_SetNoteTuning(currentTuning.frequencyForMidiNote(i), i);
+        freqs[i] = currentTuning.frequencyForMidiNote(i);
     }
+
+    MTS_SetNoteTunings(freqs);
     MTS_SetScaleName(currentTuning.scale.description.c_str());
 }
 #endif

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -24,6 +24,7 @@
 #include "SurgeStorage.h"
 #include <set>
 #include <numeric>
+#include <algorithm>
 #include <cctype>
 #include <map>
 #include <queue>
@@ -3769,6 +3770,43 @@ void SurgeStorage::publish_tuning_as_oddsound_main()
 
     MTS_SetNoteTunings(freqs);
     MTS_SetScaleName(currentTuning.scale.description.c_str());
+
+    /*
+     * Beyond the frequencies themselves, MTS-ESP lets a source describe the shape of the
+     * scale, and clients lean on that for octave shifts and for transposition by one
+     * period. If we never supply it they see the library defaults - a map size of -1 and
+     * a period of an octave - no matter what we are actually broadcasting, so a client
+     * shifting by an octave on a Bohlen-Pierce scale lands nowhere near the right note.
+     */
+    const auto &scale = currentTuning.scale;
+    const auto &mapping = currentTuning.keyboardMapping;
+
+    // The formal octave of a scale is its last tone, which is not necessarily a 2/1
+    MTS_SetPeriodRatio(scale.count > 0 ? pow(2.0, scale.tones[scale.count - 1].cents / 1200.0)
+                                       : 2.0);
+
+    // A mapping with no explicit key list repeats the scale pattern every scale.count keys
+    auto mapSize = (mapping.count > 0) ? mapping.count : scale.count;
+
+    MTS_SetMapSize((char)std::clamp(mapSize, 0, 127));
+    MTS_SetMapStartKey((char)std::clamp(mapping.middleNote, 0, 127));
+    MTS_SetRefKey((char)std::clamp(mapping.tuningConstantNote, 0, 127));
+
+    /*
+     * Surge drops notes the mapping skips rather than sounding them (see
+     * SurgeSynthesizer::playNote), so tell clients to do the same. We still broadcast an
+     * interpolated frequency for those notes, as the MTS-ESP API asks us to, since
+     * checking the note filter is optional for a client.
+     */
+    MTS_ClearNoteFilter();
+
+    for (int i = 0; i < 128; ++i)
+    {
+        if (!currentTuning.isMidiNoteMapped(i))
+        {
+            MTS_FilterNote(true, (char)i, -1);
+        }
+    }
 }
 #endif
 

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -1273,6 +1273,7 @@ struct DAWExtraStateStorage
     bool isDirty{false};
 
     bool disconnectFromOddSoundMTS{false};
+    bool oddsoundMTSActiveAsMain{false};
 
     int oscPortIn{DEFAULT_OSC_PORT_IN};
     int oscPortInLastBound{0}; // Tracks bound port for restoration, 0 = never bound
@@ -1991,6 +1992,7 @@ class alignas(16) SurgeStorage
     void disconnect_as_oddsound_main();
     uint64_t lastSentTuningUpdate{0}; // since tuning update starts at 2
     void send_tuning_update();
+    void publish_tuning_as_oddsound_main();
     std::atomic<bool> uiThreadChecksTunings{false};
 #endif
     MTSClient *oddsound_mts_client = nullptr;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -5217,6 +5217,7 @@ void SurgeSynthesizer::populateDawExtraState()
 
     des.mapChannelToOctave = storage.mapChannelToOctave;
     des.transposeByTuningPeriod = storage.transposeByTuningPeriod;
+    des.oddsoundMTSActiveAsMain = storage.oddsound_mts_active_as_main;
 
     int n = n_global_params + (n_scene_params * n_scenes);
 
@@ -5322,6 +5323,15 @@ void SurgeSynthesizer::loadFromDawExtraState()
 
     storage.mapChannelToOctave = des.mapChannelToOctave;
     storage.transposeByTuningPeriod = des.transposeByTuningPeriod;
+
+#ifndef SURGE_SKIP_ODDSOUND_MTS
+    // Only once the scale and mapping above are in place, so the session gets our tuning
+    // rather than the 12-TET table MTS_RegisterMaster() starts everyone off with
+    if (des.oddsoundMTSActiveAsMain && !storage.oddsound_mts_active_as_main)
+    {
+        storage.connect_as_oddsound_main();
+    }
+#endif
 
     int n = n_global_params + (n_scene_params * n_scenes);
     int nOld = n_global_params + n_scene_params;


### PR DESCRIPTION
`MTS_RegisterMaster()` starts the session off at 12-TET, and Surge only pushed its own table afterwards if no editor was open. With the tuning
editor open the push was left to `send_tuning_update()` on the next UI idle tick, so every client in the session was retuned to 12-TET for a frame, and any client latching tuning at note on kept the wrong pitches until the next note. Becoming a source is always a deliberate main thread act, so publish right there; the deferral only exists because a retune can arrive on the audio thread, which is still handled by the idle path.

Restoring a session had the same problem for a different reason: the `oddsound_mts_active_as_main flag` was acted on while the DAW extra state XML was still being parsed, before the scale and mapping were read. Stage it in `dawExtraState` like every other field and connect in `loadFromDawExtraState()` once the tuning is in place.

Also fold the three copies of the broadcast into one `publish_tuning_as_oddsound_main()`, which now sends the table with a single `MTS_SetNoteTunings()` call instead of 128 individual ones.

Fixes #7812

Assisted-By: Claude Opus 5 <noreply@anthropic.com>