### PR TITLE
Start OSC from streamed state after the patch has been deserialized

### DIFF
--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -574,11 +574,6 @@ void SurgeSynthProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         return;
     }
 
-    if (oscCheckStartup)
-    {
-        tryLazyOscStartupFromStreamedState();
-    }
-
     priorCallWasProcessBlockNotBypassed = true;
 
     // Make sure we have a main output
@@ -1089,6 +1084,13 @@ void SurgeSynthProcessor::processBlockOSC()
 
 void SurgeSynthProcessor::processBlockPostFunction()
 {
+    // This has to run *after* the block, since a patch enqueued by setStateInformation
+    // is only deserialized part way through it, by processControl. See #8096.
+    if (oscCheckStartup)
+    {
+        tryLazyOscStartupFromStreamedState();
+    }
+
     if (checkNamesEvery++ > 10)
     {
         checkNamesEvery = 0;
@@ -1626,6 +1628,13 @@ void SurgeSynthProcessor::reset() { blockPos = 0; }
 
 void SurgeSynthProcessor::tryLazyOscStartupFromStreamedState()
 {
+    if (surge->rawLoadEnqueued)
+    {
+        // The streamed state hasn't landed yet, so oscStartIn/oscStartOut would read
+        // stale. Leave oscCheckStartup set and try again once the load has been applied.
+        return;
+    }
+
     if ((!oscHandler.listening && surge->storage.oscStartIn && surge->storage.oscPortIn > 0) ||
         (!oscHandler.sendingOSC && surge->storage.oscStartOut && surge->storage.oscPortOut > 0))
     {


### PR DESCRIPTION
`setStateInformation` only enqueues the patch blob. When the audio engine is already running, `processAudioThreadOpsWhenAudioEngineUnavailable` is a no-op and the actual deserialization happens later, on the audio thread, inside `processControl`. But the deferred OSC startup check ran at the very top of `processBlock`, before that, so it read the default `oscStartIn`/`oscStartOut` of `false`, did nothing, and then cleared `oscCheckStartup` unconditionally. By the time the streamed values arrived, nothing looked at them again, so the OSC server never started.

The settings dialog checkboxes track the live server state (`storage.oscReceiving`/`oscSending`) rather than the streamed flags, which is why they show up unticked while the ports are remembered correctly.

This is deterministic whenever the host restores state onto an already active instance, which is why it is systematic in Ardour and only erratic with VST3 in hosts that set state before the first process call.

### The fix

Move the check to `processBlockPostFunction`, which runs at the end of both `processBlock` and `clap_direct_process`, so the enqueued patch has been applied by then. That also gives CLAP a lazy startup path it never had, since `clap_direct_process` bypasses `processBlock` entirely.

Also keep `oscCheckStartup` set while a raw load is still pending, so the request survives a block that returns early, such as while bypassed, instead of being silently dropped.

`surge-fx` has the same `oscCheckStartup` pattern but is deliberately untouched: `SurgefxAudioProcessor::setStateInformation` sets `oscStartIn` directly from the XML before raising the flag, so there is no deferred deserialization to race.

### Testing

Compiles clean and passes the clang-format check. The failure itself has not been reproduced locally, since it needs a host that restores state onto an already active instance, so this is reasoned from the source rather than observed. There is no unit test either, as the test suite does not instantiate the JUCE processor. Confirmation will have to come from the reporter on a nightly.

Fixes #8096

Assisted-By: Claude Opus 5 <noreply@anthropic.com>
