### PR TITLE
Add wavetable export and parameter features to the Python bindings

### DIFF
--- a/src/surge-python/surgepy.cpp
+++ b/src/surge-python/surgepy.cpp
@@ -23,6 +23,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
+#include <optional>
 #include <thread>
 #include <utility>
 
@@ -603,6 +604,38 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
         oss << "Parameter value type: " << val_type << std::endl;
         oss << "Parameter display value: " << display << std::endl;
 
+        // Only report the features which actually apply to this parameter
+        const auto p = paramPtr(id);
+        const auto onOff = [](bool b) { return b ? "on" : "off"; };
+
+        if (p->can_extend_range())
+        {
+            oss << "Parameter extended range: " << onOff(p->extend_range) << std::endl;
+        }
+
+        if (p->can_temposync())
+        {
+            oss << "Parameter temposync: " << onOff(p->temposync) << std::endl;
+        }
+
+        if (p->can_be_absolute())
+        {
+            oss << "Parameter absolute mode: " << onOff(p->absolute) << std::endl;
+        }
+
+        if (p->has_deformoptions())
+        {
+            oss << "Parameter deform type: " << p->deform_type << std::endl;
+        }
+
+        if (p->has_portaoptions())
+        {
+            oss << "Parameter portamento constant rate: " << onOff(p->porta_constrate) << std::endl;
+            oss << "Parameter portamento glissando: " << onOff(p->porta_gliss) << std::endl;
+            oss << "Parameter portamento retrigger: " << onOff(p->porta_retrigger) << std::endl;
+            oss << "Parameter portamento curve: " << p->porta_curve << std::endl;
+        }
+
         return oss.str();
     }
 
@@ -613,6 +646,143 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
             return;
 
         setParameter01(id.getID(), p->value_to_normalized(f));
+    }
+
+    /*
+     * Parameter features are the per-parameter flags which sit alongside a value and stream with
+     * the patch: extended range, temposync, absolute mode, the deform type, and the portamento
+     * options. Each of them is only meaningful on the parameters which support it, so every feature
+     * pairs its accessors with a query, and the setters raise rather than quietly writing a flag
+     * the engine will never read back.
+     */
+    Parameter *paramPtr(const SurgePyNamedParam &id)
+    {
+        auto p = storage.getPatch().param_ptr[id.getID().getSynthSideId()];
+
+        if (!p)
+        {
+            throw std::invalid_argument(std::string("Unknown parameter '") + id.getName() + "'!");
+        }
+
+        return p;
+    }
+
+    void requireFeature(Parameter *p, bool supported, const std::string &feature)
+    {
+        if (!supported)
+        {
+            throw std::invalid_argument(std::string("Parameter '") + p->get_name() +
+                                        "' does not support " + feature + "!");
+        }
+    }
+
+    bool canExtend(const SurgePyNamedParam &id) { return paramPtr(id)->can_extend_range(); }
+
+    bool getExtend(const SurgePyNamedParam &id) { return paramPtr(id)->extend_range; }
+
+    void setExtend(const SurgePyNamedParam &id, bool b)
+    {
+        auto p = paramPtr(id);
+
+        requireFeature(p, p->can_extend_range(), "extended range");
+        // set_extend_range also rescales the current value, so never assign the flag directly
+        p->set_extend_range(b);
+        storage.getPatch().isDirty = true;
+    }
+
+    bool canTempoSync(const SurgePyNamedParam &id) { return paramPtr(id)->can_temposync(); }
+
+    bool getTempoSync(const SurgePyNamedParam &id) { return paramPtr(id)->temposync; }
+
+    void setTempoSync(const SurgePyNamedParam &id, bool b)
+    {
+        auto p = paramPtr(id);
+
+        requireFeature(p, p->can_temposync(), "temposync");
+        p->temposync = b;
+        storage.getPatch().isDirty = true;
+    }
+
+    bool canBeAbsolute(const SurgePyNamedParam &id) { return paramPtr(id)->can_be_absolute(); }
+
+    bool getAbsolute(const SurgePyNamedParam &id) { return paramPtr(id)->absolute; }
+
+    void setAbsolute(const SurgePyNamedParam &id, bool b)
+    {
+        auto p = paramPtr(id);
+
+        requireFeature(p, p->can_be_absolute(), "absolute mode");
+        p->absolute = b;
+        storage.getPatch().isDirty = true;
+    }
+
+    bool canDeform(const SurgePyNamedParam &id) { return paramPtr(id)->has_deformoptions(); }
+
+    int getDeform(const SurgePyNamedParam &id) { return paramPtr(id)->deform_type; }
+
+    void setDeform(const SurgePyNamedParam &id, int deformType)
+    {
+        auto p = paramPtr(id);
+
+        requireFeature(p, p->has_deformoptions(), "deform types");
+        // What a deform type means is up to the control type, so there's no range to check here
+        p->deform_type = deformType;
+        storage.getPatch().isDirty = true;
+    }
+
+    bool canPortamento(const SurgePyNamedParam &id) { return paramPtr(id)->has_portaoptions(); }
+
+    py::dict getPortamentoOptions(const SurgePyNamedParam &id)
+    {
+        auto p = paramPtr(id);
+
+        requireFeature(p, p->has_portaoptions(), "portamento options");
+
+        py::dict res;
+
+        res["constantRate"] = p->porta_constrate;
+        res["glissando"] = p->porta_gliss;
+        res["retrigger"] = p->porta_retrigger;
+        res["curve"] = p->porta_curve;
+
+        return res;
+    }
+
+    void setPortamentoOptions(const SurgePyNamedParam &id, std::optional<bool> constantRate,
+                              std::optional<bool> glissando, std::optional<bool> retrigger,
+                              std::optional<int> curve)
+    {
+        auto p = paramPtr(id);
+
+        requireFeature(p, p->has_portaoptions(), "portamento options");
+
+        if (constantRate.has_value())
+        {
+            p->porta_constrate = *constantRate;
+        }
+
+        if (glissando.has_value())
+        {
+            p->porta_gliss = *glissando;
+        }
+
+        if (retrigger.has_value())
+        {
+            p->porta_retrigger = *retrigger;
+        }
+
+        if (curve.has_value())
+        {
+            if (*curve < porta_log || *curve > porta_exp)
+            {
+                throw std::invalid_argument("Portamento curve must be one of porta_log, porta_lin "
+                                            "or porta_exp from surgepy.constants!");
+            }
+
+            p->porta_curve = *curve;
+        }
+
+        storage.getPatch().isDirty = true;
     }
 
     void releaseNoteWithInts(int ch, int note, int vel) { releaseNote(ch, note, vel); }
@@ -629,12 +799,51 @@ class SurgeSynthesizerWithPythonExtensions : public SurgeSynthesizer
         {
             throw std::invalid_argument((std::string("File not found: ") + s).c_str());
         }
-        std::cout << "Would load " << scene << " " << osc << " with " << s << std::endl;
         auto os = &(storage.getPatch().scene[scene].osc[osc]);
         auto wt = &(os->wt);
         storage.load_wt(s, wt, os);
 
         return true;
+    }
+
+    bool saveWavetablePy(int scene, int osc, const std::string &s)
+    {
+        if (scene < 0 || scene >= n_scenes || osc < 0 || osc >= n_oscs)
+        {
+            throw std::invalid_argument("OSC and SCENE out of range in saveWavetable");
+        }
+
+        auto os = &(storage.getPatch().scene[scene].osc[osc]);
+
+        // Every oscillator carries a wavetable buffer, but only the wavetable and window types
+        // actually have one which means anything, so don't hand back an init table for the rest.
+        if (!uses_wavetabledata(os->type.val.i))
+        {
+            throw std::invalid_argument("This oscillator type has no wavetable to save!");
+        }
+
+        if (!os->wt.everBuilt || os->wt.n_tables <= 0 || os->wt.size <= 0)
+        {
+            throw std::invalid_argument("This oscillator has no wavetable to save!");
+        }
+
+        auto path = string_to_path(s);
+
+        if (path.extension() != ".wt")
+        {
+            path.replace_extension(".wt");
+        }
+
+        // Copy the live wavetable under waveTableDataMutex so the write can't race a rebuild, then
+        // export the copy lock-free, exactly as the editor's wavetable export does.
+        Wavetable copy;
+
+        {
+            std::lock_guard<std::mutex> lock(storage.waveTableDataMutex);
+            copy.Copy(&os->wt);
+        }
+
+        return storage.export_wt_wt_portable(path, &copy, storage.make_wt_metadata(os));
     }
     bool loadPatchPy(const std::string &s)
     {
@@ -1125,6 +1334,50 @@ PYBIND11_MODULE(surgepy, m)
         .def("setParamVal", &SurgeSynthesizerWithPythonExtensions::setParamVal,
              "Set a parameter value", py::arg("param"), py::arg("toThis"))
 
+        .def("canExtend", &SurgeSynthesizerWithPythonExtensions::canExtend,
+             "Can this parameter have an extended range?", py::arg("param"))
+        .def("getExtend", &SurgeSynthesizerWithPythonExtensions::getExtend,
+             "Is this parameter in extended range mode?", py::arg("param"))
+        .def("setExtend", &SurgeSynthesizerWithPythonExtensions::setExtend,
+             "Set the extended range mode of a parameter, rescaling its value to the new range.",
+             py::arg("param"), py::arg("toThis"))
+
+        .def("canTempoSync", &SurgeSynthesizerWithPythonExtensions::canTempoSync,
+             "Can this parameter be tempo synced?", py::arg("param"))
+        .def("getTempoSync", &SurgeSynthesizerWithPythonExtensions::getTempoSync,
+             "Is this parameter tempo synced?", py::arg("param"))
+        .def("setTempoSync", &SurgeSynthesizerWithPythonExtensions::setTempoSync,
+             "Set the tempo sync mode of a parameter.", py::arg("param"), py::arg("toThis"))
+
+        .def("canBeAbsolute", &SurgeSynthesizerWithPythonExtensions::canBeAbsolute,
+             "Can this parameter be switched to absolute mode?", py::arg("param"))
+        .def("getAbsolute", &SurgeSynthesizerWithPythonExtensions::getAbsolute,
+             "Is this parameter in absolute mode?", py::arg("param"))
+        .def("setAbsolute", &SurgeSynthesizerWithPythonExtensions::setAbsolute,
+             "Set the absolute mode of a parameter.", py::arg("param"), py::arg("toThis"))
+
+        .def("canDeform", &SurgeSynthesizerWithPythonExtensions::canDeform,
+             "Does this parameter have deform options?", py::arg("param"))
+        .def("getDeform", &SurgeSynthesizerWithPythonExtensions::getDeform,
+             "The deform type of this parameter, as an integer whose meaning depends on the "
+             "parameter.",
+             py::arg("param"))
+        .def("setDeform", &SurgeSynthesizerWithPythonExtensions::setDeform,
+             "Set the deform type of a parameter.", py::arg("param"), py::arg("toThis"))
+
+        .def("canPortamento", &SurgeSynthesizerWithPythonExtensions::canPortamento,
+             "Does this parameter have portamento options?", py::arg("param"))
+        .def("getPortamentoOptions", &SurgeSynthesizerWithPythonExtensions::getPortamentoOptions,
+             "The portamento options of this parameter, as a dictionary with the keys "
+             "'constantRate', 'glissando', 'retrigger' and 'curve'.",
+             py::arg("param"))
+        .def("setPortamentoOptions", &SurgeSynthesizerWithPythonExtensions::setPortamentoOptions,
+             "Set the portamento options of a parameter. Options which are not given are left "
+             "alone. The curve is one of surgepy.constants.porta_log, porta_lin or porta_exp.",
+             py::arg("param"), py::arg("constantRate") = py::none(),
+             py::arg("glissando") = py::none(), py::arg("retrigger") = py::none(),
+             py::arg("curve") = py::none())
+
         .def("loadPatch", &SurgeSynthesizerWithPythonExtensions::loadPatchPy,
              "Load a Surge XT .fxp patch from the file system.", py::arg("path"))
         .def("savePatch", &SurgeSynthesizerWithPythonExtensions::savePatchPy,
@@ -1132,6 +1385,11 @@ PYBIND11_MODULE(surgepy, m)
 
         .def("loadWavetable", &SurgeSynthesizerWithPythonExtensions::loadWavetablePy,
              "Load a wavetable file directly into a scene and oscillator immediately on this "
+             "thread.",
+             py::arg("scene"), py::arg("osc"), py::arg("path"))
+
+        .def("saveWavetable", &SurgeSynthesizerWithPythonExtensions::saveWavetablePy,
+             "Save the wavetable of a scene and oscillator to a .wt file, immediately on this "
              "thread.",
              py::arg("scene"), py::arg("osc"), py::arg("path"))
 
@@ -1243,6 +1501,10 @@ PYBIND11_MODULE(surgepy, m)
         m.def_submodule("constants", "Constants which are used to navigate Surge XT");
 
 #define C(x) m_const.attr(#x) = py::int_((int)(x));
+    C(porta_log);
+    C(porta_lin);
+    C(porta_exp);
+
     C(cg_GLOBAL);
     C(cg_OSC);
     C(cg_MIX);

--- a/src/surge-python/surgepy/_surgepy/__init__.pyi
+++ b/src/surge-python/surgepy/_surgepy/__init__.pyi
@@ -62,6 +62,26 @@ class SurgeSynthesizer:
         """
         Turn off all playing notes
         """
+    def canBeAbsolute(self, param: SurgePyNamedParam) -> bool:
+        """
+        Can this parameter be switched to absolute mode?
+        """
+    def canDeform(self, param: SurgePyNamedParam) -> bool:
+        """
+        Does this parameter have deform options?
+        """
+    def canExtend(self, param: SurgePyNamedParam) -> bool:
+        """
+        Can this parameter have an extended range?
+        """
+    def canPortamento(self, param: SurgePyNamedParam) -> bool:
+        """
+        Does this parameter have portamento options?
+        """
+    def canTempoSync(self, param: SurgePyNamedParam) -> bool:
+        """
+        Can this parameter be tempo synced?
+        """
     def channelAftertouch(self, channel: int, value: int) -> None:
         """
         Send the channel aftertouch MIDI message
@@ -78,6 +98,10 @@ class SurgeSynthesizer:
         ...
     def fromSynthSideId(self, arg0: int, arg1: SurgeSynthesizer_ID) -> bool:
         ...
+    def getAbsolute(self, param: SurgePyNamedParam) -> bool:
+        """
+        Is this parameter in absolute mode?
+        """
     def getAllModRoutings(self) -> dict:
         """
         Get the entire modulation matrix for this instance.
@@ -87,6 +111,14 @@ class SurgeSynthesizer:
     def getControlGroup(self, entry: int) -> SurgePyControlGroup:
         """
         Gather the parameters groups for a surge.constants.cg_ control group
+        """
+    def getDeform(self, param: SurgePyNamedParam) -> int:
+        """
+        The deform type of this parameter, as an integer whose meaning depends on the parameter.
+        """
+    def getExtend(self, param: SurgePyNamedParam) -> bool:
+        """
+        Is this parameter in extended range mode?
         """
     def getFactoryDataPath(self) -> str:
         ...
@@ -142,8 +174,16 @@ class SurgeSynthesizer:
         """
         Get a Python dictionary with the Surge XT parameters laid out in the logical patch format
         """
+    def getPortamentoOptions(self, param: SurgePyNamedParam) -> dict:
+        """
+        The portamento options of this parameter, as a dictionary with the keys 'constantRate', 'glissando', 'retrigger' and 'curve'.
+        """
     def getSampleRate(self) -> float:
         ...
+    def getTempoSync(self, param: SurgePyNamedParam) -> bool:
+        """
+        Is this parameter tempo synced?
+        """
     def getUserDataPath(self) -> str:
         ...
     def isActiveModulation(self, targetParameter: SurgePyNamedParam, modulationSource: SurgePyModSource, scene: int = 0, index: int = 0) -> bool:
@@ -169,6 +209,10 @@ class SurgeSynthesizer:
     def loadSCLFile(self, arg0: str) -> None:
         """
         Load an SCL tuning file and apply tuning to this instance
+        """
+    def loadWavetable(self, scene: int, osc: int, path: str) -> bool:
+        """
+        Load a wavetable file directly into a scene and oscillator immediately on this thread.
         """
     def pitchBend(self, channel: int, bend: int) -> None:
         """
@@ -217,6 +261,22 @@ class SurgeSynthesizer:
         """
         Save the current state of Surge XT to an .fxp file.
         """
+    def saveWavetable(self, scene: int, osc: int, path: str) -> bool:
+        """
+        Save the wavetable of a scene and oscillator to a .wt file, immediately on this thread.
+        """
+    def setAbsolute(self, param: SurgePyNamedParam, toThis: bool) -> None:
+        """
+        Set the absolute mode of a parameter.
+        """
+    def setDeform(self, param: SurgePyNamedParam, toThis: int) -> None:
+        """
+        Set the deform type of a parameter.
+        """
+    def setExtend(self, param: SurgePyNamedParam, toThis: bool) -> None:
+        """
+        Set the extended range mode of a parameter, rescaling its value to the new range.
+        """
     def setModDepth01(self, targetParameter: SurgePyNamedParam, modulationSource: SurgePyModSource, depth: float, scene: int = 0, index: int = 0) -> None:
         """
         Set a modulation to a given depth
@@ -224,6 +284,14 @@ class SurgeSynthesizer:
     def setParamVal(self, param: SurgePyNamedParam, toThis: float) -> None:
         """
         Set a parameter value
+        """
+    def setPortamentoOptions(self, param: SurgePyNamedParam, constantRate: bool | None = None, glissando: bool | None = None, retrigger: bool | None = None, curve: int | None = None) -> None:
+        """
+        Set the portamento options of a parameter. Options which are not given are left alone. The curve is one of surgepy.constants.porta_log, porta_lin or porta_exp.
+        """
+    def setTempoSync(self, param: SurgePyNamedParam, toThis: bool) -> None:
+        """
+        Set the tempo sync mode of a parameter.
         """
 class SurgeSynthesizer_ID:
     def __init__(self) -> None:

--- a/src/surge-python/surgepy/_surgepy/constants.pyi
+++ b/src/surge-python/surgepy/_surgepy/constants.pyi
@@ -2,7 +2,7 @@
 Constants which are used to navigate Surge XT
 """
 from __future__ import annotations
-__all__ = ['adsr_ampeg', 'adsr_filteg', 'cg_ENV', 'cg_FILTER', 'cg_FX', 'cg_GLOBAL', 'cg_LFO', 'cg_MIX', 'cg_OSC', 'fc_dual1', 'fc_dual2', 'fc_ring', 'fc_serial1', 'fc_serial2', 'fc_serial3', 'fc_stereo', 'fc_wide', 'fm_2and3to1', 'fm_2to1', 'fm_3to2to1', 'fm_off', 'fxslot_ains1', 'fxslot_ains2', 'fxslot_bins1', 'fxslot_bins2', 'fxslot_global1', 'fxslot_global2', 'fxslot_send1', 'fxslot_send2', 'fxt_airwindows', 'fxt_chorus4', 'fxt_conditioner', 'fxt_delay', 'fxt_distortion', 'fxt_eq', 'fxt_flanger', 'fxt_freqshift', 'fxt_neuron', 'fxt_off', 'fxt_phaser', 'fxt_reverb', 'fxt_reverb2', 'fxt_ringmod', 'fxt_rotaryspeaker', 'fxt_vocoder', 'lt_envelope', 'lt_formula', 'lt_mseg', 'lt_noise', 'lt_ramp', 'lt_sine', 'lt_snh', 'lt_square', 'lt_tri', 'ms_aftertouch', 'ms_alternate_bipolar', 'ms_alternate_unipolar', 'ms_ampeg', 'ms_breath', 'ms_ctrl1', 'ms_ctrl2', 'ms_ctrl3', 'ms_ctrl4', 'ms_ctrl5', 'ms_ctrl6', 'ms_ctrl7', 'ms_ctrl8', 'ms_expression', 'ms_filtereg', 'ms_highest_key', 'ms_keytrack', 'ms_latest_key', 'ms_lfo1', 'ms_lfo2', 'ms_lfo3', 'ms_lfo4', 'ms_lfo5', 'ms_lfo6', 'ms_lowest_key', 'ms_modwheel', 'ms_pitchbend', 'ms_polyaftertouch', 'ms_random_bipolar', 'ms_random_unipolar', 'ms_releasevelocity', 'ms_slfo1', 'ms_slfo2', 'ms_slfo3', 'ms_slfo4', 'ms_slfo5', 'ms_slfo6', 'ms_sustain', 'ms_timbre', 'ms_velocity', 'ot_FM2', 'ot_FM3', 'ot_audioinput', 'ot_classic', 'ot_shnoise', 'ot_sine', 'ot_wavetable', 'ot_window', 'pm_latch', 'pm_mono', 'pm_mono_fp', 'pm_mono_st', 'pm_mono_st_fp', 'pm_poly', 'sm_chsplit', 'sm_dual', 'sm_single', 'sm_split']
+__all__ = ['adsr_ampeg', 'adsr_filteg', 'cg_ENV', 'cg_FILTER', 'cg_FX', 'cg_GLOBAL', 'cg_LFO', 'cg_MIX', 'cg_OSC', 'fc_dual1', 'fc_dual2', 'fc_ring', 'fc_serial1', 'fc_serial2', 'fc_serial3', 'fc_stereo', 'fc_wide', 'fm_2and3to1', 'fm_2to1', 'fm_3to2to1', 'fm_off', 'fxslot_ains1', 'fxslot_ains2', 'fxslot_bins1', 'fxslot_bins2', 'fxslot_global1', 'fxslot_global2', 'fxslot_send1', 'fxslot_send2', 'fxt_airwindows', 'fxt_chorus4', 'fxt_conditioner', 'fxt_delay', 'fxt_distortion', 'fxt_eq', 'fxt_flanger', 'fxt_freqshift', 'fxt_neuron', 'fxt_off', 'fxt_phaser', 'fxt_reverb', 'fxt_reverb2', 'fxt_ringmod', 'fxt_rotaryspeaker', 'fxt_vocoder', 'lt_envelope', 'lt_formula', 'lt_mseg', 'lt_noise', 'lt_ramp', 'lt_sine', 'lt_snh', 'lt_square', 'lt_tri', 'ms_aftertouch', 'ms_alternate_bipolar', 'ms_alternate_unipolar', 'ms_ampeg', 'ms_breath', 'ms_ctrl1', 'ms_ctrl2', 'ms_ctrl3', 'ms_ctrl4', 'ms_ctrl5', 'ms_ctrl6', 'ms_ctrl7', 'ms_ctrl8', 'ms_expression', 'ms_filtereg', 'ms_highest_key', 'ms_keytrack', 'ms_latest_key', 'ms_lfo1', 'ms_lfo2', 'ms_lfo3', 'ms_lfo4', 'ms_lfo5', 'ms_lfo6', 'ms_lowest_key', 'ms_modwheel', 'ms_pitchbend', 'ms_polyaftertouch', 'ms_random_bipolar', 'ms_random_unipolar', 'ms_releasevelocity', 'ms_slfo1', 'ms_slfo2', 'ms_slfo3', 'ms_slfo4', 'ms_slfo5', 'ms_slfo6', 'ms_sustain', 'ms_timbre', 'ms_velocity', 'ot_FM2', 'ot_FM3', 'ot_audioinput', 'ot_classic', 'ot_shnoise', 'ot_sine', 'ot_wavetable', 'ot_window', 'pm_latch', 'pm_mono', 'pm_mono_fp', 'pm_mono_st', 'pm_mono_st_fp', 'pm_poly', 'porta_exp', 'porta_lin', 'porta_log', 'sm_chsplit', 'sm_dual', 'sm_single', 'sm_split']
 adsr_ampeg: int = 0
 adsr_filteg: int = 1
 cg_ENV: int = 5
@@ -111,6 +111,9 @@ pm_mono_fp: int = 3
 pm_mono_st: int = 2
 pm_mono_st_fp: int = 4
 pm_poly: int = 0
+porta_exp: int = 1
+porta_lin: int = 0
+porta_log: int = -1
 sm_chsplit: int = 3
 sm_dual: int = 2
 sm_single: int = 0

--- a/src/surge-python/tests/test_surgepy.py
+++ b/src/surge-python/tests/test_surgepy.py
@@ -2,7 +2,11 @@
 Tests for Surge XT Python bindings.
 """
 
+import glob
+import os
+
 import numpy as np
+import pytest
 import surgepy
 
 
@@ -67,3 +71,150 @@ def test_set_tuningApplicationMode():
     s = surgepy.createSurge(44100)
     s.tuningApplicationMode = surgepy.TuningApplicationMode.RETUNE_ALL
     assert s.tuningApplicationMode == surgepy.TuningApplicationMode.RETUNE_ALL
+
+
+def test_param_extend_range():
+    """
+    Test reading and writing the extended range of a parameter.
+    """
+    s = surgepy.createSurge(44100)
+    pitch = s.getPatch()["scene"][0]["osc"][0]["pitch"]
+
+    assert s.canExtend(pitch) is True
+    assert s.getExtend(pitch) is False
+
+    s.setExtend(pitch, True)
+    assert s.getExtend(pitch) is True
+
+    # Extending osc pitch turns semitones into semitones times twelve
+    s.setParamVal(pitch, 1)
+    assert s.getParamDisplay(pitch).startswith("12.00")
+
+
+def test_param_tempo_sync():
+    """
+    Test reading and writing the tempo sync of a parameter.
+    """
+    s = surgepy.createSurge(44100)
+    rate = s.getPatch()["scene"][0]["lfo"][0]["rate"]
+
+    assert s.canTempoSync(rate) is True
+    assert s.getTempoSync(rate) is False
+
+    s.setTempoSync(rate, True)
+    assert s.getTempoSync(rate) is True
+    assert "note" in s.getParamDisplay(rate)
+
+
+def test_param_absolute():
+    """
+    Test reading and writing the absolute mode of a parameter.
+    """
+    s = surgepy.createSurge(44100)
+    pitch = s.getPatch()["scene"][0]["osc"][0]["pitch"]
+
+    assert s.canBeAbsolute(pitch) is True
+    assert s.getAbsolute(pitch) is False
+
+    s.setAbsolute(pitch, True)
+    assert s.getAbsolute(pitch) is True
+
+
+def test_param_deform():
+    """
+    Test reading and writing the deform type of a parameter.
+    """
+    s = surgepy.createSurge(44100)
+    deform = s.getPatch()["scene"][0]["lfo"][0]["deform"]
+
+    assert s.canDeform(deform) is True
+    assert s.getDeform(deform) == 0
+
+    s.setDeform(deform, 2)
+    assert s.getDeform(deform) == 2
+
+
+def test_param_portamento_options():
+    """
+    Test reading and writing the portamento options of a parameter.
+    """
+    s = surgepy.createSurge(44100)
+    porta = s.getPatch()["scene"][0]["portamento"]
+
+    assert s.canPortamento(porta) is True
+    assert s.getPortamentoOptions(porta) == {
+        "constantRate": False,
+        "glissando": False,
+        "retrigger": False,
+        "curve": surgepy.constants.porta_lin,
+    }
+
+    # Options which aren't given are left alone
+    s.setPortamentoOptions(porta, glissando=True, curve=surgepy.constants.porta_exp)
+    assert s.getPortamentoOptions(porta) == {
+        "constantRate": False,
+        "glissando": True,
+        "retrigger": False,
+        "curve": surgepy.constants.porta_exp,
+    }
+
+    with pytest.raises(ValueError):
+        s.setPortamentoOptions(porta, curve=7)
+
+
+def test_param_features_on_unsupported_param():
+    """
+    Test that setting a feature a parameter doesn't have raises rather than being ignored.
+    """
+    s = surgepy.createSurge(44100)
+    volume = s.getPatch()["volume"]
+
+    assert s.canExtend(volume) is False
+    assert s.canDeform(volume) is False
+    assert s.canPortamento(volume) is False
+
+    with pytest.raises(ValueError):
+        s.setExtend(volume, True)
+
+    with pytest.raises(ValueError):
+        s.setDeform(volume, 1)
+
+    with pytest.raises(ValueError):
+        s.getPortamentoOptions(volume)
+
+
+def test_save_wavetable_round_trip(tmp_path):
+    """
+    Test that a factory wavetable loaded into an oscillator saves back out byte for byte.
+    """
+    s = surgepy.createSurge(44100)
+    wavetables = sorted(
+        glob.glob(os.path.join(s.getFactoryDataPath(), "wavetables", "**", "*.wt"), recursive=True)
+    )
+
+    if not wavetables:
+        pytest.skip("No factory wavetables are installed")
+
+    source = wavetables[0]
+    osc = s.getPatch()["scene"][0]["osc"][0]
+    s.setParamVal(osc["type"], surgepy.constants.ot_wavetable)
+    s.loadWavetable(0, 0, source)
+
+    target = str(tmp_path / "exported.wt")
+    assert s.saveWavetable(0, 0, target) is True
+
+    with open(source, "rb") as f, open(target, "rb") as g:
+        assert f.read() == g.read()
+
+
+def test_save_wavetable_without_a_wavetable(tmp_path):
+    """
+    Test that an oscillator which doesn't use wavetable data has nothing to save.
+    """
+    s = surgepy.createSurge(44100)
+
+    with pytest.raises(ValueError):
+        s.saveWavetable(0, 0, str(tmp_path / "nope.wt"))
+
+    with pytest.raises(ValueError):
+        s.saveWavetable(0, 9, str(tmp_path / "nope.wt"))


### PR DESCRIPTION
The pybind API could load a wavetable into an oscillator but had no way to get one back out, and it exposed a parameter's value while ignoring the per-parameter flags which stream alongside it.

`saveWavetable()` writes the wavetable of a scene and oscillator to a .wt file, copying it under `waveTableDataMutex` first so the write can't race a rebuild, exactly as the editor's wavetable export does. Oscillator types which don't use wavetable data are rejected rather than handing back the init table every oscillator happens to carry.

The parameter features - extended range, temposync, absolute mode, deform type and the portamento options - each pair their accessors with a query, and the setters raise on a parameter which doesn't support the feature instead of quietly writing a flag the engine will never read back. Extended range goes through `set_extend_range()` so the current value is rescaled with it. `getParamInfo()` now reports whichever of these features apply.

Addresses #7763

Assisted-By: Claude Opus 5 <noreply@anthropic.com>